### PR TITLE
Update requirements.txt - praisonai pip install broken

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ rich>=13.7
 pyautogen>=0.2.19
 crewai>=0.22.5
 gradio>=4.20.0
+crewai_tools
+duckduckgo_search
+praisonai_tools


### PR DESCRIPTION
required to run the example file in current version of development branch.

It seems after `pip installing praisonai` it also breaks since the error 
```
...
    from duckduckgo_search import DDGS
ModuleNotFoundError: No module named 'duckduckgo_search'
```