### PR TITLE
Update CLI Documentation with Latest LLM Model Option

### DIFF
--- a/docs/features/cli.mdx
+++ b/docs/features/cli.mdx
@@ -52,7 +52,7 @@ PraisonAI CLI provides a simple way to interact with AI agents directly from you
   <Accordion title="With LLM Option" icon="wand-magic-sparkles" defaultOpen>
     Specify a different LLM model:
     ```bash
-    praisonai "write a movie script in 3 lines" --llm gpt-4-mini
+    praisonai "write a movie script in 3 lines" --llm gpt-4o-mini
     ```
   </Accordion>
 


### PR DESCRIPTION
- Updated CLI documentation to reflect the latest LLM model option
- Changed example command to use `gpt-4o-mini` instead of `gpt-4-mini`
- Minor documentation refinement for CLI feature