### PR TITLE
Bump version to 2.0.80 and update praisonaiagents dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY . .
-RUN pip install flask praisonai==2.0.79 gunicorn markdown
+RUN pip install flask praisonai==2.0.80 gunicorn markdown
 EXPOSE 8080
 CMD ["gunicorn", "-b", "0.0.0.0:8080", "api:app"]

--- a/docs/api/praisonai/deploy.html
+++ b/docs/api/praisonai/deploy.html
@@ -110,7 +110,7 @@ Loads environment variables from .env file or system and sets them.</p>
             file.write(&#34;FROM python:3.11-slim\n&#34;)
             file.write(&#34;WORKDIR /app\n&#34;)
             file.write(&#34;COPY . .\n&#34;)
-            file.write(&#34;RUN pip install flask praisonai==2.0.79 gunicorn markdown\n&#34;)
+            file.write(&#34;RUN pip install flask praisonai==2.0.80 gunicorn markdown\n&#34;)
             file.write(&#34;EXPOSE 8080\n&#34;)
             file.write(&#39;CMD [&#34;gunicorn&#34;, &#34;-b&#34;, &#34;0.0.0.0:8080&#34;, &#34;api:app&#34;]\n&#39;)
             

--- a/praisonai.rb
+++ b/praisonai.rb
@@ -3,7 +3,7 @@ class Praisonai < Formula
   
     desc "AI tools for various AI applications"
     homepage "https://github.com/MervinPraison/PraisonAI"
-    url "https://github.com/MervinPraison/PraisonAI/archive/refs/tags/2.0.79.tar.gz"
+    url "https://github.com/MervinPraison/PraisonAI/archive/refs/tags/2.0.80.tar.gz"
     sha256 "1828fb9227d10f991522c3f24f061943a254b667196b40b1a3e4a54a8d30ce32"  # Replace with actual SHA256 checksum
     license "MIT"
   

--- a/praisonai/deploy.py
+++ b/praisonai/deploy.py
@@ -56,7 +56,7 @@ class CloudDeployer:
             file.write("FROM python:3.11-slim\n")
             file.write("WORKDIR /app\n")
             file.write("COPY . .\n")
-            file.write("RUN pip install flask praisonai==2.0.79 gunicorn markdown\n")
+            file.write("RUN pip install flask praisonai==2.0.80 gunicorn markdown\n")
             file.write("EXPOSE 8080\n")
             file.write('CMD ["gunicorn", "-b", "0.0.0.0:8080", "api:app"]\n')
             

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PraisonAI"
-version = "2.0.79"
+version = "2.0.80"
 description = "PraisonAI is an AI Agents Framework with Self Reflection. PraisonAI application combines PraisonAI Agents, AutoGen, and CrewAI into a low-code solution for building and managing multi-agent LLM systems, focusing on simplicity, customisation, and efficient human-agent collaboration."
 readme = "README.md"
 license = ""
@@ -12,7 +12,7 @@ dependencies = [
     "rich>=13.7",
     "markdown>=3.5",
     "pyparsing>=3.0.0",
-    "praisonaiagents>=0.0.64",
+    "praisonaiagents>=0.0.65",
     "python-dotenv>=0.19.0",
     "instructor>=1.3.3",
     "PyYAML>=6.0",
@@ -84,7 +84,7 @@ autogen = ["pyautogen>=0.2.19", "praisonai-tools>=0.0.7", "crewai"]
 
 [tool.poetry]
 name = "PraisonAI"
-version = "2.0.79"
+version = "2.0.80"
 description = "PraisonAI is an AI Agents Framework with Self Reflection. PraisonAI application combines PraisonAI Agents, AutoGen, and CrewAI into a low-code solution for building and managing multi-agent LLM systems, focusing on simplicity, customisation, and efficient human–agent collaboration."
 authors = ["Mervin Praison"]
 license = ""
@@ -102,7 +102,7 @@ python = ">=3.10,<3.13"
 rich = ">=13.7"
 markdown = ">=3.5"
 pyparsing = ">=3.0.0"
-praisonaiagents = ">=0.0.64"
+praisonaiagents = ">=0.0.65"
 python-dotenv = ">=0.19.0"
 instructor = ">=1.3.3"
 PyYAML = ">=6.0"

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -477,8 +477,14 @@ Context:
                 else:
                     self.run_task(task_id)
 
-    async def astart(self, content=None, **kwargs):
-        """Async version of start method"""
+    async def astart(self, content=None, return_dict=False, **kwargs):
+        """Async version of start method
+        
+        Args:
+            content: Optional content to add to all tasks' context
+            return_dict: If True, returns the full results dictionary instead of only the final response
+            **kwargs: Additional arguments
+        """
         if content:
             # Add content to context of all tasks
             for task in self.tasks.values():
@@ -488,10 +494,25 @@ Context:
                     task.context.append(content)
 
         await self.arun_all_tasks()
-        return {
+        
+        # Get results
+        results = {
             "task_status": self.get_all_tasks_status(),
             "task_results": {task_id: self.get_task_result(task_id) for task_id in self.tasks}
         }
+        
+        # By default, return only the final agent's response
+        if not return_dict:
+            # Get the last task (assuming sequential processing)
+            task_ids = list(self.tasks.keys())
+            if task_ids:
+                last_task_id = task_ids[-1]
+                last_result = self.get_task_result(last_task_id)
+                if last_result:
+                    return last_result.raw
+                    
+        # Return full results dict if return_dict is True or if no final result was found
+        return results
 
     def save_output_to_file(self, task, task_output):
         if task.output_file:
@@ -801,8 +822,14 @@ Context:
             return str(agent[0])
         return None
 
-    def start(self, content=None, **kwargs):
-        """Start agent execution with optional content and config"""
+    def start(self, content=None, return_dict=False, **kwargs):
+        """Start agent execution with optional content and config
+        
+        Args:
+            content: Optional content to add to all tasks' context
+            return_dict: If True, returns the full results dictionary instead of only the final response
+            **kwargs: Additional arguments
+        """
         if content:
             # Add content to context of all tasks
             for task in self.tasks.values():
@@ -815,10 +842,25 @@ Context:
                 
         # Run tasks as before
         self.run_all_tasks()
-        return {
+        
+        # Get results
+        results = {
             "task_status": self.get_all_tasks_status(),
             "task_results": {task_id: self.get_task_result(task_id) for task_id in self.tasks}
         }
+        
+        # By default, return only the final agent's response
+        if not return_dict:
+            # Get the last task (assuming sequential processing)
+            task_ids = list(self.tasks.keys())
+            if task_ids:
+                last_task_id = task_ids[-1]
+                last_result = self.get_task_result(last_task_id)
+                if last_result:
+                    return last_result.raw
+                    
+        # Return full results dict if return_dict is True or if no final result was found
+        return results
 
     def set_state(self, key: str, value: Any) -> None:
         """Set a state value"""

--- a/src/praisonai-agents/pyproject.toml
+++ b/src/praisonai-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "praisonaiagents"
-version = "0.0.64"
+version = "0.0.65"
 description = "Praison AI agents for completing complex tasks with Self Reflection Agents"
 authors = [
     { name="Mervin Praison" }

--- a/src/praisonai-agents/uv.lock
+++ b/src/praisonai-agents/uv.lock
@@ -1868,7 +1868,7 @@ wheels = [
 
 [[package]]
 name = "praisonaiagents"
-version = "0.0.64"
+version = "0.0.65"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },

--- a/uv.lock
+++ b/uv.lock
@@ -3060,7 +3060,7 @@ wheels = [
 
 [[package]]
 name = "praisonai"
-version = "2.0.79"
+version = "2.0.80"
 source = { editable = "." }
 dependencies = [
     { name = "instructor" },
@@ -3197,7 +3197,7 @@ requires-dist = [
     { name = "plotly", marker = "extra == 'realtime'", specifier = ">=5.24.0" },
     { name = "praisonai-tools", marker = "extra == 'autogen'", specifier = ">=0.0.7" },
     { name = "praisonai-tools", marker = "extra == 'crewai'", specifier = ">=0.0.7" },
-    { name = "praisonaiagents", specifier = ">=0.0.64" },
+    { name = "praisonaiagents", specifier = ">=0.0.65" },
     { name = "pyautogen", marker = "extra == 'autogen'", specifier = ">=0.2.19" },
     { name = "pydantic", marker = "extra == 'chat'", specifier = "<=2.10.1" },
     { name = "pydantic", marker = "extra == 'code'", specifier = "<=2.10.1" },
@@ -3250,16 +3250,16 @@ wheels = [
 
 [[package]]
 name = "praisonaiagents"
-version = "0.0.64"
+version = "0.0.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/88/44ab243ef5948d3994d7991d0824fdceda1c1a8f169fa4ee2ec1e389f7f3/praisonaiagents-0.0.64.tar.gz", hash = "sha256:f50be9210c1ae5169a297c3654a62c22549d56368a7f0548d6825b1d90d52ccd", size = 104948 }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/58/6e07c4abf57d78be642f1517fe0692a003dfc253ad91a03c70521d246b5e/praisonaiagents-0.0.65.tar.gz", hash = "sha256:16627166f1b42bd8d21759fbd67015fff0b4730ca224b4a566cffe2b5bb770e8", size = 105128 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/7a/e93640fdeaa066dfa089bf5c2e0fae4db9cce35bd44c61791381a297fd8b/praisonaiagents-0.0.64-py3-none-any.whl", hash = "sha256:a843260b3fb6c3efe57ee994592c5cdccdbee24bd619242d6a88121c949cdf66", size = 124059 },
+    { url = "https://files.pythonhosted.org/packages/04/02/e4f2ef3c008a407d3b945256d1513bf0159989055e9462c691265be3d294/praisonaiagents-0.0.65-py3-none-any.whl", hash = "sha256:f53e9c3ddf31c575dd5f65315db70b35487adb0f9ae908596e74ed315c12afc5", size = 124306 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Updated version to 2.0.80 across multiple files including praisonai.rb, pyproject.toml, uv.lock, Dockerfile, and docs
- Upgraded praisonaiagents dependency from 0.0.64 to 0.0.65
- Enhanced agent start methods with optional return_dict parameter
- Improved result handling in start and astart methods to return final response by default
- Synchronized version updates across project configuration files