### PR TITLE
Fix UnicodeDecodeError in Docker for MCP Google Maps

### DIFF
--- a/src/praisonai-agents/npx_mcp_wrapper_main.py
+++ b/src/praisonai-agents/npx_mcp_wrapper_main.py
@@ -40,11 +40,25 @@ class MCP:
             logging.getLogger("npx-mcp-wrapper").setLevel(logging.DEBUG)
             os.environ["DEBUG"] = "mcp:*"
         
+        # Ensure UTF-8 encoding for Docker compatibility
+        self._setup_utf8_environment()
+        
         self._tools = []
         self._function_declarations = []
         
         # Initialize the MCP tools
         self._initialize_mcp_tools()
+    
+    def _setup_utf8_environment(self):
+        """
+        Set up UTF-8 encoding environment variables for Docker compatibility.
+        This prevents UnicodeDecodeError when using subprocess in Docker containers.
+        """
+        os.environ.update({
+            'PYTHONIOENCODING': 'utf-8',
+            'LC_ALL': 'C.UTF-8',
+            'LANG': 'C.UTF-8'
+        })
     
     def _initialize_mcp_tools(self):
         """
@@ -109,12 +123,12 @@ if __name__ == "__main__":
             
             # Write the temporary script to a file
             temp_script_path = os.path.join(os.path.dirname(__file__), "_temp_extract_mcp_tools.py")
-            with open(temp_script_path, "w") as f:
+            with open(temp_script_path, "w", encoding='utf-8') as f:
                 f.write(temp_script)
             
             # Run the temporary script to extract the tool definitions
             cmd = ["python", temp_script_path, self.command] + self.args
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout)
+            result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', env=os.environ.copy(), timeout=self.timeout)
             
             # Remove the temporary script
             os.remove(temp_script_path)
@@ -197,12 +211,12 @@ if __name__ == "__main__":
             try:
                 # Write the temporary script to a file
                 temp_script_path = os.path.join(os.path.dirname(__file__), f"_temp_call_mcp_tool_{tool_name}.py")
-                with open(temp_script_path, "w") as f:
+                with open(temp_script_path, "w", encoding='utf-8') as f:
                     f.write(temp_script)
                 
                 # Run the temporary script to call the MCP tool
                 cmd = ["python", temp_script_path, self.command] + self.args + [tool_name, json.dumps(kwargs)]
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout)
+                result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', env=os.environ.copy(), timeout=self.timeout)
                 
                 # Remove the temporary script
                 os.remove(temp_script_path)

--- a/src/praisonai-agents/praisonaiagents/mcp/mcp.py
+++ b/src/praisonai-agents/praisonaiagents/mcp/mcp.py
@@ -212,6 +212,18 @@ class MCP:
         
         # Set up stdio client
         self.is_sse = False
+        
+        # Ensure UTF-8 encoding in environment for Docker compatibility
+        env = kwargs.get('env', {})
+        if not env:
+            env = os.environ.copy()
+        env.update({
+            'PYTHONIOENCODING': 'utf-8',
+            'LC_ALL': 'C.UTF-8',
+            'LANG': 'C.UTF-8'
+        })
+        kwargs['env'] = env
+        
         self.server_params = StdioServerParameters(
             command=cmd,
             args=arguments,


### PR DESCRIPTION
Fixes #469

This PR resolves the UnicodeDecodeError that occurs during MCP Google Maps initialization in Docker containers.

## Changes
- Added explicit UTF-8 encoding to all subprocess.run() calls
- Set UTF-8 environment variables for Docker compatibility
- Ensured consistent encoding across MCP implementations

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility with Docker and enhanced Unicode handling to prevent errors when running subprocesses and file operations involving UTF-8 encoded data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->