### PR TITLE
Update GitHub Actions workflows to remove Python 3.9 support

### DIFF
--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: [3.10, 3.11]
     
     steps:
     - name: Checkout code
@@ -159,7 +159,6 @@ jobs:
         echo "# 🎯 Test Matrix Summary" > matrix_summary.md
         echo "" >> matrix_summary.md
         echo "## Python Version Results:" >> matrix_summary.md
-        echo "- Python 3.9: ${{ needs.comprehensive-test.result }}" >> matrix_summary.md
         echo "- Python 3.10: ${{ needs.comprehensive-test.result }}" >> matrix_summary.md  
         echo "- Python 3.11: ${{ needs.comprehensive-test.result }}" >> matrix_summary.md
         echo "" >> matrix_summary.md

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.11]
+        python-version: [3.11]
     
     steps:
     - name: Checkout code

--- a/.github/workflows/test-frameworks.yml
+++ b/.github/workflows/test-frameworks.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.11]
+        python-version: [3.11]
         framework: [autogen, crewai]
     
     steps:
@@ -120,11 +120,9 @@ jobs:
         echo "## Test Results by Framework and Python Version:" >> framework_summary.md
         echo "" >> framework_summary.md
         echo "### AutoGen Framework:" >> framework_summary.md
-        echo "- Python 3.9: ${{ needs.framework-tests.result }}" >> framework_summary.md
         echo "- Python 3.11: ${{ needs.framework-tests.result }}" >> framework_summary.md
         echo "" >> framework_summary.md
         echo "### CrewAI Framework:" >> framework_summary.md
-        echo "- Python 3.9: ${{ needs.framework-tests.result }}" >> framework_summary.md
         echo "- Python 3.11: ${{ needs.framework-tests.result }}" >> framework_summary.md
         echo "" >> framework_summary.md
         echo "## Overall Status:" >> framework_summary.md


### PR DESCRIPTION
- Modified workflow files to exclude Python 3.9 from the test matrix, focusing on Python 3.10 and 3.11 for improved compatibility.
- Ensured minimal changes to existing code while streamlining the testing process.