### PR TITLE
Update version to 2.2.7 across project files

### DIFF
--- a/.github/workflows/test-comprehensive.yml
+++ b/.github/workflows/test-comprehensive.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
     
     steps:
     - name: Checkout code

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY . .
-RUN pip install flask praisonai==2.2.6 gunicorn markdown
+RUN pip install flask praisonai==2.2.7 gunicorn markdown
 EXPOSE 8080
 CMD ["gunicorn", "-b", "0.0.0.0:8080", "api:app"]

--- a/docker/Dockerfile.chat
+++ b/docker/Dockerfile.chat
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
     praisonaiagents>=0.0.4 \
     praisonai_tools \
-    "praisonai==2.2.6" \
+    "praisonai==2.2.7" \
     "praisonai[chat]" \
     "embedchain[github,youtube]"
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
     praisonaiagents>=0.0.4 \
     praisonai_tools \
-    "praisonai==2.2.6" \
+    "praisonai==2.2.7" \
     "praisonai[ui]" \
     "praisonai[chat]" \
     "praisonai[realtime]" \

--- a/docker/Dockerfile.ui
+++ b/docker/Dockerfile.ui
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
     praisonaiagents>=0.0.4 \
     praisonai_tools \
-    "praisonai==2.2.6" \
+    "praisonai==2.2.7" \
     "praisonai[ui]" \
     "praisonai[crewai]"
 

--- a/docs/api/praisonai/deploy.html
+++ b/docs/api/praisonai/deploy.html
@@ -110,7 +110,7 @@ Loads environment variables from .env file or system and sets them.</p>
             file.write(&#34;FROM python:3.11-slim\n&#34;)
             file.write(&#34;WORKDIR /app\n&#34;)
             file.write(&#34;COPY . .\n&#34;)
-            file.write(&#34;RUN pip install flask praisonai==2.2.6 gunicorn markdown\n&#34;)
+            file.write(&#34;RUN pip install flask praisonai==2.2.7 gunicorn markdown\n&#34;)
             file.write(&#34;EXPOSE 8080\n&#34;)
             file.write(&#39;CMD [&#34;gunicorn&#34;, &#34;-b&#34;, &#34;0.0.0.0:8080&#34;, &#34;api:app&#34;]\n&#39;)
             

--- a/docs/developers/local-development.mdx
+++ b/docs/developers/local-development.mdx
@@ -27,7 +27,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install flask praisonai==2.2.6 watchdog
+RUN pip install flask praisonai==2.2.7 watchdog
 
 EXPOSE 5555
 

--- a/docs/ui/chat.mdx
+++ b/docs/ui/chat.mdx
@@ -155,7 +155,7 @@ To facilitate local development with live reload, you can use Docker. Follow the
 
     COPY . .
 
-    RUN pip install flask praisonai==2.2.6 watchdog
+    RUN pip install flask praisonai==2.2.7 watchdog
 
     EXPOSE 5555
 

--- a/docs/ui/code.mdx
+++ b/docs/ui/code.mdx
@@ -208,7 +208,7 @@ To facilitate local development with live reload, you can use Docker. Follow the
 
     COPY . .
 
-    RUN pip install flask praisonai==2.2.6 watchdog
+    RUN pip install flask praisonai==2.2.7 watchdog
 
     EXPOSE 5555
 

--- a/praisonai/deploy.py
+++ b/praisonai/deploy.py
@@ -56,7 +56,7 @@ class CloudDeployer:
             file.write("FROM python:3.11-slim\n")
             file.write("WORKDIR /app\n")
             file.write("COPY . .\n")
-            file.write("RUN pip install flask praisonai==2.2.6 gunicorn markdown\n")
+            file.write("RUN pip install flask praisonai==2.2.7 gunicorn markdown\n")
             file.write("EXPOSE 8080\n")
             file.write('CMD ["gunicorn", "-b", "0.0.0.0:8080", "api:app"]\n')
             

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PraisonAI"
-version = "2.2.6"
+version = "2.2.7"
 description = "PraisonAI is an AI Agents Framework with Self Reflection. PraisonAI application combines PraisonAI Agents, AutoGen, and CrewAI into a low-code solution for building and managing multi-agent LLM systems, focusing on simplicity, customisation, and efficient human-agent collaboration."
 readme = "README.md"
 license = ""
@@ -89,7 +89,7 @@ autogen = ["pyautogen>=0.2.19", "praisonai-tools>=0.0.15", "crewai"]
 
 [tool.poetry]
 name = "PraisonAI"
-version = "2.2.6"
+version = "2.2.7"
 description = "PraisonAI is an AI Agents Framework with Self Reflection. PraisonAI application combines PraisonAI Agents, AutoGen, and CrewAI into a low-code solution for building and managing multi-agent LLM systems, focusing on simplicity, customisation, and efficient human-agent collaboration."
 authors = ["Mervin Praison"]
 license = ""

--- a/uv.lock
+++ b/uv.lock
@@ -3614,7 +3614,7 @@ wheels = [
 
 [[package]]
 name = "praisonai"
-version = "2.2.6"
+version = "2.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "instructor" },


### PR DESCRIPTION
- Incremented PraisonAI version from 2.2.6 to 2.2.7 in `pyproject.toml`, `uv.lock`, and all relevant Dockerfiles for consistency.
- Updated Python version specification in `test-comprehensive.yml` to focus solely on Python 3.11.
- Ensured minimal changes to existing code while maintaining versioning accuracy.