### PR TITLE
fix: Add asyncio import to local scope in launch() method

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1478,6 +1478,7 @@ Your Goal: {self.goal}
                 from pydantic import BaseModel
                 import threading
                 import time
+                import asyncio
                 
                 # Define the request model here since we need pydantic
                 class AgentQuery(BaseModel):
@@ -1656,7 +1657,6 @@ Your Goal: {self.goal}
                 import threading
                 import time
                 import inspect
-                import asyncio # Ensure asyncio is imported
                 # logging is already imported at the module level
                 
             except ImportError as e:


### PR DESCRIPTION
This fixes the NameError: cannot access free variable 'asyncio' where it is not associated with a value in enclosing scope error that occurs at line 1563.

The issue was that the handle_agent_query function (containing line 1563) is defined inside a try/except block that imports FastAPI dependencies but didn't include asyncio. Added import asyncio to the try block and removed redundant import from line 1659.

Fixes #514

Generated with [Claude Code](https://claude.ai/code)