### PR TITLE
Update version to 2.2.15 across project files

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY . .
-RUN pip install flask praisonai==2.2.14 gunicorn markdown
+RUN pip install flask praisonai==2.2.15 gunicorn markdown
 EXPOSE 8080
 CMD ["gunicorn", "-b", "0.0.0.0:8080", "api:app"]

--- a/docker/Dockerfile.chat
+++ b/docker/Dockerfile.chat
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
     praisonaiagents>=0.0.4 \
     praisonai_tools \
-    "praisonai==2.2.14" \
+    "praisonai==2.2.15" \
     "praisonai[chat]" \
     "embedchain[github,youtube]"
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
     praisonaiagents>=0.0.4 \
     praisonai_tools \
-    "praisonai==2.2.14" \
+    "praisonai==2.2.15" \
     "praisonai[ui]" \
     "praisonai[chat]" \
     "praisonai[realtime]" \

--- a/docker/Dockerfile.ui
+++ b/docker/Dockerfile.ui
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
     praisonaiagents>=0.0.4 \
     praisonai_tools \
-    "praisonai==2.2.14" \
+    "praisonai==2.2.15" \
     "praisonai[ui]" \
     "praisonai[crewai]"
 

--- a/docs/api/praisonai/deploy.html
+++ b/docs/api/praisonai/deploy.html
@@ -110,7 +110,7 @@ Loads environment variables from .env file or system and sets them.</p>
             file.write(&#34;FROM python:3.11-slim\n&#34;)
             file.write(&#34;WORKDIR /app\n&#34;)
             file.write(&#34;COPY . .\n&#34;)
-            file.write(&#34;RUN pip install flask praisonai==2.2.14 gunicorn markdown\n&#34;)
+            file.write(&#34;RUN pip install flask praisonai==2.2.15 gunicorn markdown\n&#34;)
             file.write(&#34;EXPOSE 8080\n&#34;)
             file.write(&#39;CMD [&#34;gunicorn&#34;, &#34;-b&#34;, &#34;0.0.0.0:8080&#34;, &#34;api:app&#34;]\n&#39;)
             

--- a/docs/developers/local-development.mdx
+++ b/docs/developers/local-development.mdx
@@ -27,7 +27,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install flask praisonai==2.2.14 watchdog
+RUN pip install flask praisonai==2.2.15 watchdog
 
 EXPOSE 5555
 

--- a/docs/ui/chat.mdx
+++ b/docs/ui/chat.mdx
@@ -155,7 +155,7 @@ To facilitate local development with live reload, you can use Docker. Follow the
 
     COPY . .
 
-    RUN pip install flask praisonai==2.2.14 watchdog
+    RUN pip install flask praisonai==2.2.15 watchdog
 
     EXPOSE 5555
 

--- a/docs/ui/code.mdx
+++ b/docs/ui/code.mdx
@@ -208,7 +208,7 @@ To facilitate local development with live reload, you can use Docker. Follow the
 
     COPY . .
 
-    RUN pip install flask praisonai==2.2.14 watchdog
+    RUN pip install flask praisonai==2.2.15 watchdog
 
     EXPOSE 5555
 

--- a/praisonai/deploy.py
+++ b/praisonai/deploy.py
@@ -56,7 +56,7 @@ class CloudDeployer:
             file.write("FROM python:3.11-slim\n")
             file.write("WORKDIR /app\n")
             file.write("COPY . .\n")
-            file.write("RUN pip install flask praisonai==2.2.14 gunicorn markdown\n")
+            file.write("RUN pip install flask praisonai==2.2.15 gunicorn markdown\n")
             file.write("EXPOSE 8080\n")
             file.write('CMD ["gunicorn", "-b", "0.0.0.0:8080", "api:app"]\n')
             

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PraisonAI"
-version = "2.2.14"
+version = "2.2.15"
 description = "PraisonAI is an AI Agents Framework with Self Reflection. PraisonAI application combines PraisonAI Agents, AutoGen, and CrewAI into a low-code solution for building and managing multi-agent LLM systems, focusing on simplicity, customisation, and efficient human-agent collaboration."
 readme = "README.md"
 license = ""
@@ -12,7 +12,7 @@ dependencies = [
     "rich>=13.7",
     "markdown>=3.5",
     "pyparsing>=3.0.0",
-    "praisonaiagents>=0.0.87",
+    "praisonaiagents>=0.0.88",
     "python-dotenv>=0.19.0",
     "instructor>=1.3.3",
     "PyYAML>=6.0",
@@ -89,7 +89,7 @@ autogen = ["pyautogen>=0.2.19", "praisonai-tools>=0.0.15", "crewai"]
 
 [tool.poetry]
 name = "PraisonAI"
-version = "2.2.14"
+version = "2.2.15"
 description = "PraisonAI is an AI Agents Framework with Self Reflection. PraisonAI application combines PraisonAI Agents, AutoGen, and CrewAI into a low-code solution for building and managing multi-agent LLM systems, focusing on simplicity, customisation, and efficient human-agent collaboration."
 authors = ["Mervin Praison"]
 license = ""
@@ -107,7 +107,7 @@ python = ">=3.10,<3.13"
 rich = ">=13.7"
 markdown = ">=3.5"
 pyparsing = ">=3.0.0"
-praisonaiagents = ">=0.0.87"
+praisonaiagents = ">=0.0.88"
 python-dotenv = ">=0.19.0"
 instructor = ">=1.3.3"
 PyYAML = ">=6.0"

--- a/src/praisonai-agents/pyproject.toml
+++ b/src/praisonai-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "praisonaiagents"
-version = "0.0.87"
+version = "0.0.88"
 description = "Praison AI agents for completing complex tasks with Self Reflection Agents"
 authors = [
     { name="Mervin Praison" }

--- a/src/praisonai-agents/uv.lock
+++ b/src/praisonai-agents/uv.lock
@@ -1457,7 +1457,7 @@ wheels = [
 
 [[package]]
 name = "praisonaiagents"
-version = "0.0.87"
+version = "0.0.88"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -3614,7 +3614,7 @@ wheels = [
 
 [[package]]
 name = "praisonai"
-version = "2.2.14"
+version = "2.2.15"
 source = { editable = "." }
 dependencies = [
     { name = "instructor" },
@@ -3756,7 +3756,7 @@ requires-dist = [
     { name = "plotly", marker = "extra == 'realtime'", specifier = ">=5.24.0" },
     { name = "praisonai-tools", marker = "extra == 'autogen'", specifier = ">=0.0.15" },
     { name = "praisonai-tools", marker = "extra == 'crewai'", specifier = ">=0.0.15" },
-    { name = "praisonaiagents", specifier = ">=0.0.87" },
+    { name = "praisonaiagents", specifier = ">=0.0.88" },
     { name = "pyautogen", marker = "extra == 'autogen'", specifier = ">=0.2.19" },
     { name = "pydantic", marker = "extra == 'chat'", specifier = "<=2.10.1" },
     { name = "pydantic", marker = "extra == 'code'", specifier = "<=2.10.1" },
@@ -3813,7 +3813,7 @@ wheels = [
 
 [[package]]
 name = "praisonaiagents"
-version = "0.0.87"
+version = "0.0.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mcp" },
@@ -3821,9 +3821,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/46/9761f0fc2d21361d418df9978ec71de74fd5a24e324c9ee7c8b0ad0f1965/praisonaiagents-0.0.87.tar.gz", hash = "sha256:d86c223e5b6f03c83a144270128e0b3f8b0929fb0e8389a85939b659048c04d1", size = 126602 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/63/62364a63a0da65dae0e0bf438f011659a34e6271dcbda9c7e636f97d1a44/praisonaiagents-0.0.88.tar.gz", hash = "sha256:d5850cf4e873c08abfe6b256c91ffb77e89e9d09301eb3ba9e59e33c316637bc", size = 126629 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/6f/6e1253bacf0026a57ec4bb2467401f5e541082d5cc8580e22cdc483b6419/praisonaiagents-0.0.87-py3-none-any.whl", hash = "sha256:fa6779c4980cd1318de33489552b69e612f1ca7aae482a4788c6d89e5b974c08", size = 146337 },
+    { url = "https://files.pythonhosted.org/packages/77/6a/7402127e393f573f2cd09c14a45552cb814082168721cbf9bf9c007ae066/praisonaiagents-0.0.88-py3-none-any.whl", hash = "sha256:2f1b81e82b63b4edc662a7b4a80b3c3b64528b91cc04dc6a6073de1978945aa4", size = 146331 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Incremented PraisonAI version from 2.2.14 to 2.2.15 in `pyproject.toml`, `uv.lock`, and all relevant Dockerfiles for consistency.
- Updated dependency version for `praisonaiagents` from 0.0.87 to 0.0.88.
- Ensured minimal changes to existing code while maintaining versioning accuracy across the project.