### PR TITLE
Fix TypeError in AutoAgents: change knowledge_sources to knowledge parameter

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/autoagents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/autoagents.py
@@ -283,7 +283,7 @@ Return the configuration in a structured JSON format matching the AutoAgentsConf
                 respect_context_window=self.respect_context_window,
                 code_execution_mode=self.code_execution_mode,
                 embedder_config=self.embedder_config,
-                knowledge_sources=self.knowledge_sources,
+                knowledge=self.knowledge_sources,
                 use_system_prompt=self.use_system_prompt,
                 cache=self.cache,
                 allow_delegation=self.allow_delegation,


### PR DESCRIPTION
Fixes #404

### Description
This PR fixes a TypeError that occurs when creating AutoAgents instances. The issue was caused by a parameter name mismatch between the AutoAgents class and the Agent constructor.

### Changes
- Changed `knowledge_sources=self.knowledge_sources` to `knowledge=self.knowledge_sources` in autoagents.py line 286
- This aligns with the Agent constructor which expects `knowledge` parameter, not `knowledge_sources`

### Testing
The user's original example code from the issue should now work without the TypeError.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal naming for knowledge-related data when creating agents. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->