### PR TITLE
fix: correct knowledge_sources parameter in AutoAgents

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/autoagents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/autoagents.py
@@ -283,7 +283,7 @@ Return the configuration in a structured JSON format matching the AutoAgentsConf
                 respect_context_window=self.respect_context_window,
                 code_execution_mode=self.code_execution_mode,
                 embedder_config=self.embedder_config,
-                knowledge_sources=self.knowledge_sources,
+                knowledge=self.knowledge_sources,
                 use_system_prompt=self.use_system_prompt,
                 cache=self.cache,
                 allow_delegation=self.allow_delegation,


### PR DESCRIPTION
Fixes #457 - TypeError when using AutoAgents with DuckDuckGo tool

## Problem
AutoAgents was passing `knowledge_sources` parameter to Agent constructor, but Agent class expects `knowledge` parameter. This caused TypeError preventing AutoAgents from working.

## Solution
Changed parameter name from `knowledge_sources` to `knowledge` in AutoAgents implementation.

## Testing
Verified that AutoAgents can now be initialized without the TypeError.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->