### PR TITLE
fix: update chainlit Action constructor to use payload parameter

### DIFF
--- a/src/praisonai/praisonai/chainlit_ui.py
+++ b/src/praisonai/praisonai/chainlit_ui.py
@@ -24,8 +24,8 @@ config_list = [
 agent_file = "test.yaml"
 
 actions=[
-    cl.Action(name="run", value="run", label="✅ Run"),
-    cl.Action(name="modify", value="modify", label="🔧 Modify"),
+    cl.Action(name="run", payload="run", label="✅ Run"),
+    cl.Action(name="modify", payload="modify", label="🔧 Modify"),
 ]
 
 @cl.action_callback("run")

--- a/src/praisonai/praisonai/ui/agents.py
+++ b/src/praisonai/praisonai/ui/agents.py
@@ -17,8 +17,8 @@ config_list = [
 ]
 
 actions = [
-    cl.Action(name="run", value="run", label="✅ Run"),
-    cl.Action(name="modify", value="modify", label="🔧 Modify"),
+    cl.Action(name="run", payload="run", label="✅ Run"),
+    cl.Action(name="modify", payload="modify", label="🔧 Modify"),
 ]
 
 @cl.action_callback("run")


### PR DESCRIPTION
Fixes ValidationError when executing `python -m praisonai ui`

The issue was caused by using the deprecated `value` parameter in the chainlit Action constructor. With chainlit version 2.5.5, the `value` parameter was replaced with `payload`.

**Changes:**
- Replace deprecated 'value' parameter with 'payload' in cl.Action constructor
- Updates both agents.py and chainlit_ui.py files
- Resolves compatibility issue with chainlit 2.5.5

Resolves #393

Generated with [Claude Code](https://claude.ai/code)