### PR TITLE
fix: resolve Python 3.8 compatibility issue with tuple type annotation

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/autoagents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/autoagents.py
@@ -8,7 +8,7 @@ It automatically handles agent creation, task setup, and execution flow.
 from .agents import PraisonAIAgents
 from ..agent.agent import Agent
 from ..task.task import Task
-from typing import List, Any, Optional, Dict
+from typing import List, Any, Optional, Dict, Tuple
 import logging
 import os
 from pydantic import BaseModel
@@ -255,7 +255,7 @@ Return the configuration in a structured JSON format matching the AutoAgentsConf
             logging.error(f"Error generating configuration: {e}")
             raise
 
-    def _create_agents_and_tasks(self, config: AutoAgentsConfig) -> tuple[List[Agent], List[Task]]:
+    def _create_agents_and_tasks(self, config: AutoAgentsConfig) -> Tuple[List[Agent], List[Task]]:
         """Create agents and tasks from configuration"""
         agents = []
         tasks = []

--- a/src/praisonai-agents/pyproject.toml
+++ b/src/praisonai-agents/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "praisonaiagents"
 version = "0.0.89"
 description = "Praison AI agents for completing complex tasks with Self Reflection Agents"
+requires-python = ">=3.8"
 authors = [
     { name="Mervin Praison" }
 ]


### PR DESCRIPTION
Fixes #388

This PR resolves the `TypeError: 'type' object is not subscriptable` issue that occurs when using Python versions < 3.9.

## Changes
- Changed `tuple[List[Agent], List[Task]]` to `Tuple[List[Agent], List[Task]]` in autoagents.py:258
- Added `Tuple` import to typing imports
- Added `requires-python = ">=3.8"` to pyproject.toml

The issue was caused by using the lowercase `tuple[...]` syntax which is only available in Python 3.9+. The fix uses the `Tuple[...]` import from the typing module for backward compatibility.

Generated with [Claude Code](https://claude.ai/code)