### PR TITLE
fix: resolve PydanticSchemaGenerationError for List[Any] and BaseModel fields

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/autoagents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/autoagents.py
@@ -11,7 +11,7 @@ from ..task.task import Task
 from typing import List, Any, Optional, Dict
 import logging
 import os
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from ..main import display_instruction, display_tool_call, display_interaction, client
 
 # Define Pydantic models for structured output
@@ -22,6 +22,7 @@ class TaskConfig(BaseModel):
     tools: List[str]
 
 class AgentConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     name: str
     role: str
     goal: str
@@ -30,6 +31,7 @@ class AgentConfig(BaseModel):
     tasks: List[TaskConfig]
 
 class AutoAgentsConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     main_instruction: str
     process_type: str
     agents: List[AgentConfig]

--- a/src/praisonai-agents/praisonaiagents/main.py
+++ b/src/praisonai-agents/praisonaiagents/main.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import List, Optional, Dict, Any, Union, Literal, Type
 from openai import OpenAI
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from rich import print
 from rich.console import Console
 from rich.panel import Panel
@@ -365,6 +365,7 @@ class ReflectionOutput(BaseModel):
 client = OpenAI(api_key=(os.environ["OPENAI_API_KEY"] if os.environ.get("OPENAI_API_KEY") else "xxxx"))
 
 class TaskOutput(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     description: str
     summary: Optional[str] = None
     raw: str

--- a/src/praisonai-agents/praisonaiagents/process/process.py
+++ b/src/praisonai-agents/praisonaiagents/process/process.py
@@ -1,7 +1,7 @@
 import logging
 import asyncio
 from typing import Dict, Optional, List, Any, AsyncGenerator
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from ..agent.agent import Agent
 from ..task.task import Task
 from ..main import display_error, client
@@ -9,6 +9,7 @@ import csv
 import os
 
 class LoopItems(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     items: List[Any]
 
 class Process:


### PR DESCRIPTION
Fixes #247

This PR resolves the PydanticSchemaGenerationError that occurred during installation when importing from praisonaiagents.

## Changes Made

- Added `arbitrary_types_allowed=True` to LoopItems model in process.py
- Added `arbitrary_types_allowed=True` to TaskOutput model in main.py
- Added `arbitrary_types_allowed=True` to AgentConfig and AutoAgentsConfig models in autoagents.py
- Imported ConfigDict from pydantic in all affected files

## Root Cause

The error was caused by Pydantic v2's strict schema generation for complex types like `List[Any]` and `Optional[BaseModel]`. Without the proper configuration, Pydantic couldn't generate schemas for these fields.

## Testing

The fix has been tested to ensure:
- Import statements work without errors
- BaseModel instantiation works correctly
- Existing functionality remains intact

Generated with [Claude Code](https://claude.ai/code)