### PR TITLE
fix: resolve asyncio event loop error in memory callbacks

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -443,12 +443,12 @@ Context:
                     if task.callback:
                         try:
                             if asyncio.iscoroutinefunction(task.callback):
-                                if asyncio.get_event_loop().is_running():
-                                    asyncio.create_task(task.callback(task_output))
-                                else:
-                                    loop = asyncio.new_event_loop()
-                                    asyncio.set_event_loop(loop)
-                                    loop.run_until_complete(task.callback(task_output))
+                                try:
+                                    loop = asyncio.get_running_loop()
+                                    loop.create_task(task.callback(task_output))
+                                except RuntimeError:
+                                    # No event loop running, create new one
+                                    asyncio.run(task.callback(task_output))
                             else:
                                 task.callback(task_output)
                         except Exception as e:
@@ -765,12 +765,12 @@ Context:
                     if task.callback:
                         try:
                             if asyncio.iscoroutinefunction(task.callback):
-                                if asyncio.get_event_loop().is_running():
-                                    asyncio.create_task(task.callback(task_output))
-                                else:
-                                    loop = asyncio.new_event_loop()
-                                    asyncio.set_event_loop(loop)
-                                    loop.run_until_complete(task.callback(task_output))
+                                try:
+                                    loop = asyncio.get_running_loop()
+                                    loop.create_task(task.callback(task_output))
+                                except RuntimeError:
+                                    # No event loop running, create new one
+                                    asyncio.run(task.callback(task_output))
                             else:
                                 task.callback(task_output)
                         except Exception as e:

--- a/src/praisonai-agents/praisonaiagents/task/task.py
+++ b/src/praisonai-agents/praisonaiagents/task/task.py
@@ -47,11 +47,11 @@ class Task:
             try:
                 from ..memory.memory import Memory
                 MEMORY_AVAILABLE = True
-            except ImportError:
-                raise ImportError(
-                    "Memory features requested in Task but memory dependencies not installed. "
-                    "Please install with: pip install \"praisonaiagents[memory]\""
-                )
+            except ImportError as e:
+                logger.warning(f"Memory dependency missing: {e}")
+                logger.warning("Some memory features may not work. Install with: pip install \"praisonaiagents[memory]\"")
+                MEMORY_AVAILABLE = False
+                # Don't raise - let it continue with limited functionality
 
         self.input_file = input_file
         self.id = str(uuid.uuid4()) if id is None else str(id)


### PR DESCRIPTION
**Summary**

- Fixes RuntimeError in Streamlit environments when memory callbacks are executed
- Improves memory dependency checking to be more user-friendly

**Changes**

1. **Asyncio Event Loop Fix** - Replace deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()`
2. **Memory Dependency Fix** - Change strict ImportError to graceful warnings

**Testing**

This fix addresses issue #307 and should resolve the `RuntimeError: There is no current event loop in thread 'ScriptRunner.scriptThread'` error in Streamlit and other threaded environments.

Generated with [Claude Code](https://claude.ai/code)