### PR TITLE
Add Joke Agent notebook to cookbooks

### DIFF
--- a/examples/cookbooks/Joke_Agent.ipynb
+++ b/examples/cookbooks/Joke_Agent.ipynb
@@ -1,0 +1,176 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "🤖 Joke Agent with OpenAI API and PraisonAIAgents"
+      ],
+      "metadata": {
+        "id": "A3YD7LN7ywHP"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Install** **Dependencies**"
+      ],
+      "metadata": {
+        "id": "I9TtWAtSzb4P"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install openai praisonaiagents"
+      ],
+      "metadata": {
+        "id": "C-ZSX--E4gLs"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Define a Joke Tool**"
+      ],
+      "metadata": {
+        "id": "Y67TQ6LhzmOg"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import random\n",
+        "\n",
+        "def get_random_joke():\n",
+        "    jokes = [\n",
+        "        \"Why don't scientists trust atoms? Because they make up everything!\",\n",
+        "        \"Why did the scarecrow win an award? Because he was outstanding in his field!\",\n",
+        "        \"What do you call fake spaghetti? An impasta!\",\n",
+        "        \"Why did the math book look sad? Because it had too many problems.\"\n",
+        "    ]\n",
+        "    return random.choice(jokes)\n"
+      ],
+      "metadata": {
+        "id": "dku0-r7z4rVk"
+      },
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Set Up OpenAI API Key**"
+      ],
+      "metadata": {
+        "id": "g8rlbQD2zsWS"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "from openai import OpenAI\n",
+        "\n",
+        "os.environ[\"OPENAI_API_KEY\"] = \"enter your api key\"  # Replace with your API key\n",
+        "client = OpenAI()\n"
+      ],
+      "metadata": {
+        "id": "w2Yy9w1X42sE"
+      },
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Define the GPT Joke Agent**"
+      ],
+      "metadata": {
+        "id": "YYhxNzl_zylY"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from praisonaiagents import Agent\n",
+        "\n",
+        "class GPTJokeAgent(Agent):\n",
+        "    def __init__(self, prompt):\n",
+        "        super().__init__({})\n",
+        "        self.prompt = prompt\n",
+        "        self.tools = {\n",
+        "            \"get_random_joke\": get_random_joke\n",
+        "        }\n",
+        "\n",
+        "    def run(self, message: str):\n",
+        "        response = client.chat.completions.create(\n",
+        "            model=\"gpt-4o-mini\",\n",
+        "            messages=[\n",
+        "                {\"role\": \"system\", \"content\": self.prompt},\n",
+        "                {\"role\": \"user\", \"content\": message}\n",
+        "            ]\n",
+        "        )\n",
+        "        return response.choices[0].message.content.strip()\n"
+      ],
+      "metadata": {
+        "id": "uR51qVwQ5Kcm"
+      },
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "**Define the System Prompt. Instantiate and Run**"
+      ],
+      "metadata": {
+        "id": "m1FGnR8Nz6gJ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "joke_prompt = \"You are a helpful assistant who tells jokes. If the user asks for a joke, tell one. Otherwise, guide them to ask for a joke.\"\n",
+        "\n",
+        "agent = GPTJokeAgent(joke_prompt)\n",
+        "\n",
+        "print(agent.run(\"Tell me a joke\"))\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "080jATyc5QN_",
+        "outputId": "e0205dbe-767f-4b5d-a456-8c91c1ef2310"
+      },
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Why don't scientists trust atoms? \n",
+            "\n",
+            "Because they make up everything!\n"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds a new Jupyter notebook, Joke_Agent.ipynb, to the examples/cookbooks directory.
The notebook demonstrates how to build a simple joke-telling agent using Python, OpenAI API, and PraisonAIAgents.
It includes:
A function to randomly select and display jokes
Example usage of the agent
Instructions for setting up the OpenAI API key
This notebook can serve as a reference for users who want to create fun, interactive agents with PraisonAI.