### PR TITLE
fix: add console scripts to project.scripts section for pip compatibility

### DIFF
--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -19,6 +19,11 @@ dependencies = [
     "mcp>=1.6.0",
 ]
 
+[project.scripts]
+praisonai = "praisonai.__main__:main"
+setup-conda-env = "praisonai.setup.setup_conda_env:main"
+praisonai-call = "praisonai.api.call:main"
+
 [project.optional-dependencies]
 ui = [
     "chainlit==2.5.5",


### PR DESCRIPTION
Fixes #190

Adds console scripts to the standard [project.scripts] section in pyproject.toml to ensure the praisonai command is available when installing with pip.

### Changes
- Add [project.scripts] section with praisonai, setup-conda-env, and praisonai-call entry points
- Fixes issue where praisonai command was not found when installing with pip instead of Poetry
- Entry points were only defined in [tool.poetry.scripts] which pip ignores
- Maintains compatibility with both pip and Poetry installation methods

### Testing
After this fix, users should be able to:
- Install with `pip install praisonai`
- Use `praisonai --help` command directly
- Use `python -m praisonai --help` module syntax

Generated with [Claude Code](https://claude.ai/code)