### PR TITLE
fix: move OpenAI API key validation from import-time to runtime

### DIFF
--- a/src/praisonai/praisonai/api/call.py
+++ b/src/praisonai/praisonai/api/call.py
@@ -39,9 +39,6 @@ LOG_EVENT_TYPES = [
 
 app = FastAPI()
 
-if not OPENAI_API_KEY:
-    raise ValueError('Missing the OpenAI API key. Please set it in the .env file.')
-
 # Set up logging
 logger = logging.getLogger(__name__)
 log_level = os.getenv("LOGLEVEL", "INFO").upper()
@@ -266,6 +263,9 @@ def setup_public_url(port):
 
 def run_server(port: int, use_public: bool = False):
     """Run the FastAPI server using uvicorn."""
+    if not OPENAI_API_KEY:
+        raise ValueError('Missing the OpenAI API key. Please set it in the .env file or configure it through the GUI.')
+    
     if use_public:
         setup_public_url(port)
     else:


### PR DESCRIPTION
Fixes #201

- Removes import-time API key requirement that prevented GUI startup
- Moves validation to run_server() function where it's actually needed
- Allows PraisonAI to start without OpenAI API key for non-voice features
- Users can now configure API key through existing GUI interfaces
- Follows existing codebase patterns for conditional feature validation

Generated with [Claude Code](https://claude.ai/code)