### PR TITLE
fix: resolve MCP function signature parameter ordering issue

### DIFF
--- a/src/praisonai-agents/praisonaiagents/mcp/mcp.py
+++ b/src/praisonai-agents/praisonaiagents/mcp/mcp.py
@@ -299,7 +299,11 @@ class MCP:
                     required_params.append(name)
         
         # Create the function signature
-        params = []
+        # Separate required and optional parameters to ensure proper ordering
+        # (required parameters must come before optional parameters)
+        required_param_objects = []
+        optional_param_objects = []
+        
         for name in param_names:
             is_required = name in required_params
             param = inspect.Parameter(
@@ -308,7 +312,14 @@ class MCP:
                 default=inspect.Parameter.empty if is_required else None,
                 annotation=param_annotations.get(name, Any)
             )
-            params.append(param)
+            
+            if is_required:
+                required_param_objects.append(param)
+            else:
+                optional_param_objects.append(param)
+        
+        # Combine parameters with required first, then optional
+        params = required_param_objects + optional_param_objects
         
         # Create function template to be properly decorated
         def template_function(*args, **kwargs):


### PR DESCRIPTION
Fix ValueError "non-default argument follows default argument" in MCP tool wrapper creation by ensuring required parameters come before optional parameters in function signatures.

- Separate required and optional parameters during signature creation
- Maintain backward compatibility and preserve all functionality
- Resolves GitHub MCP server initialization failures

Fixes #460

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the ordering of function parameters so that required parameters now appear before optional ones in tool wrappers. This change does not affect user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->