### PR TITLE
feat: support LiteLLM provider-specific parameters

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1512,6 +1512,10 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         if self.stop_phrases:
             params["stop"] = self.stop_phrases
         
+        # Add extra settings for provider-specific parameters (e.g., num_ctx for Ollama)
+        if self.extra_settings:
+            params.update(self.extra_settings)
+        
         # Override with any provided parameters
         params.update(override_params)
         


### PR DESCRIPTION
Addresses #421

This PR adds support for passing LiteLLM provider-specific parameters like `num_ctx` for Ollama models through PraisonAI's LLM interface.

## Changes
- Add extra_settings to LLM completion parameters in `_build_completion_params()`
- Enables passing Ollama `num_ctx` and other provider parameters
- Maintains backward compatibility
- Minimal 3-line code change

## Usage
```python
agent = Agent(
    instructions="You are a helpful assistant",
    llm={
        "model": "ollama/llama3-gradient:70b",
        "num_ctx": 256000,  # Increase context window
        "temperature": 0.7
    }
)
```

Generated with [Claude Code](https://claude.ai/code)