### PR TITLE
fix: resolve Knowledge RAG errors with mem0 API compatibility

### DIFF
--- a/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
+++ b/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
@@ -17,9 +17,13 @@ class CustomMemory:
         }).from_config(config)
 
     @staticmethod
-    def _add_to_vector_store(self, messages, metadata, filters, infer):
+    def _add_to_vector_store(self, messages, metadata=None, filters=None, infer=None):
         # Custom implementation that doesn't use LLM
-        parsed_messages = "\n".join([msg["content"] for msg in messages])
+        # Handle different message formats for backward compatibility
+        if isinstance(messages, list):
+            parsed_messages = "\n".join([msg.get("content", str(msg)) if isinstance(msg, dict) else str(msg) for msg in messages])
+        else:
+            parsed_messages = str(messages)
         
         # Create a simple fact without using LLM
         new_retrieved_facts = [parsed_messages]
@@ -34,7 +38,7 @@ class CustomMemory:
         memory_id = self._create_memory(
             data=parsed_messages,
             existing_embeddings=new_message_embeddings,
-            metadata=metadata
+            metadata=metadata or {}
         )
         
         return [{
@@ -188,7 +192,22 @@ class Knowledge:
                 if not content:
                     return []
                 
-            result = self.memory.add(content, user_id=user_id, agent_id=agent_id, run_id=run_id, metadata=metadata)
+            # Try new API format first, fall back to old format for backward compatibility
+            try:
+                # Convert content to messages format for mem0 API compatibility
+                if isinstance(content, str):
+                    messages = [{"role": "user", "content": content}]
+                else:
+                    messages = content if isinstance(content, list) else [{"role": "user", "content": str(content)}]
+                
+                result = self.memory.add(messages=messages, user_id=user_id, agent_id=agent_id, run_id=run_id, metadata=metadata)
+            except TypeError as e:
+                # Fallback to old API format if messages parameter is not supported
+                if "unexpected keyword argument" in str(e) or "positional argument" in str(e):
+                    self._log(f"Falling back to legacy API format due to: {e}")
+                    result = self.memory.add(content, user_id=user_id, agent_id=agent_id, run_id=run_id, metadata=metadata)
+                else:
+                    raise
             self._log(f"Store operation result: {result}")
             return result
         except Exception as e:


### PR DESCRIPTION
Fixes #444

Resolves two critical errors in the Knowledge RAG feature:

1. `CustomMemory._add_to_vector_store() takes 4 positional arguments but 5 were given`
2. `CustomMemory._add_to_vector_store() missing 1 required positional argument: 'infer'`

## Changes

- Fix CustomMemory._add_to_vector_store method signature to support optional parameters with defaults
- Add backward compatibility for different message formats
- Update memory.add() call to use correct messages format for mem0 API
- Add fallback mechanism to support both new and legacy API formats

## Testing

The changes maintain backward compatibility and handle:
- PDF file processing
- String content storage
- List content storage
- Different mem0 API versions

Generated with [Claude Code](https://claude.ai/code)