### PR TITLE
Fix redundant tool invocation

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1012,43 +1012,7 @@ Your Goal: {self.goal}
                     if not response:
                         return None
 
-                    tool_calls = getattr(response.choices[0].message, 'tool_calls', None)
                     response_text = response.choices[0].message.content.strip()
-                    if tool_calls: ## TODO: Most likely this tool call is already called in _chat_completion, so maybe we can remove this.
-                        messages.append({
-                            "role": "assistant",
-                            "content": response_text,
-                            "tool_calls": tool_calls
-                        })
-                        
-                        for tool_call in tool_calls:
-                            function_name = tool_call.function.name
-                            arguments = json.loads(tool_call.function.arguments)
-
-                            if self.verbose:
-                                display_tool_call(f"Agent {self.name} is calling function '{function_name}' with arguments: {arguments}", console=self.console)
-
-                            tool_result = self.execute_tool(function_name, arguments)
-
-                            if tool_result:
-                                if self.verbose:
-                                    display_tool_call(f"Function '{function_name}' returned: {tool_result}", console=self.console)
-                                messages.append({
-                                    "role": "tool",
-                                    "tool_call_id": tool_call.id,
-                                    "content": json.dumps(tool_result)
-                                })
-                            else:
-                                messages.append({
-                                    "role": "tool",
-                                    "tool_call_id": tool_call.id,
-                                    "content": "Function returned an empty output"
-                                })
-                            
-                        response = self._chat_completion(messages, temperature=temperature, stream=stream)
-                        if not response:
-                            return None
-                        response_text = response.choices[0].message.content.strip()
 
                     # Handle output_json or output_pydantic if specified
                     if output_json or output_pydantic:


### PR DESCRIPTION
### **User description**
## Summary
- remove duplicate tool-calling block in `Agent.chat`

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_683fcf556fe0832bb4e3456ed8c69e19


___

### **PR Type**
Bug fix


___

### **Description**
- Removed redundant tool invocation block in `Agent.chat` method

- Prevented duplicate execution of tools during chat completion


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.py</strong><dd><code>Removed redundant tool call handling in chat method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/praisonai-agents/praisonaiagents/agent/agent.py

<li>Deleted code block that redundantly handled tool calls after chat <br>completion<br> <li> Ensured tools are not executed twice in the chat flow<br> <li> Simplified the chat method logic for tool handling


</details>


  </td>
  <td><a href="https://github.com/MervinPraison/PraisonAI/pull/594/files#diff-d535c234c473d9a5415e16b5793afed8bbf02b3c555bed20b8f776c4fed2a58c">+0/-36</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of chat responses for a more streamlined experience, removing redundant processing steps. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->