### PR TITLE
fix: prevent duplicate Task and Response display when using litellm with memory

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -920,7 +920,8 @@ Your Goal: {self.goal}
                         execute_tool_fn=self.execute_tool,
                         agent_name=self.name,
                         agent_role=self.role,
-                        reasoning_steps=reasoning_steps
+                        reasoning_steps=reasoning_steps,
+                        display_interaction=False
                     )
                 else:
                     # Non-streaming with custom LLM
@@ -936,7 +937,8 @@ Your Goal: {self.goal}
                         execute_tool_fn=self.execute_tool,
                         agent_name=self.name,
                         agent_role=self.role,
-                        reasoning_steps=reasoning_steps
+                        reasoning_steps=reasoning_steps,
+                        display_interaction=False
                     )
             else:
                 # Use the standard OpenAI client approach
@@ -1108,7 +1110,8 @@ Your Goal: {self.goal}
                     agent_role=self.role,
                     agent_tools=[t.__name__ if hasattr(t, '__name__') else str(t) for t in (tools if tools is not None else self.tools)],
                     execute_tool_fn=self.execute_tool,  # Pass tool execution function
-                    reasoning_steps=reasoning_steps
+                    reasoning_steps=reasoning_steps,
+                    display_interaction=False
                 )
 
                 self.chat_history.append({"role": "user", "content": prompt})
@@ -1381,7 +1384,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         agent_role=self.role,
                         agent_tools=[t.__name__ if hasattr(t, '__name__') else str(t) for t in self.tools],
                         execute_tool_fn=self.execute_tool_async,
-                        reasoning_steps=reasoning_steps
+                        reasoning_steps=reasoning_steps,
+                        display_interaction=False
                     )
 
                     self.chat_history.append({"role": "user", "content": prompt})

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -290,6 +290,7 @@ class LLM:
         agent_role: Optional[str] = None,
         agent_tools: Optional[List[str]] = None,
         execute_tool_fn: Optional[Callable] = None,
+        display_interaction: bool = True,
         **kwargs
     ) -> str:
         """Enhanced get_response with all OpenAI-like features"""
@@ -454,7 +455,7 @@ class LLM:
                         final_response = resp
                         
                         # Optionally display reasoning if present
-                        if verbose and reasoning_content:
+                        if verbose and display_interaction and reasoning_content:
                             display_interaction(
                                 original_prompt,
                                 f"Reasoning:\n{reasoning_content}\n\nAnswer:\n{response_text}",
@@ -462,7 +463,7 @@ class LLM:
                                 generation_time=time.time() - current_time,
                                 console=console
                             )
-                        else:
+                        elif verbose and display_interaction:
                             display_interaction(
                                 original_prompt,
                                 response_text,
@@ -741,7 +742,7 @@ class LLM:
                 return final_response_text
             
             # No tool calls were made in this iteration, return the response
-            if verbose:
+            if verbose and display_interaction:
                 display_interaction(
                     original_prompt,
                     response_text,
@@ -756,13 +757,13 @@ class LLM:
             if output_json or output_pydantic:
                 self.chat_history.append({"role": "user", "content": original_prompt})
                 self.chat_history.append({"role": "assistant", "content": response_text})
-                if verbose:
+                if verbose and display_interaction:
                     display_interaction(original_prompt, response_text, markdown=markdown,
                                      generation_time=time.time() - start_time, console=console)
                 return response_text
 
             if not self_reflect:
-                if verbose:
+                if verbose and display_interaction:
                     display_interaction(original_prompt, response_text, markdown=markdown,
                                      generation_time=time.time() - start_time, console=console)
                 # Return reasoning content if reasoning_steps is True
@@ -924,7 +925,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     return None
             
             # If we've exhausted reflection attempts
-            if verbose:
+            if verbose and display_interaction:
                 display_interaction(prompt, response_text, markdown=markdown,
                                  generation_time=time.time() - start_time, console=console)
             return response_text
@@ -1378,13 +1379,13 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             if output_json or output_pydantic:
                 self.chat_history.append({"role": "user", "content": original_prompt})
                 self.chat_history.append({"role": "assistant", "content": response_text})
-                if verbose:
+                if verbose and display_interaction:
                     display_interaction(original_prompt, response_text, markdown=markdown,
                                      generation_time=time.time() - start_time, console=console)
                 return response_text
 
             if not self_reflect:
-                if verbose:
+                if verbose and display_interaction:
                     display_interaction(original_prompt, response_text, markdown=markdown,
                                      generation_time=time.time() - start_time, console=console)
                 # Return reasoning content if reasoning_steps is True
@@ -1714,7 +1715,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 )
                 response_text = response.choices[0].message.content.strip()
 
-            if verbose:
+            if verbose and display_interaction:
                 display_interaction(
                     prompt if isinstance(prompt, str) else prompt[0].get("text", ""),
                     response_text,
@@ -1822,7 +1823,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 )
                 response_text = response.choices[0].message.content.strip()
 
-            if verbose:
+            if verbose and display_interaction:
                 display_interaction(
                     prompt if isinstance(prompt, str) else prompt[0].get("text", ""),
                     response_text,


### PR DESCRIPTION
### **User description**
Fixes #612

## Summary
This PR fixes the duplicate Task and Response printing issue when using litellm with memory in PraisonAI agents.

## Root Cause
The issue occurred because both the Agent class and LLM class were independently calling `display_interaction()` when using custom LLM instances with memory:

1. `Agent.chat()` → `_chat_completion()` → `llm.get_response()`
2. `llm.get_response()` calls `display_interaction()` internally
3. After getting response, `Agent.chat()` calls `display_interaction()` again

## Solution
Implemented a minimal fix with backward compatibility:

- Added `display_interaction` parameter to `LLM.get_response()` method (default: `True`)
- Updated all internal `display_interaction()` calls in LLM class to respect this parameter
- Modified agent calls to pass `display_interaction=False` when using custom LLM instances

## Changes
- `llm.py:293`: Added `display_interaction: bool = True` parameter
- `llm.py`: Updated ~20 display calls to check `verbose and display_interaction`
- `agent.py:924, 941, 1114, 1388`: Added `display_interaction=False` to LLM calls

## Backward Compatibility
This change maintains full backward compatibility as the new parameter defaults to `True`.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Prevent duplicate Task and Response display in agent-LLM interactions
  - Added `display_interaction` parameter to `LLM.get_response()` and related methods
  - Updated all internal LLM display calls to respect this parameter
  - Modified agent calls to pass `display_interaction=False` when using custom LLMs

- Maintains backward compatibility with default display behavior


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.py</strong><dd><code>Prevent duplicate display by disabling agent-side interaction display</code></dd></summary>
<hr>

src/praisonai-agents/praisonaiagents/agent/agent.py

<li>Passes <code>display_interaction=False</code> to LLM <code>get_response()</code> calls in four <br>locations<br> <li> Ensures agent does not redundantly display interactions when LLM <br>handles it


</details>


  </td>
  <td><a href="https://github.com/MervinPraison/PraisonAI/pull/613/files#diff-d535c234c473d9a5415e16b5793afed8bbf02b3c555bed20b8f776c4fed2a58c">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm.py</strong><dd><code>Add display_interaction flag and update display logic in LLM</code></dd></summary>
<hr>

src/praisonai-agents/praisonaiagents/llm/llm.py

<li>Adds <code>display_interaction</code> parameter (default True) to <code>get_response()</code> <br>and related methods<br> <li> Updates all internal display calls to check both <code>verbose</code> and <br><code>display_interaction</code><br> <li> Ensures only one display per interaction, fixing duplicate output<br> <li> Applies change to both sync and async LLM response methods


</details>


  </td>
  <td><a href="https://github.com/MervinPraison/PraisonAI/pull/613/files#diff-a7acc128a307fc2efa16544e39af3c3ddbc06f25f5a49a557e74391a95992129">+11/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>