### PR TITLE
fix: prevent duplicate Task and Response display when using litellm with memory

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1108,11 +1108,17 @@ Your Goal: {self.goal}
                     agent_role=self.role,
                     agent_tools=[t.__name__ if hasattr(t, '__name__') else str(t) for t in (tools if tools is not None else self.tools)],
                     execute_tool_fn=self.execute_tool,  # Pass tool execution function
-                    reasoning_steps=reasoning_steps
+                    reasoning_steps=reasoning_steps,
+                    suppress_display=True  # Prevent duplicate displays - Agent will handle display
                 )
 
                 self.chat_history.append({"role": "user", "content": prompt})
                 self.chat_history.append({"role": "assistant", "content": response_text})
+
+                # Display interaction for custom LLM (since we suppressed LLM display)
+                if self.verbose:
+                    display_interaction(prompt, response_text, markdown=self.markdown, 
+                                     generation_time=time.time() - start_time, console=self.console)
 
                 # Log completion time if in debug mode
                 if logging.getLogger().getEffectiveLevel() == logging.DEBUG:

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -290,6 +290,7 @@ class LLM:
         agent_role: Optional[str] = None,
         agent_tools: Optional[List[str]] = None,
         execute_tool_fn: Optional[Callable] = None,
+        suppress_display: bool = False,
         **kwargs
     ) -> str:
         """Enhanced get_response with all OpenAI-like features"""
@@ -454,7 +455,7 @@ class LLM:
                         final_response = resp
                         
                         # Optionally display reasoning if present
-                        if verbose and reasoning_content:
+                        if verbose and not suppress_display and reasoning_content:
                             display_interaction(
                                 original_prompt,
                                 f"Reasoning:\n{reasoning_content}\n\nAnswer:\n{response_text}",
@@ -462,7 +463,7 @@ class LLM:
                                 generation_time=time.time() - current_time,
                                 console=console
                             )
-                        else:
+                        elif verbose and not suppress_display:
                             display_interaction(
                                 original_prompt,
                                 response_text,
@@ -665,7 +666,7 @@ class LLM:
                             response_text = resp["choices"][0]["message"]["content"]
                             
                             # Optionally display reasoning if present
-                            if verbose and reasoning_content:
+                            if verbose and not suppress_display and reasoning_content:
                                 display_interaction(
                                     original_prompt,
                                     f"Reasoning:\n{reasoning_content}\n\nAnswer:\n{response_text}",
@@ -673,7 +674,7 @@ class LLM:
                                     generation_time=time.time() - start_time,
                                     console=console
                                 )
-                            else:
+                            elif verbose and not suppress_display:
                                 display_interaction(
                                     original_prompt,
                                     response_text,
@@ -718,7 +719,7 @@ class LLM:
                             final_response_text = final_response_text.strip()
                         
                         # Display final response
-                        if verbose:
+                        if verbose and not suppress_display:
                             display_interaction(
                                 original_prompt,
                                 final_response_text,
@@ -741,7 +742,7 @@ class LLM:
                 return final_response_text
             
             # No tool calls were made in this iteration, return the response
-            if verbose:
+            if verbose and not suppress_display:
                 display_interaction(
                     original_prompt,
                     response_text,

--- a/test_duplicate_fix.py
+++ b/test_duplicate_fix.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+from src.praisonaiagents import Agent, Task, PraisonAIAgents
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+llm_config = {
+    "model": "openai/gpt-4o-mini",
+    "api_key": os.getenv('OPENAI_API_KEY'),
+    "temperature": 0.7,
+    "max_tokens": 2000
+}
+
+blog_agent = Agent(
+    role="Blog Writer",
+    goal="Write a blog post about AI",
+    backstory="Expert at writing blog posts",
+    llm=llm_config,
+)
+
+blog_task = Task(
+    description="Write a blog post about AI trends in 1 paragraph",
+    expected_output="Well-written blog post about AI trends",
+    agent=blog_agent
+)
+
+agents = PraisonAIAgents(
+    agents=[blog_agent],
+    tasks=[blog_task],
+    memory=True
+)
+
+print("Testing fix for duplicate display issue...")
+result = agents.start()
+print("Test completed successfully!")


### PR DESCRIPTION
Fixes #612

## Summary
This PR fixes the duplicate Task and Response printing issue when using litellm with memory in PraisonAI agents.

## Root Cause
The issue occurred because the LLM class was calling `display_interaction()` multiple times internally while the Agent class also expected to handle display, causing duplicates when using custom LLM instances.

## Solution
Implemented a minimal fix with backward compatibility:

- Added `suppress_display` parameter to `LLM.get_response()` method (default: `False`)
- Updated all internal `display_interaction()` calls in LLM class to respect this parameter
- Modified agent calls to pass `suppress_display=True` when using custom LLM instances
- Agent handles display centrally to ensure single display per interaction

## Changes
- `llm.py:293`: Added `suppress_display: bool = False` parameter
- `llm.py`: Updated ~4 display calls to check `verbose and not suppress_display`
- `agent.py:1112`: Added `suppress_display=True` to LLM calls
- `agent.py:1119-1121`: Added centralized Agent-level display

## Backward Compatibility
This change maintains full backward compatibility as the new parameter defaults to `False`.

Generated with [Claude Code](https://claude.ai/code)