### PR TITLE
Allow to configure reflection prompt

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -374,6 +374,91 @@ class Agent:
         guardrail: Optional[Union[Callable[['TaskOutput'], Tuple[bool, Any]], str]] = None,
         max_guardrail_retries: int = 3
     ):
+        """Initialize an Agent instance.
+
+        Args:
+            name (Optional[str], optional): Name of the agent used for identification and logging.
+                If None, defaults to "Agent". Defaults to None.
+            role (Optional[str], optional): Role or job title that defines the agent's expertise
+                and behavior patterns. Examples: "Data Analyst", "Content Writer". Defaults to None.
+            goal (Optional[str], optional): Primary objective or goal the agent aims to achieve.
+                Defines the agent's purpose and success criteria. Defaults to None.
+            backstory (Optional[str], optional): Background story or context that shapes the agent's
+                personality and decision-making approach. Defaults to None.
+            instructions (Optional[str], optional): Direct instructions that override role, goal,
+                and backstory when provided. Used for simple, task-specific agents. Defaults to None.
+            llm (Optional[Union[str, Any]], optional): Language model configuration. Can be a model
+                name string (e.g., "gpt-4o", "anthropic/claude-3-sonnet") or a configured LLM object.
+                Defaults to environment variable OPENAI_MODEL_NAME or "gpt-4o".
+            tools (Optional[List[Any]], optional): List of tools, functions, or capabilities
+                available to the agent for task execution. Can include callables, tool objects,
+                or MCP instances. Defaults to None.
+            function_calling_llm (Optional[Any], optional): Dedicated language model for function
+                calling operations. If None, uses the main llm parameter. Defaults to None.
+            max_iter (int, optional): Maximum number of iterations the agent can perform during
+                task execution to prevent infinite loops. Defaults to 20.
+            max_rpm (Optional[int], optional): Maximum requests per minute to rate limit API calls
+                and prevent quota exhaustion. If None, no rate limiting is applied. Defaults to None.
+            max_execution_time (Optional[int], optional): Maximum execution time in seconds for
+                agent operations before timeout. If None, no time limit is enforced. Defaults to None.
+            memory (Optional[Any], optional): Memory system for storing and retrieving information
+                across conversations. Requires memory dependencies to be installed. Defaults to None.
+            verbose (bool, optional): Enable detailed logging and status updates during agent
+                execution for debugging and monitoring. Defaults to True.
+            allow_delegation (bool, optional): Allow the agent to delegate tasks to other agents
+                or sub-processes when appropriate. Defaults to False.
+            step_callback (Optional[Any], optional): Callback function called after each step
+                of agent execution for custom monitoring or intervention. Defaults to None.
+            cache (bool, optional): Enable caching of responses and computations to improve
+                performance and reduce API costs. Defaults to True.
+            system_template (Optional[str], optional): Custom template for system prompts that
+                overrides the default system prompt generation. Defaults to None.
+            prompt_template (Optional[str], optional): Template for formatting user prompts
+                before sending to the language model. Defaults to None.
+            response_template (Optional[str], optional): Template for formatting agent responses
+                before returning to the user. Defaults to None.
+            allow_code_execution (Optional[bool], optional): Enable the agent to execute code
+                snippets during task completion. Use with caution for security. Defaults to False.
+            max_retry_limit (int, optional): Maximum number of retry attempts for failed operations
+                before giving up. Helps handle transient errors. Defaults to 2.
+            respect_context_window (bool, optional): Automatically manage context window size
+                to prevent token limit errors with large conversations. Defaults to True.
+            code_execution_mode (Literal["safe", "unsafe"], optional): Safety mode for code execution.
+                "safe" restricts dangerous operations, "unsafe" allows full code execution. Defaults to "safe".
+            embedder_config (Optional[Dict[str, Any]], optional): Configuration dictionary for
+                text embedding models used in knowledge retrieval and similarity search. Defaults to None.
+            knowledge (Optional[List[str]], optional): List of knowledge sources (file paths, URLs,
+                or text content) to be processed and made available to the agent. Defaults to None.
+            knowledge_config (Optional[Dict[str, Any]], optional): Configuration for knowledge
+                processing and retrieval system including chunking and indexing parameters. Defaults to None.
+            use_system_prompt (Optional[bool], optional): Whether to include system prompts in
+                conversations to establish agent behavior and context. Defaults to True.
+            markdown (bool, optional): Enable markdown formatting in agent responses for better
+                readability and structure. Defaults to True.
+            self_reflect (bool, optional): Enable self-reflection capabilities where the agent
+                evaluates and improves its own responses. Defaults to False.
+            max_reflect (int, optional): Maximum number of self-reflection iterations to prevent
+                excessive reflection loops. Defaults to 3.
+            min_reflect (int, optional): Minimum number of self-reflection iterations required
+                before accepting a response as satisfactory. Defaults to 1.
+            reflect_llm (Optional[str], optional): Dedicated language model for self-reflection
+                operations. If None, uses the main llm parameter. Defaults to None.
+            reflect_prompt (Optional[str], optional): Custom prompt template for self-reflection
+                that guides the agent's self-evaluation process. Defaults to None.
+            user_id (Optional[str], optional): Unique identifier for the user or session to
+                enable personalized responses and memory isolation. Defaults to "praison".
+            reasoning_steps (bool, optional): Enable step-by-step reasoning output to show the
+                agent's thought process during problem solving. Defaults to False.
+            guardrail (Optional[Union[Callable[['TaskOutput'], Tuple[bool, Any]], str]], optional):
+                Safety mechanism to validate agent outputs. Can be a validation function or
+                description string for LLM-based validation. Defaults to None.
+            max_guardrail_retries (int, optional): Maximum number of retry attempts when guardrail
+                validation fails before giving up. Defaults to 3.
+
+        Raises:
+            ValueError: If all of name, role, goal, backstory, and instructions are None.
+            ImportError: If memory or LLM features are requested but dependencies are not installed.
+        """
         # Add check at start if memory is requested
         if memory is not None:
             try:


### PR DESCRIPTION
### **User description**
I currently struggle to get any use from the self-reflection feature. During reflection, LLM always reports that the response is satisfactory. I want to provide clear requirements for reflection through the additional parameter `reflect_prompt`.

This change was useful in my own project, so it will probably be useful for someone else.


___

### **PR Type**
Enhancement


___

### **Description**
• Add configurable `reflect_prompt` parameter to Agent class
• Replace hardcoded reflection prompt with customizable option
• Enable users to provide specific reflection requirements
• Maintain backward compatibility with default prompt fallback


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.py</strong><dd><code>Add configurable reflection prompt parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/praisonai-agents/praisonaiagents/agent/agent.py

• Added <code>reflect_prompt</code> parameter to Agent <code>__init__</code> method<br> • Stored <br><code>reflect_prompt</code> as instance variable<br> • Modified reflection logic to use <br>custom prompt when provided<br> • Added fallback to default prompt for <br>backward compatibility


</details>


  </td>
  <td><a href="https://github.com/MervinPraison/PraisonAI/pull/636/files#diff-d535c234c473d9a5415e16b5793afed8bbf02b3c555bed20b8f776c4fed2a58c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the reflection prompt used during agent self-reflection in chat interactions. If no custom prompt is provided, the default prompt will be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->