### PR TITLE
Update PraisonAI and dependencies to version 2.2.32

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p /root/.praison
 # Install Python packages (using latest versions)
 RUN pip install --no-cache-dir \
     flask \
-    "praisonai>=2.2.31" \
+    "praisonai>=2.2.32" \
     "praisonai[api]" \
     gunicorn \
     markdown

--- a/docker/Dockerfile.chat
+++ b/docker/Dockerfile.chat
@@ -16,7 +16,7 @@ RUN mkdir -p /root/.praison
 # Install Python packages (using latest versions)
 RUN pip install --no-cache-dir \
     praisonai_tools \
-    "praisonai>=2.2.31" \
+    "praisonai>=2.2.32" \
     "praisonai[chat]" \
     "embedchain[github,youtube]"
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -20,7 +20,7 @@ RUN mkdir -p /root/.praison
 # Install Python packages (using latest versions)
 RUN pip install --no-cache-dir \
     praisonai_tools \
-    "praisonai>=2.2.31" \
+    "praisonai>=2.2.32" \
     "praisonai[ui]" \
     "praisonai[chat]" \
     "praisonai[realtime]" \

--- a/docker/Dockerfile.ui
+++ b/docker/Dockerfile.ui
@@ -16,7 +16,7 @@ RUN mkdir -p /root/.praison
 # Install Python packages (using latest versions)
 RUN pip install --no-cache-dir \
     praisonai_tools \
-    "praisonai>=2.2.31" \
+    "praisonai>=2.2.32" \
     "praisonai[ui]" \
     "praisonai[crewai]"
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -121,7 +121,7 @@ healthcheck:
 ## 📦 Package Versions
 
 All Docker images use consistent, up-to-date versions:
-- PraisonAI: `>=2.2.31`
+- PraisonAI: `>=2.2.32`
 - PraisonAI Agents: `>=0.0.92`
 - Python: `3.11-slim`
 
@@ -218,7 +218,7 @@ docker-compose up -d
 ### Version Pinning
 To use specific versions, update the Dockerfile:
 ```dockerfile
-RUN pip install "praisonai==2.2.31" "praisonaiagents==0.0.92"
+RUN pip install "praisonai==2.2.32" "praisonaiagents==0.0.92"
 ```
 
 ## 🌐 Production Deployment

--- a/src/praisonai-agents/pyproject.toml
+++ b/src/praisonai-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "praisonaiagents"
-version = "0.0.104"
+version = "0.0.105"
 description = "Praison AI agents for completing complex tasks with Self Reflection Agents"
 requires-python = ">=3.10"
 authors = [

--- a/src/praisonai-agents/uv.lock
+++ b/src/praisonai-agents/uv.lock
@@ -2374,7 +2374,7 @@ wheels = [
 
 [[package]]
 name = "praisonaiagents"
-version = "0.0.104"
+version = "0.0.105"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },

--- a/src/praisonai/praisonai.rb
+++ b/src/praisonai/praisonai.rb
@@ -3,8 +3,8 @@ class Praisonai < Formula
   
     desc "AI tools for various AI applications"
     homepage "https://github.com/MervinPraison/PraisonAI"
-    url "https://github.com/MervinPraison/PraisonAI/archive/refs/tags/v2.2.31.tar.gz"
-    sha256 `curl -sL https://github.com/MervinPraison/PraisonAI/archive/refs/tags/v2.2.31.tar.gz | shasum -a 256`.split.first
+    url "https://github.com/MervinPraison/PraisonAI/archive/refs/tags/v2.2.32.tar.gz"
+    sha256 `curl -sL https://github.com/MervinPraison/PraisonAI/archive/refs/tags/v2.2.32.tar.gz | shasum -a 256`.split.first
     license "MIT"
   
     depends_on "python@3.11"

--- a/src/praisonai/praisonai/deploy.py
+++ b/src/praisonai/praisonai/deploy.py
@@ -56,7 +56,7 @@ class CloudDeployer:
             file.write("FROM python:3.11-slim\n")
             file.write("WORKDIR /app\n")
             file.write("COPY . .\n")
-            file.write("RUN pip install flask praisonai==2.2.31 gunicorn markdown\n")
+            file.write("RUN pip install flask praisonai==2.2.32 gunicorn markdown\n")
             file.write("EXPOSE 8080\n")
             file.write('CMD ["gunicorn", "-b", "0.0.0.0:8080", "api:app"]\n')
             

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PraisonAI"
-version = "2.2.31"
+version = "2.2.32"
 description = "PraisonAI is an AI Agents Framework with Self Reflection. PraisonAI application combines PraisonAI Agents, AutoGen, and CrewAI into a low-code solution for building and managing multi-agent LLM systems, focusing on simplicity, customisation, and efficient human-agent collaboration."
 readme = "README.md"
 license = ""
@@ -12,7 +12,7 @@ dependencies = [
     "rich>=13.7",
     "markdown>=3.5",
     "pyparsing>=3.0.0",
-    "praisonaiagents>=0.0.104",
+    "praisonaiagents>=0.0.105",
     "python-dotenv>=0.19.0",
     "instructor>=1.3.3",
     "PyYAML>=6.0",
@@ -95,7 +95,7 @@ autogen = ["pyautogen>=0.2.19", "praisonai-tools>=0.0.15", "crewai"]
 
 [tool.poetry]
 name = "PraisonAI"
-version = "2.2.31"
+version = "2.2.32"
 description = "PraisonAI is an AI Agents Framework with Self Reflection. PraisonAI application combines PraisonAI Agents, AutoGen, and CrewAI into a low-code solution for building and managing multi-agent LLM systems, focusing on simplicity, customisation, and efficient human-agent collaboration."
 authors = ["Mervin Praison"]
 license = ""
@@ -113,7 +113,7 @@ python = ">=3.10,<3.13"
 rich = ">=13.7"
 markdown = ">=3.5"
 pyparsing = ">=3.0.0"
-praisonaiagents = ">=0.0.104"
+praisonaiagents = ">=0.0.105"
 python-dotenv = ">=0.19.0"
 instructor = ">=1.3.3"
 PyYAML = ">=6.0"

--- a/src/praisonai/uv.lock
+++ b/src/praisonai/uv.lock
@@ -3931,7 +3931,7 @@ wheels = [
 
 [[package]]
 name = "praisonai"
-version = "2.2.31"
+version = "2.2.32"
 source = { editable = "." }
 dependencies = [
     { name = "instructor" },
@@ -4073,7 +4073,7 @@ requires-dist = [
     { name = "plotly", marker = "extra == 'realtime'", specifier = ">=5.24.0" },
     { name = "praisonai-tools", marker = "extra == 'autogen'", specifier = ">=0.0.15" },
     { name = "praisonai-tools", marker = "extra == 'crewai'", specifier = ">=0.0.15" },
-    { name = "praisonaiagents", specifier = ">=0.0.104" },
+    { name = "praisonaiagents", specifier = ">=0.0.105" },
     { name = "pyautogen", marker = "extra == 'autogen'", specifier = ">=0.2.19" },
     { name = "pydantic", marker = "extra == 'chat'", specifier = "<=2.10.1" },
     { name = "pydantic", marker = "extra == 'code'", specifier = "<=2.10.1" },
@@ -4130,7 +4130,7 @@ wheels = [
 
 [[package]]
 name = "praisonaiagents"
-version = "0.0.104"
+version = "0.0.105"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mcp" },
@@ -4139,9 +4139,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/e5/f7f0f4a6c2ce517332b0799f6081cc4d3b8016a3a8bc12df61d50004012a/praisonaiagents-0.0.104.tar.gz", hash = "sha256:88239bc9de3f6a6777bac13695d844aa9b3c8968d973e7ee1d3cf31d3ff9ac8b", size = 150329 }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/9b/a95d221c85d222bc265c5817335a8c57dc345e6f7808b6d7dac0b50bfe42/praisonaiagents-0.0.105.tar.gz", hash = "sha256:347ac596f9baea7daeac718ef5c9992c5f3a487b22d53623fc53f6b32dbf4808", size = 154675 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/53/34c367bf701082690194cc823c4e36784efd24fa07488022906153f48b0e/praisonaiagents-0.0.104-py3-none-any.whl", hash = "sha256:37a0ae97c63aa1cece4f5db67f7cc09b0e3d2b5ea7ba8d021062ee41edd03743", size = 171834 },
+    { url = "https://files.pythonhosted.org/packages/36/93/3797957c4a72e756d0a2d49b25cf300e3c0781b86b0308ae2871a52761e4/praisonaiagents-0.0.105-py3-none-any.whl", hash = "sha256:ad52505ba715970d812a72ae18f00bde6c92ed6838fee0375324b15cd3e32324", size = 175599 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Updated PraisonAI version from 2.2.31 to 2.2.32 across multiple Dockerfiles and relevant files.
- Adjusted dependency versions in pyproject.toml and other files for consistency.
- Enhanced README documentation to reflect the updated version.

This change integrates the latest features and improvements from PraisonAI while ensuring compatibility with existing code.