### PR TITLE
fix: Add base_url and api_key parameters to Agent class for Ollama support

### DIFF
--- a/examples/python/providers/ollama/ollama-base-url-example.py
+++ b/examples/python/providers/ollama/ollama-base-url-example.py
@@ -1,0 +1,34 @@
+# Example: Using Ollama with a remote host via base_url parameter
+# pip install praisonaiagents
+
+from praisonaiagents import Agent
+
+# Method 1: Using base_url parameter directly (NEW)
+agent = Agent(
+    instructions="You are a helpful assistant",
+    llm="ollama/llama3.2",
+    base_url="http://remote-host:11434"
+)
+
+response = agent.start("Why is the sky blue?")
+print(response)
+
+# Method 2: Using dict configuration
+agent2 = Agent(
+    instructions="You are a helpful assistant",
+    llm={
+        "model": "ollama/llama3.2",
+        "base_url": "http://remote-host:11434"
+    }
+)
+
+response2 = agent2.start("What is the capital of France?")
+print(response2)
+
+# Method 3: Using environment variable (existing method)
+# export OPENAI_BASE_URL=http://remote-host:11434
+# Then just:
+# agent3 = Agent(
+#     instructions="You are a helpful assistant",
+#     llm="ollama/llama3.2"
+# )


### PR DESCRIPTION
This PR fixes the issue where Ollama doesn't work with remote hosts by adding `base_url` and `api_key` parameters to the Agent class.

## Problem
Users couldn't connect to remote Ollama instances without setting environment variables. The Agent class didn't accept `base_url` parameter, causing connection refused errors.

## Solution
- Added `base_url` and `api_key` as optional parameters to Agent's `__init__` method
- When `base_url` is provided, automatically create a custom LLM instance
- Support for api_key parameter for authentication

## Usage
```python
agent = Agent(
    llm="ollama/llama3.2",
    base_url="http://remote-host:11434"
)
```

Fixes #482

Generated with [Claude Code](https://claude.ai/code)