### PR TITLE
fix: handle MCP tools returning lists in agent.py

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -934,7 +934,12 @@ Your Goal: {self.goal}
                     logging.warning(f"Could not generate definition for tool: {tool}")
             # Handle objects with to_openai_tool method (MCP tools)
             elif hasattr(tool, "to_openai_tool"):
-                formatted_tools.append(tool.to_openai_tool())
+                openai_tools = tool.to_openai_tool()
+                # MCP tools can return either a single tool or a list of tools
+                if isinstance(openai_tools, list):
+                    formatted_tools.extend(openai_tools)
+                elif openai_tools is not None:
+                    formatted_tools.append(openai_tools)
             # Handle callable functions
             elif callable(tool):
                 tool_def = self._generate_tool_definition(tool.__name__)

--- a/test_mcp_fix.py
+++ b/test_mcp_fix.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Test script to verify MCP schema fix"""
+
+import os
+import sys
+
+# Add the src directory to Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src', 'praisonai-agents'))
+
+from dotenv import load_dotenv
+from praisonaiagents import Agent, MCP
+
+# Load .env before importing anything else
+load_dotenv()
+
+# Define allowed directories for filesystem access
+allowed_dirs = [
+    "/Users/praison/praisonai-package/src/praisonai-agents",
+]
+
+# Test with minimal example
+print("Testing MCP filesystem agent...")
+
+try:
+    # Use the correct pattern from filesystem MCP documentation
+    filesystem_agent = Agent(
+        instructions="""You are a helpful assistant that can interact with the filesystem.
+        Use the available tools when relevant to manage files and directories.""",
+        llm="gpt-4o-mini",
+        tools=MCP(
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem"] + allowed_dirs
+        )
+    )
+    
+    print("✓ Agent created successfully")
+    print("✓ MCP tools loaded without schema errors")
+    
+    # Try to start the agent (this will validate the tool schemas)
+    result = filesystem_agent.start("List files in /Users/praison/praisonai-package/src/praisonai-agents directory using MCP list_files")
+    print("✓ Agent executed successfully")
+    print(f"Result: {result}")
+    
+except Exception as e:
+    print(f"✗ Error: {e}")
+    import traceback
+    traceback.print_exc()
+    sys.exit(1)
+
+print("\nTest passed! The MCP schema fix is working correctly.")


### PR DESCRIPTION
Fixes #767 - Invalid schema for function error

## Problem
The MCP's `to_openai_tool()` method returns a list of tools, but `agent.py` was expecting a single tool, causing nested list structures and schema validation errors.

## Solution
Updated the MCP tool handling in `agent.py` to properly extend the tools list when MCP returns multiple tools, while maintaining backward compatibility for single tool returns.

## Testing
Added `test_mcp_fix.py` to verify the fix works correctly with the filesystem MCP server.

Generated with [Claude Code](https://claude.ai/code)