### PR TITLE
refactor: eliminate sync/async duplication in llm.py

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -775,34 +775,34 @@ class LLM:
                             follow_up_messages = [
                                 {"role": "user", "content": follow_up_prompt}
                             ]
-                                    
-                                    # Get response with streaming
-                                    if verbose:
-                                        with Live(display_generating("", start_time), console=console, refresh_per_second=4) as live:
-                                            response_text = ""
-                                            for chunk in litellm.completion(
-                                                **self._build_completion_params(
-                                                    messages=follow_up_messages,
-                                                    temperature=temperature,
-                                                    stream=stream
-                                                )
-                                            ):
-                                                if chunk and chunk.choices and chunk.choices[0].delta.content:
-                                                    content = chunk.choices[0].delta.content
-                                                    response_text += content
-                                                    live.update(display_generating(response_text, start_time))
-                                    else:
-                                        response_text = ""
-                                        for chunk in litellm.completion(
-                                            **self._build_completion_params(
-                                                messages=follow_up_messages,
-                                                temperature=temperature,
-                                                stream=stream
-                                            )
-                                        ):
-                                            if chunk and chunk.choices and chunk.choices[0].delta.content:
-                                                response_text += chunk.choices[0].delta.content
-                                    
+                            
+                            # Get response with streaming
+                            if verbose:
+                                with Live(display_generating("", start_time), console=console, refresh_per_second=4) as live:
+                                    response_text = ""
+                                    for chunk in litellm.completion(
+                                        **self._build_completion_params(
+                                            messages=follow_up_messages,
+                                            temperature=temperature,
+                                            stream=stream
+                                        )
+                                    ):
+                                        if chunk and chunk.choices and chunk.choices[0].delta.content:
+                                            content = chunk.choices[0].delta.content
+                                            response_text += content
+                                            live.update(display_generating(response_text, start_time))
+                            else:
+                                response_text = ""
+                                for chunk in litellm.completion(
+                                    **self._build_completion_params(
+                                        messages=follow_up_messages,
+                                        temperature=temperature,
+                                        stream=stream
+                                    )
+                                ):
+                                    if chunk and chunk.choices and chunk.choices[0].delta.content:
+                                        response_text += chunk.choices[0].delta.content
+                            
                             # Set flag to indicate Ollama was handled
                             ollama_handled = True
                             final_response_text = response_text.strip()

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1359,34 +1359,34 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         follow_up_messages = [
                             {"role": "user", "content": follow_up_prompt}
                         ]
-                                
-                                # Get response with streaming
-                                if verbose:
-                                    response_text = ""
-                                    async for chunk in await litellm.acompletion(
-                                        **self._build_completion_params(
-                                            messages=follow_up_messages,
-                                            temperature=temperature,
-                                            stream=stream
-                                        )
-                                    ):
-                                        if chunk and chunk.choices and chunk.choices[0].delta.content:
-                                            content = chunk.choices[0].delta.content
-                                            response_text += content
-                                            print("\033[K", end="\r")
-                                            print(f"Processing results... {time.time() - start_time:.1f}s", end="\r")
-                                else:
-                                    response_text = ""
-                                    async for chunk in await litellm.acompletion(
-                                        **self._build_completion_params(
-                                            messages=follow_up_messages,
-                                            temperature=temperature,
-                                            stream=stream
-                                        )
-                                    ):
-                                        if chunk and chunk.choices and chunk.choices[0].delta.content:
-                                            response_text += chunk.choices[0].delta.content
-                                
+                        
+                        # Get response with streaming
+                        if verbose:
+                            response_text = ""
+                            async for chunk in await litellm.acompletion(
+                                **self._build_completion_params(
+                                    messages=follow_up_messages,
+                                    temperature=temperature,
+                                    stream=stream
+                                )
+                            ):
+                                if chunk and chunk.choices and chunk.choices[0].delta.content:
+                                    content = chunk.choices[0].delta.content
+                                    response_text += content
+                                    print("\033[K", end="\r")
+                                    print(f"Processing results... {time.time() - start_time:.1f}s", end="\r")
+                        else:
+                            response_text = ""
+                            async for chunk in await litellm.acompletion(
+                                **self._build_completion_params(
+                                    messages=follow_up_messages,
+                                    temperature=temperature,
+                                    stream=stream
+                                )
+                            ):
+                                if chunk and chunk.choices and chunk.choices[0].delta.content:
+                                    response_text += chunk.choices[0].delta.content
+                        
                         # Set flag to indicate Ollama was handled
                         ollama_handled = True
                         final_response_text = response_text.strip()

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -791,7 +791,7 @@ class LLM:
                                 response_text = ""
                                 for chunk in litellm.completion(
                                     **self._build_completion_params(
-                                        messages=follow_up_messages,
+                                        messages=ollama_params["follow_up_messages"],
                                         temperature=temperature,
                                         stream=stream
                                     )
@@ -1357,7 +1357,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             response_text = ""
                             async for chunk in await litellm.acompletion(
                                 **self._build_completion_params(
-                                    messages=follow_up_messages,
+                                    messages=ollama_params["follow_up_messages"],
                                     temperature=temperature,
                                     stream=stream
                                 )
@@ -1371,7 +1371,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             response_text = ""
                             async for chunk in await litellm.acompletion(
                                 **self._build_completion_params(
-                                    messages=follow_up_messages,
+                                    messages=ollama_params["follow_up_messages"],
                                     temperature=temperature,
                                     stream=stream
                                 )


### PR DESCRIPTION
### **User description**
Fixes #754

## Summary

This PR eliminates code duplication between sync and async methods in `llm.py` by extracting common logic into shared helper methods.

## Changes

- Extract common logic into shared helper methods
- Reduce code duplication between `get_response`/`get_response_async`
- Reduce code duplication between `response`/`aresponse`
- Maintain 100% backward compatibility
- No API changes or breaking changes

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Extract common streaming and tool call logic into helper methods

- Eliminate code duplication between sync/async response methods

- Refactor Ollama follow-up handling into shared function

- Maintain 100% backward compatibility with no API changes


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Duplicated Code"] --> B["Helper Methods"]
  B --> C["_process_tool_calls_from_stream"]
  B --> D["_serialize_tool_calls"]
  B --> E["_extract_tool_call_info"]
  B --> F["_prepare_ollama_followup"]
  B --> G["_process_streaming_chunk"]
  C --> H["Sync Methods"]
  C --> I["Async Methods"]
  D --> H
  D --> I
  E --> H
  E --> I
  F --> H
  F --> I
  G --> H
  G --> I
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm.py</strong><dd><code>Extract common streaming and tool call logic into helper methods</code></dd></summary>
<hr>

src/praisonai-agents/praisonaiagents/llm/llm.py

<li>Extract streaming tool call processing into <br><code>_process_tool_calls_from_stream</code> helper<br> <li> Create <code>_serialize_tool_calls</code> method to handle tool call serialization<br> <li> Add <code>_extract_tool_call_info</code> to unify tool call parsing logic<br> <li> Implement <code>_prepare_ollama_followup</code> for Ollama-specific handling<br> <li> Refactor <code>response</code>/<code>aresponse</code> methods to use shared streaming logic<br> <li> Remove duplicate code blocks in sync and async streaming paths


</details>


  </td>
  <td><a href="https://github.com/MervinPraison/PraisonAI/pull/781/files#diff-a7acc128a307fc2efa16544e39af3c3ddbc06f25f5a49a557e74391a95992129">+238/-324</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of streaming responses and tool calls to enhance system reliability and maintainability without affecting user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->