### PR TITLE
refactor: extract streaming chunk processor to eliminate code duplication

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -229,6 +229,39 @@ class LLM:
         
         return any(endpoint in base_url or endpoint in api_base for endpoint in ollama_endpoints)
 
+    def _process_stream_delta(self, delta, response_text: str, tool_calls: List[Dict], formatted_tools: Optional[List] = None) -> tuple:
+        """
+        Process a streaming delta chunk to extract content and tool calls.
+        
+        Args:
+            delta: The delta object from a streaming chunk
+            response_text: The accumulated response text so far
+            tool_calls: The accumulated tool calls list so far
+            formatted_tools: Optional list of formatted tools for tool call support check
+            
+        Returns:
+            tuple: (updated_response_text, updated_tool_calls)
+        """
+        # Process content
+        if delta.content:
+            response_text += delta.content
+        
+        # Capture tool calls from streaming chunks if provider supports it
+        if formatted_tools and self._supports_streaming_tools() and hasattr(delta, 'tool_calls') and delta.tool_calls:
+            for tc in delta.tool_calls:
+                if tc.index >= len(tool_calls):
+                    tool_calls.append({
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": "", "arguments": ""}
+                    })
+                if tc.function.name:
+                    tool_calls[tc.index]["function"]["name"] = tc.function.name
+                if tc.function.arguments:
+                    tool_calls[tc.index]["function"]["arguments"] += tc.function.arguments
+        
+        return response_text, tool_calls
+
     def _parse_tool_call_arguments(self, tool_call: Dict, is_ollama: bool = False) -> tuple:
         """
         Safely parse tool call arguments with proper error handling
@@ -651,23 +684,11 @@ class LLM:
                                     ):
                                         if chunk and chunk.choices and chunk.choices[0].delta:
                                             delta = chunk.choices[0].delta
+                                            response_text, tool_calls = self._process_stream_delta(
+                                                delta, response_text, tool_calls, formatted_tools
+                                            )
                                             if delta.content:
-                                                response_text += delta.content
                                                 live.update(display_generating(response_text, current_time))
-                                            
-                                            # Capture tool calls from streaming chunks if provider supports it
-                                            if formatted_tools and self._supports_streaming_tools() and hasattr(delta, 'tool_calls') and delta.tool_calls:
-                                                for tc in delta.tool_calls:
-                                                    if tc.index >= len(tool_calls):
-                                                        tool_calls.append({
-                                                            "id": tc.id,
-                                                            "type": "function",
-                                                            "function": {"name": "", "arguments": ""}
-                                                        })
-                                                    if tc.function.name:
-                                                        tool_calls[tc.index]["function"]["name"] = tc.function.name
-                                                    if tc.function.arguments:
-                                                        tool_calls[tc.index]["function"]["arguments"] += tc.function.arguments
                             else:
                                 # Non-verbose streaming
                                 for chunk in litellm.completion(
@@ -681,22 +702,9 @@ class LLM:
                                 ):
                                     if chunk and chunk.choices and chunk.choices[0].delta:
                                         delta = chunk.choices[0].delta
-                                        if delta.content:
-                                            response_text += delta.content
-                                        
-                                        # Capture tool calls from streaming chunks if provider supports it
-                                        if formatted_tools and self._supports_streaming_tools() and hasattr(delta, 'tool_calls') and delta.tool_calls:
-                                            for tc in delta.tool_calls:
-                                                if tc.index >= len(tool_calls):
-                                                    tool_calls.append({
-                                                        "id": tc.id,
-                                                        "type": "function",
-                                                        "function": {"name": "", "arguments": ""}
-                                                    })
-                                                if tc.function.name:
-                                                    tool_calls[tc.index]["function"]["name"] = tc.function.name
-                                                if tc.function.arguments:
-                                                    tool_calls[tc.index]["function"]["arguments"] += tc.function.arguments
+                                        response_text, tool_calls = self._process_stream_delta(
+                                            delta, response_text, tool_calls, formatted_tools
+                                        )
                             
                             response_text = response_text.strip()
                             
@@ -1340,24 +1348,12 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         ):
                             if chunk and chunk.choices and chunk.choices[0].delta:
                                 delta = chunk.choices[0].delta
+                                response_text, tool_calls = self._process_stream_delta(
+                                    delta, response_text, tool_calls, formatted_tools
+                                )
                                 if delta.content:
-                                    response_text += delta.content
                                     print("\033[K", end="\r")  
                                     print(f"Generating... {time.time() - start_time:.1f}s", end="\r")
-                                
-                                # Capture tool calls from streaming chunks if provider supports it
-                                if formatted_tools and self._supports_streaming_tools() and hasattr(delta, 'tool_calls') and delta.tool_calls:
-                                    for tc in delta.tool_calls:
-                                        if tc.index >= len(tool_calls):
-                                            tool_calls.append({
-                                                "id": tc.id,
-                                                "type": "function",
-                                                "function": {"name": "", "arguments": ""}
-                                            })
-                                        if tc.function.name:
-                                            tool_calls[tc.index]["function"]["name"] = tc.function.name
-                                        if tc.function.arguments:
-                                            tool_calls[tc.index]["function"]["arguments"] += tc.function.arguments
                     else:
                         # Non-verbose streaming
                         async for chunk in await litellm.acompletion(
@@ -1371,22 +1367,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         ):
                             if chunk and chunk.choices and chunk.choices[0].delta:
                                 delta = chunk.choices[0].delta
-                                if delta.content:
-                                    response_text += delta.content
-                                
-                                # Capture tool calls from streaming chunks if provider supports it
-                                if formatted_tools and self._supports_streaming_tools() and hasattr(delta, 'tool_calls') and delta.tool_calls:
-                                    for tc in delta.tool_calls:
-                                        if tc.index >= len(tool_calls):
-                                            tool_calls.append({
-                                                "id": tc.id,
-                                                "type": "function",
-                                                "function": {"name": "", "arguments": ""}
-                                            })
-                                        if tc.function.name:
-                                            tool_calls[tc.index]["function"]["name"] = tc.function.name
-                                        if tc.function.arguments:
-                                            tool_calls[tc.index]["function"]["arguments"] += tc.function.arguments
+                                response_text, tool_calls = self._process_stream_delta(
+                                    delta, response_text, tool_calls, formatted_tools
+                                )
                     
                     response_text = response_text.strip()
                     


### PR DESCRIPTION
Addresses issue #754 by extracting the duplicated streaming chunk processing logic into a single helper method.

## Changes
- Add `_process_stream_delta()` helper method to consolidate duplicate logic
- Refactor 4 duplicated streaming sections (sync/async, verbose/non-verbose)
- Eliminates ~50 lines of duplicated code
- Maintains 100% backward compatibility with no API changes

Generated with [Claude Code](https://claude.ai/code)