### PR TITLE
fix: prevent double output when using litellm models

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1244,8 +1244,8 @@ Your Goal: {self.goal}
                         self.chat_history.append({"role": "assistant", "content": response_text})
                         if self.verbose:
                             logging.debug(f"Agent {self.name} final response: {response_text}")
-                        # Only display interaction if not using custom LLM (to avoid double output)
-                        if not self._using_custom_llm:
+                        # Only display interaction if not using custom LLM (to avoid double output) and verbose is True
+                        if self.verbose and not self._using_custom_llm:
                             display_interaction(original_prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
                         # Return only reasoning content if reasoning_steps is True
                         if reasoning_steps and hasattr(response.choices[0].message, 'reasoning_content'):
@@ -1282,8 +1282,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             # Return the original response without reflection
                             self.chat_history.append({"role": "user", "content": prompt})
                             self.chat_history.append({"role": "assistant", "content": response_text})
-                            # Only display interaction if not using custom LLM (to avoid double output)
-                            if not self._using_custom_llm:
+                            # Only display interaction if not using custom LLM (to avoid double output) and verbose is True
+                            if self.verbose and not self._using_custom_llm:
                                 display_interaction(prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
                             return response_text
                         
@@ -1307,8 +1307,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 display_self_reflection("Agent marked the response as satisfactory after meeting minimum reflections", console=self.console)
                             self.chat_history.append({"role": "user", "content": prompt})
                             self.chat_history.append({"role": "assistant", "content": response_text})
-                            # Only display interaction if not using custom LLM (to avoid double output)
-                            if not self._using_custom_llm:
+                            # Only display interaction if not using custom LLM (to avoid double output) and verbose is True
+                            if self.verbose and not self._using_custom_llm:
                                 display_interaction(prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
                             # Apply guardrail validation after satisfactory reflection
                             try:
@@ -1324,8 +1324,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 display_self_reflection("Maximum reflection count reached, returning current response", console=self.console)
                             self.chat_history.append({"role": "user", "content": prompt})
                             self.chat_history.append({"role": "assistant", "content": response_text})
-                            # Only display interaction if not using custom LLM (to avoid double output)
-                            if not self._using_custom_llm:
+                            # Only display interaction if not using custom LLM (to avoid double output) and verbose is True
+                            if self.verbose and not self._using_custom_llm:
                                 display_interaction(prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
                             # Apply guardrail validation after max reflections
                             try:

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1233,7 +1233,8 @@ Your Goal: {self.goal}
                         # Add to chat history and return raw response
                         self.chat_history.append({"role": "user", "content": original_prompt})
                         self.chat_history.append({"role": "assistant", "content": response_text})
-                        if self.verbose:
+                        # Only display interaction if not using custom LLM (to avoid double output) and verbose is True
+                        if self.verbose and not self._using_custom_llm:
                             display_interaction(original_prompt, response_text, markdown=self.markdown, 
                                              generation_time=time.time() - start_time, console=self.console)
                         return response_text
@@ -1243,7 +1244,9 @@ Your Goal: {self.goal}
                         self.chat_history.append({"role": "assistant", "content": response_text})
                         if self.verbose:
                             logging.debug(f"Agent {self.name} final response: {response_text}")
-                        display_interaction(original_prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
+                        # Only display interaction if not using custom LLM (to avoid double output)
+                        if not self._using_custom_llm:
+                            display_interaction(original_prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
                         # Return only reasoning content if reasoning_steps is True
                         if reasoning_steps and hasattr(response.choices[0].message, 'reasoning_content'):
                             # Apply guardrail to reasoning content
@@ -1279,7 +1282,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             # Return the original response without reflection
                             self.chat_history.append({"role": "user", "content": prompt})
                             self.chat_history.append({"role": "assistant", "content": response_text})
-                            display_interaction(prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
+                            # Only display interaction if not using custom LLM (to avoid double output)
+                            if not self._using_custom_llm:
+                                display_interaction(prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
                             return response_text
                         
                         reflection_response = self._openai_client.sync_client.beta.chat.completions.parse(
@@ -1302,7 +1307,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 display_self_reflection("Agent marked the response as satisfactory after meeting minimum reflections", console=self.console)
                             self.chat_history.append({"role": "user", "content": prompt})
                             self.chat_history.append({"role": "assistant", "content": response_text})
-                            display_interaction(prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
+                            # Only display interaction if not using custom LLM (to avoid double output)
+                            if not self._using_custom_llm:
+                                display_interaction(prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
                             # Apply guardrail validation after satisfactory reflection
                             try:
                                 validated_response = self._apply_guardrail_with_retry(response_text, prompt, temperature, tools)
@@ -1317,7 +1324,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 display_self_reflection("Maximum reflection count reached, returning current response", console=self.console)
                             self.chat_history.append({"role": "user", "content": prompt})
                             self.chat_history.append({"role": "assistant", "content": response_text})
-                            display_interaction(prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
+                            # Only display interaction if not using custom LLM (to avoid double output)
+                            if not self._using_custom_llm:
+                                display_interaction(prompt, response_text, markdown=self.markdown, generation_time=time.time() - start_time, console=self.console)
                             # Apply guardrail validation after max reflections
                             try:
                                 validated_response = self._apply_guardrail_with_retry(response_text, prompt, temperature, tools)


### PR DESCRIPTION
### **User description**
Fixes #787

## Summary

This PR fixes the issue where task and response are printed twice when using litellm models (e.g., "gemini/gemini-1.5-flash-8b").

## Changes

- Added checks for `self._using_custom_llm` before calling `display_interaction()` in the Agent's chat method
- Prevents duplicate output since custom LLM instances already handle display in their `get_response` method
- Modified 5 locations in agent.py where display_interaction was called

## Testing

The fix ensures that when using litellm models, the task and response are displayed only once instead of twice.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed double output display when using litellm models

- Added conditional checks to prevent duplicate task/response printing

- Modified 5 locations in agent.py chat method


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Agent.chat() method"] --> B["Check _using_custom_llm flag"]
  B --> C["Skip display_interaction() if custom LLM"]
  C --> D["Prevent duplicate output"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.py</strong><dd><code>Prevent double output for custom LLM providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/praisonai-agents/praisonaiagents/agent/agent.py

<li>Added <code>not self._using_custom_llm</code> condition to 5 <code>display_interaction()</code> <br>calls<br> <li> Prevents duplicate output when using custom LLM providers like litellm<br> <li> Modified conditional logic in chat method's various code paths<br> <li> Added explanatory comments for the conditional checks


</details>


  </td>
  <td><a href="https://github.com/MervinPraison/PraisonAI/pull/789/files#diff-d535c234c473d9a5415e16b5793afed8bbf02b3c555bed20b8f776c4fed2a58c">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where duplicate interaction outputs could appear when using a custom language model, ensuring cleaner and more accurate chat display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->