### PR TITLE
PR #791: Changes from Claude

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/autoagents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/autoagents.py
@@ -13,7 +13,7 @@ import logging
 import os
 from pydantic import BaseModel, ConfigDict
 from ..main import display_instruction, display_tool_call, display_interaction
-from ..llm import get_openai_client, LLM
+from ..llm import get_openai_client, LLM, OpenAIClient
 import json
 
 # Define Pydantic models for structured output
@@ -248,7 +248,11 @@ Return the configuration in a structured JSON format matching the AutoAgentsConf
             try:
                 # Check if we have OpenAI API and the model supports structured output
                 if self.llm and (self.llm.startswith('gpt-') or self.llm.startswith('o1-') or self.llm.startswith('o3-')):
-                    client = get_openai_client()
+                    # Create a new client instance if custom parameters are provided
+                    if self.api_key or self.base_url:
+                        client = OpenAIClient(api_key=self.api_key, base_url=self.base_url)
+                    else:
+                        client = get_openai_client()
                     use_openai_structured = True
             except:
                 # If OpenAI client is not available, we'll use the LLM class
@@ -351,7 +355,9 @@ Return the configuration in a structured JSON format matching the AutoAgentsConf
                 max_rpm=self.max_rpm,
                 max_execution_time=self.max_execution_time,
                 max_iter=self.max_iter,
-                reflect_llm=self.reflect_llm
+                reflect_llm=self.reflect_llm,
+                base_url=self.base_url,
+                api_key=self.api_key
             )
             agents.append(agent)
             

--- a/src/praisonai-agents/praisonaiagents/agents/autoagents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/autoagents.py
@@ -109,6 +109,8 @@ class AutoAgents(PraisonAIAgents):
         self.max_execution_time = max_execution_time
         self.max_iter = max_iter
         self.reflect_llm = reflect_llm
+        self.base_url = base_url
+        self.api_key = api_key
         
         # Display initial instruction
         if self.verbose:
@@ -254,15 +256,14 @@ Return the configuration in a structured JSON format matching the AutoAgentsConf
             
             if use_openai_structured and client:
                 # Use OpenAI's structured output for OpenAI models (backward compatibility)
-                response = client.beta.chat.completions.parse(
-                    model=self.llm,
-                    response_format=AutoAgentsConfig,
+                config = client.parse_structured_output(
                     messages=[
                         {"role": "system", "content": "You are a helpful assistant designed to generate AI agent configurations."},
                         {"role": "user", "content": prompt}
-                    ]
+                    ],
+                    response_format=AutoAgentsConfig,
+                    model=self.llm
                 )
-                config = response.choices[0].message.parsed
             else:
                 # Use LLM class for all other providers (Gemini, Anthropic, etc.)
                 llm_instance = LLM(


### PR DESCRIPTION
### **User description**
This PR addresses pr #791

Generated with [Claude Code](https://claude.ai/code)

@claude this is the latest doc

review the issue again 

```
Structured Outputs
Ensure responses adhere to a JSON schema.
Try it out
Try it out in the Playground or generate a ready-to-use schema definition to experiment with structured outputs.

Introduction
JSON is one of the most widely used formats in the world for applications to exchange data.

Structured Outputs is a feature that ensures the model will always generate responses that adhere to your supplied JSON Schema, so you don't need to worry about the model omitting a required key, or hallucinating an invalid enum value.

Some benefits of Structured Outputs include:

Reliable type-safety: No need to validate or retry incorrectly formatted responses
Explicit refusals: Safety-based model refusals are now programmatically detectable
Simpler prompting: No need for strongly worded prompts to achieve consistent formatting
In addition to supporting JSON Schema in the REST API, the OpenAI SDKs for Python and JavaScript also make it easy to define object schemas using Pydantic and Zod respectively. Below, you can see how to extract information from unstructured text that conforms to a schema defined in code.

Getting a structured response
from openai import OpenAI
from pydantic import BaseModel

client = OpenAI()

class CalendarEvent(BaseModel):
    name: str
    date: str
    participants: list[str]

response = client.responses.parse(
    model="gpt-4o-2024-08-06",
    input=[
        {"role": "system", "content": "Extract the event information."},
        {
            "role": "user",
            "content": "Alice and Bob are going to a science fair on Friday.",
        },
    ],
    text_format=CalendarEvent,
)

event = response.output_parsed
Supported models
Structured Outputs is available in our latest large language models, starting with GPT-4o. Older models like gpt-4-turbo and earlier may use JSON mode instead.

When to use Structured Outputs via function calling vs via text.format
Structured Outputs is available in two forms in the OpenAI API:

When using function calling
When using a json_schema response format
Function calling is useful when you are building an application that bridges the models and functionality of your application.

For example, you can give the model access to functions that query a database in order to build an AI assistant that can help users with their orders, or functions that can interact with the UI.

Conversely, Structured Outputs via response_format are more suitable when you want to indicate a structured schema for use when the model responds to the user, rather than when the model calls a tool.

For example, if you are building a math tutoring application, you might want the assistant to respond to your user using a specific JSON Schema so that you can generate a UI that displays different parts of the model's output in distinct ways.

Put simply:

If you are connecting the model to tools, functions, data, etc. in your system, then you should use function calling
If you want to structure the model's output when it responds to the user, then you should use a structured text.format
The remainder of this guide will focus on non-function calling use cases in the Responses API. To learn more about how to use Structured Outputs with function calling, check out the Function Calling guide.

Structured Outputs vs JSON mode
Structured Outputs is the evolution of JSON mode. While both ensure valid JSON is produced, only Structured Outputs ensure schema adherance. Both Structured Outputs and JSON mode are supported in the Responses API,Chat Completions API, Assistants API, Fine-tuning API and Batch API.

We recommend always using Structured Outputs instead of JSON mode when possible.

However, Structured Outputs with response_format: {type: "json_schema", ...} is only supported with the gpt-4o-mini, gpt-4o-mini-2024-07-18, and gpt-4o-2024-08-06 model snapshots and later.

Structured Outputs	JSON Mode
Outputs valid JSON	Yes	Yes
Adheres to schema	Yes (see supported schemas)	No
Compatible models	gpt-4o-mini, gpt-4o-2024-08-06, and later	gpt-3.5-turbo, gpt-4-* and gpt-4o-* models
Enabling	text: { format: { type: "json_schema", "strict": true, "schema": ... } }	text: { format: { type: "json_object" } }
Examples

Chain of thought

Structured data extraction

UI generation

Moderation
Chain of thought
You can ask the model to output an answer in a structured, step-by-step way, to guide the user through the solution.

Structured Outputs for chain-of-thought math tutoring
from openai import OpenAI
from pydantic import BaseModel

client = OpenAI()

class Step(BaseModel):
    explanation: str
    output: str

class MathReasoning(BaseModel):
    steps: list[Step]
    final_answer: str

response = client.responses.parse(
    model="gpt-4o-2024-08-06",
    input=[
        {
            "role": "system",
            "content": "You are a helpful math tutor. Guide the user through the solution step by step.",
        },
        {"role": "user", "content": "how can I solve 8x + 7 = -23"},
    ],
    text_format=MathReasoning,
)

math_reasoning = response.output_parsed
Example response
{
  "steps": [
    {
      "explanation": "Start with the equation 8x + 7 = -23.",
      "output": "8x + 7 = -23"
    },
    {
      "explanation": "Subtract 7 from both sides to isolate the term with the variable.",
      "output": "8x = -23 - 7"
    },
    {
      "explanation": "Simplify the right side of the equation.",
      "output": "8x = -30"
    },
    {
      "explanation": "Divide both sides by 8 to solve for x.",
      "output": "x = -30 / 8"
    },
    {
      "explanation": "Simplify the fraction.",
      "output": "x = -15 / 4"
    }
  ],
  "final_answer": "x = -15 / 4"
}
How to use Structured Outputs with text.format
Step 1: Define your schema
Step 2: Supply your schema in the API call
Step 3: Handle edge cases
Refusals with Structured Outputs
When using Structured Outputs with user-generated input, OpenAI models may occasionally refuse to fulfill the request for safety reasons. Since a refusal does not necessarily follow the schema you have supplied in response_format, the API response will include a new field called refusal to indicate that the model refused to fulfill the request.

When the refusal property appears in your output object, you might present the refusal in your UI, or include conditional logic in code that consumes the response to handle the case of a refused request.

class Step(BaseModel):
    explanation: str
    output: str

class MathReasoning(BaseModel):
    steps: list[Step]
    final_answer: str

completion = client.chat.completions.parse(
    model="gpt-4o-2024-08-06",
    messages=[
        {"role": "system", "content": "You are a helpful math tutor. Guide the user through the solution step by step."},
        {"role": "user", "content": "how can I solve 8x + 7 = -23"}
    ],
    response_format=MathReasoning,
)

math_reasoning = completion.choices[0].message

# If the model refuses to respond, you will get a refusal message
if (math_reasoning.refusal):
    print(math_reasoning.refusal)
else:
    print(math_reasoning.parsed)
```


___

### **PR Type**
Bug fix


___

### **Description**
- Fix OpenAI client API usage in AutoAgents

- Store base_url and api_key as instance variables

- Replace deprecated beta.chat.completions.parse with parse_structured_output


___

### **Changes diagram**

```mermaid
flowchart LR
  A["AutoAgents __init__"] --> B["Store base_url/api_key"]
  C["_generate_config method"] --> D["Use parse_structured_output"]
  D --> E["Fix AttributeError with non-OpenAI providers"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>autoagents.py</strong><dd><code>Fix OpenAI client API and store connection parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/praisonai-agents/praisonaiagents/agents/autoagents.py

<li>Add <code>base_url</code> and <code>api_key</code> instance variables in <code>__init__</code><br> <li> Replace <code>client.beta.chat.completions.parse</code> with <br><code>client.parse_structured_output</code><br> <li> Update method parameters and response handling for structured output


</details>


  </td>
  <td><a href="https://github.com/MervinPraison/PraisonAI/pull/794/files#diff-b27075bb35aef2799878b8980fc041b932415a8a65b3e3d7054a6c73dbf1cb81">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom base URL and API key when initializing agents, allowing for greater flexibility in connecting to different AI service endpoints.

* **Improvements**
  * Enhanced the way agent configurations are generated for OpenAI providers, streamlining the process for structured output parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->