### PR TITLE
fix: handle string tasks in AutoAgents configuration

### DIFF
--- a/src/praisonai-agents/test_autoagents_fix.py
+++ b/src/praisonai-agents/test_autoagents_fix.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Test script to verify the AutoAgents fix for string tasks"""
+
+import json
+from praisonaiagents.agents.autoagents import AutoAgents
+
+# Test the _normalize_config method directly
+def test_normalize_config():
+    # Create a minimal AutoAgents instance just to test the method
+    agents = AutoAgents(
+        instructions="Test",
+        max_agents=1
+    )
+    
+    # Test case 1: Tasks as strings (the problematic case)
+    config_dict = {
+        "main_instruction": "Test instruction",
+        "process_type": "sequential",
+        "agents": [
+            {
+                "name": "Agent 1",
+                "role": "Test role",
+                "goal": "Test goal",
+                "backstory": "Test backstory",
+                "tools": [],
+                "tasks": [
+                    "Get the current stock price for Google (GOOG).",
+                    "Get the current stock price for Apple (AAPL)."
+                ]
+            }
+        ]
+    }
+    
+    print("Original config with string tasks:")
+    print(json.dumps(config_dict, indent=2))
+    
+    # Normalize the config
+    normalized = agents._normalize_config(config_dict.copy())
+    
+    print("\nNormalized config:")
+    print(json.dumps(normalized, indent=2))
+    
+    # Verify tasks are now dictionaries
+    for agent in normalized['agents']:
+        for task in agent['tasks']:
+            assert isinstance(task, dict), f"Task should be dict, got {type(task)}"
+            assert 'name' in task, "Task missing 'name' field"
+            assert 'description' in task, "Task missing 'description' field"
+            assert 'expected_output' in task, "Task missing 'expected_output' field"
+            assert 'tools' in task, "Task missing 'tools' field"
+    
+    print("\n✅ Test passed: String tasks are properly normalized to TaskConfig format")
+    
+    # Test case 2: Tasks already as dictionaries (should work as before)
+    config_dict2 = {
+        "main_instruction": "Test instruction",
+        "process_type": "sequential",
+        "agents": [
+            {
+                "name": "Agent 1",
+                "role": "Test role",
+                "goal": "Test goal",
+                "backstory": "Test backstory",
+                "tools": [],
+                "tasks": [
+                    {
+                        "name": "Get Google stock",
+                        "description": "Get the current stock price for Google (GOOG).",
+                        "expected_output": "Stock price of Google",
+                        "tools": ["get_stock_price"]
+                    }
+                ]
+            }
+        ]
+    }
+    
+    normalized2 = agents._normalize_config(config_dict2.copy())
+    print("\n✅ Test passed: Dict tasks remain properly formatted")
+
+if __name__ == "__main__":
+    test_normalize_config()

--- a/src/praisonai-agents/test_autoagents_fix.py
+++ b/src/praisonai-agents/test_autoagents_fix.py
@@ -75,6 +75,7 @@ def test_normalize_config():
     }
     
     normalized2 = agents._normalize_config(config_dict2.copy())
+    assert normalized2 == config_dict2, "Normalization should not alter valid configurations"
     print("\n✅ Test passed: Dict tasks remain properly formatted")
 
 if __name__ == "__main__":


### PR DESCRIPTION
### **User description**
Fixes AutoAgents validation errors when using custom LLMs like Gemini.

## Problem
LLMs sometimes return tasks as simple strings instead of TaskConfig objects, causing Pydantic validation errors.

## Solution
- Add `_normalize_config` method to convert string tasks to proper TaskConfig format
- Normalize configuration before validation in `_generate_config`
- Handle incomplete task dictionaries by adding missing required fields

This ensures AutoAgents works reliably with all LLM providers.

Related to PR #800

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add `_normalize_config` method to handle string tasks from LLMs

- Convert string tasks to proper TaskConfig dictionary format

- Ensure all required fields are present in task configurations

- Add test script to verify the normalization functionality


___

### **Changes diagram**

```mermaid
flowchart LR
  A["LLM Response"] --> B["String Tasks"]
  B --> C["_normalize_config"]
  C --> D["TaskConfig Objects"]
  D --> E["Pydantic Validation"]
  E --> F["AutoAgents Success"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>autoagents.py</strong><dd><code>Add task normalization for LLM responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/praisonai-agents/praisonaiagents/agents/autoagents.py

<li>Add <code>_normalize_config</code> method to convert string tasks to TaskConfig <br>format<br> <li> Handle incomplete task dictionaries by adding missing required fields<br> <li> Integrate normalization into <code>_generate_config</code> method before validation<br> <li> Add logging for invalid task types


</details>


  </td>
  <td><a href="https://github.com/MervinPraison/PraisonAI/pull/802/files#diff-b27075bb35aef2799878b8980fc041b932415a8a65b3e3d7054a6c73dbf1cb81">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_autoagents_fix.py</strong><dd><code>Add test script for task normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/praisonai-agents/test_autoagents_fix.py

<li>Create test script to verify <code>_normalize_config</code> functionality<br> <li> Test string tasks conversion to proper TaskConfig format<br> <li> Verify dictionary tasks remain properly formatted<br> <li> Include assertions for all required task fields


</details>


  </td>
  <td><a href="https://github.com/MervinPraison/PraisonAI/pull/802/files#diff-79b8c541975851450e981276b311c3112f25a7c4693ac2f7c6fb3277857b2a4d">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>