### PR TITLE
fix: implement openai-style tool execution flow in llm.py

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -857,10 +857,7 @@ class LLM:
                             iteration_count += 1
                             continue
 
-                        # If we reach here, no more tool calls needed - get final response
-                        # Make one more call to get the final summary response
                         # Special handling for Ollama models that don't automatically process tool results
-                        ollama_handled = False
                         ollama_params = self._handle_ollama_model(response_text, tool_results, messages, original_prompt)
                         
                         if ollama_params:
@@ -903,8 +900,6 @@ class LLM:
                                 )
                                 response_text = resp.get("choices", [{}])[0].get("message", {}).get("content", "") or ""
                             
-                            # Set flag to indicate Ollama was handled
-                            ollama_handled = True
                             final_response_text = response_text.strip()
                             logging.debug(f"[OLLAMA_DEBUG] Ollama follow-up response: {final_response_text[:200]}...")
                             
@@ -924,102 +919,11 @@ class LLM:
                             else:
                                 logging.warning("[OLLAMA_DEBUG] Ollama follow-up returned empty response")
                         
-                        # If reasoning_steps is True and we haven't handled Ollama already, do a single non-streaming call
-                        if reasoning_steps and not ollama_handled:
-                            resp = litellm.completion(
-                                **self._build_completion_params(
-                                    messages=messages,
-                                    temperature=temperature,
-                                    stream=False,  # force non-streaming
-                                    **{k:v for k,v in kwargs.items() if k != 'reasoning_steps'}
-                                )
-                            )
-                            reasoning_content = resp["choices"][0]["message"].get("provider_specific_fields", {}).get("reasoning_content")
-                            response_text = resp["choices"][0]["message"]["content"]
-                            
-                            # Optionally display reasoning if present
-                            if verbose and reasoning_content:
-                                display_interaction(
-                                    original_prompt,
-                                    f"Reasoning:\n{reasoning_content}\n\nAnswer:\n{response_text}",
-                                    markdown=markdown,
-                                    generation_time=time.time() - start_time,
-                                    console=console
-                                )
-                            else:
-                                display_interaction(
-                                    original_prompt,
-                                    response_text,
-                                    markdown=markdown,
-                                    generation_time=time.time() - start_time,
-                                    console=console
-                                )
-                        
-                        # Otherwise do the existing streaming approach if not already handled
-                        elif not ollama_handled:
-                            # Get response after tool calls
-                            if stream:
-                                # Streaming approach
-                                if verbose:
-                                    with Live(display_generating("", current_time), console=console, refresh_per_second=4) as live:
-                                        final_response_text = ""
-                                        for chunk in litellm.completion(
-                                            **self._build_completion_params(
-                                                messages=messages,
-                                                tools=formatted_tools,
-                                                temperature=temperature,
-                                                stream=True,
-                                                **kwargs
-                                            )
-                                        ):
-                                            if chunk and chunk.choices and chunk.choices[0].delta.content:
-                                                content = chunk.choices[0].delta.content
-                                                final_response_text += content
-                                                live.update(display_generating(final_response_text, current_time))
-                                else:
-                                    final_response_text = ""
-                                    for chunk in litellm.completion(
-                                        **self._build_completion_params(
-                                            messages=messages,
-                                            tools=formatted_tools,
-                                            temperature=temperature,
-                                            stream=True,
-                                            **kwargs
-                                        )
-                                    ):
-                                        if chunk and chunk.choices and chunk.choices[0].delta.content:
-                                            final_response_text += chunk.choices[0].delta.content
-                            else:
-                                # Non-streaming approach
-                                resp = litellm.completion(
-                                    **self._build_completion_params(
-                                        messages=messages,
-                                        tools=formatted_tools,
-                                        temperature=temperature,
-                                        stream=False,
-                                        **kwargs
-                                    )
-                                )
-                                final_response_text = resp.get("choices", [{}])[0].get("message", {}).get("content", "") or ""
-                            
-                            final_response_text = final_response_text.strip()
-                        
-                        # Display final response
-                        if verbose:
-                            display_interaction(
-                                original_prompt,
-                                final_response_text,
-                                markdown=markdown,
-                                generation_time=time.time() - start_time,
-                                console=console
-                            )
-                        
-                        return final_response_text
+                        # After tool execution, increment iteration count and continue the loop
+                        # This allows the LLM to decide if more tools need to be called or provide the final answer
+                        iteration_count += 1
                     else:
                         # No tool calls, we're done with this iteration
-                        # If we've executed tools in previous iterations, this response contains the final answer
-                        if iteration_count > 0:
-                            final_response_text = response_text.strip()
                         break
                         
                 except Exception as e:


### PR DESCRIPTION
Fixes #835 (again)

The previous fix in PR #836 didn't fully resolve the issue. This PR implements the same approach as `openai_client.py` for handling tool execution.

## Problem
After executing tools, `llm.py` was trying to capture the response immediately instead of making another API call to let the LLM process the tool results. This prevented multi-tool scenarios from working correctly.

## Solution
- After tool execution, continue the loop to make another API call
- This allows the LLM to process tool results and decide next steps
- Matches the approach used in `openai_client.py`

## Testing
The fix should be tested with the provided `gemini-sequential.py` script to ensure multi-tool execution works correctly.

Generated with [Claude Code](https://claude.ai/code)