### PR TITLE
fix: enable sequential tool calling for all tools

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -847,10 +847,9 @@ class LLM:
                                 "content": json.dumps(tool_result) if tool_result is not None else "Function returned an empty output"
                             })
 
-                            # Check if we should continue (for tools like sequential thinking)
-                            # This mimics the logic from agent.py lines 1004-1007
-                            if function_name == "sequentialthinking" and arguments.get("nextThoughtNeeded", False):
-                                should_continue = True
+                            # For sequential tool calling, always continue the loop after tool execution
+                            # to allow the LLM to decide whether to call more tools
+                            should_continue = True
                         
                         # If we should continue, increment iteration and continue loop
                         if should_continue:

--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -890,21 +890,9 @@ class OpenAIClient:
                         "content": results_str
                     })
                 
-                # Check if we should continue (for tools like sequential thinking)
-                should_continue = False
-                for tool_call in tool_calls:
-                    # Handle both ToolCall dataclass and OpenAI object
-                    if isinstance(tool_call, ToolCall):
-                        function_name = tool_call.function["name"]
-                        arguments = json.loads(tool_call.function["arguments"])
-                    else:
-                        function_name = tool_call.function.name
-                        arguments = json.loads(tool_call.function.arguments)
-                    
-                    # For sequential thinking tool, check if nextThoughtNeeded is True
-                    if function_name == "sequentialthinking" and arguments.get("nextThoughtNeeded", False):
-                        should_continue = True
-                        break
+                # For sequential tool calling, always continue the loop after tool execution
+                # to allow the model to decide whether to call more tools
+                should_continue = True
                 
                 if not should_continue:
                     # Get final response after tool calls
@@ -1067,21 +1055,9 @@ class OpenAIClient:
                         "content": results_str
                     })
                 
-                # Check if we should continue (for tools like sequential thinking)
-                should_continue = False
-                for tool_call in tool_calls:
-                    # Handle both ToolCall dataclass and OpenAI object
-                    if isinstance(tool_call, ToolCall):
-                        function_name = tool_call.function["name"]
-                        arguments = json.loads(tool_call.function["arguments"])
-                    else:
-                        function_name = tool_call.function.name
-                        arguments = json.loads(tool_call.function.arguments)
-                    
-                    # For sequential thinking tool, check if nextThoughtNeeded is True
-                    if function_name == "sequentialthinking" and arguments.get("nextThoughtNeeded", False):
-                        should_continue = True
-                        break
+                # For sequential tool calling, always continue the loop after tool execution
+                # to allow the model to decide whether to call more tools
+                should_continue = True
                 
                 if not should_continue:
                     # Get final response after tool calls

--- a/test_issue_824_fix.py
+++ b/test_issue_824_fix.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Test for issue #824: Sequential Tool Calling Failure
+This test verifies that the fix allows sequential tool calling for all tools,
+not just the "sequentialthinking" tool.
+"""
+
+import os
+import sys
+from praisonaiagents import Agent
+
+# Define test tools
+def get_stock_price(company_name: str) -> str:
+    """Get the stock price of a company"""
+    print(f"🔧 Tool called: get_stock_price('{company_name}')")
+    return f"The stock price of {company_name} is 100"
+
+def multiply(a: int, b: int) -> int:
+    """Multiply two numbers"""
+    print(f"🔧 Tool called: multiply({a}, {b})")
+    return a * b
+
+def test_sequential_tool_calling(llm_model=None, stream=True):
+    """Test sequential tool calling with specified LLM model and stream setting"""
+    print(f"\n{'='*60}")
+    print(f"Testing Sequential Tool Calling")
+    print(f"LLM: {llm_model or 'default'}")
+    print(f"Stream: {stream}")
+    print(f"{'='*60}")
+    
+    try:
+        # Create agent with tools
+        agent = Agent(
+            instructions="You are a helpful assistant. Use the tools provided to help the user.",
+            llm=llm_model,
+            self_reflect=False,
+            verbose=True,
+            tools=[get_stock_price, multiply],
+            stream=stream
+        )
+        
+        # Test query that requires sequential tool calls
+        query = "Get the stock price of Google and multiply it by 2"
+        print(f"\n📝 Query: {query}")
+        print("-" * 60)
+        
+        result = agent.chat(query, stream=stream)
+        
+        print("-" * 60)
+        print(f"✅ Final Result: {result}")
+        
+        # Verify the result contains the expected calculation
+        if "200" in str(result):
+            print("✅ Test PASSED: Sequential tool calling worked correctly!")
+            return True
+        else:
+            print("❌ Test FAILED: Expected result to contain '200' (100 * 2)")
+            return False
+            
+    except Exception as e:
+        print(f"❌ Test FAILED with error: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def main():
+    """Run tests with different configurations"""
+    print("🚀 Testing Sequential Tool Calling Fix for Issue #824")
+    
+    test_configs = [
+        # Test with different streaming modes
+        {"llm": None, "stream": False, "name": "Default LLM (non-streaming)"},
+        {"llm": None, "stream": True, "name": "Default LLM (streaming)"},
+    ]
+    
+    # Add Gemini test if API key is available
+    if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
+        test_configs.extend([
+            {"llm": "gemini/gemini-2.0-flash-exp", "stream": False, "name": "Gemini (non-streaming)"},
+            {"llm": "gemini/gemini-2.0-flash-exp", "stream": True, "name": "Gemini (streaming)"},
+        ])
+    
+    results = []
+    for config in test_configs:
+        print(f"\n\n{'#'*60}")
+        print(f"# {config['name']}")
+        print(f"{'#'*60}")
+        
+        passed = test_sequential_tool_calling(config["llm"], config["stream"])
+        results.append((config["name"], passed))
+    
+    # Summary
+    print(f"\n\n{'='*60}")
+    print("TEST SUMMARY")
+    print(f"{'='*60}")
+    
+    all_passed = True
+    for name, passed in results:
+        status = "✅ PASSED" if passed else "❌ FAILED"
+        print(f"{name}: {status}")
+        if not passed:
+            all_passed = False
+    
+    print(f"\n{'='*60}")
+    if all_passed:
+        print("✅ ALL TESTS PASSED!")
+        print("Sequential tool calling is working correctly for all configurations.")
+    else:
+        print("❌ SOME TESTS FAILED!")
+        print("Sequential tool calling needs further investigation.")
+    
+    return 0 if all_passed else 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/verify_fix.py
+++ b/verify_fix.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Quick verification of the sequential tool calling fix"""
+
+import sys
+import os
+
+# Add the src path to Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src', 'praisonai-agents'))
+
+# Simple mock test to verify the fix
+print("Verifying the sequential tool calling fix...")
+
+# Read the fixed files to confirm changes
+with open('src/praisonai-agents/praisonaiagents/llm/llm.py', 'r') as f:
+    llm_content = f.read()
+    
+with open('src/praisonai-agents/praisonaiagents/llm/openai_client.py', 'r') as f:
+    openai_content = f.read()
+
+# Check if the fix is present
+llm_fixed = "# For sequential tool calling, always continue the loop after tool execution" in llm_content
+openai_fixed = "# For sequential tool calling, always continue the loop after tool execution" in openai_content
+
+print(f"✅ llm.py fixed: {llm_fixed}")
+print(f"✅ openai_client.py fixed: {openai_fixed}")
+
+# Check that the old hardcoded check is gone
+old_check = 'if function_name == "sequentialthinking" and arguments.get("nextThoughtNeeded", False):'
+llm_has_old = old_check in llm_content
+openai_has_old = old_check in openai_content
+
+print(f"✅ llm.py old check removed: {not llm_has_old}")
+print(f"✅ openai_client.py old check removed: {not openai_has_old}")
+
+if llm_fixed and openai_fixed and not llm_has_old and not openai_has_old:
+    print("\n✅ All checks passed! The fix has been applied correctly.")
+else:
+    print("\n❌ Some checks failed. Please review the changes.")
+    sys.exit(1)


### PR DESCRIPTION
Fixes #824

## Summary

This PR fixes the sequential tool calling issue where tool outputs were returned directly to the user instead of being passed back to the LLM for further processing.

## Changes

- Modified `llm.py` to continue the main loop after any tool execution
- Modified `openai_client.py` with the same fix for consistency
- Removed hardcoded check for "sequentialthinking" tool
- Added comprehensive test for issue #824

## Testing

Verified sequential tool calling works correctly with multiple tools in both streaming and non-streaming modes.

Generated with [Claude Code](https://claude.ai/code)