### PR TITLE
fix: add return_dict=True to fix TypeError in prompt_chaining tests

### DIFF
--- a/examples/python/general/prompt_chaining.py
+++ b/examples/python/general/prompt_chaining.py
@@ -72,7 +72,7 @@ workflow = PraisonAIAgents(
 )
 
 # Run the workflow
-results = workflow.start()
+results = workflow.start(return_dict=True)
 
 # Print results
 print("\nWorkflow Results:")

--- a/src/praisonai-agents/tests/prompt_chaining.py
+++ b/src/praisonai-agents/tests/prompt_chaining.py
@@ -69,7 +69,7 @@ workflow = PraisonAIAgents(
 )
 
 # Run the workflow
-results = workflow.start()
+results = workflow.start(return_dict=True)
 
 # Print results
 print("\nWorkflow Results:")


### PR DESCRIPTION
Fixes #841

The workflow.start() method returns a string by default (for backward compatibility), but the test files were expecting a dictionary. Fixed by adding return_dict=True parameter to get the expected dictionary format with task_results and task_status keys.

Generated with [Claude Code](https://claude.ai/code)