### PR TITLE
docs: add OLLAMA_HANDLING.md to explain ollama_handled flag usage

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/OLLAMA_HANDLING.md
+++ b/src/praisonai-agents/praisonaiagents/llm/OLLAMA_HANDLING.md
@@ -1,0 +1,25 @@
+# Ollama Handling in LLM.py
+
+The `ollama_handled` flag is used in `llm.py` (not in `agent.py`) to track whether special Ollama model handling has been applied for tool results. Here's what I found:
+
+## Where it's used in llm.py:
+- **Line 863**: `ollama_handled = False` - initialized at the beginning of the tool execution loop
+- **Line 864**: Special handling logic via `_handle_ollama_model()` method
+- **Line 907**: `ollama_handled = True` - set when Ollama special handling is applied
+- **Line 928 & 959**: Checks `if not ollama_handled` to avoid duplicate processing
+
+## Why it's needed:
+The flag prevents duplicate processing when Ollama models require special handling. Some Ollama models return only the tool call JSON without processing the results, requiring a follow-up prompt to get the final answer. The `ollama_handled` flag ensures this special handling happens only once.
+
+## Does this contradict the requirement?
+**No, it doesn't.** The issue states:
+
+> "ollama/xxxx model is already handled via llm.py via litellm, so no special condition or handling required for ollama inside agent.py"
+
+✅ **Current implementation is correct:**
+
+- `agent.py` has NO ollama-specific conditions (only one documentation mention as an example)
+- All ollama handling is contained within `llm.py` as intended
+- The `ollama_handled` flag is an internal implementation detail within `llm.py`
+
+The codebase already follows the desired pattern where ollama models are handled through the generic LLM interface via litellm without special conditions in agent.py.


### PR DESCRIPTION
Add documentation to clarify that ollama handling is correctly implemented
in llm.py and not in agent.py, addressing issue #840

Generated with [Claude Code](https://claude.ai/code)