### PR TITLE
fix: Implement Ollama sequential tool calling fix

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -277,15 +277,21 @@ class LLM:
         # Direct ollama/ prefix
         if self.model.startswith("ollama/"):
             return True
+        
+        # Check base_url if provided
+        if self.base_url and "ollama" in self.base_url.lower():
+            return True
             
         # Check environment variables for Ollama base URL
         base_url = os.getenv("OPENAI_BASE_URL", "")
         api_base = os.getenv("OPENAI_API_BASE", "")
         
-        # Common Ollama endpoints
-        ollama_endpoints = ["localhost:11434", "127.0.0.1:11434", ":11434"]
+        # Common Ollama endpoints (including custom ports)
+        if any(url and ("ollama" in url.lower() or ":11434" in url) 
+               for url in [base_url, api_base, self.base_url or ""]):
+            return True
         
-        return any(endpoint in base_url or endpoint in api_base for endpoint in ollama_endpoints)
+        return False
 
     def _process_stream_delta(self, delta, response_text: str, tool_calls: List[Dict], formatted_tools: Optional[List] = None) -> tuple:
         """


### PR DESCRIPTION
Fixes #854

## Summary
Implemented fix for Ollama sequential tool calling issue where it was getting stuck in an infinite loop.

## Changes
- Modified conversation format for Ollama providers
- Assistant messages no longer include `tool_calls` field for Ollama
- Tool results are passed as user messages with natural language format
- Maintains backward compatibility for all other LLM providers

This allows Ollama to properly understand tool results and execute sequential tool calls.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the Ollama provider, ensuring tool call messages are formatted correctly for both synchronous and asynchronous responses. This results in more accurate and consistent assistant replies when using Ollama.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->