### PR TITLE
fix: prevent infinite loop in parallel task execution

### DIFF
--- a/src/praisonai-agents/praisonaiagents/process/process.py
+++ b/src/praisonai-agents/praisonaiagents/process/process.py
@@ -324,7 +324,7 @@ Tasks by type:
             if all(task.status == "completed" for task in self.tasks.values()):
                 logging.info("All tasks are completed.")
                 self.workflow_finished = True
-                # The next iteration loop check will break the workflow
+                break  # Exit immediately to prevent task reset
 
             task_id = current_task.id
             logging.debug(f"""
@@ -884,7 +884,7 @@ Tasks by type:
             if all(task.status == "completed" for task in self.tasks.values()):
                 logging.info("All tasks are completed.")
                 self.workflow_finished = True
-                # The next iteration loop check will break the workflow
+                break  # Exit immediately to prevent task reset
 
 
             # Handle loop task file reading at runtime

--- a/src/praisonai-agents/praisonaiagents/process/process.py
+++ b/src/praisonai-agents/praisonaiagents/process/process.py
@@ -259,6 +259,17 @@ class Process:
         except (json.JSONDecodeError, ValueError) as e:
             raise Exception(f"Failed to parse JSON response: {json_content}") from e
 
+    def _check_all_tasks_completed(self) -> bool:
+        """Check if all tasks are completed and handle workflow completion.
+        
+        Returns:
+            bool: True if all tasks are completed and workflow should exit, False otherwise.
+        """
+        if all(task.status == "completed" for task in self.tasks.values()):
+            logging.info("All tasks are completed.")
+            self.workflow_finished = True
+            return True
+        return False
 
     async def aworkflow(self) -> AsyncGenerator[str, None]:
         """Async version of workflow method"""
@@ -321,9 +332,7 @@ Tasks by type:
             """)
 
             # ADDED: Check if all tasks are completed and set workflow_finished flag
-            if all(task.status == "completed" for task in self.tasks.values()):
-                logging.info("All tasks are completed.")
-                self.workflow_finished = True
+            if self._check_all_tasks_completed():
                 break  # Exit immediately to prevent task reset
 
             task_id = current_task.id
@@ -881,9 +890,7 @@ Tasks by type:
             """)
 
             # ADDED: Check if all tasks are completed and set workflow_finished flag
-            if all(task.status == "completed" for task in self.tasks.values()):
-                logging.info("All tasks are completed.")
-                self.workflow_finished = True
+            if self._check_all_tasks_completed():
                 break  # Exit immediately to prevent task reset
 
 


### PR DESCRIPTION
Fixes #874

When all tasks are completed and workflow_finished is set to True, the workflow now immediately exits to prevent tasks from being reset to "not started" state. This fixes the issue where parallel tasks would repeat in a loop and the aggregator task would never run.

Generated with [Claude Code](https://claude.ai/code)