### PR TITLE
feat: Add Gemini structured output support

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/model_capabilities.py
+++ b/src/praisonai-agents/praisonaiagents/llm/model_capabilities.py
@@ -67,16 +67,23 @@ def supports_structured_outputs(model_name: str) -> bool:
     if not model_name:
         return False
     
+    # Strip provider prefixes (e.g., 'google/', 'openai/', etc.)
+    model_without_provider = model_name
+    for prefix in ['google/', 'openai/', 'anthropic/', 'gemini/', 'mistral/', 'deepseek/', 'groq/']:
+        if model_name.startswith(prefix):
+            model_without_provider = model_name[len(prefix):]
+            break
+    
     # First check if it's explicitly in the NOT supporting list
-    if model_name in MODELS_NOT_SUPPORTING_STRUCTURED_OUTPUTS:
+    if model_without_provider in MODELS_NOT_SUPPORTING_STRUCTURED_OUTPUTS:
         return False
     
     # Then check if it's in the supporting list
-    if model_name in MODELS_SUPPORTING_STRUCTURED_OUTPUTS:
+    if model_without_provider in MODELS_SUPPORTING_STRUCTURED_OUTPUTS:
         return True
     
     # For models with version suffixes, check the base model name
-    base_model = model_name.split('-2024-')[0].split('-2025-')[0]
+    base_model = model_without_provider.split('-2024-')[0].split('-2025-')[0]
     if base_model in MODELS_SUPPORTING_STRUCTURED_OUTPUTS:
         return True
     

--- a/src/praisonai-agents/praisonaiagents/llm/model_capabilities.py
+++ b/src/praisonai-agents/praisonaiagents/llm/model_capabilities.py
@@ -30,6 +30,16 @@ MODELS_SUPPORTING_STRUCTURED_OUTPUTS = {
     "gpt-4.1-mini",
     "o4-mini",
     "o3",
+    
+    # Gemini models that support structured outputs
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-exp",
+    "gemini-1.5-pro",
+    "gemini-1.5-pro-latest",
+    "gemini-1.5-flash",
+    "gemini-1.5-flash-latest",
+    "gemini-1.5-flash-8b",
+    "gemini-1.5-flash-8b-latest",
 }
 
 # Models that explicitly DON'T support structured outputs


### PR DESCRIPTION
Fixes #871

## Summary

This PR adds native support for Gemini's structured output capabilities in PraisonAI, allowing users to get structured JSON responses from Gemini models using Pydantic schemas.

## Changes

- Added Gemini models to the list of models supporting structured outputs
- Implemented native Gemini structured output using `response_mime_type` and `response_schema` parameters
- Modified prompt building to skip JSON instructions for Gemini models with structured output support
- Updated all internal calls to properly pass through structured output parameters

## Backward Compatibility

- OpenAI models continue to use prompt engineering as before
- Models without structured output support gracefully fall back to prompt engineering
- No changes to existing API or behavior

## Testing

The implementation has been designed to maintain full backward compatibility while adding the new Gemini features.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini models to natively handle structured outputs such as JSON or Pydantic models, without requiring prompt modifications.
  * Expanded the range of Gemini models recognized as supporting structured outputs.

* **Improvements**
  * Enhanced model detection to better identify and handle models with structured output capabilities.
  * Streamlined handling of structured output parameters for both synchronous and asynchronous responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->