### PR TITLE
fix: exclude response_format parameter for Gemini image models

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/image_agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/image_agent.py
@@ -144,11 +144,15 @@ class ImageAgent(Agent):
         config = self.image_config.dict(exclude_none=True)
         config.update(kwargs)
         
-        # Use llm parameter as the model
-        config['model'] = self.llm
+        # Get the model name robustly from the parent Agent's property
+        model_info = self.llm_model
+        model_name = model_info.model if hasattr(model_info, 'model') else str(model_info)
+        
+        # Use the model name in config
+        config['model'] = model_name
 
         # Check if we're using a Gemini model and remove unsupported parameters
-        if self.llm and 'gemini' in str(self.llm).lower():
+        if 'gemini' in model_name.lower():
             # Gemini models don't support response_format parameter
             config.pop('response_format', None)
 
@@ -159,7 +163,7 @@ class ImageAgent(Agent):
         ) as progress:
             try:
                 # Add a task for image generation
-                task = progress.add_task(f"[cyan]Generating image with {self.llm}...", total=None)
+                task = progress.add_task(f"[cyan]Generating image with {model_name}...", total=None)
                 
                 # Use litellm's image generation
                 response = self.litellm(


### PR DESCRIPTION
Fixes #899

## Summary
- Add detection logic to identify Gemini models (case-insensitive)
- Exclude response_format parameter for Gemini models to prevent litellm.UnsupportedParamsError
- Maintain backward compatibility for non-Gemini models

## Test Plan
- [x] Verify Gemini models exclude response_format parameter
- [x] Verify non-Gemini models preserve response_format parameter
- [x] Test case-insensitive detection
- [x] Ensure backward compatibility

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Gemini models during image generation by adjusting configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->