### PR TITLE
fix: resolve litellm.BadRequestError with unrecognized output_json/output_pydantic parameters

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1910,10 +1910,11 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         output_json = override_params.get('output_json')
         output_pydantic = override_params.get('output_pydantic')
         
+        # Always remove these from params as they're not native litellm parameters
+        params.pop('output_json', None)
+        params.pop('output_pydantic', None)
+        
         if output_json or output_pydantic:
-            # Always remove these from params as they're not native litellm parameters
-            params.pop('output_json', None)
-            params.pop('output_pydantic', None)
             
             # Check if this is a Gemini model that supports native structured outputs
             if self._is_gemini_model():


### PR DESCRIPTION
Fixes #905

## Summary

Resolved the litellm.BadRequestError where OpenAI API was receiving unrecognized arguments `output_json` and `output_pydantic`.

## Root Cause

The issue was in the `_build_completion_params` method in `llm.py` where custom parameters `output_json` and `output_pydantic` were only conditionally removed when not None, causing them to be passed to LiteLLM which doesn't recognize them.

## Solution

- Moved parameter removal outside conditional check to ensure these custom parameters are always removed before LiteLLM calls
- Maintains full backward compatibility
- Preserves all existing functionality
- Minimal, targeted fix addressing the exact error reported

## Testing

The fix directly addresses the root cause identified in the error logs. The test script provided in the issue should now run without the "Unrecognized request arguments supplied" error.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of certain parameters to prevent potential conflicts or errors during AI completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->