### PR TITLE
fix: Add support for Gemini internal tools in tool formatting

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -542,6 +542,7 @@ class LLM:
         - Lists of pre-formatted tools
         - Callable functions
         - String function names
+        - Gemini internal tools ({"googleSearch": {}}, {"urlContext": {}}, {"codeExecution": {}})
         
         Args:
             tools: List of tools in various formats
@@ -588,6 +589,16 @@ class LLM:
                 tool_def = self._generate_tool_definition(tool)
                 if tool_def:
                     formatted_tools.append(tool_def)
+            # Handle Gemini internal tools (e.g., {"googleSearch": {}}, {"urlContext": {}}, {"codeExecution": {}})
+            elif isinstance(tool, dict) and len(tool) == 1:
+                tool_name = next(iter(tool.keys()))
+                # List of supported Gemini internal tools
+                gemini_internal_tools = {'googleSearch', 'urlContext', 'codeExecution'}
+                if tool_name in gemini_internal_tools:
+                    logging.debug(f"Using Gemini internal tool: {tool_name}")
+                    formatted_tools.append(tool)
+                else:
+                    logging.debug(f"Skipping unknown tool: {tool_name}")
             else:
                 logging.debug(f"Skipping tool of unsupported type: {type(tool)}")
                 

--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -360,6 +360,7 @@ class OpenAIClient:
         - Callable functions
         - String function names
         - MCP tools
+        - Gemini internal tools ({"googleSearch": {}}, {"urlContext": {}}, {"codeExecution": {}})
         
         Args:
             tools: List of tools in various formats
@@ -404,6 +405,16 @@ class OpenAIClient:
                 tool_def = self._generate_tool_definition_from_name(tool)
                 if tool_def:
                     formatted_tools.append(tool_def)
+            # Handle Gemini internal tools (e.g., {"googleSearch": {}}, {"urlContext": {}}, {"codeExecution": {}})
+            elif isinstance(tool, dict) and len(tool) == 1:
+                tool_name = next(iter(tool.keys()))
+                # List of supported Gemini internal tools
+                gemini_internal_tools = {'googleSearch', 'urlContext', 'codeExecution'}
+                if tool_name in gemini_internal_tools:
+                    logging.debug(f"Using Gemini internal tool: {tool_name}")
+                    formatted_tools.append(tool)
+                else:
+                    logging.debug(f"Skipping unknown tool: {tool_name}")
             else:
                 logging.debug(f"Skipping tool of unsupported type: {type(tool)}")
                 


### PR DESCRIPTION
**Summary**
- Add explicit handling for Gemini internal tools (googleSearch, urlContext, codeExecution)
- Update docstrings to document new capability
- Resolves issue where Gemini internal tools were skipped with 'unsupported type' error
- Maintains backward compatibility with existing tool formats

**Fixes**
Closes #919

**Test Plan**
- Tested individual Gemini internal tools
- Tested combined tools usage
- Verified unknown tools are properly rejected
- Confirmed backward compatibility

Generated with [Claude Code](https://claude.ai/code)