### PR TITLE
Fix AutoGen ImportError by making tests conditional

### DIFF
--- a/src/praisonai/tests/source/autogen_function_tools.py
+++ b/src/praisonai/tests/source/autogen_function_tools.py
@@ -1,6 +1,16 @@
 from typing import Annotated, Literal
 import os
-from autogen import ConversableAgent
+
+# Conditional import for AutoGen
+try:
+    from autogen import ConversableAgent, register_function
+    AUTOGEN_AVAILABLE = True
+except ImportError:
+    AUTOGEN_AVAILABLE = False
+    print("AutoGen not available - install with: pip install 'praisonai[autogen]'")
+    
+if not AUTOGEN_AVAILABLE:
+    exit(0)
 
 Operator = Literal["+", "-", "*", "/"]
 
@@ -31,7 +41,6 @@ user_proxy = ConversableAgent(
     human_input_mode="NEVER",
 )
 
-from autogen import register_function
 # Register the calculator function to the agent and user proxy to add a calculator tool.
 register_function(
     calculator,

--- a/src/praisonai/tests/source/autogen_langchain_tools.py
+++ b/src/praisonai/tests/source/autogen_langchain_tools.py
@@ -13,7 +13,16 @@ from langchain.tools import BaseTool
 from langchain.tools.file_management.read import ReadFileTool
 from langchain.utilities.spark_sql import SparkSQL
 
-import autogen
+# Conditional import for AutoGen
+try:
+    import autogen
+    AUTOGEN_AVAILABLE = True
+except ImportError:
+    AUTOGEN_AVAILABLE = False
+    print("AutoGen not available - install with: pip install 'praisonai[autogen]'")
+    
+if not AUTOGEN_AVAILABLE:
+    exit(0)
 
 class CircumferenceToolInput(BaseModel):
     radius: float = Field()

--- a/src/praisonai/tests/test.py
+++ b/src/praisonai/tests/test.py
@@ -8,6 +8,12 @@ from .basic_example import main
 from .auto_example import auto
 # from xmlrunner import XMLTestRunner
 
+# Import availability flags for conditional testing
+try:
+    from praisonai.auto import AUTOGEN_AVAILABLE
+except ImportError:
+    AUTOGEN_AVAILABLE = False
+
 # Patch for collections.abc MutableMapping issue
 import collections.abc
 collections.MutableMapping = collections.abc.MutableMapping
@@ -21,6 +27,7 @@ class TestPraisonAIFramework(unittest.TestCase):
         self.assertIsNotNone(result)
 
     @pytest.mark.real
+    @unittest.skipUnless(AUTOGEN_AVAILABLE, "AutoGen not available - install with: pip install 'praisonai[autogen]'")
     def test_main_with_autogen_framework(self):
         praisonai = PraisonAI(agent_file="tests/autogen-agents.yaml")
         result = praisonai.run()
@@ -63,6 +70,7 @@ class TestPraisonAICommandLine(unittest.TestCase):
         return result.stdout + result.stderr
 
     @pytest.mark.real
+    @unittest.skipUnless(AUTOGEN_AVAILABLE, "AutoGen not available - install with: pip install 'praisonai[autogen]'")
     def test_praisonai_command(self):
         # Test basic praisonai command
         command = "praisonai --framework autogen --auto \"create a 2-agent team to write a simple python game\""
@@ -71,6 +79,7 @@ class TestPraisonAICommandLine(unittest.TestCase):
         self.assertIn('TERMINATE', result)
 
     @pytest.mark.real
+    @unittest.skipUnless(AUTOGEN_AVAILABLE, "AutoGen not available - install with: pip install 'praisonai[autogen]'")
     def test_praisonai_init_command(self):
         # Test praisonai --init command
         # This command primarily creates files, but let's ensure it uses the real key if any underlying PraisonAI init involves API calls
@@ -89,6 +98,7 @@ class TestExamples(unittest.TestCase):
         self.assertIsNotNone(result)
 
     @pytest.mark.real
+    @unittest.skipUnless(AUTOGEN_AVAILABLE, "AutoGen not available - install with: pip install 'praisonai[autogen]'")
     def test_auto_example(self):
         result = auto()
         print(f"Result: {result}")

--- a/src/praisonai/tests/test_agents_playbook.py
+++ b/src/praisonai/tests/test_agents_playbook.py
@@ -5,9 +5,16 @@ import pytest
 import os
 from praisonai import PraisonAI
 
+# Import availability flags for conditional testing
+try:
+    from praisonai.auto import AUTOGEN_AVAILABLE
+except ImportError:
+    AUTOGEN_AVAILABLE = False
+
 class TestPraisonAIFramework(unittest.TestCase):
     
     @pytest.mark.real
+    @unittest.skipUnless(AUTOGEN_AVAILABLE, "AutoGen not available - install with: pip install 'praisonai[autogen]'")
     def test_main_with_autogen_framework(self):
         """Test AutoGen framework integration with real API calls"""
         praisonai = PraisonAI(agent_file='tests/autogen-agents.yaml')


### PR DESCRIPTION
Fixes #927

## Summary
- Add conditional test skipping for AutoGen-related tests when AutoGen is not available
- Import AUTOGEN_AVAILABLE flag from praisonai.auto module
- Add @unittest.skipUnless decorators to tests that require AutoGen framework
- Tests now skip with helpful message instead of failing
- Maintains backward compatibility and existing functionality

## Test Plan
- [x] Verified AutoGen tests are skipped when AutoGen not available
- [x] Verified other tests continue to work correctly
- [x] Verified no breaking changes to existing functionality

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test suite to automatically skip tests requiring the AutoGen feature if it is not installed, preventing unnecessary test failures.
  * Added conditional checks to ensure tests and scripts depending on AutoGen only run when the feature is available, improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->