### PR TITLE
fix: prevent premature termination in Ollama sequential tool execution

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1109,10 +1109,12 @@ class LLM:
                             break
                         
                         # Special handling for Ollama to prevent infinite loops
-                        tool_summary = self._generate_ollama_tool_summary(tool_results, response_text)
-                        if tool_summary:
-                            final_response_text = tool_summary
-                            break
+                        # Only generate summary after multiple iterations to allow sequential execution
+                        if iteration_count >= 3:
+                            tool_summary = self._generate_ollama_tool_summary(tool_results, response_text)
+                            if tool_summary:
+                                final_response_text = tool_summary
+                                break
                         
                         # Otherwise, continue the loop to check if more tools are needed
                         iteration_count += 1
@@ -1858,10 +1860,12 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         break
                     
                     # Special handling for Ollama to prevent infinite loops
-                    tool_summary = self._generate_ollama_tool_summary(tool_results, response_text)
-                    if tool_summary:
-                        final_response_text = tool_summary
-                        break
+                    # Only generate summary after multiple iterations to allow sequential execution
+                    if iteration_count >= 3:
+                        tool_summary = self._generate_ollama_tool_summary(tool_results, response_text)
+                        if tool_summary:
+                            final_response_text = tool_summary
+                            break
                     
                     # Continue the loop to check if more tools are needed
                     iteration_count += 1

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -93,6 +93,9 @@ class LLM:
     # Ollama-specific prompt constants
     OLLAMA_TOOL_USAGE_PROMPT = "Please analyze the request and use the available tools to help answer the question. Start by identifying what information you need."
     OLLAMA_FINAL_ANSWER_PROMPT = "Based on the tool results above, please provide the final answer to the original question."
+    
+    # Ollama iteration threshold for summary generation
+    OLLAMA_SUMMARY_ITERATION_THRESHOLD = 3
 
     def _log_llm_config(self, method_name: str, **config):
         """Centralized debug logging for LLM configuration and parameters.
@@ -1112,7 +1115,7 @@ class LLM:
                         
                         # Special handling for Ollama to prevent infinite loops
                         # Only generate summary after multiple iterations to allow sequential execution
-                        if iteration_count >= 3:
+                        if iteration_count >= self.OLLAMA_SUMMARY_ITERATION_THRESHOLD:
                             tool_summary = self._generate_ollama_tool_summary(accumulated_tool_results, response_text)
                             if tool_summary:
                                 final_response_text = tool_summary
@@ -1865,7 +1868,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     
                     # Special handling for Ollama to prevent infinite loops
                     # Only generate summary after multiple iterations to allow sequential execution
-                    if iteration_count >= 3:
+                    if iteration_count >= self.OLLAMA_SUMMARY_ITERATION_THRESHOLD:
                         tool_summary = self._generate_ollama_tool_summary(accumulated_tool_results, response_text)
                         if tool_summary:
                             final_response_text = tool_summary

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -827,6 +827,7 @@ class LLM:
             iteration_count = 0
             final_response_text = ""
             stored_reasoning_content = None  # Store reasoning content from tool execution
+            accumulated_tool_results = []  # Store all tool results across iterations
 
             while iteration_count < max_iterations:
                 try:
@@ -1052,7 +1053,7 @@ class LLM:
                             })
                         
                         should_continue = False
-                        tool_results = []  # Store all tool results
+                        tool_results = []  # Store current iteration tool results
                         for tool_call in tool_calls:
                             # Handle both object and dict access patterns
                             is_ollama = self._is_ollama_provider()
@@ -1066,6 +1067,7 @@ class LLM:
                             tool_result = execute_tool_fn(function_name, arguments)
                             logging.debug(f"[TOOL_EXEC_DEBUG] Tool execution result: {tool_result}")
                             tool_results.append(tool_result)  # Store the result
+                            accumulated_tool_results.append(tool_result)  # Accumulate across iterations
 
                             if verbose:
                                 display_message = f"Agent {agent_name} called function '{function_name}' with arguments: {arguments}\n"
@@ -1111,7 +1113,7 @@ class LLM:
                         # Special handling for Ollama to prevent infinite loops
                         # Only generate summary after multiple iterations to allow sequential execution
                         if iteration_count >= 3:
-                            tool_summary = self._generate_ollama_tool_summary(tool_results, response_text)
+                            tool_summary = self._generate_ollama_tool_summary(accumulated_tool_results, response_text)
                             if tool_summary:
                                 final_response_text = tool_summary
                                 break
@@ -1545,6 +1547,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             iteration_count = 0
             final_response_text = ""
             stored_reasoning_content = None  # Store reasoning content from tool execution
+            accumulated_tool_results = []  # Store all tool results across iterations
 
             while iteration_count < max_iterations:
                 response_text = ""
@@ -1715,7 +1718,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             "tool_calls": serializable_tool_calls
                         })
                     
-                    tool_results = []  # Store all tool results
+                    tool_results = []  # Store current iteration tool results
                     for tool_call in tool_calls:
                         # Handle both object and dict access patterns
                         is_ollama = self._is_ollama_provider()
@@ -1727,6 +1730,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
 
                         tool_result = await execute_tool_fn(function_name, arguments)
                         tool_results.append(tool_result)  # Store the result
+                        accumulated_tool_results.append(tool_result)  # Accumulate across iterations
 
                         if verbose:
                             display_message = f"Agent {agent_name} called function '{function_name}' with arguments: {arguments}\n"
@@ -1862,7 +1866,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     # Special handling for Ollama to prevent infinite loops
                     # Only generate summary after multiple iterations to allow sequential execution
                     if iteration_count >= 3:
-                        tool_summary = self._generate_ollama_tool_summary(tool_results, response_text)
+                        tool_summary = self._generate_ollama_tool_summary(accumulated_tool_results, response_text)
                         if tool_summary:
                             final_response_text = tool_summary
                             break


### PR DESCRIPTION
## Summary

This PR fixes the issue where Ollama models would terminate after the first tool call instead of continuing with sequential execution.

## Problem

The original issue was in the tool execution logic where `_generate_ollama_tool_summary` was being called immediately after the first tool execution, causing premature termination:

1. `get_stock_price` executes → returns "The stock price of Google is 100"
2. Ollama provides empty/None response
3. `_generate_ollama_tool_summary` was called immediately → generates summary
4. Loop terminates before `multiply` tool can be called

## Solution

Added iteration count threshold before generating Ollama tool summary:

```python
# Before (problematic)
tool_summary = self._generate_ollama_tool_summary(tool_results, response_text)
if tool_summary:
    final_response_text = tool_summary
    break

# After (fixed)
if iteration_count >= 3:
    tool_summary = self._generate_ollama_tool_summary(tool_results, response_text)
    if tool_summary:
        final_response_text = tool_summary
        break
```

## Key Changes

- ✅ **Sequential execution**: Now allows multiple tool calls (get_stock_price → multiply)
- ✅ **Smart termination**: Only generates summary after 3+ iterations to prevent infinite loops
- ✅ **Backward compatibility**: No impact on other LLM providers
- ✅ **Applied to both sync and async methods**

## Expected Behavior

1. Execute `get_stock_price('Google')` → returns "100"
2. LLM provides empty/None response → `iteration_count < 3` → skip summary generation, continue loop
3. Execute `multiply(100, 2)` → returns "200"
4. LLM provides final answer combining both results

Fixes #940

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the timing of tool summary generation for Ollama, ensuring summaries are created only after at least three iterations. This prevents premature summarization and allows for more complete tool execution sequences.
  * Enhanced accumulation of tool execution results across multiple iterations for more comprehensive summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->