### PR TITLE
fix: comprehensive task_name undefined error resolution

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1536,7 +1536,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             cleaned = cleaned[:-3].strip()
         return cleaned  
 
-    async def achat(self, prompt: str, temperature=0.2, tools=None, output_json=None, output_pydantic=None, reasoning_steps=False):
+    async def achat(self, prompt: str, temperature=0.2, tools=None, output_json=None, output_pydantic=None, reasoning_steps=False, task_name=None, task_description=None, task_id=None):
         """Async version of chat method with self-reflection support.""" 
         # Log all parameter values when in debug mode
         if logging.getLogger().getEffectiveLevel() == logging.DEBUG:
@@ -1944,7 +1944,11 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             prompt = task
         else:
             prompt = str(task)
-        return await self.achat(prompt)
+        # Extract task info if available
+        task_name = getattr(task, 'name', None) if hasattr(task, 'name') else None
+        task_description = getattr(task, 'description', None) if hasattr(task, 'description') else None
+        task_id = getattr(task, 'id', None) if hasattr(task, 'id') else None
+        return await self.achat(prompt, task_name=task_name, task_description=task_description, task_id=task_id)
 
     async def execute_tool_async(self, function_name: str, arguments: Dict[str, Any]) -> Any:
         """Async version of execute_tool"""
@@ -2113,7 +2117,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 try:
                     # Use async version if available, otherwise use sync version
                     if asyncio.iscoroutinefunction(self.chat):
-                        response = await self.achat(query)
+                        response = await self.achat(query, task_name=None, task_description=None, task_id=None)
                     else:
                         # Run sync function in a thread to avoid blocking
                         loop = asyncio.get_event_loop()
@@ -2234,7 +2238,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 try:
                     # Ensure self.achat is used as it's the async version and pass its tools
                     if hasattr(self, 'achat') and asyncio.iscoroutinefunction(self.achat):
-                        response = await self.achat(prompt, tools=self.tools)
+                        response = await self.achat(prompt, tools=self.tools, task_name=None, task_description=None, task_id=None)
                     elif hasattr(self, 'chat'): # Fallback for synchronous chat
                         loop = asyncio.get_event_loop()
                         response = await loop.run_in_executor(None, lambda p=prompt: self.chat(p, tools=self.tools))

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1945,9 +1945,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         else:
             prompt = str(task)
         # Extract task info if available
-        task_name = getattr(task, 'name', None) if hasattr(task, 'name') else None
-        task_description = getattr(task, 'description', None) if hasattr(task, 'description') else None
-        task_id = getattr(task, 'id', None) if hasattr(task, 'id') else None
+        task_name = getattr(task, 'name', None)
+        task_description = getattr(task, 'description', None)
+        task_id = getattr(task, 'id', None)
         return await self.achat(prompt, task_name=task_name, task_description=task_description, task_id=task_id)
 
     async def execute_tool_async(self, function_name: str, arguments: Dict[str, Any]) -> Any:

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -362,14 +362,20 @@ Context:
                 _get_multimodal_message(task_prompt, task.images),
                 tools=tools,
                 output_json=task.output_json,
-                output_pydantic=task.output_pydantic
+                output_pydantic=task.output_pydantic,
+                task_name=task.name,
+                task_description=task.description,
+                task_id=task.id
             )
         else:
             agent_output = await executor_agent.achat(
                 task_prompt,
                 tools=tools,
                 output_json=task.output_json,
-                output_pydantic=task.output_pydantic
+                output_pydantic=task.output_pydantic,
+                task_name=task.name,
+                task_description=task.description,
+                task_id=task.id
             )
 
         if agent_output:
@@ -1138,7 +1144,7 @@ Context:
                         try:
                             # Use async version if available, otherwise use sync version
                             if asyncio.iscoroutinefunction(agent_instance.chat):
-                                response = await agent_instance.achat(current_input)
+                                response = await agent_instance.achat(current_input, task_name=None, task_description=None, task_id=None)
                             else:
                                 # Run sync function in a thread to avoid blocking
                                 loop = asyncio.get_running_loop()
@@ -1294,7 +1300,7 @@ Context:
                     try:
                         logging.debug(f"Processing with agent: {agent_instance.name}")
                         if hasattr(agent_instance, 'achat') and asyncio.iscoroutinefunction(agent_instance.achat):
-                            response = await agent_instance.achat(current_input, tools=agent_instance.tools)
+                            response = await agent_instance.achat(current_input, tools=agent_instance.tools, task_name=None, task_description=None, task_id=None)
                         elif hasattr(agent_instance, 'chat'): # Fallback to sync chat if achat not suitable
                             loop = asyncio.get_running_loop()
                             response = await loop.run_in_executor(None, lambda ci=current_input: agent_instance.chat(ci, tools=agent_instance.tools))

--- a/test_task_name_fix.py
+++ b/test_task_name_fix.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Test script to validate the task_name fix for agentic parallelization.
+This script tests the structure without requiring API keys.
+"""
+
+import asyncio
+import sys
+import os
+
+# Add the source path to sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src', 'praisonai-agents'))
+
+def test_achat_signature():
+    """Test that achat method has the correct signature"""
+    try:
+        from praisonaiagents import Agent
+        
+        # Create a basic agent
+        agent = Agent(
+            name="TestAgent",
+            role="Test Role",
+            goal="Test Goal",
+            llm="mock-llm"  # Using a mock LLM
+        )
+        
+        # Check if achat method exists and has the correct signature
+        import inspect
+        achat_sig = inspect.signature(agent.achat)
+        params = list(achat_sig.parameters.keys())
+        
+        required_params = ['prompt', 'temperature', 'tools', 'output_json', 'output_pydantic', 'reasoning_steps', 'task_name', 'task_description', 'task_id']
+        
+        print("✅ Agent.achat signature test:")
+        print(f"  Method parameters: {params}")
+        
+        missing_params = [p for p in required_params if p not in params]
+        if missing_params:
+            print(f"  ❌ Missing parameters: {missing_params}")
+            return False
+        else:
+            print(f"  ✅ All required parameters present")
+            return True
+            
+    except Exception as e:
+        print(f"❌ Error testing achat signature: {e}")
+        return False
+
+def test_task_structure():
+    """Test that Task objects have the required attributes"""
+    try:
+        from praisonaiagents import Agent, Task
+        
+        # Create a basic task
+        agent = Agent(
+            name="TestAgent",
+            role="Test Role", 
+            goal="Test Goal",
+            llm="mock-llm"
+        )
+        
+        task = Task(
+            name="test_task",
+            description="Test task description",
+            expected_output="Test output",
+            agent=agent
+        )
+        
+        print("✅ Task structure test:")
+        print(f"  Task name: {getattr(task, 'name', 'MISSING')}")
+        print(f"  Task description: {getattr(task, 'description', 'MISSING')}")
+        print(f"  Task id: {getattr(task, 'id', 'MISSING')}")
+        
+        has_name = hasattr(task, 'name')
+        has_description = hasattr(task, 'description') 
+        has_id = hasattr(task, 'id')
+        
+        if has_name and has_description and has_id:
+            print(f"  ✅ Task has all required attributes")
+            return True
+        else:
+            print(f"  ❌ Task missing attributes - name: {has_name}, description: {has_description}, id: {has_id}")
+            return False
+            
+    except Exception as e:
+        print(f"❌ Error testing task structure: {e}")
+        return False
+
+async def test_achat_call():
+    """Test that achat can be called with task parameters"""
+    try:
+        from praisonaiagents import Agent
+        
+        # Create a basic agent  
+        agent = Agent(
+            name="TestAgent",
+            role="Test Role",
+            goal="Test Goal",
+            llm="mock-llm"  # This should gracefully handle mock LLM
+        )
+        
+        print("✅ Testing achat call with task parameters:")
+        
+        # This should not raise a NameError for task_name anymore
+        try:
+            # We expect this to fail due to mock LLM, but NOT due to NameError: task_name not defined
+            response = await agent.achat(
+                "Test prompt",
+                task_name="test_task",
+                task_description="Test description", 
+                task_id="test_id"
+            )
+            print(f"  ✅ achat call succeeded (unexpected but good!)")
+            return True
+        except NameError as e:
+            if "task_name" in str(e):
+                print(f"  ❌ Still getting task_name NameError: {e}")
+                return False
+            else:
+                print(f"  ⚠️ Different NameError (acceptable): {e}")
+                return True
+        except Exception as e:
+            if "task_name" in str(e) and "not defined" in str(e):
+                print(f"  ❌ Still getting task_name error: {e}")
+                return False
+            else:
+                print(f"  ✅ Different error (expected with mock LLM): {type(e).__name__}: {e}")
+                return True
+            
+    except Exception as e:
+        print(f"❌ Error testing achat call: {e}")
+        return False
+
+async def main():
+    """Run all tests"""
+    print("🧪 Testing task_name fix for agentic parallelization...")
+    print()
+    
+    results = []
+    
+    # Test 1: Check achat signature
+    results.append(test_achat_signature())
+    print()
+    
+    # Test 2: Check task structure  
+    results.append(test_task_structure())
+    print()
+    
+    # Test 3: Test achat call
+    results.append(await test_achat_call())
+    print()
+    
+    # Summary
+    passed = sum(results)
+    total = len(results)
+    
+    print(f"📊 Test Results: {passed}/{total} tests passed")
+    
+    if passed == total:
+        print("🎉 All tests passed! The task_name fix appears to be working.")
+        return 0
+    else:
+        print("❌ Some tests failed. The fix may need more work.")
+        return 1
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    sys.exit(exit_code)

--- a/test_task_name_fix.py
+++ b/test_task_name_fix.py
@@ -39,7 +39,7 @@ def test_achat_signature():
             print(f"  ❌ Missing parameters: {missing_params}")
             return False
         else:
-            print(f"  ✅ All required parameters present")
+            print("  ✅ All required parameters present")
             return True
             
     except Exception as e:
@@ -76,7 +76,7 @@ def test_task_structure():
         has_id = hasattr(task, 'id')
         
         if has_name and has_description and has_id:
-            print(f"  ✅ Task has all required attributes")
+            print("  ✅ Task has all required attributes")
             return True
         else:
             print(f"  ❌ Task missing attributes - name: {has_name}, description: {has_description}, id: {has_id}")
@@ -104,13 +104,13 @@ async def test_achat_call():
         # This should not raise a NameError for task_name anymore
         try:
             # We expect this to fail due to mock LLM, but NOT due to NameError: task_name not defined
-            response = await agent.achat(
+            await agent.achat(
                 "Test prompt",
                 task_name="test_task",
                 task_description="Test description", 
                 task_id="test_id"
             )
-            print(f"  ✅ achat call succeeded (unexpected but good!)")
+            print("  ✅ achat call succeeded (unexpected but good!)")
             return True
         except NameError as e:
             if "task_name" in str(e):


### PR DESCRIPTION
Comprehensive fix for persistent task_name undefined errors in agentic parallelization workflows.

## Problem
The `Agent.achat` method was trying to pass `task_name`, `task_description`, and `task_id` parameters to the LLM's `get_response_async` method, but these parameters were not included in the `achat` method signature, causing `NameError: name 'task_name' is not defined`.

## Solution
- Fixed `achat` method signature to include task parameters
- Updated all achat call sites to pass task information where available
- Provided fallback values for API handler contexts without task context
- Enhanced task context extraction in Agent.aexecute

## Files Changed
- `src/praisonai-agents/praisonaiagents/agent/agent.py`
- `src/praisonai-agents/praisonaiagents/agents/agents.py`

## Testing
- Both files compile without syntax errors
- Task parameters properly passed through execution chain
- Backward compatibility maintained

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing task metadata (name, description, ID) through the agent's asynchronous chat interface, enabling enhanced context handling during agent interactions.

* **Bug Fixes**
  * Addressed potential issues with missing task metadata parameters in agent parallelization scenarios.

* **Tests**
  * Introduced new tests to validate the correct handling and propagation of task metadata parameters in agent methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->