### PR TITLE
fix: properly shutdown telemetry aiohttp sessions to prevent ImportError during Python shutdown

### DIFF
--- a/src/praisonai-agents/praisonaiagents/telemetry/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/telemetry/__init__.py
@@ -65,8 +65,8 @@ def _ensure_atexit():
     ])
     
     if not telemetry_disabled:
-        # Register atexit handler to flush telemetry on exit
-        atexit.register(lambda: get_telemetry().flush())
+        # Register atexit handler to properly shutdown telemetry on exit
+        atexit.register(lambda: get_telemetry().shutdown())
         _atexit_registered = True
 
 def _initialize_telemetry():


### PR DESCRIPTION
Fixes #963

This PR resolves the ImportError that occurs during Python shutdown when aiohttp sessions from telemetry's PostHog client aren't properly closed.

**Root Cause:**
- Telemetry atexit handler only called `flush()` instead of `shutdown()`
- PostHog client uses aiohttp sessions that need explicit cleanup
- During Python shutdown, unclosed sessions cause ImportError when `sys.meta_path` becomes None

**Solution:**
- Changed atexit handler from `flush()` to `shutdown()`
- `shutdown()` method properly closes aiohttp sessions
- Maintains backward compatibility and all existing functionality

**Testing:**
- Verified telemetry shutdown completes successfully
- No existing features affected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the telemetry exit handler to perform a full shutdown instead of only flushing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->