### PR TITLE
fix: make TelemetryCollector.stop() consistent with shutdown behavior

### DIFF
--- a/src/praisonai-agents/praisonaiagents/telemetry/telemetry.py
+++ b/src/praisonai-agents/praisonaiagents/telemetry/telemetry.py
@@ -354,8 +354,8 @@ class TelemetryCollector:
         pass
         
     def stop(self):
-        """Stop telemetry collection and flush data."""
-        self.telemetry.flush()
+        """Stop telemetry collection and properly shutdown."""
+        self.telemetry.shutdown()
     
     def trace_agent_execution(self, agent_name: str, **attributes):
         """Compatibility method for agent execution tracking."""


### PR DESCRIPTION
Ensures TelemetryCollector.stop() calls shutdown() instead of just flush() for consistency with the main atexit handler and proper PostHog session cleanup.