### PR TITLE
Fix: Comprehensive telemetry cleanup to prevent agent termination hang

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1958,12 +1958,10 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         """Clean up telemetry system to ensure proper program termination."""
         try:
             # Import here to avoid circular imports
-            from ..telemetry import get_telemetry
+            from ..telemetry import force_shutdown_telemetry
             
-            # Get the global telemetry instance and shut it down
-            telemetry = get_telemetry()
-            if telemetry and hasattr(telemetry, 'shutdown'):
-                telemetry.shutdown()
+            # Force shutdown of telemetry system with comprehensive cleanup
+            force_shutdown_telemetry()
         except Exception as e:
             # Log error but don't fail the execution
             logging.debug(f"Error cleaning up telemetry: {e}")

--- a/src/praisonai-agents/praisonaiagents/telemetry/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/telemetry/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     'get_telemetry',
     'enable_telemetry',
     'disable_telemetry',
+    'force_shutdown_telemetry',
     'MinimalTelemetry',
     'TelemetryCollector',  # For backward compatibility
 ]
@@ -45,6 +46,12 @@ def disable_telemetry():
     """Disable telemetry."""
     from .telemetry import disable_telemetry as _disable_telemetry
     _disable_telemetry()
+
+
+def force_shutdown_telemetry():
+    """Force shutdown of telemetry system with comprehensive cleanup."""
+    from .telemetry import force_shutdown_telemetry as _force_shutdown_telemetry
+    _force_shutdown_telemetry()
 
 
 # Auto-instrumentation and cleanup setup


### PR DESCRIPTION
This PR addresses the critical issue where PraisonAI agents would not terminate properly after completing their tasks, requiring manual interruption.

**Root Cause:** PostHog telemetry client running in async mode creates background threads that persist after standard shutdown() calls.

**Solution:**
- Enhanced telemetry shutdown mechanism with comprehensive thread cleanup
- Added force_shutdown_telemetry() function for robust cleanup
- Implemented timeout-based thread termination with proper error handling
- Updated agent._cleanup_telemetry() to use the new robust cleanup method

**Impact:**
✅ Agents now terminate cleanly without hanging
✅ Maintains full backward compatibility
✅ Comprehensive thread cleanup prevents resource leaks
✅ Timeout mechanism prevents infinite waiting

Closes the original termination issue reported in PR #999

🤖 Generated with [Claude Code](https://claude.ai/code)