### PR TITLE
Fix: Agent.start() now properly displays streaming output

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -2012,9 +2012,17 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     return result
                 else:
                     # Auto-consume the generator for convenience while preserving display
-                    final_response = None
+                    final_response = ""
                     for chunk in result:
-                        final_response = chunk  # Last chunk is typically the final response
+                        if chunk:  # Only process non-empty chunks
+                            if self.verbose:
+                                print(chunk, end='', flush=True)
+                            final_response += chunk
+                    
+                    # Print newline after streaming is complete
+                    if self.verbose and final_response:
+                        print()
+                    
                     return final_response
             else:
                 result = self.chat(prompt, **kwargs)


### PR DESCRIPTION
This PR fixes the remaining issue from #1004 where Agent.start() was not properly displaying streaming output.

## Changes
- Fixed the auto-consume mechanism to display streaming chunks as they're processed
- Returns complete accumulated response instead of just the last chunk
- Maintains backward compatibility with return_generator=True parameter
- Ensures proper output display when verbose=True

## Root Cause
The issue was that the Agent.start() method was consuming the generator silently without showing streaming output to the user. The method would iterate through all chunks but only return the last one, providing no visual feedback during execution.

## Testing
- ✅ Now shows streaming output during execution
- ✅ Returns complete accumulated response
- ✅ Backward compatibility maintained with return_generator=True
- ✅ Works with both streaming and non-streaming modes

Generated with [Claude Code](https://claude.ai/code)