### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -91,7 +91,7 @@ call = [
 ]
 train = []
 crewai = ["crewai>=0.32.0", "praisonai-tools>=0.0.22"]
-autogen = ["pyautogen==0.2.29", "praisonai-tools>=0.0.22", "crewai"]
+autogen = ["ag2==0.2.29", "praisonai-tools>=0.0.22", "crewai"]
 autogen-v4 = [
     "autogen-agentchat>=0.4.0", 
     "autogen-ext[openai]>=0.4.0", 
@@ -125,7 +125,7 @@ python-dotenv = ">=0.19.0"
 instructor = ">=1.3.3"
 PyYAML = ">=6.0"
 mcp = ">=1.6.0"
-pyautogen = {version = "==0.2.29", optional = true}
+ag2 = {version = "==0.2.29", optional = true}
 autogen-agentchat = {version = ">=0.4.0", optional = true}
 autogen-ext = {version = ">=0.4.0", optional = true}
 autogen-core = {version = ">=0.4.0", optional = true}
@@ -286,7 +286,7 @@ call = [
     "openai",
 ]
 crewai = ["crewai", "praisonai-tools"]
-autogen = ["pyautogen", "praisonai-tools", "crewai"]
+autogen = ["ag2", "praisonai-tools", "crewai"]
 autogen-v4 = ["autogen-agentchat", "autogen-ext", "autogen-core", "praisonai-tools", "crewai"]
 
 [tool.poetry-dynamic-versioning]

--- a/src/praisonai/tests/integration/README.md
+++ b/src/praisonai/tests/integration/README.md
@@ -145,7 +145,7 @@ python -m pytest tests/integration/autogen/test_autogen_basic.py::TestAutoGenInt
 
 ### Required for AutoGen Tests:
 ```bash
-pip install pyautogen
+pip install ag2
 ```
 
 ### Required for CrewAI Tests:
@@ -251,7 +251,7 @@ To add tests for a new framework (e.g., `langchain`):
 ```
 ImportError: No module named 'autogen'
 ```
-**Solution:** Install the framework: `pip install pyautogen`
+**Solution:** Install the framework: `pip install ag2`
 
 **Path Issues:**
 ```


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
