### PR TITLE
fix: prevent PostHog shutdown errors during interpreter shutdown

### DIFF
--- a/src/praisonai-agents/praisonaiagents/telemetry/telemetry.py
+++ b/src/praisonai-agents/praisonaiagents/telemetry/telemetry.py
@@ -347,6 +347,12 @@ class MinimalTelemetry:
         posthog_client = getattr(self, '_posthog', None)
         if posthog_client:
             try:
+                # Check if Python interpreter is shutting down
+                if self._is_interpreter_shutting_down():
+                    self.logger.debug("Interpreter shutting down, skipping PostHog operations")
+                    self._posthog = None
+                    return
+                
                 # Use a timeout-based flush to prevent hanging
                 import threading
                 import time
@@ -368,27 +374,90 @@ class MinimalTelemetry:
                 # Cleanup PostHog threads safely
                 self._shutdown_posthog_threads(posthog_client)
                 
-                # Standard shutdown
-                posthog_client.shutdown()
+                # Standard shutdown - with interpreter shutdown check
+                if not self._is_interpreter_shutting_down():
+                    posthog_client.shutdown()
+                else:
+                    self.logger.debug("Skipping PostHog shutdown call due to interpreter shutdown")
                 
             except Exception as e:
-                # Log the error but don't fail shutdown
-                self.logger.error(f"Error during PostHog shutdown: {e}")
+                # Handle specific shutdown-related errors gracefully
+                error_msg = str(e).lower()
+                if any(phrase in error_msg for phrase in [
+                    'cannot schedule new futures',
+                    'interpreter shutdown',
+                    'atexit after shutdown',
+                    'event loop closed',
+                    'runtime is shutting down'
+                ]):
+                    self.logger.debug(f"PostHog shutdown prevented due to interpreter shutdown: {e}")
+                else:
+                    self.logger.error(f"Error during PostHog shutdown: {e}")
             finally:
                 self._posthog = None
+    
+    def _is_interpreter_shutting_down(self) -> bool:
+        """
+        Check if the Python interpreter is shutting down.
+        
+        Returns:
+            True if interpreter is shutting down, False otherwise
+        """
+        try:
+            import sys
+            import threading
+            
+            # Check if the interpreter is in shutdown mode
+            if hasattr(sys, 'is_finalizing') and sys.is_finalizing():
+                return True
+            
+            # Check if we can create new threads (fails during shutdown)
+            try:
+                import threading
+                test_thread = threading.Thread(target=lambda: None)
+                test_thread.daemon = True
+                test_thread.start()
+                test_thread.join(timeout=0.001)
+                return False
+            except (RuntimeError, threading.ThreadError):
+                return True
+                
+        except Exception:
+            # If we can't determine state, assume we're shutting down to be safe
+            return True
     
     def _safe_flush_posthog(self, posthog_client):
         """Safely flush PostHog data with error handling."""
         try:
+            # Skip flush if interpreter is shutting down
+            if self._is_interpreter_shutting_down():
+                self.logger.debug("Skipping PostHog flush due to interpreter shutdown")
+                return False
+                
             posthog_client.flush()
             return True
         except Exception as e:
-            self.logger.debug(f"PostHog flush error: {e}")
+            error_msg = str(e).lower()
+            if any(phrase in error_msg for phrase in [
+                'cannot schedule new futures',
+                'interpreter shutdown',
+                'atexit after shutdown',
+                'event loop closed',
+                'runtime is shutting down'
+            ]):
+                self.logger.debug(f"PostHog flush prevented due to interpreter shutdown: {e}")
+            else:
+                self.logger.debug(f"PostHog flush error: {e}")
             return False
     
     def _shutdown_posthog_threads(self, posthog_client):
         """Safely shutdown PostHog background threads."""
         try:
+            # Skip thread cleanup if interpreter is shutting down
+            if self._is_interpreter_shutting_down():
+                self.logger.debug("Skipping PostHog thread cleanup due to interpreter shutdown")
+                return
+                
             # Access thread pool safely (fix double shutdown issue)
             thread_pool = getattr(posthog_client, '_thread_pool', None)
             if thread_pool:
@@ -400,7 +469,16 @@ class MinimalTelemetry:
                         import time
                         time.sleep(0.5)
                 except Exception as e:
-                    self.logger.debug(f"Thread pool shutdown error: {e}")
+                    error_msg = str(e).lower()
+                    if any(phrase in error_msg for phrase in [
+                        'cannot schedule new futures',
+                        'interpreter shutdown',
+                        'atexit after shutdown',
+                        'event loop closed'
+                    ]):
+                        self.logger.debug(f"Thread pool shutdown prevented due to interpreter shutdown: {e}")
+                    else:
+                        self.logger.debug(f"Thread pool shutdown error: {e}")
             
             # Clean up consumer
             consumer = getattr(posthog_client, '_consumer', None)
@@ -411,10 +489,28 @@ class MinimalTelemetry:
                     if hasattr(consumer, 'shutdown'):
                         consumer.shutdown()
                 except Exception as e:
-                    self.logger.debug(f"Consumer shutdown error: {e}")
+                    error_msg = str(e).lower()
+                    if any(phrase in error_msg for phrase in [
+                        'cannot schedule new futures',
+                        'interpreter shutdown',
+                        'atexit after shutdown',
+                        'event loop closed'
+                    ]):
+                        self.logger.debug(f"Consumer shutdown prevented due to interpreter shutdown: {e}")
+                    else:
+                        self.logger.debug(f"Consumer shutdown error: {e}")
                     
         except Exception as e:
-            self.logger.debug(f"Error during PostHog thread cleanup: {e}")
+            error_msg = str(e).lower()
+            if any(phrase in error_msg for phrase in [
+                'cannot schedule new futures',
+                'interpreter shutdown',
+                'atexit after shutdown',
+                'event loop closed'
+            ]):
+                self.logger.debug(f"PostHog thread cleanup prevented due to interpreter shutdown: {e}")
+            else:
+                self.logger.debug(f"Error during PostHog thread cleanup: {e}")
 
 
 # Global telemetry instance

--- a/src/praisonai-agents/praisonaiagents/telemetry/telemetry.py
+++ b/src/praisonai-agents/praisonaiagents/telemetry/telemetry.py
@@ -419,7 +419,6 @@ class MinimalTelemetry:
         """
         try:
             import sys
-            import threading
             
             # Check if the interpreter is in shutdown mode
             if hasattr(sys, 'is_finalizing') and sys.is_finalizing():


### PR DESCRIPTION
Fixes # 1011

This PR addresses the PostHog shutdown error "cannot schedule new futures after interpreter shutdown" by implementing robust interpreter shutdown detection and prevention mechanisms.

## Changes
- Add interpreter shutdown detection using `sys.is_finalizing()` and thread tests
- Skip PostHog operations when interpreter is shutting down
- Enhanced error handling with specific shutdown error message filtering
- Apply shutdown prevention to flush, thread cleanup, and shutdown operations
- Maintain full backward compatibility with existing API
- Add comprehensive debug logging for shutdown scenarios

## Testing
- Custom test script verifies no shutdown errors
- Interpreter shutdown detection working correctly
- All existing functionality preserved

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the shutdown process of the telemetry system to prevent errors or hangs during Python interpreter shutdown.
  * Enhanced error handling and logging for telemetry cleanup operations during application exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->