### PR TITLE
fix: correct display_generating logic to only show when stream=False AND verbose=True

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1070,7 +1070,7 @@ Your Goal: {self.goal}"""
             tools=formatted_tools,
             start_time=start_time,
             console=self.console,
-            display_fn=display_generating if (not True and self.verbose) else None,  # stream is True in this context
+            display_fn=display_generating if (not stream and self.verbose) else None,  # stream is True in this context
             reasoning_steps=reasoning_steps
         )
 

--- a/test_comprehensive_display_fix.py
+++ b/test_comprehensive_display_fix.py
@@ -18,8 +18,8 @@ def test_display_logic():
     test_cases = [
         {"stream": False, "verbose": False, "expected": False, "description": "No display (stream=False, verbose=False)"},
         {"stream": False, "verbose": True, "expected": True, "description": "Display in verbose mode (stream=False, verbose=True) - MAIN FIX"},
-        {"stream": True, "verbose": False, "expected": True, "description": "Display in stream mode (stream=True, verbose=False)"},
-        {"stream": True, "verbose": True, "expected": True, "description": "Display in both modes (stream=True, verbose=True)"},
+        {"stream": True, "verbose": False, "expected": False, "description": "No display when streaming (stream=True, verbose=False)"},
+        {"stream": True, "verbose": True, "expected": False, "description": "No display when streaming (stream=True, verbose=True)"},
     ]
     
     print(f"{'Description':<55} {'Stream':<8} {'Verbose':<8} {'Expected':<8} {'Result':<8} {'Status'}")
@@ -28,7 +28,7 @@ def test_display_logic():
     all_passed = True
     for case in test_cases:
         # Test the actual logic used in the fix
-        result = (case["stream"] or case["verbose"])
+        result = (not case["stream"] and case["verbose"])
         expected = case["expected"]
         status = "✅ PASS" if result == expected else "❌ FAIL"
         
@@ -61,11 +61,11 @@ def test_agent_paths():
         content = f.read()
     
     # Check for OpenAI path fix
-    openai_fix = "display_fn=display_generating if (stream or self.verbose) else None"
+    openai_fix = "display_fn=display_generating if (not stream and self.verbose) else None"
     has_openai_fix = openai_fix in content
     
     # Check for custom LLM path fix  
-    custom_llm_fix = "if (stream or self.verbose) and self.console:"
+    custom_llm_fix = "if (not stream and self.verbose) and self.console:"
     has_custom_fix = custom_llm_fix in content
     
     print(f"OpenAI path fix present: {'✅ YES' if has_openai_fix else '❌ NO'}")
@@ -84,14 +84,14 @@ def test_backward_compatibility():
     
     # Test cases that should maintain existing behavior
     scenarios = [
-        {"name": "Default streaming behavior", "stream": True, "verbose": True, "should_display": True},
+        {"name": "Default streaming behavior", "stream": True, "verbose": True, "should_display": False},
         {"name": "Non-verbose non-streaming", "stream": False, "verbose": False, "should_display": False},
-        {"name": "Streaming with verbose off", "stream": True, "verbose": False, "should_display": True},
+        {"name": "Streaming with verbose off", "stream": True, "verbose": False, "should_display": False},
     ]
     
     all_compat = True
     for scenario in scenarios:
-        result = (scenario["stream"] or scenario["verbose"])
+        result = (not scenario["stream"] and scenario["verbose"])
         expected = scenario["should_display"]
         status = "✅ COMPATIBLE" if result == expected else "❌ INCOMPATIBLE"
         

--- a/test_logic.py
+++ b/test_logic.py
@@ -8,7 +8,7 @@ def original_logic(stream, verbose):
 
 # Fixed logic  
 def fixed_logic(stream, verbose):
-    return (stream or verbose)
+    return (not stream and verbose)
 
 print("=== Testing display_generating logic fix ===")
 
@@ -16,8 +16,8 @@ print("=== Testing display_generating logic fix ===")
 test_cases = [
     {"stream": False, "verbose": False, "expected_display": False, "description": "No verbose, no stream"},
     {"stream": False, "verbose": True, "expected_display": True, "description": "Verbose but no stream (user's case)"},
-    {"stream": True, "verbose": False, "expected_display": True, "description": "Stream but no verbose"}, 
-    {"stream": True, "verbose": True, "expected_display": True, "description": "Both stream and verbose"},
+    {"stream": True, "verbose": False, "expected_display": False, "description": "Stream but no verbose (no display when streaming)"}, 
+    {"stream": True, "verbose": True, "expected_display": False, "description": "Both stream and verbose (no display when streaming)"},
 ]
 
 print(f"{'Description':<35} {'Stream':<8} {'Verbose':<8} {'Original':<10} {'Fixed':<8} {'Expected':<8} {'Status'}")
@@ -39,10 +39,10 @@ for case in test_cases:
 print("-" * 80)
 if all_passed:
     print("✅ All tests PASSED! The fix should work correctly.")
-    print("✅ display_generating will now be called when verbose=True, even with stream=False")
+    print("✅ display_generating will now ONLY be called when stream=False AND verbose=True")
 else:
     print("❌ Some tests FAILED!")
 
 print("\n=== Key Fix ===")
-print("Before: display_fn=display_generating if stream else None") 
-print("After:  display_fn=display_generating if (stream or verbose) else None")
+print("Before: display_fn=display_generating if (stream or verbose) else None") 
+print("After:  display_fn=display_generating if (not stream and verbose) else None")


### PR DESCRIPTION
Fixes the display_generating logic to match user requirements:

- Only show "Generating..." when stream=False AND verbose=True
- No display when streaming is active
- Updated both OpenAI and custom LLM code paths
- Updated test files to reflect correct expected behavior

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the "Generating..." message appeared during streaming responses; it now only displays in non-streaming verbose mode.
  * Adjusted async chat behavior to remove live console updates during streaming.

* **Tests**
  * Updated test cases to reflect the new display logic, ensuring output is only shown when streaming is off and verbose mode is on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->