### PR TITLE
fix: resolve display_generating issue by ensuring stream parameter is correctly passed

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1967,6 +1967,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             return self._start_stream(prompt, **kwargs)
         else:
             # Return regular chat response for backward compatibility
+            # Explicitly pass the resolved stream parameter to avoid chat() method default
+            kwargs['stream'] = stream_enabled
             return self.chat(prompt, **kwargs)
 
     def _start_stream(self, prompt: str, **kwargs) -> Generator[str, None, None]:


### PR DESCRIPTION
Fixes the display_generating functionality that wasn't working when calling `agent.start()` with default parameters.

## Problem
The `start() method wasn't explicitly passing the resolved `stream` parameter to the `chat() method, causing the chat method's default `stream=True` to override the agent's intended `stream=False` setting.

## Solution
Explicitly pass the resolved stream parameter in the start() method to ensure display_generating shows when `stream=False` and `verbose=True`.

## Testing
- Verified logic flow: (not stream and verbose) now correctly evaluates to True
- Agent defaults work as expected: verbose=True, stream=False
- display_generating will now appear for the user's test case

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in handling streaming preferences, ensuring the correct streaming option is always applied during agent interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->