### PR TITLE
Fix: Add display_generating support for OpenAI non-streaming mode

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -838,14 +838,30 @@ class OpenAIClient:
                 )
             else:
                 # Process as regular non-streaming response
-                final_response = self.create_completion(
-                    messages=messages,
-                    model=model,
-                    temperature=temperature,
-                    tools=formatted_tools,
-                    stream=False,
-                    **kwargs
-                )
+                if display_fn and console:
+                    # Show display_generating animation for non-streaming mode when display_fn is provided
+                    with Live(display_fn("", start_time), console=console, refresh_per_second=4) as live:
+                        final_response = self.create_completion(
+                            messages=messages,
+                            model=model,
+                            temperature=temperature,
+                            tools=formatted_tools,
+                            stream=False,
+                            **kwargs
+                        )
+                        # Update display with empty content as we don't have streaming chunks
+                        if final_response and final_response.choices:
+                            content = final_response.choices[0].message.content or ""
+                            live.update(display_fn(content, start_time))
+                else:
+                    final_response = self.create_completion(
+                        messages=messages,
+                        model=model,
+                        temperature=temperature,
+                        tools=formatted_tools,
+                        stream=False,
+                        **kwargs
+                    )
             
             if not final_response:
                 return None


### PR DESCRIPTION
This PR fixes the missing display_generating functionality for OpenAI models by adding support for the display_fn parameter in non-streaming mode.

## Problem
OpenAI models were not showing the "Generating..." display while Gemini models were working correctly.

## Root Cause
Gemini models use the custom LLM path (`_using_custom_llm=True`) which has built-in display_generating support, while OpenAI models use the OpenAI client path (`_using_custom_llm=False`). In the OpenAI client's `chat_completion_with_tools` method, the non-streaming path was calling `create_completion` without using the `display_fn` parameter.

## Solution
Modified `/src/praisonai-agents/praisonaiagents/llm/openai_client.py` to wrap the `create_completion` call with a `Live(display_fn(...))` context when `display_fn` and `console` are provided.

## Testing
Now both model types show the "Generating..." display:
- Gemini (`llm="gemini/gemini-2.5-pro"`) ✅ Working
- OpenAI (`llm="gpt-4o-mini"`) ✅ Now working

Generated with [Claude Code](https://claude.ai/code)