### PR TITLE
fix: Remove display_generating when stream=false to prevent streaming-like behavior

### DIFF
--- a/display_generating_fix_summary.md
+++ b/display_generating_fix_summary.md
@@ -1,0 +1,37 @@
+# Fix for display_generating Issue
+
+## Problem
+When `stream=false` but `verbose=true`, the system was still showing streaming-like visual behavior ("Generating... X.Xs") because the code was using `display_generating` function even when the user explicitly set `stream=false`.
+
+## Root Cause
+Two locations in `agent.py` were passing `display_generating` as `display_fn` when `stream=False` and `verbose=True`:
+
+- **Line 1073**: `display_fn=display_generating if (not stream and self.verbose) else None`
+- **Line 1172**: `display_fn=display_generating if (not stream and self.verbose) else None`
+
+This conflated two different concepts:
+- **Verbose**: Show detailed information  
+- **Visual Progress**: Show animated progress indicators
+
+## Solution
+Changed both locations to:
+```python
+display_fn=None,  # Don't use display_generating when stream=False to avoid streaming-like behavior
+```
+
+## Expected Behavior After Fix
+
+| Stream | Verbose | Visual Behavior |
+|--------|---------|----------------|
+| False  | False   | No display |
+| False  | True    | **No streaming-like behavior (FIXED)** |
+| True   | False   | Native streaming display |  
+| True   | True    | Native streaming display |
+
+## Files Modified
+- `src/praisonai-agents/praisonaiagents/agent/agent.py` - Lines 1073 and 1172
+
+## Verification
+- Test script: `test_display_generating_fix.py` 
+- All old problematic patterns removed
+- New safe patterns implemented at both locations

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1070,7 +1070,7 @@ Your Goal: {self.goal}"""
             tools=formatted_tools,
             start_time=start_time,
             console=self.console,
-            display_fn=display_generating if (not stream and self.verbose) else None,  # stream is True in this context
+            display_fn=None,  # Don't use display_generating when stream=False to avoid streaming-like behavior
             reasoning_steps=reasoning_steps
         )
 
@@ -1169,7 +1169,7 @@ Your Goal: {self.goal}"""
                     execute_tool_fn=self.execute_tool,
                     stream=stream,
                     console=self.console if (self.verbose or stream) else None,
-                    display_fn=display_generating if (not stream and self.verbose) else None,
+                    display_fn=None,  # Don't use display_generating when stream=False to avoid streaming-like behavior
                     reasoning_steps=reasoning_steps,
                     verbose=self.verbose,
                     max_iterations=10

--- a/test_display_generating_fix.py
+++ b/test_display_generating_fix.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Test script to verify that display_generating fix is working correctly.
+This script checks that the problematic patterns have been removed from agent.py.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+def test_display_generating_fix():
+    """Test that the display_generating fix has been applied correctly."""
+    
+    agent_file = Path("src/praisonai-agents/praisonaiagents/agent/agent.py")
+    
+    if not agent_file.exists():
+        print(f"❌ ERROR: {agent_file} not found")
+        return False
+    
+    content = agent_file.read_text()
+    
+    # Check that the old problematic patterns are gone
+    old_pattern = r"display_fn=display_generating if \(not stream and self\.verbose\) else None"
+    old_matches = re.findall(old_pattern, content)
+    
+    if old_matches:
+        print(f"❌ FAILED: Found {len(old_matches)} instances of old problematic pattern:")
+        print(f"   'display_fn=display_generating if (not stream and self.verbose) else None'")
+        return False
+    
+    # Check that the new safe patterns are present
+    new_pattern = r"display_fn=None,\s*# Don't use display_generating when stream=False to avoid streaming-like behavior"
+    new_matches = re.findall(new_pattern, content)
+    
+    if len(new_matches) < 2:
+        print(f"❌ FAILED: Expected at least 2 instances of new pattern, found {len(new_matches)}")
+        print("   Expected: 'display_fn=None,  # Don't use display_generating when stream=False to avoid streaming-like behavior'")
+        return False
+    
+    print("✅ SUCCESS: display_generating fix has been applied correctly!")
+    print(f"   - Removed old problematic patterns: 0 found (expected 0)")
+    print(f"   - Added new safe patterns: {len(new_matches)} found (expected >= 2)")
+    
+    # Show the context of the changes
+    lines = content.split('\n')
+    for i, line in enumerate(lines, 1):
+        if "Don't use display_generating when stream=False" in line:
+            print(f"   - Line {i}: {line.strip()}")
+    
+    return True
+
+if __name__ == "__main__":
+    success = test_display_generating_fix()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
This PR fixes the issue where `display_generating` was creating streaming-like visual behavior even when `stream=false` was explicitly set.

## Problem
When `stream=false` but `verbose=true`, the system was incorrectly showing streaming-like visual behavior ("Generating... X.Xs") due to `display_generating` being used even when users explicitly set `stream=false`.

## Solution
Fixed by changing `display_fn` from `display_generating` to `None` when `stream=false` in both locations (lines 1073 and 1172) in agent.py.

This ensures true non-streaming behavior when `stream=false` is set, regardless of verbose setting.

## Files Modified
- `src/praisonai-agents/praisonaiagents/agent/agent.py` - Core fix
- `test_display_generating_fix.py` - Verification test
- `display_generating_fix_summary.md` - Documentation

## Testing
- Test script confirms old problematic patterns removed
- New safe patterns implemented at both locations
- No `display_generating` calls when `stream=False`

Generated with [Claude Code](https://claude.ai/code)