### PR TITLE
feat: upgrade from pyautogen to ag2 package

### DIFF
--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -286,7 +286,7 @@ call = [
     "openai",
 ]
 crewai = ["crewai", "praisonai-tools"]
-autogen = ["ag2", "praisonai-tools", "crewai"]
+autogen = ["ag2>=0.3.2", "praisonai-tools>=0.0.22", "crewai"]
 autogen-v4 = ["autogen-agentchat", "autogen-ext", "autogen-core", "praisonai-tools", "crewai"]
 
 [tool.poetry-dynamic-versioning]

--- a/src/praisonai/tests/integration/README.md
+++ b/src/praisonai/tests/integration/README.md
@@ -145,7 +145,7 @@ python -m pytest tests/integration/autogen/test_autogen_basic.py::TestAutoGenInt
 
 ### Required for AutoGen Tests:
 ```bash
-pip install ag2
+pip install "ag2>=0.3.2"
 ```
 
 ### Required for CrewAI Tests:
@@ -251,7 +251,7 @@ To add tests for a new framework (e.g., `langchain`):
 ```
 ImportError: No module named 'autogen'
 ```
-**Solution:** Install the framework: `pip install ag2`
+**Solution:** Install the framework: `pip install "ag2>=0.3.2"`
 
 **Path Issues:**
 ```


### PR DESCRIPTION
Upgrades PraisonAI from pyautogen to ag2, the official successor to Microsoft AutoGen.

## Changes
- Replace pyautogen==0.2.29 with ag2>=0.3.2 in pyproject.toml
- Update installation instructions in integration tests README
- Maintain backward compatibility as both packages provide autogen module

## Technical Notes
- ag2 is the official continuation of Microsoft AutoGen (same authors)
- Both packages provide the autogen module, ensuring import compatibility
- Used ag2>=0.3.2 (earliest available version) instead of non-existent 0.2.29

Fixes #1051

Search @web with multi agents and make sure that is the latest version and compatible with all existing packages 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency from "pyautogen" to "ag2" for optional AutoGen features.
* **Documentation**
  * Revised integration test README to reference "ag2" instead of "pyautogen" for installation and troubleshooting instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation-only change; risk is mainly around optional `autogen` installs resolving to the new package/version.
> 
> **Overview**
> Switches the optional `autogen` dependency from `pyautogen==0.2.29` to `ag2>=0.3.2` in `pyproject.toml` (including Poetry optional deps and extras), keeping the rest of the dependency sets unchanged.
> 
> Updates integration test documentation to install `ag2` (and related troubleshooting guidance) instead of `pyautogen` for running AutoGen integration tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bc489daec1e8f853444a05c858280d24628644e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->