### PR TITLE
fix: resolve zero token metrics by fixing agent LLM instance access

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -414,7 +414,6 @@ Context:
             )
             
             # Add token metrics if available
-            llm = getattr(executor_agent, 'llm', None) or getattr(executor_agent, 'llm_instance', None)
             if llm and hasattr(llm, 'last_token_metrics'):
                 token_metrics = llm.last_token_metrics
                 if token_metrics:
@@ -774,7 +773,6 @@ Context:
             )
             
             # Add token metrics if available
-            llm = getattr(executor_agent, 'llm', None) or getattr(executor_agent, 'llm_instance', None)
             if llm and hasattr(llm, 'last_token_metrics'):
                 token_metrics = llm.last_token_metrics
                 if token_metrics:

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -313,8 +313,9 @@ class PraisonAIAgents:
         executor_agent = task.agent
         
         # Set current agent for token tracking
-        if hasattr(executor_agent, 'llm') and hasattr(executor_agent.llm, 'set_current_agent'):
-            executor_agent.llm.set_current_agent(executor_agent.name)
+        llm = getattr(executor_agent, 'llm', None) or getattr(executor_agent, 'llm_instance', None)
+        if llm and hasattr(llm, 'set_current_agent'):
+            llm.set_current_agent(executor_agent.name)
 
         # Ensure tools are available from both task and agent
         tools = task.tools or []
@@ -413,8 +414,9 @@ Context:
             )
             
             # Add token metrics if available
-            if hasattr(executor_agent, 'llm') and hasattr(executor_agent.llm, 'last_token_metrics'):
-                token_metrics = executor_agent.llm.last_token_metrics
+            llm = getattr(executor_agent, 'llm', None) or getattr(executor_agent, 'llm_instance', None)
+            if llm and hasattr(llm, 'last_token_metrics'):
+                token_metrics = llm.last_token_metrics
                 if token_metrics:
                     task_output.token_metrics = token_metrics
 
@@ -651,8 +653,9 @@ Context:
         executor_agent = task.agent
         
         # Set current agent for token tracking
-        if hasattr(executor_agent, 'llm') and hasattr(executor_agent.llm, 'set_current_agent'):
-            executor_agent.llm.set_current_agent(executor_agent.name)
+        llm = getattr(executor_agent, 'llm', None) or getattr(executor_agent, 'llm_instance', None)
+        if llm and hasattr(llm, 'set_current_agent'):
+            llm.set_current_agent(executor_agent.name)
 
         task_prompt = f"""
 You need to do the following task: {task.description}.
@@ -771,8 +774,9 @@ Context:
             )
             
             # Add token metrics if available
-            if hasattr(executor_agent, 'llm') and hasattr(executor_agent.llm, 'last_token_metrics'):
-                token_metrics = executor_agent.llm.last_token_metrics
+            llm = getattr(executor_agent, 'llm', None) or getattr(executor_agent, 'llm_instance', None)
+            if llm and hasattr(llm, 'last_token_metrics'):
+                token_metrics = llm.last_token_metrics
                 if token_metrics:
                     task_output.token_metrics = token_metrics
 


### PR DESCRIPTION
Fixes # 1060 - Token metrics not displaying when using `agents.run()`

This PR fixes the critical bug in token tracking where agents.run() with metrics=True showed 0 tokens.

## Problem
The code tried to access `executor_agent.llm` directly, but agents might have either `llm` or `llm_instance` attributes.

## Solution
- Updated 4 locations in agents.py to use correct getattr pattern
- Ensures proper agent name attribution for token tracking
- Zero performance impact - maintains existing execution flow
- Fully backward compatible

## Testing
- Verified LLM instance access works with new pattern
- Confirmed agent name attribution for token tracking
- Tested in execute_task context

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with agents that use either an `llm` or `llm_instance` attribute, ensuring smoother handling of token tracking and metrics in various agent configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->