### PR TITLE
fix: resolve MongoDB SearchIndexModel missing definition argument

### DIFF
--- a/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
+++ b/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
@@ -159,7 +159,14 @@ class MongoDBMemory:
                 }
             }
             
-            self.collection.create_search_index(vector_index_def, "vector_index")
+            # Use SearchIndexModel for PyMongo 4.6+ compatibility
+            try:
+                from pymongo.operations import SearchIndexModel
+                search_index_model = SearchIndexModel(definition=vector_index_def, name="vector_index")
+                self.collection.create_search_index(search_index_model)
+            except ImportError:
+                # Fallback for older PyMongo versions
+                self.collection.create_search_index(vector_index_def, "vector_index")
             
         except Exception as e:
             logging.warning(f"Could not create vector search index: {e}")

--- a/src/praisonai-agents/praisonaiagents/memory/memory.py
+++ b/src/praisonai-agents/praisonaiagents/memory/memory.py
@@ -377,8 +377,16 @@ class Memory:
             
             # Create vector indexes for both short and long term collections
             try:
-                self.mongo_short_term.create_search_index(vector_index_def, "vector_index")
-                self.mongo_long_term.create_search_index(vector_index_def, "vector_index")
+                # Use SearchIndexModel for PyMongo 4.6+ compatibility
+                try:
+                    from pymongo.operations import SearchIndexModel
+                    search_index_model = SearchIndexModel(definition=vector_index_def, name="vector_index")
+                    self.mongo_short_term.create_search_index(search_index_model)
+                    self.mongo_long_term.create_search_index(search_index_model)
+                except ImportError:
+                    # Fallback for older PyMongo versions
+                    self.mongo_short_term.create_search_index(vector_index_def, "vector_index")
+                    self.mongo_long_term.create_search_index(vector_index_def, "vector_index")
                 self._log_verbose("Vector search indexes created successfully")
             except Exception as e:
                 self._log_verbose(f"Could not create vector search indexes: {e}", logging.WARNING)

--- a/src/praisonai-agents/praisonaiagents/tools/mongodb_tools.py
+++ b/src/praisonai-agents/praisonaiagents/tools/mongodb_tools.py
@@ -335,7 +335,14 @@ class MongoDBTools:
             }
             
             try:
-                collection.create_search_index(index_definition, index_name)
+                # Use SearchIndexModel for PyMongo 4.6+ compatibility
+                try:
+                    from pymongo.operations import SearchIndexModel
+                    search_index_model = SearchIndexModel(definition=index_definition, name=index_name)
+                    collection.create_search_index(search_index_model)
+                except ImportError:
+                    # Fallback for older PyMongo versions
+                    collection.create_search_index(index_definition, index_name)
                 return {
                     "success": True,
                     "message": f"Vector search index '{index_name}' created successfully"


### PR DESCRIPTION
Fixes MongoDB vector search index creation error by using SearchIndexModel with proper definition parameter.

## Changes
- Import SearchIndexModel from pymongo.operations for PyMongo 4.6+ compatibility
- Use SearchIndexModel with definition parameter in _create_vector_index()
- Add backward compatibility fallback for older PyMongo versions
- Maintains zero performance overhead and preserves existing functionality

Fixes #1071

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility with multiple PyMongo versions for reliable vector index creation across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->