### PR TITLE
fix: Fix RAG integration tests to respect lazy loading pattern

### DIFF
--- a/src/praisonai/tests/integration/test_rag_integration.py
+++ b/src/praisonai/tests/integration/test_rag_integration.py
@@ -79,7 +79,11 @@ class TestRAGIntegration:
         
         assert agent.name == "RAG Knowledge Agent"
         assert hasattr(agent, 'knowledge')
-        # knowledge_config is passed to Knowledge constructor, not stored as attribute
+        # With lazy loading, knowledge is None until first use
+        assert agent._knowledge_sources is not None
+        assert agent._knowledge_processed == False
+        # Trigger knowledge processing
+        agent._ensure_knowledge_processed()
         assert agent.knowledge is not None
     
     @patch('chromadb.Client')
@@ -256,6 +260,11 @@ class TestRAGIntegration:
         
         assert agent.name == "Ollama RAG Agent"
         assert hasattr(agent, 'knowledge')
+        # With lazy loading, knowledge is None until first use
+        assert agent._knowledge_sources is not None
+        assert agent._knowledge_processed == False
+        # Trigger knowledge processing
+        agent._ensure_knowledge_processed()
         assert agent.knowledge is not None
     
     @patch('chromadb.Client')


### PR DESCRIPTION
## Summary
- Fixed RAG integration tests that were incorrectly expecting immediate knowledge availability
- Tests now properly check for lazy loading behavior instead of breaking the performance optimization
- Both failing tests (`test_agent_with_knowledge_config` and `test_ollama_rag_integration`) now pass

## Changes Made
- Modified two test cases to respect the lazy loading pattern:
  - Verify knowledge sources are stored (`_knowledge_sources is not None`)
  - Verify knowledge hasn't been processed yet (`_knowledge_processed == False`)
  - Manually trigger knowledge processing (`_ensure_knowledge_processed()`)
  - Then verify knowledge is available (`knowledge is not None`)

## Testing
- ✅ Both previously failing tests now pass
- ✅ All RAG integration tests pass (11/11)
- ✅ No performance impact - lazy loading preserved
- ✅ No regressions in existing functionality

## Technical Details
The issue was that the tests were checking implementation details rather than actual behavior. The agent correctly uses lazy loading where `knowledge` is `None` until first access, which is an intentional performance optimization. The tests were incorrectly expecting immediate availability.

This fix maintains the lazy loading performance benefits while ensuring the tests validate the correct behavior.

Resolves #1074

🤖 Generated with [Claude Code](https://claude.ai/code)