### PR TITLE
fix: handle None agent name when generating history session ID

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -996,7 +996,7 @@ class Agent:
             session_id = _history_session_id
         elif _history_enabled and session_id is None and _history_session_id is None:
             import hashlib as _hl
-            _agent_hash = _hl.md5(name.encode()).hexdigest()[:8]
+            _agent_hash = _hl.md5((name or "agent").encode()).hexdigest()[:8]
             session_id = f"history_{_agent_hash}"
             _history_session_id = session_id
         


### PR DESCRIPTION
## Problem

When creating an agent with `instructions` but without an explicit `name`, and memory history is enabled (`history=True`), the agent crashes with:

```
AttributeError: 'NoneType' object has no attribute 'encode'
```

This happens at line 999 in `agent.py`:

```python
_agent_hash = _hl.md5(name.encode()).hexdigest()[:8]
```

When no name is provided, `name` remains `None`, and calling `.encode()` on it fails.

## Fix

Use a fallback string when `name` is `None`:

```python
_agent_hash = _hl.md5((name or "agent").encode()).hexdigest()[:8]
```

This ensures a valid session ID is always generated, even for unnamed agents.

## How to reproduce

```python
from praisonaiagents import Agent

agent = Agent(instructions="Do something", history=True)
# Crashes with AttributeError before this fix
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session ID generation for agents created without explicit names, ensuring more reliable behavior when history tracking is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->