### PR TITLE
fix: correct duplicate gpt-4o-mini key in MODEL_WINDOWS to gpt-4o

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -107,7 +107,7 @@ class LLM:
     MODEL_WINDOWS = {
         # OpenAI
         "gpt-4": 6144,                    # 8,192 actual
-        "gpt-4o-mini": 96000,                  # 128,000 actual
+        "gpt-4o": 96000,                       # 128,000 actual
         "gpt-4o-mini": 96000,            # 128,000 actual
         "gpt-4-turbo": 96000,            # 128,000 actual
         "o1-preview": 96000,             # 128,000 actual


### PR DESCRIPTION
## Problem

The `MODEL_WINDOWS` dictionary in `llm.py` has a duplicate key bug:

```python
MODEL_WINDOWS = {
    "gpt-4o-mini": 96000,    # line 110 — should be "gpt-4o"
    "gpt-4o-mini": 96000,    # line 111 — actual gpt-4o-mini
    ...
}
```

Python dictionaries silently discard duplicate keys, keeping only the last value. The first entry was clearly intended to be `"gpt-4o"` (the full model, not the mini variant), but it was typed as `"gpt-4o-mini"` by mistake.

As a result, there is no context window entry for `gpt-4o`, so any agent using that model falls through to the default/fallback window size instead of getting the correct 96,000 token window.

## Fix

Changed the first entry from `"gpt-4o-mini"` to `"gpt-4o"` so both models are properly represented in the lookup table.

## How I found it

Noticed it while reviewing the model configuration — the comment structure and surrounding entries make it clear the intent was to list `gpt-4o` followed by `gpt-4o-mini`, matching the pattern used for other model families.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for GPT-4o model with a 96,000 token context window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->