### PR TITLE
feat(novita): add Novita AI provider integration

### DIFF
--- a/src/praisonai-agents/novita-basic.py
+++ b/src/praisonai-agents/novita-basic.py
@@ -14,11 +14,18 @@ Prerequisites:
 import os
 from praisonaiagents import Agent
 
+api_key = os.environ.get("NOVITA_API_KEY")
+if not api_key:
+    raise ValueError(
+        "The NOVITA_API_KEY environment variable is not set. "
+        "Please set it to your Novita AI API key."
+    )
+
 agent = Agent(
     instructions="You are a helpful assistant",
     llm="openai/moonshotai/kimi-k2.5",
     base_url="https://api.novita.ai/openai",
-    api_key=os.environ.get("NOVITA_API_KEY"),
+    api_key=api_key,
 )
 
 agent.start("Why is the sky blue?")

--- a/src/praisonai-agents/tests/unit/test_novita_provider.py
+++ b/src/praisonai-agents/tests/unit/test_novita_provider.py
@@ -44,54 +44,24 @@ class TestNovitaProviderConfig:
             )
         assert agent is not None
 
-    def test_agent_novita_kimi_model(self):
-        """Agent should accept Novita's Kimi model."""
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "openai/moonshotai/kimi-k2.5",
+            "openai/deepseek/deepseek-v3.2",
+            "openai/zai-org/glm-5",
+        ],
+    )
+    def test_agent_novita_models(self, model_name):
+        """Agent should accept various Novita models and store them correctly."""
         from praisonaiagents import Agent
 
         agent = Agent(
-            name="KimiTest",
+            name=f"NovitaModelTest-{model_name.split('/')[-1]}",
             instructions="You are a helpful assistant",
-            llm="openai/moonshotai/kimi-k2.5",
+            llm=model_name,
             base_url="https://api.novita.ai/openai",
             api_key="test-key",
         )
         assert agent is not None
-
-    def test_agent_novita_deepseek_model(self):
-        """Agent should accept Novita's DeepSeek model."""
-        from praisonaiagents import Agent
-
-        agent = Agent(
-            name="DeepSeekNovitaTest",
-            instructions="You are a helpful assistant",
-            llm="openai/deepseek/deepseek-v3.2",
-            base_url="https://api.novita.ai/openai",
-            api_key="test-key",
-        )
-        assert agent is not None
-
-    def test_agent_novita_glm_model(self):
-        """Agent should accept Novita's GLM model."""
-        from praisonaiagents import Agent
-
-        agent = Agent(
-            name="GLMNovitaTest",
-            instructions="You are a helpful assistant",
-            llm="openai/zai-org/glm-5",
-            base_url="https://api.novita.ai/openai",
-            api_key="test-key",
-        )
-        assert agent is not None
-
-    def test_agent_novita_model_stored(self):
-        """Agent should store the Novita model name correctly."""
-        from praisonaiagents import Agent
-
-        agent = Agent(
-            name="ModelStoreTest",
-            instructions="You are a helpful assistant",
-            llm="openai/moonshotai/kimi-k2.5",
-            base_url="https://api.novita.ai/openai",
-            api_key="test-key",
-        )
-        assert "kimi-k2.5" in agent.llm or "moonshotai" in agent.llm
+        assert agent.llm == model_name


### PR DESCRIPTION
## Summary

- Adds `novita-basic.py` example showing how to use Novita AI's OpenAI-compatible endpoint (`https://api.novita.ai/openai`) with PraisonAI agents
- Adds `tests/unit/test_novita_provider.py` with unit tests covering Novita provider configuration (base URL, API key, Kimi/DeepSeek/GLM model names)
- No changes to existing providers or core code — fully backward-compatible

## Usage

Set `NOVITA_API_KEY` to your Novita AI API key. Novita AI offers fast inference for Kimi K2.5, DeepSeek V3.2, GLM-5, and other open-source models.

## Test plan

- [ ] `pytest src/praisonai-agents/tests/unit/test_novita_provider.py` passes without real API calls
- [ ] Run `python src/praisonai-agents/novita-basic.py` with a valid `NOVITA_API_KEY` for end-to-end verification

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an example demonstrating Novita AI integration with PraisonAI Agents (uses environment-based API key and runs a sample query).

* **Tests**
  * Added unit tests validating Novita provider configuration, API key retrieval from environment, and support for multiple AI model identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->