### PR TITLE
fix: reject dangerous environment variable keys from YAML schedule config

### DIFF
--- a/src/praisonai/praisonai/cli/main.py
+++ b/src/praisonai/praisonai/cli/main.py
@@ -85,21 +85,28 @@ _BLOCKED_ENV_KEYS = frozenset({
     "CLASSPATH",
     # Proxy / redirect (could exfiltrate traffic)
     "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY",
-    "http_proxy", "https_proxy", "all_proxy",
     # Miscellaneous dangerous keys
     "BASH_ENV", "ENV", "CDPATH",
     "PROMPT_COMMAND",
     "SHLVL",
 })
 
+# Pre-compute uppercase lookup set once at module load (avoids rebuilding per call)
+_BLOCKED_ENV_KEYS_UPPER = frozenset(k.upper() for k in _BLOCKED_ENV_KEYS)
 
-def _validate_env_key(key: str) -> None:
+
+def _validate_env_key(key) -> None:
     """Raise ``ValueError`` if *key* is a blocked environment variable name.
 
     The check is case-insensitive so that ``ld_preload`` is caught as well as
-    ``LD_PRELOAD``.
+    ``LD_PRELOAD``.  Non-string keys (e.g. YAML integer or null keys) are
+    rejected with a clear validation error.
     """
-    if key.upper() in {k.upper() for k in _BLOCKED_ENV_KEYS}:
+    if not isinstance(key, str):
+        raise ValueError(
+            f"Environment variable key must be a string, got {type(key).__name__}: {key!r}"
+        )
+    if key.upper() in _BLOCKED_ENV_KEYS_UPPER:
         raise ValueError(
             f"Setting environment variable '{key}' is not allowed in schedule "
             f"config files because it can be used to execute arbitrary code."
@@ -492,12 +499,20 @@ class PraisonAI:
                         
                         # Apply environment variables if specified
                         env_vars = file_config.get('environment', {})
+                        if not isinstance(env_vars, dict):
+                            raise ValueError("'environment' must be a mapping of KEY: value pairs")
+                        # Validate all keys first (fail-closed) before mutating os.environ
+                        validated_env = {}
                         for key, value in env_vars.items():
                             _validate_env_key(key)
-                            os.environ[key] = str(value)
+                            validated_env[key] = str(value)
+                        os.environ.update(validated_env)
                             
                     except FileNotFoundError:
                         print(f"Configuration file not found: {args.schedule_config}")
+                        sys.exit(1)
+                    except ValueError as e:
+                        print(f"Invalid schedule configuration: {e}")
                         sys.exit(1)
                     except yaml.YAMLError as e:
                         print(f"Error parsing configuration file: {e}")

--- a/src/praisonai/tests/unit/test_cwe78_env_injection.py
+++ b/src/praisonai/tests/unit/test_cwe78_env_injection.py
@@ -18,9 +18,11 @@ import yaml
 DANGEROUS_KEYS = [
     "LD_PRELOAD",
     "LD_LIBRARY_PATH",
+    "LD_AUDIT",
     "DYLD_INSERT_LIBRARIES",
     "DYLD_LIBRARY_PATH",
     "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
     "PATH",
     "PYTHONPATH",
     "PYTHONSTARTUP",
@@ -29,7 +31,16 @@ DANGEROUS_KEYS = [
     "NODE_PATH",
     "RUBYLIB",
     "PERL5LIB",
+    "PERL5OPT",
     "CLASSPATH",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "BASH_ENV",
+    "ENV",
+    "CDPATH",
+    "PROMPT_COMMAND",
+    "SHLVL",
     "ld_preload",        # lowercase variant
     "Ld_Preload",        # mixed case variant
 ]
@@ -46,10 +57,16 @@ SAFE_KEYS = [
 
 @pytest.fixture(autouse=True)
 def _clean_env():
-    """Remove any test-set env vars after each test."""
+    """Snapshot env vars before each test and restore them afterwards."""
+    # Save original values (None means the key was not set)
+    _snapshot = {k: os.environ.get(k) for k in DANGEROUS_KEYS + SAFE_KEYS}
     yield
-    for key in DANGEROUS_KEYS + SAFE_KEYS:
-        os.environ.pop(key, None)
+    # Restore: reinstate original values or remove if they didn't exist
+    for key, original in _snapshot.items():
+        if original is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original
 
 
 def _get_validate_env_key():
@@ -72,7 +89,7 @@ def test_dangerous_env_keys_are_blocked():
     for key in DANGEROUS_KEYS:
         with pytest.raises(
             ValueError,
-            match="[Nn]ot allowed|[Bb]locked|[Dd]angerous",
+            match=r"[Nn]ot allowed|[Bb]locked|[Dd]angerous",
         ):
             validate(key)
 
@@ -88,8 +105,22 @@ def test_safe_env_keys_are_allowed():
 
 
 @pytest.mark.unit
+def test_non_string_key_rejected():
+    """Non-string YAML keys (int, None) must produce a clear ValueError."""
+    validate = _get_validate_env_key()
+
+    for bad_key in [123, None, 3.14, True]:
+        with pytest.raises(ValueError, match=r"must be a string"):
+            validate(bad_key)
+
+
+@pytest.mark.unit
 def test_vulnerability_scenario_ld_preload():
-    """LD_PRELOAD in a YAML environment section must be blocked."""
+    """LD_PRELOAD in a YAML environment section must be blocked.
+
+    This test simulates the schedule-config loading path: parse the YAML,
+    then validate-all-then-apply (matching the fail-closed logic in main.py).
+    """
     validate = _get_validate_env_key()
 
     config_content = textwrap.dedent("""\
@@ -104,9 +135,17 @@ def test_vulnerability_scenario_ld_preload():
     file_config = yaml.safe_load(config_content)
     env_vars = file_config.get("environment", {})
 
+    # Simulate the validate-all-then-apply pattern from main.py
     with pytest.raises(ValueError):
-        for key in env_vars:
+        validated_env = {}
+        for key, value in env_vars.items():
             validate(key)
+            validated_env[key] = str(value)
+        # If we reach here, no key was blocked — the test fails via pytest.raises
+        os.environ.update(validated_env)
+
+    # LD_PRELOAD must NOT have been applied (fail-closed)
+    assert "LD_PRELOAD" not in os.environ or os.environ.get("LD_PRELOAD") != "/tmp/evil.so"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The `--schedule-config` CLI flag loads a YAML file and applies its `environment` section directly to `os.environ` with **no validation** on the key names. A malicious or social-engineered config file can set dangerous environment variables (`LD_PRELOAD`, `PATH`, `PYTHONPATH`, proxy vars, etc.) that alter code-loading or subprocess behaviour, potentially leading to arbitrary code execution or traffic interception.

**File:** `src/praisonai/praisonai/cli/main.py` (around line 496)  
**Data flow:** `--schedule-config <file>` → `yaml.safe_load()` → `file_config["environment"]` → `os.environ[key] = str(value)` (no filtering)

### CWE Classification

The audit initially flagged this as **CWE-78 (OS Command Injection)**, but the disprove analysis determined the more precise classifications are:

- **CWE-426** (Untrusted Search Path) — `PATH`, `PYTHONPATH`, `NODE_PATH` manipulation
- **CWE-427** (Uncontrolled Search Path Element) — `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`
- **CWE-114** (Process Control) — environment-variable-based library injection

**Severity: Medium** — Requires the user to explicitly run `praisonai --deploy --schedule-config <malicious_file>`, which is a local CLI action.

---

## Fix Description

This PR adds a **blocklist of 28 dangerous environment variable keys** and a `_validate_env_key()` function that rejects them (case-insensitive) before they reach `os.environ`. The blocklist covers:

| Category | Keys |
|----------|------|
| Dynamic linker injection | `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`, `DYLD_FALLBACK_LIBRARY_PATH` |
| Executable / module search paths | `PATH`, `PYTHONPATH`, `PYTHONHOME`, `PYTHONSTARTUP`, `NODE_PATH`, `NODE_OPTIONS`, `RUBYLIB`, `PERL5LIB`, `PERL5OPT`, `CLASSPATH` |
| Proxy / traffic redirect | `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY` (+ lowercase variants) |
| Misc dangerous | `BASH_ENV`, `ENV`, `CDPATH`, `PROMPT_COMMAND`, `SHLVL` |

**Rationale:** A blocklist (rather than allowlist) was chosen to preserve flexibility — users legitimately need to set provider-specific keys like `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, custom `MODEL_*` vars, etc. An allowlist would require enumerating all valid LLM provider keys and break when new providers are added.

### Changes (2 files, +153 lines)

- `src/praisonai/praisonai/cli/main.py` — Added `_BLOCKED_ENV_KEYS` frozenset + `_validate_env_key()` function + call at line 496
- `src/praisonai/tests/unit/test_cwe78_env_injection.py` — Unit tests covering blocked keys, safe keys, and the LD_PRELOAD YAML scenario

---

## Test Results

The test file includes 3 test cases:

1. **`test_dangerous_env_keys_are_blocked`** — Verifies all 16 dangerous keys (including lowercase/mixed-case variants) raise `ValueError`
2. **`test_safe_env_keys_are_allowed`** — Verifies benign keys like `MODEL_NAME`, `MY_API_KEY` pass without error
3. **`test_vulnerability_scenario_ld_preload`** — End-to-end scenario: parses a malicious YAML with `LD_PRELOAD: /tmp/evil.so` and confirms it is rejected

All tests validate the `_validate_env_key` function directly (no heavyweight integration setup required).

---

## Disprove Analysis (Stage 4)

We performed a thorough adversarial analysis of our own finding. Key results:

### What we confirmed
- **The vulnerability pattern is real** — untrusted YAML config can set arbitrary environment variables with zero validation before the fix
- **No authentication or authorization** guards this code path (expected — it is a local CLI tool)
- **No network attack surface** — `--schedule-config` is a CLI-only flag, not reachable via any API/web endpoint
- **`yaml.safe_load` is used** — no deserialization-based code execution possible from the YAML parsing itself

### Honest limitations of this fix
1. **Blocklist is inherently incomplete** — vars like `GCONV_PATH`, `OPENSSL_CONF`, `GIT_SSH_COMMAND`, `HOME`, `IFS`, `LD_DEBUG` are NOT blocked and could be abused in specific scenarios. An allowlist approach would be more robust but less flexible for this use case.
2. **Same unprotected pattern exists elsewhere** — `bots_cli.py:136` has `os.environ[key] = value` from `.env` parsing with no blocklist at all. This PR does not address that location.
3. **Practical exploitability is low** — the user explicitly provides the file path on the CLI. An attacker who can trick a user into running `--schedule-config malicious.yaml` could equally trick them into running `LD_PRELOAD=/evil.so praisonai ...`.
4. **The `--schedule-config` feature appears undocumented** — minimal real-world attack surface.

### Verdict
**LIKELY_VALID / Medium confidence** — This is a real defense-in-depth improvement. It prevents the most obvious dangerous env vars from being set through config files while preserving the legitimate use case. We recommend the maintainers also consider:
- Migrating to an **allowlist** in a follow-up (e.g., only env vars matching `^[A-Z][A-Z0-9_]*_(KEY|TOKEN|URL|MODEL|NAME|BASE|HOST|PORT)$`)
- Applying the same validation in `bots_cli.py`

### Prior related issues
- Issue #1134: `python_tools.py` uses `exec()` without sandbox (adjacent security concern)
- Multiple recent security fixes in adjacent code (#1122, #1125, #1120, #1129)

---

This fix has passed 4 review stages. Happy to discuss or adjust the approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent scheduled deployment configs from setting restricted environment variables; invalid configs now print an error and exit.
  * Environment updates from schedule configs are validated first and applied atomically to avoid partial application.

* **Tests**
  * Added unit tests covering environment-key validation, rejection of non-string keys, and blocking of dangerous keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->