### PR TITLE
security: cap litellm<=1.82.6 (supply chain incident)

### DIFF
--- a/src/praisonai-agents/pyproject.toml
+++ b/src/praisonai-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "praisonaiagents"
-version = "1.5.83"
+version = "1.5.84"
 description = "Praison AI agents for completing complex tasks with Self Reflection Agents"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -29,7 +29,7 @@ mcp = [
 
 memory = [
     "chromadb>=1.0.0",
-    "litellm>=1.81.0",
+    "litellm>=1.81.0,<=1.82.6",
 ]
 
 knowledge = [
@@ -47,7 +47,7 @@ graph = [
 
 # Add LLM dependencies
 llm = [
-    "litellm>=1.81.0",
+    "litellm>=1.81.0,<=1.82.6",
     "pydantic>=2.10.0"
 ]
 

--- a/src/praisonai-agents/uv.lock
+++ b/src/praisonai-agents/uv.lock
@@ -2951,7 +2951,7 @@ wheels = [
 
 [[package]]
 name = "praisonaiagents"
-version = "1.5.83"
+version = "1.5.84"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -3054,8 +3054,8 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.115.0" },
     { name = "fastapi", marker = "extra == 'mcp'", specifier = ">=0.115.0" },
     { name = "fastapi", marker = "extra == 'os'", specifier = ">=0.115.0" },
-    { name = "litellm", marker = "extra == 'llm'", specifier = ">=1.81.0" },
-    { name = "litellm", marker = "extra == 'memory'", specifier = ">=1.81.0" },
+    { name = "litellm", marker = "extra == 'llm'", specifier = ">=1.81.0,<=1.82.6" },
+    { name = "litellm", marker = "extra == 'memory'", specifier = ">=1.81.0,<=1.82.6" },
     { name = "markitdown", extras = ["all"], marker = "extra == 'knowledge'", specifier = ">=0.1.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.20.0" },
     { name = "mem0ai", marker = "extra == 'knowledge'", specifier = ">=0.1.0" },

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pyparsing>=3.0.0",
     "praisonaiagents>=1.5.83",
     "python-dotenv>=0.19.0",
-    "litellm>=1.81.0",
+    "litellm>=1.81.0,<=1.82.6",
     "PyYAML>=6.0",
     "mcp>=1.20.0",
     "typer>=0.9.0",


### PR DESCRIPTION
## Summary

Defensive version pin in response to the [LiteLLM supply chain incident](https://docs.litellm.ai/blog/security-update-march-2026) (March 24, 2026).

**PraisonAI was NOT affected** — installed version was `1.81.1`, compromised versions were `1.82.7`/`1.82.8` (both removed from PyPI).

### Changes
- Cap `litellm<=1.82.6` (latest safe version) in all 3 `pyproject.toml` files
- Prevents any future install from pulling untested versions during the active investigation

### Files Changed
- `src/praisonai-agents/pyproject.toml` (memory + llm extras)
- `src/praisonai/pyproject.toml` (core deps)

### Testing
- ✅ Upgraded local install to `litellm==1.82.6`
- ✅ 6053 tests pass, 0 regressions from upgrade
- ✅ IoC scan clean (no `litellm_init.pth`, no exfil traffic)

> The cap can be lifted once LiteLLM completes their supply-chain review and resumes safe releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v1.5.84

* **Chores**
  * Updated package version to 1.5.84
  * Refined dependency version constraints for litellm to ensure compatibility with supported versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->