### PR TITLE
fix: prevent RuntimeError by offloading asyncio.run to ThreadPool in …

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -5038,10 +5038,12 @@ Your Goal: {self.goal}"""
         from ..approval import get_approval_registry
         backend = getattr(self, '_approval_backend', None)
         approve_all = getattr(self, '_approve_all_tools', False)
+        
         if backend is not None:
             from ..approval.protocols import ApprovalRequest, ApprovalDecision
             from ..approval.registry import DEFAULT_DANGEROUS_TOOLS
             needs_approval = approve_all or function_name in DEFAULT_DANGEROUS_TOOLS
+            
             if needs_approval:
                 request = ApprovalRequest(
                     tool_name=function_name,
@@ -5049,6 +5051,7 @@ Your Goal: {self.goal}"""
                     risk_level=DEFAULT_DANGEROUS_TOOLS.get(function_name, "medium"),
                     agent_name=getattr(self, 'name', None),
                 )
+                
                 cfg_timeout = getattr(self, '_approval_timeout', 0)
                 if cfg_timeout is None:
                     orig_timeout = getattr(backend, '_timeout', None)
@@ -5060,11 +5063,27 @@ Your Goal: {self.goal}"""
                         backend._timeout = cfg_timeout
                 else:
                     orig_timeout = None
+                    
                 try:
                     if hasattr(backend, 'request_approval_sync'):
                         decision = backend.request_approval_sync(request)
                     else:
-                        decision = asyncio.run(backend.request_approval(request))
+                        import asyncio
+                        import concurrent.futures
+                        
+                        try:
+                            loop = asyncio.get_running_loop()
+                        except RuntimeError:
+                            loop = None
+
+                        if loop is None:
+                            # No running loop, safe to block the main thread
+                            decision = asyncio.run(backend.request_approval(request))
+                        else:
+                            # Inside an active async loop, offload to prevent RuntimeError
+                            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                                future = pool.submit(lambda: asyncio.run(backend.request_approval(request)))
+                                decision = future.result()
                 finally:
                     if orig_timeout is not None and hasattr(backend, '_timeout'):
                         backend._timeout = orig_timeout
@@ -5074,14 +5093,20 @@ Your Goal: {self.goal}"""
             decision = get_approval_registry().approve_sync(
                 getattr(self, 'name', None), function_name, arguments,
             )
+            
         if not decision.approved:
             error_msg = f"Tool execution denied: {decision.reason}"
+            import logging
             logging.warning(error_msg)
             return {"error": error_msg, "approval_denied": True}
+            
         get_approval_registry().mark_approved(function_name)
+        
         if decision.modified_args:
             arguments = decision.modified_args
+            import logging
             logging.info(f"Using modified arguments: {arguments}")
+            
         return None, arguments
 
     async def _check_tool_approval_async(self, function_name, arguments):

--- a/src/praisonai-agents/praisonaiagents/approval/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/approval/__init__.py
@@ -189,15 +189,29 @@ def require_approval(risk_level: RiskLevel = "high"):
             if is_env_auto_approve():
                 mark_approved(tool_name)
                 return func(*args, **kwargs)
+            
             try:
+                import asyncio
+                import concurrent.futures
+
                 try:
-                    asyncio.get_running_loop()
-                    raise RuntimeError("Use sync fallback in async context")
+                    loop = asyncio.get_running_loop()
                 except RuntimeError:
+                    loop = None
+
+                if loop is None:
+                    # No running loop, safe to block the main thread
                     decision = asyncio.run(request_approval(tool_name, kwargs))
+                else:
+                    # Inside an active async loop, offload to prevent RuntimeError
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                        future = pool.submit(lambda: asyncio.run(request_approval(tool_name, kwargs)))
+                        decision = future.result()
             except Exception as e:
+                import logging
                 logging.warning(f"Async approval failed, using sync fallback: {e}")
                 decision = console_approval_callback(tool_name, kwargs, risk_level)
+                
             if not decision.approved:
                 raise PermissionError(f"Execution of {tool_name} denied: {decision.reason}")
             mark_approved(tool_name)
@@ -214,13 +228,16 @@ def require_approval(risk_level: RiskLevel = "high"):
             if is_env_auto_approve():
                 mark_approved(tool_name)
                 return await func(*args, **kwargs)
+            
             decision = await request_approval(tool_name, kwargs)
+            
             if not decision.approved:
                 raise PermissionError(f"Execution of {tool_name} denied: {decision.reason}")
             mark_approved(tool_name)
             kwargs.update(decision.modified_args)
             return await func(*args, **kwargs)
 
+        import asyncio
         if asyncio.iscoroutinefunction(func):
             return async_wrapper
         else:

--- a/src/praisonai-agents/praisonaiagents/tools/crawl4ai_tools.py
+++ b/src/praisonai-agents/praisonaiagents/tools/crawl4ai_tools.py
@@ -609,9 +609,20 @@ def crawl4ai_sync(
     Returns:
         Dict with crawl results
     """
-    return asyncio.run(
-        crawl4ai(url, css_selector, js_code, wait_for)
-    )
+    import asyncio
+    import concurrent.futures
+    
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is None:
+        return asyncio.run(crawl4ai(url, css_selector, js_code, wait_for))
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(lambda: asyncio.run(crawl4ai(url, css_selector, js_code, wait_for)))
+            return future.result()
 
 
 def crawl4ai_extract_sync(
@@ -629,9 +640,20 @@ def crawl4ai_extract_sync(
     Returns:
         Dict with extracted data
     """
-    return asyncio.run(
-        crawl4ai_extract(url, schema, js_code)
-    )
+    import asyncio
+    import concurrent.futures
+    
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is None:
+        return asyncio.run(crawl4ai_extract(url, schema, js_code))
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(lambda: asyncio.run(crawl4ai_extract(url, schema, js_code)))
+            return future.result()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The codebase contained several synchronous methods (like _check_tool_approval_sync) and decorators (like require_approval) that used asyncio.run() to execute coroutines. When these sync paths were triggered from within an already running async event loop (e.g., in async multi-agent workflows), it caused a hard RuntimeError.

Solution:
Implemented a robust "sync-to-async" bridge using a ThreadPoolExecutor fallback.

If no event loop is running: Uses asyncio.run() as before.

If an event loop is detected: Offloads the task to a worker thread where a new loop can be safely created, blocking the main thread until the result returns. This maintains the synchronous signature while preventing loop conflicts.

Changes:

agent.py: Updated _check_tool_approval_sync to use safe thread-pool offloading.

approval/__init__.py: Fixed a logical trap in the require_approval decorator's sync wrapper that was failing during async execution.

crawl4ai wrappers:  Updated sync utility wrappers to be async-safe.

Audit: Performed a global search for asyncio.run calls in sync contexts to ensure the pattern is consistent across the core agent logic.
