### PR TITLE
fix: Cleanup dead acp_enabled and lsp_enabled code from YAML workflow generator

### DIFF
--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -1211,13 +1211,7 @@ class AgentsGenerator:
         # Create and run the PraisonAI agents
         memory = config.get('memory', False)
         
-        # Extract global config for CLI parity features
-        global_config = config.get('config', {})
-        acp_enabled = global_config.get('acp', False)
-        lsp_enabled = global_config.get('lsp', False)
-        
         self.logger.debug(f"Memory: {memory}")
-        self.logger.debug(f"Global config - ACP: {acp_enabled}, LSP: {lsp_enabled}")
         
         if config.get('process') == 'hierarchical':
             agents = AgentTeam(


### PR DESCRIPTION
# Issue: Cleanup dead `acp_enabled` and `lsp_enabled` code from YAML workflow generator

## 1. Acceptance Criteria
- Remove unused extraction of `acp` (Automated Context Purge / Agent Control Protocol) and `lsp` (Language Server Protocol) from the global section of YAML files within the `praisonai` wrapper's `agents_generator.py`.
- Prevent logging of dead variables.
- Maintain full parity and API usage rules defined by the `praisonaiagents` core SDK.

## 2. Repo Inventory & Evidence
**Target File**: `/src/praisonai/praisonai/agents_generator.py` (Wrapper package)
**Dead Code Snippet**:
```python
        # Extract global config for CLI parity features
        global_config = config.get('config', {})
        acp_enabled = global_config.get('acp', False)
        lsp_enabled = global_config.get('lsp', False)
```
**Evidence of Dead Code**: 
- `acp_enabled` and `lsp_enabled` were initialized but never passed to `AgentTeam` (`praisonaiagents.agents.AgentTeam.__init__`).
- The SDK `AgentTeam` protocol previously consumed these, but as of the v4 architectural refinement, `acp` and `lsp` are no longer accepted.
- A `grep` of `agents_generator.py` for `acp_enabled` or `lsp_enabled` confirms these local variables are only used in a debug `self.logger.debug` statement, consuming CPU cycles for no functional benefit.

## 3. Detailed Analysis
- **Architecture**: The YAML `agents_generator.py` acts as a translating shim between CLI YAML declarations and the core SDK. Over time, config keys from legacy experimental features (`acp`, `lsp`, `trust`) were left dangling.
- **Invariants Violated**: DRY code and API Simplicity. The wrapper should only extract configuration variables that it intends to pass to the core SDK `AgentTeam` or `Agent` interfaces.

## 4. Detailed Review (Quality vs Principles)
The lingering variables violated the **DRY** and **Simple API** principles. Extracting `acp` and `lsp` logic without utilizing them resulted in misleading debug logs (`Global config - ACP: False, LSP: False`) that obfuscate genuine debugging efforts. 

## 5. Gap Analysis
- **Core SDK**: Clean (already removed `acp`/`lsp` from `AgentTeam` signature).
- **Wrapper**: `agents_generator.py` had a gap showing legacy extraction of `acp` and `lsp` from `config['config']`.
- **Severity**: Low. (Cosmetic/Code Style). No functional break, but it misleads maintainers.

## 6. Critical Review
- **Risks**: Passing unused arguments in legacy architectures often caused `TypeError: __init__() got an unexpected keyword argument`. While `acp_enabled` wasn't passed, maintaining this code risks developers assuming `acp` is fully wired when defined via YAML docs.
- **Safe by Default Mitigation**: Eliminate strictly unused code paths. 

## 7. Plan
1. **Implementation**: Delete `acp_enabled` and `lsp_enabled` assignments in `agents_generator.py`, keeping only `memory = config.get('memory', False)` extraction.
2. **Testing**: Run standard suite and smoke test parser outputs to verify standard instantiation.
3. **Verification**: `python -m pytest tests/unit/workflows` & verify agent creation via YAML configurations without regression.

## 8. Proposal
Implement a direct structural cleanup in `agents_generator.py` to ensure only schema-supported features from the `praisonaiagents` core are parsed and surfaced. This aligns the Wrapper seamlessly with the underlying SDK protocols.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal configuration extraction and logging code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->