### PR TITLE
fix: Update valid inputs for claude-code-action in issue triage

### DIFF
--- a/.github/actions/claude-issue-triage-action/action.yml
+++ b/.github/actions/claude-issue-triage-action/action.yml
@@ -21,7 +21,8 @@ runs:
       with:
         fetch-depth: 0
 
-    - name: Create prompt file
+    - name: Create prompt
+      id: generate_prompt
       shell: bash
       run: |
         mkdir -p /tmp/claude-prompts
@@ -75,13 +76,16 @@ runs:
         - Your ONLY action should be to apply labels using mcp__github__update_issue
         - It's okay to not add any labels if none are clearly applicable
         EOF
+        
+        echo "PROMPT<<DELIMITER" >> $GITHUB_OUTPUT
+        cat /tmp/claude-prompts/claude-issue-triage-prompt.txt >> $GITHUB_OUTPUT
+        echo "DELIMITER" >> $GITHUB_OUTPUT
 
     - name: Run Claude Code
       uses: ./.github/actions/claude-code-action
       with:
-        prompt_file: /tmp/claude-prompts/claude-issue-triage-prompt.txt
+        direct_prompt: ${{ steps.generate_prompt.outputs.PROMPT }}
         allowed_tools: "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"
-        install_github_mcp: "true"
         timeout_minutes: ${{ inputs.timeout_minutes }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         github_token: ${{ inputs.github_token }} 


### PR DESCRIPTION
Fixes a crashing GitHub Action where the Claude Issue Triage workflow supplied invalid arguments `prompt_file` and `install_github_mcp` to the base action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal prompt delivery mechanism in the issue triage action. Action functionality and user experience remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->