### PR TITLE
fix(gha): Add id-token write permission and switch to GH_TOKEN for Claude actions

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -20,4 +20,4 @@ jobs:
         uses: ./.github/actions/claude-issue-triage-action
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.PAT_TOKEN }} 
+          github_token: ${{ secrets.GH_TOKEN }} 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,7 @@ jobs:
       pull-requests: write
       issues: write
       actions: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,7 +39,7 @@ jobs:
       - uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.PAT_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
           trigger_phrase: "@claude"
           label_trigger: "claude"
           direct_prompt: |


### PR DESCRIPTION
Fixes OIDC token fetch failure and 401 Bad Credentials errors in the Claude workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for improved authentication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->