### PR TITLE
fix(sandbox): update sandlock integration to use real API surface

### DIFF
--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -215,6 +215,36 @@ class SandlockSandbox:
             )
 
             completed_at = time.time()
+            duration = completed_at - started_at
+
+            # Check result.success and exit_code to determine actual status
+            if not result.success:
+                # Check if this was a timeout based on duration
+                if duration >= limits.timeout_seconds:
+                    return SandboxResult(
+                        execution_id=execution_id,
+                        status=SandboxStatus.TIMEOUT,
+                        error=f"Execution timed out after {limits.timeout_seconds}s",
+                        exit_code=result.exit_code,
+                        stdout=result.stdout,
+                        stderr=result.stderr,
+                        duration_seconds=duration,
+                        started_at=started_at,
+                        completed_at=completed_at,
+                    )
+                else:
+                    # Non-zero exit or other failure
+                    return SandboxResult(
+                        execution_id=execution_id,
+                        status=SandboxStatus.FAILED,
+                        error=f"Execution failed with exit code {result.exit_code}: {result.stderr}",
+                        exit_code=result.exit_code,
+                        stdout=result.stdout,
+                        stderr=result.stderr,
+                        duration_seconds=duration,
+                        started_at=started_at,
+                        completed_at=completed_at,
+                    )
 
             return SandboxResult(
                 execution_id=execution_id,
@@ -222,7 +252,7 @@ class SandlockSandbox:
                 exit_code=result.exit_code,
                 stdout=result.stdout,
                 stderr=result.stderr,
-                duration_seconds=completed_at - started_at,
+                duration_seconds=duration,
                 started_at=started_at,
                 completed_at=completed_at,
                 metadata={

--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -79,7 +79,7 @@ class SandlockSandbox:
     def is_available(self) -> bool:
         """Whether sandlock backend is available."""
         try:
-            return self._sandlock.landlock_abi_version() >= 6
+            return self._sandlock.landlock_abi_version() >= 1
         except (AttributeError, ImportError):
             return False
     
@@ -195,20 +195,20 @@ class SandlockSandbox:
 
         Centralises all sandlock Sandbox/Policy construction and error handling
         so that ``execute`` and ``run_command`` share a single code path.
+
+        Note: ``env`` is accepted for API compatibility but sandlock's
+        ``Sandbox.run()`` does not support per-run environment injection;
+        callers requiring custom env vars should set them in the policy or
+        prior to sandbox creation.  ``working_dir`` is applied via the policy
+        (added to the writable-path allow-list).
         """
         policy = self._create_policy(limits, working_dir)
-
-        process_env = os.environ.copy()
-        if env:
-            process_env.update(env)
 
         started_at = time.time()
 
         try:
             sandbox = self._sandlock.Sandbox(policy)
 
-            # Configure environment before sandbox creation if needed
-            # sandlock.run() only accepts cmd and optional timeout parameter
             result = await asyncio.get_running_loop().run_in_executor(
                 None,
                 lambda: sandbox.run(cmd, timeout=limits.timeout_seconds)
@@ -232,11 +232,9 @@ class SandlockSandbox:
                 },
             )
 
-        # Note: Sandlock doesn't raise timeout/security exceptions
-        # Instead, check result.exit_code for timeout/termination conditions
         except Exception as e:
-            # Check if this was a timeout by examining exit code or duration
-            duration = time.time() - started_at
+            completed_at = time.time()
+            duration = completed_at - started_at
             if duration >= limits.timeout_seconds:
                 return SandboxResult(
                     execution_id=execution_id,
@@ -244,25 +242,15 @@ class SandlockSandbox:
                     error=f"Execution timed out after {limits.timeout_seconds}s",
                     duration_seconds=duration,
                     started_at=started_at,
-                    completed_at=time.time(),
+                    completed_at=completed_at,
                 )
-            else:
-                return SandboxResult(
-                    execution_id=execution_id,
-                    status=SandboxStatus.FAILED,
-                    error=f"Execution failed: {e}",
-                    duration_seconds=duration,
-                    started_at=started_at,
-                    completed_at=time.time(),
-                )
-        except Exception as e:
             return SandboxResult(
                 execution_id=execution_id,
                 status=SandboxStatus.FAILED,
-                error=str(e),
-                duration_seconds=time.time() - started_at,
+                error=f"Execution failed: {e}",
+                duration_seconds=duration,
                 started_at=started_at,
-                completed_at=time.time(),
+                completed_at=completed_at,
             )
 
     async def execute(

--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -78,7 +78,10 @@ class SandlockSandbox:
     @property
     def is_available(self) -> bool:
         """Whether sandlock backend is available."""
-        return self._sandlock.is_available()
+        try:
+            return self._sandlock.landlock_abi_version() >= 6
+        except (AttributeError, ImportError):
+            return False
     
     @property
     def sandbox_type(self) -> str:
@@ -155,8 +158,8 @@ class SandlockSandbox:
             max_processes=limits.max_processes,
             max_open_files=limits.max_open_files,
             
-            # CPU and timeout limits
-            max_cpu_time_seconds=limits.timeout_seconds,
+            # Note: CPU throttle percentage, not time limit
+            # Execution timeout is handled via Sandbox.run(timeout=...)
         )
         
         return policy
@@ -204,9 +207,11 @@ class SandlockSandbox:
         try:
             sandbox = self._sandlock.Sandbox(policy)
 
+            # Configure environment before sandbox creation if needed
+            # sandlock.run() only accepts cmd and optional timeout parameter
             result = await asyncio.get_running_loop().run_in_executor(
                 None,
-                lambda: sandbox.run(cmd, env=process_env, cwd=working_dir)
+                lambda: sandbox.run(cmd, timeout=limits.timeout_seconds)
             )
 
             completed_at = time.time()
@@ -227,24 +232,29 @@ class SandlockSandbox:
                 },
             )
 
-        except self._sandlock.TimeoutError:
-            return SandboxResult(
-                execution_id=execution_id,
-                status=SandboxStatus.TIMEOUT,
-                error=f"Execution timed out after {limits.timeout_seconds}s",
-                duration_seconds=limits.timeout_seconds,
-                started_at=started_at,
-                completed_at=time.time(),
-            )
-        except self._sandlock.SecurityViolationError as e:
-            return SandboxResult(
-                execution_id=execution_id,
-                status=SandboxStatus.FAILED,
-                error=f"Security violation: {e}",
-                duration_seconds=time.time() - started_at,
-                started_at=started_at,
-                completed_at=time.time(),
-            )
+        # Note: Sandlock doesn't raise timeout/security exceptions
+        # Instead, check result.exit_code for timeout/termination conditions
+        except Exception as e:
+            # Check if this was a timeout by examining exit code or duration
+            duration = time.time() - started_at
+            if duration >= limits.timeout_seconds:
+                return SandboxResult(
+                    execution_id=execution_id,
+                    status=SandboxStatus.TIMEOUT,
+                    error=f"Execution timed out after {limits.timeout_seconds}s",
+                    duration_seconds=duration,
+                    started_at=started_at,
+                    completed_at=time.time(),
+                )
+            else:
+                return SandboxResult(
+                    execution_id=execution_id,
+                    status=SandboxStatus.FAILED,
+                    error=f"Execution failed: {e}",
+                    duration_seconds=duration,
+                    started_at=started_at,
+                    completed_at=time.time(),
+                )
         except Exception as e:
             return SandboxResult(
                 execution_id=execution_id,

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -148,11 +148,18 @@ class TestSandlockSandbox:
 
         sandbox = _make_sandbox(mock_sandlock)
 
-        # Simulate timeout by raising generic exception after enough time
+        # Create a mock Result object indicating timeout
+        mock_timeout_result = Mock()
+        mock_timeout_result.success = False
+        mock_timeout_result.exit_code = 124  # Common timeout exit code
+        mock_timeout_result.stdout = ""
+        mock_timeout_result.stderr = "Process timed out"
+
+        # Simulate timeout by returning failed Result after enough time
         with patch("asyncio.get_running_loop") as mock_loop, \
-             patch("time.time", side_effect=[0, 11]):  # Started at 0, ended at 11s (> 10s timeout)
+             patch("time.time", side_effect=[0, 11, 11]):  # Started at 0, ended at 11s (> 10s timeout)
             mock_loop.return_value.run_in_executor = AsyncMock(
-                side_effect=Exception("Process timed out")
+                return_value=mock_timeout_result
             )
 
             await sandbox.start()
@@ -171,18 +178,26 @@ class TestSandlockSandbox:
 
         sandbox = _make_sandbox(mock_sandlock)
 
-        # Simulate execution failure (not timeout)
+        # Create a mock Result object indicating non-zero exit
+        mock_failed_result = Mock()
+        mock_failed_result.success = False
+        mock_failed_result.exit_code = 1  # Non-zero exit code
+        mock_failed_result.stdout = ""
+        mock_failed_result.stderr = "Permission denied"
+
+        # Simulate execution failure (not timeout) 
         with patch("asyncio.get_running_loop") as mock_loop, \
-             patch("time.time", side_effect=[0, 2]):  # Started at 0, ended at 2s (< 10s timeout)
+             patch("time.time", side_effect=[0, 2, 2]):  # Started at 0, ended at 2s (< 10s timeout)
             mock_loop.return_value.run_in_executor = AsyncMock(
-                side_effect=Exception("Execution failed")
+                return_value=mock_failed_result
             )
 
             await sandbox.start()
             result = await sandbox.execute("import os; os.system('rm -rf /')")
 
         assert result.status == SandboxStatus.FAILED
-        assert "Execution failed" in result.error
+        assert "exit code 1" in result.error
+        assert "Permission denied" in result.error
 
     @pytest.mark.asyncio
     async def test_safe_sandbox_path_traversal_blocked(self):
@@ -217,3 +232,42 @@ class TestSandlockSandbox:
         assert success is False
 
         await sandbox.stop()
+
+    @pytest.mark.asyncio
+    async def test_real_sandlock_integration(self):
+        """Integration test with real sandlock package if available.
+        
+        This test uses the actual sandlock package (if available) to ensure
+        the integration works with the real API surface, not just mocks.
+        """
+        try:
+            # Try to import real sandlock
+            import sandlock
+            
+            # Only run if Landlock is actually supported on this system
+            if sandlock.landlock_abi_version() < 1:
+                pytest.skip("Landlock not supported on this system")
+            
+            # Test with real sandlock package
+            from praisonai.sandbox.sandlock import SandlockSandbox
+            
+            sandbox = SandlockSandbox()
+            assert sandbox.is_available
+            
+            await sandbox.start()
+            
+            # Execute simple code that should succeed
+            result = await sandbox.execute(
+                "print('Real sandlock integration test')", 
+                limits=ResourceLimits(timeout_seconds=5, memory_mb=64)
+            )
+            
+            # Should complete successfully
+            assert result.status == SandboxStatus.COMPLETED
+            assert result.exit_code == 0
+            assert "Real sandlock integration test" in result.stdout
+            
+            await sandbox.stop()
+            
+        except ImportError:
+            pytest.skip("sandlock package not available for integration test")

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -45,7 +45,7 @@ class TestSandlockSandbox:
     def test_fallback_to_subprocess_when_unavailable(self):
         """Test fallback to subprocess when sandlock is not available."""
         mock_sandlock = Mock()
-        mock_sandlock.is_available.return_value = False
+        mock_sandlock.landlock_abi_version.return_value = 5  # < 6, so unavailable
 
         sandbox = _make_sandbox(mock_sandlock)
         assert not sandbox.is_available
@@ -55,7 +55,7 @@ class TestSandlockSandbox:
     async def test_fallback_execution(self):
         """Test that execution falls back to subprocess when sandlock unavailable."""
         mock_sandlock = Mock()
-        mock_sandlock.is_available.return_value = False
+        mock_sandlock.landlock_abi_version.return_value = 5  # < 6, so unavailable
 
         sandbox = _make_sandbox(mock_sandlock)
 
@@ -98,7 +98,7 @@ class TestSandlockSandbox:
     def test_status_reporting(self):
         """Test sandbox status reporting."""
         mock_sandlock = Mock()
-        mock_sandlock.is_available.return_value = True
+        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
 
         sandbox = _make_sandbox(mock_sandlock)
         status = sandbox.get_status()
@@ -122,7 +122,7 @@ class TestSandlockSandbox:
 
         mock_sandlock.Policy.return_value = Mock()
         mock_sandlock.Sandbox.return_value = Mock(run=Mock(return_value=mock_result))
-        mock_sandlock.is_available.return_value = True
+        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
 
         sandbox = _make_sandbox(mock_sandlock)
 
@@ -142,65 +142,53 @@ class TestSandlockSandbox:
     async def test_sandlock_execution_timeout(self):
         """Test timeout handling in sandlock execution."""
         mock_sandlock = Mock()
-
-        class FakeTimeoutError(Exception):
-            pass
-
-        mock_sandlock.TimeoutError = FakeTimeoutError
-        mock_sandlock.SecurityViolationError = Exception
         mock_sandlock.Policy.return_value = Mock()
         mock_sandlock.Sandbox.return_value = Mock()
-        mock_sandlock.is_available.return_value = True
+        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
 
         sandbox = _make_sandbox(mock_sandlock)
 
-        with patch("asyncio.get_running_loop") as mock_loop:
+        # Simulate timeout by raising generic exception after enough time
+        with patch("asyncio.get_running_loop") as mock_loop, \
+             patch("time.time", side_effect=[0, 11]):  # Started at 0, ended at 11s (> 10s timeout)
             mock_loop.return_value.run_in_executor = AsyncMock(
-                side_effect=FakeTimeoutError()
+                side_effect=Exception("Process timed out")
             )
 
             await sandbox.start()
-            result = await sandbox.execute("import time; time.sleep(100)")
+            result = await sandbox.execute("import time; time.sleep(100)", limits=ResourceLimits(timeout_seconds=10))
 
         assert result.status == SandboxStatus.TIMEOUT
         assert "timed out" in result.error.lower()
 
     @pytest.mark.asyncio
-    async def test_sandlock_security_violation(self):
-        """Test security violation handling."""
+    async def test_sandlock_execution_failure(self):
+        """Test general execution failure handling."""
         mock_sandlock = Mock()
-
-        class FakeTimeoutError(Exception):
-            pass
-
-        class FakeSecurityViolationError(Exception):
-            pass
-
-        mock_sandlock.SecurityViolationError = FakeSecurityViolationError
-        mock_sandlock.TimeoutError = FakeTimeoutError
         mock_sandlock.Policy.return_value = Mock()
         mock_sandlock.Sandbox.return_value = Mock()
-        mock_sandlock.is_available.return_value = True
+        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
 
         sandbox = _make_sandbox(mock_sandlock)
 
-        with patch("asyncio.get_running_loop") as mock_loop:
+        # Simulate execution failure (not timeout)
+        with patch("asyncio.get_running_loop") as mock_loop, \
+             patch("time.time", side_effect=[0, 2]):  # Started at 0, ended at 2s (< 10s timeout)
             mock_loop.return_value.run_in_executor = AsyncMock(
-                side_effect=FakeSecurityViolationError("Access denied")
+                side_effect=Exception("Execution failed")
             )
 
             await sandbox.start()
             result = await sandbox.execute("import os; os.system('rm -rf /')")
 
         assert result.status == SandboxStatus.FAILED
-        assert "Security violation" in result.error
-        assert "Access denied" in result.error
+        assert "Execution failed" in result.error
 
     @pytest.mark.asyncio
     async def test_safe_sandbox_path_traversal_blocked(self):
         """Test that path traversal attempts are blocked by _safe_sandbox_path."""
         mock_sandlock = Mock()
-        mock_sandlock.is_available.return_value = True
+        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
 
         sandbox = _make_sandbox(mock_sandlock)
         await sandbox.start()
@@ -220,7 +208,7 @@ class TestSandlockSandbox:
     async def test_write_file_blocks_traversal(self):
         """Test that write_file refuses paths that escape the sandbox root."""
         mock_sandlock = Mock()
-        mock_sandlock.is_available.return_value = True
+        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
 
         sandbox = _make_sandbox(mock_sandlock)
         await sandbox.start()

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -45,7 +45,7 @@ class TestSandlockSandbox:
     def test_fallback_to_subprocess_when_unavailable(self):
         """Test fallback to subprocess when sandlock is not available."""
         mock_sandlock = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 5  # < 6, so unavailable
+        mock_sandlock.landlock_abi_version.return_value = 0  # < 1, so unavailable
 
         sandbox = _make_sandbox(mock_sandlock)
         assert not sandbox.is_available
@@ -55,7 +55,7 @@ class TestSandlockSandbox:
     async def test_fallback_execution(self):
         """Test that execution falls back to subprocess when sandlock unavailable."""
         mock_sandlock = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 5  # < 6, so unavailable
+        mock_sandlock.landlock_abi_version.return_value = 0  # < 1, so unavailable
 
         sandbox = _make_sandbox(mock_sandlock)
 


### PR DESCRIPTION
- [x] Review PR changes and identify issues
- [x] Fix `landlock_abi_version() >= 6` → `>= 1` (ABI v6 not yet in any released kernel — max is v5 in 6.10)
- [x] Remove duplicate unreachable `except Exception as e` block (dead code that could never execute)
- [x] Remove unused `process_env` variable; add docstring note explaining `env` limitation vs sandlock API
- [x] Refactor exception handler to capture `completed_at = time.time()` once — eliminates extra `time.time()` calls that caused `StopIteration` in tests
- [x] Update test mocks: version `5` → `0` for "unavailable" tests to align with `>= 1` threshold
- [x] All 10 unit tests pass
- [x] Code review completed, feedback addressed
- [x] CodeQL scan clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timeout detection for sandboxed code execution with more accurate wall-clock timing
  * Enhanced error reporting for failed executions with clearer status messages

* **Tests**
  * Updated and expanded test coverage for timeout and execution failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->