### PR TITLE
fix(sandbox): correct sandlock integration semantics and fail loud

### DIFF
--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -290,21 +290,19 @@ class SandlockSandbox:
         stdout = self._decode(result.stdout)
         stderr = self._decode(result.stderr)
 
-        # sandlock surfaces timeouts via result.error containing "timed out".
-        # This is authoritative — wall-clock guesses are unreliable because a
-        # process can legitimately finish just under the limit.
-        err_text = (result.error or "") if not result.success else ""
-        is_timeout = "timed out" in err_text.lower() or "timeout" in err_text.lower()
-
+        # sandlock uses exit_code == -1 as the ExitStatus::Timeout sentinel
+        # (see sandlock's python/src/sandlock/_sdk.py).  This is a
+        # structural signal — Sandbox.run() doesn't populate result.error
+        # for timeouts, so string-matching on it is unreliable.
         if result.success:
             status = SandboxStatus.COMPLETED
             error = None
-        elif is_timeout:
+        elif result.exit_code == -1:
             status = SandboxStatus.TIMEOUT
             error = f"Execution timed out after {limits.timeout_seconds}s"
         else:
             status = SandboxStatus.FAILED
-            error = f"Execution failed with exit code {result.exit_code}: {stderr or err_text}"
+            error = f"Execution failed with exit code {result.exit_code}: {stderr}"
 
         return SandboxResult(
             execution_id=execution_id,

--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -74,6 +74,21 @@ class SandlockSandbox:
                 "sandlock package required for SandlockSandbox. "
                 "Install with: pip install 'praisonai[sandbox]' or pip install sandlock"
             )
+
+        # Fail loud if Landlock isn't supported on this kernel.
+        try:
+            abi = self._sandlock.landlock_abi_version()
+        except Exception as e:
+            raise RuntimeError(
+                f"failed to query Landlock ABI version: {e}"
+            ) from e
+        if abi < 1:
+            raise RuntimeError(
+                "SandlockSandbox requires Landlock support (Linux kernel "
+                ">= 6.12 with CONFIG_SECURITY_LANDLOCK=y).  This kernel "
+                f"reports Landlock ABI version {abi}.  Use SubprocessSandbox "
+                "explicitly if weaker isolation is acceptable."
+            )
     
     @property
     def is_available(self) -> bool:
@@ -112,20 +127,24 @@ class SandlockSandbox:
         self,
         limits: ResourceLimits,
         working_dir: Optional[str] = None,
+        extra_readable: Optional[List[str]] = None,
     ) -> Any:
         """Create sandlock policy from resource limits.
-        
+
         Args:
             limits: Resource limits configuration
-            working_dir: Working directory for execution
-            
-        Returns:
-            Sandlock Policy object
+            working_dir: Working directory for execution (added to the
+                writable allowlist).
+            extra_readable: Additional directories to add to the Landlock
+                read allowlist (e.g. the parent of a script passed to
+                ``execute_file``).
         """
         Policy = self._sandlock.Policy
-        
-        # Determine allowed paths
-        allowed_read_paths = [
+
+        # Landlock requires every path in the allowlist to exist at rule-
+        # attach time; passing a missing directory makes sandlock_spawn
+        # fail outright.  Filter to paths that actually exist on this host.
+        _candidate_read_paths = [
             "/usr/lib/python3",
             "/usr/local/lib/python3",
             "/lib",
@@ -133,36 +152,76 @@ class SandlockSandbox:
             "/bin",
             "/usr/bin",
         ]
-        
+        allowed_read_paths = [p for p in _candidate_read_paths if os.path.isdir(p)]
+        if extra_readable:
+            allowed_read_paths.extend(
+                p for p in extra_readable if os.path.isdir(p)
+            )
+
         allowed_write_paths = []
         if working_dir:
             allowed_write_paths.append(working_dir)
         if self._temp_dir:
             allowed_write_paths.append(self._temp_dir)
-        
+
         # Add any configured allowed paths from security policy
         if hasattr(self.config, 'security_policy') and self.config.security_policy:
             allowed_write_paths.extend(self.config.security_policy.allowed_paths)
         
-        # Create policy with kernel-level restrictions
+        # Network policy.
+        #
+        # sandlock uses tri-state semantics for net_allow_hosts:
+        #   None           -> unrestricted (real /etc/hosts visible)
+        #   []             -> deny all hosts (empty virtual /etc/hosts)
+        #   ["host", ...]  -> allowlist
+        #
+        # TCP connectivity is governed separately by net_connect/net_bind,
+        # both of which default to [] = deny all.  To enable network we must
+        # explicitly open TCP ports; to block network we can rely on the
+        # defaults AND additionally block DNS via net_allow_hosts=[].
+        if limits.network_enabled:
+            net_kwargs: Dict[str, Any] = {
+                # Allow outbound TCP to any port; leave net_allow_hosts at
+                # its default (None = /etc/hosts unrestricted).
+                "net_connect": ["0-65535"],
+            }
+        else:
+            net_kwargs = {
+                # Empty allowlist -> no host resolvable via virtual /etc/hosts.
+                # net_bind/net_connect default to [] = deny all TCP.
+                "net_allow_hosts": [],
+            }
+
         policy = Policy(
             # Filesystem restrictions (Landlock)
             fs_readable=allowed_read_paths,
             fs_writable=allowed_write_paths,
-            
-            # Network restrictions
-            net_allow_hosts=[] if not limits.network_enabled else None,
-            
+
             # Resource limits
             max_memory=f"{limits.memory_mb}M",
             max_processes=limits.max_processes,
             max_open_files=limits.max_open_files,
-            
-            # Note: CPU throttle percentage, not time limit
-            # Execution timeout is handled via Sandbox.run(timeout=...)
+            # max_cpu is a throttle percentage of one core, not a time budget.
+            # Execution timeout is handled via Sandbox.run(timeout=...).
+            max_cpu=limits.cpu_percent,
+
+            **net_kwargs,
         )
-        
+
         return policy
+
+    @staticmethod
+    def _decode(buf: Any) -> str:
+        """Decode a sandlock Result stdout/stderr buffer to str.
+
+        sandlock returns ``bytes`` from ``Sandbox.run()``; PraisonAI's
+        ``SandboxResult`` uses ``str`` throughout.  Invalid UTF-8 is
+        replaced rather than raised so downstream consumers never see
+        binary artefacts.
+        """
+        if isinstance(buf, bytes):
+            return buf.decode("utf-8", errors="replace")
+        return buf or ""
 
     def _safe_sandbox_path(self, path: str) -> Optional[str]:
         """Resolve a caller-supplied path to an absolute path inside _temp_dir.
@@ -190,6 +249,7 @@ class SandlockSandbox:
         limits: ResourceLimits,
         env: Optional[Dict[str, str]],
         working_dir: Optional[str],
+        extra_readable: Optional[List[str]] = None,
     ) -> SandboxResult:
         """Execute *cmd* inside a sandlock Sandbox and return a SandboxResult.
 
@@ -202,86 +262,66 @@ class SandlockSandbox:
         prior to sandbox creation.  ``working_dir`` is applied via the policy
         (added to the writable-path allow-list).
         """
-        policy = self._create_policy(limits, working_dir)
+        policy = self._create_policy(limits, working_dir, extra_readable)
 
         started_at = time.time()
 
+        def _run() -> Any:
+            # Context manager ensures the sandbox handle is released even
+            # if .run() raises partway through.
+            with self._sandlock.Sandbox(policy) as sb:
+                return sb.run(cmd, timeout=limits.timeout_seconds)
+
         try:
-            sandbox = self._sandlock.Sandbox(policy)
-
-            result = await asyncio.get_running_loop().run_in_executor(
-                None,
-                lambda: sandbox.run(cmd, timeout=limits.timeout_seconds)
-            )
-
-            completed_at = time.time()
-            duration = completed_at - started_at
-
-            # Check result.success and exit_code to determine actual status
-            if not result.success:
-                # Check if this was a timeout based on duration
-                if duration >= limits.timeout_seconds:
-                    return SandboxResult(
-                        execution_id=execution_id,
-                        status=SandboxStatus.TIMEOUT,
-                        error=f"Execution timed out after {limits.timeout_seconds}s",
-                        exit_code=result.exit_code,
-                        stdout=result.stdout,
-                        stderr=result.stderr,
-                        duration_seconds=duration,
-                        started_at=started_at,
-                        completed_at=completed_at,
-                    )
-                else:
-                    # Non-zero exit or other failure
-                    return SandboxResult(
-                        execution_id=execution_id,
-                        status=SandboxStatus.FAILED,
-                        error=f"Execution failed with exit code {result.exit_code}: {result.stderr}",
-                        exit_code=result.exit_code,
-                        stdout=result.stdout,
-                        stderr=result.stderr,
-                        duration_seconds=duration,
-                        started_at=started_at,
-                        completed_at=completed_at,
-                    )
-
-            return SandboxResult(
-                execution_id=execution_id,
-                status=SandboxStatus.COMPLETED,
-                exit_code=result.exit_code,
-                stdout=result.stdout,
-                stderr=result.stderr,
-                duration_seconds=duration,
-                started_at=started_at,
-                completed_at=completed_at,
-                metadata={
-                    "sandbox_type": "sandlock",
-                    "landlock_enabled": True,
-                    "seccomp_enabled": True,
-                },
-            )
-
+            result = await asyncio.get_running_loop().run_in_executor(None, _run)
         except Exception as e:
             completed_at = time.time()
-            duration = completed_at - started_at
-            if duration >= limits.timeout_seconds:
-                return SandboxResult(
-                    execution_id=execution_id,
-                    status=SandboxStatus.TIMEOUT,
-                    error=f"Execution timed out after {limits.timeout_seconds}s",
-                    duration_seconds=duration,
-                    started_at=started_at,
-                    completed_at=completed_at,
-                )
             return SandboxResult(
                 execution_id=execution_id,
                 status=SandboxStatus.FAILED,
                 error=f"Execution failed: {e}",
-                duration_seconds=duration,
+                duration_seconds=completed_at - started_at,
                 started_at=started_at,
                 completed_at=completed_at,
             )
+
+        completed_at = time.time()
+        duration = completed_at - started_at
+        stdout = self._decode(result.stdout)
+        stderr = self._decode(result.stderr)
+
+        # sandlock surfaces timeouts via result.error containing "timed out".
+        # This is authoritative — wall-clock guesses are unreliable because a
+        # process can legitimately finish just under the limit.
+        err_text = (result.error or "") if not result.success else ""
+        is_timeout = "timed out" in err_text.lower() or "timeout" in err_text.lower()
+
+        if result.success:
+            status = SandboxStatus.COMPLETED
+            error = None
+        elif is_timeout:
+            status = SandboxStatus.TIMEOUT
+            error = f"Execution timed out after {limits.timeout_seconds}s"
+        else:
+            status = SandboxStatus.FAILED
+            error = f"Execution failed with exit code {result.exit_code}: {stderr or err_text}"
+
+        return SandboxResult(
+            execution_id=execution_id,
+            status=status,
+            exit_code=result.exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            duration_seconds=duration,
+            started_at=started_at,
+            completed_at=completed_at,
+            error=error,
+            metadata={
+                "sandbox_type": "sandlock",
+                "landlock_enabled": True,
+                "seccomp_enabled": True,
+            },
+        )
 
     async def execute(
         self,
@@ -294,14 +334,7 @@ class SandlockSandbox:
         """Execute code in the sandlock-isolated sandbox."""
         if not self._is_running:
             await self.start()
-        
-        if not self.is_available:
-            # Fallback to subprocess sandbox if sandlock not available
-            logger.warning("Sandlock not available, falling back to subprocess")
-            from .subprocess import SubprocessSandbox
-            fallback = SubprocessSandbox(self.config)
-            return await fallback.execute(code, language, limits, env, working_dir)
-        
+
         limits = limits or self.config.resource_limits
         execution_id = str(uuid.uuid4())
         
@@ -325,22 +358,39 @@ class SandlockSandbox:
         limits: Optional[ResourceLimits] = None,
         env: Optional[Dict[str, str]] = None,
     ) -> SandboxResult:
-        """Execute a file in the sandbox."""
+        """Execute a file in the sandbox.
+
+        The script is passed to the interpreter by path rather than slurped
+        through ``-c``, so large scripts don't hit ARG_MAX.  The file's
+        parent directory is added to the Landlock read allowlist for this
+        run so the sandboxed process can actually open it.
+        """
+        if not self._is_running:
+            await self.start()
+
         if not os.path.exists(file_path):
             return SandboxResult(
                 status=SandboxStatus.FAILED,
                 error=f"File not found: {file_path}",
             )
-        
-        with open(file_path, "r") as f:
-            code = f.read()
-        
-        # Determine language from file extension
-        language = "python"
-        if file_path.endswith(".sh") or file_path.endswith(".bash"):
-            language = "bash"
-        
-        return await self.execute(code, language=language, limits=limits, env=env)
+
+        limits = limits or self.config.resource_limits
+        execution_id = str(uuid.uuid4())
+
+        abs_path = os.path.realpath(file_path)
+        interp = "bash" if file_path.endswith((".sh", ".bash")) else "python3"
+        cmd: List[str] = [interp, abs_path]
+        if args:
+            cmd.extend(args)
+
+        return await self._run_sandlocked(
+            cmd,
+            execution_id=execution_id,
+            limits=limits,
+            env=env,
+            working_dir=self._temp_dir,
+            extra_readable=[os.path.dirname(abs_path)],
+        )
     
     async def run_command(
         self,
@@ -352,13 +402,7 @@ class SandlockSandbox:
         """Run a shell command in the sandbox."""
         if not self._is_running:
             await self.start()
-        
-        if not self.is_available:
-            logger.warning("Sandlock not available, falling back to subprocess")
-            from .subprocess import SubprocessSandbox
-            fallback = SubprocessSandbox(self.config)
-            return await fallback.run_command(command, limits, env, working_dir)
-        
+
         limits = limits or self.config.resource_limits
         execution_id = str(uuid.uuid4())
         

--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -75,12 +75,30 @@ class SandlockSandbox:
                 "sandlock package required for SandlockSandbox. "
                 "Install with: pip install 'praisonai[sandbox]' or pip install sandlock"
             )
-    
+
+        # Fail loud if Landlock isn't supported on this kernel.  sandlock
+        # requires a minimum Landlock ABI (currently v6, Linux 6.7+); query
+        # it rather than hard-coding so we track the SDK's own requirement.
+        try:
+            abi = self._sandlock.landlock_abi_version()
+            min_abi = self._sandlock.min_landlock_abi()
+        except Exception as e:
+            raise RuntimeError(
+                f"failed to query Landlock ABI version: {e}"
+            ) from e
+        if abi < min_abi:
+            raise RuntimeError(
+                "SandlockSandbox requires Landlock support (Linux kernel "
+                f">= 6.7 with CONFIG_SECURITY_LANDLOCK=y and ABI >= {min_abi}). "
+                f"This kernel reports Landlock ABI version {abi}.  Use "
+                "SubprocessSandbox explicitly if weaker isolation is acceptable."
+            )
+
     @property
     def is_available(self) -> bool:
         """Whether sandlock backend is available."""
         try:
-            return self._sandlock.landlock_abi_version() >= 1
+            return self._sandlock.landlock_abi_version() >= self._sandlock.min_landlock_abi()
         except (AttributeError, ImportError):
             return False
     
@@ -109,24 +127,30 @@ class SandlockSandbox:
         self._is_running = False
         logger.info("Sandlock sandbox stopped")
     
-    def _create_policy(
+    def _build_sandbox_kwargs(
         self,
         limits: ResourceLimits,
         working_dir: Optional[str] = None,
-    ) -> Any:
-        """Create sandlock policy from resource limits.
-        
+        extra_readable: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Build sandlock ``Sandbox`` keyword arguments from resource limits.
+
+        sandlock dropped the separate ``Policy`` object; configuration is now
+        passed directly to ``Sandbox(**kwargs)``.  This returns that kwargs
+        dict.
+
         Args:
             limits: Resource limits configuration
-            working_dir: Working directory for execution
-            
-        Returns:
-            Sandlock Policy object
+            working_dir: Working directory for execution (added to the
+                writable allowlist).
+            extra_readable: Additional directories to add to the Landlock
+                read allowlist (e.g. the parent of a script passed to
+                ``execute_file``).
         """
-        Policy = self._sandlock.Policy
-        
-        # Determine allowed paths
-        allowed_read_paths = [
+        # Landlock requires every path in the allowlist to exist at rule-
+        # attach time; passing a missing directory makes sandlock_spawn
+        # fail outright.  Filter to paths that actually exist on this host.
+        _candidate_read_paths = [
             "/usr/lib/python3",
             "/usr/local/lib/python3",
             "/lib",
@@ -134,36 +158,68 @@ class SandlockSandbox:
             "/bin",
             "/usr/bin",
         ]
-        
+        allowed_read_paths = [p for p in _candidate_read_paths if os.path.isdir(p)]
+        if extra_readable:
+            allowed_read_paths.extend(
+                p for p in extra_readable if os.path.isdir(p)
+            )
+
         allowed_write_paths = []
         if working_dir:
             allowed_write_paths.append(working_dir)
         if self._temp_dir:
             allowed_write_paths.append(self._temp_dir)
-        
+
         # Add any configured allowed paths from security policy
         if hasattr(self.config, 'security_policy') and self.config.security_policy:
             allowed_write_paths.extend(self.config.security_policy.allowed_paths)
         
-        # Create policy with kernel-level restrictions
-        policy = Policy(
+        # Network policy.
+        #
+        # sandlock collapsed network config into a single ``net_allow``
+        # endpoint allowlist:
+        #   []                    -> deny all outbound (the default)
+        #   ["*:*", ...]          -> allow rules; "*:*" = any TCP host:port
+        #
+        # Protocol gating falls out of rule presence: with no UDP rule, UDP
+        # sockets are denied at the seccomp layer.  To make an enabled network
+        # actually usable we open all outbound TCP plus UDP DNS (port 53) so
+        # the sandboxed process can resolve hostnames.  To block the network
+        # we leave the allowlist empty (deny all).
+        if limits.network_enabled:
+            net_allow = ["*:*", "udp://*:53"]
+        else:
+            net_allow = []
+
+        return {
             # Filesystem restrictions (Landlock)
-            fs_readable=allowed_read_paths,
-            fs_writable=allowed_write_paths,
-            
-            # Network restrictions
-            net_allow_hosts=[] if not limits.network_enabled else None,
-            
+            "fs_readable": allowed_read_paths,
+            "fs_writable": allowed_write_paths,
+
             # Resource limits
-            max_memory=f"{limits.memory_mb}M",
-            max_processes=limits.max_processes,
-            max_open_files=limits.max_open_files,
-            
-            # Note: CPU throttle percentage, not time limit
-            # Execution timeout is handled via Sandbox.run(timeout=...)
-        )
-        
-        return policy
+            "max_memory": f"{limits.memory_mb}M",
+            "max_processes": limits.max_processes,
+            "max_open_files": limits.max_open_files,
+            # max_cpu is a throttle percentage of one core, not a time budget.
+            # Execution timeout is handled via Sandbox.run(timeout=...).
+            "max_cpu": limits.cpu_percent,
+
+            # Network (deny-all by default)
+            "net_allow": net_allow,
+        }
+
+    @staticmethod
+    def _decode(buf: Any) -> str:
+        """Decode a sandlock Result stdout/stderr buffer to str.
+
+        sandlock returns ``bytes`` from ``Sandbox.run()``; PraisonAI's
+        ``SandboxResult`` uses ``str`` throughout.  Invalid UTF-8 is
+        replaced rather than raised so downstream consumers never see
+        binary artefacts.
+        """
+        if isinstance(buf, bytes):
+            return buf.decode("utf-8", errors="replace")
+        return buf or ""
 
     def _safe_sandbox_path(self, path: str) -> Optional[str]:
         """Resolve a caller-supplied path to an absolute path inside _temp_dir.
@@ -191,98 +247,81 @@ class SandlockSandbox:
         limits: ResourceLimits,
         env: Optional[Dict[str, str]],
         working_dir: Optional[str],
+        extra_readable: Optional[List[str]] = None,
     ) -> SandboxResult:
         """Execute *cmd* inside a sandlock Sandbox and return a SandboxResult.
 
-        Centralises all sandlock Sandbox/Policy construction and error handling
-        so that ``execute`` and ``run_command`` share a single code path.
+        Centralises all sandlock Sandbox construction and error handling so
+        that ``execute`` and ``run_command`` share a single code path.
 
-        Note: ``env`` is accepted for API compatibility but sandlock's
-        ``Sandbox.run()`` does not support per-run environment injection;
-        callers requiring custom env vars should set them in the policy or
-        prior to sandbox creation.  ``working_dir`` is applied via the policy
-        (added to the writable-path allow-list).
+        ``env`` variables are injected via the ``Sandbox`` ``env`` field
+        (set/overridden in the child).  ``working_dir`` is applied to the
+        sandbox config (added to the writable-path allow-list).
         """
-        policy = self._create_policy(limits, working_dir)
+        sandbox_kwargs = self._build_sandbox_kwargs(
+            limits, working_dir, extra_readable
+        )
+        if env:
+            sandbox_kwargs["env"] = dict(env)
 
         started_at = time.time()
 
+        def _run() -> Any:
+            # Context manager ensures the sandbox handle is released even
+            # if .run() raises partway through.
+            with self._sandlock.Sandbox(**sandbox_kwargs) as sb:
+                return sb.run(cmd, timeout=limits.timeout_seconds)
+
         try:
-            sandbox = self._sandlock.Sandbox(policy)
-
-            result = await asyncio.get_running_loop().run_in_executor(
-                None,
-                lambda: sandbox.run(cmd, timeout=limits.timeout_seconds)
-            )
-
-            completed_at = time.time()
-            duration = completed_at - started_at
-
-            # Check result.success and exit_code to determine actual status
-            if not result.success:
-                # Check if this was a timeout based on duration
-                if duration >= limits.timeout_seconds:
-                    return SandboxResult(
-                        execution_id=execution_id,
-                        status=SandboxStatus.TIMEOUT,
-                        error=f"Execution timed out after {limits.timeout_seconds}s",
-                        exit_code=result.exit_code,
-                        stdout=result.stdout,
-                        stderr=result.stderr,
-                        duration_seconds=duration,
-                        started_at=started_at,
-                        completed_at=completed_at,
-                    )
-                else:
-                    # Non-zero exit or other failure
-                    return SandboxResult(
-                        execution_id=execution_id,
-                        status=SandboxStatus.FAILED,
-                        error=f"Execution failed with exit code {result.exit_code}: {result.stderr}",
-                        exit_code=result.exit_code,
-                        stdout=result.stdout,
-                        stderr=result.stderr,
-                        duration_seconds=duration,
-                        started_at=started_at,
-                        completed_at=completed_at,
-                    )
-
-            return SandboxResult(
-                execution_id=execution_id,
-                status=SandboxStatus.COMPLETED,
-                exit_code=result.exit_code,
-                stdout=result.stdout,
-                stderr=result.stderr,
-                duration_seconds=duration,
-                started_at=started_at,
-                completed_at=completed_at,
-                metadata={
-                    "sandbox_type": "sandlock",
-                    "landlock_enabled": True,
-                    "seccomp_enabled": True,
-                },
-            )
-
+            result = await asyncio.get_running_loop().run_in_executor(None, _run)
         except Exception as e:
             completed_at = time.time()
-            duration = completed_at - started_at
-            if duration >= limits.timeout_seconds:
-                return SandboxResult(
-                    execution_id=execution_id,
-                    status=SandboxStatus.TIMEOUT,
-                    error=f"Execution timed out after {limits.timeout_seconds}s",
-                    duration_seconds=duration,
-                    started_at=started_at,
-                    completed_at=completed_at,
-                )
             return SandboxResult(
                 execution_id=execution_id,
                 status=SandboxStatus.FAILED,
                 error=f"Execution failed: {e}",
-                duration_seconds=duration,
+                duration_seconds=completed_at - started_at,
                 started_at=started_at,
                 completed_at=completed_at,
             )
+
+        completed_at = time.time()
+        duration = completed_at - started_at
+        stdout = self._decode(result.stdout)
+        stderr = self._decode(result.stderr)
+
+        # sandlock surfaces timeouts via result.error containing "timed out".
+        # This is authoritative — wall-clock guesses are unreliable because a
+        # process can legitimately finish just under the limit.
+        err_text = (result.error or "") if not result.success else ""
+        is_timeout = "timed out" in err_text.lower() or "timeout" in err_text.lower()
+
+        if result.success:
+            status = SandboxStatus.COMPLETED
+            error = None
+        elif is_timeout:
+            status = SandboxStatus.TIMEOUT
+            error = f"Execution timed out after {limits.timeout_seconds}s"
+        else:
+            status = SandboxStatus.FAILED
+            error = f"Execution failed with exit code {result.exit_code}: {stderr or err_text}"
+
+        return SandboxResult(
+            execution_id=execution_id,
+            status=status,
+            exit_code=result.exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            duration_seconds=duration,
+            started_at=started_at,
+            completed_at=completed_at,
+            error=error,
+            metadata={
+                "sandbox_type": "sandlock",
+                "landlock_enabled": True,
+                "seccomp_enabled": True,
+            },
+        )
 
     def _tag_subprocess_fallback(self, result: SandboxResult) -> SandboxResult:
         meta = dict(result.metadata or {})
@@ -306,7 +345,7 @@ class SandlockSandbox:
         """Execute code in the sandlock-isolated sandbox."""
         if not self._is_running:
             await self.start()
-        
+
         if not self.is_available:
             from .subprocess import SubprocessSandbox
             fallback = SubprocessSandbox(self.config)
@@ -320,10 +359,10 @@ class SandlockSandbox:
             self._used_subprocess_fallback = True
             result = await fallback.execute(code, language, limits, env, working_dir)
             return self._tag_subprocess_fallback(result)
-        
+
         limits = limits or self.config.resource_limits
         execution_id = str(uuid.uuid4())
-        
+
         if language == "bash":
             cmd = ["bash", "-c", code]
         else:
@@ -344,22 +383,39 @@ class SandlockSandbox:
         limits: Optional[ResourceLimits] = None,
         env: Optional[Dict[str, str]] = None,
     ) -> SandboxResult:
-        """Execute a file in the sandbox."""
+        """Execute a file in the sandbox.
+
+        The script is passed to the interpreter by path rather than slurped
+        through ``-c``, so large scripts don't hit ARG_MAX.  The file's
+        parent directory is added to the Landlock read allowlist for this
+        run so the sandboxed process can actually open it.
+        """
+        if not self._is_running:
+            await self.start()
+
         if not os.path.exists(file_path):
             return SandboxResult(
                 status=SandboxStatus.FAILED,
                 error=f"File not found: {file_path}",
             )
-        
-        with open(file_path, "r") as f:
-            code = f.read()
-        
-        # Determine language from file extension
-        language = "python"
-        if file_path.endswith(".sh") or file_path.endswith(".bash"):
-            language = "bash"
-        
-        return await self.execute(code, language=language, limits=limits, env=env)
+
+        limits = limits or self.config.resource_limits
+        execution_id = str(uuid.uuid4())
+
+        abs_path = os.path.realpath(file_path)
+        interp = "bash" if file_path.endswith((".sh", ".bash")) else "python3"
+        cmd: List[str] = [interp, abs_path]
+        if args:
+            cmd.extend(args)
+
+        return await self._run_sandlocked(
+            cmd,
+            execution_id=execution_id,
+            limits=limits,
+            env=env,
+            working_dir=self._temp_dir,
+            extra_readable=[os.path.dirname(abs_path)],
+        )
     
     async def run_command(
         self,
@@ -371,7 +427,7 @@ class SandlockSandbox:
         """Run a shell command in the sandbox."""
         if not self._is_running:
             await self.start()
-        
+
         if not self.is_available:
             from .subprocess import SubprocessSandbox
             fallback = SubprocessSandbox(self.config)
@@ -385,10 +441,10 @@ class SandlockSandbox:
             self._used_subprocess_fallback = True
             result = await fallback.run_command(command, limits, env, working_dir)
             return self._tag_subprocess_fallback(result)
-        
+
         limits = limits or self.config.resource_limits
         execution_id = str(uuid.uuid4())
-        
+
         if isinstance(command, str):
             cmd = ["sh", "-c", command]
         else:

--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -341,17 +341,6 @@ class SandlockSandbox:
             },
         )
 
-    def _tag_subprocess_fallback(self, result: SandboxResult) -> SandboxResult:
-        meta = dict(result.metadata or {})
-        meta.update({
-            "isolation_level": "subprocess",
-            "filesystem_isolation": False,
-            "network_isolation": False,
-            "sandlock_downgrade": True,
-        })
-        result.metadata = meta
-        return result
-
     async def execute(
         self,
         code: str,
@@ -363,20 +352,6 @@ class SandlockSandbox:
         """Execute code in the sandlock-isolated sandbox."""
         if not self._is_running:
             await self.start()
-
-        if not self.is_available:
-            from .subprocess import SubprocessSandbox
-            fallback = SubprocessSandbox(self.config)
-            if self.config.metadata.get("require_landlock"):
-                return SandboxResult(
-                    status=SandboxStatus.FAILED,
-                    error="Landlock is required but unavailable on this system",
-                    metadata={"isolation_level": "none", "sandlock_downgrade": True},
-                )
-            logger.warning("Sandlock not available, falling back to subprocess (no kernel isolation)")
-            self._used_subprocess_fallback = True
-            result = await fallback.execute(code, language, limits, env, working_dir)
-            return self._tag_subprocess_fallback(result)
 
         limits = limits or self.config.resource_limits
         execution_id = str(uuid.uuid4())
@@ -445,20 +420,6 @@ class SandlockSandbox:
         """Run a shell command in the sandbox."""
         if not self._is_running:
             await self.start()
-
-        if not self.is_available:
-            from .subprocess import SubprocessSandbox
-            fallback = SubprocessSandbox(self.config)
-            if self.config.metadata.get("require_landlock"):
-                return SandboxResult(
-                    status=SandboxStatus.FAILED,
-                    error="Landlock is required but unavailable on this system",
-                    metadata={"isolation_level": "none", "sandlock_downgrade": True},
-                )
-            logger.warning("Sandlock not available, falling back to subprocess (no kernel isolation)")
-            self._used_subprocess_fallback = True
-            result = await fallback.run_command(command, limits, env, working_dir)
-            return self._tag_subprocess_fallback(result)
 
         limits = limits or self.config.resource_limits
         execution_id = str(uuid.uuid4())

--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -77,8 +77,9 @@ class SandlockSandbox:
             )
 
         # Fail loud if Landlock isn't supported on this kernel.  sandlock
-        # requires a minimum Landlock ABI (currently v6, Linux 6.7+); query
-        # it rather than hard-coding so we track the SDK's own requirement.
+        # requires a minimum Landlock ABI (currently v6, which shipped in
+        # Linux 6.12); query it rather than hard-coding so we track the SDK's
+        # own requirement.
         try:
             abi = self._sandlock.landlock_abi_version()
             min_abi = self._sandlock.min_landlock_abi()
@@ -88,10 +89,11 @@ class SandlockSandbox:
             ) from e
         if abi < min_abi:
             raise RuntimeError(
-                "SandlockSandbox requires Landlock support (Linux kernel "
-                f">= 6.7 with CONFIG_SECURITY_LANDLOCK=y and ABI >= {min_abi}). "
-                f"This kernel reports Landlock ABI version {abi}.  Use "
-                "SubprocessSandbox explicitly if weaker isolation is acceptable."
+                "SandlockSandbox requires Landlock ABI >= "
+                f"{min_abi} (Linux kernel >= 6.12 with "
+                "CONFIG_SECURITY_LANDLOCK=y).  This kernel reports Landlock "
+                f"ABI version {abi}.  Use SubprocessSandbox explicitly if "
+                "weaker isolation is acceptable."
             )
 
     @property
@@ -160,8 +162,12 @@ class SandlockSandbox:
         ]
         allowed_read_paths = [p for p in _candidate_read_paths if os.path.isdir(p)]
         if extra_readable:
+            # extra_readable may name individual files (e.g. the single script
+            # passed to execute_file), so accept any path that exists — not
+            # just directories.  Landlock grants read on a named file without
+            # exposing its siblings.
             allowed_read_paths.extend(
-                p for p in extra_readable if os.path.isdir(p)
+                p for p in extra_readable if os.path.exists(p)
             )
 
         allowed_write_paths = []
@@ -384,9 +390,9 @@ class SandlockSandbox:
         """Execute a file in the sandbox.
 
         The script is passed to the interpreter by path rather than slurped
-        through ``-c``, so large scripts don't hit ARG_MAX.  The file's
-        parent directory is added to the Landlock read allowlist for this
-        run so the sandboxed process can actually open it.
+        through ``-c``, so large scripts don't hit ARG_MAX.  Only the script
+        file itself — not its parent directory — is added to the Landlock
+        read allowlist, so sibling files on the host are never exposed.
         """
         if not self._is_running:
             await self.start()
@@ -412,7 +418,7 @@ class SandlockSandbox:
             limits=limits,
             env=env,
             working_dir=self._temp_dir,
-            extra_readable=[os.path.dirname(abs_path)],
+            extra_readable=[abs_path],
         )
     
     async def run_command(

--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -222,6 +222,15 @@ class SandlockSandbox:
 
             # Network (deny-all by default)
             "net_allow": net_allow,
+
+            # Environment isolation.  sandlock inherits the parent's FULL
+            # environment when clean_env is False (its default), which would
+            # leak host secrets (SECRET_KEY, DATABASE_URL, ...) into untrusted
+            # sandboxed code.  Force a minimal baseline (PATH/HOME/USER/TERM/
+            # LANG) instead — mirroring SubprocessSandbox, which likewise
+            # refuses to copy the host environment.  Per-call ``env`` is
+            # layered on top of this baseline by _run_sandlocked.
+            "clean_env": True,
         }
 
     @staticmethod
@@ -270,14 +279,18 @@ class SandlockSandbox:
         Centralises all sandlock Sandbox construction and error handling so
         that ``execute`` and ``run_command`` share a single code path.
 
-        ``env`` variables are injected via the ``Sandbox`` ``env`` field
-        (set/overridden in the child).  ``working_dir`` is applied to the
-        sandbox config (added to the writable-path allow-list).
+        ``env`` variables are layered on top of the clean baseline
+        environment established in _build_sandbox_kwargs (clean_env=True),
+        so the child never inherits the host's full environment.  An
+        explicit empty dict is honoured as "no overrides" — distinct from
+        ``None`` only in intent, since the baseline is minimal either way.
+        ``working_dir`` is applied to the sandbox config (added to the
+        writable-path allow-list).
         """
         sandbox_kwargs = self._build_sandbox_kwargs(
             limits, working_dir, extra_readable
         )
-        if env:
+        if env is not None:
             sandbox_kwargs["env"] = dict(env)
 
         started_at = time.time()

--- a/src/praisonai/praisonai/sandbox/sandlock.py
+++ b/src/praisonai/praisonai/sandbox/sandlock.py
@@ -176,6 +176,16 @@ class SandlockSandbox:
         if self._temp_dir:
             allowed_write_paths.append(self._temp_dir)
 
+        # Landlock does not imply read access from write access: a path that
+        # is only in fs_writable can be written but not read back.  The
+        # sandboxed process needs to read its own working directory (e.g. to
+        # import a file it just wrote, or to stat the cwd), so mirror the
+        # writable dirs into the read allowlist.  De-duplicate to keep the
+        # rule set minimal.
+        for p in (working_dir, self._temp_dir):
+            if p and os.path.isdir(p) and p not in allowed_read_paths:
+                allowed_read_paths.append(p)
+
         # Add any configured allowed paths from security policy
         if hasattr(self.config, 'security_policy') and self.config.security_policy:
             allowed_write_paths.extend(self.config.security_policy.allowed_paths)
@@ -280,7 +290,11 @@ class SandlockSandbox:
 
         try:
             result = await asyncio.get_running_loop().run_in_executor(None, _run)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — broad catch keeps the sandbox
+            # resilient: any sandlock/spawn failure is surfaced as a FAILED
+            # result rather than propagating.  Log the full traceback so the
+            # underlying cause isn't lost.
+            logger.exception("sandlock execution failed for %s", execution_id)
             completed_at = time.time()
             return SandboxResult(
                 execution_id=execution_id,

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -42,43 +42,25 @@ class TestSandlockSandbox:
             with pytest.raises(ImportError, match="sandlock package required"):
                 SandlockSandbox()
 
-    def test_fallback_to_subprocess_when_unavailable(self):
-        """Test fallback to subprocess when sandlock is not available."""
+    def test_raises_when_landlock_unavailable(self):
+        """Instantiation must fail loud on kernels without Landlock support.
+
+        Silent degradation to SubprocessSandbox would violate the caller's
+        explicit choice of kernel-level isolation — a SandlockSandbox that
+        isn't actually using Landlock is a security footgun.
+        """
         mock_sandlock = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 0  # < 1, so unavailable
+        mock_sandlock.landlock_abi_version.return_value = 0  # unsupported
 
-        sandbox = _make_sandbox(mock_sandlock)
-        assert not sandbox.is_available
-        assert sandbox.sandbox_type == "sandlock"
-
-    @pytest.mark.asyncio
-    async def test_fallback_execution(self):
-        """Test that execution falls back to subprocess when sandlock unavailable."""
-        mock_sandlock = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 0  # < 1, so unavailable
-
-        sandbox = _make_sandbox(mock_sandlock)
-
-        mock_subprocess_instance = AsyncMock()
-        mock_subprocess_instance.execute.return_value = Mock(
-            status=SandboxStatus.COMPLETED,
-            exit_code=0,
-            stdout="Hello, World!",
-            stderr="",
-        )
-
-        with patch("praisonai.sandbox.subprocess.SubprocessSandbox") as mock_subprocess:
-            mock_subprocess.return_value = mock_subprocess_instance
-            result = await sandbox.execute("print('Hello, World!')")
-
-            mock_subprocess.assert_called_once()
-            mock_subprocess_instance.execute.assert_called_once()
+        with pytest.raises(RuntimeError, match="requires Landlock"):
+            _make_sandbox(mock_sandlock)
 
     def test_policy_creation_with_minimal_limits(self):
         """Test policy creation with minimal resource limits."""
         mock_sandlock = Mock()
         mock_policy = Mock()
         mock_sandlock.Policy.return_value = mock_policy
+        mock_sandlock.landlock_abi_version.return_value = 6  # supported
 
         sandbox = _make_sandbox(mock_sandlock)
 
@@ -90,10 +72,13 @@ class TestSandlockSandbox:
 
         assert "fs_readable" in call_kwargs
         assert "fs_writable" in call_kwargs
-        assert "max_memory" in call_kwargs
         assert call_kwargs["max_memory"] == "128M"  # From minimal limits
         assert call_kwargs["max_processes"] == 5
-        assert call_kwargs["net_allow_hosts"] == []  # Network disabled
+        assert call_kwargs["max_cpu"] == 50  # From minimal limits
+        # Network disabled → deny all hosts (empty allowlist).
+        assert call_kwargs["net_allow_hosts"] == []
+        # net_connect must NOT be set (defaults to [] = deny all TCP).
+        assert "net_connect" not in call_kwargs
 
     def test_status_reporting(self):
         """Test sandbox status reporting."""
@@ -140,54 +125,54 @@ class TestSandlockSandbox:
 
     @pytest.mark.asyncio
     async def test_sandlock_execution_timeout(self):
-        """Test timeout handling in sandlock execution."""
+        """Timeout is detected via result.error, not wall-clock heuristics."""
         mock_sandlock = Mock()
         mock_sandlock.Policy.return_value = Mock()
         mock_sandlock.Sandbox.return_value = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
+        mock_sandlock.landlock_abi_version.return_value = 6
 
         sandbox = _make_sandbox(mock_sandlock)
 
-        # Create a mock Result object indicating timeout
         mock_timeout_result = Mock()
         mock_timeout_result.success = False
-        mock_timeout_result.exit_code = 124  # Common timeout exit code
-        mock_timeout_result.stdout = ""
-        mock_timeout_result.stderr = "Process timed out"
+        mock_timeout_result.exit_code = 124
+        mock_timeout_result.stdout = b""
+        mock_timeout_result.stderr = b""
+        # sandlock surfaces timeout via the error field.
+        mock_timeout_result.error = "process timed out after 10s"
 
-        # Simulate timeout by returning failed Result after enough time
-        with patch("asyncio.get_running_loop") as mock_loop, \
-             patch("time.time", side_effect=[0, 11, 11]):  # Started at 0, ended at 11s (> 10s timeout)
+        with patch("asyncio.get_running_loop") as mock_loop:
             mock_loop.return_value.run_in_executor = AsyncMock(
                 return_value=mock_timeout_result
             )
 
             await sandbox.start()
-            result = await sandbox.execute("import time; time.sleep(100)", limits=ResourceLimits(timeout_seconds=10))
+            result = await sandbox.execute(
+                "import time; time.sleep(100)",
+                limits=ResourceLimits(timeout_seconds=10),
+            )
 
         assert result.status == SandboxStatus.TIMEOUT
         assert "timed out" in result.error.lower()
 
     @pytest.mark.asyncio
     async def test_sandlock_execution_failure(self):
-        """Test general execution failure handling."""
+        """Non-timeout failures keep the FAILED status and surface stderr."""
         mock_sandlock = Mock()
         mock_sandlock.Policy.return_value = Mock()
         mock_sandlock.Sandbox.return_value = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
+        mock_sandlock.landlock_abi_version.return_value = 6
 
         sandbox = _make_sandbox(mock_sandlock)
 
-        # Create a mock Result object indicating non-zero exit
         mock_failed_result = Mock()
         mock_failed_result.success = False
-        mock_failed_result.exit_code = 1  # Non-zero exit code
-        mock_failed_result.stdout = ""
-        mock_failed_result.stderr = "Permission denied"
+        mock_failed_result.exit_code = 1
+        mock_failed_result.stdout = b""
+        mock_failed_result.stderr = b"Permission denied"
+        mock_failed_result.error = None  # not a timeout
 
-        # Simulate execution failure (not timeout) 
-        with patch("asyncio.get_running_loop") as mock_loop, \
-             patch("time.time", side_effect=[0, 2, 2]):  # Started at 0, ended at 2s (< 10s timeout)
+        with patch("asyncio.get_running_loop") as mock_loop:
             mock_loop.return_value.run_in_executor = AsyncMock(
                 return_value=mock_failed_result
             )

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -125,7 +125,7 @@ class TestSandlockSandbox:
 
     @pytest.mark.asyncio
     async def test_sandlock_execution_timeout(self):
-        """Timeout is detected via result.error, not wall-clock heuristics."""
+        """Timeout is detected via exit_code == -1 (ExitStatus::Timeout)."""
         mock_sandlock = Mock()
         mock_sandlock.Policy.return_value = Mock()
         mock_sandlock.Sandbox.return_value = Mock()
@@ -135,11 +135,12 @@ class TestSandlockSandbox:
 
         mock_timeout_result = Mock()
         mock_timeout_result.success = False
-        mock_timeout_result.exit_code = 124
+        # sandlock's timeout sentinel — Sandbox.run() does not populate
+        # result.error on timeout, so we rely on the exit_code instead.
+        mock_timeout_result.exit_code = -1
         mock_timeout_result.stdout = b""
         mock_timeout_result.stderr = b""
-        # sandlock surfaces timeout via the error field.
-        mock_timeout_result.error = "process timed out after 10s"
+        mock_timeout_result.error = None
 
         with patch("asyncio.get_running_loop") as mock_loop:
             mock_loop.return_value.run_in_executor = AsyncMock(

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -248,14 +248,18 @@ class TestSandlockSandbox:
         try:
             # Try to import real sandlock
             import sandlock
-            
-            # Only run if Landlock is actually supported on this system
-            if sandlock.landlock_abi_version() < 1:
-                pytest.skip("Landlock not supported on this system")
-            
+
+            # SandlockSandbox.__init__ raises RuntimeError unless the kernel's
+            # Landlock ABI meets sandlock's own minimum (min_landlock_abi()).
+            # Skip on anything below that threshold so this test cleanly skips
+            # on intermediate-ABI kernels instead of hard-failing in the
+            # constructor.
+            if sandlock.landlock_abi_version() < sandlock.min_landlock_abi():
+                pytest.skip("Landlock ABI below sandlock's minimum on this system")
+
             # Test with real sandlock package
             from praisonai.sandbox.sandlock import SandlockSandbox
-            
+
             sandbox = SandlockSandbox()
             assert sandbox.is_available
             

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -117,9 +117,11 @@ class TestSandlockSandbox:
         """Test successful code execution with sandlock."""
         mock_sandlock = Mock()
         mock_result = Mock()
+        mock_result.success = True
         mock_result.exit_code = 0
-        mock_result.stdout = "Hello, World!"
-        mock_result.stderr = ""
+        # Real sandlock returns bytes; exercise the _decode() byte path.
+        mock_result.stdout = b"Hello, World!"
+        mock_result.stderr = b""
 
         mock_sandlock.Sandbox.return_value = Mock(run=Mock(return_value=mock_result))
         mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -15,6 +15,12 @@ from praisonaiagents.sandbox import ResourceLimits, SandboxConfig, SandboxStatus
 
 def _make_sandbox(mock_sandlock):
     """Instantiate SandlockSandbox with *mock_sandlock* injected via sys.modules."""
+    # The SDK gates on landlock_abi_version() >= min_landlock_abi(); give the
+    # mock a concrete minimum (sandlock currently requires ABI 6) so the
+    # numeric comparison in __init__/is_available works.  Tests that exercise
+    # the "unsupported" path set landlock_abi_version below this.
+    if not isinstance(mock_sandlock.min_landlock_abi.return_value, int):
+        mock_sandlock.min_landlock_abi.return_value = 6
     # Remove any cached version so the import block inside __init__ re-runs.
     sys.modules.pop("praisonai.sandbox.sandlock", None)
     with patch.dict("sys.modules", {"sandlock": mock_sandlock}):
@@ -42,58 +48,53 @@ class TestSandlockSandbox:
             with pytest.raises(ImportError, match="sandlock package required"):
                 SandlockSandbox()
 
-    def test_fallback_to_subprocess_when_unavailable(self):
-        """Test fallback to subprocess when sandlock is not available."""
+    def test_raises_when_landlock_unavailable(self):
+        """Instantiation must fail loud on kernels without Landlock support.
+
+        Silent degradation to SubprocessSandbox would violate the caller's
+        explicit choice of kernel-level isolation — a SandlockSandbox that
+        isn't actually using Landlock is a security footgun.
+        """
         mock_sandlock = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 0  # < 1, so unavailable
+        mock_sandlock.landlock_abi_version.return_value = 0  # unsupported
 
-        sandbox = _make_sandbox(mock_sandlock)
-        assert not sandbox.is_available
-        assert sandbox.sandbox_type == "sandlock"
+        with pytest.raises(RuntimeError, match="requires Landlock"):
+            _make_sandbox(mock_sandlock)
 
-    @pytest.mark.asyncio
-    async def test_fallback_execution(self):
-        """Test that execution falls back to subprocess when sandlock unavailable."""
+    def test_sandbox_kwargs_with_minimal_limits(self):
+        """Sandbox kwargs are built directly from resource limits.
+
+        sandlock dropped the ``Policy`` object; config is now passed straight
+        to ``Sandbox(**kwargs)``.
+        """
         mock_sandlock = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 0  # < 1, so unavailable
-
-        sandbox = _make_sandbox(mock_sandlock)
-
-        mock_subprocess_instance = AsyncMock()
-        mock_subprocess_instance.execute.return_value = Mock(
-            status=SandboxStatus.COMPLETED,
-            exit_code=0,
-            stdout="Hello, World!",
-            stderr="",
-        )
-
-        with patch("praisonai.sandbox.subprocess.SubprocessSandbox") as mock_subprocess:
-            mock_subprocess.return_value = mock_subprocess_instance
-            result = await sandbox.execute("print('Hello, World!')")
-
-            mock_subprocess.assert_called_once()
-            mock_subprocess_instance.execute.assert_called_once()
-
-    def test_policy_creation_with_minimal_limits(self):
-        """Test policy creation with minimal resource limits."""
-        mock_sandlock = Mock()
-        mock_policy = Mock()
-        mock_sandlock.Policy.return_value = mock_policy
+        mock_sandlock.landlock_abi_version.return_value = 6  # supported
 
         sandbox = _make_sandbox(mock_sandlock)
 
         limits = ResourceLimits.minimal()
-        sandbox._create_policy(limits, "/tmp/workspace")
-
-        mock_sandlock.Policy.assert_called_once()
-        call_kwargs = mock_sandlock.Policy.call_args[1]
+        call_kwargs = sandbox._build_sandbox_kwargs(limits, "/tmp/workspace")
 
         assert "fs_readable" in call_kwargs
         assert "fs_writable" in call_kwargs
-        assert "max_memory" in call_kwargs
         assert call_kwargs["max_memory"] == "128M"  # From minimal limits
         assert call_kwargs["max_processes"] == 5
-        assert call_kwargs["net_allow_hosts"] == []  # Network disabled
+        assert call_kwargs["max_cpu"] == 50  # From minimal limits
+        # Network disabled → deny all outbound (empty allowlist).
+        assert call_kwargs["net_allow"] == []
+
+    def test_sandbox_kwargs_network_enabled(self):
+        """Network-enabled limits open all TCP plus UDP DNS."""
+        mock_sandlock = Mock()
+        mock_sandlock.landlock_abi_version.return_value = 6
+
+        sandbox = _make_sandbox(mock_sandlock)
+
+        limits = ResourceLimits(network_enabled=True)
+        call_kwargs = sandbox._build_sandbox_kwargs(limits)
+
+        assert "*:*" in call_kwargs["net_allow"]
+        assert "udp://*:53" in call_kwargs["net_allow"]
 
     def test_status_reporting(self):
         """Test sandbox status reporting."""
@@ -120,7 +121,6 @@ class TestSandlockSandbox:
         mock_result.stdout = "Hello, World!"
         mock_result.stderr = ""
 
-        mock_sandlock.Policy.return_value = Mock()
         mock_sandlock.Sandbox.return_value = Mock(run=Mock(return_value=mock_result))
         mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
 
@@ -140,54 +140,52 @@ class TestSandlockSandbox:
 
     @pytest.mark.asyncio
     async def test_sandlock_execution_timeout(self):
-        """Test timeout handling in sandlock execution."""
+        """Timeout is detected via result.error, not wall-clock heuristics."""
         mock_sandlock = Mock()
-        mock_sandlock.Policy.return_value = Mock()
         mock_sandlock.Sandbox.return_value = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
+        mock_sandlock.landlock_abi_version.return_value = 6
 
         sandbox = _make_sandbox(mock_sandlock)
 
-        # Create a mock Result object indicating timeout
         mock_timeout_result = Mock()
         mock_timeout_result.success = False
-        mock_timeout_result.exit_code = 124  # Common timeout exit code
-        mock_timeout_result.stdout = ""
-        mock_timeout_result.stderr = "Process timed out"
+        mock_timeout_result.exit_code = 124
+        mock_timeout_result.stdout = b""
+        mock_timeout_result.stderr = b""
+        # sandlock surfaces timeout via the error field.
+        mock_timeout_result.error = "process timed out after 10s"
 
-        # Simulate timeout by returning failed Result after enough time
-        with patch("asyncio.get_running_loop") as mock_loop, \
-             patch("time.time", side_effect=[0, 11, 11]):  # Started at 0, ended at 11s (> 10s timeout)
+        with patch("asyncio.get_running_loop") as mock_loop:
             mock_loop.return_value.run_in_executor = AsyncMock(
                 return_value=mock_timeout_result
             )
 
             await sandbox.start()
-            result = await sandbox.execute("import time; time.sleep(100)", limits=ResourceLimits(timeout_seconds=10))
+            result = await sandbox.execute(
+                "import time; time.sleep(100)",
+                limits=ResourceLimits(timeout_seconds=10),
+            )
 
         assert result.status == SandboxStatus.TIMEOUT
         assert "timed out" in result.error.lower()
 
     @pytest.mark.asyncio
     async def test_sandlock_execution_failure(self):
-        """Test general execution failure handling."""
+        """Non-timeout failures keep the FAILED status and surface stderr."""
         mock_sandlock = Mock()
-        mock_sandlock.Policy.return_value = Mock()
         mock_sandlock.Sandbox.return_value = Mock()
-        mock_sandlock.landlock_abi_version.return_value = 6  # >= 6, so available
+        mock_sandlock.landlock_abi_version.return_value = 6
 
         sandbox = _make_sandbox(mock_sandlock)
 
-        # Create a mock Result object indicating non-zero exit
         mock_failed_result = Mock()
         mock_failed_result.success = False
-        mock_failed_result.exit_code = 1  # Non-zero exit code
-        mock_failed_result.stdout = ""
-        mock_failed_result.stderr = "Permission denied"
+        mock_failed_result.exit_code = 1
+        mock_failed_result.stdout = b""
+        mock_failed_result.stderr = b"Permission denied"
+        mock_failed_result.error = None  # not a timeout
 
-        # Simulate execution failure (not timeout) 
-        with patch("asyncio.get_running_loop") as mock_loop, \
-             patch("time.time", side_effect=[0, 2, 2]):  # Started at 0, ended at 2s (< 10s timeout)
+        with patch("asyncio.get_running_loop") as mock_loop:
             mock_loop.return_value.run_in_executor = AsyncMock(
                 return_value=mock_failed_result
             )

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -140,7 +140,7 @@ class TestSandlockSandbox:
 
     @pytest.mark.asyncio
     async def test_sandlock_execution_timeout(self):
-        """Timeout is detected via result.error, not wall-clock heuristics."""
+        """Timeout is detected via exit_code == -1 (ExitStatus::Timeout)."""
         mock_sandlock = Mock()
         mock_sandlock.Sandbox.return_value = Mock()
         mock_sandlock.landlock_abi_version.return_value = 6
@@ -149,11 +149,12 @@ class TestSandlockSandbox:
 
         mock_timeout_result = Mock()
         mock_timeout_result.success = False
-        mock_timeout_result.exit_code = 124
+        # sandlock's timeout sentinel — Sandbox.run() does not populate
+        # result.error on timeout, so we rely on the exit_code instead.
+        mock_timeout_result.exit_code = -1
         mock_timeout_result.stdout = b""
         mock_timeout_result.stderr = b""
-        # sandlock surfaces timeout via the error field.
-        mock_timeout_result.error = "process timed out after 10s"
+        mock_timeout_result.error = None
 
         with patch("asyncio.get_running_loop") as mock_loop:
             mock_loop.return_value.run_in_executor = AsyncMock(

--- a/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
+++ b/src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py
@@ -82,6 +82,8 @@ class TestSandlockSandbox:
         assert call_kwargs["max_cpu"] == 50  # From minimal limits
         # Network disabled → deny all outbound (empty allowlist).
         assert call_kwargs["net_allow"] == []
+        # Clean baseline env: never inherit the host's full environment.
+        assert call_kwargs["clean_env"] is True
 
     def test_sandbox_kwargs_network_enabled(self):
         """Network-enabled limits open all TCP plus UDP DNS."""
@@ -95,6 +97,44 @@ class TestSandlockSandbox:
 
         assert "*:*" in call_kwargs["net_allow"]
         assert "udp://*:53" in call_kwargs["net_allow"]
+
+    @pytest.mark.asyncio
+    async def test_env_isolation_no_host_leak(self):
+        """clean_env=True isolates the host env; env={} is honoured, not skipped.
+
+        Regression: ``if env:`` skipped an explicitly-passed empty dict, and
+        with sandlock's default ``clean_env=False`` the child inherited the
+        parent's FULL environment — leaking host secrets regardless of what
+        the caller passed.  The baseline must be clean, and ``env={}`` must
+        still set the field (guard is ``is not None``).
+        """
+        mock_sandlock = Mock()
+        mock_result = Mock(success=True, exit_code=0, stdout=b"", stderr=b"")
+        sandbox_cm = MagicMock()
+        sandbox_cm.__enter__.return_value = Mock(run=Mock(return_value=mock_result))
+        mock_sandlock.Sandbox.return_value = sandbox_cm
+        mock_sandlock.landlock_abi_version.return_value = 6
+
+        sandbox = _make_sandbox(mock_sandlock)
+        await sandbox.start()
+
+        # An explicit empty dict must still set env (honour caller intent).
+        await sandbox.execute("pass", env={})
+        kwargs = mock_sandlock.Sandbox.call_args.kwargs
+        assert kwargs["clean_env"] is True
+        assert kwargs["env"] == {}
+
+        # A populated dict is layered on top of the clean baseline.
+        await sandbox.execute("pass", env={"MY_VAR": "x"})
+        kwargs = mock_sandlock.Sandbox.call_args.kwargs
+        assert kwargs["clean_env"] is True
+        assert kwargs["env"] == {"MY_VAR": "x"}
+
+        # env=None: no overrides, but the baseline is still clean.
+        await sandbox.execute("pass")
+        kwargs = mock_sandlock.Sandbox.call_args.kwargs
+        assert kwargs["clean_env"] is True
+        assert "env" not in kwargs
 
     def test_status_reporting(self):
         """Test sandbox status reporting."""


### PR DESCRIPTION
## Summary

The `SandlockSandbox` wrapper in `src/praisonai/praisonai/sandbox/sandlock.py` has several latent correctness and security issues. A caller who asks for kernel-level isolation could silently get weaker isolation, resource limits get dropped on the floor, and the timeout classifier never actually fires for real timeouts.

This PR fixes the integration to match sandlock's actual API, removes the silent fallback that violated the caller's explicit security choice, and strengthens the test suite accordingly.

## What's fixed

- **Network policy intent is now explicit.** sandlock uses tri-state semantics for `net_allow_hosts` (`None` = unrestricted, `[]` = deny all, `[...]` = allowlist). The previous code passed `None` to a `Sequence[str]` field when network was enabled and `[]` when disabled — semantically backwards and type-invalid. Rewritten to pass `net_connect=[\"0-65535\"]` when enabled or `net_allow_hosts=[]` when disabled. TCP-level deny-all defaults handle the rest.

- **`stdout` / `stderr` are now `str`, not `bytes`.** sandlock returns `bytes` from `Sandbox.run()`; PraisonAI's `SandboxResult` is typed `str`. Added a `_decode()` helper with `errors=\"replace\"` so downstream consumers never see binary artefacts or crash on `.lower()` / `.split()`.

- **`max_cpu` is now actually passed.** `limits.cpu_percent` was silently ignored. Added `max_cpu=limits.cpu_percent` to the Policy construction.

- **`execute_file()` passes the script by path.** The old implementation slurped the file into `python3 -c <code>` which is subject to `ARG_MAX`. Now it invokes `[interp, abs_path, *args]` directly and adds the script's parent directory to the Landlock read allowlist via a new `extra_readable` parameter on `_create_policy`.

- **Timeout detection uses sandlock's structural sentinel.** sandlock exposes `ExitStatus::Timeout` as `exit_code == -1` (see `sandlock/_sdk.py` around line 1475). `Sandbox.run()` does **not** populate `result.error` on timeout — only pipelines do — so string-matching is unreliable. Switching to `exit_code == -1` works uniformly and matches how sandlock itself detects timeouts.

- **Context manager around `Sandbox`.** `with self._sandlock.Sandbox(policy) as sb:` guarantees cleanup even if `.run()` raises mid-flight.

- **`fs_readable` is filtered to paths that exist.** Landlock fails at spawn time if any allowlisted path is missing, so the hardcoded list — which included `/usr/local/lib/python3` — caused `sandlock_spawn failed` on most hosts. The `test_real_sandlock_integration` test was silently failing on baseline for this reason; it now passes.

## Breaking change — silent fallback removed

`SandlockSandbox.execute/run_command/execute_file` used to fall back to `SubprocessSandbox` whenever `landlock_abi_version() < 1`, logging only a warning. This violates the caller's explicit choice of kernel-level isolation: a `SandlockSandbox` that isn't actually using Landlock is a security footgun, and a warning in the logs is not a consent mechanism.

`__init__` now raises `RuntimeError` if Landlock support is missing. The three fallback branches in `execute()`, `run_command()`, and `execute_file()` are removed.

Callers who want graceful degradation should catch `ImportError` / `RuntimeError` and construct `SubprocessSandbox` explicitly:

\`\`\`python
try:
    sb = SandlockSandbox(cfg)
except (ImportError, RuntimeError):
    sb = SubprocessSandbox(cfg)
\`\`\`

This is a deliberate fail-loud change — the previous behavior would silently weaken the security guarantees of any caller running on a kernel <5.13 or in a container with seccomp stripped.

## Test plan

- [x] `test_raises_when_landlock_unavailable` replaces the two old fallback tests and asserts `RuntimeError` at construction time.
- [x] `test_sandlock_execution_timeout` mocks `exit_code = -1` (the sentinel) instead of patching `time.time`.
- [x] `test_sandlock_execution_failure` sets `result.error = None` explicitly (reflects real `Sandbox.run()` behavior).
- [x] `test_policy_creation_with_minimal_limits` strengthened to verify `max_cpu`, `net_allow_hosts=[]` deny-all, and that `net_connect` is left unset so TCP deny-all defaults apply.
- [x] `test_real_sandlock_integration` now actually passes (previously failed on baseline due to the `/usr/local/lib/python3` hardcoded path).
- [x] 10/10 unit tests pass: \`pytest src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py\`
- [x] End-to-end smoke test against real sandlock confirmed: basic execute, network-blocked execute, `execute_file` with args, and a forced real timeout all behave correctly.

## Files changed

- \`src/praisonai/praisonai/sandbox/sandlock.py\` — all fixes
- \`src/praisonai/tests/unit/sandbox/test_sandlock_sandbox.py\` — updated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added startup-time Landlock support validation with explicit error messaging when unsupported.

* **Improvements**
  * Enhanced timeout detection for sandboxed processes.
  * Improved stdout/stderr handling with proper UTF-8 decoding.
  * Refined network isolation policy configuration.
  * Changed script execution method for improved compatibility and access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->