### PR TITLE
feat(cli): add examples find command for searchable example discovery

### DIFF
--- a/src/praisonai/praisonai/cli/commands/examples.py
+++ b/src/praisonai/praisonai/cli/commands/examples.py
@@ -388,11 +388,17 @@ def find_examples(
     if not examples_path.exists():
         typer.echo(f"❌ Examples path not found: {examples_path}")
         raise typer.Exit(2)
+    if not examples_path.is_dir():
+        typer.echo(f"❌ Examples path is not a directory: {examples_path}")
+        raise typer.Exit(2)
 
     terms = _tokenize_query(query)
     if not terms:
         typer.echo("❌ Please provide a non-empty search query")
         raise typer.Exit(2)
+
+    # Resolve path to ensure it's absolute for relative_to operations
+    examples_path = examples_path.resolve()
 
     source = ExamplesSource(
         root=examples_path,
@@ -454,7 +460,7 @@ def find_examples(
 
     typer.echo(f"Found {len(matches)} matches for '{query}' in {examples_path}\n")
 
-    for idx, (score, rel_path, item) in enumerate(matches[: max(1, limit)], 1):
+    for idx, (score, rel_path, item) in enumerate(matches[:limit], 1):
         tags = []
         if item.uses_agent:
             tags.append("agent")

--- a/src/praisonai/praisonai/cli/commands/examples.py
+++ b/src/praisonai/praisonai/cli/commands/examples.py
@@ -371,6 +371,7 @@ def find_examples(
         10,
         "--limit", "-n",
         help="Maximum number of matches to show",
+        min=1,
     ),
 ):
     """

--- a/src/praisonai/praisonai/cli/commands/examples.py
+++ b/src/praisonai/praisonai/cli/commands/examples.py
@@ -12,6 +12,7 @@ Usage:
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, List
+import re
 
 import typer
 
@@ -346,6 +347,125 @@ def list_examples(
             typer.echo(f"  {idx:3}. [{item.group}] {rel_path}{flag_str}")
         else:
             typer.echo(f"  {idx:3}. [{item.group}] {rel_path}")
+
+
+def _tokenize_query(query: str) -> List[str]:
+    """Tokenize query into lowercase search terms."""
+    return [t for t in re.split(r"[^a-zA-Z0-9_\-]+", query.lower()) if t]
+
+
+@app.command("find")
+def find_examples(
+    query: str = typer.Argument(..., help="Search query (e.g. rag, mcp, gemini)"),
+    path: Optional[Path] = typer.Option(
+        None,
+        "--path", "-p",
+        help="Path to examples directory",
+    ),
+    group: Optional[List[str]] = typer.Option(
+        None,
+        "--group", "-g",
+        help="Filter by group (top-level dir), can be repeated",
+    ),
+    limit: int = typer.Option(
+        10,
+        "--limit", "-n",
+        help="Maximum number of matches to show",
+    ),
+):
+    """
+    Find examples by keyword with lightweight relevance scoring.
+
+    Examples:
+        praisonai examples find rag
+        praisonai examples find mcp --group python
+        praisonai examples find gemini --limit 20
+    """
+    from praisonai.suite_runner import ExamplesSource
+
+    examples_path = path or _get_default_examples_path()
+
+    if not examples_path.exists():
+        typer.echo(f"❌ Examples path not found: {examples_path}")
+        raise typer.Exit(2)
+
+    terms = _tokenize_query(query)
+    if not terms:
+        typer.echo("❌ Please provide a non-empty search query")
+        raise typer.Exit(2)
+
+    source = ExamplesSource(
+        root=examples_path,
+        groups=list(group) if group else None,
+    )
+    items = source.discover()
+
+    matches = []
+    for item in items:
+        rel_path = item.source_path.relative_to(examples_path).as_posix()
+        rel_lower = rel_path.lower()
+        filename_lower = item.source_path.name.lower()
+        group_lower = item.group.lower()
+
+        # Build searchable text with metadata signals
+        searchable = [
+            rel_lower,
+            filename_lower,
+            group_lower,
+            (item.runnable_decision or "").lower(),
+            " ".join((item.require_env or [])).lower(),
+        ]
+        if item.uses_agent:
+            searchable.append("agent")
+        if item.uses_agents:
+            searchable.append("agents")
+        if item.uses_workflow:
+            searchable.append("workflow")
+        haystack = " ".join(searchable)
+
+        score = 0
+        matched_terms = 0
+        for term in terms:
+            term_score = 0
+            if term in filename_lower:
+                term_score = max(term_score, 8)
+            if f"/{term}" in rel_lower or rel_lower.startswith(term):
+                term_score = max(term_score, 6)
+            if term in group_lower:
+                term_score = max(term_score, 5)
+            if term in haystack:
+                term_score = max(term_score, 3)
+
+            if term_score > 0:
+                matched_terms += 1
+                score += term_score
+
+        # Prefer results matching all terms; allow partial for flexibility
+        if score > 0:
+            if matched_terms == len(terms):
+                score += 2
+            matches.append((score, rel_path, item))
+
+    matches.sort(key=lambda x: (-x[0], x[1]))
+
+    if not matches:
+        typer.echo(f"No examples found for query: {query}")
+        raise typer.Exit(0)
+
+    typer.echo(f"Found {len(matches)} matches for '{query}' in {examples_path}\n")
+
+    for idx, (score, rel_path, item) in enumerate(matches[: max(1, limit)], 1):
+        tags = []
+        if item.uses_agent:
+            tags.append("agent")
+        if item.uses_agents:
+            tags.append("agents")
+        if item.uses_workflow:
+            tags.append("workflow")
+        if item.require_env:
+            tags.append("env")
+        tag_str = f" [{' '.join(tags)}]" if tags else ""
+        typer.echo(f"  {idx:2}. [{item.group}] {rel_path} (score={score}){tag_str}")
 
 
 @app.command()

--- a/src/praisonai/tests/unit/cli/test_examples_runner.py
+++ b/src/praisonai/tests/unit/cli/test_examples_runner.py
@@ -463,6 +463,20 @@ class TestCLIIntegration:
 
         assert result.exit_code == 0
         assert "No examples found" in result.stdout
+
+    def test_examples_find_command_invalid_limit(self, tmp_path):
+        """Test 'praisonai examples find' validates --limit is >= 1."""
+        from typer.testing import CliRunner
+
+        (tmp_path / "demo.py").write_text("print('hello')")
+
+        from praisonai.cli.commands.examples import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["find", "demo", "--path", str(tmp_path), "--limit", "0"])
+
+        assert result.exit_code == 2
+        assert "range x>=1" in (result.stderr or "")
     
     def test_examples_list_command(self, tmp_path):
         """Test 'praisonai examples list' command."""

--- a/src/praisonai/tests/unit/cli/test_examples_runner.py
+++ b/src/praisonai/tests/unit/cli/test_examples_runner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 class TestExampleMetadata:
     """Tests for ExampleMetadata parsing from comment directives."""
-    
+
     def test_parse_skip_directive(self, tmp_path):
         """Test parsing # praisonai: skip=true directive."""
         from praisonai.cli.features.examples import ExampleMetadata
@@ -466,6 +466,7 @@ class TestCLIIntegration:
 
     def test_examples_find_command_invalid_limit(self, tmp_path):
         """Test 'praisonai examples find' validates --limit is >= 1."""
+        import re
         from typer.testing import CliRunner
 
         (tmp_path / "demo.py").write_text("print('hello')")
@@ -476,7 +477,8 @@ class TestCLIIntegration:
         result = runner.invoke(app, ["find", "demo", "--path", str(tmp_path), "--limit", "0"])
 
         assert result.exit_code == 2
-        assert "range x>=1" in (result.stderr or "")
+        clean_stderr = re.sub(r"\x1b\[[0-9;]*m", "", result.stderr or "")
+        assert "Invalid value for '--limit'" in clean_stderr
     
     def test_examples_list_command(self, tmp_path):
         """Test 'praisonai examples list' command."""

--- a/src/praisonai/tests/unit/cli/test_examples_runner.py
+++ b/src/praisonai/tests/unit/cli/test_examples_runner.py
@@ -430,6 +430,39 @@ class TestReportGenerator:
 
 class TestCLIIntegration:
     """Tests for CLI command integration."""
+
+    def test_examples_find_command(self, tmp_path):
+        """Test 'praisonai examples find' command returns relevant matches."""
+        from typer.testing import CliRunner
+
+        # Create test examples
+        (tmp_path / "rag").mkdir()
+        (tmp_path / "rag" / "basic_rag.py").write_text("print('rag')")
+        (tmp_path / "mcp").mkdir()
+        (tmp_path / "mcp" / "tool_demo.py").write_text("print('mcp')")
+
+        from praisonai.cli.commands.examples import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["find", "rag", "--path", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "basic_rag.py" in result.stdout
+        assert "tool_demo.py" not in result.stdout
+
+    def test_examples_find_command_no_matches(self, tmp_path):
+        """Test 'praisonai examples find' with no matches exits cleanly."""
+        from typer.testing import CliRunner
+
+        (tmp_path / "demo.py").write_text("print('hello')")
+
+        from praisonai.cli.commands.examples import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["find", "nonexistent-keyword", "--path", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "No examples found" in result.stdout
     
     def test_examples_list_command(self, tmp_path):
         """Test 'praisonai examples list' command."""


### PR DESCRIPTION
## Summary\n- add `praisonai examples find <query>` command for searchable example discovery\n- implement lightweight relevance scoring based on filename/path/group/metadata signals\n- add unit tests for find command success and no-match behavior\n\n## Testing\n- tests added in `src/praisonai/tests/unit/cli/test_examples_runner.py`\n- note: unable to run pytest in this environment because test dependencies are unavailable (no pytest/typer installed in runtime)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added example search capability: discover and filter examples by keyword, path, and group; results ranked by relevance, shown up to a configurable limit, with graceful error messaging for invalid inputs or no matches.
* **Tests**
  * Added integration tests validating matching, group/path filtering, and no-results behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->