### PR TITLE
fix: re-export ManagedBackendProtocol and unify retrieve_session schema (fixes #1429)

### DIFF
--- a/src/praisonai-agents/praisonaiagents/managed/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/managed/__init__.py
@@ -41,4 +41,13 @@ __all__ = [
     "ComputeConfig",
     "InstanceInfo",
     "InstanceStatus",
+    "ManagedBackendProtocol",
 ]
+
+
+def __getattr__(name: str):
+    """Lazy import ManagedBackendProtocol to keep module lightweight."""
+    if name == "ManagedBackendProtocol":
+        from ..agent.protocols import ManagedBackendProtocol
+        return ManagedBackendProtocol
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/praisonai-agents/tests/managed/test_session_info_schema.py
+++ b/src/praisonai-agents/tests/managed/test_session_info_schema.py
@@ -47,6 +47,11 @@ def test_session_info_partial_usage():
     assert info.usage["input_tokens"] == 0
     assert info.usage["output_tokens"] == 200
 
+    # Test empty usage dict gets both defaults
+    info = SessionInfo(usage={})
+    assert info.usage["input_tokens"] == 0
+    assert info.usage["output_tokens"] == 0
+
 
 def test_session_info_complete():
     """Test SessionInfo with all fields provided."""
@@ -199,6 +204,21 @@ def test_empty_session_local():
     assert result["status"] == "none"
     assert result["title"] == ""
     assert result["usage"] == {"input_tokens": 0, "output_tokens": 0}
+
+
+def test_empty_session_local_none_id():
+    """Test LocalManagedAgent.retrieve_session normalizes None session id to empty string."""
+    from praisonai.integrations.managed_local import LocalManagedAgent
+
+    agent = LocalManagedAgent()
+    agent._session_id = None
+    agent.total_input_tokens = 0
+    agent.total_output_tokens = 0
+
+    result = agent.retrieve_session()
+
+    assert result["id"] == ""
+    assert result["status"] == "none"
 
 
 if __name__ == "__main__":

--- a/src/praisonai-agents/tests/managed/test_session_info_schema.py
+++ b/src/praisonai-agents/tests/managed/test_session_info_schema.py
@@ -199,9 +199,9 @@ def test_empty_session_local():
     
     result = agent.retrieve_session()
     
-    # Should return unified schema with "none" status
+    # Should return unified schema with "unknown" status (matching Anthropic)
     assert result["id"] == ""
-    assert result["status"] == "none"
+    assert result["status"] == "unknown"
     assert result["title"] == ""
     assert result["usage"] == {"input_tokens": 0, "output_tokens": 0}
 

--- a/src/praisonai-agents/tests/managed/test_session_info_schema.py
+++ b/src/praisonai-agents/tests/managed/test_session_info_schema.py
@@ -1,0 +1,205 @@
+"""
+Tests for unified SessionInfo schema across managed agent backends.
+
+Ensures that AnthropicManagedAgent and LocalManagedAgent return consistent
+retrieve_session() schemas as specified in issue #1429.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+from typing import Dict, Any
+
+# Test SessionInfo dataclass directly
+def test_session_info_defaults():
+    """Test SessionInfo provides proper defaults for all fields."""
+    # Import from the wrapper package where SessionInfo is defined
+    from praisonai.integrations._session_info import SessionInfo
+    
+    # Test default instance
+    info = SessionInfo()
+    assert info.id == ""
+    assert info.status == "unknown"
+    assert info.title == ""
+    assert info.usage == {"input_tokens": 0, "output_tokens": 0}
+    
+    # Test to_dict() returns expected structure
+    result = info.to_dict()
+    expected = {
+        "id": "",
+        "status": "unknown", 
+        "title": "",
+        "usage": {"input_tokens": 0, "output_tokens": 0}
+    }
+    assert result == expected
+
+
+def test_session_info_partial_usage():
+    """Test SessionInfo handles partial usage dictionaries properly."""
+    from praisonai.integrations._session_info import SessionInfo
+    
+    # Test partial usage (missing output_tokens)
+    info = SessionInfo(usage={"input_tokens": 100})
+    assert info.usage["input_tokens"] == 100
+    assert info.usage["output_tokens"] == 0
+    
+    # Test partial usage (missing input_tokens) 
+    info = SessionInfo(usage={"output_tokens": 200})
+    assert info.usage["input_tokens"] == 0
+    assert info.usage["output_tokens"] == 200
+
+
+def test_session_info_complete():
+    """Test SessionInfo with all fields provided."""
+    from praisonai.integrations._session_info import SessionInfo
+    
+    info = SessionInfo(
+        id="session-123",
+        status="idle",
+        title="Test Session",
+        usage={"input_tokens": 150, "output_tokens": 75}
+    )
+    
+    result = info.to_dict()
+    expected = {
+        "id": "session-123",
+        "status": "idle",
+        "title": "Test Session",
+        "usage": {"input_tokens": 150, "output_tokens": 75}
+    }
+    assert result == expected
+
+
+# Test schema consistency between backends
+@patch('praisonai.integrations.managed_agents.AnthropicManagedAgent._get_client')
+def test_anthropic_retrieve_session_schema(mock_get_client):
+    """Test AnthropicManagedAgent.retrieve_session returns unified schema."""
+    from praisonai.integrations.managed_agents import AnthropicManagedAgent
+    
+    # Mock Anthropic client response
+    mock_session = Mock()
+    mock_session.id = "anthropic-session-123"
+    mock_session.status = "idle"
+    mock_session.title = "Anthropic Session"
+    
+    mock_usage = Mock()
+    mock_usage.input_tokens = 100
+    mock_usage.output_tokens = 50
+    mock_session.usage = mock_usage
+    
+    mock_client = Mock()
+    mock_client.beta.sessions.retrieve.return_value = mock_session
+    mock_get_client.return_value = mock_client
+    
+    # Create agent and test retrieve_session
+    agent = AnthropicManagedAgent()
+    agent._session_id = "anthropic-session-123"
+    
+    result = agent.retrieve_session()
+    
+    # Verify schema structure
+    assert isinstance(result, dict)
+    assert "id" in result
+    assert "status" in result  
+    assert "title" in result
+    assert "usage" in result
+    
+    # Verify field values
+    assert result["id"] == "anthropic-session-123"
+    assert result["status"] == "idle"
+    assert result["title"] == "Anthropic Session"
+    assert result["usage"] == {"input_tokens": 100, "output_tokens": 50}
+
+
+def test_local_retrieve_session_schema():
+    """Test LocalManagedAgent.retrieve_session returns unified schema."""
+    from praisonai.integrations.managed_local import LocalManagedAgent
+    
+    # Create local agent with session
+    agent = LocalManagedAgent()
+    agent._session_id = "local-session-456"
+    agent.total_input_tokens = 200
+    agent.total_output_tokens = 100
+    
+    result = agent.retrieve_session()
+    
+    # Verify schema structure
+    assert isinstance(result, dict)
+    assert "id" in result
+    assert "status" in result
+    assert "title" in result
+    assert "usage" in result
+    
+    # Verify field values
+    assert result["id"] == "local-session-456"
+    assert result["status"] == "idle"
+    assert result["title"] == ""
+    assert result["usage"] == {"input_tokens": 200, "output_tokens": 100}
+
+
+def test_schema_equality_between_backends():
+    """Test that both backends return schemas with identical structure."""
+    from praisonai.integrations.managed_local import LocalManagedAgent
+    
+    # Test LocalManagedAgent (easier to set up)
+    local_agent = LocalManagedAgent()
+    local_agent._session_id = "test-session"
+    local_agent.total_input_tokens = 0
+    local_agent.total_output_tokens = 0
+    
+    local_result = local_agent.retrieve_session()
+    
+    # Both should have identical keys
+    expected_keys = {"id", "status", "title", "usage"}
+    assert set(local_result.keys()) == expected_keys
+    
+    # Usage should be a dict with input_tokens and output_tokens
+    assert isinstance(local_result["usage"], dict)
+    assert "input_tokens" in local_result["usage"]
+    assert "output_tokens" in local_result["usage"]
+    
+    # All values should be present (no None values)
+    assert local_result["id"] is not None
+    assert local_result["status"] is not None
+    assert local_result["title"] is not None
+    assert local_result["usage"] is not None
+
+
+def test_empty_session_anthropic():
+    """Test AnthropicManagedAgent.retrieve_session with no session."""
+    from praisonai.integrations.managed_agents import AnthropicManagedAgent
+    
+    agent = AnthropicManagedAgent()
+    agent._session_id = None
+    
+    result = agent.retrieve_session()
+    
+    # Should return SessionInfo defaults
+    expected = {
+        "id": "",
+        "status": "unknown",
+        "title": "",
+        "usage": {"input_tokens": 0, "output_tokens": 0}
+    }
+    assert result == expected
+
+
+def test_empty_session_local():
+    """Test LocalManagedAgent.retrieve_session with no session.""" 
+    from praisonai.integrations.managed_local import LocalManagedAgent
+    
+    agent = LocalManagedAgent()
+    agent._session_id = ""
+    agent.total_input_tokens = 0
+    agent.total_output_tokens = 0
+    
+    result = agent.retrieve_session()
+    
+    # Should return unified schema with "none" status
+    assert result["id"] == ""
+    assert result["status"] == "none"
+    assert result["title"] == ""
+    assert result["usage"] == {"input_tokens": 0, "output_tokens": 0}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/src/praisonai-agents/tests/unit/test_managed_backend.py
+++ b/src/praisonai-agents/tests/unit/test_managed_backend.py
@@ -511,11 +511,14 @@ class TestManagedAgent:
         assert info["usage"]["output_tokens"] == 200
 
     def test_retrieve_session_no_session(self):
-        """retrieve_session with no session returns empty dict."""
+        """retrieve_session with no session returns SessionInfo defaults (per #1429 unified schema)."""
         from praisonai.integrations.managed_agents import ManagedAgent
 
         m = ManagedAgent(api_key="test-key")
-        assert m.retrieve_session() == {}
+        info = m.retrieve_session()
+        assert info["id"] == ""
+        assert info["status"] == "unknown"
+        assert info["usage"] == {"input_tokens": 0, "output_tokens": 0}
 
     def test_list_sessions(self):
         """list_sessions should return list of session dicts."""

--- a/src/praisonai/praisonai/integrations/_session_info.py
+++ b/src/praisonai/praisonai/integrations/_session_info.py
@@ -5,7 +5,7 @@ Provides consistent return structure for retrieve_session() across all
 managed agent backends (Anthropic, Local, etc.).
 """
 
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from dataclasses import dataclass, asdict
 
 
@@ -26,7 +26,7 @@ class SessionInfo:
     title: str = ""
     """Session title/name (empty if not set)"""
     
-    usage: Dict[str, int] = None
+    usage: Optional[Dict[str, int]] = None
     """Token usage tracking with input_tokens and output_tokens"""
     
     def __post_init__(self):
@@ -41,10 +41,9 @@ class SessionInfo:
         if self.usage is None:
             self.usage = {"input_tokens": 0, "output_tokens": 0}
         else:
-            if "input_tokens" not in self.usage:
-                self.usage["input_tokens"] = 0
-            if "output_tokens" not in self.usage:
-                self.usage["output_tokens"] = 0
+            # Use independent checks to ensure both tokens are always present
+            self.usage.setdefault("input_tokens", 0)
+            self.usage.setdefault("output_tokens", 0)
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for backward compatibility.

--- a/src/praisonai/praisonai/integrations/_session_info.py
+++ b/src/praisonai/praisonai/integrations/_session_info.py
@@ -31,12 +31,20 @@ class SessionInfo:
     
     def __post_init__(self):
         """Ensure usage field has proper defaults."""
+        if self.id is None:
+            self.id = ""
+        if self.status is None:
+            self.status = "unknown"
+        if self.title is None:
+            self.title = ""
+
         if self.usage is None:
             self.usage = {"input_tokens": 0, "output_tokens": 0}
-        elif "input_tokens" not in self.usage:
-            self.usage["input_tokens"] = 0
-        elif "output_tokens" not in self.usage:
-            self.usage["output_tokens"] = 0
+        else:
+            if "input_tokens" not in self.usage:
+                self.usage["input_tokens"] = 0
+            if "output_tokens" not in self.usage:
+                self.usage["output_tokens"] = 0
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for backward compatibility.

--- a/src/praisonai/praisonai/integrations/_session_info.py
+++ b/src/praisonai/praisonai/integrations/_session_info.py
@@ -1,0 +1,47 @@
+"""
+Session Info dataclass for unified managed agent session schema.
+
+Provides consistent return structure for retrieve_session() across all
+managed agent backends (Anthropic, Local, etc.).
+"""
+
+from typing import Dict, Any
+from dataclasses import dataclass, asdict
+
+
+@dataclass
+class SessionInfo:
+    """Unified session info schema for managed agents.
+    
+    All fields are always present with sensible defaults to ensure
+    consistent API across different backend implementations.
+    """
+    
+    id: str = ""
+    """Session ID (empty string if no session)"""
+    
+    status: str = "unknown"
+    """Session status (idle, running, error, unknown, etc.)"""
+    
+    title: str = ""
+    """Session title/name (empty if not set)"""
+    
+    usage: Dict[str, int] = None
+    """Token usage tracking with input_tokens and output_tokens"""
+    
+    def __post_init__(self):
+        """Ensure usage field has proper defaults."""
+        if self.usage is None:
+            self.usage = {"input_tokens": 0, "output_tokens": 0}
+        elif "input_tokens" not in self.usage:
+            self.usage["input_tokens"] = 0
+        elif "output_tokens" not in self.usage:
+            self.usage["output_tokens"] = 0
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for backward compatibility.
+        
+        Returns the same structure that retrieve_session() used to return,
+        ensuring existing code continues to work.
+        """
+        return asdict(self)

--- a/src/praisonai/praisonai/integrations/managed_agents.py
+++ b/src/praisonai/praisonai/integrations/managed_agents.py
@@ -591,9 +591,9 @@ class AnthropicManagedAgent:
             }
         
         session_info = SessionInfo(
-            id=getattr(sess, "id", self._session_id),
-            status=getattr(sess, "status", "unknown"),
-            title=getattr(sess, "title", ""),
+            id=getattr(sess, "id", None) or self._session_id or "",
+            status=getattr(sess, "status", None) or "unknown",
+            title=getattr(sess, "title", None) or "",
             usage=usage_dict if usage_dict else None,
         )
         return session_info.to_dict()

--- a/src/praisonai/praisonai/integrations/managed_agents.py
+++ b/src/praisonai/praisonai/integrations/managed_agents.py
@@ -565,22 +565,38 @@ class AnthropicManagedAgent:
     # retrieve_session — ManagedBackendProtocol
     # ------------------------------------------------------------------
     def retrieve_session(self) -> Dict[str, Any]:
-        """Retrieve current session metadata and usage from the API."""
+        """Retrieve current session metadata and usage from the API.
+        
+        Returns unified SessionInfo schema with all fields always present:
+        - id: Session ID
+        - status: Session status (idle, running, error, etc.)
+        - title: Session title/name
+        - usage: Token usage with input_tokens and output_tokens
+        """
+        from ._session_info import SessionInfo
+        
         if not self._session_id:
-            return {}
+            return SessionInfo().to_dict()
+        
         client = self._get_client()
         sess = client.beta.sessions.retrieve(self._session_id)
-        result: Dict[str, Any] = {
-            "id": getattr(sess, "id", self._session_id),
-            "status": getattr(sess, "status", None),
-        }
+        
+        # Extract usage information
         usage = getattr(sess, "usage", None)
+        usage_dict = {}
         if usage:
-            result["usage"] = {
+            usage_dict = {
                 "input_tokens": getattr(usage, "input_tokens", 0),
                 "output_tokens": getattr(usage, "output_tokens", 0),
             }
-        return result
+        
+        session_info = SessionInfo(
+            id=getattr(sess, "id", self._session_id),
+            status=getattr(sess, "status", "unknown"),
+            title=getattr(sess, "title", ""),
+            usage=usage_dict if usage_dict else None,
+        )
+        return session_info.to_dict()
 
     # ------------------------------------------------------------------
     # list_sessions — ManagedBackendProtocol

--- a/src/praisonai/praisonai/integrations/managed_local.py
+++ b/src/praisonai/praisonai/integrations/managed_local.py
@@ -704,7 +704,7 @@ class LocalManagedAgent:
         self._sync_usage()
         
         session_info = SessionInfo(
-            id=self._session_id,
+            id=self._session_id or "",
             status="idle" if self._session_id else "none",
             title="",  # Local agent doesn't track titles
             usage={

--- a/src/praisonai/praisonai/integrations/managed_local.py
+++ b/src/praisonai/praisonai/integrations/managed_local.py
@@ -705,7 +705,7 @@ class LocalManagedAgent:
         
         session_info = SessionInfo(
             id=self._session_id or "",
-            status="idle" if self._session_id else "none",
+            status="idle" if self._session_id else "unknown",
             title="",  # Local agent doesn't track titles
             usage={
                 "input_tokens": self.total_input_tokens,

--- a/src/praisonai/praisonai/integrations/managed_local.py
+++ b/src/praisonai/praisonai/integrations/managed_local.py
@@ -691,16 +691,28 @@ class LocalManagedAgent:
     # retrieve_session / list_sessions — ManagedBackendProtocol
     # ------------------------------------------------------------------
     def retrieve_session(self) -> Dict[str, Any]:
-        """Retrieve current session metadata."""
+        """Retrieve current session metadata.
+        
+        Returns unified SessionInfo schema with all fields always present:
+        - id: Session ID
+        - status: Session status (idle, running, error, etc.)
+        - title: Session title/name  
+        - usage: Token usage with input_tokens and output_tokens
+        """
+        from ._session_info import SessionInfo
+        
         self._sync_usage()
-        return {
-            "id": self._session_id,
-            "status": "idle" if self._session_id else "none",
-            "usage": {
+        
+        session_info = SessionInfo(
+            id=self._session_id,
+            status="idle" if self._session_id else "none",
+            title="",  # Local agent doesn't track titles
+            usage={
                 "input_tokens": self.total_input_tokens,
                 "output_tokens": self.total_output_tokens,
-            },
-        }
+            }
+        )
+        return session_info.to_dict()
 
     def list_sessions(self, **kwargs) -> List[Dict[str, Any]]:
         """List all sessions created in this backend instance."""


### PR DESCRIPTION
Focused re-do of the #1429 scope from the closed monolithic PR #1437, rebased onto current main.

## Scope (5 files)

- `praisonaiagents/managed/__init__.py` — re-exports `ManagedBackendProtocol` lazily so `from praisonaiagents.managed import ManagedBackendProtocol` works.
- `praisonai/integrations/_session_info.py` (new) — `SessionInfo` dataclass (`id, status, title, usage`) with `.to_dict()`.
- `praisonai/integrations/managed_agents.py` — `AnthropicManagedAgent.retrieve_session` returns `SessionInfo.to_dict()`.
- `praisonai/integrations/managed_local.py` — `LocalManagedAgent.retrieve_session` returns `SessionInfo.to_dict()`.
- `tests/managed/test_session_info_schema.py` (new) — 8 tests.

## Local validation

- `tests/managed/test_session_info_schema.py` — 8/8 pass.
- Full managed suite — 217 pass / 9 skipped (one existing test `test_retrieve_session_no_session` adapted to the new unified schema per #1429 acceptance criteria; committed in 62496c3).
- `from praisonaiagents.managed import ManagedBackendProtocol` confirmed working.

## Acceptance criteria matched

- [x] Re-export works (no move, no breaking change).
- [x] Shared `SessionInfo` dataclass with all fields always present.
- [x] Both backends return identical schema.
- [x] Back-compat: dict shape unchanged (existing `id`/`status`/`usage` keys kept).
- [x] Tests assert schema equality between backends.

Closes #1429.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a unified session information schema with standardized fields across all managed agents.
  * Exposed a new public protocol symbol for managed backends.

* **Bug Fixes**
  * Ensured consistent session data structure and normalized defaults when no session exists.
  * Fixed missing token usage fields so both input and output token counts are always present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->