### PR TITLE
fix(gateway): unbreak daemon after onboard — remove duplicate block + guard push attrs

### DIFF
--- a/src/praisonai/praisonai/gateway/server.py
+++ b/src/praisonai/praisonai/gateway/server.py
@@ -960,15 +960,18 @@ class WebSocketGateway:
             "channels": channel_status,
         }
         
-        # Add push status if enabled
-        if self._push_enabled:
+        # Add push status if enabled (push infra lives in wrapper; guard defensively)
+        if getattr(self, "_push_enabled", False):
             push_status: Dict[str, Any] = {"enabled": True}
-            if self._channel_mgr is not None:
-                push_status["push_channels"] = len(self._channel_mgr.list_channels())
-            if self._presence_mgr is not None:
-                push_status["online_clients"] = self._presence_mgr.get_online_count()
-            if self._redis_pubsub is not None:
-                push_status["redis_connected"] = self._redis_pubsub._client is not None
+            channel_mgr = getattr(self, "_channel_mgr", None)
+            if channel_mgr is not None:
+                push_status["push_channels"] = len(channel_mgr.list_channels())
+            presence_mgr = getattr(self, "_presence_mgr", None)
+            if presence_mgr is not None:
+                push_status["online_clients"] = presence_mgr.get_online_count()
+            redis_pubsub = getattr(self, "_redis_pubsub", None)
+            if redis_pubsub is not None:
+                push_status["redis_connected"] = redis_pubsub._client is not None
             result["push"] = push_status
         
         return result
@@ -1781,90 +1784,6 @@ class WebSocketGateway:
         # Register signal handlers for graceful shutdown using
         # loop.add_signal_handler (async-safe) with signal.signal fallback.
         import signal
-
-        def _request_shutdown():
-            logger.info("Received shutdown signal, stopping gateway...")
-            if self._server:
-                self._server.should_exit = True
-
-        loop = asyncio.get_event_loop()
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            try:
-                loop.add_signal_handler(sig, _request_shutdown)
-            except (NotImplementedError, OSError, ValueError):
-                # Fallback for platforms where add_signal_handler is unavailable
-                try:
-                    signal.signal(sig, lambda s, f: _request_shutdown())
-                except (OSError, ValueError):
-                    pass
-
-        try:
-            await _run_all()
-        finally:
-            if self._config_watch_task:
-                self._config_watch_task.cancel()
-            if self._scheduler_task:
-                self._scheduler_task.cancel()
-            await self.stop_channels()
-                except (OSError, ValueError):
-                    pass
-
-        try:
-            await _run_all()
-        finally:
-            if self._config_watch_task:
-                self._config_watch_task.cancel()
-            if self._scheduler_task:
-                self._scheduler_task.cancel()
-            await self.stop_channels()
-        loop = asyncio.get_event_loop()
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            try:
-                loop.add_signal_handler(sig, _request_shutdown)
-            except (NotImplementedError, OSError, ValueError):
-                # Fallback for platforms where add_signal_handler is unavailable
-                try:
-                    signal.signal(sig, lambda s, f: _request_shutdown())
-                except (OSError, ValueError):
-                    pass
-
-        try:
-            await _run_all()
-        finally:
-            if self._config_watch_task:
-                self._config_watch_task.cancel()
-            if self._scheduler_task:
-                self._scheduler_task.cancel()
-            await self.stop_channels()
-
-        try:
-            await _run_all()
-        finally:
-            if self._config_watch_task:
-                self._config_watch_task.cancel()
-            if self._scheduler_task:
-                self._scheduler_task.cancel()
-            await self.stop_channels()
-                loop.add_signal_handler(sig, _request_shutdown)
-            except (NotImplementedError, OSError, ValueError):
-                # Fallback for platforms where add_signal_handler is unavailable
-                try:
-                    signal.signal(sig, lambda s, f: _request_shutdown())
-                except (OSError, ValueError):
-                    pass
-
-        try:
-            await _run_all()
-        finally:
-            if self._config_watch_task:
-                self._config_watch_task.cancel()
-            if self._scheduler_task:
-                self._scheduler_task.cancel()
-            await self.stop_channels()
-                self._config_watch_task.cancel()
-            if self._scheduler_task:
-                self._scheduler_task.cancel()
-            await self.stop_channels()
 
         def _request_shutdown():
             logger.info("Received shutdown signal, stopping gateway...")

--- a/src/praisonai/praisonai/gateway/server.py
+++ b/src/praisonai/praisonai/gateway/server.py
@@ -971,7 +971,7 @@ class WebSocketGateway:
                 push_status["online_clients"] = presence_mgr.get_online_count()
             redis_pubsub = getattr(self, "_redis_pubsub", None)
             if redis_pubsub is not None:
-                push_status["redis_connected"] = redis_pubsub._client is not None
+                push_status["redis_connected"] = getattr(redis_pubsub, "_client", None) is not None
             result["push"] = push_status
         
         return result


### PR DESCRIPTION
## Problem

After a fresh `curl -fsSL https://praison.ai/install.sh | bash` on v4.6.22, the onboarding wizard completes successfully and installs the launchd daemon, but:

```
❯ praisonai gateway status
✅ Daemon service: Running (launchd)
Gateway not reachable at http://127.0.0.1:8765/health
Error: <urlopen error [Errno 61] Connection refused>
```

## Root causes (two)

**1. `IndentationError` crash loop in `praisonai/gateway/server.py`**

`start_with_config()` had its last 28 lines duplicated four times with broken indentation (84 spurious lines, 1809-1892). Python refused to import the module; launchd's `KeepAlive=true` crash-looped the daemon, producing a **68 MB** `bot-stderr.log` in minutes. Port 8765 never opened, hence 'Connection refused'.

**2. `AttributeError: _push_enabled` → HTTP 500**

Once the daemon stayed up, `/health` still failed:
```
File ".../praisonai/gateway/server.py", line 964, in health
    if self._push_enabled:
AttributeError: 'WebSocketGateway' object has no attribute '_push_enabled'
```
PR #1483 moved `PushClient` and transports out of the core gateway into the wrapper, but left stale references (`_push_enabled`, `_channel_mgr`, `_presence_mgr`, `_redis_pubsub`) in `health()`.

## Fix (minimal, 1 file)

- Delete the 84 duplicated lines so `start_with_config()` ends cleanly at `await self.stop_channels()`.
- Guard each push attribute access in `health()` with `getattr(self, "_attr", default)` so core gateways without push report healthy.

## Verification

```bash
launchctl kickstart -k gui/$(id -u)/ai.praison.bot
curl -sS http://127.0.0.1:8765/health
# {"status": "healthy", "uptime": 3.6, "agents": 1, ...}
praisonai gateway status
# ✅ Daemon service: Running (launchd)
# Gateway Status: healthy
```

Diff: `1 file changed, 11 insertions(+), 92 deletions(-)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved server stability by adding defensive checks to avoid missing push-related state
  * Simplified startup/shutdown flow to remove redundant shutdown paths and ensure cleaner task cancellation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->