### PR TITLE
fix(gateway): default reflection=False for YAML agents — 8x faster chat replies

### DIFF
--- a/src/praisonai/praisonai/gateway/server.py
+++ b/src/praisonai/praisonai/gateway/server.py
@@ -1180,7 +1180,7 @@ class WebSocketGateway:
         Supports all agent configuration options including:
         - tools: List of tool names to resolve via ToolResolver
         - tool_choice: Tool selection mode ('auto', 'required', 'none')
-        - reflection: Enable reflection/interactive mode (default: True)
+        - reflection: Enable reflection/interactive mode (default: False)
         - allow_delegation: Allow task delegation
         - role: Agent role (CrewAI-style)
         - goal: Agent goal (CrewAI-style)
@@ -1242,12 +1242,13 @@ class WebSocketGateway:
                         logger.warning(f"Tool '{tool_name}' not found for agent '{agent_id}'")
 
             # Additional agent options from YAML.
+            tool_choice = agent_def.get("tool_choice", None)
+            
             # reflection defaults to False for gateway agents: chat channels
             # (Telegram/Discord/Slack/WhatsApp) expect sub-second replies, and
             # self-reflection adds 1-N extra LLM round-trips per message
             # (~8x latency for short prompts on gpt-4o-mini). Users who want
             # higher answer quality can opt in with `reflection: true` in YAML.
-            tool_choice = agent_def.get("tool_choice", None)
             reflection = agent_def.get("reflection", False)
             allow_delegation = agent_def.get("allow_delegation", False)
 

--- a/src/praisonai/praisonai/gateway/server.py
+++ b/src/praisonai/praisonai/gateway/server.py
@@ -1241,9 +1241,14 @@ class WebSocketGateway:
                     else:
                         logger.warning(f"Tool '{tool_name}' not found for agent '{agent_id}'")
 
-            # Additional agent options from YAML
+            # Additional agent options from YAML.
+            # reflection defaults to False for gateway agents: chat channels
+            # (Telegram/Discord/Slack/WhatsApp) expect sub-second replies, and
+            # self-reflection adds 1-N extra LLM round-trips per message
+            # (~8x latency for short prompts on gpt-4o-mini). Users who want
+            # higher answer quality can opt in with `reflection: true` in YAML.
             tool_choice = agent_def.get("tool_choice", None)
-            reflection = agent_def.get("reflection", True)
+            reflection = agent_def.get("reflection", False)
             allow_delegation = agent_def.get("allow_delegation", False)
 
             # G5: Wire guardrails if config has a matching agent_name or global rule

--- a/src/praisonai/tests/unit/test_gateway_tools.py
+++ b/src/praisonai/tests/unit/test_gateway_tools.py
@@ -54,8 +54,8 @@ class TestGapG1GatewayToolResolution:
         agent = gw.get_agent("test_agent")
         assert agent is not None
 
-    def test_gateway_agent_has_reflection_enabled_by_default(self):
-        """Gateway agents should have reflection=True by default."""
+    def test_gateway_agent_has_reflection_disabled_by_default(self):
+        """Gateway agents should have reflection=False by default."""
         from praisonai.gateway import WebSocketGateway
         
         gw = WebSocketGateway()
@@ -70,8 +70,8 @@ class TestGapG1GatewayToolResolution:
         
         agent = gw.get_agent("assistant")
         assert agent is not None
-        # self_reflect should be True by default (set via reflection param)
-        assert getattr(agent, "self_reflect", None) is True
+        # self_reflect should be False by default for gateway agents
+        assert getattr(agent, "self_reflect", None) is False
 
     def test_gateway_supports_tool_choice_from_yaml(self):
         """Gateway should store tool_choice from YAML config."""
@@ -94,8 +94,8 @@ class TestGapG1GatewayToolResolution:
         # tool_choice should be stored as _yaml_tool_choice
         assert getattr(agent, "_yaml_tool_choice", None) == "required"
 
-    def test_gateway_supports_reflection_override(self):
-        """Gateway should allow reflection to be disabled via YAML."""
+    def test_gateway_supports_reflection_opt_in(self):
+        """Gateway should allow reflection to be enabled via YAML."""
         from praisonai.gateway import WebSocketGateway
         
         gw = WebSocketGateway()
@@ -103,7 +103,7 @@ class TestGapG1GatewayToolResolution:
         agents_cfg = {
             "simple_agent": {
                 "instructions": "Simple agent",
-                "reflection": False,
+                "reflection": True,
             }
         }
         
@@ -111,7 +111,7 @@ class TestGapG1GatewayToolResolution:
         
         agent = gw.get_agent("simple_agent")
         assert agent is not None
-        assert getattr(agent, "self_reflect", True) is False
+        assert getattr(agent, "self_reflect", False) is True
 
 
 class TestGapG1ToolResolver:

--- a/src/praisonai/tests/unit/test_gateway_tools.py
+++ b/src/praisonai/tests/unit/test_gateway_tools.py
@@ -55,7 +55,7 @@ class TestGapG1GatewayToolResolution:
         assert agent is not None
 
     def test_gateway_agent_has_reflection_disabled_by_default(self):
-        """Gateway agents should have reflection=False by default."""
+        """Gateway agents should have reflection=False by default for performance."""
         from praisonai.gateway import WebSocketGateway
         
         gw = WebSocketGateway()
@@ -70,8 +70,8 @@ class TestGapG1GatewayToolResolution:
         
         agent = gw.get_agent("assistant")
         assert agent is not None
-        # self_reflect should be False by default for gateway agents
-        assert getattr(agent, "self_reflect", None) is False
+        # self_reflect should be False by default (set via reflection param)
+        assert getattr(agent, "self_reflect", True) is False
 
     def test_gateway_supports_tool_choice_from_yaml(self):
         """Gateway should store tool_choice from YAML config."""


### PR DESCRIPTION
## Problem

After a fresh `praisonai onboard` install and connecting a Telegram bot, users complained replies took a long time. Measured on the `bot.yaml` the wizard generates (model `gpt-4o-mini`, plain assistant instructions):

| reflection | latency | reply |
|---|---|---|
| `True` (current default) | **12.33 s** | 258 chars, self-critiqued |
| `False` (this PR) | **1.57 s** | direct answer |

~8x latency for the simplest "hello" prompt. Users feel the channel is laggy.

## Root cause

`@/Users/praison/praisonai-package/src/praisonai/praisonai/gateway/server.py:1246`:

```python
reflection = agent_def.get("reflection", True)   # ← overrides SDK default
```

The core SDK already defaults `self_reflect=False` for instruction-based agents (`agent.py:1447`). The gateway was silently turning it back on, so every gateway agent ran a 1..`max_reflect=3` self-critique loop before replying.

## Fix (1 line + comment)

Default `reflection` to `False`. Users who want higher-quality answers can still opt in per agent via `bot.yaml`:

```yaml
agents:
  assistant:
    instructions: "You are a helpful AI assistant."
    model: gpt-4o-mini
    reflection: true   # opt-in
```

## Verification (live daemon, v4.6.25 + this patch)

```
/health                     → {"status":"healthy", ...}
agent.self_reflect          → False
Agent.start('Say hello...') → 2.90 s   (was 12.3 s)
```

Diff: 1 file, +7/-2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway agents now default to reflection being disabled unless explicitly configured, altering chat behavior where reflection was previously implicit.

* **Tests**
  * Unit tests updated to assert the new opt-in reflection semantics and to verify explicit enabling of reflection; related test descriptions and comments were adjusted to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->