### PR TITLE
fix(install.sh): don't print duplicate next-steps after 'praisonai onboard' completes

### DIFF
--- a/src/praisonai/scripts/install.sh
+++ b/src/praisonai/scripts/install.sh
@@ -510,12 +510,9 @@ print_next_steps() {
         echo ""
     fi
     
-    # Only suggest 'praisonai onboard' when the user hasn't just completed it.
-    if [[ "$BOT_ONBOARDED" != "1" ]]; then
-        echo "  Set up a messaging bot (Telegram / Discord / Slack / WhatsApp):"
-        echo -e "     ${CYAN}praisonai onboard${NC}"
-        echo ""
-    fi
+    echo "  Set up a messaging bot (Telegram / Discord / Slack / WhatsApp):"
+    echo -e "     ${CYAN}praisonai onboard${NC}"
+    echo ""
     echo "  Open the dashboard UI (localhost only):"
     echo -e "     ${CYAN}praisonai claw${NC}    ${BOLD}→${NC} http://127.0.0.1:8082"
     echo ""

--- a/src/praisonai/scripts/install.sh
+++ b/src/praisonai/scripts/install.sh
@@ -32,6 +32,13 @@ SKIP_VENV="${PRAISONAI_SKIP_VENV:-0}"
 NO_ONBOARD="${PRAISONAI_NO_ONBOARD:-0}"
 MIN_PYTHON_VERSION="3.10"
 
+# Set to 1 inside maybe_offer_bot_onboarding() when the bot wizard
+# succeeds. The wizard already prints a complete "✅ Done" panel with
+# the dashboard URL, bot-start command, gateway endpoints and doctor
+# hints — so we suppress the installer's own next-steps block to avoid
+# showing a second, partially duplicated summary after it.
+BOT_ONBOARDED=0
+
 # Logging functions - all output to stderr to avoid capturing in $()
 log_info() {
     echo -e "${BLUE}==>${NC} $1" >&2
@@ -503,10 +510,13 @@ print_next_steps() {
         echo ""
     fi
     
-    echo "  Set up a messaging bot (Telegram / Discord / Slack / WhatsApp):"
-    echo -e "     ${CYAN}praisonai onboard${NC}"
-    echo ""
-    echo "  Open the dashboard UI:"
+    # Only suggest 'praisonai onboard' when the user hasn't just completed it.
+    if [[ "$BOT_ONBOARDED" != "1" ]]; then
+        echo "  Set up a messaging bot (Telegram / Discord / Slack / WhatsApp):"
+        echo -e "     ${CYAN}praisonai onboard${NC}"
+        echo ""
+    fi
+    echo "  Open the dashboard UI (localhost only):"
     echo -e "     ${CYAN}praisonai claw${NC}    ${BOLD}→${NC} http://127.0.0.1:8082"
     echo ""
     echo "  Quick start:"
@@ -706,6 +716,7 @@ maybe_offer_bot_onboarding() {
         *)
             if "$py" -m praisonai onboard < /dev/tty > /dev/tty 2> /dev/tty; then
                 log_success "Bot onboarding completed!"
+                BOT_ONBOARDED=1
             else
                 log_warn "Bot onboarding skipped or failed — you can retry with 'praisonai onboard'."
             fi
@@ -754,9 +765,13 @@ main() {
     
     # Offer bot onboarding
     maybe_offer_bot_onboarding "$venv_dir"
-    
-    # Print next steps
-    print_next_steps "$venv_dir"
+
+    # Print next steps only when the bot wizard did NOT run to completion.
+    # When it did, its "✅ Done" panel is the final and most useful summary,
+    # and appending another next-steps block creates a confusing duplicate.
+    if [[ "$BOT_ONBOARDED" != "1" ]]; then
+        print_next_steps "$venv_dir"
+    fi
 }
 
 # Run main


### PR DESCRIPTION
## Problem

After a fresh `curl | bash` where the user completes bot onboarding, install.sh prints the onboard wizard's full '✅ Done' panel **and then** its own `print_next_steps` block — which partially duplicates the panel and still says:

```
Set up a messaging bot (Telegram / Discord / Slack / WhatsApp):
   praisonai onboard
```

…which is exactly what the user just finished. The resulting UX shows two summaries and tells the user to redo the step they just completed.

## Fix (minimal, install.sh only, +22/-7)

- Track `BOT_ONBOARDED=1` when `praisonai onboard` returns success.
- Skip `print_next_steps` entirely in that path — the wizard's '✅ Done' panel is the canonical final summary (dashboard URL, bot-start cmd, gateway /health and /info + auth token, doctor).
- If the user declined onboarding or the wizard failed, `print_next_steps` still runs, and it no longer suggests `praisonai onboard` as a next step when the flag is set.
- Clarified the dashboard line as '(localhost only)' because `praisonai claw` binds to `127.0.0.1` with no URL-level auth by default (see `praisonai/cli/commands/claw.py` for the LAN-exposure warning path).

## After this PR

- Onboard completed → flow ends on the '✅ Done' panel. Clean, single summary.
- Onboard skipped/declined → existing `print_next_steps` block still shown, guiding the user to run it later.

## Verification

```
$ bash -n install.sh   # syntax OK
$ BOT_ONBOARDED=0 → print_next_steps
$ BOT_ONBOARDED=1 → skip
```

Related user feedback:
> 'the box need to come at the end right? / the installation steps is already done in the onboarding process right? / then why the users need to try again'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved installer onboarding flow to avoid showing duplicate post-install instructions after completing the interactive bot onboarding.
  * Clarified dashboard guidance text shown after installation to indicate the dashboard is for localhost access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->