### PR TITLE
feat(approval): default tool-safety policy (block destructive ops, zero new kwargs)

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1763,10 +1763,10 @@ Your Goal: {self.goal}
             # Users who want the pre-4.6.27 "trust everything" behaviour
             # export PRAISONAI_TOOL_SAFETY=off. This adds zero Agent kwargs.
             _safety_env = os.environ.get("PRAISONAI_TOOL_SAFETY", "default").strip().lower()
-            if _safety_env and _safety_env not in ("off", "full", "none", "0", "false"):
+            if _safety_env:
                 from ..approval.registry import PERMISSION_PRESETS
                 _preset_deny = PERMISSION_PRESETS.get(_safety_env)
-                if _preset_deny is not None:
+                if _preset_deny:
                     self._perm_deny = _preset_deny
         elif isinstance(approval, ApprovalConfig):
             self._approval_backend = approval.backend

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1762,10 +1762,21 @@ Your Goal: {self.goal}
             # while leaving read / create / edit tools fully auto-approved.
             # Users who want the pre-4.6.27 "trust everything" behaviour
             # export PRAISONAI_TOOL_SAFETY=off. This adds zero Agent kwargs.
-            _safety_env = os.environ.get("PRAISONAI_TOOL_SAFETY", "default").strip().lower()
-            if _safety_env:
+            _raw_safety_env = os.environ.get("PRAISONAI_TOOL_SAFETY")
+            _safety_env = (_raw_safety_env or "").strip().lower()
+            if _safety_env not in ("off", "full", "none", "0", "false"):
                 from ..approval.registry import PERMISSION_PRESETS
-                _preset_deny = PERMISSION_PRESETS.get(_safety_env)
+                _resolved_safety_env = _safety_env or "default"
+                _preset_deny = PERMISSION_PRESETS.get(_resolved_safety_env)
+                if _preset_deny is None and _safety_env:
+                    # Unknown env value - fall back to safe default and log warning
+                    import logging
+                    logging.getLogger(__name__).warning(
+                        "Unknown PRAISONAI_TOOL_SAFETY value %r; falling back to 'default' preset.",
+                        _raw_safety_env,
+                    )
+                    _resolved_safety_env = "default"
+                    _preset_deny = PERMISSION_PRESETS.get(_resolved_safety_env)
                 if _preset_deny is not None:
                     self._perm_deny = _preset_deny
         elif isinstance(approval, ApprovalConfig):

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1756,6 +1756,18 @@ Your Goal: {self.goal}
             self._approval_backend = None
             self._approve_all_tools = False
             self._approval_timeout = 0
+            # No explicit approval kwarg — honour PRAISONAI_TOOL_SAFETY.
+            # Default preset "default" blocks only destructive ops
+            # (delete_*, execute_command, execute_code, kill_process, move/copy)
+            # while leaving read / create / edit tools fully auto-approved.
+            # Users who want the pre-4.6.27 "trust everything" behaviour
+            # export PRAISONAI_TOOL_SAFETY=off. This adds zero Agent kwargs.
+            _safety_env = os.environ.get("PRAISONAI_TOOL_SAFETY", "default").strip().lower()
+            if _safety_env and _safety_env not in ("off", "full", "none", "0", "false"):
+                from ..approval.registry import PERMISSION_PRESETS
+                _preset_deny = PERMISSION_PRESETS.get(_safety_env)
+                if _preset_deny is not None:
+                    self._perm_deny = _preset_deny
         elif isinstance(approval, ApprovalConfig):
             self._approval_backend = approval.backend
             self._approve_all_tools = approval.all_tools

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1766,7 +1766,7 @@ Your Goal: {self.goal}
             if _safety_env:
                 from ..approval.registry import PERMISSION_PRESETS
                 _preset_deny = PERMISSION_PRESETS.get(_safety_env)
-                if _preset_deny:
+                if _preset_deny is not None:
                     self._perm_deny = _preset_deny
         elif isinstance(approval, ApprovalConfig):
             self._approval_backend = approval.backend

--- a/src/praisonai-agents/praisonaiagents/approval/registry.py
+++ b/src/praisonai-agents/praisonaiagents/approval/registry.py
@@ -47,16 +47,33 @@ DEFAULT_DANGEROUS_TOOLS: Dict[str, str] = {
 }
 
 # Permission presets — resolved to deny frozensets at Agent.__init__ time.
-# Usage: Agent(approval="safe")
+# Usage: Agent(approval="safe") — or set PRAISONAI_TOOL_SAFETY=<preset>
+# which applies as the default when no ``approval=`` kwarg is passed.
+#
+# ``default`` is the baseline we apply when nothing is configured: it
+# only blocks operations the LLM should never execute unattended —
+# destructive file ops (delete/move/copy) and arbitrary shell/code
+# execution. Read, create and edit stay allowed because those are
+# what 99% of useful agent workflows need. Users who want the old
+# ``trust the LLM with everything`` behaviour pass ``approval="full"``
+# or set ``PRAISONAI_TOOL_SAFETY=off``; users who want stricter
+# controls can opt into ``approval="safe"`` or ``"read_only"``.
 PERMISSION_PRESETS = {
+    # "default" — blocks delete + shell/code exec. Allows read/create/edit.
+    "default": frozenset({
+        "execute_command", "kill_process", "execute_code", "acp_execute_command",
+        "delete_file", "move_file", "copy_file", "acp_delete_file",
+    }),
     # "safe" — blocks all dangerous tools (file writes, shell exec, etc.)
     "safe": frozenset(DEFAULT_DANGEROUS_TOOLS.keys()),
     # "read_only" — blocks dangerous tools + write operations
     "read_only": frozenset(DEFAULT_DANGEROUS_TOOLS.keys()) | frozenset({
         "write_file", "copy_file", "move_file",
     }),
-    # "full" — no restrictions
+    # "full" — no restrictions (trust the LLM). Equivalent to "off" env.
     "full": frozenset(),
+    # "off" — alias of "full" for the env-var off-switch.
+    "off": frozenset(),
 }
 
 class ApprovalRegistry:

--- a/src/praisonai-agents/praisonaiagents/approval/registry.py
+++ b/src/praisonai-agents/praisonaiagents/approval/registry.py
@@ -66,10 +66,8 @@ PERMISSION_PRESETS = {
     }),
     # "safe" — blocks all dangerous tools (file writes, shell exec, etc.)
     "safe": frozenset(DEFAULT_DANGEROUS_TOOLS.keys()),
-    # "read_only" — blocks dangerous tools + write operations
-    "read_only": frozenset(DEFAULT_DANGEROUS_TOOLS.keys()) | frozenset({
-        "write_file", "copy_file", "move_file",
-    }),
+    # "read_only" — alias of "safe" (blocks all dangerous tools)
+    "read_only": frozenset(DEFAULT_DANGEROUS_TOOLS.keys()),
     # "full" — no restrictions (trust the LLM). Equivalent to "off" env.
     "full": frozenset(),
     # "off" — alias of "full" for the env-var off-switch.

--- a/src/praisonai-agents/tests/unit/approval/test_default_tool_safety.py
+++ b/src/praisonai-agents/tests/unit/approval/test_default_tool_safety.py
@@ -1,0 +1,122 @@
+"""
+Default tool-safety policy tests.
+
+Covers the zero-kwarg, env-var-driven default that lands an
+``Agent()`` into the ``PERMISSION_PRESETS['default']`` deny set when
+no explicit ``approval=`` is passed.
+
+Policy (see praisonaiagents/approval/registry.py):
+- Allowed by default: read / create / edit tools (write_file,
+  acp_create_file, acp_edit_file, read_file, search_*, get_*, ...).
+- Blocked by default: destructive + arbitrary execution —
+  delete_file, acp_delete_file, move_file, copy_file,
+  execute_command, acp_execute_command, execute_code, kill_process.
+- User escape hatches:
+    - ``PRAISONAI_TOOL_SAFETY=off``   → behave like pre-4.6.27 (no blocks)
+    - ``PRAISONAI_TOOL_SAFETY=full``  → alias of off
+    - ``PRAISONAI_TOOL_SAFETY=safe``  → stricter preset (blocks writes too)
+    - ``Agent(approval="full")``      → disable per-agent without env
+- Ergonomic invariant: no new Agent kwarg was added.
+"""
+from __future__ import annotations
+
+from praisonaiagents.approval.registry import PERMISSION_PRESETS
+
+
+def _make_agent(**kwargs):
+    # Import late so monkeypatched env is respected at Agent.__init__ time.
+    from praisonaiagents import Agent
+    return Agent(instructions="t", llm="gpt-4o-mini", **kwargs)
+
+
+def test_default_preset_exists_and_blocks_destructive():
+    d = PERMISSION_PRESETS["default"]
+    for blocked in (
+        "delete_file", "acp_delete_file", "move_file", "copy_file",
+        "execute_command", "acp_execute_command", "execute_code",
+        "kill_process",
+    ):
+        assert blocked in d, f"'default' preset should block {blocked}"
+
+
+def test_default_preset_allows_read_create_edit():
+    d = PERMISSION_PRESETS["default"]
+    for allowed in (
+        "read_file", "write_file", "acp_create_file", "acp_edit_file",
+        "search_web", "get_weather", "list_directory",
+    ):
+        assert allowed not in d, (
+            f"'default' preset must not block {allowed} — read/create/edit "
+            f"is what 99% of agent workflows need."
+        )
+
+
+def test_off_and_full_presets_are_empty():
+    assert PERMISSION_PRESETS["off"] == frozenset()
+    assert PERMISSION_PRESETS["full"] == frozenset()
+
+
+def test_agent_applies_default_preset_when_no_env_and_no_kwarg(monkeypatch):
+    monkeypatch.delenv("PRAISONAI_TOOL_SAFETY", raising=False)
+    a = _make_agent()
+    assert "delete_file" in a._perm_deny
+    assert "execute_command" in a._perm_deny
+    assert "write_file" not in a._perm_deny  # create/edit stays allowed
+    assert "read_file" not in a._perm_deny
+
+
+def test_env_off_disables_default_policy(monkeypatch):
+    monkeypatch.setenv("PRAISONAI_TOOL_SAFETY", "off")
+    a = _make_agent()
+    # Pre-4.6.27 behaviour: nothing blocked
+    assert a._perm_deny == frozenset()
+
+
+def test_env_full_is_alias_of_off(monkeypatch):
+    monkeypatch.setenv("PRAISONAI_TOOL_SAFETY", "full")
+    a = _make_agent()
+    assert a._perm_deny == frozenset()
+
+
+def test_env_safe_applies_stricter_preset(monkeypatch):
+    monkeypatch.setenv("PRAISONAI_TOOL_SAFETY", "safe")
+    a = _make_agent()
+    # "safe" blocks writes too, per existing PERMISSION_PRESETS["safe"]
+    assert "write_file" in a._perm_deny
+    assert "delete_file" in a._perm_deny
+
+
+def test_explicit_approval_kwarg_overrides_env(monkeypatch):
+    monkeypatch.setenv("PRAISONAI_TOOL_SAFETY", "safe")
+    a = _make_agent(approval="full")
+    # Explicit kwarg wins — user opted out per-agent even with strict env.
+    assert a._perm_deny == frozenset()
+
+
+def test_unknown_env_value_falls_back_to_no_blocks(monkeypatch):
+    # Defensive: a typo ("sfae") must not silently apply the strictest
+    # preset or crash. It should leave the agent in the no-policy state.
+    monkeypatch.setenv("PRAISONAI_TOOL_SAFETY", "sfae")
+    a = _make_agent()
+    assert a._perm_deny == frozenset()
+
+
+def test_no_new_agent_kwarg_was_added():
+    """Guard-rail: the feature must not add any new Agent() kwarg.
+
+    The commit that introduced the default tool-safety policy must stay
+    strictly behind the existing ``approval=`` knob and the
+    ``PRAISONAI_TOOL_SAFETY`` env var. If a future refactor adds a
+    dedicated ``tool_safety=`` parameter, this test fails loudly so it
+    gets a conscious review.
+    """
+    import inspect
+    from praisonaiagents import Agent
+    params = set(inspect.signature(Agent.__init__).parameters)
+    forbidden = {"tool_safety", "safety", "permission", "permissions", "deny_tools"}
+    leaked = params & forbidden
+    assert not leaked, (
+        f"New Agent() kwarg(s) leaked: {leaked}. The tool-safety "
+        f"feature must stay behind the existing 'approval=' kwarg + "
+        f"PRAISONAI_TOOL_SAFETY env — see AGENTS.md 'Minimal API'."
+    )

--- a/src/praisonai-agents/tests/unit/approval/test_default_tool_safety.py
+++ b/src/praisonai-agents/tests/unit/approval/test_default_tool_safety.py
@@ -93,12 +93,15 @@ def test_explicit_approval_kwarg_overrides_env(monkeypatch):
     assert a._perm_deny == frozenset()
 
 
-def test_unknown_env_value_falls_back_to_no_blocks(monkeypatch):
-    # Defensive: a typo ("sfae") must not silently apply the strictest
-    # preset or crash. It should leave the agent in the no-policy state.
+def test_unknown_env_value_falls_back_to_default_preset(monkeypatch):
+    # Defensive: a typo ("sfae") must not silently disable the default
+    # safety policy. Unknown values should preserve the safe baseline.
     monkeypatch.setenv("PRAISONAI_TOOL_SAFETY", "sfae")
     a = _make_agent()
-    assert a._perm_deny == frozenset()
+    assert "delete_file" in a._perm_deny
+    assert "execute_command" in a._perm_deny
+    assert "write_file" not in a._perm_deny
+    assert "read_file" not in a._perm_deny
 
 
 def test_no_new_agent_kwarg_was_added():


### PR DESCRIPTION
## Problem

User ask (#1491 discussion):
> *'by default are you not auto approving tools, you auto approve tools, if users need they can disable, the tools shouldnt delete, but could get all required information and create and edit'*
> *'don't bloat Agent() class'*

Pre-4.6.27 behaviour: when an LLM decided to call `delete_file` or `execute_command`, the Agent ran it silently. This PR blocks destructive ops **by default**, without adding any new `Agent()` kwarg.

## Design

Reuses the existing per-agent permission-tier fast-path (`_perm_deny` frozenset, O(1) check in `_check_tool_approval_sync/async`). Zero new plumbing.

### 1. `praisonaiagents/approval/registry.py`

Added one new preset + one alias (+19 / -3 lines):

```python
PERMISSION_PRESETS = {
    # NEW: applied by default when no approval= kwarg is passed
    "default": frozenset({
        "execute_command", "kill_process", "execute_code", "acp_execute_command",
        "delete_file", "move_file", "copy_file", "acp_delete_file",
    }),
    "safe":      frozenset(DEFAULT_DANGEROUS_TOOLS.keys()),
    "read_only": frozenset(DEFAULT_DANGEROUS_TOOLS.keys()) | frozenset({
        "write_file", "copy_file", "move_file",
    }),
    "full":      frozenset(),
    "off":       frozenset(),  # NEW: alias of full for the env knob
}
```

The `default` preset intentionally leaves `write_file`, `acp_create_file`, `acp_edit_file`, `read_file`, `search_*`, `get_*` UNBLOCKED — per the user's 'create and edit should work, delete should not' rule.

### 2. `praisonaiagents/agent/agent.py` (10 lines)

Inside the existing `elif approval is False or approval is None:` branch (i.e. *no explicit kwarg*):

```python
_safety_env = os.environ.get("PRAISONAI_TOOL_SAFETY", "default").strip().lower()
if _safety_env and _safety_env not in ("off", "full", "none", "0", "false"):
    from ..approval.registry import PERMISSION_PRESETS
    _preset_deny = PERMISSION_PRESETS.get(_safety_env)
    if _preset_deny is not None:
        self._perm_deny = _preset_deny
```

**Escape hatches (all pre-existing APIs, no new kwargs):**
- `export PRAISONAI_TOOL_SAFETY=off` — global opt-out
- `Agent(..., approval="full")` — per-agent opt-out  
- `Agent(..., approval="safe")` — stricter preset (also blocks writes)
- `export PRAISONAI_TOOL_SAFETY=read_only` — even stricter

### 3. `tests/unit/approval/test_default_tool_safety.py` (new, 10 tests)

Includes a **guard-rail test** that fails loudly if a future refactor adds a dedicated `tool_safety=` kwarg — keeps the 'no bloat' invariant self-enforcing:

```python
def test_no_new_agent_kwarg_was_added():
    params = set(inspect.signature(Agent.__init__).parameters)
    forbidden = {"tool_safety", "safety", "permission", "permissions", "deny_tools"}
    leaked = params & forbidden
    assert not leaked, (
        f"New Agent() kwarg(s) leaked: {leaked}. Feature must stay behind "
        f"'approval=' + PRAISONAI_TOOL_SAFETY. See AGENTS.md 'Minimal API'."
    )
```

## Verification

```
10 passed in 0.25s
```

End-to-end against a live Agent with 3 tools:

```
deny set: [acp_delete_file, acp_execute_command, copy_file,
           delete_file, execute_code, execute_command,
           kill_process, move_file]

read_file('/tmp/x')        → 'content of /tmp/x'                    (allowed)
delete_file('/tmp/x')      → {'error': 'blocked by permission policy'}
execute_command('rm -rf /') → {'error': 'blocked by permission policy'}

# With PRAISONAI_TOOL_SAFETY=off
deny set: []               → pre-4.6.27 behaviour restored
```

The blocked path returns a clean error dict (`permission_denied: True`) that the LLM sees and typically reasons around rather than failing the session.

## Backward compatibility note

This flips a default from 'block nothing' to 'block destructive ops'. Agents that relied on silent `delete_file` / `execute_command` now need:

- `export PRAISONAI_TOOL_SAFETY=off` (global), **or**
- `Agent(..., approval="full")` (per-agent)

The env knob means zero code changes are needed to opt out.

## Diff
`3 files changed, 153 insertions(+), 2 deletions(-)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool safety can now be controlled via the PRAISONAI_TOOL_SAFETY environment variable when no explicit approval is provided.
  * A new default safety preset blocks destructive file operations and arbitrary code execution while allowing common read/write actions.
  * The "off" and "full" settings act as the environment off-switch; a stricter preset alias ensures "read-only" aligns with the safe behavior.

* **Tests**
  * Added tests verifying env-driven defaults, preset behaviors, and resilience to unrecognized env values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->