### PR TITLE
fix(onboard): honour PRAISONAI_NO_PROMPT + add --yes flag (non-interactive)

### DIFF
--- a/src/praisonai/praisonai/cli/commands/onboard.py
+++ b/src/praisonai/praisonai/cli/commands/onboard.py
@@ -38,6 +38,8 @@ def onboard_callback(
     if ctx.invoked_subcommand:
         return
     if yes:
+        # Propagate to run_onboard() and any subprocesses it spawns.
+        # Intentionally not restored afterwards: the CLI is a one-shot entrypoint.
         os.environ["PRAISONAI_NO_PROMPT"] = "1"
     try:
         run_onboard()

--- a/src/praisonai/praisonai/cli/commands/onboard.py
+++ b/src/praisonai/praisonai/cli/commands/onboard.py
@@ -4,7 +4,10 @@ Onboard command group for PraisonAI CLI.
 Provides the bot onboarding wizard command.
 """
 
+import os
+
 import typer
+
 from ..output.console import get_output_controller
 
 app = typer.Typer(help="Messaging bot onboarding (platforms, tokens, daemon)")
@@ -17,10 +20,25 @@ def run_onboard() -> None:
 
 
 @app.callback(invoke_without_command=True)
-def onboard_callback(ctx: typer.Context):
+def onboard_callback(
+    ctx: typer.Context,
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        "--non-interactive",
+        help=(
+            "Non-interactive mode: skip all prompts and accept defaults. "
+            "Tokens/allowlists are taken from existing env vars; missing "
+            "values are left blank. Equivalent to PRAISONAI_NO_PROMPT=1."
+        ),
+    ),
+):
     """Run the bot onboarding wizard."""
     if ctx.invoked_subcommand:
         return
+    if yes:
+        os.environ["PRAISONAI_NO_PROMPT"] = "1"
     try:
         run_onboard()
     except KeyboardInterrupt:

--- a/src/praisonai/praisonai/cli/features/onboard.py
+++ b/src/praisonai/praisonai/cli/features/onboard.py
@@ -558,6 +558,7 @@ class OnboardWizard:
         # Guard: refuse to install a daemon that has no tokens — it would loop
         # in a crash-restart cycle. List the platforms missing tokens so the
         # user can rerun onboard once they have them.
+        daemon_success = False
         missing_tokens = [
             PLATFORMS[p]["name"]
             for p in self.selected_platforms
@@ -582,9 +583,6 @@ class OnboardWizard:
             daemon_success = self._install_daemon_with_feedback(
                 console.print, self.config_path
             )
-        
-        if 'daemon_success' not in locals():
-            daemon_success = False
 
         # Done panel. Commands referenced here must exist in `praisonai --help`.
         # OS-aware daemon management hints: non-developers struggle to find

--- a/src/praisonai/praisonai/cli/features/onboard.py
+++ b/src/praisonai/praisonai/cli/features/onboard.py
@@ -39,7 +39,7 @@ def _is_non_interactive() -> bool:
     ``bot.yaml`` simply references the env vars — the user can populate
     them later and re-run ``praisonai onboard --yes`` to finalise setup.
     """
-    if os.environ.get("PRAISONAI_NO_PROMPT", "").strip() in ("1", "true", "yes", "on"):
+    if os.environ.get("PRAISONAI_NO_PROMPT", "").strip().lower() in ("1", "true", "yes", "on"):
         return True
     try:
         if not sys.stdin.isatty():

--- a/src/praisonai/praisonai/cli/features/onboard.py
+++ b/src/praisonai/praisonai/cli/features/onboard.py
@@ -18,10 +18,72 @@ import asyncio
 import getpass
 import logging
 import os
+import sys
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _is_non_interactive() -> bool:
+    """Return True when the wizard must not block on user input.
+
+    Triggers on either:
+      - ``PRAISONAI_NO_PROMPT=1`` (explicit opt-out; set by the ``--yes``
+        CLI flag and by ``install.sh`` when running non-interactively), or
+      - ``stdin`` is not a TTY (e.g. piped from a script or CI).
+
+    In non-interactive mode every prompt short-circuits to its declared
+    default. Tokens / allowlists already present in the environment are
+    preserved; missing values are left blank and the generated
+    ``bot.yaml`` simply references the env vars — the user can populate
+    them later and re-run ``praisonai onboard --yes`` to finalise setup.
+    """
+    if os.environ.get("PRAISONAI_NO_PROMPT", "").strip() in ("1", "true", "yes", "on"):
+        return True
+    try:
+        if not sys.stdin.isatty():
+            return True
+    except (AttributeError, ValueError):
+        return True
+    return False
+
+
+def _prompt_ask(prompt_cls: Any, *args, **kwargs) -> str:
+    """Wrapper around ``rich.prompt.Prompt.ask`` that honours non-interactive mode.
+
+    Returns the declared ``default`` (or empty string) without blocking.
+    """
+    if _is_non_interactive():
+        return kwargs.get("default", "") or ""
+    return prompt_cls.ask(*args, **kwargs)
+
+
+def _confirm_ask(confirm_cls: Any, *args, **kwargs) -> bool:
+    """Wrapper around ``rich.prompt.Confirm.ask`` that honours non-interactive mode."""
+    if _is_non_interactive():
+        return bool(kwargs.get("default", False))
+    return confirm_cls.ask(*args, **kwargs)
+
+
+def _plain_input(msg: str, default: str = "") -> str:
+    """Non-blocking ``input()`` replacement for the plain fallback path."""
+    if _is_non_interactive():
+        return default
+    try:
+        return input(msg)
+    except EOFError:
+        return default
+
+
+def _plain_getpass(msg: str) -> str:
+    """Non-blocking ``getpass.getpass()`` replacement for the plain fallback path."""
+    if _is_non_interactive():
+        return ""
+    try:
+        return getpass.getpass(msg)
+    except EOFError:
+        return ""
 
 # Platform info for the wizard. ``allowed_users_env`` is a per-platform
 # allowlist of user IDs used by the channel adapter to restrict inbound
@@ -231,6 +293,8 @@ class OnboardWizard:
 
         console = Console()
 
+        non_interactive = _is_non_interactive()
+
         # Welcome
         console.print(Panel(
             "[bold]Welcome to PraisonAI Bot Setup[/bold]\n\n"
@@ -239,13 +303,20 @@ class OnboardWizard:
             title="🤖 PraisonAI Onboard",
             border_style="blue",
         ))
+        if non_interactive:
+            console.print(
+                "[dim]Non-interactive mode (PRAISONAI_NO_PROMPT=1 or --yes). "
+                "Tokens/allowlists taken from env vars; missing values left blank. "
+                "Existing bot.yaml will be kept (no overwrite).[/dim]"
+            )
 
         # Step 1: Platform selection
         console.print("\n[bold]Step 1: Choose your platform(s)[/bold]\n")
         for key, info in PLATFORMS.items():
             console.print(f"  [cyan]{key}[/cyan] — {info['name']}")
 
-        platforms_input = Prompt.ask(
+        platforms_input = _prompt_ask(
+            Prompt,
             "\nPlatform(s) [comma-separated]",
             default="telegram",
         )
@@ -284,7 +355,8 @@ class OnboardWizard:
                     f"  [green]✓[/green] {info['name']}: {env_var} = [cyan]{_mask(existing)}[/cyan]"
                 )
                 console.print(f"    [dim]{info['token_help']}[/dim]")
-                new_token = Prompt.ask(
+                new_token = _prompt_ask(
+                    Prompt,
                     f"  Update {info['name']} token? (Enter = keep current)",
                     password=True,
                     default="",
@@ -299,7 +371,8 @@ class OnboardWizard:
                     self.tokens[plat] = existing
             else:
                 console.print(f"  [dim]{info['token_help']}[/dim]")
-                token = Prompt.ask(
+                token = _prompt_ask(
+                    Prompt,
                     f"  {info['name']} token ({env_var})",
                     password=True,
                     default="",
@@ -322,7 +395,8 @@ class OnboardWizard:
                     console.print(
                         f"    [green]✓[/green] {extra_env} = [cyan]{_mask(existing_extra)}[/cyan]"
                     )
-                    new_extra = Prompt.ask(
+                    new_extra = _prompt_ask(
+                        Prompt,
                         f"    Update {extra_desc}? (Enter = keep current)",
                         password=True,
                         default="",
@@ -333,7 +407,8 @@ class OnboardWizard:
                         env_to_save[extra_env] = new_extra
                         console.print(f"    [green]✓[/green] {extra_env} updated")
                 else:
-                    extra_val = Prompt.ask(
+                    extra_val = _prompt_ask(
+                        Prompt,
                         f"  {extra_desc} ({extra_env})",
                         password=True,
                         default="",
@@ -354,7 +429,8 @@ class OnboardWizard:
                     console.print(
                         f"    [dim]{info.get('user_id_help', 'Comma-separated user IDs')}[/dim]"
                     )
-                    new_allow = Prompt.ask(
+                    new_allow = _prompt_ask(
+                        Prompt,
                         f"  Update allowed users for {info['name']}? (Enter = keep, 'clear' = remove)",
                         default="",
                         show_default=False,
@@ -377,7 +453,8 @@ class OnboardWizard:
                     console.print(
                         f"  [dim]{info.get('user_id_help', 'Enter comma-separated user IDs')}[/dim]"
                     )
-                    allow_val = Prompt.ask(
+                    allow_val = _prompt_ask(
+                        Prompt,
                         "  Allowed user IDs (comma-separated, empty = open access)",
                         default="",
                         show_default=False,
@@ -465,7 +542,8 @@ class OnboardWizard:
         os.makedirs(os.path.dirname(os.path.abspath(self.config_path)) or ".", exist_ok=True)
 
         if os.path.exists(self.config_path):
-            if not Confirm.ask(
+            if not _confirm_ask(
+                Confirm,
                 f"  {self.config_path} exists. Overwrite with fresh config?",
                 default=False,
             ):
@@ -601,7 +679,10 @@ class OnboardWizard:
         """
         print("\n=== PraisonAI Bot Setup ===\n")
         print("Available platforms: telegram, discord, slack, whatsapp")
-        platforms_input = input("Platform(s) [comma-separated, default=telegram]: ").strip() or "telegram"
+        platforms_input = _plain_input(
+            "Platform(s) [comma-separated, default=telegram]: ",
+            default="telegram",
+        ).strip() or "telegram"
         self.selected_platforms = [p.strip().lower() for p in platforms_input.split(",")]
 
         env_to_save: Dict[str, str] = {}
@@ -613,7 +694,7 @@ class OnboardWizard:
                 self.tokens[plat] = existing
             else:
                 print(f"\n  {info.get('token_help', '')}")
-                token = getpass.getpass(f"  {env_var} (hidden): ").strip()
+                token = _plain_getpass(f"  {env_var} (hidden): ").strip()
                 if token:
                     os.environ[env_var] = token
                     env_to_save[env_var] = token
@@ -622,7 +703,10 @@ class OnboardWizard:
             allowed_env = info.get("allowed_users_env")
             if allowed_env and not os.environ.get(allowed_env):
                 print(f"\n  🔒 {info.get('user_id_help', 'Enter allowed user IDs')}")
-                allow = input("  Allowed user IDs (comma-separated, empty = open): ").strip().replace(" ", "")
+                allow = _plain_input(
+                    "  Allowed user IDs (comma-separated, empty = open): ",
+                    default="",
+                ).strip().replace(" ", "")
                 if allow:
                     os.environ[allowed_env] = allow
                     env_to_save[allowed_env] = allow

--- a/src/praisonai/tests/unit/cli/test_onboard_non_interactive.py
+++ b/src/praisonai/tests/unit/cli/test_onboard_non_interactive.py
@@ -54,10 +54,12 @@ def test_is_non_interactive_false_by_default():
 def test_is_non_interactive_true_when_env_set():
     onboard = _import_onboard()
     import io
+    class _TTYStdin(io.StringIO):
+        def isatty(self):
+            return True
     saved = sys.stdin
     try:
-        sys.stdin = io.StringIO("")
-        sys.stdin.isatty = lambda: True  # isolate env-var branch
+        sys.stdin = _TTYStdin("")  # isolate env-var branch
         for val in ("1", "true", "yes", "on", "TRUE", "Yes"):
             os.environ["PRAISONAI_NO_PROMPT"] = val
             assert onboard._is_non_interactive() is True, f"failed for value {val!r}"
@@ -78,10 +80,12 @@ def test_is_non_interactive_false_when_env_explicitly_off():
         #
         # To isolate the env branch, monkey-patch isatty temporarily.
         import io
+        class _TTYStdin(io.StringIO):
+            def isatty(self):
+                return True
         saved = sys.stdin
         try:
-            sys.stdin = io.StringIO("")
-            sys.stdin.isatty = lambda: True  # pretend we have a tty
+            sys.stdin = _TTYStdin("")  # pretend we have a tty
             assert onboard._is_non_interactive() is False, f"failed for value {val!r}"
         finally:
             sys.stdin = saved

--- a/src/praisonai/tests/unit/cli/test_onboard_non_interactive.py
+++ b/src/praisonai/tests/unit/cli/test_onboard_non_interactive.py
@@ -53,9 +53,16 @@ def test_is_non_interactive_false_by_default():
 
 def test_is_non_interactive_true_when_env_set():
     onboard = _import_onboard()
-    for val in ("1", "true", "yes", "on", "TRUE", "Yes"):
-        os.environ["PRAISONAI_NO_PROMPT"] = val
-        assert onboard._is_non_interactive() is True, f"failed for value {val!r}"
+    import io
+    saved = sys.stdin
+    try:
+        sys.stdin = io.StringIO("")
+        sys.stdin.isatty = lambda: True  # isolate env-var branch
+        for val in ("1", "true", "yes", "on", "TRUE", "Yes"):
+            os.environ["PRAISONAI_NO_PROMPT"] = val
+            assert onboard._is_non_interactive() is True, f"failed for value {val!r}"
+    finally:
+        sys.stdin = saved
 
 
 def test_is_non_interactive_false_when_env_explicitly_off():

--- a/src/praisonai/tests/unit/cli/test_onboard_non_interactive.py
+++ b/src/praisonai/tests/unit/cli/test_onboard_non_interactive.py
@@ -1,0 +1,186 @@
+"""Unit tests for non-interactive mode in ``praisonai onboard``.
+
+Verifies that when ``PRAISONAI_NO_PROMPT=1`` is set (or ``--yes``/``-y``
+is passed, which sets the same env var), the wizard never blocks on any
+blocking prompt — every ``Prompt.ask`` / ``Confirm.ask`` / ``input`` /
+``getpass.getpass`` call short-circuits to its declared default.
+
+Regression protection: if a new blocking prompt is added later, this
+suite fails because unpatched blocking I/O would hang and the test
+runner's timeout would fire.
+"""
+
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_no_prompt_env():
+    """Ensure PRAISONAI_NO_PROMPT is scoped to each test."""
+    original = os.environ.pop("PRAISONAI_NO_PROMPT", None)
+    yield
+    if original is None:
+        os.environ.pop("PRAISONAI_NO_PROMPT", None)
+    else:
+        os.environ["PRAISONAI_NO_PROMPT"] = original
+
+
+def _import_onboard():
+    """Lazy import so the test suite doesn't pay onboard's import cost
+    when it's collecting unrelated tests."""
+    from praisonai.cli.features import onboard
+    return onboard
+
+
+def test_is_non_interactive_false_by_default():
+    onboard = _import_onboard()
+    # stdin in pytest is typically not a TTY — acknowledge that.
+    # When NO_PROMPT is unset, detection falls back to stdin.isatty.
+    # Most CI/pytest runs are not TTYs, so this returns True.
+    # We only assert the env-var branch here.
+    os.environ.pop("PRAISONAI_NO_PROMPT", None)
+    # If stdin happens to be a TTY (rare in CI), we can't assert anything
+    # stronger — the function should return False.
+    try:
+        is_tty = sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        is_tty = False
+    expected = not is_tty
+    assert onboard._is_non_interactive() is expected
+
+
+def test_is_non_interactive_true_when_env_set():
+    onboard = _import_onboard()
+    for val in ("1", "true", "yes", "on", "TRUE", "Yes"):
+        os.environ["PRAISONAI_NO_PROMPT"] = val
+        assert onboard._is_non_interactive() is True, f"failed for value {val!r}"
+
+
+def test_is_non_interactive_false_when_env_explicitly_off():
+    onboard = _import_onboard()
+    # Empty / zero / "false" / "no" must NOT trigger non-interactive mode
+    # by themselves. (Whether it's on because stdin isn't a tty is a
+    # separate concern and is tested elsewhere.)
+    for val in ("0", "false", "no", "off", ""):
+        os.environ["PRAISONAI_NO_PROMPT"] = val
+        # In pytest stdin is likely not a tty, so this may still be True
+        # via the tty-fallback. We only test that the env branch doesn't
+        # force it on for these values.
+        #
+        # To isolate the env branch, monkey-patch isatty temporarily.
+        import io
+        saved = sys.stdin
+        try:
+            sys.stdin = io.StringIO("")
+            sys.stdin.isatty = lambda: True  # pretend we have a tty
+            assert onboard._is_non_interactive() is False, f"failed for value {val!r}"
+        finally:
+            sys.stdin = saved
+
+
+def test_prompt_ask_returns_default_in_non_interactive():
+    onboard = _import_onboard()
+    os.environ["PRAISONAI_NO_PROMPT"] = "1"
+
+    class _FakePrompt:
+        @staticmethod
+        def ask(*args, **kwargs):
+            raise AssertionError(
+                "Prompt.ask must not be called in non-interactive mode"
+            )
+
+    # Non-interactive + default provided → returns the default
+    assert onboard._prompt_ask(_FakePrompt, "irrelevant", default="telegram") == "telegram"
+    # No default → returns empty string
+    assert onboard._prompt_ask(_FakePrompt, "irrelevant") == ""
+
+
+def test_confirm_ask_returns_default_in_non_interactive():
+    onboard = _import_onboard()
+    os.environ["PRAISONAI_NO_PROMPT"] = "1"
+
+    class _FakeConfirm:
+        @staticmethod
+        def ask(*args, **kwargs):
+            raise AssertionError(
+                "Confirm.ask must not be called in non-interactive mode"
+            )
+
+    assert onboard._confirm_ask(_FakeConfirm, "irrelevant", default=False) is False
+    assert onboard._confirm_ask(_FakeConfirm, "irrelevant", default=True) is True
+    # No default → False
+    assert onboard._confirm_ask(_FakeConfirm, "irrelevant") is False
+
+
+def test_plain_input_returns_default_in_non_interactive(monkeypatch):
+    onboard = _import_onboard()
+    os.environ["PRAISONAI_NO_PROMPT"] = "1"
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("input() must not be called in non-interactive mode")
+
+    monkeypatch.setattr("builtins.input", _boom)
+    assert onboard._plain_input("irrelevant: ", default="telegram") == "telegram"
+    assert onboard._plain_input("irrelevant: ") == ""
+
+
+def test_plain_getpass_returns_empty_in_non_interactive(monkeypatch):
+    onboard = _import_onboard()
+    os.environ["PRAISONAI_NO_PROMPT"] = "1"
+
+    def _boom(*args, **kwargs):
+        raise AssertionError(
+            "getpass.getpass() must not be called in non-interactive mode"
+        )
+
+    monkeypatch.setattr("getpass.getpass", _boom)
+    assert onboard._plain_getpass("irrelevant: ") == ""
+
+
+def test_wizard_run_does_not_block_in_non_interactive(monkeypatch, tmp_path):
+    """End-to-end: ``OnboardWizard.run()`` completes in non-interactive mode
+    without ever invoking a blocking prompt.
+
+    Regression canary — if any future Prompt.ask / Confirm.ask slips in
+    that bypasses the wrapper, this test will raise via the fake classes.
+    """
+    onboard = _import_onboard()
+    os.environ["PRAISONAI_NO_PROMPT"] = "1"
+
+    # Redirect the config file into tmp_path so we don't touch the real home.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Ensure daemon installation is skipped — we don't want this test
+    # trying to launchctl/systemctl anything.
+    monkeypatch.setattr(
+        "praisonai.cli.features.onboard.OnboardWizard._install_daemon_with_feedback",
+        lambda self, print_fn, config_path: False,
+    )
+    # Skip the live telegram probe — we have no real token.
+    async def _fake_probe(self, platform):
+        class _R:
+            ok = False
+            error = "skipped in test"
+            elapsed_ms = 0
+            bot_username = "n/a"
+        return _R()
+    monkeypatch.setattr(
+        "praisonai.cli.features.onboard.OnboardWizard._probe", _fake_probe
+    )
+
+    # Install tripwires on any blocking prompt path.
+    import rich.prompt
+
+    def _boom(*args, **kwargs):
+        raise AssertionError(
+            "blocking prompt called during non-interactive onboard run"
+        )
+    monkeypatch.setattr(rich.prompt.Prompt, "ask", _boom)
+    monkeypatch.setattr(rich.prompt.Confirm, "ask", _boom)
+    monkeypatch.setattr("builtins.input", _boom)
+    monkeypatch.setattr("getpass.getpass", _boom)
+
+    wizard = onboard.OnboardWizard()
+    # Must complete without raising.
+    wizard.run()


### PR DESCRIPTION
## Problem (before)

`praisonai onboard` had no non-interactive mode. In several real situations it would hang forever on a blocking prompt:

- **install.sh piped flow** — when the user answered `Y` to "Set up a messaging bot?" and then walked away; the wizard would block on the first `Prompt.ask()`.
- **Daemon post-install reconfig** — no stdin at all → infinite hang.
- **CI / scripted installs** — pytest and CI runners don't give a TTY.
- **Docker / remote bootstrap** — same.

`install.sh` already honoured `PRAISONAI_NO_PROMPT=1`, but once control passed to the Python wizard every `rich.prompt.Prompt.ask` / `Confirm.ask` / `input()` / `getpass.getpass()` call ignored it.

## Fix (after)

Two new entry points, same env-var semantics `install.sh` already documents:

### CLI flag
```bash
praisonai onboard --yes
praisonai onboard -y
praisonai onboard --non-interactive
```

### Env var
```bash
PRAISONAI_NO_PROMPT=1 praisonai onboard
```

Both paths short-circuit every blocking prompt in `@src/praisonai/praisonai/cli/features/onboard.py` to its declared default:

- Platform: defaults to `telegram`
- Token: kept from existing env var (`TELEGRAM_BOT_TOKEN` etc.) if present; left blank otherwise (wizard prints the usual `⚠ No token` warning)
- Allowlist: kept from existing `TELEGRAM_ALLOWED_USERS` etc.
- Overwrite existing `bot.yaml`: declined (safer default — never clobbers a hand-edited config non-interactively)

The wizard also auto-detects and goes non-interactive when `stdin` is not a TTY, so nothing new is needed in `install.sh` (the env var was already forwarded) or in daemon reconfig paths.

### Implementation

1. New `_is_non_interactive()` helper (`onboard.py:28-49`):
   ```python
   def _is_non_interactive() -> bool:
       if os.environ.get("PRAISONAI_NO_PROMPT", "").strip() in ("1", "true", "yes", "on"):
           return True
       try:
           if not sys.stdin.isatty():
               return True
       except (AttributeError, ValueError):
           return True
       return False
   ```

2. Four thin wrappers that every blocking call now routes through:
   - `_prompt_ask(Prompt, …)` → returns `default` instead of calling `Prompt.ask`
   - `_confirm_ask(Confirm, …)` → returns `default` instead of calling `Confirm.ask`
   - `_plain_input(msg, default=…)` → returns `default` instead of calling `input()`
   - `_plain_getpass(msg)` → returns `""` instead of calling `getpass.getpass()`

3. All 11 call sites across `run()` (rich path) and `_run_plain()` (no-rich fallback) were migrated to the wrappers. Zero behavioural change in interactive mode.

4. `praisonai onboard --yes` (`@src/praisonai/praisonai/cli/commands/onboard.py`) sets `PRAISONAI_NO_PROMPT=1` for the process so every nested import and subprocess inherits it.

## Evidence per claim

| Claim | Evidence |
|---|---|
| 11 blocking prompt sites in the wizard, all now wrapped | `grep -nE "Prompt\\.ask\\\|Confirm\\.ask\\\|input\\(\\\|getpass\\.getpass" src/praisonai/praisonai/cli/features/onboard.py` returns 0 matches outside the wrapper functions themselves |
| Env var detection works for `1`, `true`, `yes`, `on`, and variants | `test_is_non_interactive_true_when_env_set` exercises each |
| Does NOT force non-interactive when stdin is a TTY and env is off/empty | `test_is_non_interactive_false_when_env_explicitly_off` |
| End-to-end wizard completes without any blocking call | `test_wizard_run_does_not_block_in_non_interactive` — boobytraps `rich.prompt.Prompt.ask`, `Confirm.ask`, `input`, `getpass.getpass` with `AssertionError` and asserts `OnboardWizard().run()` completes |
| No regression for interactive users | No code path changed when `_is_non_interactive()` returns False — all wrappers delegate unchanged to the original call |
| CLI flag sets the env var cleanly | `onboard_callback(yes=True)` sets `os.environ["PRAISONAI_NO_PROMPT"] = "1"` before invoking the wizard |

## Verification

```
$ PYTHONPATH=src/praisonai pytest tests/unit/cli/test_onboard_non_interactive.py
8 passed in 0.21s
```

Manual:
```bash
# curl|bash flow (no TTY) — no longer hangs
PRAISONAI_NO_PROMPT=1 praisonai onboard

# Explicit opt-in from a user's terminal
praisonai onboard --yes

# Existing interactive behaviour preserved
praisonai onboard                  # → full wizard, unchanged
```

## Diff

```
src/praisonai/praisonai/cli/commands/onboard.py          |  22 ++-
src/praisonai/praisonai/cli/features/onboard.py          |  89 +++++++++--
src/praisonai/tests/unit/cli/test_onboard_non_interactive.py | +187 (new)
3 files changed, 301 insertions(+), 13 deletions(-)
```

## Rollback

Single-commit revert. No schema migration, no yaml change, no env-var semantic change (the variable `install.sh` already forwards just now *works* in the wizard too).

## Related

- Follow-up to the observation in #1493: `install.sh` forwarded `PRAISONAI_NO_PROMPT` but the downstream wizard ignored it.
- Independent of #1496 (bot default tools) — this PR only touches the wizard's prompt gating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--yes` / `-y` non-interactive onboarding: suppresses prompts, uses defaults, preserves env-provided values, and prints a dim informational banner so onboarding can run in scripts without blocking

* **Tests**
  * Added unit and end-to-end tests validating non-interactive detection, prompt short-circuiting, and non-blocking onboarding runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->