### PR TITLE
fix(gateway): remove duplicate PairingStore.list_pending and preserve legacy keys

### DIFF
--- a/src/praisonai/praisonai/gateway/pairing.py
+++ b/src/praisonai/praisonai/gateway/pairing.py
@@ -270,7 +270,7 @@ class PairingStore:
         label = user_name or f"User {channel_id}"
         return self.verify_and_pair(code, channel_id, channel_type, label)
 
-    def list_pending(self, channel_type: Optional[str] = None) -> List[Dict[str, str]]:
+    def list_pending(self, channel_type: Optional[str] = None) -> List[Dict[str, any]]:
         """List pending pairing requests.
         
         Args:
@@ -291,16 +291,17 @@ class PairingStore:
                     
                 ct = info.get("channel_type", "unknown")
                 cid = info.get("channel_id")
+                created_at = info.get("created_at", now)
                 pending_list.append({
                     "code": code,
                     "channel_type": ct,
                     "channel_id": cid,
-                    "created_at": info.get("created_at", now),
+                    "created_at": created_at,
                     # UI-friendly aliases (used by praisonai.ui._pairing banner)
                     "channel": ct,
-                    "user_id": cid or code,
-                    "user_name": f"User {cid or code}",
-                    "age_seconds": int(now - info.get("created_at", now)),
+                    "user_id": code,
+                    "user_name": f"User {code}",
+                    "age_seconds": int(now - created_at),
                 })
                 
         return pending_list

--- a/src/praisonai/praisonai/gateway/pairing.py
+++ b/src/praisonai/praisonai/gateway/pairing.py
@@ -237,15 +237,6 @@ class PairingStore:
         with self._lock:
             return list(self._paired.values())
 
-    def list_pending(self) -> List[dict]:
-        """List all pending pairing codes."""
-        with self._lock:
-            self._prune_expired()
-            return [
-                {"code": code, **info} 
-                for code, info in self._pending.items()
-            ]
-
     def revoke(self, channel_id: str, channel_type: str) -> bool:
         """Revoke a paired channel.  Returns ``True`` if it existed."""
         with self._lock:
@@ -298,11 +289,17 @@ class PairingStore:
                 if channel_type and info.get("channel_type") != channel_type:
                     continue
                     
+                ct = info.get("channel_type", "unknown")
+                cid = info.get("channel_id")
                 pending_list.append({
-                    "channel": info.get("channel_type", "unknown"),
                     "code": code,
-                    "user_id": code,  # Use code as user_id for consistency
-                    "user_name": f"User {code}",
+                    "channel_type": ct,
+                    "channel_id": cid,
+                    "created_at": info.get("created_at", now),
+                    # UI-friendly aliases (used by praisonai.ui._pairing banner)
+                    "channel": ct,
+                    "user_id": cid or code,
+                    "user_name": f"User {cid or code}",
                     "age_seconds": int(now - info.get("created_at", now)),
                 })
                 


### PR DESCRIPTION
## Summary

Found during local end-to-end validation of the Gateway-Auth chain. Two `list_pending()` methods existed on `PairingStore` (lines 240 and 282 in `src/praisonai/praisonai/gateway/pairing.py`). The second overrode the first at class-define time, dropping the `channel_type` / `channel_id` / `created_at` keys that the CLI (`praisonai pairing approve`) and `test_pending_persists_across_instances` depend on.

## Fix

- Delete the legacy method at line 240.
- Extend the remaining (UI-banner) method at line 282 to include BOTH the new UI-friendly keys (`channel`, `user_id`, `user_name`, `age_seconds`) AND the original canonical keys (`code`, `channel_type`, `channel_id`, `created_at`).

Purely additive keys — no behavioural change for the UI banner or the `/api/pairing/pending` response.

## Validation

Full gateway + bots + UI suite locally:

- **Before**: 171 passed, 1 skipped, 1 failed (`test_pending_persists_across_instances`)
- **After**: **172 passed, 1 skipped, 0 failed**

## Context

This bug was introduced when the UI pairing-banner PR (#1513) added a second `list_pending()` without removing the original. CodeRabbit didn't flag it; it only surfaces when both CLI and UI code paths are exercised together.

Surfaced during live end-to-end testing of the Gateway-Auth chain (#1506, #1508, #1509, #1510, #1511).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Pending-items listing now returns explicit fields for channel_type, channel_id, and created_at (while preserving a channel alias).
  * Age calculations use the captured creation timestamp for accuracy.
  * Added optional filtering by channel type and broadened the returned payload to support mixed-value fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->