### PR TITLE
fix(phase1b): make CLI backend tests actually run

### DIFF
--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -140,6 +140,47 @@ def sanitize_agent_name_for_autogen_v4(name):
     
     return sanitized
 
+def _resolve_yaml_cli_backend(cli_backend_config, logger):
+    """Resolve a YAML ``cli_backend`` field to a CliBackendProtocol instance.
+
+    Accepts ``None`` (no backend), a string id (e.g. ``"claude-code"``), or a
+    dict of shape ``{"id": "claude-code", "overrides": {...}}``. Returns
+    ``None`` on any error after logging a warning, so YAML parsing never raises.
+
+    Kept at module scope so it is unit-testable without constructing a full
+    ``AgentsGenerator`` instance.
+    """
+    if not cli_backend_config:
+        return None
+
+    label = None
+    try:
+        from praisonai.cli_backends import resolve_cli_backend
+        if isinstance(cli_backend_config, str):
+            label = cli_backend_config
+            return resolve_cli_backend(cli_backend_config)
+        if isinstance(cli_backend_config, dict):
+            backend_id = cli_backend_config.get('id')
+            label = backend_id or "<missing>"
+            if not backend_id:
+                raise ValueError("cli_backend dict must contain an 'id' field")
+            overrides = cli_backend_config.get('overrides') or {}
+            return resolve_cli_backend(backend_id, overrides=overrides)
+        label = type(cli_backend_config).__name__
+        raise ValueError(
+            f"cli_backend must be string or dict, got: {type(cli_backend_config).__name__}"
+        )
+    except ImportError:
+        logger.warning(
+            "CLI backend '%s' requested but not available", label or "<unknown>"
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to resolve CLI backend '%s': %s", label or "<unknown>", e
+        )
+    return None
+
+
 class AgentsGenerator:
     def __init__(self, agent_file, framework, config_list, log_level=None, agent_callback=None, task_callback=None, agent_yaml=None, tools=None, cli_config=None):
         """
@@ -1248,31 +1289,9 @@ class AgentsGenerator:
             agent_skills = details.get('skills')
 
             # H17: CLI Backend support - delegates full turns to external CLI tools
-            cli_backend_config = details.get('cli_backend')
-            cli_backend_resolved = None
-            cli_backend_label = None
-            if cli_backend_config:
-                try:
-                    from praisonai.cli_backends import resolve_cli_backend
-                    if isinstance(cli_backend_config, str):
-                        # Simple string ID: "claude-code"
-                        cli_backend_label = cli_backend_config
-                        cli_backend_resolved = resolve_cli_backend(cli_backend_config)
-                    elif isinstance(cli_backend_config, dict):
-                        # Dict format: {id: "claude-code", overrides: {timeout_ms: 60000}}
-                        backend_id = cli_backend_config.get('id')
-                        cli_backend_label = backend_id or "<missing>"
-                        overrides = cli_backend_config.get('overrides', {})
-                        if not backend_id:
-                            raise ValueError("cli_backend dict must contain an 'id' field")
-                        cli_backend_resolved = resolve_cli_backend(backend_id, overrides=overrides)
-                    else:
-                        cli_backend_label = type(cli_backend_config).__name__
-                        raise ValueError(f"cli_backend must be string or dict, got: {type(cli_backend_config).__name__}")
-                except ImportError:
-                    self.logger.warning("CLI backend '%s' requested but not available", cli_backend_label or "<unknown>")
-                except Exception as e:
-                    self.logger.warning("Failed to resolve CLI backend '%s': %s", cli_backend_label or "<unknown>", e)
+            cli_backend_resolved = _resolve_yaml_cli_backend(
+                details.get('cli_backend'), self.logger
+            )
 
             agent = PraisonAgent(
                 name=role_filled,

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -153,30 +153,34 @@ def _resolve_yaml_cli_backend(cli_backend_config, logger):
     if not cli_backend_config:
         return None
 
-    label = None
+    # Pre-seed label from config before import so we can show it in error logs
+    if isinstance(cli_backend_config, str):
+        label = cli_backend_config
+    elif isinstance(cli_backend_config, dict):
+        label = cli_backend_config.get('id') or "<missing>"
+    else:
+        label = type(cli_backend_config).__name__
+
     try:
         from praisonai.cli_backends import resolve_cli_backend
         if isinstance(cli_backend_config, str):
-            label = cli_backend_config
             return resolve_cli_backend(cli_backend_config)
         if isinstance(cli_backend_config, dict):
             backend_id = cli_backend_config.get('id')
-            label = backend_id or "<missing>"
             if not backend_id:
                 raise ValueError("cli_backend dict must contain an 'id' field")
             overrides = cli_backend_config.get('overrides') or {}
             return resolve_cli_backend(backend_id, overrides=overrides)
-        label = type(cli_backend_config).__name__
         raise ValueError(
             f"cli_backend must be string or dict, got: {type(cli_backend_config).__name__}"
         )
     except ImportError:
         logger.warning(
-            "CLI backend '%s' requested but not available", label or "<unknown>"
+            "CLI backend '%s' requested but not available", label
         )
     except Exception as e:
         logger.warning(
-            "Failed to resolve CLI backend '%s': %s", label or "<unknown>", e
+            "Failed to resolve CLI backend '%s': %s", label, e
         )
     return None
 

--- a/src/praisonai/tests/unit/test_cli_backend_flag.py
+++ b/src/praisonai/tests/unit/test_cli_backend_flag.py
@@ -26,11 +26,14 @@ def _build_env():
         k: v for k, v in os.environ.items()
         if not k.startswith("PYTEST_")
     }
-    env["PYTHONPATH"] = os.pathsep.join([
+    # Build PYTHONPATH without trailing separator
+    pythonpath_parts = [
         os.path.join(REPO_ROOT, "src", "praisonai-agents"),
         os.path.join(REPO_ROOT, "src", "praisonai"),
-        env.get("PYTHONPATH", ""),
-    ])
+    ]
+    if env.get("PYTHONPATH"):
+        pythonpath_parts.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
     return env
 
 
@@ -56,17 +59,10 @@ def test_cli_backend_flag_in_help():
 
 
 def test_cli_backend_flag_accepts_registered_backend():
-    """``--cli-backend claude-code <prompt>`` must parse without argparse error."""
-    # We intentionally pass an unrealistic prompt that won't trigger LLM work and
-    # rely on the default timeout to abort quickly. We only assert that argparse
-    # accepts the flag (no "invalid choice" or "unrecognized" in stderr).
-    try:
-        r = _run_cli(
-            "--cli-backend", "claude-code", "--help",
-            timeout=15,
-        )
-    except subprocess.TimeoutExpired:
-        pytest.skip("CLI startup exceeded timeout; unrelated to flag parsing")
+    """``--cli-backend claude-code --help`` must parse without argparse error."""
+    # Use --help to short-circuit argparse; we only want to prove the flag+value
+    # is accepted (no "invalid choice" / "unrecognized" in stderr).
+    r = _run_cli("--cli-backend", "claude-code", "--help", timeout=15)
     assert r.returncode == 0
     assert "invalid choice" not in r.stderr
     assert "unrecognized arguments" not in r.stderr
@@ -108,6 +104,7 @@ def test_backends_bare_subcommand_lists():
 def test_backends_unknown_subcommand_reports_error():
     """``praisonai backends bogus`` prints an error message."""
     r = _run_cli("backends", "bogus", timeout=15)
-    # Must not crash, must surface the unknown subcommand in stdout or stderr
+    # Must exit with error and surface the unknown subcommand in stdout or stderr
+    assert r.returncode != 0
     combined = (r.stdout + r.stderr).lower()
     assert "unknown" in combined or "bogus" in combined

--- a/src/praisonai/tests/unit/test_cli_backend_flag.py
+++ b/src/praisonai/tests/unit/test_cli_backend_flag.py
@@ -1,161 +1,113 @@
-"""Unit tests for CLI backend flag and backends list command."""
+"""Unit tests for the ``--cli-backend`` CLI flag and ``backends`` subcommand.
+
+These tests drive the real CLI via subprocess so they exercise the complete
+argparse configuration (including the ``PYTEST_CURRENT_TEST`` short-circuit
+in ``PraisonAI.parse_args``) rather than internal helpers. Each subprocess
+runs with an explicit timeout so a hung process cannot stall the suite.
+"""
+
+import os
+import subprocess
+import sys
 
 import pytest
-import sys
-from unittest.mock import patch, MagicMock
-from io import StringIO
 
-def test_cli_backend_flag_choices():
-    """Test that CLI backend flag includes registered backend choices."""
-    from praisonai.cli.main import PraisonAI
-    
-    with patch('praisonai.cli_backends.list_cli_backends', return_value=['claude-code', 'test-backend']):
-        praison = PraisonAI()
-        
-        # Parse help to check choices are included
-        with patch('sys.argv', ['praisonai', '--help']):
-            with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
-                with pytest.raises(SystemExit):
-                    praison.parse_args()
-                help_output = mock_stdout.getvalue()
 
-        assert '--cli-backend' in help_output
-        assert 'claude-code' in help_output
-        assert 'test-backend' in help_output
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
 
-def test_cli_backend_flag_with_prompt():
-    """Test CLI backend flag with direct prompt."""
-    from praisonai.cli.main import PraisonAI
-    
-    with patch('praisonai.cli_backends.list_cli_backends', return_value=['claude-code']):
-        with patch('praisonai.cli_backends.resolve_cli_backend') as mock_resolve:
-            mock_backend = MagicMock()
-            mock_resolve.return_value = mock_backend
-            
-            praison = PraisonAI()
-            
-            # Mock agent creation and execution
-            with patch.object(praison, 'handle_direct_prompt') as mock_handler:
-                mock_handler.return_value = "test result"
-                
-                # Test with CLI backend flag
-                with patch('sys.argv', ['praisonai', '--cli-backend', 'claude-code', 'Hello']):
-                    args = praison.parse_args()
-                    assert args.cli_backend == 'claude-code'
-                    assert args.command == 'Hello'
-                    
-                    # Test the full execution path
-                    praison.args = args
-                    result = praison.main()
-                    
-                    assert result == "test result"
-                    mock_handler.assert_called_once()
-                    mock_resolve.assert_called_once_with('claude-code')
+
+def _build_env():
+    """Return a child env with PYTEST_* vars stripped so the CLI doesn't
+    short-circuit argparse (see ``PraisonAI.parse_args`` in-test-env check).
+    """
+    env = {
+        k: v for k, v in os.environ.items()
+        if not k.startswith("PYTEST_")
+    }
+    env["PYTHONPATH"] = os.pathsep.join([
+        os.path.join(REPO_ROOT, "src", "praisonai-agents"),
+        os.path.join(REPO_ROOT, "src", "praisonai"),
+        env.get("PYTHONPATH", ""),
+    ])
+    return env
+
+
+def _run_cli(*args, timeout=30):
+    """Invoke the praisonai CLI with the given argv and return CompletedProcess."""
+    return subprocess.run(
+        [sys.executable, "-m", "praisonai.cli.main", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=REPO_ROOT,
+        env=_build_env(),
+    )
+
+
+def test_cli_backend_flag_in_help():
+    """``--cli-backend`` must appear in ``--help`` with registered backend choices."""
+    r = _run_cli("--help")
+    assert r.returncode == 0
+    assert "--cli-backend" in r.stdout
+    # ``claude-code`` is a registered backend and must appear as a valid choice
+    assert "claude-code" in r.stdout
+
+
+def test_cli_backend_flag_accepts_registered_backend():
+    """``--cli-backend claude-code <prompt>`` must parse without argparse error."""
+    # We intentionally pass an unrealistic prompt that won't trigger LLM work and
+    # rely on the default timeout to abort quickly. We only assert that argparse
+    # accepts the flag (no "invalid choice" or "unrecognized" in stderr).
+    try:
+        r = _run_cli(
+            "--cli-backend", "claude-code", "--help",
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip("CLI startup exceeded timeout; unrelated to flag parsing")
+    assert r.returncode == 0
+    assert "invalid choice" not in r.stderr
+    assert "unrecognized arguments" not in r.stderr
+
+
+def test_cli_backend_flag_rejects_unknown_backend():
+    """Unknown backend id must be rejected by argparse with non-zero exit."""
+    r = _run_cli("--cli-backend", "does-not-exist", "hi", timeout=15)
+    assert r.returncode != 0
+    assert "invalid choice" in r.stderr or "does-not-exist" in r.stderr
+
 
 def test_mutual_exclusion_cli_backend_external_agent():
-    """Test mutual exclusion between --cli-backend and --external-agent."""
-    from praisonai.cli.main import PraisonAI
-    
-    with patch('praisonai.cli_backends.list_cli_backends', return_value=['claude-code']):
-        praison = PraisonAI()
-        
-        # Test that both flags trigger argparse error
-        with patch('sys.argv', ['praisonai', '--cli-backend', 'claude-code', '--external-agent', 'claude', 'Hello']):
-            with pytest.raises(SystemExit):
-                praison.parse_args()
+    """``--cli-backend`` and ``--external-agent`` must be mutually exclusive."""
+    r = _run_cli(
+        "--cli-backend", "claude-code",
+        "--external-agent", "claude",
+        "hi",
+        timeout=15,
+    )
+    assert r.returncode != 0
+    assert "not allowed with" in r.stderr or "mutually exclusive" in r.stderr
 
-def test_backends_list_command():
-    """Test 'praisonai backends list' command."""
-    from praisonai.cli.main import PraisonAI
-    
-    with patch('praisonai.cli_backends.list_cli_backends', return_value=['claude-code', 'test-backend']):
-        praison = PraisonAI()
-        
-        with patch('sys.argv', ['praisonai', 'backends', 'list']):
-            args = praison.parse_args()
-            assert args.command == 'backends'
-            
-            # Mock main method execution
-            with patch('builtins.print') as mock_print:
-                result = praison.main()
-                
-                # Should print each backend
-                expected_calls = [
-                    (('claude-code',),),
-                    (('test-backend',),)
-                ]
-                mock_print.assert_has_calls(expected_calls)
-                assert result == ""
 
-def test_backends_command_no_subcommand():
-    """Test 'praisonai backends' command without subcommand (defaults to list)."""
-    from praisonai.cli.main import PraisonAI
-    
-    with patch('praisonai.cli_backends.list_cli_backends', return_value=['claude-code']):
-        praison = PraisonAI()
-        
-        with patch('sys.argv', ['praisonai', 'backends']):
-            args = praison.parse_args()
-            assert args.command == 'backends'
-            
-            # Mock main method execution
-            with patch('builtins.print') as mock_print:
-                result = praison.main()
-                
-                # Should print backend
-                mock_print.assert_called_with('claude-code')
-                assert result == ""
+def test_backends_list_subcommand():
+    """``praisonai backends list`` prints the registered backend ids."""
+    r = _run_cli("backends", "list", timeout=15)
+    assert r.returncode == 0
+    assert "claude-code" in r.stdout
 
-def test_backends_command_unknown_subcommand():
-    """Test 'praisonai backends unknown' with invalid subcommand."""
-    from praisonai.cli.main import PraisonAI
-    
-    praison = PraisonAI()
-    
-    with patch('sys.argv', ['praisonai', 'backends', 'unknown']):
-        args = praison.parse_args()
-        assert args.command == 'backends'
-        
-        # Mock main method execution
-        with patch('builtins.print') as mock_print:
-            result = praison.main()
-            
-            # Should print error
-            expected_calls = [
-                (('[red]Unknown backends subcommand: unknown[/red]',),),
-                (('Available subcommands: list',),)
-            ]
-            mock_print.assert_has_calls(expected_calls)
-            assert result is None
 
-def test_backends_command_import_error():
-    """Test backends command when CLI backends not available."""
-    from praisonai.cli.main import PraisonAI
-    
-    praison = PraisonAI()
-    
-    with patch('sys.argv', ['praisonai', 'backends', 'list']):
-        args = praison.parse_args()
-        assert args.command == 'backends'
-        
-        # Mock import error
-        with patch('builtins.__import__', side_effect=ImportError("No module")):
-            with patch('builtins.print') as mock_print:
-                result = praison.main()
-                
-                # Should print error
-                mock_print.assert_called_with("[red]CLI backends not available[/red]")
-                assert result is None
+def test_backends_bare_subcommand_lists():
+    """``praisonai backends`` (no sub-sub-arg) defaults to listing."""
+    r = _run_cli("backends", timeout=15)
+    assert r.returncode == 0
+    assert "claude-code" in r.stdout
 
-def test_cli_backend_flag_no_choices_when_import_fails():
-    """Test CLI backend flag when list_cli_backends import fails."""
-    from praisonai.cli.main import PraisonAI
-    
-    with patch('praisonai.cli_backends.list_cli_backends', side_effect=ImportError("Not available")):
-        praison = PraisonAI()
-        
-        # Should not crash during argument parsing
-        with patch('sys.argv', ['praisonai', '--help']):
-            with pytest.raises(SystemExit):
-                with patch('sys.stdout', new_callable=StringIO):
-                    praison.parse_args()
+
+def test_backends_unknown_subcommand_reports_error():
+    """``praisonai backends bogus`` prints an error message."""
+    r = _run_cli("backends", "bogus", timeout=15)
+    # Must not crash, must surface the unknown subcommand in stdout or stderr
+    combined = (r.stdout + r.stderr).lower()
+    assert "unknown" in combined or "bogus" in combined

--- a/src/praisonai/tests/unit/test_cli_backend_flag.py
+++ b/src/praisonai/tests/unit/test_cli_backend_flag.py
@@ -95,16 +95,26 @@ def test_backends_list_subcommand():
 
 
 def test_backends_bare_subcommand_lists():
-    """``praisonai backends`` (no sub-sub-arg) defaults to listing."""
+    """``praisonai backends`` (no sub-sub-arg) defaults to listing.
+
+    NOTE: this assertion is coupled to the ``backends`` handler in
+    ``praisonai.cli.main`` which treats a missing/None subcommand as ``list``.
+    If that default ever changes, this test must be updated in lockstep.
+    """
     r = _run_cli("backends", timeout=15)
     assert r.returncode == 0
     assert "claude-code" in r.stdout
 
 
 def test_backends_unknown_subcommand_reports_error():
-    """``praisonai backends bogus`` prints an error message."""
+    """``praisonai backends bogus`` prints an error message.
+
+    NOTE: the error string comes from the ``backends`` handler in
+    ``praisonai.cli.main`` (``[red]Unknown backends subcommand: ...[/red]``),
+    so this test is coupled to that handler and will need updating if the
+    wording changes.
+    """
     r = _run_cli("backends", "bogus", timeout=15)
-    # Must exit with error and surface the unknown subcommand in stdout or stderr
-    assert r.returncode != 0
+    # Must not crash, must surface the unknown subcommand in stdout or stderr
     combined = (r.stdout + r.stderr).lower()
     assert "unknown" in combined or "bogus" in combined

--- a/src/praisonai/tests/unit/test_external_agents_backcompat.py
+++ b/src/praisonai/tests/unit/test_external_agents_backcompat.py
@@ -1,124 +1,87 @@
-"""Unit tests for external agents backward compatibility."""
+"""Backward-compatibility tests for the legacy ``--external-agent`` flag.
 
-import pytest
-from unittest.mock import patch, MagicMock
+These tests guard against regressions introduced by the Phase 1b CLI Backend
+Protocol work (PRs #1521 / #1531). They mix direct-import tests for the
+integration classes and subprocess tests for argparse surface.
+"""
 
-def test_external_agent_claude_integration_exists():
-    """Test that external agent claude integration can be resolved."""
+import os
+import subprocess
+import sys
+
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+
+
+def _build_env():
+    env = {k: v for k, v in os.environ.items() if not k.startswith("PYTEST_")}
+    env["PYTHONPATH"] = os.pathsep.join([
+        os.path.join(REPO_ROOT, "src", "praisonai-agents"),
+        os.path.join(REPO_ROOT, "src", "praisonai"),
+        env.get("PYTHONPATH", ""),
+    ])
+    return env
+
+
+def _run_cli(*args, timeout=30):
+    return subprocess.run(
+        [sys.executable, "-m", "praisonai.cli.main", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=REPO_ROOT,
+        env=_build_env(),
+    )
+
+
+# ---- Direct-import back-compat ---------------------------------------------
+
+
+def test_external_agents_handler_still_importable():
+    """``ExternalAgentsHandler`` must remain importable at its original path."""
     from praisonai.cli.features.external_agents import ExternalAgentsHandler
-    
     handler = ExternalAgentsHandler(verbose=False)
-    
-    # Mock the integration to avoid actual subprocess calls
-    with patch.object(handler, 'get_integration') as mock_get_integration:
-        mock_integration = MagicMock()
-        mock_integration.is_available = True
-        mock_integration.cli_command = 'claude'
-        mock_get_integration.return_value = mock_integration
-        
-        integration = handler.get_integration('claude', workspace='/tmp')
-        
-        assert integration is not None
-        assert integration.is_available
-        assert integration.cli_command == 'claude'
-        mock_get_integration.assert_called_once_with('claude', workspace='/tmp')
+    assert handler.list_integrations() == ['claude', 'gemini', 'codex', 'cursor']
 
-def test_external_agent_claude_flag_still_works():
-    """Test that --external-agent claude flag still works via CLI."""
-    from praisonai.cli.main import PraisonAI
-    
-    praison = PraisonAI()
-    
-    with patch('sys.argv', ['praisonai', '--external-agent', 'claude', 'Hello']):
-        args = praison.parse_args()
-        assert args.external_agent == 'claude'
-        assert args.command == 'Hello'
 
-def test_external_agent_gemini_flag_still_works():
-    """Test that --external-agent gemini flag still works via CLI."""
-    from praisonai.cli.main import PraisonAI
-    
-    praison = PraisonAI()
-    
-    with patch('sys.argv', ['praisonai', '--external-agent', 'gemini', 'Hello']):
-        args = praison.parse_args()
-        assert args.external_agent == 'gemini'
-        assert args.command == 'Hello'
+def test_claude_code_integration_still_importable():
+    """Legacy ``ClaudeCodeIntegration`` class must remain importable."""
+    from praisonai.integrations.claude_code import ClaudeCodeIntegration
+    integration = ClaudeCodeIntegration()
+    assert integration.cli_command == 'claude'
 
-def test_external_agent_direct_flag():
-    """Test that --external-agent-direct flag still works."""
-    from praisonai.cli.main import PraisonAI
-    
-    praison = PraisonAI()
-    
-    with patch('sys.argv', ['praisonai', '--external-agent', 'claude', '--external-agent-direct', 'Hello']):
-        args = praison.parse_args()
-        assert args.external_agent == 'claude'
-        assert args.external_agent_direct is True
-        assert args.command == 'Hello'
 
-def test_external_agent_handler_get_integration():
-    """Test that ExternalAgentsHandler.get_integration method works for all supported agents."""
-    from praisonai.cli.features.external_agents import ExternalAgentsHandler
-    
-    handler = ExternalAgentsHandler(verbose=False)
-    supported_agents = ['claude', 'gemini', 'codex', 'cursor']
-    
-    for agent_name in supported_agents:
-        with patch.object(handler, 'get_integration') as mock_get_integration:
-            mock_integration = MagicMock()
-            mock_integration.is_available = True
-            mock_integration.cli_command = agent_name
-            mock_get_integration.return_value = mock_integration
-            
-            integration = handler.get_integration(agent_name, workspace='/tmp')
-            
-            assert integration is not None
-            assert integration.is_available
-            assert integration.cli_command == agent_name
-            mock_get_integration.assert_called_once_with(agent_name, workspace='/tmp')
+# ---- argparse-surface back-compat ------------------------------------------
 
-def test_external_agent_execution_path_still_accessible():
-    """Smoke test that external agent execution path is still accessible in main()."""
-    from praisonai.cli.main import PraisonAI
-    
-    praison = PraisonAI()
-    
-    # Mock the external agent handler to avoid actual execution
-    with patch('praisonai.cli.features.external_agents.ExternalAgentsHandler') as mock_handler_class:
-        mock_handler = MagicMock()
-        mock_integration = MagicMock()
-        mock_integration.is_available = True
-        mock_integration.cli_command = 'claude'
-        mock_handler.get_integration.return_value = mock_integration
-        mock_handler_class.return_value = mock_handler
-        
-        with patch('sys.argv', ['praisonai', '--external-agent', 'claude', 'Hello']):
-            args = praison.parse_args()
-            praison.args = args
-            
-            # Mock the actual execution to avoid subprocess calls
-            with patch.object(praison, 'handle_direct_prompt') as mock_direct:
-                mock_direct.return_value = "test result"
-                
-                # This should not raise an exception - the path should still be accessible
-                result = praison.main()
-                # Result should be empty string due to external agent handling
-                assert result == ""
 
-def test_external_agent_choices_preserved():
-    """Test that external agent choices are preserved from original implementation."""
-    from praisonai.cli.main import PraisonAI
-    
-    praison = PraisonAI()
-    parser = praison.create_parser()
-    
-    # Find the external-agent argument
-    external_agent_action = None
-    for action in parser._actions:
-        if hasattr(action, 'dest') and action.dest == 'external_agent':
-            external_agent_action = action
-            break
-    
-    assert external_agent_action is not None
-    assert external_agent_action.choices == ['claude', 'gemini', 'codex', 'cursor']
+def test_external_agent_flag_present_in_help():
+    """``--external-agent`` must still be listed in ``--help``."""
+    r = _run_cli("--help")
+    assert r.returncode == 0
+    assert "--external-agent" in r.stdout
+
+
+def test_external_agent_flag_choices_preserved():
+    """Help text must still include all four legacy choices."""
+    r = _run_cli("--help")
+    assert r.returncode == 0
+    for choice in ("claude", "gemini", "codex", "cursor"):
+        assert choice in r.stdout, (
+            f"legacy --external-agent choice '{choice}' missing from --help"
+        )
+
+
+def test_external_agent_direct_flag_present_in_help():
+    """``--external-agent-direct`` must still be listed in ``--help``."""
+    r = _run_cli("--help")
+    assert r.returncode == 0
+    assert "--external-agent-direct" in r.stdout
+
+
+def test_external_agent_rejects_unknown_value():
+    """``--external-agent notreal`` must still be rejected by argparse."""
+    r = _run_cli("--external-agent", "notreal", "hi", timeout=15)
+    assert r.returncode != 0
+    assert "invalid choice" in r.stderr or "notreal" in r.stderr

--- a/src/praisonai/tests/unit/test_external_agents_backcompat.py
+++ b/src/praisonai/tests/unit/test_external_agents_backcompat.py
@@ -17,11 +17,14 @@ REPO_ROOT = os.path.abspath(
 
 def _build_env():
     env = {k: v for k, v in os.environ.items() if not k.startswith("PYTEST_")}
-    env["PYTHONPATH"] = os.pathsep.join([
+    # Build PYTHONPATH without trailing separator
+    pythonpath_parts = [
         os.path.join(REPO_ROOT, "src", "praisonai-agents"),
         os.path.join(REPO_ROOT, "src", "praisonai"),
-        env.get("PYTHONPATH", ""),
-    ])
+    ]
+    if env.get("PYTHONPATH"):
+        pythonpath_parts.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
     return env
 
 

--- a/src/praisonai/tests/unit/test_yaml_cli_backend.py
+++ b/src/praisonai/tests/unit/test_yaml_cli_backend.py
@@ -1,11 +1,29 @@
-"""Unit tests for YAML CLI backend parsing."""
+"""Unit tests for YAML CLI backend parsing.
 
-import pytest
+Tests the ``_resolve_yaml_cli_backend`` helper directly so the parse/resolve
+logic can be validated without constructing a full ``AgentsGenerator`` and
+exercising unrelated framework code paths.
+"""
+
+import logging
 import yaml
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+from praisonai.agents_generator import _resolve_yaml_cli_backend
+
+
+def _logger():
+    return logging.getLogger("test_yaml_cli_backend")
+
+
+def _role_details(yaml_text):
+    """Extract the first role's details dict from a YAML snippet."""
+    config = yaml.safe_load(yaml_text)
+    return next(iter(config['roles'].values()))
+
 
 def test_yaml_cli_backend_string():
-    """Test YAML parsing with string CLI backend."""
+    """YAML ``cli_backend: claude-code`` resolves via registry."""
     yaml_content = """
 framework: praisonai
 topic: coding
@@ -15,31 +33,21 @@ roles:
     goal: Refactor Python modules
     backstory: Senior engineer
     cli_backend: claude-code
-    tasks:
-      refactor:
-        description: Refactor utils.py
-        expected_output: Refactored code
 """
-    
-    from praisonai.agents_generator import AgentsGenerator
-    
+    details = _role_details(yaml_content)
+
     with patch('praisonai.cli_backends.resolve_cli_backend') as mock_resolve:
         mock_backend = MagicMock()
         mock_resolve.return_value = mock_backend
-        
-        generator = AgentsGenerator(config=yaml_content)
-        agents, _tasks = generator.create_agents_and_tasks()
-        
-        # Verify agent was created with CLI backend
-        assert 'coder' in agents
-        agent = agents['coder']
-        assert getattr(agent, '_cli_backend', None) is mock_backend
-        
-        # Verify CLI backend was resolved correctly
-        mock_resolve.assert_called_once_with('claude-code')
+
+        resolved = _resolve_yaml_cli_backend(details.get('cli_backend'), _logger())
+
+    assert resolved is mock_backend
+    mock_resolve.assert_called_once_with('claude-code')
+
 
 def test_yaml_cli_backend_dict():
-    """Test YAML parsing with dict CLI backend configuration."""
+    """YAML ``cli_backend: {id, overrides}`` passes overrides through."""
     yaml_content = """
 framework: praisonai
 topic: coding
@@ -52,138 +60,87 @@ roles:
       id: claude-code
       overrides:
         timeout_ms: 60000
-    tasks:
-      refactor:
-        description: Refactor utils.py
-        expected_output: Refactored code
 """
-    
-    from praisonai.agents_generator import AgentsGenerator
-    
+    details = _role_details(yaml_content)
+
     with patch('praisonai.cli_backends.resolve_cli_backend') as mock_resolve:
         mock_backend = MagicMock()
         mock_resolve.return_value = mock_backend
-        
-        generator = AgentsGenerator(config=yaml_content)
-        agents, _tasks = generator.create_agents_and_tasks()
-        
-        # Verify agent was created with CLI backend
-        assert 'coder' in agents
-        agent = agents['coder']
-        assert getattr(agent, '_cli_backend', None) is mock_backend
-        
-        # Verify CLI backend was resolved with overrides
-        mock_resolve.assert_called_once_with('claude-code', overrides={'timeout_ms': 60000})
+
+        resolved = _resolve_yaml_cli_backend(details.get('cli_backend'), _logger())
+
+    assert resolved is mock_backend
+    mock_resolve.assert_called_once_with('claude-code', overrides={'timeout_ms': 60000})
+
 
 def test_yaml_cli_backend_dict_missing_id():
-    """Test YAML parsing with invalid dict CLI backend (missing id)."""
-    yaml_content = """
+    """Dict without ``id`` key yields ``None`` and logs a warning (no raise)."""
+    details = _role_details("""
 framework: praisonai
 topic: coding
 roles:
   coder:
-    role: Code refactorer
-    goal: Refactor Python modules
-    backstory: Senior engineer
+    role: r
+    goal: g
+    backstory: b
     cli_backend:
       overrides:
         timeout_ms: 60000
-    tasks:
-      refactor:
-        description: Refactor utils.py
-        expected_output: Refactored code
-"""
-    
-    from praisonai.agents_generator import AgentsGenerator
-    
-    # Should not raise exception but log warning
-    generator = AgentsGenerator(config=yaml_content)
-    agents, _tasks = generator.create_agents_and_tasks()
-    
-    # Agent should be created without CLI backend
-    assert 'coder' in agents
-    agent = agents['coder']
-    # Agent should not have cli_backend set due to invalid config
-    assert not hasattr(agent, '_cli_backend') or agent._cli_backend is None
+""")
+    logger = MagicMock()
+    resolved = _resolve_yaml_cli_backend(details.get('cli_backend'), logger)
+    assert resolved is None
+    assert logger.warning.called
+
 
 def test_yaml_no_cli_backend():
-    """Test YAML parsing without CLI backend."""
-    yaml_content = """
+    """Missing ``cli_backend`` field yields ``None`` with no warning."""
+    details = _role_details("""
 framework: praisonai
 topic: coding
 roles:
   coder:
-    role: Code refactorer
-    goal: Refactor Python modules
-    backstory: Senior engineer
-    tasks:
-      refactor:
-        description: Refactor utils.py
-        expected_output: Refactored code
-"""
-    
-    from praisonai.agents_generator import AgentsGenerator
-    
-    generator = AgentsGenerator(config=yaml_content)
-    agents, _tasks = generator.create_agents_and_tasks()
-    
-    # Verify agent was created without CLI backend
-    assert 'coder' in agents
-    agent = agents['coder']
-    assert not hasattr(agent, '_cli_backend') or agent._cli_backend is None
+    role: r
+    goal: g
+    backstory: b
+""")
+    logger = MagicMock()
+    resolved = _resolve_yaml_cli_backend(details.get('cli_backend'), logger)
+    assert resolved is None
+    logger.warning.assert_not_called()
+
 
 def test_yaml_cli_backend_import_error():
-    """Test YAML parsing with CLI backend when import fails."""
-    yaml_content = """
-framework: praisonai
-topic: coding
-roles:
-  coder:
-    role: Code refactorer
-    goal: Refactor Python modules
-    backstory: Senior engineer
-    cli_backend: claude-code
-    tasks:
-      refactor:
-        description: Refactor utils.py
-        expected_output: Refactored code
-"""
-    
-    from praisonai.agents_generator import AgentsGenerator
-    
-    with patch('praisonai.cli_backends.resolve_cli_backend', side_effect=ImportError("CLI backends not available")):
-        generator = AgentsGenerator(config=yaml_content)
-        agents, _tasks = generator.create_agents_and_tasks()
-        
-        # Agent should be created without CLI backend due to import error
-        assert 'coder' in agents
-        agent = agents['coder']
-        assert not hasattr(agent, '_cli_backend') or agent._cli_backend is None
+    """When registry resolver raises ImportError, return ``None`` and warn."""
+    logger = MagicMock()
+    with patch(
+        'praisonai.cli_backends.resolve_cli_backend',
+        side_effect=ImportError("CLI backends not available"),
+    ):
+        resolved = _resolve_yaml_cli_backend('claude-code', logger)
+    assert resolved is None
+    assert logger.warning.called
+
+
+def test_yaml_cli_backend_unknown_id():
+    """Unknown backend id yields ``None`` after the registry raises ValueError."""
+    logger = MagicMock()
+    resolved = _resolve_yaml_cli_backend('does-not-exist', logger)
+    assert resolved is None
+    assert logger.warning.called
+
 
 def test_yaml_cli_backend_invalid_type():
-    """Test YAML parsing with invalid CLI backend type."""
-    yaml_content = """
-framework: praisonai
-topic: coding
-roles:
-  coder:
-    role: Code refactorer
-    goal: Refactor Python modules
-    backstory: Senior engineer
-    cli_backend: 123
-    tasks:
-      refactor:
-        description: Refactor utils.py
-        expected_output: Refactored code
-"""
-    
-    from praisonai.agents_generator import AgentsGenerator
-    
-    # Should not raise exception but log warning
-    generator = AgentsGenerator(config=yaml_content)
-    agents, _tasks = generator.create_agents_and_tasks()
-    
-    # Agent should be created without CLI backend due to invalid type
-    assert 'coder' in agents
-    agent = agents['coder']
-    assert not hasattr(agent, '_cli_backend') or agent._cli_backend is None
+    """Non-str/dict value (e.g. int) yields ``None`` and logs a warning."""
+    logger = MagicMock()
+    resolved = _resolve_yaml_cli_backend(123, logger)
+    assert resolved is None
+    assert logger.warning.called
+
+
+def test_yaml_cli_backend_registered_claude_code_resolves():
+    """End-to-end: the shipped ``claude-code`` id really resolves without mocking."""
+    resolved = _resolve_yaml_cli_backend('claude-code', _logger())
+    assert resolved is not None
+    assert hasattr(resolved, 'execute')
+    assert hasattr(resolved, 'stream')


### PR DESCRIPTION
## Summary

Follow-up to PR #1531 (Phase 1b). After that PR merged, **19/34** of its shipped unit tests were failing locally because they asserted against fabricated APIs. CI just skipped them so the breakage was silent. This PR makes the tests actually exercise the real code.

**Production behaviour: unchanged.** Only changes are (a) one tiny helper extraction in `agents_generator.py` for testability, and (b) rewritten test files.

## Before / after

### Before (on `main` at `39f2c79d`)

```
$ pytest src/praisonai/tests/unit/test_cli_backend_flag.py \
         src/praisonai/tests/unit/test_external_agents_backcompat.py \
         src/praisonai/tests/unit/test_yaml_cli_backend.py \
         src/praisonai/tests/unit/test_claude_backend.py
==========================================
19 failed, 15 passed in 0.65s
==========================================
```

Failures breakdown:

| File | Failures | Root cause |
|---|---|---|
| `test_yaml_cli_backend.py` | 6/6 | `AgentsGenerator(config=...)` — kwarg doesn't exist; `.create_agents_and_tasks()` — method doesn't exist |
| `test_cli_backend_flag.py` | 8/8 | `PraisonAI().parse_args()` short-circuits to `parse_known_args([])` when `PYTEST_CURRENT_TEST` is in env (see `main.py:1137-1138`), so patched `sys.argv` is ignored and `--help` never raises `SystemExit` |
| `test_external_agents_backcompat.py` | 5/7 | Same `parse_args()` short-circuit |

### After (on this branch)

```
$ pytest src/praisonai/tests/unit/test_cli_backend_flag.py \
         src/praisonai/tests/unit/test_external_agents_backcompat.py \
         src/praisonai/tests/unit/test_yaml_cli_backend.py \
         src/praisonai/tests/unit/test_claude_backend.py
==========================================
34 passed in 1.18s
==========================================
```

Plus `src/praisonai-agents/tests/unit/test_cli_backend_protocol.py` — **8/8 still pass** (no changes).

## Evidence that the feature still works (regression proof)

```
$ python -m praisonai.cli.main backends list
claude-code

$ python -m praisonai.cli.main --help | grep -E '(cli-backend|external-agent)'
  --external-agent {claude,gemini,codex,cursor}
  --cli-backend {claude-code}
  --external-agent-direct

$ python -m praisonai.cli.main --cli-backend claude-code --external-agent claude hi
usage: praisonai ...
praisonai: error: argument --external-agent: not allowed with argument --cli-backend
```

## Changes

### 1. `src/praisonai/praisonai/agents_generator.py` — small helper extraction

Moved the 23-line YAML `cli_backend` resolve block out of `generate_crew_and_kickoff` into a module-level function `_resolve_yaml_cli_backend(cli_backend_config, logger)`. Zero behaviour change — the PraisonAgent construction still receives `cli_backend=cli_backend_resolved`. The extraction simply makes the logic unit-testable without spinning up a full generator.

### 2. `test_yaml_cli_backend.py` — 8 tests (was 6)

Direct calls to `_resolve_yaml_cli_backend(...)`. Covers:

- string id → `resolve_cli_backend('claude-code')`
- dict with overrides → `resolve_cli_backend('claude-code', overrides={...})`
- dict missing `id` → `None` + warning (no raise)
- missing field → `None` (no warning)
- `ImportError` in resolver → `None` + warning
- unknown id (ValueError from registry) → `None` + warning
- invalid type (e.g. `123`) → `None` + warning
- **end-to-end**: real `'claude-code'` id resolves without any mocking

### 3. `test_cli_backend_flag.py` — 7 tests (was 8)

Subprocess-driven to avoid the `PYTEST_CURRENT_TEST` short-circuit. Child env has all `PYTEST_*` vars stripped. Each subprocess has a bounded timeout so hangs fail fast. Covers:

- `--cli-backend` in `--help`
- registered backend accepted
- unknown backend rejected by argparse
- mutual exclusion with `--external-agent`
- `backends list` subcommand
- bare `backends` (defaults to list)
- unknown `backends bogus` subcommand

### 4. `test_external_agents_backcompat.py` — 6 tests (was 7)

Mix of direct imports and subprocess argparse checks. Covers:

- `ExternalAgentsHandler` still importable + `list_integrations()` preserves original 4
- `ClaudeCodeIntegration` still importable + `.cli_command == 'claude'`
- `--external-agent` in `--help`
- all 4 choices (`claude`, `gemini`, `codex`, `cursor`) in `--help`
- `--external-agent-direct` in `--help`
- unknown value rejected

## Out of scope

- Fixing the `parse_args()` `PYTEST_CURRENT_TEST` short-circuit itself. That's a pre-existing CLI-wide testability issue unrelated to Phase 1b; touching it would balloon this PR.
- Adding `--cli-backend` back-compat alias for `--external-agent claude`. Separate design decision.

## Verification

```bash
cd /path/to/praisonai-package
git fetch origin pull/<this-pr>/head:fix-phase1b && git checkout fix-phase1b

# Wrapper tests
PYTHONPATH=src/praisonai-agents:src/praisonai python3 -m pytest \
  src/praisonai/tests/unit/test_cli_backend_flag.py \
  src/praisonai/tests/unit/test_external_agents_backcompat.py \
  src/praisonai/tests/unit/test_yaml_cli_backend.py \
  src/praisonai/tests/unit/test_claude_backend.py -v
# 34 passed

# Core tests (unchanged)
PYTHONPATH=src/praisonai-agents:src/praisonai python3 -m pytest \
  src/praisonai-agents/tests/unit/test_cli_backend_protocol.py -v
# 8 passed

# Functional smoke (feature still works)
PYTHONPATH=src/praisonai-agents:src/praisonai python3 -m praisonai.cli.main backends list
# claude-code
```

Closes the bug silently introduced by #1531. Refs #1530.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized YAML CLI-backend resolution for more consistent validation and tolerant error handling when loading configured backends.

* **Tests**
  * Expanded end-to-end CLI tests that run the real CLI to verify help text, acceptance/rejection of backend and external-agent flags, mutual-exclusion behavior, subcommand listing and error reporting, and legacy back-compat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->