### PR TITLE
docs: add 'self-improving' to README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 </div>
 
-PraisonAI 🦞 — **Hire a 24/7 AI Workforce.** Stop writing boilerplate and start shipping autonomous agents that research, plan, and execute tasks across your apps. From one agent to an entire organization, deployed in 5 lines of code.
+PraisonAI 🦞 — **Hire a 24/7 AI Workforce.** Stop writing boilerplate and start shipping autonomous, self-improving agents that research, plan, and execute tasks across your apps. From one agent to an entire organization, deployed in 5 lines of code.
 
 ```bash
 curl -fsSL https://praison.ai/install.sh | bash

--- a/src/praisonai/README.md
+++ b/src/praisonai/README.md
@@ -23,7 +23,7 @@
 
 </div>
 
-PraisonAI 🦞 — **Hire a 24/7 AI Workforce.** Stop writing boilerplate and start shipping autonomous agents that research, plan, and execute tasks across your apps. From one agent to an entire organization, deployed in 5 lines of code.
+PraisonAI 🦞 — **Hire a 24/7 AI Workforce.** Stop writing boilerplate and start shipping autonomous, self-improving agents that research, plan, and execute tasks across your apps. From one agent to an entire organization, deployed in 5 lines of code.
 
 ```bash
 curl -fsSL https://praison.ai/install.sh | bash


### PR DESCRIPTION
Adds **self-improving** to the top-level README.md and src/praisonai/README.md taglines so they match src/praisonai-agents/README.md which already advertises 'autonomous, self-improving agents'.

Pure docs change, two-word edit per file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product positioning tagline in README documentation to reflect "autonomous, self-improving agents" descriptor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->