### PR TITLE
fix(security): reject SSRF-smuggling URL characters in spider_tools._validate_url

### DIFF
--- a/src/praisonai-agents/praisonaiagents/tools/spider_tools.py
+++ b/src/praisonai-agents/praisonaiagents/tools/spider_tools.py
@@ -38,6 +38,17 @@ class SpiderTools:
             bool: True if URL is safe, False otherwise
         """
         try:
+            # Reject URLs containing characters that cause urlparse and the
+            # underlying HTTP client (e.g. requests) to disagree on the
+            # destination host. Backslashes and ASCII control characters in
+            # the authority portion can be used to smuggle a private host
+            # past hostname-based SSRF checks (e.g. ``http://127.0.0.1:6666\@1.1.1.1``
+            # parses as host ``1.1.1.1`` but is dispatched to ``127.0.0.1``).
+            if not isinstance(url, str):
+                return False
+            if "\\" in url or any(ord(c) < 0x20 or ord(c) == 0x7f for c in url):
+                return False
+
             parsed = urlparse(url)
             
             # Only allow http/https protocols

--- a/src/praisonai-agents/tests/unit/tools/test_spider_url_validation.py
+++ b/src/praisonai-agents/tests/unit/tools/test_spider_url_validation.py
@@ -1,0 +1,44 @@
+"""Regression tests for SSRF hardening in spider_tools._validate_url.
+
+Covers GHSA-q9pw-vmhh-384g: a URL such as ``http://127.0.0.1:6666\\@1.1.1.1``
+parses with hostname ``1.1.1.1`` via :func:`urllib.parse.urlparse` but is
+dispatched to ``127.0.0.1`` by ``requests``. The validator must reject any
+URL whose authority disagrees with the actual destination so that hostname
+allow/deny checks cannot be smuggled past.
+"""
+
+from praisonaiagents.tools.spider_tools import SpiderTools
+
+
+def test_rejects_backslash_smuggle_in_authority():
+    spider = SpiderTools()
+    # Real-world bypass payload from the advisory.
+    assert spider._validate_url("http://127.0.0.1:6666\\@1.1.1.1") is False
+
+
+def test_rejects_backslash_anywhere_in_url():
+    spider = SpiderTools()
+    assert spider._validate_url("http://example.com\\foo") is False
+
+
+def test_rejects_control_characters():
+    spider = SpiderTools()
+    assert spider._validate_url("http://example.com\x00.evil.com") is False
+    assert spider._validate_url("http://example.com\r\n.evil.com") is False
+
+
+def test_allows_normal_public_url():
+    spider = SpiderTools()
+    assert spider._validate_url("https://example.com/path?q=1") is True
+
+
+def test_still_blocks_loopback():
+    spider = SpiderTools()
+    assert spider._validate_url("http://127.0.0.1:6666/") is False
+    assert spider._validate_url("http://localhost/") is False
+
+
+def test_rejects_non_string_input():
+    spider = SpiderTools()
+    assert spider._validate_url(None) is False  # type: ignore[arg-type]
+    assert spider._validate_url(123) is False  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Hardens `SpiderTools._validate_url` against an SSRF bypass that exploits parser disagreement between `urllib.parse.urlparse` and the underlying HTTP client (`requests`, `httpx`).

## Threat

A URL such as

```
http://127.0.0.1:6666\@1.1.1.1
```

parses with hostname `1.1.1.1` via `urllib.parse.urlparse` (so any allow/deny check that consults `parsed.hostname` sees a public IP) **but is actually dispatched to `127.0.0.1:6666` by `requests` / `httpx`**, because those clients treat the backslash differently and re-resolve the authority. The result: hostname-based SSRF guards are silently bypassed and the agent ends up issuing requests to internal services on the local host.

ASCII control characters (NUL, CR, LF, DEL, …) in the authority section can produce a similar parser disagreement and have been used in HTTP request smuggling and CRLF-injection attacks.

```python
>>> from urllib.parse import urlparse
>>> urlparse("http://127.0.0.1:6666\\@1.1.1.1").hostname
'1.1.1.1'                       # <- what the SSRF allow-list sees
>>> import requests
>>> requests.get("http://127.0.0.1:6666\\@1.1.1.1")  # <- actual destination
# attempts to connect to 127.0.0.1:6666
```

## Fix

Before `urlparse` runs, reject any URL that:

1. is not a `str`,
2. contains a backslash anywhere, or
3. contains any ASCII control character (codepoint `< 0x20` or `== 0x7f`).

These rejections are early-return so the existing `urlparse` + IP / private / metadata / internal-domain checks below them remain unchanged.

```python
if not isinstance(url, str):
    return False
if "\\" in url or any(ord(c) < 0x20 or ord(c) == 0x7f for c in url):
    return False
```

## Tests

`src/praisonai-agents/tests/unit/tools/test_spider_url_validation.py` (new — 6 tests):

| Test | Asserts |
|---|---|
| `test_rejects_backslash_smuggle_in_authority` | The real-world advisory payload `http://127.0.0.1:6666\@1.1.1.1` is rejected |
| `test_rejects_backslash_anywhere_in_url` | Backslash in path/query also rejected |
| `test_rejects_control_characters` | NUL and CR+LF in URL rejected |
| `test_allows_normal_public_url` | `https://example.com/path?q=1` still allowed (regression) |
| `test_still_blocks_loopback` | `127.0.0.1` and `localhost` still blocked (regression) |
| `test_rejects_non_string_input` | `None` and `int` rejected without crashing |

```bash
$ PYTHONPATH=src/praisonai-agents:src/praisonai pytest \
    src/praisonai-agents/tests/unit/tools/test_spider_url_validation.py -q
6 passed in 0.37s
```

## AGENTS.md conformance

- ✅ **Core SDK scoped**: only touches `praisonaiagents.tools.spider_tools`. No wrapper changes, no protocol changes.
- ✅ **Backward compatible**: tightens an existing security check; only rejects URLs that were never expected to be valid (and that no legitimate caller would construct).
- ✅ **No performance impact**: two `O(n)` scans of the URL string ahead of the existing `urlparse` call. Negligible cost vs. an HTTP roundtrip.
- ✅ **Fail safe**: defaults to denying the suspect input.
- ✅ **Test discipline**: 6 new tests covering both the bypass and the regressions.

## Files changed

| File | Δ |
|---|---|
| `src/praisonai-agents/praisonaiagents/tools/spider_tools.py` | +11 (early-reject guard with comment) |
| `src/praisonai-agents/tests/unit/tools/test_spider_url_validation.py` | new (45 lines, 6 tests) |
