### PR TITLE
fix(security): gate template tools.py autoload behind PRAISONAI_ALLOW_TEMPLATE_TOOLS

### DIFF
--- a/src/praisonai/praisonai/templates/tool_override.py
+++ b/src/praisonai/praisonai/templates/tool_override.py
@@ -7,11 +7,14 @@ Supports runtime tool registration with context manager pattern.
 
 import ast
 import importlib.util
+import logging
 import os
 import sys
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 def _autoload_tools_enabled() -> bool:
@@ -361,7 +364,13 @@ def create_tool_registry_with_overrides(
                 tools = loader.load_from_file(str(cwd_tools_py))
                 registry.update(tools)
             except Exception:
-                pass
+                # Skip-on-error is the documented contract here, but log
+                # at debug level so opt-in users can troubleshoot a
+                # broken cwd ``tools.py`` without us going silent.
+                logger.debug(
+                    "failed to autoload cwd tools.py at %s", cwd_tools_py,
+                    exc_info=True,
+                )
 
         # 4. Template-local tools.py
         if template_dir:
@@ -371,7 +380,10 @@ def create_tool_registry_with_overrides(
                     tools = loader.load_from_file(str(tools_py))
                     registry.update(tools)
                 except Exception:
-                    pass
+                    logger.debug(
+                        "failed to autoload template tools.py at %s", tools_py,
+                        exc_info=True,
+                    )
     
     # 3. Template tools_sources (from TEMPLATE.yaml)
     if tools_sources:
@@ -460,7 +472,10 @@ def resolve_tools(
                 local_tools = loader.load_from_file(str(tools_py))
                 registry.update(local_tools)
             except Exception:
-                pass
+                logger.debug(
+                    "failed to autoload template tools.py at %s", tools_py,
+                    exc_info=True,
+                )
     
     for tool in tool_names:
         if callable(tool):

--- a/src/praisonai/praisonai/templates/tool_override.py
+++ b/src/praisonai/praisonai/templates/tool_override.py
@@ -7,10 +7,27 @@ Supports runtime tool registration with context manager pattern.
 
 import ast
 import importlib.util
+import os
 import sys
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional
+
+
+def _autoload_tools_enabled() -> bool:
+    """Return True when implicit ``tools.py`` autoload is opted in.
+
+    Loading and executing arbitrary ``tools.py`` files from a recipe
+    template directory or the current working directory is unsafe whenever
+    the recipe source is not fully trusted (e.g. when it was fetched from
+    a remote registry such as GitHub). We therefore disable the implicit
+    autoload by default and require explicit opt-in.
+
+    The env var ``PRAISONAI_ALLOW_TEMPLATE_TOOLS`` is honored to keep
+    legacy local workflows working without a code change.
+    """
+    val = os.environ.get("PRAISONAI_ALLOW_TEMPLATE_TOOLS", "").strip().lower()
+    return val in ("1", "true", "yes", "on")
 
 
 class SecurityError(Exception):
@@ -329,24 +346,32 @@ def create_tool_registry_with_overrides(
                 except Exception:
                     pass
     
-    # 4.5. Current working directory tools.py (if exists)
-    cwd_tools_py = Path.cwd() / "tools.py"
-    if cwd_tools_py.exists():
-        try:
-            tools = loader.load_from_file(str(cwd_tools_py))
-            registry.update(tools)
-        except Exception:
-            pass
-    
-    # 4. Template-local tools.py
-    if template_dir:
-        tools_py = Path(template_dir) / "tools.py"
-        if tools_py.exists():
+    # 4.5/4. Implicit ``tools.py`` autoload is only honored when the operator
+    # explicitly opts in via the ``PRAISONAI_ALLOW_TEMPLATE_TOOLS`` environment
+    # variable. This prevents arbitrary code execution when recipes are
+    # fetched from remote registries (e.g. GitHub) where ``tools.py`` cannot
+    # be considered trusted. Explicit ``override_files`` / ``override_dirs``
+    # / ``tools_sources`` continue to work and are the supported way to load
+    # custom tool modules.
+    if _autoload_tools_enabled():
+        # 4.5. Current working directory tools.py (if exists)
+        cwd_tools_py = Path.cwd() / "tools.py"
+        if cwd_tools_py.exists():
             try:
-                tools = loader.load_from_file(str(tools_py))
+                tools = loader.load_from_file(str(cwd_tools_py))
                 registry.update(tools)
             except Exception:
                 pass
+
+        # 4. Template-local tools.py
+        if template_dir:
+            tools_py = Path(template_dir) / "tools.py"
+            if tools_py.exists():
+                try:
+                    tools = loader.load_from_file(str(tools_py))
+                    registry.update(tools)
+                except Exception:
+                    pass
     
     # 3. Template tools_sources (from TEMPLATE.yaml)
     if tools_sources:
@@ -424,8 +449,10 @@ def resolve_tools(
     if registry is None:
         registry = create_tool_registry_with_overrides(include_defaults=True)
     
-    # Load template-local tools.py if exists
-    if template_dir:
+    # Load template-local tools.py if exists. Gated behind the same opt-in
+    # flag as create_tool_registry_with_overrides() to prevent implicit code
+    # execution from untrusted (e.g. remotely fetched) recipe directories.
+    if template_dir and _autoload_tools_enabled():
         loader = ToolOverrideLoader()
         tools_py = Path(template_dir) / "tools.py"
         if tools_py.exists():

--- a/src/praisonai/tests/unit/templates/test_tool_override_autoload_gate.py
+++ b/src/praisonai/tests/unit/templates/test_tool_override_autoload_gate.py
@@ -1,0 +1,115 @@
+"""Regression tests for GHSA-xcmw-grxf-wjhj.
+
+A malicious recipe shipping a ``tools.py`` file would previously be
+``exec_module``'d during tool registry construction, regardless of where
+the recipe came from. When the recipe is fetched from a remote registry
+(e.g. GitHub) this gives an unauthenticated attacker arbitrary code
+execution in the server process.
+
+The fix gates the implicit ``tools.py`` autoload behind the
+``PRAISONAI_ALLOW_TEMPLATE_TOOLS`` environment variable. Explicit override
+files / dirs / template ``tools_sources`` continue to work unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from praisonai.templates.tool_override import (
+    create_tool_registry_with_overrides,
+    resolve_tools,
+)
+
+
+PAYLOAD = textwrap.dedent(
+    """
+    import os, tempfile
+    _MARKER = os.path.join(tempfile.gettempdir(), 'praisonai_autoload_marker.txt')
+    with open(_MARKER, 'w') as f:
+        f.write('pwned')
+    def evil_tool():
+        return 'evil'
+    """
+).strip()
+
+
+@pytest.fixture
+def malicious_template(tmp_path: Path) -> Path:
+    template_dir = tmp_path / "evil_recipe"
+    template_dir.mkdir()
+    (template_dir / "tools.py").write_text(PAYLOAD)
+    return template_dir
+
+
+@pytest.fixture(autouse=True)
+def _clean_marker(tmp_path: Path):
+    import tempfile
+    marker = Path(tempfile.gettempdir()) / "praisonai_autoload_marker.txt"
+    if marker.exists():
+        marker.unlink()
+    yield
+    if marker.exists():
+        marker.unlink()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("PRAISONAI_ALLOW_TEMPLATE_TOOLS", raising=False)
+    yield
+
+
+def _marker_path() -> Path:
+    import tempfile
+    return Path(tempfile.gettempdir()) / "praisonai_autoload_marker.txt"
+
+
+def test_template_tools_py_not_executed_by_default(malicious_template: Path):
+    registry = create_tool_registry_with_overrides(
+        include_defaults=False,
+        template_dir=str(malicious_template),
+    )
+    assert "evil_tool" not in registry
+    assert not _marker_path().exists(), "tools.py must not execute by default"
+
+
+def test_resolve_tools_does_not_execute_template_tools_py_by_default(
+    malicious_template: Path,
+):
+    resolve_tools(["evil_tool"], registry={}, template_dir=str(malicious_template))
+    assert not _marker_path().exists()
+
+
+def test_cwd_tools_py_not_executed_by_default(tmp_path: Path, monkeypatch):
+    (tmp_path / "tools.py").write_text(PAYLOAD)
+    monkeypatch.chdir(tmp_path)
+    registry = create_tool_registry_with_overrides(include_defaults=False)
+    assert "evil_tool" not in registry
+    assert not _marker_path().exists()
+
+
+def test_opt_in_env_var_re_enables_autoload(
+    malicious_template: Path, monkeypatch
+):
+    monkeypatch.setenv("PRAISONAI_ALLOW_TEMPLATE_TOOLS", "1")
+    registry = create_tool_registry_with_overrides(
+        include_defaults=False,
+        template_dir=str(malicious_template),
+    )
+    # When operator opts in the legacy behaviour is preserved.
+    assert "evil_tool" in registry
+
+
+def test_explicit_override_files_still_work_without_opt_in(
+    malicious_template: Path,
+):
+    # Explicit user-provided tool files are the supported entry point and
+    # must keep working without the opt-in flag.
+    registry = create_tool_registry_with_overrides(
+        include_defaults=False,
+        override_files=[str(malicious_template / "tools.py")],
+    )
+    assert "evil_tool" in registry

--- a/src/praisonai/tests/unit/templates/test_tool_override_autoload_gate.py
+++ b/src/praisonai/tests/unit/templates/test_tool_override_autoload_gate.py
@@ -103,6 +103,25 @@ def test_opt_in_env_var_re_enables_autoload(
     assert "evil_tool" in registry
 
 
+def test_opt_in_env_var_re_enables_cwd_autoload(tmp_path: Path, monkeypatch):
+    """Mirror of :func:`test_opt_in_env_var_re_enables_autoload` for the
+    *current working directory* autoload path.
+
+    The original PR description guarantees that legacy local workflows
+    keep working when the operator sets ``PRAISONAI_ALLOW_TEMPLATE_TOOLS=1``.
+    The previous opt-in test only covered ``template_dir``; this one
+    covers the CWD path that ``test_cwd_tools_py_not_executed_by_default``
+    asserts is denied by default.
+    """
+    (tmp_path / "tools.py").write_text(PAYLOAD)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PRAISONAI_ALLOW_TEMPLATE_TOOLS", "1")
+
+    registry = create_tool_registry_with_overrides(include_defaults=False)
+    # Legacy CWD autoload behaviour is preserved on opt-in.
+    assert "evil_tool" in registry
+
+
 def test_explicit_override_files_still_work_without_opt_in(
     malicious_template: Path,
 ):

--- a/src/praisonai/tests/unit/test_templates.py
+++ b/src/praisonai/tests/unit/test_templates.py
@@ -1701,10 +1701,19 @@ author: override-author
         assert template.version == "3.0.0"
         assert template.author == "override-author"
     
-    def test_tools_py_loaded(self, temp_simplified_recipe):
-        """Test that tools.py is loaded and custom tools are available."""
+    def test_tools_py_loaded(self, temp_simplified_recipe, monkeypatch):
+        """Test that tools.py is loaded when the operator opts in via
+        ``PRAISONAI_ALLOW_TEMPLATE_TOOLS``.
+
+        Implicit ``tools.py`` autoload is disabled by default to prevent
+        arbitrary code execution from untrusted (e.g. remotely fetched)
+        recipe directories. Legacy local workflows continue to work by
+        setting the env var.
+        """
         from praisonai.templates.tool_override import create_tool_registry_with_overrides
-        
+
+        monkeypatch.setenv("PRAISONAI_ALLOW_TEMPLATE_TOOLS", "1")
+
         registry = create_tool_registry_with_overrides(
             template_dir=str(temp_simplified_recipe)
         )


### PR DESCRIPTION
## Summary

Disable implicit `tools.py` autoload from CWD and recipe template directories. The legacy behavior is preserved for trusted local workflows behind an explicit `PRAISONAI_ALLOW_TEMPLATE_TOOLS=1` opt-in.

## Threat

`create_tool_registry_with_overrides()` walked into the current working directory and the recipe template directory and `exec_module()`-d any `tools.py` it found:

```python
# Before
cwd_tools_py = Path.cwd() / "tools.py"
if cwd_tools_py.exists():
    try:
        tools = loader.load_from_file(str(cwd_tools_py))   # <-- exec_module
        ...
if template_dir:
    tools_py = Path(template_dir) / "tools.py"
    if tools_py.exists():
        try:
            tools = loader.load_from_file(str(tools_py))   # <-- exec_module
            ...
```

When a recipe is fetched from a remote registry (e.g. via the GitHub recipe-share workflow), this gives an **unauthenticated attacker arbitrary code execution** in the server process the moment the recipe is loaded — the `tools.py` runs at import time, before any allow-list, sandbox, or approval check fires.

`resolve_tools()` had the same behavior on the same template directory.

## Fix

Gate both autoload sites behind a new helper:

```python
def _autoload_tools_enabled() -> bool:
    val = os.environ.get("PRAISONAI_ALLOW_TEMPLATE_TOOLS", "").strip().lower()
    return val in ("1", "true", "yes", "on")
```

The default is **disabled**. Trusted local workflows opt back in with one env var.

## What still works (no opt-in needed)

Explicit, caller-controlled entry points are unchanged:

| Entry point | Status |
|---|---|
| `override_files=[...]` (explicit file paths) | ✅ unchanged |
| `override_dirs=[...]` (explicit directory scan) | ✅ unchanged |
| `tools_sources=...` (TEMPLATE.yaml directive) | ✅ unchanged |
| `registry={...}` (caller-built registry) | ✅ unchanged |
| Implicit `cwd/tools.py` and `template_dir/tools.py` | 🚫 gated by env var |

## Tests

`src/praisonai/tests/unit/templates/test_tool_override_autoload_gate.py` (new, 5 tests). The malicious-template fixture writes a `tools.py` payload that drops a marker file in tempdir on import; the tests assert the marker **does not** appear under the default-deny behavior:

| Test | Asserts |
|---|---|
| `test_template_tools_py_not_executed_by_default` | template `tools.py` is NOT executed |
| `test_resolve_tools_does_not_execute_template_tools_py_by_default` | `resolve_tools()` does not execute it either |
| `test_cwd_tools_py_not_executed_by_default` | CWD `tools.py` is NOT executed |
| `test_opt_in_env_var_re_enables_autoload` | with `PRAISONAI_ALLOW_TEMPLATE_TOOLS=1`, legacy behavior is preserved |
| `test_explicit_override_files_still_work_without_opt_in` | regression: explicit `override_files` keeps working |

`src/praisonai/tests/unit/test_templates.py::test_tools_py_loaded` updated to set `PRAISONAI_ALLOW_TEMPLATE_TOOLS=1` via `monkeypatch.setenv`, since that test pins the legacy contract (which now requires explicit opt-in).

```bash
$ PYTHONPATH=src/praisonai-agents:src/praisonai pytest \
    src/praisonai/tests/unit/test_templates.py \
    src/praisonai/tests/unit/templates/ -q
83 passed in 2.65s
```

## AGENTS.md conformance

- ✅ **Wrapper-layer scoped**: only touches `praisonai/templates/tool_override.py` and its tests. No core SDK changes.
- ✅ **Safe by default**: matches the AGENTS.md invariant *"new features are opt-in, not opt-out"* — and converts a pre-existing unsafe-by-default behavior into a safe-by-default one with a single, well-documented opt-in.
- ✅ **No performance impact**: one additional `os.environ.get()` per registry build, no extra imports.
- ✅ **Backward compatible** for trusted-local users: setting `PRAISONAI_ALLOW_TEMPLATE_TOOLS=1` restores the previous behavior bit-for-bit.
- ✅ **Test discipline**: 5 new tests covering both the bypass and regressions; pre-existing test updated rather than weakened.
- ✅ **Fail-loud-but-narrow**: only `tools.py` autoload is gated; explicit `override_*` paths still work and remain the supported entry point.

## Files changed

| File | Δ |
|---|---|
| `src/praisonai/praisonai/templates/tool_override.py` | +43 / −16 (gate helper + two call sites) |
| `src/praisonai/tests/unit/templates/__init__.py` | new (empty package marker) |
| `src/praisonai/tests/unit/templates/test_tool_override_autoload_gate.py` | new (115 lines, 5 tests) |
| `src/praisonai/tests/unit/test_templates.py::test_tools_py_loaded` | + `monkeypatch.setenv("PRAISONAI_ALLOW_TEMPLATE_TOOLS", "1")` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Template tools are disabled by default to prevent execution of untrusted code. Legacy behavior can be re-enabled via the PRAISONAI_ALLOW_TEMPLATE_TOOLS environment variable. Explicit user-provided tool overrides continue to load as before. Load failures now emit debug-level logs instead of being silently ignored.

* **Tests**
  * Added and updated tests to cover the default-deny behavior and the opt-in legacy paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->