### PR TITLE
fix(tests): mark profiler timing tests with @allow_sleep (follow-up #1580)

### DIFF
--- a/src/praisonai/tests/unit/test_profiler_advanced.py
+++ b/src/praisonai/tests/unit/test_profiler_advanced.py
@@ -48,6 +48,7 @@ class TestAPICallProfiler:
         Profiler.disable()
         Profiler.clear()
     
+    @pytest.mark.allow_sleep
     def test_api_call_context_manager(self):
         """Should profile API call with context manager."""
         from praisonai.profiler import Profiler
@@ -55,13 +56,15 @@ class TestAPICallProfiler:
         Profiler.enable()
         Profiler.clear()
         
+        # ``allow_sleep`` opts out of the conftest ``fast_sleep`` fixture which
+        # otherwise clamps ``time.sleep`` to 1ms — needed here because the test
+        # asserts a real wall-clock duration was measured.
         with Profiler.api_call("https://api.example.com/test", method="GET") as call:
-            time.sleep(0.05)  # Simulate API latency (50ms for reliable measurement)
+            time.sleep(0.05)  # 50ms for reliable measurement on busy CI
         
         calls = Profiler.get_api_calls()
         assert len(calls) >= 1
-        # Use a loose lower bound: ``time.sleep`` can under-deliver by a few ms
-        # on busy CI runners, so we require at least 5ms to catch unit errors.
+        # Loose lower bound: ``time.sleep`` precision varies by ~5ms on CI.
         assert calls[-1].duration_ms >= 5
         
         Profiler.disable()
@@ -120,6 +123,7 @@ class TestStreamingProfiler:
         Profiler.disable()
         Profiler.clear()
     
+    @pytest.mark.allow_sleep
     def test_streaming_tracker(self):
         """Should track streaming with context manager."""
         from praisonai.profiler import Profiler, StreamingTracker
@@ -127,6 +131,8 @@ class TestStreamingProfiler:
         Profiler.enable()
         Profiler.clear()
         
+        # ``allow_sleep`` opts out of conftest ``fast_sleep`` clamping so the
+        # TTFT measurement reflects real elapsed time.
         tracker = StreamingTracker("test_stream")
         tracker.start()
         time.sleep(0.05)

--- a/src/praisonai/tests/unit/test_profiler_advanced.py
+++ b/src/praisonai/tests/unit/test_profiler_advanced.py
@@ -50,15 +50,17 @@ class TestAPICallProfiler:
     
     @pytest.mark.allow_sleep
     def test_api_call_context_manager(self):
-        """Should profile API call with context manager."""
+        """Should profile API call with context manager.
+
+        The ``@allow_sleep`` marker opts out of the conftest ``fast_sleep`` fixture which
+        otherwise clamps ``time.sleep`` to 1ms. This is needed here because the test
+        asserts a real wall-clock duration was measured.
+        """
         from praisonai.profiler import Profiler
         
         Profiler.enable()
         Profiler.clear()
         
-        # ``allow_sleep`` opts out of the conftest ``fast_sleep`` fixture which
-        # otherwise clamps ``time.sleep`` to 1ms — needed here because the test
-        # asserts a real wall-clock duration was measured.
         with Profiler.api_call("https://api.example.com/test", method="GET") as call:
             time.sleep(0.05)  # 50ms for reliable measurement on busy CI
         
@@ -125,14 +127,16 @@ class TestStreamingProfiler:
     
     @pytest.mark.allow_sleep
     def test_streaming_tracker(self):
-        """Should track streaming with context manager."""
+        """Should track streaming with context manager.
+
+        The ``@allow_sleep`` marker opts out of conftest ``fast_sleep`` clamping so the
+        TTFT measurement reflects real elapsed time.
+        """
         from praisonai.profiler import Profiler, StreamingTracker
         
         Profiler.enable()
         Profiler.clear()
         
-        # ``allow_sleep`` opts out of conftest ``fast_sleep`` clamping so the
-        # TTFT measurement reflects real elapsed time.
         tracker = StreamingTracker("test_stream")
         tracker.start()
         time.sleep(0.05)


### PR DESCRIPTION
## Why

The merged version of #1580 tightened the profiler-test bounds from `> 0` to `>= 5` ms during review, but failed to opt out of conftest's autouse `fast_sleep` fixture (`tests/conftest.py:183`) which clamps `time.sleep` to 1ms for unit tests.

Result on `main`:
```
test_api_call_context_manager:  AssertionError: assert 1.1379... >= 5
test_streaming_tracker:         AssertionError: assert 1.2635... >= 5
```

## Fix

Add `@pytest.mark.allow_sleep` to both timing-sensitive tests \u2014 the documented opt-out from the `fast_sleep` clamp. The 50ms sleep then runs for real and the `>= 5ms` assertion becomes meaningful.

## Verification

```bash
PYTHONPATH=src/praisonai-agents:src/praisonai pytest \
  src/praisonai/tests/unit/test_profiler_advanced.py::TestAPICallProfiler::test_api_call_context_manager \
  src/praisonai/tests/unit/test_profiler_advanced.py::TestStreamingProfiler::test_streaming_tracker
# 2 passed
```

Combined with sandbox + ag2 + push_client suites: **12 passed, 2 skipped, 0 failed**.

## Risk

Test-only diff. No runtime behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Marked timing-sensitive profiling tests to use real wall-clock sleeps so durations reflect true elapsed time during CI.
  * Clarified test documentation and timing rationale (CI sleep precision ~5ms) to explain lower-bound choices for duration and TTFT assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->