### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@v0.3.0
+      - uses: Jwrede/tokentoll@v0.4.0

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,17 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@v0.3.0

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@v0.4.0
+      - uses: Jwrede/tokentoll@a4c8ce5f97e751f34498f6503087e5583c02cbbc

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@a4c8ce5f97e751f34498f6503087e5583c02cbbc
+      - uses: Jwrede/tokentoll@cfc9307c2e820de1223fc707ee7e945f6f972379  # v0.5.2

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@ff50a35604b7858d9064cca6354b6229a94f7235  # v0.6.0
+      - uses: Jwrede/tokentoll@753ca4d1150c74169b52a843439049b65e256d2b  # v0.6.1

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@cfc9307c2e820de1223fc707ee7e945f6f972379  # v0.5.2
+      - uses: Jwrede/tokentoll@ff50a35604b7858d9064cca6354b6229a94f7235  # v0.6.0

--- a/.tokentoll.yml
+++ b/.tokentoll.yml
@@ -1,0 +1,1 @@
+default_model: gpt-4o

--- a/.tokentoll.yml
+++ b/.tokentoll.yml
@@ -1,1 +1,0 @@
-default_model: gpt-4o


### PR DESCRIPTION
## Summary

Add [tokentoll](https://github.com/Jwrede/tokentoll) GitHub Action to analyze LLM API cost changes on pull requests.

When a PR modifies code that makes LLM API calls (model swaps, max_tokens changes, new call sites), tokentoll posts a comment showing the projected cost impact. It stays silent on PRs that don't touch LLM code.

## What it detects

tokentoll uses Python AST analysis (zero runtime dependencies) to find calls to:
- OpenAI (`chat.completions.create`, `responses.create`, `embeddings.create`)
- Anthropic (`messages.create`)
- Google GenAI (`generate_content`)
- LiteLLM (`completion`, `embedding`)
- LangChain (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`)
- Zhipu AI / GLM (`ZhipuAiClient`, `ZhipuAI`)

## Current scan of this project

## tokentoll Scan Report

| File | Line | SDK | Model | Est. Cost/Call | Monthly |
|------|------|-----|-------|---------------|---------|
| `examples/capabilities/completions_example.py` | 25 | litellm | gpt-3.5-turbo-instruct | $0.000770 | $0.77 |
| `examples/embedding/agent_with_embedding.py` | 23 | litellm | Hello, world! | N/A | N/A |
| `examples/embedding/agent_with_embedding.py` | 28 | litellm | text-embedding-3-small | $0.000010 | $0.01 |
| `examples/embedding/agent_with_embedding.py` | 32 | litellm | text-embedding-3-large | $0.000065 | $0.06 |
| `examples/embedding/agent_with_embedding.py` | 106 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `examples/embedding/agent_with_embedding.py` | 110 | litellm | What language is used for web development? | N/A | N/A |
| `src/praisonai/praisonai/adapters/rerankers.py` | 140 | litellm | gpt-4o (default) | $0.000103 | $0.10 |
| `src/praisonai/praisonai/bots/_approval_base.py` | 101 | openai | gpt-4o (default) | $0.003005 | $3.00 |
| `src/praisonai/praisonai/browser/agent.py` | 504 | litellm | gpt-4o (default) | $0.006250 | $6.25 |
| `src/praisonai/praisonai/browser/agent.py` | 511 | litellm | gpt-4o (default) | $0.006250 | $6.25 |
| `src/praisonai/praisonai/browser/cdp_agent.py` | 897 | litellm | gpt-4o (default) | $0.002002 | $2.00 |
| `src/praisonai/praisonai/browser/diagnostics.py` | 113 | litellm | gpt-4o-mini | $0.000004 | $0.003750 |
| `src/praisonai/praisonai/capabilities/audio.py` | 260 | litellm | tts-1 | N/A | N/A |
| `src/praisonai/praisonai/capabilities/audio.py` | 115 | litellm | tts-1 | N/A | N/A |
| `src/praisonai/praisonai/capabilities/audio.py` | 311 | litellm | tts-1 | N/A | N/A |
| `src/praisonai/praisonai/capabilities/audio.py` | 186 | litellm | tts-1 | N/A | N/A |
| `src/praisonai/praisonai/capabilities/completions.py` | 87 | litellm | gpt-3.5-turbo-instruct | $0.002798 | $2.80 |
| `src/praisonai/praisonai/capabilities/completions.py` | 256 | litellm | gpt-3.5-turbo-instruct | $0.002798 | $2.80 |
| `src/praisonai/praisonai/capabilities/completions.py` | 170 | litellm | gpt-3.5-turbo-instruct | $0.002798 | $2.80 |
| `src/praisonai/praisonai/capabilities/embeddings.py` | 74 | litellm | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai/praisonai/capabilities/embeddings.py` | 141 | litellm | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai/praisonai/capabilities/guardrails.py` | 78 | litellm | gpt-4o-mini | $0.002458 | $2.46 |
| `src/praisonai/praisonai/capabilities/guardrails.py` | 152 | litellm | gpt-4o-mini | $0.002458 | $2.46 |
| `src/praisonai/praisonai/capabilities/images.py` | 97 | litellm | dall-e-2 | N/A | N/A |
| `src/praisonai/praisonai/capabilities/images.py` | 158 | litellm | dall-e-2 | N/A | N/A |
| `src/praisonai/praisonai/capabilities/messages.py` | 94 | litellm | gpt-4o-mini | $0.000689 | $0.69 |
| `src/praisonai/praisonai/capabilities/messages.py` | 167 | litellm | gpt-4o-mini | $0.000689 | $0.69 |
| `src/praisonai/praisonai/capabilities/rag.py` | 97 | litellm | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai/praisonai/capabilities/rag.py` | 182 | litellm | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai/praisonai/capabilities/responses.py` | 122 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai/praisonai/capabilities/responses.py` | 234 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai/praisonai/cli/features/benchmark.py` | 610 | openai | gpt-4o (default) | $0.000103 | $0.10 |
| `src/praisonai/praisonai/cli/features/capabilities.py` | 100 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai/praisonai/cli/features/capabilities.py` | 363 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai/praisonai/cli/features/image.py` | 172 | litellm | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai/praisonai/cli/features/image.py` | 218 | litellm | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai/praisonai/cli/features/knowledge.py` | 145 | openai | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai/praisonai/cli/features/recipe_creator.py` | 579 | litellm | gpt-4o (default) | $0.02 | $20.00 |
| `src/praisonai/praisonai/cli/features/recipe_optimizer.py` | 71 | litellm | gpt-4o-mini | $0.000300 | $0.30 |
| `src/praisonai/praisonai/cli/features/recipe_optimizer.py` | 862 | litellm | gpt-4o (default) | $0.03 | $25.00 |
| `src/praisonai/praisonai/cli/features/recipe_optimizer.py` | 1140 | litellm | gpt-4o (default) | $0.04 | $40.00 |
| `src/praisonai/praisonai/llm/__init__.py` | 136 | litellm | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai/praisonai/mcp_server/adapters/capabilities.py` | 38 | litellm | rerank-english-v2.0 | $0.000000 | $0.000000 |
| `src/praisonai/praisonai/replay/judge.py` | 70 | litellm | gpt-4o-mini | $0.000300 | $0.30 |
| `src/praisonai/praisonai/replay/judge.py` | 230 | litellm | gpt-4o-mini | $0.002458 | $2.46 |
| `src/praisonai/praisonai/replay/judge.py` | 513 | litellm | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai/praisonai/replay/judge.py` | 1298 | litellm | gpt-4o (default) | $0.003002 | $3.00 |
| `src/praisonai/praisonai/replay/judge.py` | 1720 | litellm | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai/praisonai/replay/judge.py` | 1892 | litellm | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai/praisonai/ui_chat/default_app.py` | 125 | openai | gpt-4o-mini | $0.002460 | $2.46 |
| `src/praisonai/tests/integration/knowledge/test_knowledge_integration.py` | 115 | openai | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai/tests/integration/knowledge/test_knowledge_integration.py` | 153 | openai | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai/tests/integration/knowledge/test_knowledge_integration.py` | 243 | openai | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai/tests/integration/knowledge/test_knowledge_integration.py` | 284 | openai | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai/tests/unit/test_capabilities.py` | 68 | litellm | tts-1 | N/A | N/A |
| `src/praisonai-agents/benchmarks/performance_benchmark.py` | 242 | langchain | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai-agents/benchmarks/simple_benchmark.py` | 97 | langchain | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai-agents/benchmarks/tools_benchmark.py` | 99 | langchain | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai-agents/praisonaiagents/agent/deep_research_agent.py` | 617 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/agent/deep_research_agent.py` | 658 | openai | o3-deep-research | $1.00 | $1005.00 |
| `src/praisonai-agents/praisonaiagents/agent/deep_research_agent.py` | 1390 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/agent/deep_research_agent.py` | 1434 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/agent/deep_research_agent.py` | 1303 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/embedding/embed.py` | 75 | litellm | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai-agents/praisonaiagents/embedding/embed.py` | 144 | litellm | text-embedding-3-small | $0.000010 | $0.01 |
| `src/praisonai-agents/praisonaiagents/eval/accuracy.py` | 118 | litellm | gpt-4o (default) | $0.002002 | $2.00 |
| `src/praisonai-agents/praisonaiagents/eval/criteria.py` | 141 | litellm | gpt-4o (default) | $0.002002 | $2.00 |
| `src/praisonai-agents/praisonaiagents/eval/grader.py` | 270 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/eval/grader.py` | 305 | litellm | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai-agents/praisonaiagents/eval/grader.py` | 348 | litellm | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai-agents/praisonaiagents/eval/media.py` | 335 | litellm | gpt-4o (default) | $0.002002 | $2.00 |
| `src/praisonai-agents/praisonaiagents/eval/media.py` | 230 | litellm | gpt-4o-mini | $0.000120 | $0.12 |
| `src/praisonai-agents/praisonaiagents/lite/__init__.py` | 251 | openai | claude-3-5-sonnet-20241022 | $0.03 | $32.22 |
| `src/praisonai-agents/praisonaiagents/lite/__init__.py` | 299 | anthropic | claude-3-5-sonnet-20241022 | $0.06 | $62.94 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3087 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3354 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 4259 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 5390 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 2098 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3153 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3224 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3803 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 4325 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 5487 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3136 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3207 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3910 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 4032 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 4308 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3862 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 3884 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 4083 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 2269 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 2451 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 2498 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 2524 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 4101 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 4119 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 2250 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 2332 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/llm.py` | 2300 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/openai_client.py` | 939 | openai | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai-agents/praisonaiagents/llm/openai_client.py` | 1413 | openai | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai-agents/praisonaiagents/llm/openai_client.py` | 1204 | openai | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai-agents/praisonaiagents/llm/openai_client.py` | 1391 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/openai_client.py` | 1472 | openai | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai-agents/praisonaiagents/llm/openai_client.py` | 1983 | openai | gpt-4o-mini | $0.002533 | $2.53 |
| `src/praisonai-agents/praisonaiagents/llm/openai_client.py` | 906 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/openai_client.py` | 1450 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/openai_client.py` | 1166 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/llm/streaming_protocol.py` | 181 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/memory/memory.py` | 1773 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai-agents/praisonaiagents/memory/memory.py` | 564 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/memory/memory.py` | 1759 | litellm | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai-agents/praisonaiagents/memory/memory.py` | 772 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/praisonaiagents/workflows/workflows.py` | 2325 | litellm | gpt-4o (default) | $0.04 | $40.96 |
| `src/praisonai-agents/test_langtrace.py` | 15 | openai | gpt-4o-mini | $0.002459 | $2.46 |
| `src/praisonai-agents/test_litellm_direct.py` | 16 | litellm | gemini/gemini-3-flash-preview | $0.003017 | $3.02 |
| `src/praisonai-agents/test_litellm_telemetry.py` | 36 | litellm | gpt-3.5-turbo | $0.001538 | $1.54 |
| `src/praisonai-agents/test_stop_sequence.py` | 17 | litellm | gemini/gemini-3-flash-preview | $0.001507 | $1.51 |
| `src/praisonai-agents/test_stop_sequence.py` | 34 | litellm | gemini/gemini-3-flash-preview | $0.001507 | $1.51 |
| `src/praisonai-agents/test_telemetry_disabled.py` | 30 | litellm | gpt-3.5-turbo | $0.001537 | $1.54 |
| `src/praisonai-agents/tests/deepseek-think.py` | 5 | openai | deepseek-reasoner | $0.006885 | $6.88 |
| `src/praisonai-agents/tests/litellm-reasoning.py` | 4 | litellm | deepseek/deepseek-reasoner | $0.007021 | $7.02 |
| `src/praisonai-agents/tests/mcp_airbnb_client_direct.py` | 45 | google_genai | gemini-2.0-flash | $0.000869 | $0.87 |
| `src/praisonai-agents/tests/mcp_airbnb_full_direct.py` | 39 | google_genai | gemini-2.0-flash | $0.000869 | $0.87 |
| `src/praisonai-agents/tests/mcp_airbnb_full_direct.py` | 89 | google_genai | gemini-2.0-flash | $0.000869 | $0.87 |
| `src/praisonai-agents/tests/mcp_wrapper.py` | 113 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `src/praisonai-agents/tests/mcp_wrapper.py` | 207 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `src/praisonai-agents/tests/unit/embedding/test_embedding.py` | 58 | litellm | Hello world | N/A | N/A |
| `src/praisonai-agents/tests/unit/embedding/test_embedding.py` | 79 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `src/praisonai-agents/tests/unit/embedding/test_embedding.py` | 97 | litellm | text-embedding-3-large | $0.000065 | $0.06 |
| `src/praisonai-agents/tests/unit/embedding/test_embedding.py` | 115 | litellm | test | N/A | N/A |
| `src/praisonai-agents/tests/unit/embedding/test_embedding.py` | 138 | litellm | Hello world | N/A | N/A |

**Total estimated monthly cost: $3597.45**

<details>
<summary>Assumptions</summary>

- 1000 calls/month per call site

</details>

*Generated by [tokentoll](https://github.com/Jwrede/tokentoll)*

## How it works

- Runs only on PRs, compares base vs head
- Posts a sticky comment (updates in place, no duplicates)
- Only comments when LLM calls are added, removed, or modified
- First run posts an initial scan (this PR) so you can see the output
- Zero runtime dependencies, ~1s scan time for most projects
- [PyPI](https://pypi.org/project/tokentoll/) | [GitHub](https://github.com/Jwrede/tokentoll)

## Changes

- Adds `.github/workflows/llm-costs.yml` (17 lines)
- No code changes, no new dependencies
