### PR TITLE
fix: move debug log from docstring to actual code in github_create_branch

### DIFF
--- a/src/praisonai-agents/praisonaiagents/tools/github_tools.py
+++ b/src/praisonai-agents/praisonaiagents/tools/github_tools.py
@@ -7,8 +7,7 @@ logger = logging.getLogger(__name__)
 @tool
 def github_create_branch(branch_name: str) -> str:
     """Create and checkout a new git branch.
-    
-logger.debug(f"Branch '{branch_name}' checked out successfully.")
+
     Args:
         branch_name: The name of the branch to create and checkout.
     """
@@ -16,6 +15,7 @@ logger.debug(f"Branch '{branch_name}' checked out successfully.")
         # Check if we are in a git repository
         subprocess.run(["git", "rev-parse", "--is-inside-work-tree"], check=True, capture_output=True)
         subprocess.run(["git", "checkout", "-B", branch_name], check=True, capture_output=True, text=True)
+        logger.debug(f"Branch '{branch_name}' checked out successfully.")
         return f"Successfully created and checked out branch '{branch_name}'"
     except subprocess.CalledProcessError as e:
         logger.error(f"Failed to create branch: {e.stderr}")


### PR DESCRIPTION
## Summary

The  call for successful branch checkout in  was accidentally placed inside the docstring instead of being executable code.

**Before:**  was inside the  docstring block (line 11), making it a comment, not actual logging.

**After:** Moved the debug log to execute after the  subprocess call succeeds (line 19), so it actually logs when a branch is checked out.

## Changes
- Removed  from docstring
- Added  after the checkout command

Fixes #1350


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure and formatting consistency for development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->