### PR TITLE
fix: add email-validator to praisonai-platform test extras

### DIFF
--- a/src/praisonai-platform/pyproject.toml
+++ b/src/praisonai-platform/pyproject.toml
@@ -33,6 +33,7 @@ postgres = [
 test = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23.0",
+    "email-validator>=2.0",
     "httpx>=0.27.0",
 ]
 


### PR DESCRIPTION
## Summary

The `[test]` optional dependency group in `src/praisonai-platform/pyproject.toml` was missing `email-validator`, causing `ImportError` during pytest collection in clean environments.

## Changes
- Added `email-validator>=2.0` to the `[test]` extras in `src/praisonai-platform/pyproject.toml`

## Verification
In a clean virtualenv:
```
pip install -e src/praisonai-platform["test"]
python -m pytest src/praisonai-platform/tests -q
```
Tests should now collect and run without the `email-validator` ImportError.

Fixes #1584


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing dependencies to support enhanced email validation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->