### PR TITLE
fix(security): bind API server to 127.0.0.1 by default instead of 0.0.0.0

### DIFF
--- a/src/praisonai/praisonai/api/call.py
+++ b/src/praisonai/praisonai/api/call.py
@@ -351,22 +351,31 @@ def setup_public_url(port):
     print(f"Praison AI Voice URL: {public_url}")
     return public_url
 
-def run_server(port: int, use_public: bool = False):
+def run_server(port: int, host: str = "127.0.0.1", use_public: bool = False):
     """Run the FastAPI server using uvicorn."""
     if not OPENAI_API_KEY:
         raise ValueError('Missing the OpenAI API key. Please set it in the .env file or configure it through the GUI.')
-    
+
     if use_public:
         setup_public_url(port)
-    else:
-        print(f"Starting Praison AI Call Server on http://localhost:{port}")
-    uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")
+        host = "0.0.0.0"  # ngrok requires binding to all interfaces
+
+    if host == "0.0.0.0" and not use_public:
+        import logging
+        logging.getLogger(__name__).warning(
+            "Binding to 0.0.0.0 exposes the server on all network interfaces. "
+            "Use --public for ngrok tunnelling, or bind to 127.0.0.1 for local-only access."
+        )
+
+    print(f"Starting Praison AI Call Server on http://{host}:{port}")
+    uvicorn.run(app, host=host, port=port, log_level="warning")
 
 def main(args=None):
     """Run the Praison AI Call Server."""
     parser = argparse.ArgumentParser(description="Run the Praison AI Call Server.")
     parser.add_argument('--public', action='store_true', help="Use ngrok to expose the server publicly")
     parser.add_argument('--port', type=int, default=PORT, help="Port to run the server on")
+    parser.add_argument('--host', type=str, default="127.0.0.1", help="Host address to bind to (default: 127.0.0.1)")
 
     if args is None:
         args = parser.parse_args()
@@ -374,9 +383,10 @@ def main(args=None):
         args = parser.parse_args(args)
 
     port = args.port
+    host = args.host
     use_public = args.public or PUBLIC
 
-    run_server(port=port, use_public=use_public)
+    run_server(port=port, host=host, use_public=use_public)
 
 if __name__ == "__main__":
     main()

--- a/src/praisonai/praisonai/api/call.py
+++ b/src/praisonai/praisonai/api/call.py
@@ -361,13 +361,13 @@ def run_server(port: int, host: str = "127.0.0.1", use_public: bool = False):
         host = "0.0.0.0"  # ngrok requires binding to all interfaces
 
     if host == "0.0.0.0" and not use_public:
-        import logging
-        logging.getLogger(__name__).warning(
+        logger.warning(
             "Binding to 0.0.0.0 exposes the server on all network interfaces. "
             "Use --public for ngrok tunnelling, or bind to 127.0.0.1 for local-only access."
         )
 
-    print(f"Starting Praison AI Call Server on http://{host}:{port}")
+    if not use_public:
+        print(f"Starting Praison AI Call Server on http://{host}:{port}")
     uvicorn.run(app, host=host, port=port, log_level="warning")
 
 def main(args=None):

--- a/src/praisonai/praisonai/bots/_http_approval.py
+++ b/src/praisonai/praisonai/bots/_http_approval.py
@@ -15,7 +15,7 @@ Usage::
     agent = Agent(
         name="assistant",
         tools=[execute_command],
-        approval=HTTPApproval(host="0.0.0.0", port=8899),
+        approval=HTTPApproval(port=8899),
     )
 """
 


### PR DESCRIPTION
Fixes the unsafe default bind address reported in #1602 (Gap 2).

The FastAPI server was binding to 0.0.0.0 (all interfaces) while printing localhost - misleading users into thinking it was local-only. This exposes the OpenAI key-handling endpoint to the LAN.

Changes:
- run_server() defaults to host=127.0.0.1
- 0.0.0.0 only used when --public (ngrok needs it)
- Added WARNING log for explicit 0.0.0.0 without --public
- Print shows actual bind address
- Added --host CLI argument
- Fixed misleading docstring in _http_approval.py

Backward compatible: default changes from unsafe to safe. Users wanting LAN access can use --host 0.0.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Server defaults to localhost (127.0.0.1) for safer local development.
  * Added a --host CLI option to customize the binding address.
  * Public/tunneling mode automatically binds to 0.0.0.0 for external access.
  * Logs a warning if 0.0.0.0 is used outside public/tunneling mode.
* **Documentation**
  * Examples updated to rely on the default host setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->