### PR TITLE
refactor: deduplicate ScheduleParser — re-export from shared.py

### DIFF
--- a/src/praisonai/praisonai/scheduler/base.py
+++ b/src/praisonai/praisonai/scheduler/base.py
@@ -14,61 +14,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-class ScheduleParser:
-    """Parse schedule expressions into intervals in seconds."""
-    
-    @staticmethod
-    def parse(schedule_expr: str) -> int:
-        """
-        Parse schedule expression and return interval in seconds.
-        
-        Supported formats:
-        - "daily" -> 86400 seconds
-        - "hourly" -> 3600 seconds
-        - "*/30m" -> 1800 seconds (every 30 minutes)
-        - "*/6h" -> 21600 seconds (every 6 hours)
-        - "*/30s" -> 30 seconds (every 30 seconds)
-        - "3600" -> 3600 seconds (plain number)
-        
-        Args:
-            schedule_expr: Schedule expression string
-            
-        Returns:
-            Interval in seconds
-            
-        Raises:
-            ValueError: If schedule format is not supported
-            
-        Examples:
-            >>> ScheduleParser.parse("hourly")
-            3600
-            >>> ScheduleParser.parse("*/30m")
-            1800
-            >>> ScheduleParser.parse("daily")
-            86400
-        """
-        schedule_expr = schedule_expr.strip().lower()
-        
-        if schedule_expr == "daily":
-            return 86400
-        elif schedule_expr == "hourly":
-            return 3600
-        elif schedule_expr.isdigit():
-            return int(schedule_expr)
-        elif schedule_expr.startswith("*/"):
-            interval_part = schedule_expr[2:]
-            if interval_part.endswith("m"):
-                minutes = int(interval_part[:-1])
-                return minutes * 60
-            elif interval_part.endswith("h"):
-                hours = int(interval_part[:-1])
-                return hours * 3600
-            elif interval_part.endswith("s"):
-                return int(interval_part[:-1])
-            else:
-                return int(interval_part)
-        else:
-            raise ValueError(f"Unsupported schedule format: {schedule_expr}")
+from .shared import ScheduleParser  # noqa: F401 — canonical definition lives in shared.py
 
 
 class ExecutorInterface(ABC):


### PR DESCRIPTION
## Summary

Two identical `ScheduleParser` classes existed in `scheduler/base.py` and `scheduler/shared.py`. This removes the duplicate from `base.py` and replaces it with a re-export from `shared.py` (the canonical location used by both sync and async schedulers).

## Changes
- Removed duplicate `ScheduleParser` class from `scheduler/base.py`
- Added `from .shared import ScheduleParser` re-export

## Verification
- `scheduler/__init__.py` still resolves `ScheduleParser` via `base.py` (now a re-export) — no public API change
- Both sync and async schedulers now use the same class object from `shared.py`
- `isinstance(parser, ScheduleParser)` works consistently regardless of import path

Pure refactor, no behaviour change.

Refs #1602 (Gap 3: DRY ScheduleParser)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->