### PR TITLE
fix(agent): critical UnboundLocalError on Agent() without max_budget

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -740,7 +740,12 @@ class Agent(UnifiedExecutionMixin, ToolExecutionMixin, ChatHandlerMixin, Session
         
         # Handle max_budget convenience parameter
         if max_budget is not None:
-            from ..config.feature_configs import ExecutionConfig, resolve_execution
+            # NOTE: ExecutionConfig is imported at module level (see top of file).
+            # Do NOT re-import it locally here — a local import statement would
+            # make Python treat ExecutionConfig as a local name throughout this
+            # entire __init__ function and break the branch below that uses it
+            # when max_budget is None (UnboundLocalError).
+            from ..config.feature_configs import resolve_execution
             if execution is None:
                 execution = ExecutionConfig(max_budget=max_budget)
             else:


### PR DESCRIPTION
## Critical Regression Fix

**Root cause**: PR #1635 introduced a local `from ..config.feature_configs import ExecutionConfig` inside `Agent.__init__` at line 743, inside the `if max_budget is not None:` branch.

Per Python scoping rules, a name assigned anywhere in a function is treated as local throughout the entire function. When `max_budget` is None (the common case), the local branch never executes but line 777 still references `ExecutionConfig` and raises:

```
UnboundLocalError: cannot access local variable 'ExecutionConfig' where it is not associated with a value
```

**This broke every single `Agent()` instantiation without `max_budget`** — effectively the entire library for most users.

## Fix

`ExecutionConfig` is already imported at module level (line 162-166). Only `resolve_execution` needs the lazy local import. Removed the redundant `ExecutionConfig` from the local import statement and added a comment explaining why it must stay at module-level.

## Validation

- `Agent(name='test', instructions='Be helpful')` — now works ✅
- `Agent(name='test', max_budget=1.0)` — still works ✅
- 311 agent unit tests pass ✅
- Test `tests/unit/agent/test_scientific_writer_agent.py::TestScientificWriterAgentIntegration::test_real_agentic_test` surfaced this bug

## Discovery

Found while doing thorough post-merge validation of PRs #1635, #1637, #1626, #1639, #1611, #1600 against AGENTS.md standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization within the agent initialization process to enhance stability and maintainability.

---
**Note:** This release contains internal optimizations with no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1643)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->