### PR TITLE
fix(tests): preserve provider API keys from the environment

### DIFF
--- a/src/praisonai/tests/conftest.py
+++ b/src/praisonai/tests/conftest.py
@@ -129,7 +129,12 @@ def temp_directory(tmp_path):
 
 @pytest.fixture(autouse=True)
 def setup_test_environment(request):
-    """Setup test environment before each test."""
+    """Setup test environment before each test.
+
+    For non-live unit/mock tests, fills missing provider API keys with placeholders
+    so imports and guardrails do not crash. Keys already present in the environment
+    (e.g. from ~/.bashrc or CI secrets) are never overwritten.
+    """
     # Only set test API keys for non-real tests
     # Real tests (marked with @pytest.mark.real) should use actual environment variables
     is_real_test = False
@@ -155,19 +160,21 @@ def setup_test_environment(request):
     original_values = {}
     
     if not is_real_test:
-        # Set test environment variables only for mock tests
+        # Placeholder keys only where unset — preserves keys from the parent shell
+        # (e.g. ~/.bashrc / ~/.zshrc) so local agentic unit tests can call real APIs.
         test_keys = {
             'OPENAI_API_KEY': 'test-key',
-            'ANTHROPIC_API_KEY': 'test-key', 
+            'ANTHROPIC_API_KEY': 'test-key',
             'GOOGLE_API_KEY': 'test-key',
             'XAI_API_KEY': 'test-key',
             'GROQ_API_KEY': 'test-key',
             'COHERE_API_KEY': 'test-key',
         }
-        
+
         for key, value in test_keys.items():
             original_values[key] = os.environ.get(key)
-            os.environ[key] = value
+            if not os.environ.get(key):
+                os.environ[key] = value
     
     yield
     

--- a/src/praisonai/tests/conftest.py
+++ b/src/praisonai/tests/conftest.py
@@ -173,7 +173,7 @@ def setup_test_environment(request):
 
         for key, value in test_keys.items():
             original_values[key] = os.environ.get(key)
-            if not os.environ.get(key):
+            if key not in os.environ:
                 os.environ[key] = value
     
     yield

--- a/src/praisonai/tests/unit/test_setup_test_environment_fixture.py
+++ b/src/praisonai/tests/unit/test_setup_test_environment_fixture.py
@@ -17,7 +17,7 @@ PROVIDER_API_KEYS = (
 
 
 class _Request:
-    def __init__(self, markers=None, fspath="tests/unit/test_setup_test_environment_fixture.py"):
+    def __init__(self, markers=None, fspath=__file__):
         markers = markers or []
         self.node = SimpleNamespace(iter_markers=lambda: markers)
         self.fspath = fspath

--- a/src/praisonai/tests/unit/test_setup_test_environment_fixture.py
+++ b/src/praisonai/tests/unit/test_setup_test_environment_fixture.py
@@ -1,0 +1,91 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from tests import conftest as test_conftest
+
+
+class _Request:
+    def __init__(self, markers=None, fspath="tests/unit/test_dummy.py"):
+        markers = markers or []
+        self.node = SimpleNamespace(iter_markers=lambda: markers)
+        self.fspath = fspath
+
+
+def _run_fixture(request):
+    fixture_impl = test_conftest.setup_test_environment.__wrapped__
+    fixture_gen = fixture_impl(request)
+    next(fixture_gen)
+    return fixture_gen
+
+
+def _teardown_fixture(fixture_gen):
+    with pytest.raises(StopIteration):
+        next(fixture_gen)
+
+
+def test_setup_environment_preserves_existing_provider_key_and_restores_missing_keys():
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("OPENAI_API_KEY", "real-openai-key")
+        mp.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        fixture_gen = _run_fixture(_Request())
+
+        assert os.environ["OPENAI_API_KEY"] == "real-openai-key"
+        assert os.environ["ANTHROPIC_API_KEY"] == "test-key"
+
+        _teardown_fixture(fixture_gen)
+
+        assert os.environ["OPENAI_API_KEY"] == "real-openai-key"
+        assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+def test_setup_environment_fills_placeholders_only_when_keys_are_missing():
+    with pytest.MonkeyPatch.context() as mp:
+        for key in (
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "GROQ_API_KEY",
+            "COHERE_API_KEY",
+        ):
+            mp.delenv(key, raising=False)
+
+        fixture_gen = _run_fixture(_Request())
+
+        for key in (
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "GROQ_API_KEY",
+            "COHERE_API_KEY",
+        ):
+            assert os.environ[key] == "test-key"
+
+        _teardown_fixture(fixture_gen)
+
+        for key in (
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "GROQ_API_KEY",
+            "COHERE_API_KEY",
+        ):
+            assert key not in os.environ
+
+
+def test_setup_environment_skips_placeholder_keys_for_provider_marked_tests():
+    marker = SimpleNamespace(name="provider_openai")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("OPENAI_API_KEY", raising=False)
+
+        fixture_gen = _run_fixture(_Request(markers=[marker]))
+
+        assert "OPENAI_API_KEY" not in os.environ
+
+        _teardown_fixture(fixture_gen)

--- a/src/praisonai/tests/unit/test_setup_test_environment_fixture.py
+++ b/src/praisonai/tests/unit/test_setup_test_environment_fixture.py
@@ -16,7 +16,7 @@ PROVIDER_API_KEYS = (
 )
 
 
-class _Request:
+class MockRequest:
     def __init__(self, markers=None, fspath=__file__):
         markers = markers or []
         self.node = SimpleNamespace(iter_markers=lambda: markers)
@@ -24,6 +24,7 @@ class _Request:
 
 
 def _run_fixture(request):
+    """Execute the fixture generator directly with a synthetic request object."""
     fixture_impl = test_conftest.setup_test_environment.__wrapped__
     fixture_gen = fixture_impl(request)
     next(fixture_gen)
@@ -40,7 +41,7 @@ def test_setup_environment_preserves_existing_provider_key_and_restores_missing_
         mp.setenv("OPENAI_API_KEY", "real-openai-key")
         mp.delenv("ANTHROPIC_API_KEY", raising=False)
 
-        fixture_gen = _run_fixture(_Request())
+        fixture_gen = _run_fixture(MockRequest())
 
         assert os.environ["OPENAI_API_KEY"] == "real-openai-key"
         assert os.environ["ANTHROPIC_API_KEY"] == "test-key"
@@ -56,7 +57,7 @@ def test_setup_environment_fills_placeholders_only_when_keys_are_missing():
         for key in PROVIDER_API_KEYS:
             mp.delenv(key, raising=False)
 
-        fixture_gen = _run_fixture(_Request())
+        fixture_gen = _run_fixture(MockRequest())
 
         for key in PROVIDER_API_KEYS:
             assert os.environ[key] == "test-key"
@@ -73,7 +74,7 @@ def test_setup_environment_skips_placeholder_keys_for_provider_marked_tests():
     with pytest.MonkeyPatch.context() as mp:
         mp.delenv("OPENAI_API_KEY", raising=False)
 
-        fixture_gen = _run_fixture(_Request(markers=[marker]))
+        fixture_gen = _run_fixture(MockRequest(markers=[marker]))
 
         assert "OPENAI_API_KEY" not in os.environ
 

--- a/src/praisonai/tests/unit/test_setup_test_environment_fixture.py
+++ b/src/praisonai/tests/unit/test_setup_test_environment_fixture.py
@@ -6,8 +6,18 @@ import pytest
 from tests import conftest as test_conftest
 
 
+PROVIDER_API_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "XAI_API_KEY",
+    "GROQ_API_KEY",
+    "COHERE_API_KEY",
+)
+
+
 class _Request:
-    def __init__(self, markers=None, fspath="tests/unit/test_dummy.py"):
+    def __init__(self, markers=None, fspath="tests/unit/test_setup_test_environment_fixture.py"):
         markers = markers or []
         self.node = SimpleNamespace(iter_markers=lambda: markers)
         self.fspath = fspath
@@ -43,38 +53,17 @@ def test_setup_environment_preserves_existing_provider_key_and_restores_missing_
 
 def test_setup_environment_fills_placeholders_only_when_keys_are_missing():
     with pytest.MonkeyPatch.context() as mp:
-        for key in (
-            "OPENAI_API_KEY",
-            "ANTHROPIC_API_KEY",
-            "GOOGLE_API_KEY",
-            "XAI_API_KEY",
-            "GROQ_API_KEY",
-            "COHERE_API_KEY",
-        ):
+        for key in PROVIDER_API_KEYS:
             mp.delenv(key, raising=False)
 
         fixture_gen = _run_fixture(_Request())
 
-        for key in (
-            "OPENAI_API_KEY",
-            "ANTHROPIC_API_KEY",
-            "GOOGLE_API_KEY",
-            "XAI_API_KEY",
-            "GROQ_API_KEY",
-            "COHERE_API_KEY",
-        ):
+        for key in PROVIDER_API_KEYS:
             assert os.environ[key] == "test-key"
 
         _teardown_fixture(fixture_gen)
 
-        for key in (
-            "OPENAI_API_KEY",
-            "ANTHROPIC_API_KEY",
-            "GOOGLE_API_KEY",
-            "XAI_API_KEY",
-            "GROQ_API_KEY",
-            "COHERE_API_KEY",
-        ):
+        for key in PROVIDER_API_KEYS:
             assert key not in os.environ
 
 


### PR DESCRIPTION
The autouse setup_test_environment fixture no longer overwrites OPENAI_API_KEY (and related vars) when they are already set, so local runs with keys from a login shell or CI behave as intended. Placeholders are still applied when a variable is missing. Integration/live/e2e paths are unchanged.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test environment setup now preserves existing API key environment values and injects placeholder keys only when keys are absent, preserving explicit empty-string values.
  * Added unit tests that verify placeholder population, correct restoration of environment after teardown, and skipping placeholder injection for tests marked as using a real provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1664)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->