### PR TITLE
fix(tests): align framework and datastore mocks with current APIs

### DIFF
--- a/src/praisonai/tests/unit/test_aiui_datastore.py
+++ b/src/praisonai/tests/unit/test_aiui_datastore.py
@@ -12,10 +12,10 @@ class TestPraisonAISessionDataStore:
         """Test initialization with default hierarchical store."""
         import praisonai.ui._aiui_datastore as _ds
 
-        with patch("praisonaiagents.session.get_hierarchical_session_store") as mock_get_store:
+        with patch("praisonaiagents.session.get_hierarchical_session_store") as mock_get_store, \
+             patch.object(_ds, "_impl_cls", None):
             mock_store = Mock()
             mock_get_store.return_value = mock_store
-            _ds._impl_cls = None
 
             adapter = PraisonAISessionDataStore()
             

--- a/src/praisonai/tests/unit/test_aiui_datastore.py
+++ b/src/praisonai/tests/unit/test_aiui_datastore.py
@@ -10,10 +10,13 @@ class TestPraisonAISessionDataStore:
 
     def test_init_with_default_store(self):
         """Test initialization with default hierarchical store."""
-        with patch('praisonai.ui._aiui_datastore.get_hierarchical_session_store') as mock_get_store:
+        import praisonai.ui._aiui_datastore as _ds
+
+        with patch("praisonaiagents.session.get_hierarchical_session_store") as mock_get_store:
             mock_store = Mock()
             mock_get_store.return_value = mock_store
-            
+            _ds._impl_cls = None
+
             adapter = PraisonAISessionDataStore()
             
             assert adapter._store == mock_store

--- a/src/praisonai/tests/unit/test_framework_validators.py
+++ b/src/praisonai/tests/unit/test_framework_validators.py
@@ -13,7 +13,6 @@ from unittest.mock import patch, MagicMock
 
 try:
     from praisonai.framework_adapters.validators import assert_framework_available
-    from praisonai.framework_adapters.registry import FrameworkAdapterRegistry
 except ImportError as e:
     pytest.skip(f"Could not import framework_adapters: {e}", allow_module_level=True)
 
@@ -22,7 +21,7 @@ class TestAssertFrameworkAvailableRaises:
     """Tests that ImportError is raised for unavailable frameworks."""
 
     def test_raises_import_error_for_missing_framework(self):
-        with patch.object(FrameworkAdapterRegistry, "get_instance") as mock_get:
+        with patch("praisonai.framework_adapters.validators.get_default_registry") as mock_get:
             mock_registry = MagicMock()
             mock_registry.is_available.return_value = False
             mock_get.return_value = mock_registry
@@ -31,7 +30,7 @@ class TestAssertFrameworkAvailableRaises:
                 assert_framework_available("crewai")
 
     def test_error_message_contains_framework_name(self):
-        with patch.object(FrameworkAdapterRegistry, "get_instance") as mock_get:
+        with patch("praisonai.framework_adapters.validators.get_default_registry") as mock_get:
             mock_registry = MagicMock()
             mock_registry.is_available.return_value = False
             mock_get.return_value = mock_registry
@@ -40,7 +39,7 @@ class TestAssertFrameworkAvailableRaises:
                 assert_framework_available("crewai")
 
     def test_error_message_contains_install_hint(self):
-        with patch.object(FrameworkAdapterRegistry, "get_instance") as mock_get:
+        with patch("praisonai.framework_adapters.validators.get_default_registry") as mock_get:
             mock_registry = MagicMock()
             mock_registry.is_available.return_value = False
             mock_get.return_value = mock_registry
@@ -49,7 +48,7 @@ class TestAssertFrameworkAvailableRaises:
                 assert_framework_available("crewai")
 
     def test_crewai_hint_mentions_praisonai_extra(self):
-        with patch.object(FrameworkAdapterRegistry, "get_instance") as mock_get:
+        with patch("praisonai.framework_adapters.validators.get_default_registry") as mock_get:
             mock_registry = MagicMock()
             mock_registry.is_available.return_value = False
             mock_get.return_value = mock_registry
@@ -60,7 +59,7 @@ class TestAssertFrameworkAvailableRaises:
             assert "praisonai[crewai]" in error_msg or "pip install crewai" in error_msg
 
     def test_autogen_hint_mentions_pyautogen(self):
-        with patch.object(FrameworkAdapterRegistry, "get_instance") as mock_get:
+        with patch("praisonai.framework_adapters.validators.get_default_registry") as mock_get:
             mock_registry = MagicMock()
             mock_registry.is_available.return_value = False
             mock_get.return_value = mock_registry
@@ -70,7 +69,7 @@ class TestAssertFrameworkAvailableRaises:
             assert "autogen" in str(exc_info.value).lower()
 
     def test_unknown_framework_generic_hint(self):
-        with patch.object(FrameworkAdapterRegistry, "get_instance") as mock_get:
+        with patch("praisonai.framework_adapters.validators.get_default_registry") as mock_get:
             mock_registry = MagicMock()
             mock_registry.is_available.return_value = False
             mock_get.return_value = mock_registry
@@ -84,7 +83,7 @@ class TestAssertFrameworkAvailableSucceeds:
     """Tests that no exception is raised for available frameworks."""
 
     def test_no_error_when_framework_available(self):
-        with patch.object(FrameworkAdapterRegistry, "get_instance") as mock_get:
+        with patch("praisonai.framework_adapters.validators.get_default_registry") as mock_get:
             mock_registry = MagicMock()
             mock_registry.is_available.return_value = True
             mock_get.return_value = mock_registry
@@ -93,7 +92,7 @@ class TestAssertFrameworkAvailableSucceeds:
             assert_framework_available("crewai")
 
     def test_returns_none_for_available_framework(self):
-        with patch.object(FrameworkAdapterRegistry, "get_instance") as mock_get:
+        with patch("praisonai.framework_adapters.validators.get_default_registry") as mock_get:
             mock_registry = MagicMock()
             mock_registry.is_available.return_value = True
             mock_get.return_value = mock_registry


### PR DESCRIPTION
- Patch `get_default_registry` instead of removed `FrameworkAdapterRegistry.get_instance`.\n- Patch `praisonaiagents.session.get_hierarchical_session_store` and reset `_impl_cls` so the default-store path is exercised correctly.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made datastore initialization tests deterministic and ensured failures surface loudly instead of falling back silently.
  * Reworked framework validator tests to mock framework-availability resolution via the registry helper, validating ImportError messages for missing, known, and unknown frameworks and confirming no-exception behavior when available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1665)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->