### PR TITLE
fix(praisonaiagents): export execute_code via lazy tools loader

### DIFF
--- a/src/praisonai-agents/praisonaiagents/tools/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/tools/__init__.py
@@ -75,7 +75,7 @@ TOOL_MAPPINGS = {
 
 
     # Python Tools
-    'execute_code': ('.python_tools', 'PythonTools'),
+    'execute_code': ('.python_tools', None),
     'analyze_code': ('.python_tools', 'PythonTools'),
     'format_code': ('.python_tools', 'PythonTools'),
     'lint_code': ('.python_tools', 'PythonTools'),
@@ -326,7 +326,7 @@ def __getattr__(name: str) -> Any:
         if name in [
             'duckduckgo', 'internet_search', 'searxng_search', 'searxng',
             'scrape_page', 'extract_links', 'crawl', 'extract_text',
-            'execute_command', 'list_processes', 'kill_process', 'get_system_info',
+            'execute_command', 'execute_code', 'list_processes', 'kill_process', 'get_system_info',
             'tavily', 'tavily_search', 'tavily_extract', 'tavily_crawl', 'tavily_map',
             'tavily_search_async', 'tavily_extract_async',
             'ydc', 'ydc_search', 'ydc_contents', 'ydc_news', 'ydc_images',

--- a/src/praisonai-agents/praisonaiagents/tools/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/tools/__init__.py
@@ -76,11 +76,11 @@ TOOL_MAPPINGS = {
 
     # Python Tools
     'execute_code': ('.python_tools', None),
-    'analyze_code': ('.python_tools', 'PythonTools'),
-    'format_code': ('.python_tools', 'PythonTools'),
-    'lint_code': ('.python_tools', 'PythonTools'),
-    'disassemble_code': ('.python_tools', 'PythonTools'),
-    'python_tools': ('.python_tools', 'PythonTools'),
+    'analyze_code': ('.python_tools', None),
+    'format_code': ('.python_tools', None),
+    'lint_code': ('.python_tools', None),
+    'disassemble_code': ('.python_tools', None),
+    'python_tools': ('.python_tools', None),
 
 
     # Chain of Thought Training Tools
@@ -326,7 +326,7 @@ def __getattr__(name: str) -> Any:
         if name in [
             'duckduckgo', 'internet_search', 'searxng_search', 'searxng',
             'scrape_page', 'extract_links', 'crawl', 'extract_text',
-            'execute_command', 'execute_code', 'list_processes', 'kill_process', 'get_system_info',
+            'execute_command', 'execute_code', 'analyze_code', 'format_code', 'lint_code', 'disassemble_code', 'list_processes', 'kill_process', 'get_system_info',
             'tavily', 'tavily_search', 'tavily_extract', 'tavily_crawl', 'tavily_map',
             'tavily_search_async', 'tavily_extract_async',
             'ydc', 'ydc_search', 'ydc_contents', 'ydc_news', 'ydc_images',

--- a/src/praisonai-agents/tests/unit/tools/test_profiles.py
+++ b/src/praisonai-agents/tests/unit/tools/test_profiles.py
@@ -361,3 +361,11 @@ class TestProfileExports:
         from praisonaiagents.tools import AUTONOMY_PROFILE
         
         assert AUTONOMY_PROFILE is not None
+
+    def test_import_execute_code_uses_module_function(self):
+        """execute_code should resolve to python_tools.execute_code function."""
+        from praisonaiagents.tools import execute_code
+        from praisonaiagents.tools.python_tools import execute_code as execute_code_impl
+
+        assert callable(execute_code)
+        assert execute_code is execute_code_impl


### PR DESCRIPTION
Maps `execute_code` to the standalone function in `python_tools` (same pattern as `execute_command`) instead of instantiating `PythonTools`, which could fail when optional formatters are missing and did not match the public function API. Verified: `from praisonaiagents.tools import execute_code` and `tests/unit/tools/test_profiles.py`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tool exports now expose module callables directly instead of creating class-based instances; attribute resolution was updated to return those callables.
* **Tests**
  * Added a unit test to verify the exported callable resolves identically to the original implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1666)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->