### PR TITLE
fix(tests): bot _BUILTIN_PLATFORMS uses lazy loaders

### DIFF
--- a/src/praisonai/tests/unit/bots/test_agentmail_bot.py
+++ b/src/praisonai/tests/unit/bots/test_agentmail_bot.py
@@ -20,11 +20,12 @@ class TestAgentMailPlatformRegistry:
     def test_agentmail_in_builtin_platforms(self):
         """AgentMail should be in _BUILTIN_PLATFORMS."""
         from praisonai.bots._registry import _BUILTIN_PLATFORMS
+        from praisonai.bots import AgentMailBot
         
         assert "agentmail" in _BUILTIN_PLATFORMS
         loader = _BUILTIN_PLATFORMS["agentmail"]
         assert callable(loader)
-        assert loader().__name__ == "AgentMailBot"
+        assert loader() is AgentMailBot
     
     def test_resolve_adapter_returns_agentmail_bot(self):
         """resolve_adapter('agentmail') should return AgentMailBot class."""

--- a/src/praisonai/tests/unit/bots/test_agentmail_bot.py
+++ b/src/praisonai/tests/unit/bots/test_agentmail_bot.py
@@ -20,19 +20,19 @@ class TestAgentMailPlatformRegistry:
     def test_agentmail_in_builtin_platforms(self):
         """AgentMail should be in _BUILTIN_PLATFORMS."""
         from praisonai.bots._registry import _BUILTIN_PLATFORMS
-        from praisonai.bots import AgentMailBot
         
         assert "agentmail" in _BUILTIN_PLATFORMS
         loader = _BUILTIN_PLATFORMS["agentmail"]
         assert callable(loader)
-        assert loader() is AgentMailBot
+        assert loader.__name__ == "_agentmail_loader"
     
     def test_resolve_adapter_returns_agentmail_bot(self):
         """resolve_adapter('agentmail') should return AgentMailBot class."""
+        from praisonai.bots import AgentMailBot
         from praisonai.bots._registry import resolve_adapter
         
         cls = resolve_adapter("agentmail")
-        assert cls.__name__ == "AgentMailBot"
+        assert cls is AgentMailBot
     
     def test_list_platforms_includes_agentmail(self):
         """list_platforms() should include 'agentmail'."""

--- a/src/praisonai/tests/unit/bots/test_agentmail_bot.py
+++ b/src/praisonai/tests/unit/bots/test_agentmail_bot.py
@@ -22,7 +22,9 @@ class TestAgentMailPlatformRegistry:
         from praisonai.bots._registry import _BUILTIN_PLATFORMS
         
         assert "agentmail" in _BUILTIN_PLATFORMS
-        assert _BUILTIN_PLATFORMS["agentmail"] == ("praisonai.bots.agentmail", "AgentMailBot")
+        loader = _BUILTIN_PLATFORMS["agentmail"]
+        assert callable(loader)
+        assert loader().__name__ == "AgentMailBot"
     
     def test_resolve_adapter_returns_agentmail_bot(self):
         """resolve_adapter('agentmail') should return AgentMailBot class."""

--- a/src/praisonai/tests/unit/bots/test_email_bot.py
+++ b/src/praisonai/tests/unit/bots/test_email_bot.py
@@ -22,19 +22,19 @@ class TestEmailPlatformRegistry:
     def test_email_in_builtin_platforms(self):
         """Verify email is registered in _BUILTIN_PLATFORMS."""
         from praisonai.bots._registry import _BUILTIN_PLATFORMS
-        from praisonai.bots import EmailBot
         
         assert "email" in _BUILTIN_PLATFORMS
         loader = _BUILTIN_PLATFORMS["email"]
         assert callable(loader)
-        assert loader() is EmailBot
+        assert loader.__name__ == "_email_loader"
     
     def test_resolve_adapter_returns_email_bot(self):
         """Verify resolve_adapter('email') returns EmailBot class."""
+        from praisonai.bots import EmailBot
         from praisonai.bots._registry import resolve_adapter
         
-        EmailBot = resolve_adapter("email")
-        assert EmailBot.__name__ == "EmailBot"
+        cls = resolve_adapter("email")
+        assert cls is EmailBot
     
     def test_list_platforms_includes_email(self):
         """Verify list_platforms() includes email."""

--- a/src/praisonai/tests/unit/bots/test_email_bot.py
+++ b/src/praisonai/tests/unit/bots/test_email_bot.py
@@ -22,11 +22,12 @@ class TestEmailPlatformRegistry:
     def test_email_in_builtin_platforms(self):
         """Verify email is registered in _BUILTIN_PLATFORMS."""
         from praisonai.bots._registry import _BUILTIN_PLATFORMS
+        from praisonai.bots import EmailBot
         
         assert "email" in _BUILTIN_PLATFORMS
         loader = _BUILTIN_PLATFORMS["email"]
         assert callable(loader)
-        assert loader().__name__ == "EmailBot"
+        assert loader() is EmailBot
     
     def test_resolve_adapter_returns_email_bot(self):
         """Verify resolve_adapter('email') returns EmailBot class."""

--- a/src/praisonai/tests/unit/bots/test_email_bot.py
+++ b/src/praisonai/tests/unit/bots/test_email_bot.py
@@ -24,7 +24,9 @@ class TestEmailPlatformRegistry:
         from praisonai.bots._registry import _BUILTIN_PLATFORMS
         
         assert "email" in _BUILTIN_PLATFORMS
-        assert _BUILTIN_PLATFORMS["email"] == ("praisonai.bots.email", "EmailBot")
+        loader = _BUILTIN_PLATFORMS["email"]
+        assert callable(loader)
+        assert loader().__name__ == "EmailBot"
     
     def test_resolve_adapter_returns_email_bot(self):
         """Verify resolve_adapter('email') returns EmailBot class."""


### PR DESCRIPTION
Updates assertions to match `_registry.py`: built-ins are loader callables; `resolve_adapter` still returns the adapter class.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated platform registry tests to treat platform entries as callable loader functions rather than strict tuple matches.
  * Strengthened adapter-resolution checks to assert exact class identity when resolving platform bots, improving test precision and robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1667)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->