### PR TITLE
fix(tests): BotOS integration tests use registry unregister

### DIFF
--- a/src/praisonai-agents/tests/unit/test_botos_integration.py
+++ b/src/praisonai-agents/tests/unit/test_botos_integration.py
@@ -25,7 +25,10 @@ def _unregister_bot_platform(name: str) -> None:
     """Remove a runtime-registered bot platform (tests only)."""
     from praisonai.bots._registry import get_default_bot_registry
 
-    get_default_bot_registry().unregister(name.lower())
+    try:
+        get_default_bot_registry().unregister(name.lower())
+    except (KeyError, ValueError):
+        pass
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/src/praisonai-agents/tests/unit/test_botos_integration.py
+++ b/src/praisonai-agents/tests/unit/test_botos_integration.py
@@ -21,6 +21,13 @@ import pytest
 from unittest.mock import MagicMock
 
 
+def _unregister_bot_platform(name: str) -> None:
+    """Remove a runtime-registered bot platform (tests only)."""
+    from praisonai.bots._registry import get_default_bot_registry
+
+    get_default_bot_registry().unregister(name.lower())
+
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Helper: Mock adapter that simulates a platform bot
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -59,9 +66,10 @@ class TestBotWithMockAdapter:
     """Integration tests for Bot class with a mock platform adapter."""
 
     def setup_method(self):
-        from praisonai.bots._registry import register_platform, _custom_platforms
+        from praisonai.bots._registry import register_platform
+
         register_platform("mockbot", MockPlatformAdapter)
-        self._cleanup = lambda: _custom_platforms.pop("mockbot", None)
+        self._cleanup = lambda: _unregister_bot_platform("mockbot")
 
     def teardown_method(self):
         self._cleanup()
@@ -148,10 +156,14 @@ class TestBotOSLifecycle:
     """Integration tests for BotOS multi-bot orchestration."""
 
     def setup_method(self):
-        from praisonai.bots._registry import register_platform, _custom_platforms
+        from praisonai.bots._registry import register_platform
+
         register_platform("mock1", MockPlatformAdapter)
         register_platform("mock2", MockPlatformAdapter)
-        self._cleanup = lambda: (_custom_platforms.pop("mock1", None), _custom_platforms.pop("mock2", None))
+        self._cleanup = lambda: (
+            _unregister_bot_platform("mock1"),
+            _unregister_bot_platform("mock2"),
+        )
 
     def teardown_method(self):
         self._cleanup()
@@ -212,9 +224,10 @@ class TestRealAgentInBot:
     """Tests with a real praisonaiagents.Agent inside Bot."""
 
     def setup_method(self):
-        from praisonai.bots._registry import register_platform, _custom_platforms
+        from praisonai.bots._registry import register_platform
+
         register_platform("mockbot", MockPlatformAdapter)
-        self._cleanup = lambda: _custom_platforms.pop("mockbot", None)
+        self._cleanup = lambda: _unregister_bot_platform("mockbot")
 
     def teardown_method(self):
         self._cleanup()
@@ -246,9 +259,10 @@ class TestAgentTeamInBotOS:
     """AgentTeam (multi-agent) inside Bot and BotOS."""
 
     def setup_method(self):
-        from praisonai.bots._registry import register_platform, _custom_platforms
+        from praisonai.bots._registry import register_platform
+
         register_platform("mockbot", MockPlatformAdapter)
-        self._cleanup = lambda: _custom_platforms.pop("mockbot", None)
+        self._cleanup = lambda: _unregister_bot_platform("mockbot")
 
     def teardown_method(self):
         self._cleanup()
@@ -300,9 +314,10 @@ class TestAgentFlowInBotOS:
     """AgentFlow (deterministic workflow) inside Bot and BotOS."""
 
     def setup_method(self):
-        from praisonai.bots._registry import register_platform, _custom_platforms
+        from praisonai.bots._registry import register_platform
+
         register_platform("mockbot", MockPlatformAdapter)
-        self._cleanup = lambda: _custom_platforms.pop("mockbot", None)
+        self._cleanup = lambda: _unregister_bot_platform("mockbot")
 
     def teardown_method(self):
         self._cleanup()
@@ -355,9 +370,8 @@ class TestPlatformExtensibility:
     """Third-party platform registration and usage."""
 
     def teardown_method(self):
-        from praisonai.bots._registry import _custom_platforms
-        _custom_platforms.pop("custom_chat", None)
-        _custom_platforms.pop("my_platform", None)
+        _unregister_bot_platform("custom_chat")
+        _unregister_bot_platform("my_platform")
 
     def test_register_and_use_custom_platform(self):
         from praisonai.bots._registry import register_platform, resolve_adapter
@@ -389,7 +403,7 @@ class TestPlatformExtensibility:
 
     def test_resolve_unknown_platform_raises(self):
         from praisonai.bots._registry import resolve_adapter
-        with pytest.raises(ValueError, match="Unknown platform"):
+        with pytest.raises(ValueError, match=r"Unknown .*plugin"):
             resolve_adapter("nonexistent_xyz")
 
 
@@ -401,9 +415,10 @@ class TestBotOSFromConfig:
     """BotOS.from_config() YAML config loading."""
 
     def setup_method(self):
-        from praisonai.bots._registry import register_platform, _custom_platforms
+        from praisonai.bots._registry import register_platform
+
         register_platform("mockbot", MockPlatformAdapter)
-        self._cleanup = lambda: _custom_platforms.pop("mockbot", None)
+        self._cleanup = lambda: _unregister_bot_platform("mockbot")
 
     def teardown_method(self):
         self._cleanup()
@@ -459,7 +474,8 @@ platforms:
 
     def test_from_config_multi_platform(self):
         from praisonai.bots import BotOS
-        from praisonai.bots._registry import register_platform, _custom_platforms
+        from praisonai.bots._registry import register_platform
+
         register_platform("mock2", MockPlatformAdapter)
 
         yaml_content = """\
@@ -484,7 +500,7 @@ platforms:
             assert "mock2" in botos.list_bots()
         finally:
             os.unlink(path)
-            _custom_platforms.pop("mock2", None)
+            _unregister_bot_platform("mock2")
 
     def test_from_config_invalid_raises(self):
         from praisonai.bots import BotOS


### PR DESCRIPTION
Replaces removed `_custom_platforms` dict usage with `get_default_bot_registry().unregister()` after the bot registry moved to `PluginRegistry`. Updates unknown-platform assertion to match the current ValueError text.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cleanup for runtime-registered bot platforms in integration tests to ensure proper unregistering and avoid residual state.
  * Relaxed platform-resolution error matching in tests to use a broader pattern for more robust validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1669)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->