### PR TITLE
fix: guard against empty/filtered LLM responses in core LLM paths

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/code_agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/code_agent.py
@@ -164,7 +164,8 @@ Follow best practices and coding standards."""
             messages=messages,
             **{k: v for k, v in kwargs.items() if k != "model"}
         )
-        
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         code = response.choices[0].message.content
         self._log("Code generated successfully", "green")
         return code
@@ -204,7 +205,8 @@ Follow best practices and coding standards."""
             messages=messages,
             **{k: v for k, v in kwargs.items() if k != "model"}
         )
-        
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         code = response.choices[0].message.content
         self._log("Code generated successfully", "green")
         return code
@@ -365,6 +367,8 @@ Provide clear, actionable feedback."""
             **{k: v for k, v in kwargs.items() if k != "model"}
         )
         
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         review = response.choices[0].message.content
         self._log("Review completed", "green")
         return review
@@ -405,6 +409,8 @@ Include:
             **{k: v for k, v in kwargs.items() if k != "model"}
         )
         
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         explanation = response.choices[0].message.content
         self._log("Explanation completed", "green")
         return explanation
@@ -451,6 +457,8 @@ Only output the refactored code."""
             **{k: v for k, v in kwargs.items() if k != "model"}
         )
         
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         refactored = response.choices[0].message.content
         self._log("Refactoring completed", "green")
         return refactored
@@ -495,6 +503,8 @@ Ensure the fix:
             **{k: v for k, v in kwargs.items() if k != "model"}
         )
         
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         fixed = response.choices[0].message.content
         self._log("Fix completed", "green")
         return fixed

--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -907,6 +907,8 @@ class OpenAIClient:
                     final_response = self._responses_to_chat_completion(raw)
                     
                     # Display the response text if display_fn provided
+                    if not final_response.choices or final_response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     response_text = final_response.choices[0].message.content or ""
                     if display_fn and response_text:
                         from rich.markdown import Markdown
@@ -1167,6 +1169,8 @@ class OpenAIClient:
                     final_response = self._responses_to_chat_completion(raw)
                     
                     # Display the response text if display_fn provided
+                    if not final_response.choices or final_response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     response_text = final_response.choices[0].message.content or ""
                     if display_fn and response_text:
                         from rich.markdown import Markdown
@@ -1638,8 +1642,10 @@ class OpenAIClient:
             )
             
             # Check for tool calls
+            if not final_response.choices or final_response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             tool_calls = getattr(final_response.choices[0].message, 'tool_calls', None)
-            
+
             # Emit llm_content for intermediate narrative display
             # (gpt-4.1+ models produce text alongside tool calls)
             response_content = getattr(final_response.choices[0].message, 'content', None)
@@ -1835,10 +1841,12 @@ class OpenAIClient:
             
             if not final_response:
                 return None
-            
+
             # Check for tool calls
+            if not final_response.choices or final_response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             tool_calls = getattr(final_response.choices[0].message, 'tool_calls', None)
-            
+
             # Emit llm_content for intermediate narrative display
             # (gpt-4.1+ models produce text alongside tool calls)
             response_content = getattr(final_response.choices[0].message, 'content', None)
@@ -2037,6 +2045,8 @@ class OpenAIClient:
                     return
                 
                 # Check for tool calls
+                if not final_response.choices or final_response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 tool_calls = getattr(final_response.choices[0].message, 'tool_calls', None)
                 
                 if tool_calls and execute_tool_fn:

--- a/src/praisonai/praisonai/capabilities/guardrails.py
+++ b/src/praisonai/praisonai/capabilities/guardrails.py
@@ -86,6 +86,8 @@ Only respond with the JSON, no other text."""
         )
         
         import json
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         result_text = response.choices[0].message.content
         result_data = json.loads(result_text)
         
@@ -160,6 +162,8 @@ Only respond with the JSON, no other text."""
         )
         
         import json
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         result_text = response.choices[0].message.content
         result_data = json.loads(result_text)
         

--- a/src/praisonai/praisonai/capabilities/rag.py
+++ b/src/praisonai/praisonai/capabilities/rag.py
@@ -103,7 +103,7 @@ def rag_query(
         **kwargs
     )
     
-    answer = response.choices[0].message.content if response.choices else ""
+    answer = response.choices[0].message.content if response.choices and response.choices[0].message is not None else ""
     
     usage = None
     if hasattr(response, 'usage') and response.usage:
@@ -188,7 +188,7 @@ async def arag_query(
         **kwargs
     )
     
-    answer = response.choices[0].message.content if response.choices else ""
+    answer = response.choices[0].message.content if response.choices and response.choices[0].message is not None else ""
     
     usage = None
     if hasattr(response, 'usage') and response.usage:


### PR DESCRIPTION
## What

Adds null checks before accessing `choices[0].message` in four files:

- `src/praisonai-agents/praisonaiagents/llm/openai_client.py` — sync tool-call path, async tool-call path, responses-API path (3 locations)
- `src/praisonai/praisonai/capabilities/guardrails.py` — `check()` and `aguard()` result extraction (2 locations)
- `src/praisonai/praisonai/capabilities/rag.py` — `query_rag()` and `aquery_rag()` answer extraction (2 locations)
- `src/praisonai-agents/praisonaiagents/agent/code_agent.py` — generate/review/explain/refactor/fix methods (6 locations)

## Why

The OpenAI SDK can return two silent failure modes that crash silently at these lines:

1. **`IndexError`** — `choices` is an empty list (`[]`) when the provider returns no completions
2. **`AttributeError`** — `choices[0].message` is `None` when content is filtered (e.g. Gemini returns HTTP 200 with `PROHIBITED_CONTENT` finish reason). Any `or ""` fallback never fires because the crash occurs on `.content` first.

## Fix pattern

For raise-on-failure (agent methods):
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```

For return-empty (RAG queries):
```python
answer = response.choices[0].message.content if response.choices and response.choices[0].message is not None else ""
```

Detected by [pact](https://github.com/qizwiz/pact) static analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of language model responses across agent processing, API operations, content safety, and information retrieval systems. Improved error handling for edge cases where responses may be empty or incomplete, ensuring graceful system behavior and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->