### PR TITLE
fix: correct import name in skills manager (fixes #1683)

### DIFF
--- a/src/praisonai-agents/praisonaiagents/skills/manager.py
+++ b/src/praisonai-agents/praisonaiagents/skills/manager.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Dict
 logger = logging.getLogger(__name__)
 
 from .models import SkillMetadata
-from .discovery import discover_skills
+from .discovery import discover_skills, get_default_skill_dirs
 from .loader import SkillLoader, LoadedSkill
 from .prompt import generate_skills_xml
 from .substitution import render_skill_body
@@ -271,7 +271,6 @@ class SkillManager:
                 return {"success": False, "error": "Skill content exceeds maximum size (100KB)"}
             
             # Create skill directory
-            from .discovery import get_default_skill_dirs
             skill_dirs = get_default_skill_dirs()
             base_dir = skill_dirs[0] if skill_dirs else "~/.praisonai/skills"
             

--- a/src/praisonai-agents/praisonaiagents/skills/manager.py
+++ b/src/praisonai-agents/praisonaiagents/skills/manager.py
@@ -271,8 +271,8 @@ class SkillManager:
                 return {"success": False, "error": "Skill content exceeds maximum size (100KB)"}
             
             # Create skill directory
-            from .discovery import get_default_skill_directories
-            skill_dirs = get_default_skill_directories()
+            from .discovery import get_default_skill_dirs
+            skill_dirs = get_default_skill_dirs()
             base_dir = skill_dirs[0] if skill_dirs else "~/.praisonai/skills"
             
             import os


### PR DESCRIPTION
Fixes ImportError affecting skill management functions by correcting function name mismatch in import statement.

**Problem:**
- `create_skill()`, `edit_skill()`, `delete_skill()`, `patch_skill()`, and `write_skill_file()` all raised ImportError
- `manager.py:274` imported non-existent function `get_default_skill_directories`
- Actual function name is `get_default_skill_dirs` in `discovery.py:14`

**Solution:**
- Fixed import statement to use correct function name
- All skill management operations now work correctly

**Testing:**
- Verified SkillManager imports successfully
- Confirmed create_skill() function executes without error

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal skill management implementation. This is a maintenance change with no visible user-facing behavior differences; it streamlines how the application references internal skill discovery logic and reduces internal inconsistencies. No functionality or configuration changes are required from users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->