### PR TITLE
fix: add UTF-8 encoding for Windows skills subsystem files (fixes #1695)

### DIFF
--- a/src/praisonai-agents/praisonaiagents/skills/loader.py
+++ b/src/praisonai-agents/praisonaiagents/skills/loader.py
@@ -108,7 +108,7 @@ class SkillLoader:
             return False
 
         try:
-            content = skill_md.read_text()
+            content = skill_md.read_text(encoding="utf-8")
             _, body = parse_frontmatter(content)
             skill.instructions = body
             return True
@@ -136,7 +136,7 @@ class SkillLoader:
             for script_file in scripts_dir.iterdir():
                 if script_file.is_file():
                     try:
-                        scripts[script_file.name] = script_file.read_text()
+                        scripts[script_file.name] = script_file.read_text(encoding="utf-8")
                     except Exception:
                         continue
         except PermissionError:
@@ -166,7 +166,7 @@ class SkillLoader:
             for ref_file in refs_dir.iterdir():
                 if ref_file.is_file():
                     try:
-                        refs[ref_file.name] = ref_file.read_text()
+                        refs[ref_file.name] = ref_file.read_text(encoding="utf-8")
                     except Exception:
                         continue
         except PermissionError:

--- a/src/praisonai-agents/praisonaiagents/skills/parser.py
+++ b/src/praisonai-agents/praisonaiagents/skills/parser.py
@@ -100,7 +100,7 @@ def read_properties(skill_dir: Path) -> SkillProperties:
     if skill_md is None:
         raise ParseError(f"SKILL.md not found in {skill_dir}")
 
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding="utf-8")
     metadata, _ = parse_frontmatter(content)
 
     if "name" not in metadata:

--- a/src/praisonai-agents/praisonaiagents/skills/validator.py
+++ b/src/praisonai-agents/praisonaiagents/skills/validator.py
@@ -191,7 +191,7 @@ def validate(skill_dir: Path, strict: bool = False) -> List[str]:
         return ["Missing required file: SKILL.md"]
 
     try:
-        content = skill_md.read_text()
+        content = skill_md.read_text(encoding="utf-8")
         metadata, _ = parse_frontmatter(content)
     except ParseError as e:
         return [str(e)]

--- a/src/praisonai-agents/praisonaiagents/skills/validator.py
+++ b/src/praisonai-agents/praisonaiagents/skills/validator.py
@@ -193,7 +193,7 @@ def validate(skill_dir: Path, strict: bool = False) -> List[str]:
     try:
         content = skill_md.read_text(encoding="utf-8")
         metadata, _ = parse_frontmatter(content)
-    except (ParseError, UnicodeDecodeError) as e:
+    except ParseError as e:
         return [str(e)]
     except UnicodeDecodeError as e:
         return [f"SKILL.md is not valid UTF-8: {e}"]

--- a/src/praisonai-agents/praisonaiagents/skills/validator.py
+++ b/src/praisonai-agents/praisonaiagents/skills/validator.py
@@ -195,5 +195,7 @@ def validate(skill_dir: Path, strict: bool = False) -> List[str]:
         metadata, _ = parse_frontmatter(content)
     except (ParseError, UnicodeDecodeError) as e:
         return [str(e)]
+    except UnicodeDecodeError as e:
+        return [f"SKILL.md is not valid UTF-8: {e}"]
 
     return validate_metadata(metadata, skill_dir, strict=strict)

--- a/src/praisonai-agents/praisonaiagents/skills/validator.py
+++ b/src/praisonai-agents/praisonaiagents/skills/validator.py
@@ -193,7 +193,7 @@ def validate(skill_dir: Path, strict: bool = False) -> List[str]:
     try:
         content = skill_md.read_text(encoding="utf-8")
         metadata, _ = parse_frontmatter(content)
-    except ParseError as e:
+    except (ParseError, UnicodeDecodeError) as e:
         return [str(e)]
 
     return validate_metadata(metadata, skill_dir, strict=strict)

--- a/src/praisonai-agents/tests/unit/skills/test_loader.py
+++ b/src/praisonai-agents/tests/unit/skills/test_loader.py
@@ -241,3 +241,89 @@ Body.
             loader.activate(skill)
             
             assert skill.is_activated is True
+    
+    def test_load_utf8_content(self):
+        """Test loading UTF-8 encoded skill content.
+        
+        Regression test for Windows encoding issues (Issue #1695).
+        Tests UTF-8 handling in SKILL.md body, scripts, and references.
+        """
+        from praisonaiagents.skills.loader import SkillLoader
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "utf8-loader-test"
+            skill_dir.mkdir()
+            
+            # Create SKILL.md with UTF-8 characters
+            skill_content = """---
+name: utf8-loader-test
+description: Loader test with UTF-8 — em dashes — and more
+---
+
+# UTF-8 Instructions
+
+This skill handles UTF-8 content:
+- Smart quotes: "hello" and 'world'
+- Em dash: —
+- Arrows: → ← ↑ ↓
+- Accented: café, naïve, résumé
+- Emoji: 🔥 📝 ✨
+"""
+            
+            with open(skill_dir / "SKILL.md", 'w', encoding='utf-8') as f:
+                f.write(skill_content)
+            
+            # Create scripts directory with UTF-8 script
+            scripts_dir = skill_dir / "scripts"
+            scripts_dir.mkdir()
+            
+            script_content = """#!/bin/bash
+# Script with UTF-8: café processing → résumé generation
+echo "Processing naïve input with émphasis"
+"""
+            
+            with open(scripts_dir / "process.sh", 'w', encoding='utf-8') as f:
+                f.write(script_content)
+            
+            # Create references directory with UTF-8 content
+            refs_dir = skill_dir / "references"
+            refs_dir.mkdir()
+            
+            ref_content = """Reference with UTF-8:
+Café automation guide — step by step
+Arrow symbols: → ← ↑ ↓
+Special chars: "smart quotes" and émphasis
+"""
+            
+            with open(refs_dir / "readme.txt", 'w', encoding='utf-8') as f:
+                f.write(ref_content)
+            
+            # Test loading and activation
+            loader = SkillLoader()
+            skill = loader.load_metadata(str(skill_dir))
+            
+            assert skill is not None
+            assert "—" in skill.properties.description  # UTF-8 in metadata
+            
+            # Test activation (loads SKILL.md body)
+            success = loader.activate(skill)
+            assert success is True
+            assert "—" in skill.instructions  # UTF-8 in instructions
+            assert "café" in skill.instructions
+            assert "🔥" in skill.instructions  # Emoji
+            
+            # Test script loading
+            scripts = loader.load_scripts(skill)
+            assert "process.sh" in scripts
+            script_text = scripts["process.sh"]
+            assert "café" in script_text
+            assert "résumé" in script_text
+            assert "naïve" in script_text
+            
+            # Test references loading
+            refs = loader.load_references(skill)
+            assert "readme.txt" in refs
+            ref_text = refs["readme.txt"]
+            assert "Café" in ref_text
+            assert "—" in ref_text
+            assert "émphasis" in ref_text

--- a/src/praisonai-agents/tests/unit/skills/test_parser.py
+++ b/src/praisonai-agents/tests/unit/skills/test_parser.py
@@ -286,3 +286,54 @@ Body.
                 assert False, "Should have raised ValidationError"
             except ValidationError as e:
                 assert "description" in str(e).lower()
+    
+    def test_read_properties_utf8_encoding(self):
+        """Test reading UTF-8 encoded SKILL.md files.
+        
+        Regression test for Windows encoding issues (Issue #1695).
+        Verifies that skills with non-ASCII characters load correctly.
+        """
+        from praisonaiagents.skills.parser import read_properties
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "utf8-skill"
+            skill_dir.mkdir()
+            
+            # Create SKILL.md with various UTF-8 characters
+            utf8_content = """---
+name: utf8-test
+description: UTF-8 encoding test — quality — verification
+license: MIT
+compatibility: Supports café files → résumé processing
+metadata:
+  author: "José María"
+  notes: "Handles naïve input with émphasis"
+---
+
+# UTF-8 Test Skill
+
+This skill demonstrates UTF-8 character handling:
+- Em dash: —
+- Smart quotes: "hello" and 'world' 
+- Arrow: →
+- Accented chars: café, naïve, résumé
+- Emoji: 🔥 📝 ✨
+
+Works with internationalization!
+"""
+            
+            # Explicitly write as UTF-8 to simulate real-world scenario
+            with open(skill_dir / "SKILL.md", 'w', encoding='utf-8') as f:
+                f.write(utf8_content)
+            
+            # Test that parsing works without UnicodeDecodeError
+            props = read_properties(skill_dir)
+            
+            # Verify UTF-8 characters are preserved correctly
+            assert props.name == "utf8-test"
+            assert "—" in props.description  # em dash
+            assert "café" in props.compatibility  # accented character
+            assert "résumé" in props.compatibility  # accented character
+            assert "José María" in props.metadata["author"]  # accented characters
+            assert "naïve" in props.metadata["notes"]  # accented character
+            assert "émphasis" in props.metadata["notes"]  # accented character

--- a/src/praisonai-agents/tests/unit/skills/test_validator.py
+++ b/src/praisonai-agents/tests/unit/skills/test_validator.py
@@ -295,3 +295,37 @@ description: A test skill for validation
             
             assert len(errors) > 0
             assert any("directory" in e.lower() for e in errors)
+    
+    def test_validate_utf8_skill(self):
+        """Test validation of UTF-8 encoded skill.
+        
+        Regression test for Windows encoding issues (Issue #1695).
+        Ensures validator can handle UTF-8 characters without errors.
+        """
+        from praisonaiagents.skills.validator import validate
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "utf8-validation-test"
+            skill_dir.mkdir()
+            
+            # Create SKILL.md with UTF-8 content
+            utf8_content = """---
+name: utf8-validation-test
+description: Validation test with UTF-8 — em dashes — and accents
+license: MIT
+compatibility: Works with café files → résumé output
+---
+
+# UTF-8 Validation Test
+
+Testing validation with various UTF-8 characters.
+"""
+            
+            # Write as UTF-8 explicitly
+            with open(skill_dir / "SKILL.md", 'w', encoding='utf-8') as f:
+                f.write(utf8_content)
+            
+            # Validate should not produce errors for UTF-8 content
+            errors = validate(skill_dir)
+            
+            assert errors == [], f"Validation should pass for UTF-8 content, got errors: {errors}"

--- a/src/praisonai-agents/tests/unit/skills/test_validator.py
+++ b/src/praisonai-agents/tests/unit/skills/test_validator.py
@@ -329,3 +329,24 @@ Testing validation with various UTF-8 characters.
             errors = validate(skill_dir)
             
             assert errors == [], f"Validation should pass for UTF-8 content, got errors: {errors}"
+
+    def test_validate_non_utf8_skill_returns_error(self):
+        """Test validation returns a structured error for non-UTF-8 SKILL.md."""
+        from praisonaiagents.skills.validator import validate
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "latin1-validation-test"
+            skill_dir.mkdir()
+
+            latin1_content = """---
+name: latin1-validation-test
+description: Café skill
+---
+"""
+            with open(skill_dir / "SKILL.md", "wb") as f:
+                f.write(latin1_content.encode("cp1252"))
+
+            errors = validate(skill_dir)
+
+            assert len(errors) > 0
+            assert any("utf-8" in e.lower() for e in errors)


### PR DESCRIPTION
Fixes #1695

## Summary
This PR fixes Unicode encoding issues in the PraisonAI skills subsystem that caused SKILL.md files with UTF-8 characters to fail loading on Windows.

## Root Cause
Files were using `Path.read_text()` without specifying `encoding="utf-8"`, causing Windows to default to `cp1252` encoding which cannot decode UTF-8 bytes.

## Changes
- `parser.py`: Added UTF-8 encoding to SKILL.md frontmatter parsing
- `validator.py`: Added UTF-8 encoding to SKILL.md validation
- `loader.py`: Added UTF-8 encoding to SKILL.md body, scripts, and references loading
- Added comprehensive UTF-8 tests to verify the fix works across all components

## Testing
Added tests covering skills with em dashes, smart quotes, arrows, accented characters, and emoji to ensure UTF-8 handling works correctly on all platforms.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UTF-8 handling when reading skill definitions, scripts, and references so international characters, accents, emoji, and other Unicode are preserved.
  * Improved validation to return a clear error when skill files are not valid UTF-8.

* **Tests**
  * Added unit tests verifying UTF-8 content is correctly read, validated, and preserved across skill files and related resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->