### PR TITLE
fix: resolve critical gaps in praisonai wrapper layer

### DIFF
--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -221,13 +221,13 @@ class AgentsGenerator:
         elif os.environ.get('LOGLEVEL'):
             self.logger.setLevel(getattr(logging, os.environ.get('LOGLEVEL', 'INFO').upper(), logging.INFO))
         
-        # Initialize tool resolver (single source of truth for tool resolution)
-        from .tool_resolver import ToolResolver
-        self.tool_resolver = ToolResolver()
-        
         # Keep tool registry for backward compatibility with autogen adapters
         self.tool_registry = ToolRegistry()
         self.tool_registry.register_builtin_autogen_adapters()
+        
+        # Initialize tool resolver with the registry wired in (single source of truth for tool resolution)
+        from .tool_resolver import ToolResolver
+        self.tool_resolver = ToolResolver(registry=self.tool_registry)
         
         # DI-friendly: tests/multi-tenant runtimes pass their own registry;
         # CLI users get the process default.

--- a/src/praisonai/praisonai/cli/features/agent_tools.py
+++ b/src/praisonai/praisonai/cli/features/agent_tools.py
@@ -110,21 +110,8 @@ def create_agent_centric_tools(
     if orchestrator is None:
         orchestrator = ActionOrchestrator(runtime)
     
-    # Helper to run async functions synchronously
-    def run_async(coro):
-        """Run async coroutine synchronously."""
-        try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # Create a new loop in a thread
-                import concurrent.futures
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    future = executor.submit(asyncio.run, coro)
-                    return future.result(timeout=60)
-            else:
-                return loop.run_until_complete(coro)
-        except RuntimeError:
-            return asyncio.run(coro)
+    # Helper to run async functions synchronously using the shared bridge
+    from praisonai._async_bridge import run_sync
     
     # =========================================================================
     # ACP-Powered File Tools
@@ -204,7 +191,7 @@ def create_agent_centric_tools(
                 "verified": result.success
             })
         
-        return run_async(_create())
+        return run_sync(_create())
     
     def acp_edit_file(filepath: str, new_content: str) -> str:
         """
@@ -261,7 +248,7 @@ def create_agent_centric_tools(
                 "error": result.error
             })
         
-        return run_async(_edit())
+        return run_sync(_edit())
     
     def acp_delete_file(filepath: str) -> str:
         """
@@ -313,7 +300,7 @@ def create_agent_centric_tools(
                 "verified": result.success
             })
         
-        return run_async(_delete())
+        return run_sync(_delete())
     
     def acp_execute_command(command: str, cwd: str = None) -> str:
         """
@@ -372,7 +359,7 @@ def create_agent_centric_tools(
                 "error": result.error
             })
         
-        return run_async(_execute())
+        return run_sync(_execute())
     
     # =========================================================================
     # LSP-Powered Code Intelligence Tools
@@ -404,7 +391,7 @@ def create_agent_centric_tools(
             except asyncio.TimeoutError:
                 return json.dumps({"error": "LSP list_symbols timed out (10s)", "success": False})
         
-        return run_async(_list())
+        return run_sync(_list())
     
     def lsp_find_definition(symbol: str, file_path: str = None) -> str:
         """
@@ -432,7 +419,7 @@ def create_agent_centric_tools(
             except asyncio.TimeoutError:
                 return json.dumps({"error": "LSP find_definition timed out (10s)", "success": False})
         
-        return run_async(_find())
+        return run_sync(_find())
     
     def lsp_find_references(symbol: str, file_path: str = None) -> str:
         """
@@ -460,7 +447,7 @@ def create_agent_centric_tools(
             except asyncio.TimeoutError:
                 return json.dumps({"error": "LSP find_references timed out (10s)", "success": False})
         
-        return run_async(_find())
+        return run_sync(_find())
     
     def lsp_get_diagnostics(file_path: str = None) -> str:
         """
@@ -487,7 +474,7 @@ def create_agent_centric_tools(
             except asyncio.TimeoutError:
                 return json.dumps({"error": "LSP diagnostics timed out (10s)", "success": False})
         
-        return run_async(_get())
+        return run_sync(_get())
     
     # =========================================================================
     # Basic File Tools (for read-only operations)

--- a/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
@@ -71,15 +71,14 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
         acp_enabled = global_config.get('acp', False)
         lsp_enabled = global_config.get('lsp', False)
         interactive_runtime = None
-        interactive_loop = None
         
         if acp_enabled or lsp_enabled:
             try:
-                import asyncio
+                from praisonai._async_bridge import run_sync
                 from praisonai.cli.features.interactive_runtime import InteractiveRuntime, RuntimeConfig
                 from praisonai.cli.features.agent_tools import create_agent_centric_tools
                 
-                # Use scoped event loop instead of process-global mutations
+                # Use scoped configuration instead of process-global mutations
                 runtime_config = RuntimeConfig(
                     workspace=os.getcwd(),
                     acp_enabled=acp_enabled,
@@ -89,11 +88,9 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
                 interactive_runtime = InteractiveRuntime(runtime_config)
                 logger.info(f"Starting InteractiveRuntime (ACP: {acp_enabled}, LSP: {lsp_enabled})")
                 
-                # Create a scoped event loop instead of modifying process globals
-                interactive_loop = asyncio.new_event_loop()
-                
-                # Start the runtime but keep it alive for agent execution
-                interactive_loop.run_until_complete(interactive_runtime.start())
+                # Start the runtime on the shared background loop where it stays alive
+                # and its asyncio primitives remain valid for the duration of this call
+                run_sync(interactive_runtime.start())
                 
                 centric_tools = create_agent_centric_tools(interactive_runtime)
                 logger.info(f"Loaded {len(centric_tools)} InteractiveRuntime tools")
@@ -204,12 +201,11 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
             return result
         finally:
             # Cleanup InteractiveRuntime if it was started
-            if interactive_runtime and interactive_loop:
+            if interactive_runtime is not None:
                 try:
                     logger.info("Stopping InteractiveRuntime")
-                    interactive_loop.run_until_complete(interactive_runtime.stop())
+                    from praisonai._async_bridge import run_sync
+                    run_sync(interactive_runtime.stop())
                 except Exception as e:
                     logger.error(f"Error stopping InteractiveRuntime: {e}")
-                finally:
-                    interactive_loop.close()
     

--- a/src/praisonai/praisonai/scheduler/__init__.py
+++ b/src/praisonai/praisonai/scheduler/__init__.py
@@ -30,20 +30,15 @@ def __getattr__(name):
         from .agent_scheduler import create_agent_scheduler
         return create_agent_scheduler
     elif name == 'create_scheduler':
-        # Return a factory function that creates a mock scheduler for testing
-        def _create_scheduler(provider='gcp', **kwargs):
-            from .agent_scheduler import AgentScheduler
-            # Create a mock agent and task for testing
-            class MockAgent:
-                pass
-            return AgentScheduler(MockAgent(), "test task")
-        return _create_scheduler
+        # Return the real deployment scheduler factory
+        from .deployment import create_deployment_scheduler
+        return create_deployment_scheduler
     elif name == 'DeploymentScheduler':
-        from .agent_scheduler import AgentScheduler
-        return AgentScheduler
+        from .deployment import DeploymentScheduler
+        return DeploymentScheduler
     elif name == 'create_deployment_scheduler':
-        from .agent_scheduler import create_agent_scheduler
-        return create_agent_scheduler
+        from .deployment import create_deployment_scheduler
+        return create_deployment_scheduler
     elif name in ('ScheduledAgentExecutor', 'JobResult'):
         from .executor import ScheduledAgentExecutor, JobResult
         return ScheduledAgentExecutor if name == 'ScheduledAgentExecutor' else JobResult

--- a/src/praisonai/praisonai/scheduler/deployment.py
+++ b/src/praisonai/praisonai/scheduler/deployment.py
@@ -105,7 +105,7 @@ class DeploymentScheduler:
             return False
             
         try:
-            from ..base import ScheduleParser
+            from .base import ScheduleParser
             interval = ScheduleParser.parse(schedule_expr)
             self.is_running = True
             self._stop_event.clear()

--- a/src/praisonai/praisonai/scheduler/deployment.py
+++ b/src/praisonai/praisonai/scheduler/deployment.py
@@ -1,11 +1,10 @@
 """
-DEPRECATED: This module is deprecated. Use praisonai.scheduler instead.
+Real deployment scheduler that integrates with the actual deployment system.
 
-This file is kept for backward compatibility only.
-All new code should import from praisonai.scheduler.
+This module provides the actual deployment scheduler implementation that was
+previously shadowed by the mock in __init__.py.
 """
 
-import warnings
 import logging
 import threading
 import time
@@ -14,18 +13,7 @@ from abc import ABC, abstractmethod
 
 logger = logging.getLogger(__name__)
 
-# Issue deprecation warning
-warnings.warn(
-    "praisonai.scheduler module (root level) is deprecated. "
-    "Use 'from praisonai.scheduler import ...' instead.",
-    DeprecationWarning,
-    stacklevel=2
-)
 
-# Import from new scheduler module for backward compatibility
-from .scheduler.base import ScheduleParser
-
-# Keep old classes for backward compatibility
 class DeployerInterface(ABC):
     """Abstract interface for deployers to ensure provider compatibility."""
     
@@ -34,35 +22,56 @@ class DeployerInterface(ABC):
         """Execute deployment. Returns True on success, False on failure."""
         pass
 
-class CloudDeployerAdapter(DeployerInterface):
-    """Adapter for existing CloudDeployer to match interface."""
+
+class DeployHandlerAdapter(DeployerInterface):
+    """Adapter for the real DeployHandler to match the scheduler interface."""
     
-    def __init__(self):
-        from .deploy import CloudDeployer
-        self._deployer = CloudDeployer()
+    def __init__(self, provider: str = "gcp", config: Optional[Dict[str, Any]] = None):
+        self.provider = provider
+        self.config = config or {}
     
     def deploy(self) -> bool:
-        """Execute deployment using CloudDeployer."""
+        """Execute deployment using the real DeployHandler."""
         try:
-            self._deployer.run_commands()
+            from praisonai.cli.features.deploy import DeployHandler
+            
+            handler = DeployHandler()
+            
+            # Create args object for handler
+            class DeployArgs:
+                def __init__(self):
+                    self.file = "agents.yaml"
+                    self.type = None
+                    self.provider = self.provider if hasattr(self, 'provider') else 'gcp'
+                    self.json = False
+                    self.background = False
+            
+            # Create args with the provider from the scheduler
+            deploy_args = DeployArgs()
+            deploy_args.provider = self.provider
+            
+            handler.handle_deploy(deploy_args)
             return True
+            
         except Exception as e:
             logger.error(f"Deployment failed: {e}")
             return False
 
+
 class DeploymentScheduler:
     """
-    Minimal deployment scheduler with provider-agnostic design.
+    Real deployment scheduler with provider-agnostic design.
     
     Features:
     - Simple interval-based scheduling
     - Thread-safe operation
-    - Extensible deployer factory pattern
-    - Minimal dependencies
+    - Integrates with actual DeployHandler
+    - Provider dispatch support
     """
     
-    def __init__(self, schedule_config: Optional[Dict[str, Any]] = None):
-        self.config = schedule_config or {}
+    def __init__(self, provider: str = "gcp", config: Optional[Dict[str, Any]] = None):
+        self.provider = provider
+        self.config = config or {}
         self.is_running = False
         self._stop_event = threading.Event()
         self._thread = None
@@ -77,8 +86,8 @@ class DeploymentScheduler:
         if self._deployer:
             return self._deployer
         
-        # Default to CloudDeployer for backward compatibility
-        return CloudDeployerAdapter()
+        # Use real DeployHandler via adapter
+        return DeployHandlerAdapter(self.provider, self.config)
     
     def start(self, schedule_expr: str, max_retries: int = 3) -> bool:
         """
@@ -96,6 +105,7 @@ class DeploymentScheduler:
             return False
             
         try:
+            from ..base import ScheduleParser
             interval = ScheduleParser.parse(schedule_expr)
             self.is_running = True
             self._stop_event.clear()
@@ -165,30 +175,16 @@ class DeploymentScheduler:
             logger.error(f"One-time deployment failed: {e}")
             return False
 
-def create_scheduler(provider: str = "gcp", config: Optional[Dict[str, Any]] = None) -> DeploymentScheduler:
+
+def create_deployment_scheduler(provider: str = "gcp", config: Optional[Dict[str, Any]] = None) -> DeploymentScheduler:
     """
-    Factory function to create scheduler for different providers.
+    Factory function to create a real deployment scheduler for different providers.
     
     Args:
         provider: Deployment provider ("gcp", "aws", "azure", etc.)
         config: Optional configuration dict
         
     Returns:
-        Configured DeploymentScheduler instance
+        Configured DeploymentScheduler instance that uses real deployment logic
     """
-    scheduler = DeploymentScheduler(config)
-    
-    # Provider-specific deployer setup can be added here
-    if provider == "gcp":
-        # Default CloudDeployer for GCP
-        pass
-    elif provider == "aws":
-        # Future: AWS deployer implementation
-        logger.warning("AWS provider not yet implemented, using default")
-    elif provider == "azure":
-        # Future: Azure deployer implementation  
-        logger.warning("Azure provider not yet implemented, using default")
-    else:
-        logger.warning(f"Unknown provider {provider}, using default")
-    
-    return scheduler
+    return DeploymentScheduler(provider, config)

--- a/src/praisonai/praisonai/tool_resolver.py
+++ b/src/praisonai/praisonai/tool_resolver.py
@@ -45,19 +45,26 @@ class ToolResolver:
     Attributes:
         _local_tools_cache: Cached tools from local tools.py
         _local_tools_loaded: Whether local tools have been loaded
+        _registry: Optional ToolRegistry for wrapper-level tool registration
     """
     
-    def __init__(self, tools_py_path: Optional[str] = None):
+    def __init__(
+        self,
+        tools_py_path: Optional[str] = None,
+        registry: Optional["ToolRegistry"] = None,
+    ):
         """Initialize the resolver.
         
         Args:
             tools_py_path: Optional path to tools.py. If None, uses ./tools.py
+            registry: Optional ToolRegistry to include in resolution chain
         """
         self._tools_py_path = tools_py_path or "tools.py"
         self._local_tools_cache: Mapping[str, Callable] = MappingProxyType({})
         self._local_tools_loaded: bool = False
         self._praisonai_tools_available: Optional[bool] = None
         self._local_tools_lock = threading.Lock()
+        self._registry = registry
     
     def _load_local_tools(self) -> Mapping[str, Callable]:
         """Load tools from local tools.py file.
@@ -186,6 +193,25 @@ class ToolResolver:
         
         return None
     
+    def _resolve_from_wrapper_registry(self, name: str) -> Optional[Callable]:
+        """Resolve tool from the wrapper ToolRegistry.
+        
+        Args:
+            name: Tool name to resolve
+            
+        Returns:
+            Callable if found, None otherwise
+        """
+        if self._registry is None:
+            return None
+        
+        tool = self._registry.get_function(name)
+        if tool is not None:
+            logger.debug(f"Resolved '{name}' from wrapper ToolRegistry")
+            return tool
+        
+        return None
+    
     def _resolve_from_registry(self, name: str) -> Optional[Callable]:
         """Resolve tool from the global tool registry.
         
@@ -213,9 +239,10 @@ class ToolResolver:
         
         Resolution order:
         1. Local tools.py (backward compat, custom tools)
-        2. praisonaiagents.tools.TOOL_MAPPINGS (built-in)
-        3. praisonai-tools package (external, optional)
-        4. Tool registry (plugins)
+        2. Wrapper ToolRegistry (register_function API)
+        3. praisonaiagents.tools.TOOL_MAPPINGS (built-in)
+        4. praisonai-tools package (external, optional)
+        5. Core SDK tool registry (plugins)
         
         Args:
             name: Tool name to resolve
@@ -236,17 +263,22 @@ class ToolResolver:
             logger.debug(f"Resolved '{name}' from local tools.py")
             return local_tools[name]
         
-        # 2. Check praisonaiagents.tools
+        # 2. Check wrapper ToolRegistry (NEW - ahead of SDK paths)
+        tool = self._resolve_from_wrapper_registry(name)
+        if tool is not None:
+            return tool
+        
+        # 3. Check praisonaiagents.tools
         tool = self._resolve_from_praisonaiagents(name)
         if tool is not None:
             return tool
         
-        # 3. Check praisonai-tools package
+        # 4. Check praisonai-tools package
         tool = self._resolve_from_praisonai_tools(name)
         if tool is not None:
             return tool
         
-        # 4. Check tool registry
+        # 5. Check core SDK tool registry
         tool = self._resolve_from_registry(name)
         if tool is not None:
             return tool

--- a/src/praisonai/tests/unit/scheduler/test_deployment_scheduler.py
+++ b/src/praisonai/tests/unit/scheduler/test_deployment_scheduler.py
@@ -1,0 +1,17 @@
+from praisonai.scheduler import DeploymentScheduler
+
+
+class _NoopDeployer:
+    def deploy(self) -> bool:
+        return True
+
+
+def test_deployment_scheduler_start_and_stop():
+    scheduler = DeploymentScheduler()
+    scheduler.set_deployer(_NoopDeployer())
+
+    assert scheduler.start("60") is True
+    assert scheduler.is_running is True
+
+    assert scheduler.stop() is True
+    assert scheduler.is_running is False


### PR DESCRIPTION
Fixes three architectural issues that violated DRY and "safe by default" principles:

1. **Shadow scheduler module issue**:
   - Remove dead scheduler.py that was shadowed by scheduler/ package
   - Replace mock create_scheduler with real DeploymentScheduler factory
   - CLI --deploy --schedule now uses actual deployment logic instead of MockAgent

2. **Disjoint tool registry/resolver issue**:
   - Connect ToolRegistry to ToolResolver resolution chain
   - Tools registered via register_function() are now discoverable by YAML resolver
   - Add ToolRegistry as step 2 in resolution order (after local tools.py)

3. **Incompatible async-bridging strategies**:
   - Standardize on _async_bridge.run_sync() as single source of truth
   - Remove per-call asyncio.run() loops from agent_tools.py
   - Fix InteractiveRuntime to run on shared background loop
   - Eliminate dormant event loop anti-pattern in praisonai_adapter.py

All fixes follow protocol-driven design principles from AGENTS.md.

Fixes #1694

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduler routing so deployment scheduling components are correctly exposed.

* **Refactor**
  * Redesigned tool resolution to use a registry-driven approach for better compatibility.
  * Improved async runtime management for more stable execution and unified async helper usage across agent tools.
  * Reworked the deployment scheduler to use the real implementation and updated factory behavior.

* **Tests**
  * Added unit tests for the deployment scheduler.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->