### PR TITLE
fix: correct callback signature mismatch in multi-agent startup (fixes #1730)

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -1611,7 +1611,7 @@ class AgentTeam:
             
             def composed_on_task_start(task, task_id):
                 try:
-                    verbose_task_start_callback(task)
+                    verbose_task_start_callback(task, task_id)
                 except Exception as e:
                     logging.debug(f"Error in verbose task start callback: {e}")
                 if original_on_task_start:
@@ -1622,7 +1622,7 @@ class AgentTeam:
             
             def composed_on_task_complete(task, task_output):
                 try:
-                    verbose_task_complete_callback(task)
+                    verbose_task_complete_callback(task, task_output)
                 except Exception as e:
                     logging.debug(f"Error in verbose task complete callback: {e}")
                 if original_on_task_complete:

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -1609,25 +1609,25 @@ class AgentTeam:
             original_on_task_start = self.on_task_start
             original_on_task_complete = self.on_task_complete
             
-            def composed_on_task_start(task):
+            def composed_on_task_start(task, task_id):
                 try:
                     verbose_task_start_callback(task)
                 except Exception as e:
                     logging.debug(f"Error in verbose task start callback: {e}")
                 if original_on_task_start:
                     try:
-                        original_on_task_start(task)
+                        original_on_task_start(task, task_id)
                     except Exception as e:
                         logging.debug(f"Error in original task start callback: {e}")
             
-            def composed_on_task_complete(task):
+            def composed_on_task_complete(task, task_output):
                 try:
                     verbose_task_complete_callback(task)
                 except Exception as e:
                     logging.debug(f"Error in verbose task complete callback: {e}")
                 if original_on_task_complete:
                     try:
-                        original_on_task_complete(task)
+                        original_on_task_complete(task, task_output)
                     except Exception as e:
                         logging.debug(f"Error in original task complete callback: {e}")
             

--- a/src/praisonai-agents/tests/unit/agents/test_start_verbose_callbacks.py
+++ b/src/praisonai-agents/tests/unit/agents/test_start_verbose_callbacks.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+import sys
+
+
+def test_start_verbose_composed_callbacks_forward_all_arguments(monkeypatch):
+    from praisonaiagents import Agent, AgentTeam
+
+    on_start_calls = []
+    on_complete_calls = []
+    debug_messages = []
+
+    def on_task_start(task, task_id):
+        on_start_calls.append((task, task_id))
+
+    def on_task_complete(task, task_output):
+        on_complete_calls.append((task, task_output))
+
+    team = AgentTeam(
+        agents=[
+            Agent(name="Researcher", instructions="Research"),
+            Agent(name="Writer", instructions="Write"),
+        ],
+        hooks={
+            "on_task_start": on_task_start,
+            "on_task_complete": on_task_complete,
+        },
+    )
+
+    def fake_run_all_tasks():
+        task_id, task = next(iter(team.tasks.items()))
+        task_output = SimpleNamespace(raw="done")
+        team.on_task_start(task, task_id)
+        team.on_task_complete(task, task_output)
+
+    monkeypatch.setattr(team, "run_all_tasks", fake_run_all_tasks)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr("praisonaiagents.agents.agents.logging.debug", lambda msg: debug_messages.append(str(msg)))
+
+    team.start(output="verbose")
+
+    assert len(on_start_calls) == 1
+    assert len(on_complete_calls) == 1
+    assert on_start_calls[0][1] == next(iter(team.tasks.keys()))
+    assert on_complete_calls[0][1].raw == "done"
+    assert all("Error in verbose task" not in message for message in debug_messages)


### PR DESCRIPTION
Fixes #1730

## Summary

- Fix function signature mismatch in AgentTeam.start callback composition
- Update composed_on_task_start to accept both task and task_id parameters
- Update composed_on_task_complete to accept both task and task_output parameters

## Root Cause

The error occurred because:
1. Line 1310: Callbacks called with 2 arguments: `self.on_task_start(task, task_id)`
2. Line 1612: `composed_on_task_start` only accepted 1 argument
3. Line 1619: Original callback only passed 1 argument

## Testing

✅ Verified the original user code now works without the signature error
✅ Multi-agent setup initializes successfully

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parameter forwarding for task start and completion callbacks so handlers receive the expected data during verbose runs.

* **Tests**
  * Added a unit test to verify verbose-mode task hooks are invoked with correct arguments and that no verbose-mode error logs are produced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->