### PR TITLE
feat: add CLIENT SETNAME to Valkey client for connection identification

### DIFF
--- a/src/praisonai/praisonai/persistence/_valkey_client.py
+++ b/src/praisonai/praisonai/persistence/_valkey_client.py
@@ -24,6 +24,8 @@ _MISSING_MSG = (
     "Install with: pip install 'praisonai[valkey]'"
 )
 
+_CLIENT_NAME = "praisonai_persistence_client"
+
 
 def create_valkey_client(
     host: str = "localhost",
@@ -40,5 +42,6 @@ def create_valkey_client(
         addresses=addresses,
         credentials=creds,
         database_id=db,
+        client_name=_CLIENT_NAME,
     )
     return GlideClientSync.create(config)


### PR DESCRIPTION
## Summary

Adds `CLIENT SETNAME` to the shared Valkey client factory so all PraisonAI connections to Valkey are identifiable in monitoring tools.

## Change

In `_valkey_client.py`, added `client_name="praisonai_persistence_client"` to the `GlideClientConfiguration`. This sends a `CLIENT SETNAME` command on connection, making PraisonAI connections visible in:
- `CLIENT LIST` output
- Monitoring dashboards (e.g., Valkey Admin)
- CloudWatch metrics (ElastiCache)

## Naming Convention

Pattern: `{project}_{purpose}_client`
- `praisonai` = project name
- `persistence` = purpose (covers state store, knowledge store, and session storage — all use this shared factory)
- `_client` = convention (matches Valkey Admin naming pattern: `valkey_admin_metrics_standalone_client`, etc.)

## Why This Matters

When multiple applications connect to the same Valkey server, operators need to identify which connection belongs to which application. Without `CLIENT SETNAME`, PraisonAI connections appear anonymous in `CLIENT LIST`. This one-liner makes them identifiable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal persistence client configuration with a standardized identifier for improved connection management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MervinPraison/PraisonAI/pull/1761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->