### PR TITLE
fix: replace undefined AgentFlow with Workflow in workflow_conditional.py (closes #1750)

### DIFF
--- a/examples/python/workflows/workflow_conditional.py
+++ b/examples/python/workflows/workflow_conditional.py
@@ -5,7 +5,7 @@ Demonstrates using should_run to conditionally execute agent steps
 based on input or previous results.
 """
 
-from praisonaiagents import Agent, Workflow, Task
+from praisonaiagents import Agent, AgentFlow, Task
 
 # Condition functions
 def is_technical(ctx) -> bool:
@@ -48,7 +48,7 @@ finalizer = Agent(
 )
 
 # Create workflow with conditional steps
-workflow = Workflow(
+workflow = AgentFlow(
     name="Conditional Agentic Pipeline",
     steps=[
         analyzer,  # Always runs

--- a/examples/python/workflows/workflow_conditional.py
+++ b/examples/python/workflows/workflow_conditional.py
@@ -48,7 +48,7 @@ finalizer = Agent(
 )
 
 # Create workflow with conditional steps
-workflow = AgentFlow(
+workflow = Workflow(
     name="Conditional Agentic Pipeline",
     steps=[
         analyzer,  # Always runs


### PR DESCRIPTION
## What
The `workflow_conditional.py` example references `AgentFlow`, which is not imported or defined anywhere in the file. This causes a `NameError` at runtime and prevents the example from running at all.

## Fix
Replace `AgentFlow` with `Workflow`, which is already imported from `praisonaiagents` at the top of the file.

Closes #1750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated example workflow code to reflect current framework naming and conventions.
  * Example behavior unchanged: conditional steps and the always-running final step remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->