### PR TITLE
docs: fix broken Full Flow docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ praisonai flow
 
 Open **http://localhost:7861** — use the **Agent** and **Agent Team** components to create sequential or parallel workflows. Connect Chat Input → Agent Team → Chat Output for instant multi-agent pipelines.
 
-> 📖 [Full Flow docs](https://docs.praison.ai/docs/concepts/flow) — visual agent building, component reference, and deployment
+> 📖 [Full Flow docs](https://docs.praison.ai/docs/concepts/agentflow) — visual agent building, component reference, and deployment
 
 ### 8. PraisonAI UI 🤖 (Clean Chat)
 


### PR DESCRIPTION
## Summary

Fixes a broken docs link in the README. The link in the **PraisonAI Flow** quickstart section points to `https://docs.praison.ai/docs/concepts/flow`, which currently returns **404**. The published page lives at `/docs/concepts/agentflow`.

## Verification

```
$ curl -sL -o /dev/null -w "%{http_code}\n" https://docs.praison.ai/docs/concepts/flow
404
$ curl -sL -o /dev/null -w "%{http_code}\n" https://docs.praison.ai/docs/concepts/agentflow
200
```

## Diff

```diff
- > 📖 [Full Flow docs](https://docs.praison.ai/docs/concepts/flow) — visual agent building, component reference, and deployment
+ > 📖 [Full Flow docs](https://docs.praison.ai/docs/concepts/agentflow) — visual agent building, component reference, and deployment
```

Single-character-class fix scoped to one line in `README.md`. Opening an issue first felt excessive for a broken link, happy to file one if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Langflow integration documentation link to reference the correct agentflow documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->