### PR TITLE
feat: add CLIENT SETNAME for connection identification

### DIFF
--- a/src/praisonai/praisonai/persistence/_valkey_client.py
+++ b/src/praisonai/praisonai/persistence/_valkey_client.py
@@ -39,6 +39,7 @@ def create_valkey_client(
     config = GlideClientConfiguration(
         addresses=addresses,
         credentials=creds,
+        client_name="praisonai_valkey_client",
         database_id=db,
     )
     return GlideClientSync.create(config)


### PR DESCRIPTION
## Summary

Adds `client_name="praisonai_valkey_client"` to the shared Valkey client factory in `_valkey_client.py` so all PraisonAI connections (StateStore, VectorKnowledgeStore, StorageAdapter) are identifiable via `CLIENT LIST` on the server.

## Changes

One-line addition to `GlideClientConfiguration` in `create_valkey_client()`.

## Motivation

Connections without a name appear anonymous in `CLIENT LIST`, making it impossible to distinguish PraisonAI from other services sharing the same Valkey cluster. Setting `client_name` sends a `CLIENT SETNAME` command on connection, making it identifiable in:
- `CLIENT LIST` output
- Monitoring dashboards (e.g., Valkey Admin)
- CloudWatch metrics (ElastiCache)

## Risk

Zero-risk — `client_name` is a metadata-only option. No behavioral changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal client identification for database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->