### PR TITLE
fix: remove duplicate import time in _chat_completion except block

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -1064,7 +1064,6 @@ Your Goal: {self.goal}"""
             # Use structured error classification for all error types (replaces legacy heuristic checks)
             from ..llm.error_classifier import classify_llm_error
             from ..llm.retry_utils import jittered_backoff
-            import time
             
             model_name = self.llm if isinstance(self.llm, str) else "unknown"
             session_id = getattr(self, '_session_id', 'unknown')


### PR DESCRIPTION
Fixes #1901

Removed redundant `import time` from except block in `_chat_completion` that shadowed the module-level import and caused UnboundLocalError on the sync chat path.

Generated with [Claude Code](https://claude.ai/code); PR opened from triage branch `claude/issue-1901-20260612-2015`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with intelligent retry logic for transient failures and better error classification.
  * Enhanced error messages with additional context information to aid debugging and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->