### PR TITLE
fix: doctor env crashes on Windows with charmap UnicodeEncodeError

### DIFF
--- a/src/praisonai/praisonai/cli/features/doctor/formatters.py
+++ b/src/praisonai/praisonai/cli/features/doctor/formatters.py
@@ -173,15 +173,49 @@ class TextFormatter(BaseFormatter):
         CheckStatus.ERROR: "✗",
     }
     
+    # ASCII fallback symbols for systems that don't support UTF-8
+    STATUS_SYMBOLS_ASCII = {
+        CheckStatus.PASS: "[OK]",
+        CheckStatus.WARN: "[!]",
+        CheckStatus.FAIL: "[X]",
+        CheckStatus.SKIP: "[-]",
+        CheckStatus.ERROR: "[X]",
+    }
+    
     def _color(self, text: str, color: str) -> str:
         """Apply color to text if colors are enabled."""
         if self.no_color:
             return text
         return f"{self.COLORS.get(color, '')}{text}{self.COLORS['reset']}"
     
+    def _can_encode_unicode(self) -> bool:
+        """Check if stdout can encode Unicode symbols."""
+        try:
+            # Get stdout encoding
+            encoding = getattr(sys.stdout, 'encoding', 'ascii') or 'ascii'
+            
+            # UTF-8 always supports Unicode
+            if encoding.lower() in ('utf-8', 'utf8'):
+                return True
+                
+            # Test if we can encode our specific Unicode symbols
+            test_symbols = ["✓", "⚠", "✗", "○"]
+            for symbol in test_symbols:
+                try:
+                    symbol.encode(encoding, errors='strict')
+                except (UnicodeEncodeError, LookupError):
+                    return False
+            return True
+        except (AttributeError, TypeError):
+            # If we can't determine encoding, assume ASCII-only is safer
+            return False
+    
     def _status_symbol(self, status: CheckStatus) -> str:
-        """Get colored status symbol."""
-        symbol = self.STATUS_SYMBOLS.get(status, "?")
+        """Get colored status symbol with encoding safety."""
+        if self._can_encode_unicode():
+            symbol = self.STATUS_SYMBOLS.get(status, "?")
+        else:
+            symbol = self.STATUS_SYMBOLS_ASCII.get(status, "[?]")
         color = self.STATUS_COLORS.get(status, "white")
         return self._color(symbol, color)
     

--- a/src/praisonai/praisonai/cli/features/doctor/formatters.py
+++ b/src/praisonai/praisonai/cli/features/doctor/formatters.py
@@ -144,6 +144,17 @@ class BaseFormatter:
 class TextFormatter(BaseFormatter):
     """Text formatter with optional color support."""
     
+    def __init__(
+        self,
+        no_color: bool = False,
+        quiet: bool = False,
+        redact: bool = True,
+        show_prefix_suffix: bool = False,
+    ):
+        super().__init__(no_color, quiet, redact, show_prefix_suffix)
+        # Cache encoding detection result at initialization
+        self._unicode_supported = self._can_encode_unicode()
+    
     # ANSI color codes
     COLORS = {
         "reset": "\033[0m",
@@ -212,7 +223,7 @@ class TextFormatter(BaseFormatter):
     
     def _status_symbol(self, status: CheckStatus) -> str:
         """Get colored status symbol with encoding safety."""
-        if self._can_encode_unicode():
+        if self._unicode_supported:
             symbol = self.STATUS_SYMBOLS.get(status, "?")
         else:
             symbol = self.STATUS_SYMBOLS_ASCII.get(status, "[?]")

--- a/src/praisonai/tests/unit/doctor/test_formatters.py
+++ b/src/praisonai/tests/unit/doctor/test_formatters.py
@@ -182,24 +182,17 @@ class TestTextFormatter:
         
         # Mock sys.stdout to report cp1252 encoding (Windows default)
         with patch.object(sys.stdout, 'encoding', 'cp1252'):
-            # Mock the encoding attempt to raise UnicodeEncodeError
-            def mock_encode(encoding, errors='strict'):
-                if errors == 'strict':
-                    raise UnicodeEncodeError('cp1252', '✓', 0, 1, 'charmap codec can\'t encode')
-                return b'?'
-            
-            with patch('str.encode', side_effect=mock_encode):
-                result = CheckResult(
-                    id="test",
-                    title="Test Check", 
-                    category=CheckCategory.ENVIRONMENT,
-                    status=CheckStatus.PASS,
-                    message="OK",
-                )
-                output = formatter.format_result(result)
-                # Should use ASCII symbol for pass instead of Unicode
-                assert "[OK]" in output
-                assert "✓" not in output
+            result = CheckResult(
+                id="test",
+                title="Test Check", 
+                category=CheckCategory.ENVIRONMENT,
+                status=CheckStatus.PASS,
+                message="OK",
+            )
+            output = formatter.format_result(result)
+            # Should use ASCII symbol for pass instead of Unicode
+            assert "[OK]" in output
+            assert "✓" not in output
 
 
 class TestJsonFormatter:

--- a/src/praisonai/tests/unit/doctor/test_formatters.py
+++ b/src/praisonai/tests/unit/doctor/test_formatters.py
@@ -1,6 +1,8 @@
 """Unit tests for doctor formatters."""
 
 import json
+import sys
+from unittest.mock import patch
 
 from praisonai.cli.features.doctor.models import (
     CheckCategory,
@@ -156,6 +158,48 @@ class TestTextFormatter:
         output = formatter.format_report(report)
         # Should not have header in quiet mode
         assert "PraisonAI Doctor" not in output
+    
+    def test_unicode_encoding_safety_with_utf8(self):
+        """Test that Unicode symbols are used when UTF-8 is supported."""
+        formatter = TextFormatter(no_color=True)
+        
+        # Mock sys.stdout to report UTF-8 encoding
+        with patch.object(sys.stdout, 'encoding', 'utf-8'):
+            result = CheckResult(
+                id="test",
+                title="Test Check",
+                category=CheckCategory.ENVIRONMENT,
+                status=CheckStatus.PASS,
+                message="OK",
+            )
+            output = formatter.format_result(result)
+            # Should use Unicode symbol for pass
+            assert "✓" in output
+    
+    def test_unicode_encoding_safety_with_cp1252(self):
+        """Test that ASCII symbols are used when encoding doesn't support Unicode."""
+        formatter = TextFormatter(no_color=True)
+        
+        # Mock sys.stdout to report cp1252 encoding (Windows default)
+        with patch.object(sys.stdout, 'encoding', 'cp1252'):
+            # Mock the encoding attempt to raise UnicodeEncodeError
+            def mock_encode(encoding, errors='strict'):
+                if errors == 'strict':
+                    raise UnicodeEncodeError('cp1252', '✓', 0, 1, 'charmap codec can\'t encode')
+                return b'?'
+            
+            with patch('str.encode', side_effect=mock_encode):
+                result = CheckResult(
+                    id="test",
+                    title="Test Check", 
+                    category=CheckCategory.ENVIRONMENT,
+                    status=CheckStatus.PASS,
+                    message="OK",
+                )
+                output = formatter.format_result(result)
+                # Should use ASCII symbol for pass instead of Unicode
+                assert "[OK]" in output
+                assert "✓" not in output
 
 
 class TestJsonFormatter:


### PR DESCRIPTION
Fixes #1878

Adds encoding-safe Unicode symbol fallback for Windows so `praisonai doctor env` does not crash with charmap codec errors.

Generated with [Claude Code](https://claude.ai/code); PR opened from triage branch `claude/issue-1878-20260610-0601`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for environments with limited Unicode support: status indicators now automatically use Unicode symbols when supported and fall back to clear ASCII alternatives when not, preventing garbled output.

* **Tests**
  * Added unit tests to verify correct status symbol selection and formatted output across different terminal encodings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->