### PR TITLE
fix: remove local 'from rich import print' causing UnboundLocalError

### DIFF
--- a/src/praisonai/praisonai/cli/main.py
+++ b/src/praisonai/praisonai/cli/main.py
@@ -425,7 +425,6 @@ class PraisonAI:
             
             # Handle backends command
             elif args.command == "backends":
-                from rich import print
                 subcommand = unknown_args[0] if unknown_args and not unknown_args[0].startswith('-') else None
                 
                 if subcommand == "list" or subcommand is None:


### PR DESCRIPTION
Fixes #1879

Removes local `from rich import print` inside `main()` that made `print` a local variable and caused UnboundLocalError on other CLI paths.

Generated with [Claude Code](https://claude.ai/code); PR opened from triage branch `claude/issue-1879-20260610-0601`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant import statement from the CLI module to improve code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->