### PR TITLE
fix: tool parameter schema generation for Optional, Union, Literal, and Enum

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -5615,7 +5615,19 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     logging.debug(f"Found tool in registry: {function_name}")
                     # If it's a BaseTool, get its schema
                     if hasattr(tool, 'get_schema'):
-                        return tool.get_schema()
+                        tool_def = tool.get_schema()
+                        # Apply same normalization as the callable path
+                        if (
+                            isinstance(tool_def, dict)
+                            and isinstance(tool_def.get("function"), dict)
+                            and isinstance(tool_def["function"].get("parameters"), dict)
+                        ):
+                            tool_def = tool_def.copy()
+                            tool_def["function"] = tool_def["function"].copy()
+                            tool_def["function"]["parameters"] = self._fix_array_schemas(
+                                tool_def["function"]["parameters"]
+                            )
+                        return tool_def
                     # If it's a callable, use it as func
                     if callable(tool):
                         func = tool
@@ -5623,11 +5635,41 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         logging.debug(f"Tool {function_name} in registry is not callable")
                         return None
                 else:
-                    logging.debug(f"Tool {function_name} not found in registry")
-                    return None
+                    logging.debug(f"Tool {function_name} not found in registry, falling back to globals/__main__")
+                    # Fall back to globals and __main__ for backward compatibility
+                    tool_def_name = f"{function_name}_definition"
+                    tool_def = globals().get(tool_def_name)
+                    if not tool_def:
+                        import __main__
+                        tool_def = getattr(__main__, tool_def_name, None)
+                    if tool_def:
+                        return tool_def
+                    
+                    func = globals().get(function_name)
+                    if not func:
+                        import __main__
+                        func = getattr(__main__, function_name, None)
+                    if not func or not callable(func):
+                        logging.debug(f"Function {function_name} not found or not callable")
+                        return None
             except ImportError:
-                logging.debug("Tool registry not available")
-                return None
+                logging.debug("Tool registry not available, falling back to globals/__main__")
+                # Fall back to globals and __main__ when registry unavailable
+                tool_def_name = f"{function_name}_definition"
+                tool_def = globals().get(tool_def_name)
+                if not tool_def:
+                    import __main__
+                    tool_def = getattr(__main__, tool_def_name, None)
+                if tool_def:
+                    return tool_def
+                
+                func = globals().get(function_name)
+                if not func:
+                    import __main__
+                    func = getattr(__main__, function_name, None)
+                if not func or not callable(func):
+                    logging.debug(f"Function {function_name} not found or not callable")
+                    return None
 
         import inspect
         from typing import get_type_hints
@@ -5680,7 +5722,10 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         logging.debug(f"Parameter descriptions: {param_descriptions}")
 
         # Get type hints for proper schema generation
-        hints = get_type_hints(func) if hasattr(func, '__annotations__') else {}
+        try:
+            hints = get_type_hints(func) if getattr(func, "__annotations__", None) else {}
+        except (NameError, TypeError, AttributeError):
+            hints = getattr(func, "__annotations__", {}) or {}
 
         for name, param in parameters_list:
             # Get type annotation

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -23,6 +23,7 @@ import json
 import xml.etree.ElementTree as ET
 # Gap 2: Tool call execution imports
 from ..tools.call_executor import ToolCall, create_tool_call_executor
+from ..tools.schema import annotation_to_json_schema, get_parameter_requirements
 # Display functions - lazy loaded to avoid importing rich at startup
 # These are only needed when output=verbose
 _display_module = None
@@ -5605,34 +5606,32 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             function_name = function_or_name
             logging.debug(f"Attempting to generate tool definition for: {function_name}")
             
-            # First try to get the tool definition if it exists
-            tool_def_name = f"{function_name}_definition"
-            tool_def = globals().get(tool_def_name)
-            logging.debug(f"Looking for {tool_def_name} in globals: {tool_def is not None}")
-            
-            if not tool_def:
-                import __main__
-                tool_def = getattr(__main__, tool_def_name, None)
-                logging.debug(f"Looking for {tool_def_name} in __main__: {tool_def is not None}")
-            
-            if tool_def:
-                logging.debug(f"Found tool definition: {tool_def}")
-                return tool_def
-
-            # Try to find the function
-            func = globals().get(function_name)
-            logging.debug(f"Looking for {function_name} in globals: {func is not None}")
-            
-            if not func:
-                import __main__
-                func = getattr(__main__, function_name, None)
-                logging.debug(f"Looking for {function_name} in __main__: {func is not None}")
-            
-            if not func or not callable(func):
-                logging.debug(f"Function {function_name} not found or not callable")
+            # First try to get from the tool registry (preferred method)
+            try:
+                from ..tools.registry import get_registry
+                registry = get_registry()
+                tool = registry.get(function_name)
+                if tool:
+                    logging.debug(f"Found tool in registry: {function_name}")
+                    # If it's a BaseTool, get its schema
+                    if hasattr(tool, 'get_schema'):
+                        return tool.get_schema()
+                    # If it's a callable, use it as func
+                    if callable(tool):
+                        func = tool
+                    else:
+                        logging.debug(f"Tool {function_name} in registry is not callable")
+                        return None
+                else:
+                    logging.debug(f"Tool {function_name} not found in registry")
+                    return None
+            except ImportError:
+                logging.debug("Tool registry not available")
                 return None
 
         import inspect
+        from typing import get_type_hints
+        
         # Handle Langchain and CrewAI tools
         if inspect.isclass(func) and hasattr(func, 'run') and not hasattr(func, '_run'):
             original_func = func
@@ -5680,26 +5679,23 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         
         logging.debug(f"Parameter descriptions: {param_descriptions}")
 
+        # Get type hints for proper schema generation
+        hints = get_type_hints(func) if hasattr(func, '__annotations__') else {}
+
         for name, param in parameters_list:
-            param_type = "string"  # Default type
-            if param.annotation != inspect.Parameter.empty:
-                if param.annotation == int:
-                    param_type = "integer"
-                elif param.annotation == float:
-                    param_type = "number"
-                elif param.annotation == bool:
-                    param_type = "boolean"
-                elif param.annotation == list:
-                    param_type = "array"
-                elif param.annotation == dict:
-                    param_type = "object"
+            # Get type annotation
+            param_type = hints.get(name, param.annotation if param.annotation != inspect.Parameter.empty else str)
             
-            parameters["properties"][name] = {
-                "type": param_type,
-                "description": param_descriptions.get(name, "Parameter description not available")
-            }
+            # Use new schema utility for proper type handling
+            prop_schema = annotation_to_json_schema(param_type)
             
-            if param.default == inspect.Parameter.empty:
+            # Add description from docstring
+            prop_schema["description"] = param_descriptions.get(name, "Parameter description not available")
+            
+            parameters["properties"][name] = prop_schema
+            
+            # Check if required using improved logic
+            if get_parameter_requirements(sig, name):
                 parameters["required"].append(name)
         
         logging.debug(f"Generated parameters: {parameters}")

--- a/src/praisonai-agents/praisonaiagents/tools/base.py
+++ b/src/praisonai-agents/praisonaiagents/tools/base.py
@@ -19,6 +19,8 @@ from typing import Any, Dict, List, Optional, Type, get_type_hints
 import inspect
 import logging
 
+from .schema import annotation_to_json_schema, get_parameter_requirements
+
 
 class ToolValidationError(Exception):
     """Raised when a tool fails validation."""
@@ -121,18 +123,17 @@ class BaseTool(ABC):
                 
                 # Get type hint
                 param_type = hints.get(param_name, Any)
-                json_type = self._python_type_to_json(param_type)
                 
-                # Build property schema
-                prop_schema = {"type": json_type}
+                # Use new schema utility for proper type handling
+                prop_schema = annotation_to_json_schema(param_type)
                 
                 # Add description from docstring if available
                 # (Could parse docstring for param descriptions)
                 
                 schema["properties"][param_name] = prop_schema
                 
-                # Check if required (no default value)
-                if param.default is inspect.Parameter.empty:
+                # Check if required using improved logic
+                if get_parameter_requirements(sig, param_name):
                     schema["required"].append(param_name)
         except Exception as e:
             logging.debug(f"Could not generate schema for {self.name}: {e}")
@@ -141,28 +142,15 @@ class BaseTool(ABC):
     
     @staticmethod
     def _python_type_to_json(python_type: Type) -> str:
-        """Convert Python type to JSON Schema type."""
-        type_map = {
-            str: "string",
-            int: "integer",
-            float: "number",
-            bool: "boolean",
-            list: "array",
-            dict: "object",
-            type(None): "null"
-        }
+        """Convert Python type to JSON Schema type.
         
-        # Handle Optional, Union, etc.
-        origin = getattr(python_type, '__origin__', None)
-        if origin is not None:
-            # For List[X], return "array"
-            if origin is list:
-                return "array"
-            # For Dict[X, Y], return "object"
-            if origin is dict:
-                return "object"
-        
-        return type_map.get(python_type, "string")
+        DEPRECATED: Use annotation_to_json_schema() from schema.py instead.
+        This method is kept for backward compatibility but will be removed.
+        """
+        # Legacy fallback - delegate to new schema utility and extract type
+        from .schema import annotation_to_json_schema
+        schema = annotation_to_json_schema(python_type)
+        return schema.get("type", "string")
     
     @abstractmethod
     def run(self, **kwargs) -> Any:

--- a/src/praisonai-agents/praisonaiagents/tools/decorator.py
+++ b/src/praisonai-agents/praisonaiagents/tools/decorator.py
@@ -300,7 +300,8 @@ def _schema_from_function(func: Callable) -> Dict[str, Any]:
             
             properties[param_name] = prop_schema
             
-            if param.default is inspect.Parameter.empty:
+            # Check if required using improved logic
+            if get_parameter_requirements(sig, param_name):
                 required.append(param_name)
     except Exception as e:
         logging.debug(f"Could not generate schema for {name}: {e}")

--- a/src/praisonai-agents/praisonaiagents/tools/decorator.py
+++ b/src/praisonai-agents/praisonaiagents/tools/decorator.py
@@ -30,6 +30,7 @@ import logging
 from typing import Any, Callable, Dict, Optional, Union, get_type_hints
 
 from .base import BaseTool
+from .schema import annotation_to_json_schema, get_parameter_requirements
 
 # Lazy load injected module functions to reduce import time
 _injected_module = None
@@ -127,12 +128,13 @@ class FunctionTool(BaseTool):
                 if is_injected_type(param_type):
                     continue
                 
-                json_type = BaseTool._python_type_to_json(param_type)
+                # Use new schema utility for proper type handling
+                prop_schema = annotation_to_json_schema(param_type)
                 
-                schema["properties"][param_name] = {"type": json_type}
+                schema["properties"][param_name] = prop_schema
                 
-                # Check if required (no default value)
-                if param.default is inspect.Parameter.empty:
+                # Check if required using improved logic  
+                if get_parameter_requirements(sig, param_name):
                     schema["required"].append(param_name)
         except Exception as e:
             logging.debug(f"Could not generate schema for {func.__name__}: {e}")
@@ -292,9 +294,11 @@ def _schema_from_function(func: Callable) -> Dict[str, Any]:
                 continue
             
             param_type = hints.get(param_name, Any)
-            json_type = BaseTool._python_type_to_json(param_type)
             
-            properties[param_name] = {"type": json_type}
+            # Use new schema utility for proper type handling
+            prop_schema = annotation_to_json_schema(param_type)
+            
+            properties[param_name] = prop_schema
             
             if param.default is inspect.Parameter.empty:
                 required.append(param_name)

--- a/src/praisonai-agents/praisonaiagents/tools/schema.py
+++ b/src/praisonai-agents/praisonaiagents/tools/schema.py
@@ -63,11 +63,31 @@ def annotation_to_json_schema(annotation: Any) -> dict:
     # Handle Literal types
     if origin is Literal or (hasattr(annotation, '__origin__') and 
                            str(annotation.__origin__).endswith('Literal')):
-        return {"type": "string", "enum": list(args)}
+        # Infer type from literal values if all are the same type
+        values = list(args)
+        if values:
+            types_seen = set(type(v) for v in values)
+            if len(types_seen) == 1:
+                single_type = next(iter(types_seen))
+                type_map = {str: "string", int: "integer", float: "number", bool: "boolean"}
+                if single_type in type_map:
+                    return {"type": type_map[single_type], "enum": values}
+        # Mixed types or non-primitive - use enum without type constraint
+        return {"enum": values}
     
     # Handle Enum subclasses
     if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
-        return {"type": "string", "enum": [e.value for e in annotation]}
+        # Infer type from enum values if all are the same type
+        values = [e.value for e in annotation]
+        if values:
+            types_seen = set(type(v) for v in values)
+            if len(types_seen) == 1:
+                single_type = next(iter(types_seen))
+                type_map = {str: "string", int: "integer", float: "number", bool: "boolean"}
+                if single_type in type_map:
+                    return {"type": type_map[single_type], "enum": values}
+        # Mixed types or non-primitive - use enum without type constraint
+        return {"enum": values}
     
     # Handle List types
     if origin is list:

--- a/src/praisonai-agents/praisonaiagents/tools/schema.py
+++ b/src/praisonai-agents/praisonaiagents/tools/schema.py
@@ -1,0 +1,132 @@
+"""JSON Schema generation utilities for tool parameters.
+
+This module provides a shared utility for converting Python type annotations
+to JSON Schema format. It handles complex types like Optional, Union, Literal,
+and Enum that were previously collapsed to simple "string" types.
+
+Usage:
+    from praisonaiagents.tools.schema import annotation_to_json_schema
+    
+    schema = annotation_to_json_schema(Optional[int])
+    # {"anyOf": [{"type": "integer"}, {"type": "null"}]}
+    
+    schema = annotation_to_json_schema(Literal["fast", "deep"])
+    # {"type": "string", "enum": ["fast", "deep"]}
+"""
+
+import enum
+import inspect
+from typing import Any, Union, Literal, get_origin, get_args
+
+
+def annotation_to_json_schema(annotation: Any) -> dict:
+    """Convert Python type annotation to JSON Schema format.
+    
+    Handles:
+    - Basic types (str, int, float, bool)
+    - Optional[T] -> {"anyOf": [T schema, {"type": "null"}]}
+    - Union[T1, T2] -> {"anyOf": [T1 schema, T2 schema]}
+    - Literal["a", "b"] -> {"type": "string", "enum": ["a", "b"]}
+    - Enum subclasses -> {"type": "string", "enum": [e.value for e in MyEnum]}
+    - List[T] -> {"type": "array", "items": T schema}
+    - Dict[K, V] -> {"type": "object", "additionalProperties": V schema}
+    
+    Args:
+        annotation: Python type annotation to convert
+        
+    Returns:
+        dict: JSON Schema representation
+    """
+    # Handle None type
+    if annotation is type(None):
+        return {"type": "null"}
+    
+    # Get typing origin and args
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    
+    # Handle Union types (including Optional[T] which is Union[T, None])
+    if origin is Union:
+        schemas = [annotation_to_json_schema(arg) for arg in args]
+        
+        # Check if this is Optional[T] (Union[T, None])
+        null_schemas = [s for s in schemas if s == {"type": "null"}]
+        non_null_schemas = [s for s in schemas if s != {"type": "null"}]
+        
+        if null_schemas and len(non_null_schemas) == 1:
+            # This is Optional[T] - simplified format
+            return {"anyOf": [non_null_schemas[0], {"type": "null"}]}
+        else:
+            # General Union type
+            return {"anyOf": schemas}
+    
+    # Handle Literal types
+    if origin is Literal or (hasattr(annotation, '__origin__') and 
+                           str(annotation.__origin__).endswith('Literal')):
+        return {"type": "string", "enum": list(args)}
+    
+    # Handle Enum subclasses
+    if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
+        return {"type": "string", "enum": [e.value for e in annotation]}
+    
+    # Handle List types
+    if origin is list:
+        if args:
+            items_schema = annotation_to_json_schema(args[0])
+            return {"type": "array", "items": items_schema}
+        else:
+            return {"type": "array"}
+    
+    # Handle Dict types
+    if origin is dict:
+        if len(args) >= 2:
+            value_schema = annotation_to_json_schema(args[1])
+            return {"type": "object", "additionalProperties": value_schema}
+        else:
+            return {"type": "object"}
+    
+    # Handle basic types
+    type_map = {
+        str: "string",
+        int: "integer", 
+        float: "number",
+        bool: "boolean",
+        list: "array",
+        dict: "object",
+        type(None): "null"
+    }
+    
+    return {"type": type_map.get(annotation, "string")}
+
+
+def get_parameter_requirements(sig: inspect.Signature, param_name: str) -> bool:
+    """Determine if a parameter is required based on its signature.
+    
+    A parameter is required if it has no default value, unless it's Optional.
+    
+    Args:
+        sig: Function signature
+        param_name: Parameter name to check
+        
+    Returns:
+        bool: True if parameter is required
+    """
+    param = sig.parameters.get(param_name)
+    if not param:
+        return False
+    
+    # Parameter with default is not required
+    if param.default is not inspect.Parameter.empty:
+        return False
+    
+    # Check if the type annotation indicates optional
+    if param.annotation is not inspect.Parameter.empty:
+        origin = get_origin(param.annotation)
+        if origin is Union:
+            args = get_args(param.annotation)
+            # Optional[T] is Union[T, None]
+            if type(None) in args:
+                return False
+    
+    # No default and not optional = required
+    return True


### PR DESCRIPTION
Fixes #1845

Comprehensive fix for tool parameter schema generation that was silently dropping Optional, Union, Literal, and Enum types across schema generation paths.

Generated with [Claude Code](https://claude.ai/code); PR opened from triage branch `claude/issue-1845-20260604-0815`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized parameter schema generation into shared utilities for consistent handling of tool/function parameters.
  * Improved detection of required vs optional parameters and richer support for complex annotation types (unions/optionals, enums/literals, lists/dicts).
  * Deprecated local type-mapping shim replaced by the centralized schema path for cleaner, more maintainable tool definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->