### PR TITLE
fix: Remove redundant import causing UnboundLocalError in tool execution

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/tool_execution.py
+++ b/src/praisonai-agents/praisonaiagents/agent/tool_execution.py
@@ -245,7 +245,6 @@ class ToolExecutionMixin:
                     blocked_result = {"error": f"[loop-guard] {decision.message}", "loop_blocked": True}
                 elif decision.action == GuardAction.HALT:
                     # Halt execution with exception
-                    from ..errors import ToolExecutionError
                     raise ToolExecutionError(
                         f"[loop-guard] {decision.message}",
                         tool_name=function_name,


### PR DESCRIPTION
Fixes #1968

This critical bug was caused by a conditional import of `ToolExecutionError` inside the `execute_tool()` method that created a Python scoping issue. When the loop guard HALT branch was not taken, the exception handler would fail with `UnboundLocalError` on `isinstance(e, ToolExecutionError)` because the local variable was never assigned.

## Changes
- Removed redundant conditional import on line 248
- Module-level import on line 18 provides sufficient scope

## Testing
- Verified fix resolves scoping issue
- Custom `@tool` agents now work without crashing

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized exception handling in tool execution by removing unnecessary local imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->