### PR TITLE
docs: fix incorrect import in simple_workflow.py example

### DIFF
--- a/examples/python/workflows/simple_workflow.py
+++ b/examples/python/workflows/simple_workflow.py
@@ -5,7 +5,7 @@ Demonstrates using Agent instances directly as workflow steps.
 Each agent processes the input and passes output to the next agent.
 """
 
-from praisonaiagents import Agent, Workflow
+from praisonaiagents import Agent, AgentFlow
 
 # Create agents with specific roles
 researcher = Agent(


### PR DESCRIPTION
## Summary

`simple_workflow.py` imports `Workflow` (line 10) but references `AgentFlow` (line 26), causing `NameError: name 'AgentFlow' is not defined` at runtime.

This is the README-linked "Simple Workflow" example — first thing new users try.

## Fix

Change import from `Workflow` to `AgentFlow` (the primary class name since v1.0; `Workflow` is a silent alias). Aligns with all other workflow examples (`workflow_conditional.py`, `workflow_branching.py`, etc.) which already import `AgentFlow`.

## Context

- Same root cause as #1750 (fixed in #1765 for `workflow_conditional.py`)
- `AgentFlow` is the primary name; `Workflow = AgentFlow` is a backward-compat alias per `workflows.py` line 3037
- 1-line change, no behavioral impact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated workflow orchestration to use `AgentFlow` instead of `Workflow`
  * Example code demonstrates new workflow configuration pattern with structured steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->