### PR TITLE
feat: add Evolink provider example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ GROQ_API_KEY=gsk_...           # Groq (fast inference)
 COHERE_API_KEY=...             # Cohere models
 AZURE_OPENAI_API_KEY=...       # Azure OpenAI
 AZURE_OPENAI_ENDPOINT=...      # Azure OpenAI endpoint
+EVOLINK_API_KEY=...            # EvoLink.AI OpenAI-compatible models. Get yours at https://evolink.ai/dashboard/keys
 
 # === Optional: Memory backends ===
 MEM0_API_KEY=...               # Mem0 memory service

--- a/examples/python/providers/evolink/evolink_example.py
+++ b/examples/python/providers/evolink/evolink_example.py
@@ -6,11 +6,18 @@ import os
 
 from praisonaiagents import Agent
 
+api_key = os.getenv("EVOLINK_API_KEY")
+if not api_key:
+    raise RuntimeError(
+        "EVOLINK_API_KEY is not set. Set it before running this example: "
+        "export EVOLINK_API_KEY=your_api_key"
+    )
+
 agent = Agent(
     instructions="You are a helpful assistant",
     llm={
         "model": "openai/gpt-5.2",
-        "api_key": os.environ["EVOLINK_API_KEY"],
+        "api_key": api_key,
         "base_url": "https://direct.evolink.ai/v1",
     },
 )

--- a/examples/python/providers/evolink/evolink_example.py
+++ b/examples/python/providers/evolink/evolink_example.py
@@ -1,0 +1,27 @@
+"""
+Basic example of using EvoLink.AI with PraisonAI.
+"""
+
+import os
+
+from praisonaiagents import Agent
+
+agent = Agent(
+    instructions="You are a helpful assistant",
+    llm={
+        "model": "openai/gpt-5.2",
+        "api_key": os.environ["EVOLINK_API_KEY"],
+        "base_url": "https://direct.evolink.ai/v1",
+    },
+)
+
+response = agent.start("Hello! Share one practical AI automation idea.")
+print(response)
+
+coding_task = """
+Write a Python function that validates whether a string is a palindrome.
+Include a short docstring and ignore spaces and capitalization.
+"""
+
+response = agent.start(coding_task)
+print(response)

--- a/src/praisonai-agents/tests/unit/test_configurable_model.py
+++ b/src/praisonai-agents/tests/unit/test_configurable_model.py
@@ -95,6 +95,28 @@ class TestConfigurableModelProvider:
         )
         assert agent is not None
 
+    def test_agent_with_evolink_openai_compatible_config(self):
+        """Agent should pass EvoLink OpenAI-compatible settings to LLM."""
+        from praisonaiagents import Agent
+
+        with patch("praisonaiagents.llm.llm.LLM") as mock_llm:
+            agent = Agent(
+                name="Test",
+                instructions="Test agent",
+                llm={
+                    "model": "openai/gpt-5.2",
+                    "api_key": "test-evolink-key",
+                    "base_url": "https://direct.evolink.ai/v1",
+                },
+            )
+
+        assert agent is not None
+        assert agent.llm == "openai/gpt-5.2"
+        mock_llm.assert_called_once()
+        assert mock_llm.call_args.kwargs["model"] == "openai/gpt-5.2"
+        assert mock_llm.call_args.kwargs["api_key"] == "test-evolink-key"
+        assert mock_llm.call_args.kwargs["base_url"] == "https://direct.evolink.ai/v1"
+
 
 class TestConfigurableModelThreadSafety:
     """Test thread safety of agent model usage."""

--- a/src/praisonai-agents/tests/unit/test_configurable_model.py
+++ b/src/praisonai-agents/tests/unit/test_configurable_model.py
@@ -112,10 +112,11 @@ class TestConfigurableModelProvider:
 
         assert agent is not None
         assert agent.llm == "openai/gpt-5.2"
-        mock_llm.assert_called_once()
-        assert mock_llm.call_args.kwargs["model"] == "openai/gpt-5.2"
-        assert mock_llm.call_args.kwargs["api_key"] == "test-evolink-key"
-        assert mock_llm.call_args.kwargs["base_url"] == "https://direct.evolink.ai/v1"
+        assert agent._llm_init_params["model"] == "openai/gpt-5.2"
+        assert agent._llm_init_params["api_key"] == "test-evolink-key"
+        assert agent._llm_init_params["base_url"] == "https://direct.evolink.ai/v1"
+        assert agent._using_custom_llm is True
+        mock_llm.assert_not_called()
 
 
 class TestConfigurableModelThreadSafety:


### PR DESCRIPTION
## Summary
- Add an Evolink provider example using PraisonAI's existing OpenAI-compatible `base_url` and `api_key` configuration path.
- Document `EVOLINK_API_KEY` in `.env.example`.
- Add an offline unit test that verifies Evolink's OpenAI-compatible model, key, and base URL are passed through to the LLM layer unchanged.

## Testing
- `env -u all_proxy -u http_proxy -u https_proxy -u ALL_PROXY -u HTTP_PROXY -u HTTPS_PROXY .venv/bin/python -m pytest src/praisonai-agents/tests/unit/test_configurable_model.py -q` -> 10 passed, 2 pytest config warnings
- `.venv/bin/python -m compileall -q examples/python/providers/evolink/evolink_example.py` -> passed
- `git diff --check` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for EvoLink.AI OpenAI-compatible models as an alternative LLM provider.

* **Documentation**
  * Documented the optional `EVOLINK_API_KEY` environment variable for EvoLink.AI.
  * Added a Python example demonstrating how to configure and use EvoLink.AI.

* **Tests**
  * Added a unit test validating EvoLink.AI OpenAI-compatible model configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->