### PR TITLE
fix: remove unreferenced dead code in core SDK

### DIFF
--- a/src/praisonai-agents/praisonaiagents/_config.py
+++ b/src/praisonai-agents/praisonaiagents/_config.py
@@ -111,32 +111,3 @@ def _get_plugins_list() -> list:
 
 PLUGINS_ENABLED = _get_plugins_enabled()
 PLUGINS_LIST = _get_plugins_list()
-
-
-def missing_dependency_error(
-    package_name: str,
-    extra_name: Optional[str] = None,
-    feature_name: Optional[str] = None
-) -> ImportError:
-    """
-    Create a standardized ImportError for missing optional dependencies.
-    
-    Args:
-        package_name: The name of the missing package (e.g., 'litellm')
-        extra_name: The pip extra to install (e.g., 'llm' for [llm])
-        feature_name: Human-readable feature name (e.g., 'LLM support')
-    
-    Returns:
-        ImportError with helpful install instructions
-    """
-    if extra_name:
-        install_cmd = f"pip install 'praisonaiagents[{extra_name}]'"
-    else:
-        install_cmd = f"pip install {package_name}"
-    
-    feature_desc = f" for {feature_name}" if feature_name else ""
-    
-    return ImportError(
-        f"{package_name} is required{feature_desc} but not installed. "
-        f"Please install with: {install_cmd}"
-    )

--- a/src/praisonai-agents/praisonaiagents/agent/summarization.py
+++ b/src/praisonai-agents/praisonaiagents/agent/summarization.py
@@ -7,20 +7,9 @@ Reuses existing telemetry/token_collector for token tracking.
 
 import logging
 from praisonaiagents._logging import get_logger
-from typing import Optional, List, Dict, Any, Callable
-from dataclasses import dataclass, field
+from typing import Optional, List, Dict, Any
 
 logger = get_logger(__name__)
-
-@dataclass
-class SummarizationConfig:
-    """Configuration for auto-summarization."""
-    enabled: bool = False
-    threshold: float = 0.8  # 80% of context window
-    context_window: int = 128000  # Default for GPT-4
-    summary_model: Optional[str] = None  # Use smaller model for summaries
-    preserve_system: bool = True  # Keep system message
-    preserve_recent: int = 2  # Keep last N message pairs
 
 class SummarizationManager:
     """
@@ -179,45 +168,3 @@ SUMMARY:"""
         """Number of times summarization has been performed."""
         return self._summarization_count
 
-async def summarize_conversation(
-    messages: List[Dict[str, str]],
-    llm_call: Callable,
-    manager: SummarizationManager,
-) -> List[Dict[str, str]]:
-    """
-    Summarize conversation using LLM.
-    
-    Args:
-        messages: Current message history
-        llm_call: Async function to call LLM
-        manager: SummarizationManager instance
-        
-    Returns:
-        New message history with summary
-    """
-    prompt = manager.generate_summary_prompt(messages)
-    
-    # Call LLM to generate summary
-    summary = await llm_call(prompt)
-    
-    # Prepare new history
-    new_history = manager.prepare_summarized_history(messages, summary)
-    
-    # Reset token count (will be recalculated on next message)
-    manager.reset_tokens()
-    
-    return new_history
-
-def summarize_conversation_sync(
-    messages: List[Dict[str, str]],
-    llm_call: Callable,
-    manager: SummarizationManager,
-) -> List[Dict[str, str]]:
-    """
-    Synchronous version of summarize_conversation.
-    """
-    prompt = manager.generate_summary_prompt(messages)
-    summary = llm_call(prompt)
-    new_history = manager.prepare_summarized_history(messages, summary)
-    manager.reset_tokens()
-    return new_history


### PR DESCRIPTION
Remove two pockets of genuinely unused code confirmed by repo-wide grep to have zero call sites:

**1. `praisonaiagents/_config.py`**
- Remove `missing_dependency_error()` — private helper with no callers in core, wrapper, or tests

**2. `praisonaiagents/agent/summarization.py`**
- Remove `SummarizationConfig` — unreferenced dataclass
- Remove `summarize_conversation()` and `summarize_conversation_sync()` — unreferenced module-level functions
- `SummarizationManager` kept intact — it is the tested public surface and is unchanged
- Clean up unused imports (`dataclass`, `field`, `Callable`)

No behavior changes. No public API affected.

Fixes #2056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored conversation summarization system for improved code organization.
  * Removed unused helper functions to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->