### PR TITLE
fix: Core SDK: trace redaction does a per-key O(N) scan despite an already-compiled regex sitting unused

### DIFF
--- a/src/praisonai-agents/praisonaiagents/trace/redact.py
+++ b/src/praisonai-agents/praisonaiagents/trace/redact.py
@@ -55,9 +55,14 @@ REDACT_KEYS: Set[str] = {
     "anthropic_api_key",
 }
 
-# Compiled regex for case-insensitive matching
+# Compiled regex for matching (no IGNORECASE needed since we normalize to lowercase)
 _REDACT_PATTERN = re.compile(
-    r"(" + "|".join(re.escape(k) for k in REDACT_KEYS) + r")",
+    r"(" + "|".join(re.escape(k) for k in REDACT_KEYS) + r")"
+)
+
+# Compiled regex for key=value pattern matching in strings (case-insensitive for raw text)
+_REDACT_KV_PATTERN = re.compile(
+    r'(["\']?)(' + '|'.join(re.escape(k) for k in REDACT_KEYS) + r')(["\']?\s*[:=]\s*["\']?)([^"\'\s,}\]]+)',
     re.IGNORECASE
 )
 
@@ -236,14 +241,5 @@ def redact_string(text: str, enabled: bool = True) -> str:
     if not enabled or not text:
         return text
     
-    # Pattern for key=value or key: value
-    patterns = [
-        (r'(["\']?)(' + '|'.join(re.escape(k) for k in REDACT_KEYS) + r')(["\']?\s*[:=]\s*["\']?)([^"\'\s,}\]]+)', 
-         r'\1\2\3[REDACTED]'),
-    ]
-    
-    result = text
-    for pattern, replacement in patterns:
-        result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
-    
-    return result
+    # Use pre-compiled pattern for better performance
+    return _REDACT_KV_PATTERN.sub(r'\1\2\3[REDACTED]', text)

--- a/src/praisonai-agents/praisonaiagents/trace/redact.py
+++ b/src/praisonai-agents/praisonaiagents/trace/redact.py
@@ -73,12 +73,8 @@ def _should_redact(key: str) -> bool:
     if normalized in REDACT_KEYS:
         return True
     
-    # Check if any redact key is contained in the normalized key
-    for redact_key in REDACT_KEYS:
-        if redact_key in normalized:
-            return True
-    
-    return False
+    # Use compiled regex for substring matching instead of O(N) loop
+    return bool(_REDACT_PATTERN.search(normalized))
 
 
 def redact_dict(data: Dict[str, Any], enabled: bool = True) -> Dict[str, Any]:

--- a/test_redact_performance.py
+++ b/test_redact_performance.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Test to verify redaction optimizations work correctly."""
+import sys
+import os
+sys.path.insert(0, 'src/praisonai-agents')
+
+from praisonaiagents.trace.redact import (
+    _should_redact, 
+    redact_string,
+    REDACT_KEYS,
+    _REDACT_PATTERN,
+    _REDACT_KV_PATTERN
+)
+
+def test_should_redact_uses_compiled_regex():
+    """Verify _should_redact uses the compiled regex pattern."""
+    # Test exact match
+    assert _should_redact("api_key") == True
+    assert _should_redact("password") == True
+    
+    # Test normalized match
+    assert _should_redact("API-KEY") == True
+    assert _should_redact("API KEY") == True
+    
+    # Test substring match via regex
+    assert _should_redact("my_api_key_field") == True
+    assert _should_redact("user_password") == True
+    
+    # Test non-sensitive
+    assert _should_redact("username") == False
+    assert _should_redact("email") == False
+    print("✓ _should_redact works correctly with compiled regex")
+
+def test_redact_string_uses_compiled_pattern():
+    """Verify redact_string uses pre-compiled pattern."""
+    # Test various formats
+    test_cases = [
+        ('api_key=sk-12345', 'api_key=[REDACTED]'),
+        ('password: secret123', 'password: [REDACTED]'),
+        ('{"token": "bearer-xyz"}', '{"token": "[REDACTED]"}'),
+        ('API_KEY="mysecret"', 'API_KEY="[REDACTED]"'),
+    ]
+    
+    for input_str, expected in test_cases:
+        result = redact_string(input_str)
+        assert result == expected, f"Failed: {input_str} -> {result} (expected {expected})"
+    
+    print("✓ redact_string works correctly with pre-compiled pattern")
+
+def test_patterns_are_compiled():
+    """Verify patterns are compiled at module level."""
+    import re
+    
+    # Check that patterns are compiled regex objects
+    assert isinstance(_REDACT_PATTERN, re.Pattern)
+    assert isinstance(_REDACT_KV_PATTERN, re.Pattern)
+    
+    # Verify _REDACT_PATTERN does not have IGNORECASE flag
+    # (since we normalize to lowercase before using it)
+    assert (_REDACT_PATTERN.flags & re.IGNORECASE) == 0
+    
+    # Verify _REDACT_KV_PATTERN has IGNORECASE flag 
+    # (since it works on raw text)
+    assert (_REDACT_KV_PATTERN.flags & re.IGNORECASE) != 0
+    
+    print("✓ Patterns are properly compiled at module level")
+
+if __name__ == "__main__":
+    test_should_redact_uses_compiled_regex()
+    test_redact_string_uses_compiled_pattern()
+    test_patterns_are_compiled()
+    print("\n✅ All tests passed!")


### PR DESCRIPTION
Fixes #1960

Auto-opened from Claude triage branch `claude/issue-1960-20260613-1714`.

Generated during issue/PR audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized data redaction handling to improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->