### PR TITLE
fix: All ~78 Typer command groups imported and registered on every CLI invocation before dispatch

### DIFF
--- a/src/praisonai/praisonai/__main__.py
+++ b/src/praisonai/praisonai/__main__.py
@@ -37,14 +37,8 @@ def _get_typer_commands():
             return _typer_commands_cache
 
         try:
-            from praisonai.cli.app import app, register_commands
-            register_commands()
-
-            import typer.main
-            import click
-            click_app = typer.main.get_command(app)
-            ctx = click.Context(click_app, info_name="praisonai")
-            commands = set(click_app.list_commands(ctx))
+            from praisonai.cli.app import get_command_names
+            commands = get_command_names()
         except Exception:
             # Do NOT poison the cache on failure — let the next caller retry.
             import logging

--- a/src/praisonai/praisonai/cli/app.py
+++ b/src/praisonai/praisonai/cli/app.py
@@ -658,8 +658,118 @@ def get_output_controller() -> OutputController:
     return state.output_controller
 
 
+# Command name to module mapping for lazy loading
+_COMMAND_GROUPS = {
+    # Core commands
+    "config": ".commands.config",
+    "traces": ".commands.traces", 
+    "env": ".commands.environment",
+    "session": ".commands.session",
+    "completion": ".commands.completion",
+    "version": ".commands.version",
+    "debug": ".commands.debug",
+    "lsp": ".commands.lsp",
+    "diag": ".commands.diag",
+    "doctor": ".commands.doctor",
+    "setup": ".commands.setup",
+    "onboard": ".commands.onboard", 
+    "obs": ".commands.obs",
+    "acp": ".commands.acp",
+    "mcp": ".commands.mcp",
+    "serve": ".commands.serve",
+    "schedule": ".commands.schedule",
+    "kanban": ".commands.kanban",
+    "run": ".commands.run",
+    "profile": ".commands.profile",
+    "benchmark": ".commands.benchmark",
+    "paths": ".commands.paths",
+    # Terminal-native commands
+    "chat": ".commands.chat",
+    "code": ".commands.code", 
+    "call": ".commands.call",
+    "realtime": ".commands.realtime",
+    "train": ".commands.train",
+    "ui": ".commands.ui",
+    "context": ".commands.context",
+    "research": ".commands.research",
+    "memory": ".commands.memory",
+    "workflow": ".commands.workflow",
+    "tools": ".commands.tools",
+    "n8n": ".commands.n8n",
+    "knowledge": ".commands.knowledge",
+    "rag": ".commands.rag",
+    "deploy": ".commands.deploy",
+    "agents": ".commands.agents",
+    "skills": ".commands.skills",
+    "eval": ".commands.eval",
+    "templates": ".commands.templates",
+    "recipe": ".commands.recipe",
+    "todo": ".commands.todo",
+    "docs": ".commands.docs",
+    "commit": ".commands.commit",
+    "publish": ".commands.publish",
+    "hooks": ".commands.hooks",
+    "rules": ".commands.rules",
+    "registry": ".commands.registry",
+    "package": ".commands.package",
+    "endpoints": ".commands.endpoints",
+    "test": ".commands.test",
+    "examples": ".commands.examples",
+    "batch": ".commands.batch",
+    "replay": ".commands.replay",
+    "loop": ".commands.loop",
+    "tracker": ".commands.tracker",
+    "github": ".commands.github",
+    # Moltbot-inspired commands
+    "bot": ".commands.bot",
+    "gateway": ".commands.gateway",
+    "pairing": ".commands.pairing",
+    "browser": ".commands.browser",
+    "plugins": ".commands.plugins",
+    "sandbox": ".commands.sandbox",
+    "claw": ".commands.claw",
+    "flow": ".commands.flow",
+    "dashboard": ".commands.dashboard",
+    "langfuse": ".commands.langfuse",
+    "langextract": ".commands.langextract",
+    "port": ".commands.port",
+    "managed": ".commands.managed",
+    "up": ".commands.up",
+    "standardise": "standardise_app_special",  # Special case
+    "standardize": "standardise_app_special",  # Special case  
+    "app": "app_special",  # Special case
+    "tui": "tui_special",  # Special case
+    "queue": "queue_special",  # Special case
+    # Retrieval commands are registered dynamically
+}
+
 # Import and register command groups
 _commands_registered = False
+
+def get_command_names():
+    """Get all available command names without importing the modules."""
+    names = set(_COMMAND_GROUPS.keys())
+    # Add dynamically registered commands that don't have modules
+    names.update({"index", "query"})  # retrieval commands
+    return names
+
+def load_command_module(name):
+    """Load a specific command module by name."""
+    if name not in _COMMAND_GROUPS:
+        return None
+    
+    module_path = _COMMAND_GROUPS[name]
+    
+    # Handle special cases
+    if module_path in ("standardise_app_special", "app_special", "tui_special", "queue_special"):
+        return None  # These are registered inline in register_commands()
+    
+    try:
+        import importlib
+        module = importlib.import_module(module_path, package=__package__)
+        return getattr(module, "app", None)
+    except (ImportError, AttributeError):
+        return None
 
 def register_commands():
     """Register all command groups (idempotent).
@@ -683,5 +793,4 @@ def register_commands():
     _commands_registered = True
 
 
-# Register commands on import
-register_commands()
+# Commands will be registered lazily when needed

--- a/src/praisonai/praisonai/cli/app.py
+++ b/src/praisonai/praisonai/cli/app.py
@@ -750,26 +750,9 @@ def get_command_names():
     """Get all available command names without importing the modules."""
     names = set(_COMMAND_GROUPS.keys())
     # Add dynamically registered commands that don't have modules
+    # NOTE: retrieval_module.register_commands(app) adds these commands dynamically
     names.update({"index", "query"})  # retrieval commands
     return names
-
-def load_command_module(name):
-    """Load a specific command module by name."""
-    if name not in _COMMAND_GROUPS:
-        return None
-    
-    module_path = _COMMAND_GROUPS[name]
-    
-    # Handle special cases
-    if module_path in ("standardise_app_special", "app_special", "tui_special", "queue_special"):
-        return None  # These are registered inline in register_commands()
-    
-    try:
-        import importlib
-        module = importlib.import_module(module_path, package=__package__)
-        return getattr(module, "app", None)
-    except (ImportError, AttributeError):
-        return None
 
 def register_commands():
     """Register all command groups (idempotent).

--- a/src/praisonai/praisonai/cli/main.py
+++ b/src/praisonai/praisonai/cli/main.py
@@ -1499,7 +1499,8 @@ class PraisonAI:
             elif args.command == 'profile':
                 # Profile command - delegate to Typer CLI for new profiler
                 # This routes to commands/profile.py which has query, imports, startup subcommands
-                from .app import app as typer_app
+                from .app import app as typer_app, register_commands
+                register_commands()
                 import sys as _sys
                 _sys.argv = ['praisonai', 'profile'] + unknown_args
                 typer_app()

--- a/src/praisonai/tests/unit/cli/test_typer_cli.py
+++ b/src/praisonai/tests/unit/cli/test_typer_cli.py
@@ -33,6 +33,12 @@ def reset_global_state():
 class TestTyperApp:
     """Tests for the main Typer app."""
     
+    @pytest.fixture(autouse=True)
+    def setup_commands(self):
+        """Register commands before each test."""
+        from praisonai.cli.app import register_commands
+        register_commands()
+    
     def test_app_import(self):
         """Test that the Typer app can be imported."""
         from praisonai.cli.app import app
@@ -364,6 +370,12 @@ class TestSessionManager:
 class TestGlobalOptions:
     """Tests for global CLI options."""
     
+    @pytest.fixture(autouse=True)
+    def setup_commands(self):
+        """Register commands before each test."""
+        from praisonai.cli.app import register_commands
+        register_commands()
+    
     def test_json_output_option(self):
         """Test --json option."""
         from praisonai.cli.app import app
@@ -386,6 +398,12 @@ class TestGlobalOptions:
 
 class TestExitCodes:
     """Tests for deterministic exit codes."""
+    
+    @pytest.fixture(autouse=True)
+    def setup_commands(self):
+        """Register commands before each test."""
+        from praisonai.cli.app import register_commands
+        register_commands()
     
     def test_success_exit_code(self):
         """Test success returns 0."""


### PR DESCRIPTION
Fixes #1950

Auto-opened from Claude triage branch `claude/issue-1950-20260613-1155`.

Generated during issue/PR audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized CLI command discovery and loading. Commands are now registered on-demand instead of at startup, improving initialization performance.

* **Tests**
  * Added command registration setup for CLI integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->