### PR TITLE
fix: Turn-time runtime resolution for handoffs and sub-agents

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/handoff.py
+++ b/src/praisonai-agents/praisonaiagents/agent/handoff.py
@@ -428,7 +428,7 @@ class Handoff:
             
             # Resolve target agent's model reference
             target_model_ref = getattr(self.agent, 'llm', None) or getattr(self.agent, 'model', None) or 'gpt-4o-mini'
-            target_agent_id = getattr(self.agent, 'agent_id', self.agent.name)
+            target_agent_id = getattr(self.agent, 'agent_id', getattr(self.agent, 'name', 'unknown'))
             
             logger.debug(f"Resolving runtime for handoff: agent_id={target_agent_id}, model={target_model_ref}")
             
@@ -441,7 +441,7 @@ class Handoff:
             
             return response
             
-        except (ImportError, Exception) as e:
+        except Exception as e:
             logger.warning(f"Runtime resolution failed, falling back to agent.chat(): {e}")
             # Fallback to traditional agent execution
             return self.agent.chat(prompt, tools=effective_tools)
@@ -469,7 +469,7 @@ class Handoff:
             
             # Resolve target agent's model reference
             target_model_ref = getattr(self.agent, 'llm', None) or getattr(self.agent, 'model', None) or 'gpt-4o-mini'
-            target_agent_id = getattr(self.agent, 'agent_id', self.agent.name)
+            target_agent_id = getattr(self.agent, 'agent_id', getattr(self.agent, 'name', 'unknown'))
             
             logger.debug(f"Resolving async runtime for handoff: agent_id={target_agent_id}, model={target_model_ref}")
             
@@ -482,14 +482,14 @@ class Handoff:
             
             return response
             
-        except (ImportError, Exception) as e:
+        except Exception as e:
             logger.warning(f"Async runtime resolution failed, falling back to agent execution: {e}")
             # Fallback to traditional agent execution
             if hasattr(self.agent, 'achat'):
                 return await self.agent.achat(prompt, tools=effective_tools)
             else:
                 # Run sync chat in executor with tool constraint
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 return await loop.run_in_executor(None, lambda: self.agent.chat(prompt, tools=effective_tools))
     
     def _check_safety(self, source_agent: 'Agent') -> None:

--- a/src/praisonai-agents/praisonaiagents/agent/handoff.py
+++ b/src/praisonai-agents/praisonaiagents/agent/handoff.py
@@ -405,6 +405,93 @@ class Handoff:
             # In intersect mode, empty list means no tools allowed - this is the security boundary
             return effective_tools
     
+    def _execute_with_runtime_resolution(
+        self, 
+        source_agent: 'Agent', 
+        prompt: str, 
+        effective_tools: List[Any], 
+        context: Dict[str, Any]
+    ) -> str:
+        """Execute handoff with turn-time runtime resolution."""
+        try:
+            # Try to use runtime resolution if available
+            from ..runtime.resolve import resolve_runtime, SessionContext
+            import time
+            
+            # Create session context for runtime resolution
+            session_ctx = SessionContext(
+                session_id=getattr(source_agent, '_session_id', 'default'),
+                timestamp=time.time(),
+                parent_agent_id=source_agent.name if hasattr(source_agent, 'name') else None,
+                handoff_depth=_get_handoff_depth()
+            )
+            
+            # Resolve target agent's model reference
+            target_model_ref = getattr(self.agent, 'llm', None) or getattr(self.agent, 'model', None) or 'gpt-4o-mini'
+            target_agent_id = getattr(self.agent, 'agent_id', self.agent.name)
+            
+            logger.debug(f"Resolving runtime for handoff: agent_id={target_agent_id}, model={target_model_ref}")
+            
+            # Resolve runtime for target agent
+            runtime = resolve_runtime(target_agent_id, target_model_ref, session_ctx)
+            
+            # Execute using resolved runtime
+            response = runtime.execute(prompt, tools=effective_tools)
+            logger.info(f"Handoff executed with turn-time resolved runtime: {runtime.provider}/{runtime.model_ref}")
+            
+            return response
+            
+        except (ImportError, Exception) as e:
+            logger.warning(f"Runtime resolution failed, falling back to agent.chat(): {e}")
+            # Fallback to traditional agent execution
+            return self.agent.chat(prompt, tools=effective_tools)
+    
+    async def _execute_with_runtime_resolution_async(
+        self, 
+        source_agent: 'Agent', 
+        prompt: str, 
+        effective_tools: List[Any], 
+        context: Dict[str, Any]
+    ) -> str:
+        """Execute handoff with turn-time runtime resolution (async)."""
+        try:
+            # Try to use runtime resolution if available
+            from ..runtime.resolve import resolve_runtime, SessionContext
+            import time
+            
+            # Create session context for runtime resolution
+            session_ctx = SessionContext(
+                session_id=getattr(source_agent, '_session_id', 'default'),
+                timestamp=time.time(),
+                parent_agent_id=source_agent.name if hasattr(source_agent, 'name') else None,
+                handoff_depth=_get_handoff_depth()
+            )
+            
+            # Resolve target agent's model reference
+            target_model_ref = getattr(self.agent, 'llm', None) or getattr(self.agent, 'model', None) or 'gpt-4o-mini'
+            target_agent_id = getattr(self.agent, 'agent_id', self.agent.name)
+            
+            logger.debug(f"Resolving async runtime for handoff: agent_id={target_agent_id}, model={target_model_ref}")
+            
+            # Resolve runtime for target agent
+            runtime = resolve_runtime(target_agent_id, target_model_ref, session_ctx)
+            
+            # Execute using resolved runtime
+            response = await runtime.aexecute(prompt, tools=effective_tools)
+            logger.info(f"Async handoff executed with turn-time resolved runtime: {runtime.provider}/{runtime.model_ref}")
+            
+            return response
+            
+        except (ImportError, Exception) as e:
+            logger.warning(f"Async runtime resolution failed, falling back to agent execution: {e}")
+            # Fallback to traditional agent execution
+            if hasattr(self.agent, 'achat'):
+                return await self.agent.achat(prompt, tools=effective_tools)
+            else:
+                # Run sync chat in executor with tool constraint
+                loop = asyncio.get_event_loop()
+                return await loop.run_in_executor(None, lambda: self.agent.chat(prompt, tools=effective_tools))
+    
     def _check_safety(self, source_agent: 'Agent') -> None:
         """
         Check safety constraints before handoff.
@@ -569,8 +656,10 @@ class Handoff:
             # Compute effective tools based on tool policy
             effective_tools = self._compute_effective_tools(source_agent)
             
-            # Execute with tool boundary enforcement
-            response = self.agent.chat(full_prompt, tools=effective_tools)
+            # Resolve runtime at turn-time instead of using construction-time pin
+            response = self._execute_with_runtime_resolution(
+                source_agent, full_prompt, effective_tools, kwargs
+            )
             
             result = HandoffResult(
                 success=True,
@@ -675,13 +764,10 @@ class Handoff:
                 # Compute effective tools based on tool policy
                 effective_tools = self._compute_effective_tools(source_agent)
                 
-                # Execute with tool boundary enforcement - check for async chat method
-                if hasattr(self.agent, 'achat'):
-                    response = await self.agent.achat(full_prompt, tools=effective_tools)
-                else:
-                    # Run sync chat in executor with tool constraint
-                    loop = asyncio.get_event_loop()
-                    response = await loop.run_in_executor(None, lambda: self.agent.chat(full_prompt, tools=effective_tools))
+                # Resolve runtime at turn-time for async execution
+                response = await self._execute_with_runtime_resolution_async(
+                    source_agent, full_prompt, effective_tools, kwargs
+                )
                 
                 result = HandoffResult(
                     success=True,
@@ -817,7 +903,10 @@ class Handoff:
                     # Compute effective tools based on tool policy
                     effective_tools = self._compute_effective_tools(source_agent)
                     
-                    response = self.agent.chat(prompt, tools=effective_tools)
+                    # Resolve runtime at turn-time for tool function execution
+                    response = self._execute_with_runtime_resolution(
+                        source_agent, prompt, effective_tools, kwargs
+                    )
                     
                     result = HandoffResult(
                         success=True,

--- a/src/praisonai-agents/praisonaiagents/agent/test_handoff_runtime_resolution.py
+++ b/src/praisonai-agents/praisonaiagents/agent/test_handoff_runtime_resolution.py
@@ -1,0 +1,393 @@
+"""
+Integration tests for handoff runtime resolution.
+
+This test suite validates that handoffs now use turn-time runtime resolution
+instead of construction-time pins, addressing issue #1938.
+"""
+
+import pytest
+import time
+from unittest.mock import Mock, patch, MagicMock
+import asyncio
+
+from .handoff import Handoff, HandoffConfig, ContextPolicy, HandoffResult
+from ..runtime.resolve import SessionContext
+
+
+class MockAgent:
+    """Mock agent for testing handoff scenarios."""
+    
+    def __init__(self, name, model="gpt-4o", agent_id=None, session_id="test"):
+        self.name = name
+        self.llm = model
+        self.model = model  
+        self.agent_id = agent_id or name
+        self._session_id = session_id
+        self.chat_history = []
+    
+    def chat(self, prompt, **kwargs):
+        """Mock chat method that returns a simple response."""
+        response = f"Response from {self.name} using {self.model}: {prompt[:50]}..."
+        self.chat_history.append({"role": "user", "content": prompt})
+        self.chat_history.append({"role": "assistant", "content": response})
+        return response
+    
+    async def achat(self, prompt, **kwargs):
+        """Mock async chat method."""
+        return self.chat(prompt, **kwargs)
+
+
+class TestHandoffRuntimeResolution:
+    """Test handoff runtime resolution functionality."""
+    
+    def test_handoff_uses_turn_time_resolution(self):
+        """Test that handoff uses turn-time runtime resolution instead of construction-time."""
+        # Create agents with different models
+        source_agent = MockAgent("SourceAgent", "gpt-3.5-turbo")
+        target_agent = MockAgent("TargetAgent", "gpt-4o")
+        
+        # Create handoff
+        handoff = Handoff(
+            agent=target_agent,
+            config=HandoffConfig(context_policy=ContextPolicy.NONE)
+        )
+        
+        # Mock the runtime resolution to verify it's called
+        with patch.object(handoff, '_execute_with_runtime_resolution') as mock_execute:
+            mock_execute.return_value = "Resolved response"
+            
+            # Execute programmatic handoff
+            result = handoff.execute_programmatic(
+                source_agent=source_agent,
+                prompt="Test handoff",
+                context={}
+            )
+            
+            # Verify runtime resolution was called instead of direct agent.chat
+            mock_execute.assert_called_once()
+            args = mock_execute.call_args[0]
+            assert args[0] == source_agent  # source_agent
+            assert "Test handoff" in args[1]  # full_prompt with context
+            assert args[3] == {}  # context kwargs
+    
+    @pytest.mark.asyncio
+    async def test_async_handoff_uses_turn_time_resolution(self):
+        """Test that async handoff uses turn-time runtime resolution."""
+        source_agent = MockAgent("SourceAgent", "gpt-3.5-turbo") 
+        target_agent = MockAgent("TargetAgent", "claude-3-sonnet")
+        
+        handoff = Handoff(
+            agent=target_agent,
+            config=HandoffConfig(context_policy=ContextPolicy.NONE)
+        )
+        
+        # Mock the async runtime resolution
+        with patch.object(handoff, '_execute_with_runtime_resolution_async') as mock_execute_async:
+            mock_execute_async.return_value = "Async resolved response"
+            
+            # Execute async handoff
+            result = await handoff.execute_async(
+                source_agent=source_agent,
+                prompt="Test async handoff", 
+                context={}
+            )
+            
+            # Verify async runtime resolution was called
+            mock_execute_async.assert_called_once()
+            args = mock_execute_async.call_args[0]
+            assert args[0] == source_agent
+            assert "Test async handoff" in args[1]
+    
+    def test_handoff_tool_function_uses_runtime_resolution(self):
+        """Test that handoff tool function uses runtime resolution."""
+        source_agent = MockAgent("SourceAgent", "gpt-4")
+        target_agent = MockAgent("TargetAgent", "gpt-4o")
+        
+        handoff = Handoff(
+            agent=target_agent,
+            config=HandoffConfig(context_policy=ContextPolicy.SUMMARY)
+        )
+        
+        # Get tool function
+        tool_func = handoff.to_tool_function(source_agent)
+        
+        # Mock the runtime resolution
+        with patch.object(handoff, '_execute_with_runtime_resolution') as mock_execute:
+            mock_execute.return_value = "Tool resolved response"
+            
+            # Execute tool function
+            result = tool_func(task="Complete this task")
+            
+            # Verify runtime resolution was called
+            mock_execute.assert_called_once()
+            args = mock_execute.call_args[0]
+            assert args[0] == source_agent
+    
+    @patch('praisonaiagents.runtime.resolve.resolve_runtime')
+    def test_runtime_resolution_with_model_override(self, mock_resolve_runtime):
+        """Test runtime resolution respects target agent's model."""
+        # Setup mock runtime
+        mock_runtime = Mock()
+        mock_runtime.execute.return_value = "Runtime response"
+        mock_runtime.provider = "openai"
+        mock_runtime.model_ref = "gpt-4o"
+        mock_resolve_runtime.return_value = mock_runtime
+        
+        source_agent = MockAgent("SourceAgent", "gpt-3.5-turbo")
+        target_agent = MockAgent("TargetAgent", "gpt-4o")
+        
+        handoff = Handoff(agent=target_agent)
+        
+        # Execute handoff runtime resolution directly
+        response = handoff._execute_with_runtime_resolution(
+            source_agent=source_agent,
+            prompt="Test prompt",
+            effective_tools=[],
+            context={}
+        )
+        
+        # Verify resolve_runtime was called with target agent's model
+        mock_resolve_runtime.assert_called_once()
+        args = mock_resolve_runtime.call_args[0]
+        agent_id, model_ref, session_ctx = args
+        
+        assert agent_id == target_agent.agent_id
+        assert model_ref == "gpt-4o"  # target agent's model
+        assert isinstance(session_ctx, SessionContext)
+        assert session_ctx.session_id == source_agent._session_id
+        assert session_ctx.parent_agent_id == source_agent.name
+        
+        # Verify runtime was used for execution
+        mock_runtime.execute.assert_called_once_with("Test prompt", tools=[])
+        assert response == "Runtime response"
+    
+    @patch('praisonaiagents.runtime.resolve.resolve_runtime')
+    @pytest.mark.asyncio 
+    async def test_async_runtime_resolution_with_model_override(self, mock_resolve_runtime):
+        """Test async runtime resolution respects target agent's model."""
+        # Setup mock runtime
+        mock_runtime = Mock()
+        mock_runtime.aexecute.return_value = asyncio.Future()
+        mock_runtime.aexecute.return_value.set_result("Async runtime response")
+        mock_runtime.provider = "anthropic"
+        mock_runtime.model_ref = "claude-3-sonnet"
+        mock_resolve_runtime.return_value = mock_runtime
+        
+        source_agent = MockAgent("SourceAgent", "gpt-4")
+        target_agent = MockAgent("TargetAgent", "claude-3-sonnet")
+        
+        handoff = Handoff(agent=target_agent)
+        
+        # Execute async handoff runtime resolution
+        response = await handoff._execute_with_runtime_resolution_async(
+            source_agent=source_agent,
+            prompt="Test async prompt",
+            effective_tools=[],
+            context={}
+        )
+        
+        # Verify resolve_runtime was called with target agent's model
+        mock_resolve_runtime.assert_called_once()
+        args = mock_resolve_runtime.call_args[0]
+        agent_id, model_ref, session_ctx = args
+        
+        assert model_ref == "claude-3-sonnet"  # target agent's model
+        assert session_ctx.handoff_depth > 0  # Should track handoff depth
+        
+        # Verify async runtime was used
+        mock_runtime.aexecute.assert_called_once_with("Test async prompt", tools=[])
+        assert response == "Async runtime response"
+    
+    def test_runtime_resolution_fallback_on_error(self):
+        """Test fallback to agent.chat when runtime resolution fails."""
+        source_agent = MockAgent("SourceAgent", "gpt-4")
+        target_agent = MockAgent("TargetAgent", "gpt-4o")
+        
+        handoff = Handoff(agent=target_agent)
+        
+        # Mock resolve_runtime to raise an exception
+        with patch('praisonaiagents.runtime.resolve.resolve_runtime') as mock_resolve:
+            mock_resolve.side_effect = Exception("Runtime resolution failed")
+            
+            # Execute should fallback to agent.chat
+            response = handoff._execute_with_runtime_resolution(
+                source_agent=source_agent,
+                prompt="Test fallback",
+                effective_tools=[],
+                context={}
+            )
+            
+            # Should get response from fallback (agent.chat)
+            assert "Response from TargetAgent using gpt-4o" in response
+            assert "Test fallback" in response
+    
+    @pytest.mark.asyncio
+    async def test_async_runtime_resolution_fallback(self):
+        """Test async fallback when runtime resolution fails."""
+        source_agent = MockAgent("SourceAgent", "gpt-4")
+        target_agent = MockAgent("TargetAgent", "claude-3-haiku")
+        
+        handoff = Handoff(agent=target_agent)
+        
+        # Mock resolve_runtime to raise an exception
+        with patch('praisonaiagents.runtime.resolve.resolve_runtime') as mock_resolve:
+            mock_resolve.side_effect = Exception("Async resolution failed")
+            
+            # Execute should fallback to agent async execution 
+            response = await handoff._execute_with_runtime_resolution_async(
+                source_agent=source_agent,
+                prompt="Test async fallback",
+                effective_tools=[], 
+                context={}
+            )
+            
+            # Should get response from fallback
+            assert "Response from TargetAgent using claude-3-haiku" in response
+    
+    def test_session_context_creation_in_handoff(self):
+        """Test that handoffs create proper session context."""
+        source_agent = MockAgent("SourceAgent", "gpt-4", session_id="session_123")
+        target_agent = MockAgent("TargetAgent", "gpt-4o")
+        
+        handoff = Handoff(agent=target_agent)
+        
+        # Mock to capture SessionContext
+        with patch('praisonaiagents.runtime.resolve.resolve_runtime') as mock_resolve:
+            mock_runtime = Mock()
+            mock_runtime.execute.return_value = "Test response"
+            mock_resolve.return_value = mock_runtime
+            
+            # Simulate handoff depth
+            with patch('praisonaiagents.agent.handoff._get_handoff_depth', return_value=2):
+                handoff._execute_with_runtime_resolution(
+                    source_agent=source_agent,
+                    prompt="Test",
+                    effective_tools=[],
+                    context={}
+                )
+            
+            # Verify SessionContext was created properly
+            args = mock_resolve.call_args[0]
+            session_ctx = args[2]
+            
+            assert session_ctx.session_id == "session_123"
+            assert session_ctx.parent_agent_id == "SourceAgent" 
+            assert session_ctx.handoff_depth == 2
+            assert session_ctx.timestamp > 0
+
+
+class TestConstructionVsTurnTimeRegression:
+    """
+    Regression tests for construction-time vs turn-time resolution.
+    
+    These tests specifically validate that the fix for issue #1938 works correctly.
+    """
+    
+    def test_model_change_after_handoff_creation(self):
+        """
+        Test the core regression case: model change after handoff creation.
+        
+        Before fix: handoff would use construction-time model
+        After fix: handoff should use turn-time model
+        """
+        source_agent = MockAgent("SourceAgent", "gpt-3.5-turbo")
+        target_agent = MockAgent("TargetAgent", "gpt-4")
+        
+        # Create handoff with initial target model
+        handoff = Handoff(agent=target_agent)
+        
+        # Target agent changes model (router decision, user preference, etc.)
+        target_agent.llm = "gpt-4o"
+        target_agent.model = "gpt-4o"
+        
+        # Mock runtime resolution to verify NEW model is used
+        with patch('praisonaiagents.runtime.resolve.resolve_runtime') as mock_resolve:
+            mock_runtime = Mock()
+            mock_runtime.execute.return_value = "New model response"
+            mock_resolve.return_value = mock_runtime
+            
+            # Execute handoff - should use NEW model (gpt-4o), not construction-time (gpt-4)
+            handoff._execute_with_runtime_resolution(
+                source_agent=source_agent,
+                prompt="Test with new model",
+                effective_tools=[],
+                context={}
+            )
+            
+            # Verify resolution was called with NEW model
+            args = mock_resolve.call_args[0]
+            model_ref = args[1]
+            assert model_ref == "gpt-4o"  # NEW model, not gpt-4
+    
+    def test_sub_agent_tool_respects_current_model(self):
+        """Test that as_tool() handoffs also respect turn-time model resolution."""
+        parent_agent = MockAgent("ParentAgent", "gpt-4")
+        sub_agent = MockAgent("SubAgent", "claude-3-sonnet")
+        
+        # Create sub-agent tool (as_tool() creates a Handoff internally)
+        from ..execution_mixin import ExecutionMixin
+        class TestAgent(MockAgent, ExecutionMixin):
+            pass
+        
+        sub_agent_with_mixin = TestAgent("SubAgent", "claude-3-sonnet")
+        sub_agent_tool = sub_agent_with_mixin.as_tool("Sub-agent for specialized tasks")
+        
+        # Sub-agent changes model after tool creation
+        sub_agent_with_mixin.llm = "claude-3-opus"
+        sub_agent_with_mixin.model = "claude-3-opus"
+        
+        # Mock runtime resolution 
+        with patch.object(sub_agent_tool, '_execute_with_runtime_resolution') as mock_execute:
+            mock_execute.return_value = "Sub-agent response"
+            
+            # Execute tool function
+            tool_func = sub_agent_tool.to_tool_function(parent_agent)
+            tool_func(task="Complete subtask")
+            
+            # Verify runtime resolution uses current model, not construction-time
+            mock_execute.assert_called_once()
+            # The handoff should resolve using sub_agent's current model (claude-3-opus)
+            
+    def test_multiple_handoffs_different_models(self):
+        """Test multiple handoffs with different models work correctly."""
+        source_agent = MockAgent("SourceAgent", "gpt-3.5-turbo")
+        target_a = MockAgent("TargetA", "gpt-4o") 
+        target_b = MockAgent("TargetB", "claude-3-sonnet")
+        
+        handoff_a = Handoff(agent=target_a)
+        handoff_b = Handoff(agent=target_b)
+        
+        # Mock runtime resolution
+        with patch('praisonaiagents.runtime.resolve.resolve_runtime') as mock_resolve:
+            def mock_resolver(agent_id, model_ref, session_ctx):
+                mock_runtime = Mock()
+                mock_runtime.execute.return_value = f"Response for {model_ref}"
+                mock_runtime.model_ref = model_ref
+                return mock_runtime
+            
+            mock_resolve.side_effect = mock_resolver
+            
+            # Execute both handoffs
+            response_a = handoff_a._execute_with_runtime_resolution(
+                source_agent, "Task A", [], {}
+            )
+            response_b = handoff_b._execute_with_runtime_resolution(
+                source_agent, "Task B", [], {}
+            )
+            
+            # Verify each used the correct model
+            assert "gpt-4o" in response_a
+            assert "claude-3-sonnet" in response_b
+            
+            # Verify resolve_runtime was called with correct models
+            assert mock_resolve.call_count == 2
+            call_args = mock_resolve.call_args_list
+            
+            # Extract model_refs from calls
+            models_used = {args[0][1] for args in call_args}
+            assert models_used == {"gpt-4o", "claude-3-sonnet"}
+
+
+# Run tests 
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/praisonai-agents/praisonaiagents/agent/unified_execution_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/unified_execution_mixin.py
@@ -45,38 +45,11 @@ class UnifiedExecutionMixin:
         Returns:
             The resolved CLI backend instance, or current backend if no override needed.
         """
-        try:
-            # Try to use runtime resolution to potentially override cli_backend
-            from ..runtime.resolve import resolve_runtime, SessionContext
-            import time
-            
-            # If no model change or runtime context, keep current backend
-            current_model = getattr(self, 'llm', None) or getattr(self, 'model', None)
-            if not current_model:
-                return self._cli_backend
-            
-            # Create session context
-            session_ctx = SessionContext(
-                session_id=getattr(self, '_session_id', 'default'),
-                timestamp=time.time(),
-                parent_agent_id=getattr(self, 'name', None),
-                handoff_depth=0
-            )
-            
-            # Resolve runtime to check if backend should change
-            agent_id = getattr(self, 'agent_id', getattr(self, 'name', 'unknown'))
-            runtime = resolve_runtime(agent_id, current_model, session_ctx)
-            
-            # Check if runtime indicates different backend needs
-            # This is where policy decisions would be made based on runtime.provider
-            # For now, just return current backend (extensibility point)
-            logger.debug(f"Turn-time CLI backend resolution: keeping {type(self._cli_backend).__name__} for {runtime.provider}/{runtime.model_ref}")
-            
-            return self._cli_backend
-            
-        except Exception as e:
-            logger.debug(f"CLI backend turn-time resolution failed, using construction-time backend: {e}")
-            return self._cli_backend
+        # For now, this is a placeholder for future backend override logic
+        # The runtime resolution infrastructure is in place, but the policy
+        # decisions about when to switch backends are not yet implemented
+        # Always return the current backend until override logic is implemented
+        return getattr(self, '_cli_backend', None)
 
     async def _unified_chat_impl(
         self,
@@ -151,53 +124,25 @@ class UnifiedExecutionMixin:
                     tool_choice=tool_choice
                 )
             elif hasattr(self, '_cli_backend') and self._cli_backend is not None:
-                # Apply turn-time resolution for CLI backend selection
-                resolved_backend = self._resolve_cli_backend_at_turn_time()
-                if resolved_backend != self._cli_backend:
-                    logger.debug(f"CLI backend override: {type(self._cli_backend).__name__} -> {type(resolved_backend).__name__}")
-                    # Use resolved backend for this turn
-                    original_backend = self._cli_backend
-                    self._cli_backend = resolved_backend
-                    try:
-                        return await self._chat_via_cli_backend(
-                            prompt=prompt,
-                            temperature=temperature,
-                            tools=tools,
-                            output_json=output_json,
-                            output_pydantic=output_pydantic,
-                            reasoning_steps=reasoning_steps,
-                            stream=stream,
-                            task_name=task_name,
-                            task_description=task_description,
-                            task_id=task_id,
-                            config=config,
-                            force_retrieval=force_retrieval,
-                            skip_retrieval=skip_retrieval,
-                            attachments=attachments,
-                            tool_choice=tool_choice
-                        )
-                    finally:
-                        # Restore original backend
-                        self._cli_backend = original_backend
-                else:
-                    # Legacy CLI backend with deprecation warning (emitted in Agent.__init__)
-                    return await self._chat_via_cli_backend(
-                        prompt=prompt,
-                        temperature=temperature,
-                        tools=tools,
-                        output_json=output_json,
-                        output_pydantic=output_pydantic,
-                        reasoning_steps=reasoning_steps,
-                        stream=stream,
-                        task_name=task_name,
-                        task_description=task_description,
-                        task_id=task_id,
-                        config=config,
-                        force_retrieval=force_retrieval,
-                        skip_retrieval=skip_retrieval,
-                        attachments=attachments,
-                        tool_choice=tool_choice
-                    )
+                # CLI Backend routing - delegate entire turn if configured
+                # Note: Turn-time resolution placeholder is in place for future backend switching
+                return await self._chat_via_cli_backend(
+                    prompt=prompt,
+                    temperature=temperature,
+                    tools=tools,
+                    output_json=output_json,
+                    output_pydantic=output_pydantic,
+                    reasoning_steps=reasoning_steps,
+                    stream=stream,
+                    task_name=task_name,
+                    task_description=task_description,
+                    task_id=task_id,
+                    config=config,
+                    force_retrieval=force_retrieval,
+                    skip_retrieval=skip_retrieval,
+                    attachments=attachments,
+                    tool_choice=tool_choice
+                )
             # Apply rate limiter if configured (before any LLM call)
             if hasattr(self, '_rate_limiter') and self._rate_limiter is not None:
                 await self._rate_limiter.acquire_async()

--- a/src/praisonai-agents/praisonaiagents/agent/unified_execution_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/unified_execution_mixin.py
@@ -34,6 +34,49 @@ class UnifiedExecutionMixin:
     This replaces the duplicated logic between chat/achat and execute_tool/execute_tool_async
     with a single async-first implementation plus sync bridge.
     """
+    
+    def _resolve_cli_backend_at_turn_time(self):
+        """
+        Resolve CLI backend at turn-time instead of construction time.
+        
+        This allows for runtime-specific backend selection based on model changes
+        or other runtime conditions.
+        
+        Returns:
+            The resolved CLI backend instance, or current backend if no override needed.
+        """
+        try:
+            # Try to use runtime resolution to potentially override cli_backend
+            from ..runtime.resolve import resolve_runtime, SessionContext
+            import time
+            
+            # If no model change or runtime context, keep current backend
+            current_model = getattr(self, 'llm', None) or getattr(self, 'model', None)
+            if not current_model:
+                return self._cli_backend
+            
+            # Create session context
+            session_ctx = SessionContext(
+                session_id=getattr(self, '_session_id', 'default'),
+                timestamp=time.time(),
+                parent_agent_id=getattr(self, 'name', None),
+                handoff_depth=0
+            )
+            
+            # Resolve runtime to check if backend should change
+            agent_id = getattr(self, 'agent_id', getattr(self, 'name', 'unknown'))
+            runtime = resolve_runtime(agent_id, current_model, session_ctx)
+            
+            # Check if runtime indicates different backend needs
+            # This is where policy decisions would be made based on runtime.provider
+            # For now, just return current backend (extensibility point)
+            logger.debug(f"Turn-time CLI backend resolution: keeping {type(self._cli_backend).__name__} for {runtime.provider}/{runtime.model_ref}")
+            
+            return self._cli_backend
+            
+        except Exception as e:
+            logger.debug(f"CLI backend turn-time resolution failed, using construction-time backend: {e}")
+            return self._cli_backend
 
     async def _unified_chat_impl(
         self,
@@ -108,24 +151,53 @@ class UnifiedExecutionMixin:
                     tool_choice=tool_choice
                 )
             elif hasattr(self, '_cli_backend') and self._cli_backend is not None:
-                # Legacy CLI backend with deprecation warning (emitted in Agent.__init__)
-                return await self._chat_via_cli_backend(
-                    prompt=prompt,
-                    temperature=temperature,
-                    tools=tools,
-                    output_json=output_json,
-                    output_pydantic=output_pydantic,
-                    reasoning_steps=reasoning_steps,
-                    stream=stream,
-                    task_name=task_name,
-                    task_description=task_description,
-                    task_id=task_id,
-                    config=config,
-                    force_retrieval=force_retrieval,
-                    skip_retrieval=skip_retrieval,
-                    attachments=attachments,
-                    tool_choice=tool_choice
-                )
+                # Apply turn-time resolution for CLI backend selection
+                resolved_backend = self._resolve_cli_backend_at_turn_time()
+                if resolved_backend != self._cli_backend:
+                    logger.debug(f"CLI backend override: {type(self._cli_backend).__name__} -> {type(resolved_backend).__name__}")
+                    # Use resolved backend for this turn
+                    original_backend = self._cli_backend
+                    self._cli_backend = resolved_backend
+                    try:
+                        return await self._chat_via_cli_backend(
+                            prompt=prompt,
+                            temperature=temperature,
+                            tools=tools,
+                            output_json=output_json,
+                            output_pydantic=output_pydantic,
+                            reasoning_steps=reasoning_steps,
+                            stream=stream,
+                            task_name=task_name,
+                            task_description=task_description,
+                            task_id=task_id,
+                            config=config,
+                            force_retrieval=force_retrieval,
+                            skip_retrieval=skip_retrieval,
+                            attachments=attachments,
+                            tool_choice=tool_choice
+                        )
+                    finally:
+                        # Restore original backend
+                        self._cli_backend = original_backend
+                else:
+                    # Legacy CLI backend with deprecation warning (emitted in Agent.__init__)
+                    return await self._chat_via_cli_backend(
+                        prompt=prompt,
+                        temperature=temperature,
+                        tools=tools,
+                        output_json=output_json,
+                        output_pydantic=output_pydantic,
+                        reasoning_steps=reasoning_steps,
+                        stream=stream,
+                        task_name=task_name,
+                        task_description=task_description,
+                        task_id=task_id,
+                        config=config,
+                        force_retrieval=force_retrieval,
+                        skip_retrieval=skip_retrieval,
+                        attachments=attachments,
+                        tool_choice=tool_choice
+                    )
             # Apply rate limiter if configured (before any LLM call)
             if hasattr(self, '_rate_limiter') and self._rate_limiter is not None:
                 await self._rate_limiter.acquire_async()

--- a/src/praisonai-agents/praisonaiagents/runtime/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/__init__.py
@@ -12,6 +12,7 @@ Key Components:
 - Doctor migration protocol: DoctorContractProtocol for config migration
 - Capability validation: RuntimeCapability, RuntimeCapabilityMatrix, validate_capabilities
 - Runtime protocols: AgentRuntimeProtocol for capability reporting
+- Turn-time runtime resolution for handoffs and sub-agents
 
 Features:
 - Turn-based runtime execution with PreparedTurnContext
@@ -19,6 +20,7 @@ Features:
 - RuntimeCapabilityMatrix for runtime capability sets
 - Capability validation at runtime selection time
 - Support for native, plugin harness, and managed runtimes
+- Dynamic runtime resolution at handoff boundaries
 """
 
 from .._lazy import create_lazy_getattr_with_groups
@@ -57,7 +59,13 @@ __all__ = [
     'RuntimeRegistry',
     'register_runtime',
     'list_runtimes', 
+    # Turn-time runtime resolution for handoffs
     'resolve_runtime',
+    'RuntimeProtocol',
+    'SessionContext',
+    'get_runtime_cache',
+    'clear_runtime_cache',
+    'set_global_resolver',
     # Doctor migration protocol
     "DoctorContractProtocol",
     "Finding",
@@ -119,7 +127,14 @@ _LAZY_GROUPS = {
         'RuntimeRegistry': ('praisonaiagents.runtime.registry', 'RuntimeRegistry'),
         'register_runtime': ('praisonaiagents.runtime.registry', 'register_runtime'),
         'list_runtimes': ('praisonaiagents.runtime.registry', 'list_runtimes'),
-        'resolve_runtime': ('praisonaiagents.runtime.registry', 'resolve_runtime'),
+    },
+    'resolve': {
+        'resolve_runtime': ('praisonaiagents.runtime.resolve', 'resolve_runtime'),
+        'RuntimeProtocol': ('praisonaiagents.runtime.resolve', 'RuntimeProtocol'),
+        'SessionContext': ('praisonaiagents.runtime.resolve', 'SessionContext'),
+        'get_runtime_cache': ('praisonaiagents.runtime.resolve', 'get_runtime_cache'),
+        'clear_runtime_cache': ('praisonaiagents.runtime.resolve', 'clear_runtime_cache'),
+        'set_global_resolver': ('praisonaiagents.runtime.resolve', 'set_global_resolver'),
     },
     'capabilities': {
         'RuntimeCapability': ('praisonaiagents.runtime.capabilities', 'RuntimeCapability'),

--- a/src/praisonai-agents/praisonaiagents/runtime/resolve.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/resolve.py
@@ -1,0 +1,365 @@
+"""
+Turn-time runtime resolution API for handoffs and sub-agents.
+
+This module addresses the issue where handoffs and sub-agents inherit
+construction-time runtime pins from the parent agent, causing wrong
+harness execution when the delegate uses a different model_ref or provider.
+
+The solution provides turn-time resolution that re-resolves runtime
+from (agent_id, model_ref) at each handoff/sub-agent invocation.
+"""
+
+import logging
+import threading
+import time
+import weakref
+from typing import Any, Dict, Optional, Protocol, Tuple, Union
+from dataclasses import dataclass
+from abc import ABC, abstractmethod
+
+logger = logging.getLogger(__name__)
+
+class RuntimeProtocol(Protocol):
+    """Protocol for agent runtime implementations."""
+    
+    def execute(self, prompt: str, **kwargs) -> Any:
+        """Execute a prompt with the runtime."""
+        ...
+    
+    async def aexecute(self, prompt: str, **kwargs) -> Any:
+        """Async execute a prompt with the runtime."""
+        ...
+    
+    @property
+    def model_ref(self) -> str:
+        """Get the model reference for this runtime."""
+        ...
+    
+    @property
+    def provider(self) -> str:
+        """Get the provider for this runtime."""
+        ...
+
+class AgentRuntimeProtocol(RuntimeProtocol):
+    """Extended protocol for agent-specific runtime features."""
+    
+    @property
+    def supports_streaming(self) -> bool:
+        """Whether this runtime supports streaming responses."""
+        ...
+    
+    @property
+    def supports_tools(self) -> bool:
+        """Whether this runtime supports tool calling."""
+        ...
+
+@dataclass
+class SessionContext:
+    """Context for runtime resolution within a session."""
+    session_id: str
+    timestamp: float
+    parent_agent_id: Optional[str] = None
+    handoff_depth: int = 0
+    
+    def __post_init__(self):
+        if self.timestamp <= 0:
+            self.timestamp = time.time()
+
+class RuntimeResolver(ABC):
+    """Abstract base class for runtime resolution strategies."""
+    
+    @abstractmethod
+    def resolve(
+        self, 
+        agent_id: str, 
+        model_ref: str, 
+        session_ctx: SessionContext
+    ) -> AgentRuntimeProtocol:
+        """Resolve runtime for the given agent and model."""
+        ...
+    
+    @abstractmethod
+    def supports_model(self, model_ref: str) -> bool:
+        """Check if this resolver can handle the given model."""
+        ...
+
+class DefaultRuntimeResolver(RuntimeResolver):
+    """Default runtime resolver that creates appropriate runtime instances."""
+    
+    def __init__(self):
+        self._model_mapping = {
+            # OpenAI models
+            'gpt-4o': 'openai',
+            'gpt-4o-mini': 'openai', 
+            'gpt-4': 'openai',
+            'gpt-3.5-turbo': 'openai',
+            # Anthropic models
+            'claude-3-sonnet': 'anthropic',
+            'claude-3-haiku': 'anthropic',
+            'claude-3-opus': 'anthropic',
+            # Add more mappings as needed
+        }
+    
+    def supports_model(self, model_ref: str) -> bool:
+        """Check if we can resolve this model."""
+        return model_ref in self._model_mapping or model_ref.startswith(('gpt-', 'claude-'))
+    
+    def resolve(
+        self, 
+        agent_id: str, 
+        model_ref: str, 
+        session_ctx: SessionContext
+    ) -> AgentRuntimeProtocol:
+        """Resolve runtime based on model reference."""
+        try:
+            # Try to import and use the existing LLM class
+            from ..llm.llm import LLM
+            
+            # Create a runtime wrapper around the LLM
+            return LLMRuntimeWrapper(
+                llm=LLM(model=model_ref),
+                model_ref=model_ref,
+                agent_id=agent_id
+            )
+        except ImportError:
+            # Fallback to a basic implementation
+            logger.warning(f"LLM class not available, using fallback runtime for {model_ref}")
+            return FallbackRuntime(model_ref=model_ref, agent_id=agent_id)
+
+class LLMRuntimeWrapper(AgentRuntimeProtocol):
+    """Wrapper around existing LLM class to provide runtime protocol."""
+    
+    def __init__(self, llm: Any, model_ref: str, agent_id: str):
+        self.llm = llm
+        self._model_ref = model_ref
+        self._agent_id = agent_id
+    
+    def execute(self, prompt: str, **kwargs) -> Any:
+        """Execute prompt using the LLM."""
+        return self.llm.chat(prompt, **kwargs)
+    
+    async def aexecute(self, prompt: str, **kwargs) -> Any:
+        """Async execute prompt using the LLM."""
+        if hasattr(self.llm, 'achat'):
+            return await self.llm.achat(prompt, **kwargs)
+        else:
+            # Run sync version in executor
+            import asyncio
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, lambda: self.llm.chat(prompt, **kwargs))
+    
+    @property
+    def model_ref(self) -> str:
+        return self._model_ref
+    
+    @property
+    def provider(self) -> str:
+        # Extract provider from model_ref or LLM instance
+        if hasattr(self.llm, 'provider'):
+            return self.llm.provider
+        elif self._model_ref.startswith('gpt-'):
+            return 'openai'
+        elif self._model_ref.startswith('claude-'):
+            return 'anthropic'
+        else:
+            return 'unknown'
+    
+    @property
+    def supports_streaming(self) -> bool:
+        return hasattr(self.llm, 'stream') or hasattr(self.llm, '_stream_chat')
+    
+    @property
+    def supports_tools(self) -> bool:
+        return True  # Most modern LLMs support tools
+
+class FallbackRuntime(AgentRuntimeProtocol):
+    """Fallback runtime implementation."""
+    
+    def __init__(self, model_ref: str, agent_id: str):
+        self._model_ref = model_ref
+        self._agent_id = agent_id
+    
+    def execute(self, prompt: str, **kwargs) -> Any:
+        return f"Fallback runtime response for: {prompt}"
+    
+    async def aexecute(self, prompt: str, **kwargs) -> Any:
+        return f"Fallback runtime async response for: {prompt}"
+    
+    @property
+    def model_ref(self) -> str:
+        return self._model_ref
+    
+    @property
+    def provider(self) -> str:
+        return 'fallback'
+    
+    @property
+    def supports_streaming(self) -> bool:
+        return False
+    
+    @property
+    def supports_tools(self) -> bool:
+        return False
+
+# Global runtime cache - thread-safe and request-scoped
+_runtime_cache_lock = threading.RLock()
+_runtime_cache: Dict[str, Dict[str, Tuple[AgentRuntimeProtocol, float]]] = {}
+_cache_ttl_seconds = 300  # 5 minutes
+_global_resolver: Optional[RuntimeResolver] = None
+
+def set_global_resolver(resolver: RuntimeResolver) -> None:
+    """Set the global runtime resolver."""
+    global _global_resolver
+    _global_resolver = resolver
+
+def get_global_resolver() -> RuntimeResolver:
+    """Get the global runtime resolver, creating default if needed."""
+    global _global_resolver
+    if _global_resolver is None:
+        _global_resolver = DefaultRuntimeResolver()
+    return _global_resolver
+
+def resolve_runtime(
+    agent_id: str, 
+    model_ref: str, 
+    session_ctx: SessionContext
+) -> AgentRuntimeProtocol:
+    """
+    Resolve runtime for the given agent and model at turn-time.
+    
+    This is the main API that handoffs and sub-agent invocations should call
+    to get the appropriate runtime instead of using construction-time pins.
+    
+    Args:
+        agent_id: Unique identifier for the agent
+        model_ref: Model reference (e.g., 'gpt-4o', 'claude-3-sonnet')  
+        session_ctx: Session context for caching and tracking
+        
+    Returns:
+        AgentRuntimeProtocol instance configured for the model
+        
+    Raises:
+        RuntimeError: If no suitable runtime can be resolved
+        
+    Example:
+        ```python
+        session_ctx = SessionContext(
+            session_id="session_123",
+            timestamp=time.time(),
+            handoff_depth=1
+        )
+        runtime = resolve_runtime("agent_1", "gpt-4o", session_ctx)
+        response = runtime.execute("Hello, world!")
+        ```
+    """
+    cache_key = f"{session_ctx.session_id}:{agent_id}:{model_ref}"
+    current_time = time.time()
+    
+    # Check cache first
+    with _runtime_cache_lock:
+        session_cache = _runtime_cache.get(session_ctx.session_id, {})
+        
+        if cache_key in session_cache:
+            runtime, cached_time = session_cache[cache_key]
+            # Check if cache entry is still valid
+            if current_time - cached_time < _cache_ttl_seconds:
+                logger.debug(f"Using cached runtime for {cache_key}")
+                return runtime
+            else:
+                # Remove expired entry
+                del session_cache[cache_key]
+                logger.debug(f"Cache expired for {cache_key}")
+    
+    # Resolve new runtime
+    logger.info(f"Resolving runtime for agent_id={agent_id}, model_ref={model_ref}")
+    
+    resolver = get_global_resolver()
+    if not resolver.supports_model(model_ref):
+        raise RuntimeError(f"No runtime resolver available for model: {model_ref}")
+    
+    try:
+        runtime = resolver.resolve(agent_id, model_ref, session_ctx)
+        
+        # Cache the resolved runtime
+        with _runtime_cache_lock:
+            if session_ctx.session_id not in _runtime_cache:
+                _runtime_cache[session_ctx.session_id] = {}
+            _runtime_cache[session_ctx.session_id][cache_key] = (runtime, current_time)
+            
+        logger.info(f"Successfully resolved runtime for {cache_key}")
+        return runtime
+        
+    except Exception as e:
+        logger.error(f"Failed to resolve runtime for {cache_key}: {e}")
+        raise RuntimeError(f"Runtime resolution failed for model {model_ref}: {e}") from e
+
+def get_runtime_cache() -> Dict[str, Dict[str, Tuple[AgentRuntimeProtocol, float]]]:
+    """Get a copy of the current runtime cache (for debugging/testing)."""
+    with _runtime_cache_lock:
+        return {
+            session_id: {
+                key: (runtime, timestamp) 
+                for key, (runtime, timestamp) in cache.items()
+            }
+            for session_id, cache in _runtime_cache.items()
+        }
+
+def clear_runtime_cache(session_id: Optional[str] = None) -> None:
+    """
+    Clear runtime cache for a specific session or all sessions.
+    
+    Args:
+        session_id: If provided, only clear cache for this session.
+                   If None, clear all cached runtimes.
+    """
+    with _runtime_cache_lock:
+        if session_id is None:
+            _runtime_cache.clear()
+            logger.info("Cleared all runtime cache")
+        elif session_id in _runtime_cache:
+            del _runtime_cache[session_id]
+            logger.info(f"Cleared runtime cache for session: {session_id}")
+
+def _cleanup_expired_cache() -> None:
+    """Clean up expired cache entries (called periodically)."""
+    current_time = time.time()
+    
+    with _runtime_cache_lock:
+        for session_id, session_cache in list(_runtime_cache.items()):
+            expired_keys = []
+            for key, (runtime, cached_time) in session_cache.items():
+                if current_time - cached_time >= _cache_ttl_seconds:
+                    expired_keys.append(key)
+            
+            for key in expired_keys:
+                del session_cache[key]
+            
+            # Remove empty session caches
+            if not session_cache:
+                del _runtime_cache[session_id]
+    
+    if expired_keys:
+        logger.debug(f"Cleaned up {len(expired_keys)} expired runtime cache entries")
+
+# Background cleanup (optional - only if needed)
+_cleanup_thread = None
+_cleanup_interval = 600  # 10 minutes
+
+def _start_cleanup_thread():
+    """Start background cache cleanup thread."""
+    global _cleanup_thread
+    if _cleanup_thread is None or not _cleanup_thread.is_alive():
+        def cleanup_worker():
+            while True:
+                try:
+                    time.sleep(_cleanup_interval)
+                    _cleanup_expired_cache()
+                except Exception as e:
+                    logger.error(f"Cache cleanup error: {e}")
+        
+        _cleanup_thread = threading.Thread(target=cleanup_worker, daemon=True)
+        _cleanup_thread.start()
+        logger.debug("Started runtime cache cleanup thread")
+
+# Initialize cleanup thread when module is imported
+_start_cleanup_thread()

--- a/src/praisonai-agents/praisonaiagents/runtime/resolve.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/resolve.py
@@ -12,7 +12,6 @@ from (agent_id, model_ref) at each handoff/sub-agent invocation.
 import logging
 import threading
 import time
-import weakref
 from typing import Any, Dict, Optional, Protocol, Tuple, Union
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
@@ -73,7 +72,8 @@ class RuntimeResolver(ABC):
         self, 
         agent_id: str, 
         model_ref: str, 
-        session_ctx: SessionContext
+        session_ctx: SessionContext,
+        **kwargs
     ) -> AgentRuntimeProtocol:
         """Resolve runtime for the given agent and model."""
         ...
@@ -108,7 +108,8 @@ class DefaultRuntimeResolver(RuntimeResolver):
         self, 
         agent_id: str, 
         model_ref: str, 
-        session_ctx: SessionContext
+        session_ctx: SessionContext,
+        **kwargs
     ) -> AgentRuntimeProtocol:
         """Resolve runtime based on model reference."""
         try:
@@ -116,8 +117,11 @@ class DefaultRuntimeResolver(RuntimeResolver):
             from ..llm.llm import LLM
             
             # Create a runtime wrapper around the LLM
+            # Pass through any configuration kwargs
+            llm_kwargs = {'model': model_ref}
+            llm_kwargs.update(kwargs)
             return LLMRuntimeWrapper(
-                llm=LLM(model=model_ref),
+                llm=LLM(**llm_kwargs),
                 model_ref=model_ref,
                 agent_id=agent_id
             )
@@ -173,17 +177,23 @@ class LLMRuntimeWrapper(AgentRuntimeProtocol):
         return True  # Most modern LLMs support tools
 
 class FallbackRuntime(AgentRuntimeProtocol):
-    """Fallback runtime implementation."""
+    """Fallback runtime implementation that raises errors instead of returning stubs."""
     
     def __init__(self, model_ref: str, agent_id: str):
         self._model_ref = model_ref
         self._agent_id = agent_id
     
     def execute(self, prompt: str, **kwargs) -> Any:
-        return f"Fallback runtime response for: {prompt}"
+        raise RuntimeError(
+            f"No LLM runtime available for model {self._model_ref}. "
+            "Please ensure the LLM module is properly installed."
+        )
     
     async def aexecute(self, prompt: str, **kwargs) -> Any:
-        return f"Fallback runtime async response for: {prompt}"
+        raise RuntimeError(
+            f"No LLM runtime available for model {self._model_ref}. "
+            "Please ensure the LLM module is properly installed."
+        )
     
     @property
     def model_ref(self) -> str:
@@ -222,7 +232,8 @@ def get_global_resolver() -> RuntimeResolver:
 def resolve_runtime(
     agent_id: str, 
     model_ref: str, 
-    session_ctx: SessionContext
+    session_ctx: SessionContext,
+    **kwargs
 ) -> AgentRuntimeProtocol:
     """
     Resolve runtime for the given agent and model at turn-time.
@@ -278,7 +289,7 @@ def resolve_runtime(
         raise RuntimeError(f"No runtime resolver available for model: {model_ref}")
     
     try:
-        runtime = resolver.resolve(agent_id, model_ref, session_ctx)
+        runtime = resolver.resolve(agent_id, model_ref, session_ctx, **kwargs)
         
         # Cache the resolved runtime
         with _runtime_cache_lock:
@@ -323,6 +334,7 @@ def clear_runtime_cache(session_id: Optional[str] = None) -> None:
 def _cleanup_expired_cache() -> None:
     """Clean up expired cache entries (called periodically)."""
     current_time = time.time()
+    total_expired = 0
     
     with _runtime_cache_lock:
         for session_id, session_cache in list(_runtime_cache.items()):
@@ -333,13 +345,14 @@ def _cleanup_expired_cache() -> None:
             
             for key in expired_keys:
                 del session_cache[key]
+            total_expired += len(expired_keys)
             
             # Remove empty session caches
             if not session_cache:
                 del _runtime_cache[session_id]
     
-    if expired_keys:
-        logger.debug(f"Cleaned up {len(expired_keys)} expired runtime cache entries")
+    if total_expired:
+        logger.debug(f"Cleaned up {total_expired} expired runtime cache entries")
 
 # Background cleanup (optional - only if needed)
 _cleanup_thread = None

--- a/src/praisonai-agents/praisonaiagents/runtime/test_resolve.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/test_resolve.py
@@ -1,0 +1,482 @@
+"""
+Unit tests for turn-time runtime resolution functionality.
+
+This test suite validates the core functionality described in issue #1938:
+- Turn-time runtime resolution for handoffs and sub-agents
+- Proper cache behavior and session isolation
+- Fallback mechanisms when resolution fails
+- Construction-time vs turn-time resolution differences
+"""
+
+import pytest
+import time
+import asyncio
+from unittest.mock import Mock, patch, MagicMock
+from typing import Any, Dict
+
+from ..resolve import (
+    resolve_runtime, 
+    SessionContext,
+    RuntimeProtocol,
+    AgentRuntimeProtocol,
+    DefaultRuntimeResolver,
+    LLMRuntimeWrapper,
+    FallbackRuntime,
+    get_runtime_cache,
+    clear_runtime_cache,
+    set_global_resolver
+)
+
+
+class TestSessionContext:
+    """Test SessionContext creation and validation."""
+    
+    def test_session_context_creation(self):
+        """Test basic SessionContext creation."""
+        session_ctx = SessionContext(
+            session_id="test_session",
+            timestamp=1234567890.0,
+            parent_agent_id="parent_agent",
+            handoff_depth=2
+        )
+        
+        assert session_ctx.session_id == "test_session"
+        assert session_ctx.timestamp == 1234567890.0
+        assert session_ctx.parent_agent_id == "parent_agent"
+        assert session_ctx.handoff_depth == 2
+    
+    def test_session_context_auto_timestamp(self):
+        """Test automatic timestamp generation."""
+        before = time.time()
+        session_ctx = SessionContext(
+            session_id="test_session",
+            timestamp=0  # Should be auto-set
+        )
+        after = time.time()
+        
+        assert before <= session_ctx.timestamp <= after
+
+
+class TestRuntimeResolvers:
+    """Test runtime resolver implementations."""
+    
+    def test_default_resolver_supports_model(self):
+        """Test DefaultRuntimeResolver model support detection."""
+        resolver = DefaultRuntimeResolver()
+        
+        # Test supported models
+        assert resolver.supports_model("gpt-4o")
+        assert resolver.supports_model("claude-3-sonnet")
+        assert resolver.supports_model("gpt-3.5-turbo")
+        
+        # Test unsupported models
+        assert not resolver.supports_model("unknown-model")
+        assert not resolver.supports_model("invalid")
+    
+    @patch('praisonaiagents.runtime.resolve.LLM')
+    def test_default_resolver_with_llm(self, mock_llm_class):
+        """Test DefaultRuntimeResolver when LLM class is available."""
+        mock_llm = Mock()
+        mock_llm_class.return_value = mock_llm
+        
+        resolver = DefaultRuntimeResolver()
+        session_ctx = SessionContext(session_id="test", timestamp=time.time())
+        
+        runtime = resolver.resolve("agent1", "gpt-4o", session_ctx)
+        
+        assert isinstance(runtime, LLMRuntimeWrapper)
+        assert runtime.model_ref == "gpt-4o"
+        mock_llm_class.assert_called_once_with(model="gpt-4o")
+    
+    @patch('praisonaiagents.runtime.resolve.LLM', side_effect=ImportError("LLM not available"))
+    def test_default_resolver_fallback(self, mock_llm_class):
+        """Test DefaultRuntimeResolver fallback when LLM is not available."""
+        resolver = DefaultRuntimeResolver()
+        session_ctx = SessionContext(session_id="test", timestamp=time.time())
+        
+        runtime = resolver.resolve("agent1", "gpt-4o", session_ctx)
+        
+        assert isinstance(runtime, FallbackRuntime)
+        assert runtime.model_ref == "gpt-4o"
+        assert runtime.provider == "fallback"
+
+
+class TestRuntimeWrappers:
+    """Test runtime wrapper implementations."""
+    
+    def test_llm_runtime_wrapper(self):
+        """Test LLMRuntimeWrapper functionality."""
+        mock_llm = Mock()
+        mock_llm.chat.return_value = "Hello response"
+        
+        wrapper = LLMRuntimeWrapper(
+            llm=mock_llm,
+            model_ref="gpt-4o", 
+            agent_id="test_agent"
+        )
+        
+        assert wrapper.model_ref == "gpt-4o"
+        assert wrapper.provider == "openai"  # inferred from model name
+        assert wrapper.supports_streaming == hasattr(mock_llm, 'stream')
+        assert wrapper.supports_tools == True
+        
+        # Test sync execution
+        result = wrapper.execute("Hello", temperature=0.7)
+        assert result == "Hello response"
+        mock_llm.chat.assert_called_once_with("Hello", temperature=0.7)
+    
+    @pytest.mark.asyncio
+    async def test_llm_runtime_wrapper_async(self):
+        """Test LLMRuntimeWrapper async functionality."""
+        mock_llm = Mock()
+        mock_llm.achat = Mock(return_value=asyncio.Future())
+        mock_llm.achat.return_value.set_result("Async response")
+        
+        wrapper = LLMRuntimeWrapper(
+            llm=mock_llm,
+            model_ref="claude-3-sonnet",
+            agent_id="test_agent" 
+        )
+        
+        assert wrapper.provider == "anthropic"  # inferred from model name
+        
+        # Test async execution
+        result = await wrapper.aexecute("Hello async", temperature=0.5)
+        assert result == "Async response"
+        mock_llm.achat.assert_called_once_with("Hello async", temperature=0.5)
+    
+    @pytest.mark.asyncio  
+    async def test_llm_runtime_wrapper_async_fallback(self):
+        """Test LLMRuntimeWrapper async fallback to sync execution."""
+        mock_llm = Mock()
+        mock_llm.chat.return_value = "Sync response"
+        # No achat method - should fall back to sync in executor
+        
+        wrapper = LLMRuntimeWrapper(
+            llm=mock_llm,
+            model_ref="gpt-4",
+            agent_id="test_agent"
+        )
+        
+        result = await wrapper.aexecute("Hello", param="value")
+        assert result == "Sync response"
+        mock_llm.chat.assert_called_once_with("Hello", param="value")
+    
+    def test_fallback_runtime(self):
+        """Test FallbackRuntime implementation."""
+        runtime = FallbackRuntime(model_ref="unknown-model", agent_id="test_agent")
+        
+        assert runtime.model_ref == "unknown-model"
+        assert runtime.provider == "fallback"
+        assert runtime.supports_streaming == False
+        assert runtime.supports_tools == False
+        
+        result = runtime.execute("Test prompt")
+        assert "Fallback runtime response for: Test prompt" in result
+    
+    @pytest.mark.asyncio
+    async def test_fallback_runtime_async(self):
+        """Test FallbackRuntime async implementation."""
+        runtime = FallbackRuntime(model_ref="unknown-model", agent_id="test_agent")
+        
+        result = await runtime.aexecute("Test async prompt")
+        assert "Fallback runtime async response for: Test async prompt" in result
+
+
+class TestRuntimeResolution:
+    """Test core runtime resolution functionality."""
+    
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_runtime_cache()
+    
+    def teardown_method(self):
+        """Clear cache after each test."""
+        clear_runtime_cache()
+    
+    @patch('praisonaiagents.runtime.resolve.get_global_resolver')
+    def test_resolve_runtime_success(self, mock_get_resolver):
+        """Test successful runtime resolution."""
+        # Setup mock resolver
+        mock_runtime = Mock(spec=AgentRuntimeProtocol)
+        mock_runtime.model_ref = "gpt-4o"
+        mock_runtime.provider = "openai"
+        
+        mock_resolver = Mock()
+        mock_resolver.supports_model.return_value = True
+        mock_resolver.resolve.return_value = mock_runtime
+        mock_get_resolver.return_value = mock_resolver
+        
+        # Test resolution
+        session_ctx = SessionContext(session_id="test_session", timestamp=time.time())
+        result = resolve_runtime("agent1", "gpt-4o", session_ctx)
+        
+        assert result == mock_runtime
+        mock_resolver.supports_model.assert_called_once_with("gpt-4o")
+        mock_resolver.resolve.assert_called_once_with("agent1", "gpt-4o", session_ctx)
+    
+    @patch('praisonaiagents.runtime.resolve.get_global_resolver')
+    def test_resolve_runtime_unsupported_model(self, mock_get_resolver):
+        """Test runtime resolution with unsupported model."""
+        mock_resolver = Mock()
+        mock_resolver.supports_model.return_value = False
+        mock_get_resolver.return_value = mock_resolver
+        
+        session_ctx = SessionContext(session_id="test_session", timestamp=time.time())
+        
+        with pytest.raises(RuntimeError, match="No runtime resolver available for model: unsupported-model"):
+            resolve_runtime("agent1", "unsupported-model", session_ctx)
+    
+    @patch('praisonaiagents.runtime.resolve.get_global_resolver')
+    def test_resolve_runtime_resolver_failure(self, mock_get_resolver):
+        """Test runtime resolution when resolver fails.""" 
+        mock_resolver = Mock()
+        mock_resolver.supports_model.return_value = True
+        mock_resolver.resolve.side_effect = Exception("Resolver failed")
+        mock_get_resolver.return_value = mock_resolver
+        
+        session_ctx = SessionContext(session_id="test_session", timestamp=time.time())
+        
+        with pytest.raises(RuntimeError, match="Runtime resolution failed for model gpt-4o: Resolver failed"):
+            resolve_runtime("agent1", "gpt-4o", session_ctx)
+
+
+class TestRuntimeCaching:
+    """Test runtime caching behavior."""
+    
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_runtime_cache()
+    
+    def teardown_method(self):
+        """Clear cache after each test."""
+        clear_runtime_cache()
+    
+    @patch('praisonaiagents.runtime.resolve.get_global_resolver')  
+    def test_runtime_caching(self, mock_get_resolver):
+        """Test that runtime resolution results are cached."""
+        mock_runtime = Mock(spec=AgentRuntimeProtocol)
+        mock_resolver = Mock()
+        mock_resolver.supports_model.return_value = True
+        mock_resolver.resolve.return_value = mock_runtime
+        mock_get_resolver.return_value = mock_resolver
+        
+        session_ctx = SessionContext(session_id="cache_test", timestamp=time.time())
+        
+        # First call should resolve
+        result1 = resolve_runtime("agent1", "gpt-4o", session_ctx)
+        assert result1 == mock_runtime
+        assert mock_resolver.resolve.call_count == 1
+        
+        # Second call should use cache  
+        result2 = resolve_runtime("agent1", "gpt-4o", session_ctx)
+        assert result2 == mock_runtime
+        assert mock_resolver.resolve.call_count == 1  # No additional calls
+    
+    @patch('praisonaiagents.runtime.resolve.get_global_resolver')
+    @patch('praisonaiagents.runtime.resolve._cache_ttl_seconds', 0.1)  # Short TTL for testing
+    def test_cache_expiration(self, mock_get_resolver):
+        """Test that cache entries expire after TTL."""
+        mock_runtime = Mock(spec=AgentRuntimeProtocol)
+        mock_resolver = Mock()
+        mock_resolver.supports_model.return_value = True  
+        mock_resolver.resolve.return_value = mock_runtime
+        mock_get_resolver.return_value = mock_resolver
+        
+        session_ctx = SessionContext(session_id="expire_test", timestamp=time.time())
+        
+        # First call
+        resolve_runtime("agent1", "gpt-4o", session_ctx)
+        assert mock_resolver.resolve.call_count == 1
+        
+        # Wait for cache to expire
+        time.sleep(0.2)
+        
+        # Second call after expiration should resolve again
+        resolve_runtime("agent1", "gpt-4o", session_ctx)
+        assert mock_resolver.resolve.call_count == 2
+    
+    def test_cache_session_isolation(self):
+        """Test that cache is isolated between sessions."""
+        # This test uses the real resolver since we're testing isolation
+        session_ctx1 = SessionContext(session_id="session1", timestamp=time.time())
+        session_ctx2 = SessionContext(session_id="session2", timestamp=time.time())
+        
+        # Cache for session1
+        runtime1 = resolve_runtime("agent1", "gpt-4o", session_ctx1) 
+        
+        # Cache for session2 should be separate
+        runtime2 = resolve_runtime("agent1", "gpt-4o", session_ctx2)
+        
+        # Should be different instances due to separate sessions
+        cache = get_runtime_cache()
+        assert "session1" in cache
+        assert "session2" in cache
+        assert len(cache["session1"]) == 1
+        assert len(cache["session2"]) == 1
+    
+    def test_clear_cache_all(self):
+        """Test clearing all cache.""" 
+        session_ctx1 = SessionContext(session_id="session1", timestamp=time.time())
+        session_ctx2 = SessionContext(session_id="session2", timestamp=time.time())
+        
+        # Add entries to cache
+        resolve_runtime("agent1", "gpt-4o", session_ctx1)
+        resolve_runtime("agent1", "gpt-4o", session_ctx2)
+        
+        cache = get_runtime_cache()
+        assert len(cache) == 2
+        
+        # Clear all cache
+        clear_runtime_cache()
+        
+        cache = get_runtime_cache()
+        assert len(cache) == 0
+    
+    def test_clear_cache_specific_session(self):
+        """Test clearing cache for specific session."""
+        session_ctx1 = SessionContext(session_id="session1", timestamp=time.time())
+        session_ctx2 = SessionContext(session_id="session2", timestamp=time.time())
+        
+        # Add entries to cache
+        resolve_runtime("agent1", "gpt-4o", session_ctx1)
+        resolve_runtime("agent1", "gpt-4o", session_ctx2)
+        
+        cache = get_runtime_cache()
+        assert len(cache) == 2
+        
+        # Clear specific session
+        clear_runtime_cache("session1")
+        
+        cache = get_runtime_cache()
+        assert len(cache) == 1
+        assert "session2" in cache
+        assert "session1" not in cache
+
+
+class TestConstructionTimeVsTurnTime:
+    """
+    Test the difference between construction-time and turn-time resolution.
+    
+    This validates the core issue addressed by #1938 - ensuring that handoffs
+    and sub-agents don't inherit construction-time runtime pins.
+    """
+    
+    def test_construction_time_pin_problem(self):
+        """
+        Test demonstrates the problem: construction-time pins don't adapt to model changes.
+        
+        This test simulates the issue where an agent is constructed with one model
+        but then switches models, yet handoffs still use the construction-time model.
+        """
+        # Simulate construction-time behavior (before fix)
+        construction_time_model = "gpt-3.5-turbo"
+        session_ctx = SessionContext(session_id="construction_test", timestamp=time.time())
+        
+        # Agent constructed with initial model
+        construction_runtime = resolve_runtime("agent1", construction_time_model, session_ctx)
+        
+        # Agent model changes at runtime (router decision, user preference, etc.)
+        runtime_model = "gpt-4o"
+        
+        # Turn-time resolution should use the NEW model, not construction-time pin
+        turn_time_runtime = resolve_runtime("agent1", runtime_model, session_ctx)
+        
+        # The runtimes should be different (addressing the core issue)
+        assert construction_runtime.model_ref == "gpt-3.5-turbo"
+        assert turn_time_runtime.model_ref == "gpt-4o"
+        assert construction_runtime.model_ref != turn_time_runtime.model_ref
+    
+    def test_turn_time_model_switching(self):
+        """Test that turn-time resolution properly handles model switching."""
+        session_ctx = SessionContext(session_id="model_switch_test", timestamp=time.time())
+        
+        # First call with model A
+        runtime_a = resolve_runtime("agent1", "gpt-4o", session_ctx)
+        assert runtime_a.model_ref == "gpt-4o"
+        
+        # Second call with model B (should get different runtime)  
+        runtime_b = resolve_runtime("agent1", "claude-3-sonnet", session_ctx)
+        assert runtime_b.model_ref == "claude-3-sonnet"
+        
+        # Verify they are cached separately
+        cache = get_runtime_cache()
+        session_cache = cache[session_ctx.session_id]
+        assert len(session_cache) == 2  # Two different cache entries
+        
+        # Keys should be different due to different models
+        cache_keys = list(session_cache.keys())
+        assert any("gpt-4o" in key for key in cache_keys)
+        assert any("claude-3-sonnet" in key for key in cache_keys)
+
+
+# Integration test with handoff simulation
+class MockAgent:
+    """Mock agent for testing handoff scenarios."""
+    
+    def __init__(self, name, model="gpt-4o", agent_id=None):
+        self.name = name
+        self.llm = model
+        self.model = model
+        self.agent_id = agent_id or name
+        self._session_id = "test_session"
+    
+    def chat(self, prompt, **kwargs):
+        return f"Response from {self.name} using {self.model}: {prompt}"
+
+
+class TestHandoffIntegration:
+    """Test integration with handoff scenarios."""
+    
+    def test_handoff_runtime_resolution_simulation(self):
+        """
+        Simulate handoff scenario to verify turn-time resolution.
+        
+        This test simulates the scenario described in issue #1938 where
+        a handoff should use the target agent's current model, not a
+        construction-time pin.
+        """
+        # Create source and target agents with different models
+        source_agent = MockAgent("SourceAgent", "gpt-3.5-turbo") 
+        target_agent = MockAgent("TargetAgent", "gpt-4o")
+        
+        session_ctx = SessionContext(
+            session_id="handoff_test",
+            timestamp=time.time(),
+            parent_agent_id=source_agent.name,
+            handoff_depth=1
+        )
+        
+        # Resolve runtime for target agent (simulating handoff)
+        target_runtime = resolve_runtime(
+            target_agent.agent_id,
+            target_agent.llm, 
+            session_ctx
+        )
+        
+        # Verify correct model is resolved
+        assert target_runtime.model_ref == "gpt-4o"
+        
+        # Target agent changes model mid-conversation
+        target_agent.llm = "claude-3-sonnet"
+        target_agent.model = "claude-3-sonnet"
+        
+        # New handoff should use updated model (turn-time resolution)
+        updated_runtime = resolve_runtime(
+            target_agent.agent_id,
+            target_agent.llm,
+            session_ctx
+        )
+        
+        assert updated_runtime.model_ref == "claude-3-sonnet"
+        assert updated_runtime.model_ref != target_runtime.model_ref
+        
+        # Verify cache has both entries
+        cache = get_runtime_cache()
+        session_cache = cache[session_ctx.session_id] 
+        assert len(session_cache) == 2
+
+
+# Run tests
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/praisonai-agents/praisonaiagents/runtime/test_resolve.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/test_resolve.py
@@ -14,7 +14,7 @@ import asyncio
 from unittest.mock import Mock, patch, MagicMock
 from typing import Any, Dict
 
-from ..resolve import (
+from .resolve import (
     resolve_runtime, 
     SessionContext,
     RuntimeProtocol,
@@ -73,7 +73,7 @@ class TestRuntimeResolvers:
         assert not resolver.supports_model("unknown-model")
         assert not resolver.supports_model("invalid")
     
-    @patch('praisonaiagents.runtime.resolve.LLM')
+    @patch('praisonaiagents.llm.llm.LLM')
     def test_default_resolver_with_llm(self, mock_llm_class):
         """Test DefaultRuntimeResolver when LLM class is available."""
         mock_llm = Mock()
@@ -171,16 +171,18 @@ class TestRuntimeWrappers:
         assert runtime.supports_streaming == False
         assert runtime.supports_tools == False
         
-        result = runtime.execute("Test prompt")
-        assert "Fallback runtime response for: Test prompt" in result
+        # FallbackRuntime should now raise RuntimeError instead of returning stubs
+        with pytest.raises(RuntimeError, match="No LLM runtime available"):
+            runtime.execute("Test prompt")
     
     @pytest.mark.asyncio
     async def test_fallback_runtime_async(self):
         """Test FallbackRuntime async implementation."""
         runtime = FallbackRuntime(model_ref="unknown-model", agent_id="test_agent")
         
-        result = await runtime.aexecute("Test async prompt")
-        assert "Fallback runtime async response for: Test async prompt" in result
+        # FallbackRuntime should now raise RuntimeError instead of returning stubs
+        with pytest.raises(RuntimeError, match="No LLM runtime available"):
+            await runtime.aexecute("Test async prompt")
 
 
 class TestRuntimeResolution:


### PR DESCRIPTION
Fixes #1938

Auto-opened from Claude triage branch `claude/issue-1938-20260613-0842`.

Generated during issue/PR audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Handoffs now resolve the target agent’s runtime at execution time, using the target agent’s most current model.
  * Added turn-time runtime resolution with short-lived, per-session caching, plus APIs to resolve runtimes and manage cache/global resolvers.

* **Bug Fixes**
  * If runtime resolution fails, handoff execution falls back to the legacy chat/achat behavior to keep handoffs working.

* **Tests**
  * Added coverage for sync/async/tool handoff paths, fallback behavior, caching/TTL, and dynamic model switching during an active conversation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->