### PR TITLE
fix: praisonai-platform[test] extras do not include required email-validator dependency

### DIFF
--- a/src/praisonai-platform/pyproject.toml
+++ b/src/praisonai-platform/pyproject.toml
@@ -34,6 +34,7 @@ test = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23.0",
     "httpx>=0.27.0",
+    "email-validator>=2.0.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/praisonai-platform/pyproject.toml
+++ b/src/praisonai-platform/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "uvicorn>=0.34.0",
     "httpx>=0.27.0",
     "pydantic>=2.10.0",
+    "email-validator>=2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #1584

Auto-opened from `claude/issue-1584-20260430-1208`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to include email validation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->