### PR TITLE
fix: remove duplicate Valkey client_name argument

### DIFF
--- a/src/praisonai/praisonai/persistence/_valkey_client.py
+++ b/src/praisonai/praisonai/persistence/_valkey_client.py
@@ -41,7 +41,6 @@ def create_valkey_client(
     config = GlideClientConfiguration(
         addresses=addresses,
         credentials=creds,
-        client_name="praisonai_valkey_client",
         database_id=db,
         client_name=_CLIENT_NAME,
     )


### PR DESCRIPTION
## Summary

- Remove the duplicate `client_name` keyword from the shared Valkey client factory.
- Keep the existing `_CLIENT_NAME` constant (`praisonai_persistence_client`) as the single client name for the shared persistence factory.

Closes #1979

## Why

`praisonai.persistence._valkey_client` currently cannot be imported or byte-compiled because `GlideClientConfiguration(...)` receives `client_name` twice. This blocks Valkey-backed persistence before it can reach either the optional-dependency error path or the runtime connection path.

## Test Plan

- `python3 -m py_compile src/praisonai/praisonai/persistence/_valkey_client.py`
- Factory config probe with fake Glide classes to confirm `client_name == _CLIENT_NAME == "praisonai_persistence_client"`
- `python3 -m compileall -q src/praisonai/praisonai/persistence/_valkey_client.py src/praisonai/praisonai/persistence/knowledge/valkey_vector.py src/praisonai/praisonai/persistence/state/valkey.py src/praisonai/praisonai/storage/valkey_adapter.py`
- `PYTHONPATH=src/praisonai python3 -m pytest src/praisonai/tests/unit/storage/test_valkey_backend.py::TestValkeyStorageAdapter::test_valkey_adapter_import_error -q`
- `git diff --check`

Note: broader local Valkey-focused tests currently report optional-Valkey-environment failures where glide symbols such as `VectorAlgorithm`, `DistanceMetricType`, `Batch`, and `ReturnField` are unavailable in this local environment; the import/compile regression above is fixed by this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal client configuration to use a module constant for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->