### PR TITLE
fix: cleanup wrapper architecture - framework adapter migration, dead ToolRegistry path, and duplicate storage stack

### DIFF
--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -16,7 +16,7 @@ from .version import __version__
 
 # Import new architecture components
 from .framework_adapters.base import FrameworkAdapter
-from .tool_registry import ToolRegistry
+from .framework_adapters.registry import FrameworkAdapterRegistry, get_default_registry
 
 
 def _rich_print(*args, **kwargs):
@@ -237,15 +237,9 @@ class AgentsGenerator:
         elif os.environ.get('LOGLEVEL'):
             self.logger.setLevel(getattr(logging, os.environ.get('LOGLEVEL', 'INFO').upper(), logging.INFO))
         
-        # Keep tool registry for backward compatibility with autogen adapters
-        self.tool_registry = ToolRegistry()
-        
-        # Initialize tool resolver with the registry wired in (single source of truth for tool resolution)
+        # Initialize tool resolver (single source of truth for tool resolution)
         from .tool_resolver import ToolResolver
-        self.tool_resolver = ToolResolver(registry=self.tool_registry)
-        
-        # Wire resolver back to registry for cache invalidation
-        self.tool_registry.set_resolver(self.tool_resolver)
+        self.tool_resolver = ToolResolver()
         
         # DI-friendly: tests/multi-tenant runtimes pass their own registry;
         # CLI users get the process default.
@@ -254,11 +248,6 @@ class AgentsGenerator:
         # Defer framework adapter creation until YAML is loaded
         # This fixes the issue where empty framework string fails before YAML framework is read
         self.framework_adapter = None
-        
-        # Only autogen-family adapters need the autogen tool shim
-        # Note: autogen_v2 is also part of the autogen family
-        if framework and framework in {"autogen", "autogen_v2", "autogen_v4", "ag2"}:
-            self.tool_registry.register_builtin_autogen_adapters()
 
     def _get_framework_adapter(self, framework: str) -> FrameworkAdapter:
         """

--- a/src/praisonai/praisonai/config/validator.py
+++ b/src/praisonai/praisonai/config/validator.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError
 
 from .schema import YAMLConfig, ValidationResult
 from ..tool_resolver import ToolResolver
-from ..tool_registry import ToolRegistry
 
 
 class ConfigValidator:
@@ -24,9 +23,7 @@ class ConfigValidator:
         self.tool_resolver = tool_resolver
         if not self.tool_resolver:
             # Create a default tool resolver
-            registry = ToolRegistry()
-            registry.register_builtin_autogen_adapters(_suppress_deprecation_warning=True)
-            self.tool_resolver = ToolResolver(registry=registry)
+            self.tool_resolver = ToolResolver()
     
     def validate_yaml_string(self, yaml_content: str, strict: bool = False) -> ValidationResult:
         """Validate YAML configuration from string.

--- a/src/praisonai/praisonai/storage/__init__.py
+++ b/src/praisonai/praisonai/storage/__init__.py
@@ -8,7 +8,10 @@ Heavy implementations that follow StorageBackendProtocol for:
 - DynamoDB (praisonai[dynamodb])
 - Valkey (praisonai[valkey])
 
-These implementations are kept in the wrapper to avoid bloating the core SDK.
+NOTE: ``praisonai.storage`` is a legacy parallel stack. The active persistence
+layer is ``praisonai.persistence``. New code should use ``create_state_store``,
+``create_conversation_store``, or ``create_knowledge_store`` from
+``praisonai.persistence.factory``.
 """
 
 # Lazy imports - only import when needed
@@ -21,6 +24,12 @@ __all__ = [
     "ValkeySearchBackend",
     "ValkeyBackend",
 ]
+
+# NOTE: To maintain backward compatibility with existing code that uses
+# ``from praisonai.storage import XxxStorageAdapter``, the lazy loader below
+# keeps the original file-based class definitions accessible. These are NOT
+# thin shims — the originals remain the canonical definition until eliminated.
+
 
 def __getattr__(name: str):
     """Lazy import storage adapters."""

--- a/src/praisonai/praisonai/tool_registry.py
+++ b/src/praisonai/praisonai/tool_registry.py
@@ -22,7 +22,6 @@ class ToolRegistry:
         self._functions: Dict[str, Callable] = {}
         self._lock = threading.Lock()
         self._resolvers: List[weakref.ref] = []  # Track multiple resolvers with weak refs
-        # Note: AutoGen-specific adapters moved to framework_adapters.autogen
         
     def register_function(self, name: str, func: Callable) -> None:
         """Register a function tool."""
@@ -34,64 +33,21 @@ class ToolRegistry:
         # Invalidate all resolver caches for this tool
         self._notify_invalidate(name)
     
-    def register_autogen_adapter(self, tool_type_name: str, adapter: Callable, _suppress_deprecation_warning: bool = False) -> None:
-        """Deprecated: AutoGen adapters moved to framework_adapters.autogen module."""
-        if not _suppress_deprecation_warning:
-            import warnings
-            warnings.warn(
-                "ToolRegistry.register_autogen_adapter is deprecated. "
-                "AutoGen-specific logic has been moved to framework_adapters.autogen module.",
-                DeprecationWarning,
-                stacklevel=2
-            )
-        # For backward compatibility, still store but warn
-        if not callable(adapter):
-            raise ValueError(f"AutoGen adapter for {tool_type_name} must be callable")
-        with self._lock:
-            if not hasattr(self, '_autogen_adapters'):
-                self._autogen_adapters: Dict[str, Callable] = {}
-            self._autogen_adapters[tool_type_name] = adapter
-        logger.debug(f"Registered AutoGen adapter: {tool_type_name} (deprecated)")
+
     
     def get_function(self, name: str) -> Optional[Callable]:
         """Get a function tool by name."""
         with self._lock:
             return self._functions.get(name)
     
-    def get_autogen_adapter(self, tool_type_name: str) -> Optional[Callable]:
-        """Deprecated: AutoGen adapters moved to framework_adapters.autogen module."""
-        import warnings
-        warnings.warn(
-            "ToolRegistry.get_autogen_adapter is deprecated. "
-            "AutoGen-specific logic has been moved to framework_adapters.autogen module.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        # For backward compatibility
-        if hasattr(self, '_autogen_adapters'):
-            with self._lock:
-                return self._autogen_adapters.get(tool_type_name)
-        return None
+
     
     def list_functions(self) -> List[str]:
         """List all registered function tool names."""
         with self._lock:
             return list(self._functions.keys())
     
-    def list_autogen_adapters(self) -> List[str]:
-        """Deprecated: AutoGen adapters moved to framework_adapters.autogen module."""
-        import warnings
-        warnings.warn(
-            "ToolRegistry.list_autogen_adapters is deprecated. "
-            "AutoGen-specific logic has been moved to framework_adapters.autogen module.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        # For backward compatibility
-        if hasattr(self, '_autogen_adapters'):
-            with self._lock:
-                return list(self._autogen_adapters.keys())
-        return []
+
     
     def get_functions_dict(self) -> Dict[str, Callable]:
         """Get a copy of all registered functions."""
@@ -102,8 +58,6 @@ class ToolRegistry:
         """Clear all registered tools."""
         with self._lock:
             self._functions.clear()
-            if hasattr(self, '_autogen_adapters'):
-                self._autogen_adapters.clear()
         logger.debug("Cleared tool registry")
         # Invalidate all resolver caches
         self._notify_invalidate()
@@ -159,37 +113,12 @@ class ToolRegistry:
         logger.debug(f"Registered {len(registered)} functions from module: {registered}")
         return registered
     
-    def register_builtin_autogen_adapters(self, _suppress_deprecation_warning: bool = False) -> None:
-        """Deprecated: AutoGen adapters moved to framework_adapters.autogen module."""
-        if not _suppress_deprecation_warning:
-            import warnings
-            warnings.warn(
-                "ToolRegistry.register_builtin_autogen_adapters is deprecated. "
-                "AutoGen-specific logic has been moved to framework_adapters.autogen module.",
-                DeprecationWarning,
-                stacklevel=2
-            )
-        # For backward compatibility, attempt old logic but warn
-        try:
-            from .inbuilt_tools import _get_autogen_tools
-            tools_module = _get_autogen_tools()
-            if tools_module:
-                for attr_name in dir(tools_module):
-                    if attr_name.startswith('autogen_') and not attr_name.startswith('__'):
-                        adapter = getattr(tools_module, attr_name)
-                        if callable(adapter):
-                            tool_type_name = attr_name.replace('autogen_', '')
-                            self.register_autogen_adapter(tool_type_name, adapter, _suppress_deprecation_warning=True)
-        except ImportError as e:
-            logger.warning(f"Could not register builtin AutoGen adapters: {e}")
-        except Exception as e:
-            logger.warning(f"Error registering builtin AutoGen adapters: {e}")
+
     
     def __len__(self) -> int:
         """Return total number of registered tools."""
         with self._lock:
-            autogen_count = len(self._autogen_adapters) if hasattr(self, '_autogen_adapters') else 0
-            return len(self._functions) + autogen_count
+            return len(self._functions)
     
     def __contains__(self, name: str) -> bool:
         """Check if a tool function is registered."""

--- a/src/praisonai/praisonai/tool_registry.py
+++ b/src/praisonai/praisonai/tool_registry.py
@@ -32,23 +32,17 @@ class ToolRegistry:
         logger.debug(f"Registered function tool: {name}")
         # Invalidate all resolver caches for this tool
         self._notify_invalidate(name)
-    
 
-    
     def get_function(self, name: str) -> Optional[Callable]:
         """Get a function tool by name."""
         with self._lock:
             return self._functions.get(name)
-    
 
-    
     def list_functions(self) -> List[str]:
         """List all registered function tool names."""
         with self._lock:
             return list(self._functions.keys())
-    
 
-    
     def get_functions_dict(self) -> Dict[str, Callable]:
         """Get a copy of all registered functions."""
         with self._lock:
@@ -112,9 +106,7 @@ class ToolRegistry:
         
         logger.debug(f"Registered {len(registered)} functions from module: {registered}")
         return registered
-    
 
-    
     def __len__(self) -> int:
         """Return total number of registered tools."""
         with self._lock:

--- a/src/praisonai/tests/unit/test_tool_registry.py
+++ b/src/praisonai/tests/unit/test_tool_registry.py
@@ -23,25 +23,12 @@ class TestToolRegistryBasic:
         registry = ToolRegistry()
         assert registry.get_function("missing") is None
 
-    def test_register_and_get_autogen_adapter(self):
-        registry = ToolRegistry()
-        adapter = lambda: None
-        registry.register_autogen_adapter("MyTool", adapter)
-        assert registry.get_autogen_adapter("MyTool") is adapter
-
     def test_list_functions(self):
         registry = ToolRegistry()
         registry.register_function("a", lambda: None)
         registry.register_function("b", lambda: None)
         names = registry.list_functions()
         assert sorted(names) == ["a", "b"]
-
-    def test_list_autogen_adapters(self):
-        registry = ToolRegistry()
-        registry.register_autogen_adapter("T1", lambda: None)
-        registry.register_autogen_adapter("T2", lambda: None)
-        names = registry.list_autogen_adapters()
-        assert sorted(names) == ["T1", "T2"]
 
     def test_get_functions_dict_returns_copy(self):
         registry = ToolRegistry()
@@ -56,7 +43,7 @@ class TestToolRegistryBasic:
     def test_clear(self):
         registry = ToolRegistry()
         registry.register_function("f", lambda: None)
-        registry.register_autogen_adapter("A", lambda: None)
+        registry.register_function("g", lambda: None)
         registry.clear()
         assert len(registry) == 0
 
@@ -65,7 +52,7 @@ class TestToolRegistryBasic:
         assert len(registry) == 0
         registry.register_function("f", lambda: None)
         assert len(registry) == 1
-        registry.register_autogen_adapter("A", lambda: None)
+        registry.register_function("g", lambda: None)
         assert len(registry) == 2
 
     def test_contains(self):


### PR DESCRIPTION
Fixes #1652

## Summary

Cleanup of three concrete architectural gaps in \src/praisonai/praisonai\:

### 1. Framework-adapter migration
- Removed dead \egister_builtin_autogen_adapters()\ call from \AgentsGenerator.__init__\
- Removed \ToolRegistry\ wiring that was only used by already-removed \_run_*\ methods
- Removed the now-unused \ToolRegistry\ import from \gents_generator.py\

### 2. Duplicate persistence stack
- Marked \storage/__init__.py\ as legacy with docstring directing new code to \praisonai.persistence.factory\
- \storage/\ adapter files retained for backward compatibility only

### 3. Dead tool-registry path
- Removed all deprecated autogen-specific methods from \ToolRegistry\: \egister_autogen_adapter\, \get_autogen_adapter\, \list_autogen_adapters\, \egister_builtin_autogen_adapters\
- Removed \_autogen_adapters\ storage and its references in \clear()\ and \__len__()\
- Removed \egister_builtin_autogen_adapters()\ call from \config/validator.py\
- Removed \ToolRegistry\ import from \config/validator.py\

## Files changed
- \src/praisonai/praisonai/agents_generator.py\ — removed ToolRegistry/autogen shim wiring
- \src/praisonai/praisonai/tool_registry.py\ — removed all deprecated autogen-only methods
- \src/praisonai/praisonai/config/validator.py\ — removed unused ToolRegistry import and autogen call
- \src/praisonai/praisonai/storage/__init__.py\ — marked as legacy with migration note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default tool resolution by using a single, direct resolver setup when no custom resolver is provided.
  * Removed legacy adapter management from tool registration; clearing and length checks now apply only to explicitly registered function tools.
* **Tests**
  * Updated unit tests to validate function-tool registration and related behaviors only.
* **Documentation**
  * Labeled the storage module as legacy and directed new persistence work to the recommended persistence helpers, while noting backward-compatible access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->