### PR TITLE
Add LiteLLM fallback support and fix AutoGenerator test issues

### DIFF
--- a/src/praisonai/praisonai/auto.py
+++ b/src/praisonai/praisonai/auto.py
@@ -47,12 +47,6 @@ def _yaml_safe_load(stream):
     return yaml.safe_load(stream)
 
 
-try:
-    import litellm
-    LITELLM_AVAILABLE = True
-except ImportError:
-    LITELLM_AVAILABLE = False
-
 # OpenAI client creation removed - create per-call instead of global cache
 
 
@@ -444,15 +438,27 @@ class BaseAutoGenerator:
         
         # Try LiteLLM first (preferred - supports 100+ providers)
         if is_available("litellm"):
-            litellm = _get_litellm()
-            response = litellm.completion(
-                model=model_name,
-                messages=messages,
-                response_format=response_model,
-                **kwargs
-            )
-            content = response.choices[0].message.content
-            return response_model.model_validate_json(content)
+            try:
+                litellm = _get_litellm()
+                response = litellm.completion(
+                    model=model_name,
+                    messages=messages,
+                    response_format=response_model,
+                    **kwargs
+                )
+                content = response.choices[0].message.content
+                return response_model.model_validate_json(content)
+            except Exception as e:
+                # Graceful execution-level fallback: if LiteLLM fails at runtime
+                # (auth error, network timeout, unsupported model, or a provider
+                # that ignores response_format and returns no content), fall
+                # through to the OpenAI SDK path below instead of propagating.
+                if not is_available("openai"):
+                    raise
+                logger.warning(
+                    "LiteLLM structured completion failed (%s); "
+                    "falling back to OpenAI SDK.", e
+                )
         
         # Fallback to OpenAI SDK (uses beta.chat.completions.parse)
         if is_available("openai"):
@@ -494,15 +500,24 @@ class BaseAutoGenerator:
         
         # Try LiteLLM async first (preferred - supports 100+ providers)
         if is_available("litellm"):
-            litellm = _get_litellm()
-            response = await litellm.acompletion(
-                model=model_name,
-                messages=messages,
-                response_format=response_model,
-                **kwargs
-            )
-            content = response.choices[0].message.content
-            return response_model.model_validate_json(content)
+            try:
+                litellm = _get_litellm()
+                response = await litellm.acompletion(
+                    model=model_name,
+                    messages=messages,
+                    response_format=response_model,
+                    **kwargs
+                )
+                content = response.choices[0].message.content
+                return response_model.model_validate_json(content)
+            except Exception as e:
+                # Graceful execution-level fallback (see _structured_completion).
+                if not is_available("openai"):
+                    raise
+                logger.warning(
+                    "LiteLLM async structured completion failed (%s); "
+                    "falling back to OpenAI SDK.", e
+                )
         
         # Fallback to OpenAI AsyncSDK (uses beta.chat.completions.parse)
         if is_available("openai"):
@@ -619,30 +634,6 @@ class BaseAutoGenerator:
 # =============================================================================
 # Pydantic Models for Structured Output - Lazy Loaded
 # =============================================================================
-from pydantic import BaseModel
-from typing import Dict, List
-
-
-class PatternRecommendation(BaseModel):
-    """LLM-based pattern recommendation with reasoning."""
-    pattern: str
-    reasoning: str
-    confidence: float
-
-class SingleAgentStructure(BaseModel):
-    name: str
-    role: str
-    goal: str
-    backstory: str
-    instructions: str
-    tools: List[str] = []
-    task_description: str
-    expected_output: str
-
-class ValidationGate(BaseModel):
-    criteria: str
-    pass_action: str
-    fail_action: str
 
 def _get_team_models():
     """Get team structure models, creating them on first use."""
@@ -651,10 +642,12 @@ def _get_team_models():
         from pydantic import BaseModel
 
         class TaskDetails(BaseModel):
+            """Details for a single task."""
             description: str
             expected_output: str
 
         class RoleDetails(BaseModel):
+            """Details for a single role/agent."""
             role: str
             goal: str
             backstory: str
@@ -662,20 +655,44 @@ def _get_team_models():
             tools: List[str]
 
         class TeamStructure(BaseModel):
+            """Structure for multi-agent team."""
             roles: Dict[str, RoleDetails]
 
+        class SingleAgentStructure(BaseModel):
+            """Structure for single-agent generation (Anthropic's 'start simple' principle)."""
+            name: str
+            role: str
+            goal: str
+            backstory: str
+            instructions: str
+            tools: List[str] = []
+            task_description: str
+            expected_output: str
 
+        class PatternRecommendation(BaseModel):
+            """LLM-based pattern recommendation with reasoning."""
+            pattern: str  # sequential, parallel, routing, orchestrator-workers, evaluator-optimizer
+            reasoning: str  # Why this pattern was chosen
+            confidence: float  # 0.0 to 1.0 confidence score
+
+        class ValidationGate(BaseModel):
+            """Validation gate for prompt chaining workflows."""
+            criteria: str  # What to validate
+            pass_action: str  # Action if validation passes (e.g., "continue", "next_step")
+            fail_action: str  # Action if validation fails (e.g., "retry", "escalate", "abort")
 
         return {
             "TaskDetails": TaskDetails,
             "RoleDetails": RoleDetails,
             "TeamStructure": TeamStructure,
             "SingleAgentStructure": SingleAgentStructure,
-            "PatternRecommendation": PatternRecommendation,  # <-- use global class
+            "PatternRecommendation": PatternRecommendation,
             "ValidationGate": ValidationGate,
         }
 
     return lazy_get("team_models", _create_team_models)
+
+
 class AutoGenerator(BaseAutoGenerator):
     """
     Auto-generates agents.yaml files from a topic description.
@@ -1026,41 +1043,7 @@ Use the recommended tools: {', '.join(recommended_tools)}
 # =============================================================================
 # Workflow Auto-Generation (Feature Parity)
 # =============================================================================
-from pydantic import BaseModel
-        
-class WorkflowStepDetails(BaseModel):
-    """Details for a workflow step."""
-    agent: str
-    action: str
-    expected_output: Optional[str] = None
-        
-class WorkflowRouteDetails(BaseModel):
-    """Details for a route step."""
-    name: str
-    route: Dict[str, List[str]]
-        
-class WorkflowParallelDetails(BaseModel):
-    """Details for a parallel step."""
-    name: str
-    parallel: List[WorkflowStepDetails]
-        
-class WorkflowAgentDetails(BaseModel):
-    """Details for a workflow agent."""
-    name: str
-    role: str
-    goal: str
-    instructions: str
-    tools: Optional[List[str]] = None
-        
-class WorkflowStructure(BaseModel):
-            
-    """Structure for auto-generated workflow."""
-    name: str
-    description: str
-    agents: Dict[str, WorkflowAgentDetails]
-    steps: List[Dict]  # Can be agent steps, route, parallel, etc.
-    gates: Optional[List[Any]] = None  # Optional validation gates, ValidationGate type resolved at runtime
-        
+
 def _get_workflow_models():
     """Get workflow structure models, creating them on first use."""
     if 'workflow_models' in _models_cache:
@@ -1070,6 +1053,39 @@ def _get_workflow_models():
         if 'workflow_models' in _models_cache:
             return _models_cache['workflow_models']
         
+        from pydantic import BaseModel
+
+        class WorkflowStepDetails(BaseModel):
+            """Details for a workflow step."""
+            agent: str
+            action: str
+            expected_output: Optional[str] = None
+
+        class WorkflowRouteDetails(BaseModel):
+            """Details for a route step."""
+            name: str
+            route: Dict[str, List[str]]
+
+        class WorkflowParallelDetails(BaseModel):
+            """Details for a parallel step."""
+            name: str
+            parallel: List[WorkflowStepDetails]
+
+        class WorkflowAgentDetails(BaseModel):
+            """Details for a workflow agent."""
+            name: str
+            role: str
+            goal: str
+            instructions: str
+            tools: Optional[List[str]] = None
+
+        class WorkflowStructure(BaseModel):
+            """Structure for auto-generated workflow."""
+            name: str
+            description: str
+            agents: Dict[str, WorkflowAgentDetails]
+            steps: List[Dict]  # Can be agent steps, route, parallel, etc.
+            gates: Optional[List[Any]] = None  # Optional validation gates, ValidationGate type resolved at runtime
 
         _models_cache['workflow_models'] = {
             'WorkflowStepDetails': WorkflowStepDetails,
@@ -1079,6 +1095,35 @@ def _get_workflow_models():
             'WorkflowStructure': WorkflowStructure
         }
         return _models_cache['workflow_models']
+
+
+# Names exposed lazily via module __getattr__ (PEP 562) so that
+# `from praisonai.auto import PatternRecommendation` keeps working without
+# importing pydantic at module load time. Each maps to its lazy factory.
+_LAZY_MODEL_EXPORTS = {
+    "PatternRecommendation": ("_get_team_models", "PatternRecommendation"),
+    "SingleAgentStructure": ("_get_team_models", "SingleAgentStructure"),
+    "ValidationGate": ("_get_team_models", "ValidationGate"),
+    "TeamStructure": ("_get_team_models", "TeamStructure"),
+    "WorkflowStructure": ("_get_workflow_models", "WorkflowStructure"),
+    "WorkflowStepDetails": ("_get_workflow_models", "WorkflowStepDetails"),
+    "WorkflowRouteDetails": ("_get_workflow_models", "WorkflowRouteDetails"),
+    "WorkflowParallelDetails": ("_get_workflow_models", "WorkflowParallelDetails"),
+    "WorkflowAgentDetails": ("_get_workflow_models", "WorkflowAgentDetails"),
+}
+
+
+def __getattr__(name: str):
+    """Lazily resolve structured-output Pydantic models (PEP 562).
+
+    Preserves the module's FULL LAZY LOADING contract: pydantic is only
+    imported when one of these models is first accessed.
+    """
+    export = _LAZY_MODEL_EXPORTS.get(name)
+    if export is not None:
+        factory_name, key = export
+        return globals()[factory_name]()[key]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class WorkflowAutoGenerator(BaseAutoGenerator):

--- a/src/praisonai/praisonai/auto.py
+++ b/src/praisonai/praisonai/auto.py
@@ -47,7 +47,11 @@ def _yaml_safe_load(stream):
     return yaml.safe_load(stream)
 
 
-
+try:
+    import litellm
+    LITELLM_AVAILABLE = True
+except ImportError:
+    LITELLM_AVAILABLE = False
 
 # OpenAI client creation removed - create per-call instead of global cache
 
@@ -615,63 +619,63 @@ class BaseAutoGenerator:
 # =============================================================================
 # Pydantic Models for Structured Output - Lazy Loaded
 # =============================================================================
+from pydantic import BaseModel
+from typing import Dict, List
+
+
+class PatternRecommendation(BaseModel):
+    """LLM-based pattern recommendation with reasoning."""
+    pattern: str
+    reasoning: str
+    confidence: float
+
+class SingleAgentStructure(BaseModel):
+    name: str
+    role: str
+    goal: str
+    backstory: str
+    instructions: str
+    tools: List[str] = []
+    task_description: str
+    expected_output: str
+
+class ValidationGate(BaseModel):
+    criteria: str
+    pass_action: str
+    fail_action: str
 
 def _get_team_models():
     """Get team structure models, creating them on first use."""
+
     def _create_team_models():
         from pydantic import BaseModel
-        
+
         class TaskDetails(BaseModel):
-            """Details for a single task."""
             description: str
             expected_output: str
-        
+
         class RoleDetails(BaseModel):
-            """Details for a single role/agent."""
             role: str
             goal: str
             backstory: str
             tasks: Dict[str, TaskDetails]
             tools: List[str]
-        
-        class TeamStructure(BaseModel):
-            """Structure for multi-agent team."""
-            roles: Dict[str, RoleDetails]
-        
-        class SingleAgentStructure(BaseModel):
-            """Structure for single-agent generation (Anthropic's 'start simple' principle)."""
-            name: str
-            role: str
-            goal: str
-            backstory: str
-            instructions: str
-            tools: List[str] = []
-            task_description: str
-            expected_output: str
-        
-        class PatternRecommendation(BaseModel):
-            """LLM-based pattern recommendation with reasoning."""
-            pattern: str  # sequential, parallel, routing, orchestrator-workers, evaluator-optimizer
-            reasoning: str  # Why this pattern was chosen
-            confidence: float  # 0.0 to 1.0 confidence score
-        
-        class ValidationGate(BaseModel):
-            """Validation gate for prompt chaining workflows."""
-            criteria: str  # What to validate
-            pass_action: str  # Action if validation passes (e.g., "continue", "next_step")
-            fail_action: str  # Action if validation fails (e.g., "retry", "escalate", "abort")
-        
-        return {
-            'TaskDetails': TaskDetails,
-            'RoleDetails': RoleDetails,
-            'TeamStructure': TeamStructure,
-            'SingleAgentStructure': SingleAgentStructure,
-            'PatternRecommendation': PatternRecommendation,
-            'ValidationGate': ValidationGate
-        }
-    
-    return lazy_get('team_models', _create_team_models)
 
+        class TeamStructure(BaseModel):
+            roles: Dict[str, RoleDetails]
+
+
+
+        return {
+            "TaskDetails": TaskDetails,
+            "RoleDetails": RoleDetails,
+            "TeamStructure": TeamStructure,
+            "SingleAgentStructure": SingleAgentStructure,
+            "PatternRecommendation": PatternRecommendation,  # <-- use global class
+            "ValidationGate": ValidationGate,
+        }
+
+    return lazy_get("team_models", _create_team_models)
 class AutoGenerator(BaseAutoGenerator):
     """
     Auto-generates agents.yaml files from a topic description.
@@ -1022,7 +1026,41 @@ Use the recommended tools: {', '.join(recommended_tools)}
 # =============================================================================
 # Workflow Auto-Generation (Feature Parity)
 # =============================================================================
-
+from pydantic import BaseModel
+        
+class WorkflowStepDetails(BaseModel):
+    """Details for a workflow step."""
+    agent: str
+    action: str
+    expected_output: Optional[str] = None
+        
+class WorkflowRouteDetails(BaseModel):
+    """Details for a route step."""
+    name: str
+    route: Dict[str, List[str]]
+        
+class WorkflowParallelDetails(BaseModel):
+    """Details for a parallel step."""
+    name: str
+    parallel: List[WorkflowStepDetails]
+        
+class WorkflowAgentDetails(BaseModel):
+    """Details for a workflow agent."""
+    name: str
+    role: str
+    goal: str
+    instructions: str
+    tools: Optional[List[str]] = None
+        
+class WorkflowStructure(BaseModel):
+            
+    """Structure for auto-generated workflow."""
+    name: str
+    description: str
+    agents: Dict[str, WorkflowAgentDetails]
+    steps: List[Dict]  # Can be agent steps, route, parallel, etc.
+    gates: Optional[List[Any]] = None  # Optional validation gates, ValidationGate type resolved at runtime
+        
 def _get_workflow_models():
     """Get workflow structure models, creating them on first use."""
     if 'workflow_models' in _models_cache:
@@ -1032,40 +1070,7 @@ def _get_workflow_models():
         if 'workflow_models' in _models_cache:
             return _models_cache['workflow_models']
         
-        from pydantic import BaseModel
-        
-        class WorkflowStepDetails(BaseModel):
-            """Details for a workflow step."""
-            agent: str
-            action: str
-            expected_output: Optional[str] = None
-        
-        class WorkflowRouteDetails(BaseModel):
-            """Details for a route step."""
-            name: str
-            route: Dict[str, List[str]]
-        
-        class WorkflowParallelDetails(BaseModel):
-            """Details for a parallel step."""
-            name: str
-            parallel: List[WorkflowStepDetails]
-        
-        class WorkflowAgentDetails(BaseModel):
-            """Details for a workflow agent."""
-            name: str
-            role: str
-            goal: str
-            instructions: str
-            tools: Optional[List[str]] = None
-        
-        class WorkflowStructure(BaseModel):
-            """Structure for auto-generated workflow."""
-            name: str
-            description: str
-            agents: Dict[str, WorkflowAgentDetails]
-            steps: List[Dict]  # Can be agent steps, route, parallel, etc.
-            gates: Optional[List[Any]] = None  # Optional validation gates, ValidationGate type resolved at runtime
-        
+
         _models_cache['workflow_models'] = {
             'WorkflowStepDetails': WorkflowStepDetails,
             'WorkflowRouteDetails': WorkflowRouteDetails,

--- a/src/praisonai/tests/unit/test_auto_generator.py
+++ b/src/praisonai/tests/unit/test_auto_generator.py
@@ -20,10 +20,14 @@ import tempfile
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 try:
-    from praisonai.auto import AutoGenerator, WorkflowAutoGenerator, LITELLM_AVAILABLE
+    from praisonai.auto import AutoGenerator, WorkflowAutoGenerator
 except ImportError as e:
     pytest.skip(f"Could not import required modules: {e}", allow_module_level=True)
 
+from pydantic import BaseModel
+
+class DummyModel(BaseModel):
+    pass
 
 class TestAutoGeneratorDefaultModel:
     """Test suite for default model configuration."""
@@ -165,7 +169,7 @@ class TestAutoGeneratorToolsPreservation:
 
 class TestAutoGeneratorLazyLoading:
     """Test suite for lazy loading of client."""
-    
+
     def test_client_is_not_created_on_init(self):
         """Test that client is not created during __init__."""
         with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
@@ -173,72 +177,92 @@ class TestAutoGeneratorLazyLoading:
                 topic="Test topic",
                 framework="praisonai"
             )
-            
-            # Check that _client is None (lazy loading)
-            assert generator._client is None
-    
+
+            # Check that clients are not created yet
+            assert generator._openai_client is None
+            assert generator._async_openai_client is None
+
     def test_client_is_created_on_first_access(self):
-        """Test that client is created on first access."""
+        """Test that OpenAI client is created on first access."""
         with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
             generator = AutoGenerator(
                 topic="Test topic",
                 framework="praisonai"
             )
+
+            # Before access
+            assert generator._openai_client is None
+
+            # Trigger lazy loading
+            client = generator._get_openai_client()
+
+            # After access
+            assert client is not None
+            assert generator._openai_client is not None
             
-            # Access client property
-            with patch('praisonai.auto.instructor') as mock_instructor:
-                mock_instructor.from_litellm.return_value = Mock()
-                mock_instructor.patch.return_value = Mock()
-                
-                client = generator.client
-                
-                # Check that client is now set
-                assert generator._client is not None
-
-
 class TestAutoGeneratorLiteLLMFallback:
     """Test suite for LiteLLM fallback to OpenAI."""
-    
-    def test_uses_litellm_when_available(self):
-        """Test that LiteLLM is used when available via from_provider."""
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
-            with patch('praisonai.auto.LITELLM_AVAILABLE', True):
-                with patch('praisonai.auto.instructor') as mock_instructor:
-                    mock_instructor.from_provider.return_value = Mock()
-                    
-                    generator = AutoGenerator(
-                        topic="Test topic",
-                        framework="praisonai"
-                    )
-                    
-                    # Access client to trigger creation
-                    _ = generator.client
-                    
-                    # Check that from_provider was called with litellm prefix
-                    mock_instructor.from_provider.assert_called_once()
-                    call_args = mock_instructor.from_provider.call_args[0][0]
-                    assert call_args.startswith('litellm/')
-    
-    def test_falls_back_to_openai_when_litellm_unavailable(self):
-        """Test that OpenAI SDK is used when LiteLLM is not available."""
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
-            with patch('praisonai.auto.LITELLM_AVAILABLE', False):
-                with patch('praisonai.auto.instructor') as mock_instructor:
-                    with patch('praisonai.auto.OpenAI') as mock_openai:
-                        mock_instructor.patch.return_value = Mock()
-                        mock_openai.return_value = Mock()
-                        
-                        generator = AutoGenerator(
-                            topic="Test topic",
-                            framework="praisonai"
-                        )
-                        
-                        # Access client to trigger creation
-                        _ = generator.client
-                        
-                        # Check that patch was called (OpenAI fallback)
-                        mock_instructor.patch.assert_called_once()
 
+    def test_uses_litellm_when_available(self):
+        with patch('praisonai.auto.is_available', return_value=True):
+            with patch('praisonai.auto._get_litellm') as mock_litellm:
+
+                mock_response = Mock()
+                mock_response.choices = [
+                    Mock(message=Mock(content="{}"))
+                ]
+
+                mock_litellm.return_value.completion.return_value = mock_response
+
+                generator = AutoGenerator(
+                    topic="Test topic",
+                    framework="praisonai"
+                )
+
+                generator._structured_completion(
+                    response_model=DummyModel,
+                    messages=[]
+                )
+
+                mock_litellm.return_value.completion.assert_called_once()
+
+
+    def test_falls_back_to_openai_when_litellm_unavailable(self):
+
+        with patch('praisonai.auto.is_available') as mock_available:
+            mock_available.side_effect = lambda x: x == "openai"
+
+            with patch.object(
+                AutoGenerator,
+                "_get_openai_client"
+            ) as mock_client:
+
+                mock_response = Mock()
+
+                choice = Mock()
+                choice.message = Mock()
+                choice.message.parsed = DummyModel()
+
+                mock_response.choices = [choice]
+
+                mock_client.return_value \
+                    .beta \
+                    .chat \
+                    .completions \
+                    .parse \
+                    .return_value = mock_response
+
+                generator = AutoGenerator(
+                    topic="Test topic",
+                    framework="praisonai"
+                )
+
+                generator._structured_completion(
+                    response_model=DummyModel,
+                    messages=[]
+                )
+
+                mock_client.assert_called_once()
 
 class TestWorkflowAutoGenerator:
     """Test suite for WorkflowAutoGenerator."""
@@ -255,85 +279,194 @@ class TestWorkflowAutoGenerator:
             assert generator.config_list[0]['model'] == 'gpt-4o-mini'
     
     def test_lazy_loading(self):
-        """Test that client uses lazy loading."""
+        """Test that OpenAI client uses lazy loading."""
         with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
             generator = WorkflowAutoGenerator(
                 topic="Test workflow"
             )
-            
-            assert generator._client is None
-    
-    def test_litellm_fallback(self):
-        """Test LiteLLM fallback to OpenAI."""
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
-            with patch('praisonai.auto.LITELLM_AVAILABLE', False):
-                with patch('praisonai.auto.instructor') as mock_instructor:
-                    with patch('praisonai.auto.OpenAI') as mock_openai:
-                        mock_instructor.patch.return_value = Mock()
-                        mock_openai.return_value = Mock()
-                        
-                        generator = WorkflowAutoGenerator(
-                            topic="Test workflow"
-                        )
-                        
-                        # Access client to trigger creation
-                        _ = generator.client
-                        
-                        # Check that patch was called (OpenAI fallback)
-                        mock_instructor.patch.assert_called_once()
 
+            assert generator._openai_client is None
+            assert generator._async_openai_client is None
+
+
+
+    def test_litellm_fallback(self):
+        with patch('praisonai.auto.is_available') as mock_available:
+
+            mock_available.side_effect = (
+                lambda provider: provider == "openai"
+            )
+
+            with patch.object(
+                WorkflowAutoGenerator,
+                "_get_openai_client"
+            ) as mock_client:
+
+                mock_response = Mock()
+                mock_response.choices = [
+                    Mock(
+                        message=Mock(
+                            parsed=DummyModel()
+                        )
+                    )
+                ]
+
+                mock_client.return_value \
+                    .beta \
+                    .chat \
+                    .completions \
+                    .parse \
+                    .return_value = mock_response
+
+                generator = WorkflowAutoGenerator(
+                    topic="Test workflow"
+                )
+
+                generator._structured_completion(
+                    response_model=DummyModel,
+                    messages=[]
+                )
+
+                mock_client.assert_called_once()
 
 class TestAutoGeneratorJSONMode:
-    """Test suite for JSON mode (critical fix for nested Dict structures)."""
-    
+    """Test suite for JSON mode structured output."""
+
     def test_uses_json_mode_not_tools_mode(self):
-        """Test that JSON mode is used instead of TOOLS mode for OpenAI fallback.
-        
-        TOOLS mode doesn't handle nested Dict[str, ...] structures properly,
-        causing validation errors. JSON mode works correctly.
         """
+        Test that OpenAI fallback uses response_format
+        instead of tools mode.
+        """
+
         with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
-            with patch('praisonai.auto.LITELLM_AVAILABLE', False):
-                with patch('praisonai.auto.instructor') as mock_instructor:
-                    with patch('praisonai.auto.OpenAI') as mock_openai:
-                        mock_instructor.patch.return_value = Mock()
-                        mock_instructor.Mode.JSON = 'JSON_MODE'
-                        mock_openai.return_value = Mock()
-                        
-                        generator = AutoGenerator(
-                            topic="Test topic",
-                            framework="praisonai"
-                        )
-                        
-                        # Access client to trigger creation
-                        _ = generator.client
-                        
-                        # Verify JSON mode was used
-                        call_kwargs = mock_instructor.patch.call_args[1]
-                        assert call_kwargs['mode'] == 'JSON_MODE'
-    
+
+            with patch(
+                'praisonai.auto.is_available'
+            ) as mock_available:
+
+                mock_available.side_effect = (
+                    lambda provider: provider == "openai"
+                )
+
+                with patch.object(
+                    AutoGenerator,
+                    "_get_openai_client"
+                ) as mock_client:
+
+                    mock_response = Mock()
+                    mock_response.choices = [
+                        Mock(message=Mock(parsed=DummyModel()))
+                    ]
+
+                    mock_client.return_value \
+                        .beta \
+                        .chat \
+                        .completions \
+                        .parse \
+                        .return_value = mock_response
+
+
+                    generator = AutoGenerator(
+                        topic="Test topic",
+                        framework="praisonai"
+                    )
+
+
+                    generator._structured_completion(
+                        response_model=DummyModel,
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": "test"
+                            }
+                        ]
+                    )
+
+
+                    call_kwargs = (
+                        mock_client
+                        .return_value
+                        .beta
+                        .chat
+                        .completions
+                        .parse
+                        .call_args
+                        .kwargs
+                    )
+
+
+                    assert "response_format" in call_kwargs
+                    assert "tools" not in call_kwargs
+
+
+
     def test_workflow_generator_uses_json_mode(self):
-        """Test that WorkflowAutoGenerator also uses JSON mode."""
+        """
+        Test that WorkflowAutoGenerator also uses
+        OpenAI structured JSON response format.
+        """
+
         with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
-            with patch('praisonai.auto.LITELLM_AVAILABLE', False):
-                with patch('praisonai.auto.instructor') as mock_instructor:
-                    with patch('praisonai.auto.OpenAI') as mock_openai:
-                        mock_instructor.patch.return_value = Mock()
-                        mock_instructor.Mode.JSON = 'JSON_MODE'
-                        mock_openai.return_value = Mock()
-                        
-                        generator = WorkflowAutoGenerator(
-                            topic="Test workflow"
-                        )
-                        
-                        # Access client to trigger creation
-                        _ = generator.client
-                        
-                        # Verify JSON mode was used
-                        call_kwargs = mock_instructor.patch.call_args[1]
-                        assert call_kwargs['mode'] == 'JSON_MODE'
+
+            with patch(
+                'praisonai.auto.is_available'
+            ) as mock_available:
+
+                mock_available.side_effect = (
+                    lambda provider: provider == "openai"
+                )
 
 
+                with patch.object(
+                    WorkflowAutoGenerator,
+                    "_get_openai_client"
+                ) as mock_client:
+
+
+                    mock_response = Mock()
+                    mock_response.choices = [
+                        Mock(message=Mock(parsed=DummyModel()))
+                    ]
+
+
+                    mock_client.return_value \
+                        .beta \
+                        .chat \
+                        .completions \
+                        .parse \
+                        .return_value = mock_response
+
+
+                    generator = WorkflowAutoGenerator(
+                        topic="Test workflow"
+                    )
+
+
+                    generator._structured_completion(
+                        response_model=DummyModel,
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": "test"
+                            }
+                        ]
+                    )
+
+
+                    call_kwargs = (
+                        mock_client
+                        .return_value
+                        .beta
+                        .chat
+                        .completions
+                        .parse
+                        .call_args
+                        .kwargs
+                    )
+
+
+                    assert "response_format" in call_kwargs
+                    assert "tools" not in call_kwargs
 class TestAutoGeneratorImprovedPrompt:
     """Test suite for improved task analysis prompt."""
     

--- a/src/praisonai/tests/unit/test_auto_generator.py
+++ b/src/praisonai/tests/unit/test_auto_generator.py
@@ -204,7 +204,7 @@ class TestAutoGeneratorLiteLLMFallback:
     """Test suite for LiteLLM fallback to OpenAI."""
 
     def test_uses_litellm_when_available(self):
-        with patch('praisonai.auto.is_available', return_value=True):
+        with patch('praisonai.auto.is_available', side_effect=lambda x: x == "litellm"):
             with patch('praisonai.auto._get_litellm') as mock_litellm:
 
                 mock_response = Mock()


### PR DESCRIPTION
## Description

This PR introduces LiteLLM support for structured completions in `AutoGenerator` and `WorkflowAutoGenerator` with a graceful fallback mechanism to the OpenAI client.

The goal of this change is to make the generation flow more flexible by allowing LiteLLM to be used as the preferred completion provider when available, while keeping the existing OpenAI structured output workflow as a reliable fallback option.

Additionally, this PR fixes several existing unit test issues related to the new completion flow, lazy-loaded clients, and structured response handling.

## Changes Made

### LiteLLM Integration

* Added LiteLLM availability detection during initialization.
* Added support for calling LiteLLM completions inside `_structured_completion`.
* Implemented provider selection logic:

  * Use LiteLLM when it is available.
  * Automatically fallback to OpenAI when LiteLLM is unavailable.
* Preserved the existing structured output behavior using Pydantic models.

### OpenAI Fallback Improvements

* Updated fallback handling to correctly use the OpenAI client path.
* Improved OpenAI response mocking in tests to match the expected SDK response structure.
* Ensured structured responses are returned correctly through `response.choices[0].message.parsed`.

### Test Fixes

Fixed failing unit tests caused by:

* Incorrect mock response structures for OpenAI completion parsing.
* Missing Pydantic test models used for structured output validation.
* Incorrect assumptions around lazy-loaded OpenAI clients.
* Tests using outdated client initialization behavior.

Updated test coverage to verify:

* LiteLLM is used when available.
* OpenAI fallback is triggered when LiteLLM is unavailable.
* `AutoGenerator` correctly handles both completion providers.
* `WorkflowAutoGenerator` follows the same fallback behavior.
* Lazy loading behavior remains intact.

## Testing

Executed:

```bash
pytest src/praisonai/tests/unit/test_auto_generator.py -v
```

Result:

```text
51 passed
```

All existing `AutoGenerator` and `WorkflowAutoGenerator` unit tests are passing after the changes.

## Notes

This change keeps backward compatibility with the current OpenAI structured completion workflow while adding LiteLLM as an optional provider. The fallback approach ensures generation continues to work even when LiteLLM is not installed or unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for structured outputs: when LiteLLM fails at runtime, the system logs a warning and automatically falls back to the OpenAI structured parsing flow (if available).
  * Updated workflow structured-output models and schema, including support for an optional `gates` field for more consistent workflow results.
* **New Features**
  * Exposed structured-output models via lazy loading, so they’re available on first use.
* **Tests**
  * Updated unit coverage to reflect the new lazy initialization, provider fallback behavior, and structured-output request details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->