### PR TITLE
fix: reliably kick review chain when bot PRs miss pull_request opened

### DIFF
--- a/.github/scripts/bot-pr-review-chain-selftest.js
+++ b/.github/scripts/bot-pr-review-chain-selftest.js
@@ -11,10 +11,20 @@ function assert(name, cond) {
   }
 }
 
-assert('detects kick from MervinPraison', chain.chainKickPosted([
+assert('chainKickPosted requires both markers', chain.chainKickPosted([
+  { user: { login: 'MervinPraison' }, body: '@coderabbitai review' },
+  { user: { login: 'MervinPraison' }, body: '/review' },
+]));
+assert('chainKickPosted false with only coderabbit', !chain.chainKickPosted([
   { user: { login: 'MervinPraison' }, body: '@coderabbitai review' },
 ]));
-assert('ignores coderabbit bot comment', !chain.chainKickPosted([
+assert('coderabbitKickPosted detects coderabbit', chain.coderabbitKickPosted([
+  { user: { login: 'MervinPraison' }, body: '@coderabbitai review' },
+]));
+assert('qodoKickPosted detects qodo', chain.qodoKickPosted([
+  { user: { login: 'github-actions[bot]' }, body: '/review' },
+]));
+assert('ignores coderabbit bot comment', !chain.coderabbitKickPosted([
   { user: { login: 'coderabbitai[bot]' }, body: '@coderabbitai review' },
 ]));
 assert('bot PR author match', chain.isBotOpenedPr({ user: { login: 'praisonai-triage-agent[bot]' } }));

--- a/.github/scripts/bot-pr-review-chain-selftest.js
+++ b/.github/scripts/bot-pr-review-chain-selftest.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const chain = require('./bot-pr-review-chain.js');
+
+let failed = 0;
+function assert(name, cond) {
+  if (!cond) {
+    console.error('FAIL:', name);
+    failed++;
+  } else {
+    console.log('ok:', name);
+  }
+}
+
+assert('detects kick from MervinPraison', chain.chainKickPosted([
+  { user: { login: 'MervinPraison' }, body: '@coderabbitai review' },
+]));
+assert('ignores coderabbit bot comment', !chain.chainKickPosted([
+  { user: { login: 'coderabbitai[bot]' }, body: '@coderabbitai review' },
+]));
+assert('bot PR author match', chain.isBotOpenedPr({ user: { login: 'praisonai-triage-agent[bot]' } }));
+assert('generic bot type match', chain.isBotOpenedPr({ user: { login: 'my-bot', type: 'Bot' } }));
+assert('human author excluded', !chain.isBotOpenedPr({ user: { login: 'MervinPraison', type: 'User' } }));
+
+process.exit(failed ? 1 : 0);

--- a/.github/scripts/bot-pr-review-chain.js
+++ b/.github/scripts/bot-pr-review-chain.js
@@ -24,12 +24,23 @@ async function listAllComments(github, owner, repo, issueNumber) {
   return data;
 }
 
-function chainKickPosted(comments) {
-  return comments.some(
-    (c) =>
-      KICK_AUTHORS.has(c.user?.login) &&
-      (c.body || '').includes('@coderabbitai review')
+function kickAuthored(comment, marker) {
+  return (
+    KICK_AUTHORS.has(comment.user?.login) &&
+    (comment.body || '').includes(marker)
   );
+}
+
+function coderabbitKickPosted(comments) {
+  return comments.some((c) => kickAuthored(c, '@coderabbitai review'));
+}
+
+function qodoKickPosted(comments) {
+  return comments.some((c) => kickAuthored(c, '/review'));
+}
+
+function chainKickPosted(comments) {
+  return coderabbitKickPosted(comments) && qodoKickPosted(comments);
 }
 
 function isBotOpenedPr(pr) {
@@ -37,27 +48,34 @@ function isBotOpenedPr(pr) {
   return pr.user?.type === 'Bot';
 }
 
-async function kickReviewChain(github, owner, repo, prNumber, core) {
-  const comments = await listAllComments(github, owner, repo, prNumber);
-  if (chainKickPosted(comments)) {
+async function kickReviewChain(github, owner, repo, prNumber, core, preFetchedComments = null) {
+  const comments = preFetchedComments || await listAllComments(github, owner, repo, prNumber);
+  const needCoderabbit = !coderabbitKickPosted(comments);
+  const needQodo = !qodoKickPosted(comments);
+
+  if (!needCoderabbit && !needQodo) {
     core?.info?.(`Review chain already kicked on PR #${prNumber}`);
     return { kicked: false, reason: 'already_kicked' };
   }
 
-  await github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: prNumber,
-    body: '@coderabbitai review',
-  });
-  await github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: prNumber,
-    body: '/review',
-  });
-  core?.info?.(`Kicked review chain for PR #${prNumber}`);
-  return { kicked: true };
+  if (needCoderabbit) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body: '@coderabbitai review',
+    });
+  }
+  if (needQodo) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body: '/review',
+    });
+  }
+  core?.info?.(`Kicked review chain for PR #${prNumber} (coderabbit=${needCoderabbit}, qodo=${needQodo})`);
+  return { kicked: true, coderabbit: needCoderabbit, qodo: needQodo };
 }
 
 async function findOpenPrForIssue(github, owner, repo, issueNumber) {
@@ -70,7 +88,11 @@ async function findOpenPrForIssue(github, owner, repo, issueNumber) {
     direction: 'desc',
     per_page: 30,
   });
-  return prs.find((p) => (p.head?.ref || '').startsWith(prefix)) || null;
+  return (
+    prs.find(
+      (p) => (p.head?.ref || '').startsWith(prefix) && isBotOpenedPr(p)
+    ) || null
+  );
 }
 
 async function kickReviewChainForIssue(github, owner, repo, issueNumber, core) {
@@ -89,6 +111,13 @@ async function recoverStalledBotPrs(github, owner, repo, options, core) {
   if (prNumber) {
     const { data } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
     prs = [data];
+  } else if (typeof github.paginate === 'function') {
+    prs = await github.paginate(github.rest.pulls.list, {
+      owner,
+      repo,
+      state: 'open',
+      per_page: 100,
+    });
   } else {
     const { data } = await github.rest.pulls.list({ owner, repo, state: 'open', per_page: 100 });
     prs = data;
@@ -98,13 +127,11 @@ async function recoverStalledBotPrs(github, owner, repo, options, core) {
   let recovered = 0;
   for (const pr of prs) {
     if (recovered >= maxRecover) break;
-    if (!prNumber) {
-      if (!isBotOpenedPr(pr)) continue;
-      if (new Date(pr.created_at).getTime() > cutoff) continue;
-    }
+    if (!isBotOpenedPr(pr)) continue;
+    if (!prNumber && new Date(pr.created_at).getTime() > cutoff) continue;
     const comments = await listAllComments(github, owner, repo, pr.number);
     if (chainKickPosted(comments)) continue;
-    await kickReviewChain(github, owner, repo, pr.number, core);
+    await kickReviewChain(github, owner, repo, pr.number, core, comments);
     recovered += 1;
   }
   core?.info?.(`Recovery complete (${recovered} PR(s) kicked)`);
@@ -116,6 +143,8 @@ module.exports = {
   BOT_PR_AUTHORS,
   listAllComments,
   chainKickPosted,
+  coderabbitKickPosted,
+  qodoKickPosted,
   isBotOpenedPr,
   kickReviewChain,
   findOpenPrForIssue,

--- a/.github/scripts/bot-pr-review-chain.js
+++ b/.github/scripts/bot-pr-review-chain.js
@@ -1,0 +1,124 @@
+/**
+ * Idempotent CodeRabbit/Qodo kick for bot-opened PRs.
+ * @see .github/workflows/auto-pr-comment.yml, claude.yml, bot-pr-recovery.yml
+ */
+
+const KICK_AUTHORS = new Set(['MervinPraison', 'github-actions[bot]']);
+const BOT_PR_AUTHORS = new Set(['praisonai-triage-agent[bot]', 'github-actions[bot]']);
+
+async function listAllComments(github, owner, repo, issueNumber) {
+  if (typeof github.paginate === 'function') {
+    return github.paginate(github.rest.issues.listComments, {
+      owner,
+      repo,
+      issue_number: issueNumber,
+      per_page: 100,
+    });
+  }
+  const { data } = await github.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+  return data;
+}
+
+function chainKickPosted(comments) {
+  return comments.some(
+    (c) =>
+      KICK_AUTHORS.has(c.user?.login) &&
+      (c.body || '').includes('@coderabbitai review')
+  );
+}
+
+function isBotOpenedPr(pr) {
+  if (BOT_PR_AUTHORS.has(pr.user?.login)) return true;
+  return pr.user?.type === 'Bot';
+}
+
+async function kickReviewChain(github, owner, repo, prNumber, core) {
+  const comments = await listAllComments(github, owner, repo, prNumber);
+  if (chainKickPosted(comments)) {
+    core?.info?.(`Review chain already kicked on PR #${prNumber}`);
+    return { kicked: false, reason: 'already_kicked' };
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body: '@coderabbitai review',
+  });
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body: '/review',
+  });
+  core?.info?.(`Kicked review chain for PR #${prNumber}`);
+  return { kicked: true };
+}
+
+async function findOpenPrForIssue(github, owner, repo, issueNumber) {
+  const prefix = `claude/issue-${issueNumber}-`;
+  const { data: prs } = await github.rest.pulls.list({
+    owner,
+    repo,
+    state: 'open',
+    sort: 'created',
+    direction: 'desc',
+    per_page: 30,
+  });
+  return prs.find((p) => (p.head?.ref || '').startsWith(prefix)) || null;
+}
+
+async function kickReviewChainForIssue(github, owner, repo, issueNumber, core) {
+  const pr = await findOpenPrForIssue(github, owner, repo, issueNumber);
+  if (!pr) {
+    core?.info?.(`No open PR for issue #${issueNumber}, skipping review kick`);
+    return { kicked: false, reason: 'no_pr' };
+  }
+  const result = await kickReviewChain(github, owner, repo, pr.number, core);
+  return { ...result, prNumber: pr.number };
+}
+
+async function recoverStalledBotPrs(github, owner, repo, options, core) {
+  const { prNumber = null, minAgeMs = 10 * 60 * 1000, maxRecover = 10 } = options || {};
+  let prs;
+  if (prNumber) {
+    const { data } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+    prs = [data];
+  } else {
+    const { data } = await github.rest.pulls.list({ owner, repo, state: 'open', per_page: 100 });
+    prs = data;
+  }
+
+  const cutoff = Date.now() - minAgeMs;
+  let recovered = 0;
+  for (const pr of prs) {
+    if (recovered >= maxRecover) break;
+    if (!prNumber) {
+      if (!isBotOpenedPr(pr)) continue;
+      if (new Date(pr.created_at).getTime() > cutoff) continue;
+    }
+    const comments = await listAllComments(github, owner, repo, pr.number);
+    if (chainKickPosted(comments)) continue;
+    await kickReviewChain(github, owner, repo, pr.number, core);
+    recovered += 1;
+  }
+  core?.info?.(`Recovery complete (${recovered} PR(s) kicked)`);
+  return recovered;
+}
+
+module.exports = {
+  KICK_AUTHORS,
+  BOT_PR_AUTHORS,
+  listAllComments,
+  chainKickPosted,
+  isBotOpenedPr,
+  kickReviewChain,
+  findOpenPrForIssue,
+  kickReviewChainForIssue,
+  recoverStalledBotPrs,
+};

--- a/.github/workflows/auto-pr-comment.yml
+++ b/.github/workflows/auto-pr-comment.yml
@@ -612,37 +612,14 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: Trigger CodeRabbit and Qodo reviews
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
+            const path = require('path');
+            const chain = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/bot-pr-review-chain.js'));
             const pr = context.payload.pull_request.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            // 1. Trigger CodeRabbit review
-            await github.rest.issues.createComment({
-              issue_number: pr, owner, repo,
-              body: '@coderabbitai review'
-            });
-            console.log(`Triggered CodeRabbit for bot PR #${pr}`);
-
-            // 2. Trigger Qodo review
-            await github.rest.issues.createComment({
-              issue_number: pr, owner, repo,
-              body: '/review'
-            });
-            console.log(`Triggered Qodo for bot PR #${pr}`);
-
-            // 3. Trigger Gemini review (commented out)
-            // await github.rest.issues.createComment({
-            //   issue_number: pr, owner, repo,
-            //   body: '@gemini review this PR'
-            // });
-            // console.log(`Triggered Gemini for bot PR #${pr}`);
-
-            // NOTE: @copilot is NOT triggered here.
-            // It will be triggered by copilot-after-coderabbit or copilot-after-qodo
-            // once those bots finish, ensuring Copilot always reviews LAST.
-            console.log('Copilot will be triggered after CodeRabbit/Qodo complete.');
+            await chain.kickReviewChain(github, context.repo.owner, context.repo.repo, pr, core);

--- a/.github/workflows/auto-pr-comment.yml
+++ b/.github/workflows/auto-pr-comment.yml
@@ -613,6 +613,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Trigger CodeRabbit and Qodo reviews
         uses: actions/github-script@v7

--- a/.github/workflows/bot-pr-recovery.yml
+++ b/.github/workflows/bot-pr-recovery.yml
@@ -1,0 +1,39 @@
+name: Bot PR Recovery
+
+# Belt-and-braces: kick CodeRabbit/Qodo when pull_request:opened never fired for bot PRs.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Specific PR number to kick (optional)'
+        required: false
+        type: string
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Find and kick stalled bot PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const path = require('path');
+            const chain = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/bot-pr-review-chain.js'));
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const manual = '${{ github.event.inputs.pr_number }}'.trim();
+            const prNumber = manual ? parseInt(manual, 10) : null;
+            if (manual && Number.isNaN(prNumber)) {
+              throw new Error(`Invalid pr_number: ${manual}`);
+            }
+            await chain.recoverStalledBotPrs(github, owner, repo, { prNumber }, core);

--- a/.github/workflows/bot-pr-recovery.yml
+++ b/.github/workflows/bot-pr-recovery.yml
@@ -21,9 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Find and kick stalled bot PRs
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number }}
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -31,7 +35,7 @@ jobs:
             const chain = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/bot-pr-review-chain.js'));
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const manual = '${{ github.event.inputs.pr_number }}'.trim();
+            const manual = (process.env.PR_NUMBER_INPUT || '').trim();
             const prNumber = manual ? parseInt(manual, 10) : null;
             if (manual && Number.isNaN(prNumber)) {
               throw new Error(`Invalid pr_number: ${manual}`);

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -336,3 +336,19 @@ jobs:
             mcp__github__get_issue_comments
             mcp__github__update_issue
           timeout_minutes: 30
+
+      - name: Kick review chain for bot-created PR
+        if: |
+          steps.check_fork.outputs.is_pr != 'true' &&
+          (github.event_name == 'issues' || github.event_name == 'issue_comment') &&
+          github.event.issue != null
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const path = require('path');
+            const chain = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/bot-pr-review-chain.js'));
+            const issueNumber = context.payload.issue.number;
+            await chain.kickReviewChainForIssue(
+              github, context.repo.owner, context.repo.repo, issueNumber, core
+            );


### PR DESCRIPTION
## Summary
- Adds shared `.github/scripts/bot-pr-review-chain.js` with idempotent review-chain kick (CodeRabbit + Qodo) and stall detection
- **`claude.yml`**: after bot PR creation, kicks the review chain via `GH_TOKEN` PAT when `pull_request: opened` is suppressed
- **`auto-pr-comment.yml`**: `bot-pr-trigger-reviews` uses the same helper (deduped if both paths fire)
- **`bot-pr-recovery.yml`**: 15-min cron + manual dispatch to recover stalled bot PRs with no review activity

Fixes #2251

## Root cause
Bot-created PRs via App token sometimes never emit `pull_request: opened`, so `bot-pr-trigger-reviews` never runs and the CodeRabbit → Qodo → Copilot → FINAL chain never starts.

## Test plan
- [x] `node .github/scripts/bot-pr-review-chain-selftest.js` passes
- [ ] Merge and verify next bot PR gets `@coderabbitai review` + `/review` within minutes
- [ ] Confirm recovery workflow picks up any PR stalled >30 min with no kick marker

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically triggers the review chain for bot-created pull requests when review activity stalls.
  * Adds a scheduled and manual “bot PR recovery” to re-activate stalled bot PRs.
  * Enhances issue-based triggering by locating the related open pull request and starting the kick flow.

* **Bug Fixes**
  * Prevents duplicate review-chain kicks by detecting whether the required markers were already posted.
  * Improves bot-vs-human PR identification and reduces unintended triggers.

* **Tests/Chores**
  * Adds a self-test to validate kick-detection and matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->