### PR TITLE
Detect Windows knowledge paths as sources

### DIFF
--- a/src/praisonai-agents/praisonaiagents/config/parse_utils.py
+++ b/src/praisonai-agents/praisonaiagents/config/parse_utils.py
@@ -108,11 +108,20 @@ def is_path_like(value: str) -> bool:
         return False
     
     # Check for path indicators
-    if value.startswith(("./", "../", "/", "~/")):
+    if value.startswith(("./", "../", "/", "~/", ".\\", "..\\", "\\\\")):
+        return True
+
+    # Check for Windows drive paths like C:\data or C:/data
+    if (
+        len(value) >= 3
+        and value[1] == ":"
+        and value[0].isalpha()
+        and value[2] in ("\\", "/")
+    ):
         return True
     
     # Check for directory indicator
-    if value.endswith("/"):
+    if value.endswith(("/", "\\")):
         return True
     
     # Check for file extension (common ones)

--- a/src/praisonai-agents/praisonaiagents/config/parse_utils.py
+++ b/src/praisonai-agents/praisonaiagents/config/parse_utils.py
@@ -108,7 +108,7 @@ def is_path_like(value: str) -> bool:
         return False
     
     # Check for path indicators
-    if value.startswith(("./", "../", "/", "~/", ".\\", "..\\", "\\\\")):
+    if value.startswith(("./", "../", "/", "~/", ".\\", "..\\", "\\\\", "\\", "~\\")):
         return True
 
     # Check for Windows drive paths like C:\data or C:/data
@@ -122,6 +122,9 @@ def is_path_like(value: str) -> bool:
     
     # Check for directory indicator
     if value.endswith(("/", "\\")):
+        return True
+
+    if "\\" in value:
         return True
     
     # Check for file extension (common ones)

--- a/src/praisonai-agents/tests/unit/config/test_agent_centric_enhancements.py
+++ b/src/praisonai-agents/tests/unit/config/test_agent_centric_enhancements.py
@@ -334,6 +334,19 @@ class TestKnowledgePresets:
         )
         assert isinstance(result, MockKnowledgeConfig)
         assert "docs/" in result.sources
+
+    def test_knowledge_windows_path_string(self):
+        """Windows-style directory paths should be treated as sources."""
+        from praisonaiagents.config.param_resolver import resolve
+
+        result = resolve(
+            value="C:\\knowledge",
+            param_name="knowledge",
+            config_class=MockKnowledgeConfig,
+            string_mode="path_as_source",
+        )
+        assert isinstance(result, MockKnowledgeConfig)
+        assert result.sources == ["C:\\knowledge"]
     
     def test_knowledge_array_sources(self):
         """Array of paths should be sources list."""

--- a/src/praisonai-agents/tests/unit/config/test_agent_centric_enhancements.py
+++ b/src/praisonai-agents/tests/unit/config/test_agent_centric_enhancements.py
@@ -339,14 +339,15 @@ class TestKnowledgePresets:
         """Windows-style directory paths should be treated as sources."""
         from praisonaiagents.config.param_resolver import resolve
 
-        result = resolve(
-            value="C:\\knowledge",
-            param_name="knowledge",
-            config_class=MockKnowledgeConfig,
-            string_mode="path_as_source",
-        )
-        assert isinstance(result, MockKnowledgeConfig)
-        assert result.sources == ["C:\\knowledge"]
+        for value in ("C:\\knowledge", "\\knowledge", "~\\knowledge", "knowledge\\docs"):
+            result = resolve(
+                value=value,
+                param_name="knowledge",
+                config_class=MockKnowledgeConfig,
+                string_mode="path_as_source",
+            )
+            assert isinstance(result, MockKnowledgeConfig)
+            assert result.sources == [value]
     
     def test_knowledge_array_sources(self):
         """Array of paths should be sources list."""


### PR DESCRIPTION
## What changed

This updates `is_path_like()` to recognize Windows-style directory paths, including drive paths (`C:\...`), backslash-relative paths, UNC paths, and trailing backslash directories.

## Why

Knowledge configuration with `string_mode="path_as_source"` already treats POSIX-style paths such as `docs/` as sources, but a Windows directory such as `C:\knowledge` fell through to the default config path instead of becoming a source. That makes equivalent Windows configurations behave differently from POSIX ones.

## Validation

- `PYTHONPATH=src/praisonai-agents python -m pytest src/praisonai-agents/tests/unit/config/test_agent_centric_enhancements.py::TestKnowledgePresets -q`
- `python -m ruff check src/praisonai-agents/praisonaiagents/config/parse_utils.py src/praisonai-agents/tests/unit/config/test_agent_centric_enhancements.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path detection to correctly recognize Windows-style paths, relative backslash-prefixed paths, and network/UNC-style paths.
  * Expanded directory handling to treat both forward slashes and backslashes as valid trailing separators.
  * Added tests to confirm Windows path strings are resolved as knowledge sources when using path-based mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->