### PR TITLE
docs: fix typo 'orginal' -> 'original' in training prompt templates

### DIFF
--- a/src/praisonai/praisonai/train.py
+++ b/src/praisonai/praisonai/train.py
@@ -353,7 +353,7 @@ class TrainModel:
     Cutting Knowledge Date: December 2023
     {{ if .System }}{{ .System }}
     {{- end }}
-    {{- if .Tools }}When you receive a tool call response, use the output to format an answer to the orginal user question.
+    {{- if .Tools }}When you receive a tool call response, use the output to format an answer to the original user question.
     You are a helpful assistant with tool calling capabilities.
     {{- end }}<|eot_id|>
     {{- range $i, $_ := .Messages }}

--- a/src/praisonai/praisonai/train/llm/trainer.py
+++ b/src/praisonai/praisonai/train/llm/trainer.py
@@ -350,7 +350,7 @@ class TrainModel:
     Cutting Knowledge Date: December 2023
     {{ if .System }}{{ .System }}
     {{- end }}
-    {{- if .Tools }}When you receive a tool call response, use the output to format an answer to the orginal user question.
+    {{- if .Tools }}When you receive a tool call response, use the output to format an answer to the original user question.
     You are a helpful assistant with tool calling capabilities.
     {{- end }}<|eot_id|>
     {{- range $i, $_ := .Messages }}


### PR DESCRIPTION
## Summary

Fixes a small typo `orginal` → `original` in the Ollama `Modelfile` prompt templates used during model training.

The misspelled word appears inside the system prompt template that gets written into the generated Modelfile:

> When you receive a tool call response, use the output to format an answer to the ~~orginal~~ **original** user question.

This text is rendered into the prompt the trained model sees, so the fix improves the quality of the generated template (and avoids a visible typo in user-facing output).

## Changes

Two identical occurrences corrected:
- `src/praisonai/praisonai/train.py` (line 356)
- `src/praisonai/praisonai/train/llm/trainer.py` (line 353)

Docs/string-only change — no logic, no API, no behavior change.

## Checklist
- [x] Follows existing code style
- [x] No functional/behavioral changes
- [x] Self-reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the LLaMA chat template guidance so tool-call responses now refer to “the original user question.”
  * Improved the generated model file content for more consistent and accurate instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->