### PR TITLE
Prepare multi-framework adapter extensibility

### DIFF
--- a/examples/python/frameworks/custom_adapter/my_framework_adapter.py
+++ b/examples/python/frameworks/custom_adapter/my_framework_adapter.py
@@ -1,0 +1,25 @@
+"""Example third-party framework adapter (entry-point template)."""
+
+from praisonaiagents.frameworks.base import BaseFrameworkAdapter
+
+
+class MyFrameworkAdapter(BaseFrameworkAdapter):
+    name = "my_framework"
+    install_hint = "pip install my-framework-bridge"
+    requires_tools_extra = False
+
+    def is_available(self) -> bool:
+        return True
+
+    def run(
+        self,
+        config,
+        llm_config,
+        topic,
+        *,
+        tools_dict=None,
+        agent_callback=None,
+        task_callback=None,
+        cli_config=None,
+    ) -> str:
+        return f"my_framework ran: {topic}"

--- a/examples/python/frameworks/custom_adapter/pyproject.toml
+++ b/examples/python/frameworks/custom_adapter/pyproject.toml
@@ -7,5 +7,8 @@ name = "my-framework-bridge"
 version = "0.0.1"
 dependencies = ["praisonaiagents"]
 
+[tool.setuptools]
+py-modules = ["my_framework_adapter"]
+
 [project.entry-points."praisonai.framework_adapters"]
 my_framework = "my_framework_adapter:MyFrameworkAdapter"

--- a/examples/python/frameworks/custom_adapter/pyproject.toml
+++ b/examples/python/frameworks/custom_adapter/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "my-framework-bridge"
+version = "0.0.1"
+dependencies = ["praisonaiagents"]
+
+[project.entry-points."praisonai.framework_adapters"]
+my_framework = "my_framework_adapter:MyFrameworkAdapter"

--- a/src/praisonai-agents/praisonaiagents/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/__init__.py
@@ -533,6 +533,10 @@ _LAZY_IMPORTS = {
     
     # Managed backend protocol (implementation + config in praisonai wrapper)
     'ManagedBackendProtocol': ('praisonaiagents.agent.protocols', 'ManagedBackendProtocol'),
+
+    # Framework adapter protocol (implementations in praisonai wrapper / praisonai-frameworks)
+    'FrameworkAdapterProtocol': ('praisonaiagents.frameworks.protocols', 'FrameworkAdapterProtocol'),
+    'BaseFrameworkAdapter': ('praisonaiagents.frameworks.base', 'BaseFrameworkAdapter'),
     
     # Managed agent events (provider-agnostic)
     'ManagedEvent': ('praisonaiagents.managed.events', 'ManagedEvent'),

--- a/src/praisonai-agents/praisonaiagents/frameworks/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/frameworks/__init__.py
@@ -1,0 +1,22 @@
+"""Framework adapter protocols and shared helpers (no third-party framework deps)."""
+
+from typing import TYPE_CHECKING
+
+__all__ = [
+    "FrameworkAdapterProtocol",
+    "BaseFrameworkAdapter",
+]
+
+if TYPE_CHECKING:
+    from .protocols import FrameworkAdapterProtocol
+    from .base import BaseFrameworkAdapter
+
+
+def __getattr__(name: str):
+    if name == "FrameworkAdapterProtocol":
+        from .protocols import FrameworkAdapterProtocol
+        return FrameworkAdapterProtocol
+    if name == "BaseFrameworkAdapter":
+        from .base import BaseFrameworkAdapter
+        return BaseFrameworkAdapter
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/praisonai-agents/praisonaiagents/frameworks/base.py
+++ b/src/praisonai-agents/praisonaiagents/frameworks/base.py
@@ -1,0 +1,90 @@
+"""Shared base helpers for framework adapters (no third-party imports)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from typing import Any, Callable, Dict, List, Optional
+
+from .protocols import FrameworkAdapterProtocol
+
+
+class BaseFrameworkAdapter:
+    """Base class for framework adapters providing common functionality."""
+
+    name: str = ""
+    install_hint: str = ""
+    requires_tools_extra: bool = False
+    is_router: bool = False
+
+    DEFAULT_MODEL = "openai/gpt-4o-mini"
+
+    def __init__(self) -> None:
+        pass
+
+    def _resolve_llm(self, spec: Any, llm_config: Optional[List[Dict]]) -> str:
+        """Resolve a model name from per-agent spec and shared llm_config."""
+        base = None
+        key = None
+        if llm_config and len(llm_config) > 0:
+            base = llm_config[0].get("base_url")
+            key = llm_config[0].get("api_key")
+
+        if isinstance(spec, str) and spec.strip():
+            model = spec.strip()
+        elif isinstance(spec, dict) and spec.get("model"):
+            model = spec["model"]
+        else:
+            model = os.environ.get("MODEL_NAME") or self.DEFAULT_MODEL
+
+        # Return model string; wrapper subclasses may upgrade to provider objects.
+        _ = (base, key)
+        return model
+
+    def _format_template(self, template: str, **kwargs: Any) -> str:
+        """Safely format template string, preserving JSON-like braces."""
+        if not isinstance(template, str):
+            return template
+
+        def _sub(match: re.Match) -> str:
+            name = match.group(1)
+            return str(kwargs[name]) if name in kwargs else match.group(0)
+
+        return re.sub(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}", _sub, template)
+
+    def resolve(
+        self, *, config: Optional[Dict[str, Any]] = None
+    ) -> FrameworkAdapterProtocol:
+        return self
+
+    def setup(self, *, framework_tag: str) -> None:
+        pass
+
+    async def arun(
+        self,
+        config: Dict[str, Any],
+        llm_config: List[Dict],
+        topic: str,
+        *,
+        tools_dict: Optional[Dict[str, Any]] = None,
+        agent_callback: Optional[Callable] = None,
+        task_callback: Optional[Callable] = None,
+        cli_config: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        return await asyncio.to_thread(
+            self.run,
+            config,
+            llm_config,
+            topic,
+            tools_dict=tools_dict,
+            agent_callback=agent_callback,
+            task_callback=task_callback,
+            cli_config=cli_config,
+        )
+
+    def cleanup(self) -> None:
+        pass
+
+    def resolve_alias(self) -> str:
+        return self.name

--- a/src/praisonai-agents/praisonaiagents/frameworks/protocols.py
+++ b/src/praisonai-agents/praisonaiagents/frameworks/protocols.py
@@ -1,0 +1,65 @@
+"""Protocol for optional third-party agent framework adapters."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class FrameworkAdapterProtocol(Protocol):
+    """Contract for YAML-driven multi-framework execution backends."""
+
+    name: str
+    install_hint: str
+    requires_tools_extra: bool
+    is_router: bool
+
+    def is_available(self) -> bool:
+        """Return True when this framework's optional dependencies are installed."""
+        ...
+
+    def resolve(
+        self, *, config: Optional[Dict[str, Any]] = None
+    ) -> "FrameworkAdapterProtocol":
+        """Pick a concrete adapter variant (e.g. autogen v0.2 vs v0.4)."""
+        ...
+
+    def setup(self, *, framework_tag: str) -> None:
+        """Framework-specific pre-run hooks (observability, SDK init, etc.)."""
+        ...
+
+    def run(
+        self,
+        config: Dict[str, Any],
+        llm_config: List[Dict],
+        topic: str,
+        *,
+        tools_dict: Optional[Dict[str, Any]] = None,
+        agent_callback: Optional[Callable] = None,
+        task_callback: Optional[Callable] = None,
+        cli_config: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Execute the framework with shared agents.yaml configuration."""
+        ...
+
+    async def arun(
+        self,
+        config: Dict[str, Any],
+        llm_config: List[Dict],
+        topic: str,
+        *,
+        tools_dict: Optional[Dict[str, Any]] = None,
+        agent_callback: Optional[Callable] = None,
+        task_callback: Optional[Callable] = None,
+        cli_config: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Async execution; default implementations may offload sync run()."""
+        ...
+
+    def cleanup(self) -> None:
+        """Release resources after execution."""
+        ...
+
+    def resolve_alias(self) -> str:
+        """Return the concrete adapter name to dispatch to."""
+        ...

--- a/src/praisonai-agents/praisonaiagents/workflows/yaml_parser.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/yaml_parser.py
@@ -364,6 +364,8 @@ class YAMLWorkflowParser:
         
         # Store additional attributes for feature parity with agents.yaml
         workflow.description = description
+        # Metadata only: native Workflow engine does not dispatch on framework != praisonai.
+        # Wrapper validates via framework_adapters.workflow_framework.validate_workflow_framework().
         workflow.framework = framework
         
         # Store approved tools for auto-approval during workflow execution

--- a/src/praisonai-agents/tests/unit/test_framework_protocol.py
+++ b/src/praisonai-agents/tests/unit/test_framework_protocol.py
@@ -1,0 +1,40 @@
+"""Core SDK framework adapter protocol exports."""
+
+from praisonaiagents.frameworks.protocols import FrameworkAdapterProtocol
+from praisonaiagents.frameworks.base import BaseFrameworkAdapter
+
+
+def test_protocol_is_runtime_checkable():
+    class _MinimalAdapter:
+        name = "x"
+        install_hint = "pip install x"
+        requires_tools_extra = False
+        is_router = False
+
+        def is_available(self):
+            return True
+
+        def resolve(self, *, config=None):
+            return self
+
+        def setup(self, *, framework_tag: str):
+            pass
+
+        def run(self, config, llm_config, topic, *, tools_dict=None, agent_callback=None, task_callback=None, cli_config=None):
+            return "ok"
+
+        async def arun(self, config, llm_config, topic, *, tools_dict=None, agent_callback=None, task_callback=None, cli_config=None):
+            return "ok"
+
+        def cleanup(self):
+            pass
+
+        def resolve_alias(self):
+            return self.name
+
+    assert isinstance(_MinimalAdapter(), FrameworkAdapterProtocol)
+
+
+def test_base_framework_adapter_format_template():
+    adapter = BaseFrameworkAdapter()
+    assert adapter._format_template("Hello {topic}", topic="world") == "Hello world"

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -713,8 +713,9 @@ class AgentsGenerator:
             framework_from_config,
             validate_workflow_framework,
         )
+        effective_framework = (self.framework or framework_from_config(config))
         validate_workflow_framework(
-            framework_from_config(config),
+            effective_framework,
             source="agents.yaml workflow section",
         )
         
@@ -777,8 +778,9 @@ class AgentsGenerator:
             framework_from_config,
             validate_workflow_framework,
         )
+        effective_framework = (self.framework or framework_from_config(config))
         validate_workflow_framework(
-            framework_from_config(config),
+            effective_framework,
             source="agents.yaml workflow section",
         )
         

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -708,6 +708,15 @@ class AgentsGenerator:
         # Ensure name is present
         if 'name' not in config:
             config['name'] = config.get('topic', 'Workflow')
+
+        from .framework_adapters.workflow_framework import (
+            framework_from_config,
+            validate_workflow_framework,
+        )
+        validate_workflow_framework(
+            framework_from_config(config),
+            source="agents.yaml workflow section",
+        )
         
         # Pass model from config_list to workflow as default_llm
         if self.config_list and self.config_list[0].get('model'):
@@ -763,6 +772,15 @@ class AgentsGenerator:
         # Ensure name is present (YAMLWorkflowParser handles roles->agents conversion)
         if 'name' not in config:
             config['name'] = config.get('topic', 'Workflow')
+
+        from .framework_adapters.workflow_framework import (
+            framework_from_config,
+            validate_workflow_framework,
+        )
+        validate_workflow_framework(
+            framework_from_config(config),
+            source="agents.yaml workflow section",
+        )
         
         # Pass model from config_list to workflow as default_llm
         if self.config_list and self.config_list[0].get('model'):

--- a/src/praisonai/praisonai/cli/commands/run.py
+++ b/src/praisonai/praisonai/cli/commands/run.py
@@ -19,7 +19,7 @@ def _framework_help() -> str:
     try:
         from ...framework_adapters.registry import framework_option_help
         return framework_option_help()
-    except Exception:
+    except ImportError:
         return "Framework: praisonai, crewai, autogen"
 
 

--- a/src/praisonai/praisonai/cli/commands/run.py
+++ b/src/praisonai/praisonai/cli/commands/run.py
@@ -15,6 +15,17 @@ from ..configuration.resolver import resolve_config
 app = typer.Typer(help="Run agents")
 
 
+def _framework_help() -> str:
+    try:
+        from ...framework_adapters.registry import framework_option_help
+        return framework_option_help()
+    except Exception:
+        return "Framework: praisonai, crewai, autogen"
+
+
+_FRAMEWORK_HELP = _framework_help()
+
+
 def _parse_permissions(allow: Optional[List[str]], deny: Optional[List[str]], permissions_file: Optional[str], default: Optional[str]) -> Optional[dict]:
     """Parse permission flags into a config dict.
     
@@ -425,7 +436,7 @@ def run_main(
     ctx: typer.Context,
     target: Optional[str] = typer.Argument(None, help="Agent file or prompt"),
     model: Optional[str] = typer.Option(None, "--model", "-m", help="LLM model to use"),
-    framework: Optional[str] = typer.Option(None, "--framework", "-f", help="Framework: praisonai, crewai, autogen"),
+    framework: Optional[str] = typer.Option(None, "--framework", "-f", help=_FRAMEWORK_HELP),
     interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactive mode"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
     stream: bool = typer.Option(False, "--stream/--no-stream", help="Stream output (default: off for production use)"),
@@ -660,7 +671,7 @@ def run_main(
             "  praisonai run --command summarize \"Long text here\"\n\n"
             "Options:\n"
             "  --model, -m       LLM model to use\n"
-            "  --framework, -f   Framework (praisonai, crewai, autogen)\n"
+            f"  --framework, -f   {_FRAMEWORK_HELP}\n"
             "  --interactive, -i Interactive mode\n"
             "  --verbose, -v     Verbose output\n"
             "  --trace           Enable tracing\n"

--- a/src/praisonai/praisonai/cli/features/doctor/checks/config_checks.py
+++ b/src/praisonai/praisonai/cli/features/doctor/checks/config_checks.py
@@ -173,9 +173,10 @@ def check_agents_yaml_schema(config: DoctorConfig) -> CheckResult:
             registered = get_default_registry().list_names()
             if framework not in registered:
                 warnings.append(f"Unknown framework: {framework} (registered: {', '.join(sorted(registered))})")
-        except Exception:
-            if framework not in ["praisonai", "crewai", "autogen"]:
-                warnings.append(f"Unknown framework: {framework}")
+        except ImportError:
+            # Registry unavailable (adapter layer not installed); skip the
+            # unknown-framework check rather than guessing against a stale list.
+            pass
     
     # Check for agents section
     agents = data.get("agents") or data.get("roles")

--- a/src/praisonai/praisonai/cli/features/doctor/checks/config_checks.py
+++ b/src/praisonai/praisonai/cli/features/doctor/checks/config_checks.py
@@ -168,8 +168,14 @@ def check_agents_yaml_schema(config: DoctorConfig) -> CheckResult:
     # Check for common fields
     if "framework" in data:
         framework = data["framework"]
-        if framework not in ["praisonai", "crewai", "autogen"]:
-            warnings.append(f"Unknown framework: {framework}")
+        try:
+            from praisonai.framework_adapters.registry import get_default_registry
+            registered = get_default_registry().list_names()
+            if framework not in registered:
+                warnings.append(f"Unknown framework: {framework} (registered: {', '.join(sorted(registered))})")
+        except Exception:
+            if framework not in ["praisonai", "crewai", "autogen"]:
+                warnings.append(f"Unknown framework: {framework}")
     
     # Check for agents section
     agents = data.get("agents") or data.get("roles")

--- a/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
+++ b/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
@@ -68,13 +68,18 @@ class RuntimeCompatibilityChecker:
         def _runtime_usable(framework_name: str, package_name: str) -> bool:
             try:
                 from praisonai.framework_adapters.registry import get_default_registry
-                registry = get_default_registry()
-                if framework_name in registry.list_names():
-                    return registry.is_available(framework_name)
-            except Exception:
-                pass
-            # Fallback to raw package probe when the registry is unavailable.
-            return is_available(package_name)
+            except ImportError:
+                # Fallback to raw package probe only when the registry module
+                # itself cannot be imported (e.g. partial install).
+                return is_available(package_name)
+
+            registry = get_default_registry()
+            # When the registry is the source of truth, an unregistered
+            # framework is not runnable even if its packages are installed,
+            # so doctor stays consistent with the `--framework` choices.
+            if framework_name not in registry.list_names():
+                return False
+            return registry.is_available(framework_name)
         
         # PraisonAI Agents runtime
         runtimes['praisonai'] = RuntimeInfo(

--- a/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
+++ b/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
@@ -105,11 +105,11 @@ class RuntimeCompatibilityChecker:
             supports_tool_loop=True
         )
         
-        # AutoGen v0.4 runtime
+        # AutoGen v0.4 runtime (optional entry-point adapter)
         runtimes['autogen_v4'] = RuntimeInfo(
             id='autogen_v4',
             name='AutoGen v0.4',
-            available=is_available('autogen') and self._check_autogen_v4(),
+            available=is_available('autogen_v4'),
             capabilities=[
                 RuntimeCapability('agent_creation', 'Create and manage agents'),
                 RuntimeCapability('tool_execution', 'Execute tools and functions'),
@@ -119,7 +119,7 @@ class RuntimeCompatibilityChecker:
             supports_tool_loop=True
         )
         
-        # AG2 runtime
+        # AG2 runtime (optional entry-point adapter)
         runtimes['ag2'] = RuntimeInfo(
             id='ag2',
             name='AG2 (AutoGen Next)',
@@ -135,11 +135,10 @@ class RuntimeCompatibilityChecker:
         return runtimes
     
     def _check_autogen_v4(self) -> bool:
-        """Check if AutoGen v0.4+ is available."""
+        """Check if AutoGen v0.4+ packages are installed."""
         try:
-            import autogen
-            version = getattr(autogen, '__version__', '0.0.0')
-            return version.startswith(('0.4', '0.5'))
+            from praisonai._framework_availability import is_available as fw_available
+            return fw_available('autogen_v4')
         except ImportError:
             return False
     

--- a/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
+++ b/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
@@ -59,6 +59,22 @@ class RuntimeCompatibilityChecker:
             from praisonai._framework_availability import is_available
         except ImportError:
             is_available = lambda x: False
+
+        # Adapter-aware availability: a runtime is only "usable" if its adapter
+        # is both installed AND implemented/registered. This keeps `doctor` in
+        # sync with the registry-backed `--framework` choices so it never
+        # reports a runtime as available when the matching framework cannot run
+        # (e.g. unimplemented AutoGen v0.4 / AG2 entry-point placeholders).
+        def _runtime_usable(framework_name: str, package_name: str) -> bool:
+            try:
+                from praisonai.framework_adapters.registry import get_default_registry
+                registry = get_default_registry()
+                if framework_name in registry.list_names():
+                    return registry.is_available(framework_name)
+            except Exception:
+                pass
+            # Fallback to raw package probe when the registry is unavailable.
+            return is_available(package_name)
         
         # PraisonAI Agents runtime
         runtimes['praisonai'] = RuntimeInfo(
@@ -109,7 +125,7 @@ class RuntimeCompatibilityChecker:
         runtimes['autogen_v4'] = RuntimeInfo(
             id='autogen_v4',
             name='AutoGen v0.4',
-            available=is_available('autogen_v4'),
+            available=_runtime_usable('autogen_v4', 'autogen_v4'),
             capabilities=[
                 RuntimeCapability('agent_creation', 'Create and manage agents'),
                 RuntimeCapability('tool_execution', 'Execute tools and functions'),
@@ -123,7 +139,7 @@ class RuntimeCompatibilityChecker:
         runtimes['ag2'] = RuntimeInfo(
             id='ag2',
             name='AG2 (AutoGen Next)',
-            available=is_available('ag2'),
+            available=_runtime_usable('ag2', 'ag2'),
             capabilities=[
                 RuntimeCapability('agent_creation', 'Create and manage agents'),
                 RuntimeCapability('tool_execution', 'Execute tools and functions'),

--- a/src/praisonai/praisonai/cli/main.py
+++ b/src/praisonai/praisonai/cli/main.py
@@ -1012,7 +1012,18 @@ class PraisonAI:
         special_commands = ['chat', 'code', 'call', 'realtime', 'train', 'ui', 'context', 'research', 'memory', 'rules', 'workflow', 'hooks', 'knowledge', 'session', 'tools', 'todo', 'docs', 'mcp', 'commit', 'serve', 'schedule', 'skills', 'profile', 'eval', 'agents', 'run', 'thinking', 'compaction', 'output', 'deploy', 'templates', 'recipe', 'endpoints', 'audio', 'embed', 'embedding', 'images', 'moderate', 'files', 'batches', 'vector-stores', 'rerank', 'ocr', 'assistants', 'fine-tuning', 'completions', 'messages', 'guardrails', 'rag', 'videos', 'a2a', 'containers', 'passthrough', 'responses', 'search', 'realtime-api', 'doctor', 'registry', 'package', 'install', 'uninstall', 'acp', 'debug', 'lsp', 'diag', 'browser', 'replay', 'bot', 'gateway', 'sandbox', 'wizard', 'migrate', 'security', 'persistence', 'paths', 'claw', 'github', 'managed', 'flow', 'dashboard', 'backends', 'audit']
         
         parser = argparse.ArgumentParser(prog="praisonai", description="praisonAI command-line interface")
-        parser.add_argument("--framework", choices=["crewai", "autogen", "praisonai"], help="Specify the framework")
+        try:
+            from ..framework_adapters.registry import list_framework_choices
+            _framework_choices = list_framework_choices(include_unavailable=True) or [
+                "praisonai", "crewai", "autogen",
+            ]
+        except Exception:
+            _framework_choices = ["praisonai", "crewai", "autogen"]
+        parser.add_argument(
+            "--framework",
+            choices=_framework_choices,
+            help="Specify the agent framework (discovered from installed adapters)",
+        )
         parser.add_argument("--ui", choices=["chainlit", "gradio"], help="Specify the UI framework (gradio or chainlit).")
         parser.add_argument("--auto", nargs=argparse.REMAINDER, help="Enable auto mode and pass arguments for it")
         parser.add_argument("--init", nargs=argparse.REMAINDER, help="Initialize agents with optional topic")
@@ -2009,13 +2020,22 @@ class PraisonAI:
 
         # Only check framework availability for agent-related operations
         if not args.command and (args.init or args.auto or args.framework):
-            if not CREWAI_AVAILABLE and not AUTOGEN_AVAILABLE and not PRAISONAI_AVAILABLE:
-                print("[red]ERROR: No framework is installed. Please install at least one framework:[/red]")
-                print("\npip install \"praisonai\\[crewai]\"  # For CrewAI")
-                print("pip install \"praisonai\\[autogen]\"  # For AutoGen")
-                print("pip install \"praisonai\\[crewai,autogen]\"  # For both frameworks\n")
-                print("pip install praisonaiagents # For Agents\n")  
-                sys.exit(1)
+            try:
+                from ..framework_adapters.registry import list_framework_choices
+                if not list_framework_choices():
+                    print("[red]ERROR: No framework adapter is installed.[/red]")
+                    print("\npip install praisonaiagents  # native PraisonAI")
+                    print("pip install \"praisonai[crewai]\"  # CrewAI")
+                    print("pip install \"praisonai[autogen]\"  # AutoGen\n")
+                    sys.exit(1)
+            except Exception:
+                if not CREWAI_AVAILABLE and not AUTOGEN_AVAILABLE and not PRAISONAI_AVAILABLE:
+                    print("[red]ERROR: No framework is installed. Please install at least one framework:[/red]")
+                    print("\npip install \"praisonai\\[crewai]\"  # For CrewAI")
+                    print("pip install \"praisonai\\[autogen]\"  # For AutoGen")
+                    print("pip install \"praisonai\\[crewai,autogen]\"  # For both frameworks\n")
+                    print("pip install praisonaiagents # For Agents\n")
+                    sys.exit(1)
 
         # Handle direct prompt if command is not a special command or file
         # Skip this during testing to avoid pytest arguments interfering
@@ -2914,6 +2934,12 @@ class PraisonAI:
             
             # Load and execute the YAML workflow with tool registry
             workflow = manager.load_yaml(yaml_file, tool_registry=tool_registry)
+
+            from ..framework_adapters.workflow_framework import validate_workflow_framework
+            validate_workflow_framework(
+                getattr(workflow, "framework", "praisonai"),
+                source=f"workflow file {yaml_file}",
+            )
             
             # Show workflow info
             table = Table(title=f"Workflow: {workflow.name}")
@@ -5635,9 +5661,20 @@ Now, {final_instruction.lower()}:"""
                 result = agents_generator.generate_crew_and_kickoff()
                 return result
 
+            try:
+                from ..framework_adapters.registry import list_framework_choices
+                _gradio_frameworks = list_framework_choices(include_unavailable=True) or [
+                    "crewai", "autogen", "praisonai",
+                ]
+            except Exception:
+                _gradio_frameworks = ["crewai", "autogen", "praisonai"]
+
             gr.Interface(
                 fn=generate_crew_and_kickoff_interface,
-                inputs=[gr.Textbox(lines=2, label="Auto Args"), gr.Dropdown(choices=["crewai", "autogen"], label="Framework")],
+                inputs=[
+                    gr.Textbox(lines=2, label="Auto Args"),
+                    gr.Dropdown(choices=_gradio_frameworks, label="Framework"),
+                ],
                 outputs="textbox",
                 title="Praison AI Studio",
                 description="Create Agents and perform tasks",

--- a/src/praisonai/praisonai/cli/main.py
+++ b/src/praisonai/praisonai/cli/main.py
@@ -1017,7 +1017,9 @@ class PraisonAI:
             _framework_choices = list_framework_choices(include_unavailable=True) or [
                 "praisonai", "crewai", "autogen",
             ]
-        except Exception:
+        except ImportError:
+            # Only fall back to the static trio when the adapter layer itself
+            # cannot be imported; genuine registry discovery errors should surface.
             _framework_choices = ["praisonai", "crewai", "autogen"]
         parser.add_argument(
             "--framework",
@@ -2028,7 +2030,7 @@ class PraisonAI:
                     print("pip install \"praisonai[crewai]\"  # CrewAI")
                     print("pip install \"praisonai[autogen]\"  # AutoGen\n")
                     sys.exit(1)
-            except Exception:
+            except ImportError:
                 if not CREWAI_AVAILABLE and not AUTOGEN_AVAILABLE and not PRAISONAI_AVAILABLE:
                     print("[red]ERROR: No framework is installed. Please install at least one framework:[/red]")
                     print("\npip install \"praisonai\\[crewai]\"  # For CrewAI")
@@ -3068,6 +3070,12 @@ class PraisonAI:
             
             parser = YAMLWorkflowParser()
             workflow = parser.parse_file(yaml_file)
+
+            from ..framework_adapters.workflow_framework import validate_workflow_framework
+            validate_workflow_framework(
+                getattr(workflow, "framework", "praisonai"),
+                source=f"workflow file {yaml_file}",
+            )
             
             # Show validation results
             table = Table(title="Workflow Validation")
@@ -5666,7 +5674,7 @@ Now, {final_instruction.lower()}:"""
                 _gradio_frameworks = list_framework_choices(include_unavailable=True) or [
                     "crewai", "autogen", "praisonai",
                 ]
-            except Exception:
+            except ImportError:
                 _gradio_frameworks = ["crewai", "autogen", "praisonai"]
 
             gr.Interface(

--- a/src/praisonai/praisonai/framework_adapters/__init__.py
+++ b/src/praisonai/praisonai/framework_adapters/__init__.py
@@ -1,14 +1,41 @@
 # Framework adapters for protocol-driven architecture
-from .base import FrameworkAdapter
-from .crewai_adapter import CrewAIAdapter
-from .autogen_adapter import AutoGenAdapter, AutoGenV4Adapter, AG2Adapter
+import warnings
+
+from .base import FrameworkAdapter, BaseFrameworkAdapter, scoped_telemetry_disable
 from .praisonai_adapter import PraisonAIAdapter
 
 __all__ = [
     "FrameworkAdapter",
-    "CrewAIAdapter", 
+    "BaseFrameworkAdapter",
+    "scoped_telemetry_disable",
+    "CrewAIAdapter",
     "AutoGenAdapter",
     "AutoGenV4Adapter",
     "AG2Adapter",
-    "PraisonAIAdapter"
+    "PraisonAIAdapter",
 ]
+
+_DEPRECATION = (
+    "Importing {name} from praisonai.framework_adapters is deprecated; "
+    "install praisonai-frameworks or use FrameworkAdapterRegistry entry points."
+)
+
+
+def __getattr__(name: str):
+    if name == "CrewAIAdapter":
+        warnings.warn(_DEPRECATION.format(name="CrewAIAdapter"), DeprecationWarning, stacklevel=2)
+        from .crewai_adapter import CrewAIAdapter
+        return CrewAIAdapter
+    if name == "AutoGenAdapter":
+        warnings.warn(_DEPRECATION.format(name="AutoGenAdapter"), DeprecationWarning, stacklevel=2)
+        from .autogen_adapter import AutoGenAdapter
+        return AutoGenAdapter
+    if name == "AutoGenV4Adapter":
+        warnings.warn(_DEPRECATION.format(name="AutoGenV4Adapter"), DeprecationWarning, stacklevel=2)
+        from .autogen_adapter import AutoGenV4Adapter
+        return AutoGenV4Adapter
+    if name == "AG2Adapter":
+        warnings.warn(_DEPRECATION.format(name="AG2Adapter"), DeprecationWarning, stacklevel=2)
+        from .autogen_adapter import AG2Adapter
+        return AG2Adapter
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
@@ -261,8 +261,9 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
     Router adapter for AutoGen family (v0.2, v0.4, AG2).
     Dispatches to concrete adapter based on config/environment.
     """
-    
+
     name = "autogen"
+    is_router = True
     
     def is_available(self) -> bool:
         """Check if any AutoGen variant is available."""

--- a/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
@@ -323,39 +323,44 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
         v4_available = _selectable("autogen_v4")
         ag2_available = _selectable("ag2")
 
-        # Explicit version pins: honour only when the variant can actually run,
-        # otherwise warn and fall back to a usable variant.
+        # Explicit version pins: honour only when the variant can actually run.
+        # An explicit pin must NOT silently fall back to a different variant —
+        # a workflow that depends on v0.4 / AG2 APIs would otherwise run under
+        # v0.2 with different behaviour. Fail fast with an actionable error so
+        # the mismatch surfaces instead of producing wrong-runtime results.
         if requested == "v0.2":
             if v2_available:
                 return "autogen_v2"
-            logger.warning("AUTOGEN_VERSION=v0.2 requested but autogen (v0.2) is not available")
+            raise ImportError(
+                "AUTOGEN_VERSION=v0.2 was requested, but the AutoGen v0.2 adapter "
+                "is not available. Install with: pip install 'praisonai[autogen]'."
+            )
         elif requested == "v0.4":
             if v4_available:
                 return "autogen_v4"
-            logger.warning(
-                "AUTOGEN_VERSION=v0.4 requested but the v0.4 adapter is not "
-                "registered/available; falling back to v0.2 if installed"
+            raise ImportError(
+                "AUTOGEN_VERSION=v0.4 was requested, but the v0.4 adapter is not "
+                "registered or available. Install/register an autogen_v4 adapter "
+                "(pip install 'praisonai[autogen-v4]'), or unset AUTOGEN_VERSION "
+                "to use auto-selection."
             )
-            if v2_available:
-                return "autogen_v2"
         elif requested == "ag2":
             if ag2_available:
                 return "ag2"
-            logger.warning(
-                "AUTOGEN_VERSION=ag2 requested but the AG2 adapter is not "
-                "registered/available; falling back to v0.2 if installed"
+            raise ImportError(
+                "AUTOGEN_VERSION=ag2 was requested, but the AG2 adapter is not "
+                "registered or available. Install/register an AG2 adapter "
+                "(pip install 'praisonai[ag2]'), or unset AUTOGEN_VERSION to use "
+                "auto-selection."
             )
-            if v2_available:
-                return "autogen_v2"
 
         # Auto selection: prefer v2 (v4/ag2 are currently unimplemented).
-        if requested not in ("v0.2", "v0.4", "ag2"):
-            if v2_available:
-                return "autogen_v2"
-            if v4_available:
-                return "autogen_v4"
-            if ag2_available:
-                return "ag2"
+        if v2_available:
+            return "autogen_v2"
+        if v4_available:
+            return "autogen_v4"
+        if ag2_available:
+            return "ag2"
 
         # Nothing selectable.
         raise ImportError(

--- a/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
@@ -335,7 +335,17 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
         logger.info(f"AutoGenFamilyAdapter resolved to: {adapter_name}")
         return concrete_adapter
     
-    def run(self, config: Dict[str, Any], llm_config: List[Dict], topic: str) -> str:
+    def run(
+        self,
+        config: Dict[str, Any],
+        llm_config: List[Dict],
+        topic: str,
+        *,
+        tools_dict: Optional[Dict[str, Any]] = None,
+        agent_callback: Optional[Callable] = None,
+        task_callback: Optional[Callable] = None,
+        cli_config: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """Router should never run directly."""
         raise RuntimeError(
             "AutoGenFamilyAdapter.run() should not be called directly. "

--- a/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
@@ -263,6 +263,7 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
     """
 
     name = "autogen"
+    install_hint = 'pip install "praisonai-frameworks[autogen]"'
     is_router = True
     
     def is_available(self) -> bool:

--- a/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
@@ -263,7 +263,7 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
     """
 
     name = "autogen"
-    install_hint = 'pip install "praisonai-frameworks[autogen]"'
+    install_hint = 'pip install "praisonai[autogen]"'
     is_router = True
     
     def is_available(self) -> bool:

--- a/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
@@ -274,40 +274,72 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
         return v2.is_available() or v4.is_available() or ag2.is_available()
     
     def resolve_alias(self) -> str:
-        """Resolve which concrete AutoGen adapter to use."""
-        requested = os.getenv("AUTOGEN_VERSION", "auto").lower()
-        
-        # Check availability
-        v2_available = AutoGenAdapter().is_available()
-        v4_available = AutoGenV4Adapter().is_available()
-        ag2_available = AG2Adapter().is_available()
+        """Resolve which concrete AutoGen adapter to use.
 
-        # Explicit version pins with warnings if not available
+        Only returns an alias whose concrete adapter is actually registered AND
+        available, so the downstream ``registry.create(alias)`` never fails with
+        an opaque lookup error. ``autogen_v4`` / ``ag2`` are unimplemented and
+        unregistered by default, so explicit pins for them fall back to v0.2
+        when possible, otherwise raise an actionable ``ImportError``.
+        """
+        requested = os.getenv("AUTOGEN_VERSION", "auto").lower()
+
+        # A variant is selectable only if its adapter is registered in the
+        # registry (built-in or entry-point) and reports availability.
+        try:
+            from .registry import get_default_registry
+            registry = get_default_registry()
+            registered = set(registry.list_names())
+
+            def _selectable(alias: str) -> bool:
+                return alias in registered and registry.is_available(alias)
+        except ImportError:
+            registered = set()
+
+            def _selectable(alias: str) -> bool:
+                return False
+
+        v2_available = _selectable("autogen_v2")
+        v4_available = _selectable("autogen_v4")
+        ag2_available = _selectable("ag2")
+
+        # Explicit version pins: honour only when the variant can actually run,
+        # otherwise warn and fall back to a usable variant.
         if requested == "v0.2":
-            if not v2_available:
-                logger.warning("AUTOGEN_VERSION=v0.2 requested but autogen (v0.2) is not installed")
-            return "autogen_v2"
-        if requested == "v0.4":
-            if not v4_available:
-                logger.warning("AUTOGEN_VERSION=v0.4 requested but autogen_agentchat (v0.4) is not installed")
-            return "autogen_v4"
-        if requested == "ag2":
-            if not ag2_available:
-                logger.warning("AUTOGEN_VERSION=ag2 requested but AG2 is not installed")
-            return "ag2"
-        
-        # Auto selection: prefer v2 (v4 is currently unimplemented)
-        if v2_available:
-            return "autogen_v2"
-        elif v4_available:
-            logger.warning("AutoGen v0.4 is installed but not yet implemented, falling back.")
-            return "autogen_v4"
-        elif ag2_available:
-            return "ag2"
-        
-        # Nothing available
+            if v2_available:
+                return "autogen_v2"
+            logger.warning("AUTOGEN_VERSION=v0.2 requested but autogen (v0.2) is not available")
+        elif requested == "v0.4":
+            if v4_available:
+                return "autogen_v4"
+            logger.warning(
+                "AUTOGEN_VERSION=v0.4 requested but the v0.4 adapter is not "
+                "registered/available; falling back to v0.2 if installed"
+            )
+            if v2_available:
+                return "autogen_v2"
+        elif requested == "ag2":
+            if ag2_available:
+                return "ag2"
+            logger.warning(
+                "AUTOGEN_VERSION=ag2 requested but the AG2 adapter is not "
+                "registered/available; falling back to v0.2 if installed"
+            )
+            if v2_available:
+                return "autogen_v2"
+
+        # Auto selection: prefer v2 (v4/ag2 are currently unimplemented).
+        if requested not in ("v0.2", "v0.4", "ag2"):
+            if v2_available:
+                return "autogen_v2"
+            if v4_available:
+                return "autogen_v4"
+            if ag2_available:
+                return "ag2"
+
+        # Nothing selectable.
         raise ImportError(
-            "No AutoGen variant is available. Install with:\n"
+            "No runnable AutoGen variant is available. Install with:\n"
             "  pip install 'praisonai[autogen]' for v0.2\n"
             "  pip install 'praisonai[autogen-v4]' for v0.4\n"
             "  pip install 'praisonai[ag2]' for AG2"

--- a/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/autogen_adapter.py
@@ -267,13 +267,26 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
     is_router = True
     
     def is_available(self) -> bool:
-        """Check if any AutoGen variant is available."""
-        v2 = AutoGenAdapter()
-        v4 = AutoGenV4Adapter()
-        ag2 = AG2Adapter()
-        return v2.is_available() or v4.is_available() or ag2.is_available()
+        """Check if any AutoGen variant is runnable.
+
+        Mirrors ``resolve_alias()``'s registry-backed selectability so router
+        availability stays consistent: ``registry.is_available("autogen")`` only
+        reports True when a concrete variant is registered AND available, and
+        thus actually dispatchable by ``resolve()``. Raw v4/ag2 packages alone
+        (no registered adapter) correctly report unavailable.
+        """
+        try:
+            from .registry import get_default_registry
+            registry = get_default_registry()
+            registered = set(registry.list_names())
+        except ImportError:
+            return False
+        return any(
+            alias in registered and registry.is_available(alias)
+            for alias in ("autogen_v2", "autogen_v4", "ag2")
+        )
     
-    def resolve_alias(self) -> str:
+    def resolve_alias(self, config: Optional[Dict[str, Any]] = None) -> str:
         """Resolve which concrete AutoGen adapter to use.
 
         Only returns an alias whose concrete adapter is actually registered AND
@@ -281,8 +294,15 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
         an opaque lookup error. ``autogen_v4`` / ``ag2`` are unimplemented and
         unregistered by default, so explicit pins for them fall back to v0.2
         when possible, otherwise raise an actionable ``ImportError``.
+
+        The workflow-supplied ``autogen_version`` (config/YAML) takes precedence
+        over the ``AUTOGEN_VERSION`` environment variable so an explicit YAML
+        pin wins over ambient env state.
         """
-        requested = os.getenv("AUTOGEN_VERSION", "auto").lower()
+        requested = str(
+            (config or {}).get("autogen_version")
+            or os.getenv("AUTOGEN_VERSION", "auto")
+        ).strip().lower()
 
         # A variant is selectable only if its adapter is registered in the
         # registry (built-in or entry-point) and reports availability.
@@ -356,8 +376,8 @@ class AutoGenFamilyAdapter(BaseFrameworkAdapter):
         Returns:
             The concrete AutoGen adapter instance
         """
-        # Get the adapter name to use
-        adapter_name = self.resolve_alias()
+        # Get the adapter name to use (config autogen_version wins over env)
+        adapter_name = self.resolve_alias(config)
         
         # Import registry to create the concrete adapter
         from .registry import get_default_registry

--- a/src/praisonai/praisonai/framework_adapters/base.py
+++ b/src/praisonai/praisonai/framework_adapters/base.py
@@ -1,218 +1,66 @@
 """
-Base framework adapter protocol for PraisonAI.
+Base framework adapter protocol for PraisonAI wrapper.
 
-This module defines the protocol that all framework adapters must implement,
-enabling lazy-loaded, protocol-driven framework support.
+Protocol and shared helpers live in praisonaiagents.frameworks; this module
+re-exports them and adds wrapper-specific LLM resolution via PraisonAIModel.
 """
 
-from typing import Protocol, Dict, List, Any, Optional, Callable
+from __future__ import annotations
+
 from contextlib import contextmanager
+from typing import Any, Callable, Dict, List, Optional
+
+from praisonaiagents.frameworks.base import BaseFrameworkAdapter as _CoreBaseFrameworkAdapter
+from praisonaiagents.frameworks.protocols import FrameworkAdapterProtocol
+
+# Backward-compatible alias used across the wrapper
+FrameworkAdapter = FrameworkAdapterProtocol
 
 
-class FrameworkAdapter(Protocol):
-    """Protocol for framework adapters."""
-    
-    name: str
-    install_hint: str
-    requires_tools_extra: bool
-    
-    def is_available(self) -> bool:
-        """Check if the framework is available for import."""
-        ...
-    
-    def resolve(self, *, config: Optional[Dict[str, Any]] = None) -> "FrameworkAdapter":
-        """Pick the concrete adapter variant (e.g. autogen v0.2 vs v0.4).
-        
-        Args:
-            config: YAML configuration that may contain version preferences
-        
-        Returns:
-            The resolved adapter instance (self or a different adapter)
-        """
-        ...
-    
-    def setup(self, *, framework_tag: str) -> None:
-        """Framework-specific pre-run hooks (observability, sdk init, etc.).
-        
-        Args:
-            framework_tag: Framework name for observability tagging
-        """
-        ...
-    
-    def run(
-        self,
-        config: Dict[str, Any],
-        llm_config: List[Dict],
-        topic: str,
-        *,
-        tools_dict: Optional[Dict[str, Any]] = None,
-        agent_callback: Optional[Callable] = None,
-        task_callback: Optional[Callable] = None,
-        cli_config: Optional[Dict[str, Any]] = None,
-    ) -> str:
-        """
-        Run the framework with given configuration.
-        
-        Args:
-            config: Framework configuration
-            llm_config: LLM configuration list
-            topic: Topic for the tasks
-            tools_dict: Available tools dictionary
-            agent_callback: Callback for agent events
-            task_callback: Callback for task events
-            cli_config: CLI configuration
-            
-        Returns:
-            Execution result as string
-        """
-        ...
+class BaseFrameworkAdapter(_CoreBaseFrameworkAdapter):
+    """Wrapper base adapter with PraisonAIModel LLM resolution for CrewAI etc."""
 
-    async def arun(
-        self,
-        config: Dict[str, Any],
-        llm_config: List[Dict],
-        topic: str,
-        *,
-        tools_dict: Optional[Dict[str, Any]] = None,
-        agent_callback: Optional[Callable] = None,
-        task_callback: Optional[Callable] = None,
-        cli_config: Optional[Dict[str, Any]] = None,
-    ) -> str:
-        """
-        Async-native execution. Default = offload sync run() to a thread.
-        
-        Args:
-            config: Framework configuration
-            llm_config: LLM configuration list
-            topic: Topic for the tasks
-            tools_dict: Available tools dictionary
-            agent_callback: Callback for agent events
-            task_callback: Callback for task events
-            cli_config: CLI configuration
-            
-        Returns:
-            Execution result as string
-        """
-        ...
-    
-    def cleanup(self) -> None:
-        """Clean up any resources after execution."""
-        ...
-    
-    def resolve_alias(self) -> str:
-        """Return the concrete adapter name to dispatch to (e.g. 'autogen_v4').
-        Default: return self.name."""
-        ...
-
-
-class BaseFrameworkAdapter:
-    """Base class for framework adapters providing common functionality."""
-    
-    DEFAULT_MODEL = "openai/gpt-4o-mini"
-    
-    def __init__(self):
-        pass
-    
-    def _resolve_llm(self, spec, llm_config):
-        """Build a PraisonAIModel from a per-agent llm/function_calling_llm spec.
-        Accepts str, dict, or None. Single source of truth for all adapters."""
+    def _resolve_llm(self, spec: Any, llm_config: Optional[List[Dict]]):
+        """Build a provider model object from spec and shared llm_config."""
         from ..inc import PraisonAIModel
-        import os
-        
-        base = llm_config[0].get('base_url') if (llm_config and len(llm_config) > 0) else None
-        key = llm_config[0].get('api_key') if (llm_config and len(llm_config) > 0) else None
+
+        base = llm_config[0].get("base_url") if (llm_config and len(llm_config) > 0) else None
+        key = llm_config[0].get("api_key") if (llm_config and len(llm_config) > 0) else None
 
         if isinstance(spec, str) and spec.strip():
             model = spec.strip()
-        elif isinstance(spec, dict) and spec.get('model'):
-            model = spec['model']
+        elif isinstance(spec, dict) and spec.get("model"):
+            model = spec["model"]
         else:
+            import os
             model = os.environ.get("MODEL_NAME") or self.DEFAULT_MODEL
 
         return PraisonAIModel(model=model, base_url=base, api_key=key).get_model()
-    
-    def _format_template(self, template: str, **kwargs) -> str:
-        """Safely format template string with given kwargs, preserving JSON-like braces."""
-        if not isinstance(template, str):
-            return template
-        
-        import re
-        
-        def _sub(m):
-            name = m.group(1)
-            return str(kwargs[name]) if name in kwargs else m.group(0)
-        
-        # Only substitute simple variable names like {topic}, not JSON like {"level":2}
-        return re.sub(r'\{([a-zA-Z_][a-zA-Z0-9_]*)\}', _sub, template)
-    
-    def resolve(self, *, config: Optional[Dict[str, Any]] = None) -> "FrameworkAdapter":
-        """Default implementation returns self."""
-        return self
-    
-    def setup(self, *, framework_tag: str) -> None:
-        """Default implementation does nothing."""
-        pass
-    
-    async def arun(
-        self,
-        config: Dict[str, Any],
-        llm_config: List[Dict],
-        topic: str,
-        *,
-        tools_dict: Optional[Dict[str, Any]] = None,
-        agent_callback: Optional[Callable] = None,
-        task_callback: Optional[Callable] = None,
-        cli_config: Optional[Dict[str, Any]] = None,
-    ) -> str:
-        """
-        Safe default: run sync implementation in a worker thread.
-        
-        Framework adapters with native async support should override this method.
-        """
-        import asyncio
-        return await asyncio.to_thread(
-            self.run, config, llm_config, topic,
-            tools_dict=tools_dict,
-            agent_callback=agent_callback,
-            task_callback=task_callback,
-            cli_config=cli_config
-        )
-    
-    def cleanup(self) -> None:
-        """Clean up resources - default implementation does nothing."""
-        pass
-    
-    def resolve_alias(self) -> str:
-        """Return the concrete adapter name to dispatch to.
-        Default: return self.name."""
-        return self.name
 
 
 @contextmanager
 def scoped_telemetry_disable(telemetry_class):
     """
     Context manager to temporarily disable telemetry methods.
-    
-    This replaces import-time monkey patching with scoped patching
+
+    Replaces import-time monkey patching with scoped patching
     that is automatically restored after use.
     """
     if not telemetry_class:
         yield
         return
-        
-    # Store original methods
+
     originals = {}
     noop = lambda *args, **kwargs: None
-    
+
     for attr_name in dir(telemetry_class):
         attr = getattr(telemetry_class, attr_name)
         if callable(attr) and not attr_name.startswith("__"):
             originals[attr_name] = attr
             setattr(telemetry_class, attr_name, noop)
-    
+
     try:
         yield
     finally:
-        # Restore original methods
         for attr_name, original_method in originals.items():
             setattr(telemetry_class, attr_name, original_method)

--- a/src/praisonai/praisonai/framework_adapters/registry.py
+++ b/src/praisonai/praisonai/framework_adapters/registry.py
@@ -190,6 +190,11 @@ def list_framework_choices(*, include_unavailable: bool = False) -> list[str]:
     return registry.list_available_frameworks()
 
 
+def list_available_frameworks() -> list[str]:
+    """Return registered framework names that report availability."""
+    return get_default_registry().list_available_frameworks()
+
+
 def get_install_hint(name: str) -> str:
     """Return install hint for a framework, consulting the adapter when registered."""
     registry = get_default_registry()
@@ -200,4 +205,19 @@ def get_install_hint(name: str) -> str:
             return hint
     except (ValueError, TypeError):
         pass
-    return f"pip install praisonai-frameworks[{name}]  # or: pip install 'praisonai[{name}]'"
+    extra_name = {"autogen_v4": "autogen-v4"}.get(name, name)
+    return (
+        f"pip install 'praisonai-frameworks[{extra_name}]'  "
+        f"# or: pip install 'praisonai[{extra_name}]'"
+    )
+
+
+def framework_option_help() -> str:
+    """Help text for CLI --framework options (registry-driven)."""
+    try:
+        names = list_framework_choices(include_unavailable=True)
+        if names:
+            return "Framework: " + ", ".join(names)
+    except Exception:
+        pass
+    return "Framework: praisonai, crewai, autogen"

--- a/src/praisonai/praisonai/framework_adapters/registry.py
+++ b/src/praisonai/praisonai/framework_adapters/registry.py
@@ -42,13 +42,12 @@ def _praisonai_loader():
     from .praisonai_adapter import PraisonAIAdapter
     return PraisonAIAdapter
 
-# Built-in framework adapters with lazy loading
+# Built-in framework adapters with lazy loading.
+# autogen_v4 / ag2 loaders remain for entry-point packages; not registered until implemented.
 _BUILTIN_ADAPTERS = {
     "crewai": _crewai_loader,
-    "autogen": _autogen_loader,      # Family adapter for version resolution
-    "autogen_v2": _autogen_v2_loader, # Direct access to v2
-    "autogen_v4": _autogen_v4_loader,
-    "ag2": _ag2_loader,
+    "autogen": _autogen_loader,       # Family adapter for version resolution
+    "autogen_v2": _autogen_v2_loader,  # Direct access to v0.2
     "praisonai": _praisonai_loader,
 }
 
@@ -116,8 +115,11 @@ class FrameworkAdapterRegistry(PluginRegistry[FrameworkAdapter]):
     
     def _validate_adapter(self, name: str, adapter) -> None:
         """Validate that adapter implements the required protocol signature."""
+        if getattr(adapter, "is_router", False):
+            return
+
         _REQUIRED_KW = {"tools_dict", "agent_callback", "task_callback", "cli_config"}
-        
+
         sig = inspect.signature(type(adapter).run)
         kw_only = {
             p.name for p in sig.parameters.values()
@@ -129,12 +131,18 @@ class FrameworkAdapterRegistry(PluginRegistry[FrameworkAdapter]):
                 f"FrameworkAdapter {name!r} does not implement the protocol: "
                 f"missing keyword-only parameters {sorted(missing)}"
             )
-    
+
     def create(self, name: str, *args, **kwargs):
         """Create an adapter instance with protocol validation."""
         adapter = super().create(name, *args, **kwargs)
         self._validate_adapter(name, adapter)
         return adapter
+
+    def list_available_frameworks(self) -> list[str]:
+        """Return registered framework names that report availability."""
+        return sorted(
+            name for name in self.list_names() if self.is_available(name)
+        )
 
     # Backward compatibility aliases - delegate to parent methods
     def list_registered(self) -> list[str]:
@@ -172,3 +180,24 @@ class FrameworkAdapterRegistry(PluginRegistry[FrameworkAdapter]):
 def get_default_registry() -> FrameworkAdapterRegistry:
     """Return the process-default registry. Prefer DI; use this only at the edge."""
     return FrameworkAdapterRegistry.default()
+
+
+def list_framework_choices(*, include_unavailable: bool = False) -> list[str]:
+    """Single source of truth for CLI/YAML framework name lists."""
+    registry = get_default_registry()
+    if include_unavailable:
+        return sorted(registry.list_names())
+    return registry.list_available_frameworks()
+
+
+def get_install_hint(name: str) -> str:
+    """Return install hint for a framework, consulting the adapter when registered."""
+    registry = get_default_registry()
+    try:
+        adapter = registry.create(name)
+        hint = getattr(adapter, "install_hint", None)
+        if hint:
+            return hint
+    except (ValueError, TypeError):
+        pass
+    return f"pip install praisonai-frameworks[{name}]  # or: pip install 'praisonai[{name}]'"

--- a/src/praisonai/praisonai/framework_adapters/registry.py
+++ b/src/praisonai/praisonai/framework_adapters/registry.py
@@ -206,18 +206,15 @@ def get_install_hint(name: str) -> str:
     except (ValueError, TypeError):
         pass
     extra_name = {"autogen_v4": "autogen-v4"}.get(name, name)
-    return (
-        f"pip install 'praisonai-frameworks[{extra_name}]'  "
-        f"# or: pip install 'praisonai[{extra_name}]'"
-    )
+    return f"pip install 'praisonai[{extra_name}]'"
 
 
 def framework_option_help() -> str:
     """Help text for CLI --framework options (registry-driven)."""
     try:
         names = list_framework_choices(include_unavailable=True)
-        if names:
-            return "Framework: " + ", ".join(names)
-    except Exception:
-        pass
+    except ImportError:
+        return "Framework: praisonai, crewai, autogen"
+    if names:
+        return "Framework: " + ", ".join(names)
     return "Framework: praisonai, crewai, autogen"

--- a/src/praisonai/praisonai/framework_adapters/validators.py
+++ b/src/praisonai/praisonai/framework_adapters/validators.py
@@ -5,31 +5,23 @@ Provides early validation of framework availability to fail fast at CLI entry
 rather than inside run() methods after expensive setup work.
 """
 
-from .registry import get_default_registry
-
-
-# Install hints for common frameworks
-_INSTALL_HINTS = {
-    "crewai": "pip install 'praisonai[crewai]'   # or: pip install crewai",
-    "autogen": "pip install 'praisonai[autogen]'  # or: pip install pyautogen",
-    "praisonai": "pip install praisonaiagents",
-}
+from .registry import get_default_registry, get_install_hint
 
 
 def assert_framework_available(name: str) -> None:
     """
     Raise ImportError immediately if the chosen framework is missing.
-    
+
     Args:
         name: Framework name to validate
-        
+
     Raises:
         ImportError: If framework is not available with actionable install hint
     """
     registry = get_default_registry()
-    
+
     if not registry.is_available(name):
-        hint = _INSTALL_HINTS.get(name, f"pip install {name}")
+        hint = get_install_hint(name)
         raise ImportError(
             f"Framework '{name}' was requested but is not installed.\n"
             f"Install it with:\n    {hint}"

--- a/src/praisonai/praisonai/framework_adapters/workflow_framework.py
+++ b/src/praisonai/praisonai/framework_adapters/workflow_framework.py
@@ -1,0 +1,31 @@
+"""Workflow YAML framework field validation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def validate_workflow_framework(
+    framework: Optional[str],
+    *,
+    source: str = "workflow YAML",
+) -> None:
+    """
+    Fail fast when a workflow file declares a non-native framework.
+
+    Multi-framework workflow dispatch is not implemented; only agents.yaml
+    via AgentsGenerator supports framework != praisonai today.
+    """
+    if not framework or str(framework).lower() == "praisonai":
+        return
+
+    raise ValueError(
+        f"framework='{framework}' in {source} is not supported for workflow execution. "
+        "Native PraisonAI Workflow engine only supports framework='praisonai'. "
+        "Use agents.yaml with framework: crewai|autogen, or set framework: praisonai."
+    )
+
+
+def framework_from_config(config: Dict[str, Any]) -> str:
+    """Return normalised framework name from a parsed YAML config dict."""
+    return str(config.get("framework") or "praisonai").lower()

--- a/src/praisonai/praisonai/framework_adapters/workflow_framework.py
+++ b/src/praisonai/praisonai/framework_adapters/workflow_framework.py
@@ -19,10 +19,21 @@ def validate_workflow_framework(
     if not framework or str(framework).lower() == "praisonai":
         return
 
+    supported = ""
+    try:
+        from .registry import list_framework_choices
+
+        choices = [f for f in list_framework_choices(include_unavailable=True) if f != "praisonai"]
+        if choices:
+            supported = f" Available registered frameworks: {', '.join(sorted(choices))}."
+    except Exception:
+        pass
+
     raise ValueError(
         f"framework='{framework}' in {source} is not supported for workflow execution. "
         "Native PraisonAI Workflow engine only supports framework='praisonai'. "
-        "Use agents.yaml with framework: crewai|autogen, or set framework: praisonai."
+        "Use a non-workflow agents.yaml with a supported registered framework, "
+        f"or set framework: praisonai.{supported}"
     )
 
 

--- a/src/praisonai/praisonai/framework_adapters/workflow_framework.py
+++ b/src/praisonai/praisonai/framework_adapters/workflow_framework.py
@@ -25,12 +25,16 @@ def validate_workflow_framework(
     supported = ""
     try:
         from .registry import list_framework_choices
+    except ImportError:
+        # Only the registry module being unavailable is tolerated here; genuine
+        # discovery/initialization errors must surface rather than be masked as
+        # a simple unsupported-framework config mistake.
+        list_framework_choices = None  # type: ignore[assignment]
 
+    if list_framework_choices is not None:
         choices = [f for f in list_framework_choices(include_unavailable=True) if f != "praisonai"]
         if choices:
             supported = f" Available registered frameworks: {', '.join(sorted(choices))}."
-    except Exception:
-        pass
 
     message = (
         f"framework='{framework}' in {source} is not supported for workflow execution. "

--- a/src/praisonai/praisonai/framework_adapters/workflow_framework.py
+++ b/src/praisonai/praisonai/framework_adapters/workflow_framework.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
 
 
 def validate_workflow_framework(
@@ -11,7 +14,7 @@ def validate_workflow_framework(
     source: str = "workflow YAML",
 ) -> None:
     """
-    Fail fast when a workflow file declares a non-native framework.
+    Warn then fail when a workflow file declares a non-native framework.
 
     Multi-framework workflow dispatch is not implemented; only agents.yaml
     via AgentsGenerator supports framework != praisonai today.
@@ -29,12 +32,14 @@ def validate_workflow_framework(
     except Exception:
         pass
 
-    raise ValueError(
+    message = (
         f"framework='{framework}' in {source} is not supported for workflow execution. "
         "Native PraisonAI Workflow engine only supports framework='praisonai'. "
         "Use a non-workflow agents.yaml with a supported registered framework, "
         f"or set framework: praisonai.{supported}"
     )
+    logger.warning(message)
+    raise ValueError(message)
 
 
 def framework_from_config(config: Dict[str, Any]) -> str:

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -93,8 +93,8 @@ call = [
     "rich"
 ]
 train = []
-crewai = ["crewai>=0.157.0", "praisonai-tools>=0.1.0"]
-autogen = ["pyautogen==0.2.29", "praisonai-tools>=0.1.0", "crewai"]
+crewai = ["crewai>=0.157.0", "praisonai-tools>=0.1.0"]  # Task 2: alias to praisonai-frameworks[crewai]
+autogen = ["pyautogen==0.2.29", "praisonai-tools>=0.1.0", "crewai"]  # Task 2: alias to praisonai-frameworks[autogen]
 ag2 = ["ag2>=0.11.0", "praisonai-tools>=0.1.0"]
 autogen-v4 = [
     "autogen-agentchat>=0.4.0", 

--- a/src/praisonai/tests/unit/test_framework_entry_point_discovery.py
+++ b/src/praisonai/tests/unit/test_framework_entry_point_discovery.py
@@ -1,5 +1,8 @@
 """Entry-point style framework adapter registration smoke test."""
 
+from types import SimpleNamespace
+from unittest import mock
+
 import pytest
 
 from praisonai.framework_adapters.base import BaseFrameworkAdapter
@@ -92,3 +95,24 @@ roles:
 
     result = gen.generate_crew_and_kickoff()
     assert "echo:hello" in result
+
+
+def test_entry_point_discovery_without_manual_register():
+    """A `praisonai.framework_adapters` entry point is discovered and usable
+    without calling registry.register() directly."""
+    fake_ep = SimpleNamespace(name="echo_test_adapter", load=lambda: _EchoAdapter)
+
+    def _fake_entry_points(*, group):
+        if group == "praisonai.framework_adapters":
+            return [fake_ep]
+        return []
+
+    with mock.patch(
+        "praisonai._registry.entry_points", side_effect=_fake_entry_points
+    ):
+        registry = FrameworkAdapterRegistry()
+
+    assert "echo_test_adapter" in registry.list_names()
+    adapter = registry.create("echo_test_adapter")
+    assert adapter.run({}, [], "world", tools_dict={}) == "echo:world"
+    assert "echo_test_adapter" in registry.list_available_frameworks()

--- a/src/praisonai/tests/unit/test_framework_entry_point_discovery.py
+++ b/src/praisonai/tests/unit/test_framework_entry_point_discovery.py
@@ -1,5 +1,7 @@
 """Entry-point style framework adapter registration smoke test."""
 
+import pytest
+
 from praisonai.framework_adapters.base import BaseFrameworkAdapter
 from praisonai.framework_adapters.registry import FrameworkAdapterRegistry
 
@@ -38,3 +40,55 @@ def test_list_available_frameworks():
     registry.register("echo_test_adapter", _EchoAdapter)
     available = registry.list_available_frameworks()
     assert "echo_test_adapter" in available
+
+
+def test_entry_point_group_discoverable():
+    from praisonai.framework_adapters.registry import get_default_registry
+
+    names = get_default_registry().list_names()
+    assert "praisonai" in names
+
+
+def test_agents_generator_uses_custom_registry(monkeypatch):
+    registry = FrameworkAdapterRegistry()
+    registry.register("echo_test_adapter", _EchoAdapter)
+
+    yaml_content = """
+framework: echo_test_adapter
+topic: hello
+roles:
+  agent:
+    role: Tester
+    goal: Echo
+    backstory: Test agent
+    tasks:
+      t1:
+        description: Say {topic}
+        expected_output: echo
+"""
+
+    from praisonai.agents_generator import AgentsGenerator
+
+    gen = AgentsGenerator(
+        agent_file="test.yaml",
+        framework="echo_test_adapter",
+        config_list=[{"model": "openai/gpt-4o-mini"}],
+        agent_yaml=yaml_content,
+        adapter_registry=registry,
+    )
+
+    class _Prep:
+        adapter = registry.create("echo_test_adapter")
+
+        def run(self, *args, **kwargs):
+            return self.adapter.run(*args, **kwargs)
+
+    monkeypatch.setattr(gen, "_prepare_for_run", lambda _config=None: {
+        "adapter": registry.create("echo_test_adapter"),
+        "config": {"framework": "echo_test_adapter", "topic": "hello", "roles": {}},
+        "topic": "hello",
+        "tools_dict": {},
+    })
+
+    result = gen.generate_crew_and_kickoff()
+    assert "echo:hello" in result

--- a/src/praisonai/tests/unit/test_framework_entry_point_discovery.py
+++ b/src/praisonai/tests/unit/test_framework_entry_point_discovery.py
@@ -1,0 +1,40 @@
+"""Entry-point style framework adapter registration smoke test."""
+
+from praisonai.framework_adapters.base import BaseFrameworkAdapter
+from praisonai.framework_adapters.registry import FrameworkAdapterRegistry
+
+
+class _EchoAdapter(BaseFrameworkAdapter):
+    name = "echo_test_adapter"
+    install_hint = "pip install echo-test"
+    requires_tools_extra = False
+
+    def is_available(self) -> bool:
+        return True
+
+    def run(
+        self,
+        config,
+        llm_config,
+        topic,
+        *,
+        tools_dict=None,
+        agent_callback=None,
+        task_callback=None,
+        cli_config=None,
+    ) -> str:
+        return f"echo:{topic}"
+
+
+def test_runtime_register_and_create():
+    registry = FrameworkAdapterRegistry()
+    registry.register("echo_test_adapter", _EchoAdapter)
+    adapter = registry.create("echo_test_adapter")
+    assert adapter.run({}, [], "hello", tools_dict={}) == "echo:hello"
+
+
+def test_list_available_frameworks():
+    registry = FrameworkAdapterRegistry()
+    registry.register("echo_test_adapter", _EchoAdapter)
+    available = registry.list_available_frameworks()
+    assert "echo_test_adapter" in available

--- a/src/praisonai/tests/unit/test_framework_entry_point_discovery.py
+++ b/src/praisonai/tests/unit/test_framework_entry_point_discovery.py
@@ -80,12 +80,6 @@ roles:
         adapter_registry=registry,
     )
 
-    class _Prep:
-        adapter = registry.create("echo_test_adapter")
-
-        def run(self, *args, **kwargs):
-            return self.adapter.run(*args, **kwargs)
-
     monkeypatch.setattr(gen, "_prepare_for_run", lambda _config=None: {
         "adapter": registry.create("echo_test_adapter"),
         "config": {"framework": "echo_test_adapter", "topic": "hello", "roles": {}},

--- a/src/praisonai/tests/unit/test_framework_registry_helpers.py
+++ b/src/praisonai/tests/unit/test_framework_registry_helpers.py
@@ -29,4 +29,4 @@ def test_ag2_not_in_default_builtins():
     from praisonai.framework_adapters.registry import get_default_registry
 
     registry = get_default_registry()
-    assert "ag2" not in registry.list_names() or not registry.is_available("ag2")
+    assert "ag2" not in registry.list_names()

--- a/src/praisonai/tests/unit/test_framework_registry_helpers.py
+++ b/src/praisonai/tests/unit/test_framework_registry_helpers.py
@@ -10,11 +10,25 @@ def test_list_framework_choices_includes_praisonai():
     assert "praisonai" in choices
 
 
+def test_list_available_frameworks_module_helper():
+    from praisonai.framework_adapters.registry import list_available_frameworks
+
+    available = list_available_frameworks()
+    assert "praisonai" in available
+
+
 def test_get_install_hint_fallback():
     from praisonai.framework_adapters.registry import get_install_hint
 
     hint = get_install_hint("unknown_framework_xyz")
     assert "unknown_framework_xyz" in hint
+
+
+def test_get_install_hint_autogen_v4_extra():
+    from praisonai.framework_adapters.registry import get_install_hint
+
+    hint = get_install_hint("autogen_v4")
+    assert "autogen-v4" in hint
 
 
 def test_autogen_family_is_router_skips_run_validation():

--- a/src/praisonai/tests/unit/test_framework_registry_helpers.py
+++ b/src/praisonai/tests/unit/test_framework_registry_helpers.py
@@ -1,0 +1,32 @@
+"""Tests for framework adapter registry helpers."""
+
+import pytest
+
+
+def test_list_framework_choices_includes_praisonai():
+    from praisonai.framework_adapters.registry import list_framework_choices
+
+    choices = list_framework_choices(include_unavailable=True)
+    assert "praisonai" in choices
+
+
+def test_get_install_hint_fallback():
+    from praisonai.framework_adapters.registry import get_install_hint
+
+    hint = get_install_hint("unknown_framework_xyz")
+    assert "unknown_framework_xyz" in hint
+
+
+def test_autogen_family_is_router_skips_run_validation():
+    from praisonai.framework_adapters.registry import FrameworkAdapterRegistry
+
+    registry = FrameworkAdapterRegistry()
+    adapter = registry.create("autogen")
+    assert getattr(adapter, "is_router", False) is True
+
+
+def test_ag2_not_in_default_builtins():
+    from praisonai.framework_adapters.registry import get_default_registry
+
+    registry = get_default_registry()
+    assert "ag2" not in registry.list_names() or not registry.is_available("ag2")

--- a/src/praisonai/tests/unit/test_workflow_framework_validation.py
+++ b/src/praisonai/tests/unit/test_workflow_framework_validation.py
@@ -10,11 +10,14 @@ def test_validate_workflow_framework_allows_praisonai():
     validate_workflow_framework(None)
 
 
-def test_validate_workflow_framework_rejects_crewai():
+def test_validate_workflow_framework_rejects_crewai(caplog):
+    import logging
     from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
 
-    with pytest.raises(ValueError, match="not supported for workflow execution"):
-        validate_workflow_framework("crewai", source="workflow.yaml")
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError, match="not supported for workflow execution"):
+            validate_workflow_framework("crewai", source="workflow.yaml")
+    assert any("crewai" in r.message for r in caplog.records)
 
 
 def test_framework_from_config_defaults_praisonai():

--- a/src/praisonai/tests/unit/test_workflow_framework_validation.py
+++ b/src/praisonai/tests/unit/test_workflow_framework_validation.py
@@ -1,0 +1,24 @@
+"""Tests for workflow YAML framework validation."""
+
+import pytest
+
+
+def test_validate_workflow_framework_allows_praisonai():
+    from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
+
+    validate_workflow_framework("praisonai")
+    validate_workflow_framework(None)
+
+
+def test_validate_workflow_framework_rejects_crewai():
+    from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
+
+    with pytest.raises(ValueError, match="not supported for workflow execution"):
+        validate_workflow_framework("crewai", source="workflow.yaml")
+
+
+def test_framework_from_config_defaults_praisonai():
+    from praisonai.framework_adapters.workflow_framework import framework_from_config
+
+    assert framework_from_config({}) == "praisonai"
+    assert framework_from_config({"framework": "CrewAI"}) == "crewai"


### PR DESCRIPTION
## Summary
- Move `FrameworkAdapterProtocol` and `BaseFrameworkAdapter` to core SDK (`praisonaiagents.frameworks`)
- Registry-driven framework discovery in CLI, doctor, and Gradio via `list_framework_choices()`
- Workflow YAML `framework` field: fail fast when non-native framework is declared
- Unregister unimplemented AutoGen v0.4/AG2 from built-in registry; router adapters skip run() validation
- Entry-point adapter registration test and custom adapter example

## Test plan
- [x] `pytest src/praisonai/tests/unit/test_framework_*`
- [x] `pytest src/praisonai-agents/tests/unit/test_framework_protocol.py`
- [ ] `praisonai doctor` lists registered frameworks dynamically
- [ ] `praisonai run --framework crewai` still works (inline adapters until Task 2 merges)

## Follow-up
- Task 2: `PraisonAI-Frameworks` repo extracts crewai/autogen adapters via entry points

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI and Gradio now populate framework options dynamically from the adapter registry (including available/unavailable choices).
  * Added an installable example framework adapter via an entry point.
  * Workflow YAML now validates the selected framework before execution; YAML agent runs validate framework configuration too.
* **Bug Fixes**
  * Improved framework discovery/availability checks and “doctor” warnings with actionable install hints.
  * Router-style adapters are handled correctly for adapter capability validation.
* **Deprecations**
  * Deprecated eager imports for built-in framework adapters in favor of lazy loading.
* **Tests**
  * Added unit coverage for adapter protocol, registry helpers, entry-point discovery, and workflow framework validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->