### PR TITLE
Add Xquik tweet search tool example

### DIFF
--- a/examples/tools/xquik_tweet_search_tool.py
+++ b/examples/tools/xquik_tweet_search_tool.py
@@ -1,0 +1,91 @@
+"""Use Xquik tweet search as a PraisonAI custom tool.
+
+Set XQUIK_API_KEY before running this example. The tool calls the public
+Xquik tweet search endpoint and returns compact tweet summaries for the agent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from praisonaiagents import Agent, tool
+
+
+XQUIK_SEARCH_URL = "https://xquik.com/api/v1/x/tweets/search"
+
+
+def _as_record(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _as_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _tweet_line(tweet: dict[str, Any]) -> str:
+    author = _as_text(tweet.get("author_username") or tweet.get("username"))
+    text = _as_text(tweet.get("text") or tweet.get("full_text"))
+    tweet_id = _as_text(tweet.get("id"))
+    prefix = f"@{author}: " if author else ""
+    suffix = f" ({tweet_id})" if tweet_id else ""
+    return f"{prefix}{text}{suffix}".strip()
+
+
+def _bounded_limit(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 5
+    return max(1, min(parsed, 10))
+
+
+@tool
+def search_x_posts(query: str, limit: int = 5) -> str:
+    """Search recent public X posts with Xquik."""
+    api_key = os.environ.get("XQUIK_API_KEY")
+    if not api_key:
+        return "Set XQUIK_API_KEY before using search_x_posts."
+
+    bounded_limit = _bounded_limit(limit)
+    params = {"q": query, "limit": bounded_limit, "queryType": "Latest"}
+    url = f"{XQUIK_SEARCH_URL}?{urlencode(params)}"
+    request = Request(
+        url,
+        headers={"X-API-Key": api_key, "Accept": "application/json"},
+    )
+
+    try:
+        with urlopen(request, timeout=20) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        return f"Xquik returned HTTP {error.code}."
+    except (URLError, TimeoutError, json.JSONDecodeError) as error:
+        return f"Xquik search failed: {error.__class__.__name__}."
+
+    tweets = _as_record(payload).get("tweets")
+    if not isinstance(tweets, list) or not tweets:
+        return "No posts found."
+
+    lines = [_tweet_line(_as_record(tweet)) for tweet in tweets[:bounded_limit]]
+    return "\n".join(line for line in lines if line) or "No readable posts found."
+
+
+agent = Agent(
+    instructions="You find recent public X posts and summarize the useful patterns.",
+    tools=[search_x_posts],
+)
+
+
+if __name__ == "__main__":
+    agent.start("Search X for recent AI agent framework discussions.")

--- a/examples/tools/xquik_tweet_search_tool.py
+++ b/examples/tools/xquik_tweet_search_tool.py
@@ -19,6 +19,10 @@ from praisonaiagents import Agent, tool
 XQUIK_SEARCH_URL = "https://xquik.com/api/v1/x/tweets/search"
 
 
+def _xquik_api_key_available() -> tuple[bool, str]:
+    return bool(os.environ.get("XQUIK_API_KEY")), "Set XQUIK_API_KEY before using search_x_posts."
+
+
 def _as_record(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
@@ -27,16 +31,23 @@ def _as_record(value: Any) -> dict[str, Any]:
 
 def _as_text(value: Any) -> str:
     if isinstance(value, str):
-        return value.strip()
+        return " ".join(value.split())
     if value is None:
         return ""
-    return str(value).strip()
+    return " ".join(str(value).split())
 
 
 def _tweet_line(tweet: dict[str, Any]) -> str:
-    author = _as_text(tweet.get("author_username") or tweet.get("username"))
-    text = _as_text(tweet.get("text") or tweet.get("full_text"))
-    tweet_id = _as_text(tweet.get("id"))
+    author_record = _as_record(tweet.get("author") or tweet.get("user"))
+    author = _as_text(
+        tweet.get("author_username")
+        or tweet.get("username")
+        or author_record.get("username")
+        or author_record.get("screen_name")
+        or author_record.get("handle")
+    )
+    text = _as_text(tweet.get("text") or tweet.get("full_text") or tweet.get("content"))
+    tweet_id = _as_text(tweet.get("id") or tweet.get("tweet_id") or tweet.get("tweetId"))
     prefix = f"@{author}: " if author else ""
     suffix = f" ({tweet_id})" if tweet_id else ""
     return f"{prefix}{text}{suffix}".strip()
@@ -44,21 +55,25 @@ def _tweet_line(tweet: dict[str, Any]) -> str:
 
 def _bounded_limit(value: Any) -> int:
     try:
-        parsed = int(value)
-    except (TypeError, ValueError):
+        parsed = int(float(value))
+    except (TypeError, ValueError, OverflowError):
         return 5
     return max(1, min(parsed, 10))
 
 
-@tool
+@tool(availability=_xquik_api_key_available)
 def search_x_posts(query: str, limit: int = 5) -> str:
     """Search recent public X posts with Xquik."""
     api_key = os.environ.get("XQUIK_API_KEY")
     if not api_key:
         return "Set XQUIK_API_KEY before using search_x_posts."
 
+    query_text = _as_text(query)
+    if not query_text:
+        return "Provide a non-empty query before using search_x_posts."
+
     bounded_limit = _bounded_limit(limit)
-    params = {"q": query, "limit": bounded_limit, "queryType": "Latest"}
+    params = {"q": query_text, "limit": bounded_limit, "queryType": "Latest"}
     url = f"{XQUIK_SEARCH_URL}?{urlencode(params)}"
     request = Request(
         url,


### PR DESCRIPTION
## Summary

- Add a standalone PraisonAI custom-tool example for Xquik tweet search.
- Keep Xquik opt-in through `XQUIK_API_KEY` and stdlib HTTP.
- Return compact tweet summaries for agent workflows.

## Validation

- `/Users/burak/.local/bin/python3.11 -m py_compile examples/tools/xquik_tweet_search_tool.py`
- `PYTHONPATH=src/praisonai-agents /Users/burak/.local/bin/python3.11 -c 'from examples.tools.xquik_tweet_search_tool import search_x_posts; result = search_x_posts("ai agents", "bad-limit"); assert "XQUIK_API_KEY" in result'`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new example tool that searches recent public posts on X and returns a compact, readable list.
  * Each result includes the author and, when available, the post ID for quick reference.
  * Added input validation and safer result limiting (with clear messages for missing credentials, empty queries, request failures, timeouts, and no results).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->