### PR TITLE
Fix Unified Web Search example link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ praisonai agents.yaml
 | Query Rewriter Agent | [Example](examples/python/agents/query-rewriter-agent.py) | [📖](https://docs.praison.ai/docs/agents/query-rewriter) |
 | Native Web Search | [Example](examples/python/agents/websearch-agent.py) | [📖](https://docs.praison.ai/docs/agents/websearch) |
 | Built-in Search Tools | [Example](examples/python/agents/websearch-agent.py) | [📖](https://docs.praison.ai/docs/tools/tavily) |
-| Unified Web Search | [Example](src/praisonai-agents/examples/web_search_example.py) | [📖](https://docs.praison.ai/docs/tools/web-search) |
+| Unified Web Search | [Example](examples/python/web_search_example.py) | [📖](https://docs.praison.ai/docs/tools/web-search) |
 | Web Fetch (Anthropic) | [Example](examples/python/agents/web-fetch-agent.py) | [📖](https://docs.praison.ai/docs/features/model-capabilities) |
 
 </details>


### PR DESCRIPTION
## Summary

Fixes the README link for the Unified Web Search example.

The previous link pointed to:

`src/praisonai-agents/examples/web_search_example.py`

That file does not exist in the current tree. The matching example is available at:

`examples/python/web_search_example.py`

## Verification

- `git diff --check`
- `python -m compileall -q examples\python\web_search_example.py`
- Confirmed the README link target exists locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a linked code example path in the AI search documentation to point to the current example location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->