### PR TITLE
fix(tests): align framework validator hint with praisonai-frameworks

### DIFF
--- a/src/praisonai/tests/unit/test_framework_validators.py
+++ b/src/praisonai/tests/unit/test_framework_validators.py
@@ -81,7 +81,7 @@ class TestAssertFrameworkAvailableRaises:
             with pytest.raises(ImportError) as exc_info:
                 assert_framework_available("some_unknown_framework_xyz")
             assert "some_unknown_framework_xyz" in str(exc_info.value)
-            assert "pip install 'praisonai[some_unknown_framework_xyz]'" in str(exc_info.value)
+            assert "praisonai-frameworks[some_unknown_framework_xyz]" in str(exc_info.value)
 
 
 class TestRegistryImportErrorIsContained:


### PR DESCRIPTION
## Summary
- Updates `test_unknown_framework_generic_hint` to expect `praisonai-frameworks[...]` install hints
- Matches `get_install_hint()` behaviour after the package split (#2464)
- Fixes `test-core (root)` failure on main and PRs like #2471

## Test plan
- [x] `pytest tests/unit/test_framework_validators.py::TestAssertFrameworkAvailableRaises::test_unknown_framework_generic_hint` passes locally
- [ ] `test-core` green on CI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a unit test to match the latest install hint shown when an unknown framework is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->