### PR TITLE
fix(release): uv pip --system on CI

### DIFF
--- a/src/praisonai/scripts/bump_and_release.py
+++ b/src/praisonai/scripts/bump_and_release.py
@@ -220,7 +220,7 @@ def validate_dependencies(
                 time.sleep(retry_interval)
             continue
 
-        base = run(["uv", "pip", "install", "--dry-run", "-e", "."], cwd=praisonai_dir, check=False)
+        base = run(["uv", "pip", "install", "--system", "--dry-run", "-e", "."], cwd=praisonai_dir, check=False)
         if base.returncode == 0:
             print("  ✅ Dependencies validated successfully")
             return True


### PR DESCRIPTION
Adds `--system` to `uv pip install --dry-run` in bump_and_release validation — CI has no venv.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow’s dependency validation step to run in the correct environment, helping make version bumps and releases more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->