### PR TITLE
Add LangGraph framework wrapper support

### DIFF
--- a/src/praisonai/praisonai/_framework_availability.py
+++ b/src/praisonai/praisonai/_framework_availability.py
@@ -40,6 +40,10 @@ _PROBES: dict[str, Callable[[], bool]] = {
     "pinecone":          lambda: importlib.util.find_spec("pinecone") is not None,
     "qdrant_client":     lambda: importlib.util.find_spec("qdrant_client") is not None,
     "weaviate":          lambda: importlib.util.find_spec("weaviate") is not None,
+    "langgraph":         lambda: (
+        importlib.util.find_spec("langgraph") is not None
+        and importlib.util.find_spec("langgraph.prebuilt") is not None
+    ),
 }
 
 def is_available(name: str) -> bool:

--- a/src/praisonai/praisonai/_framework_availability.py
+++ b/src/praisonai/praisonai/_framework_availability.py
@@ -20,6 +20,16 @@ def _autogen_v4_probe() -> bool:
     return (importlib.util.find_spec("autogen_agentchat") is not None
             and importlib.util.find_spec("autogen_ext") is not None)
 
+def _langgraph_probe() -> bool:
+    # find_spec on a submodule imports the parent package; guard against
+    # import-time errors in langgraph/its deps crashing the availability check.
+    try:
+        if importlib.util.find_spec("langgraph") is None:
+            return False
+        return importlib.util.find_spec("langgraph.prebuilt") is not None
+    except Exception:
+        return False
+
 _PROBES: dict[str, Callable[[], bool]] = {
     "crewai":            lambda: importlib.util.find_spec("crewai") is not None,
     "autogen":           lambda: importlib.util.find_spec("autogen") is not None,
@@ -40,10 +50,7 @@ _PROBES: dict[str, Callable[[], bool]] = {
     "pinecone":          lambda: importlib.util.find_spec("pinecone") is not None,
     "qdrant_client":     lambda: importlib.util.find_spec("qdrant_client") is not None,
     "weaviate":          lambda: importlib.util.find_spec("weaviate") is not None,
-    "langgraph":         lambda: (
-        importlib.util.find_spec("langgraph") is not None
-        and importlib.util.find_spec("langgraph.prebuilt") is not None
-    ),
+    "langgraph":         _langgraph_probe,
 }
 
 def is_available(name: str) -> bool:

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -362,6 +362,21 @@ class AgentsGenerator:
         # Handle agent-level overrides using unified approach
         agent_level_fields = ['tool_timeout', 'tool_retry_policy', 'planning_tools', 'autonomy', 'planning', 'web', 'web_fetch']
         agent_overrides = {k: v for k, v in cli_config.items() if k in agent_level_fields}
+
+        if "tool_retry_policy" in agent_overrides:
+            policy = agent_overrides["tool_retry_policy"]
+            try:
+                from praisonaiagents.tools.retry import RetryPolicy
+
+                if isinstance(policy, RetryPolicy):
+                    agent_overrides["tool_retry_policy"] = {
+                        "max_attempts": policy.max_attempts,
+                        "delay": policy.initial_delay_ms / 1000.0,
+                        "backoff_factor": policy.backoff_factor,
+                        "max_delay": policy.max_delay_ms / 1000.0,
+                    }
+            except ImportError:
+                pass
         
         # Handle handoff configuration - convert CLI flags into handoff dict
         handoff_fields = ['handoff', 'handoff_policy', 'handoff_timeout', 'handoff_max_depth', 'handoff_max_concurrent', 'handoff_detect_cycles']

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -375,7 +375,7 @@ class AgentsGenerator:
                         "backoff_factor": policy.backoff_factor,
                         "max_delay": policy.max_delay_ms / 1000.0,
                     }
-            except ImportError:
+            except (ImportError, AttributeError, TypeError):
                 pass
         
         # Handle handoff configuration - convert CLI flags into handoff dict

--- a/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
+++ b/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
@@ -152,6 +152,19 @@ class RuntimeCompatibilityChecker:
             supports_handoff=False,
             supports_tool_loop=True
         )
+
+        runtimes['langgraph'] = RuntimeInfo(
+            id='langgraph',
+            name='LangGraph',
+            available=_runtime_usable('langgraph', 'langgraph'),
+            capabilities=[
+                RuntimeCapability('agent_creation', 'Create and manage agents'),
+                RuntimeCapability('tool_execution', 'Execute tools and functions'),
+                RuntimeCapability('sequential_execution', 'Sequential task execution'),
+            ],
+            supports_handoff=False,
+            supports_tool_loop=True
+        )
         
         return runtimes
     

--- a/src/praisonai/praisonai/config/schema.py
+++ b/src/praisonai/praisonai/config/schema.py
@@ -133,7 +133,7 @@ class AgentConfig(BaseModel):
                         "backoff_factor": policy.backoff_factor,
                         "max_delay": policy.max_delay_ms / 1000.0,
                     }
-            except ImportError:
+            except (ImportError, AttributeError, TypeError):
                 pass
         return data
 
@@ -177,7 +177,7 @@ class AgentConfig(BaseModel):
                         backoff_factor=self.tool_retry_policy.backoff_factor,
                         max_delay=self.tool_retry_policy.max_delay_ms / 1000.0,
                     )
-            except ImportError:
+            except (ImportError, AttributeError, TypeError):
                 pass
         
         # Convert approval dict/bool to ApprovalConfig

--- a/src/praisonai/praisonai/config/schema.py
+++ b/src/praisonai/praisonai/config/schema.py
@@ -116,6 +116,29 @@ class AgentConfig(BaseModel):
     
     @model_validator(mode='before')
     @classmethod
+    def normalize_cli_retry_policy(cls, data):
+        """Accept praisonaiagents RetryPolicy objects injected by CLI merge."""
+        if isinstance(data, dict) and data.get("tool_retry_policy") is not None:
+            policy = data["tool_retry_policy"]
+            if isinstance(policy, dict):
+                return data
+            try:
+                from praisonaiagents.tools.retry import RetryPolicy as AgentRetryPolicy
+
+                if isinstance(policy, AgentRetryPolicy):
+                    data = dict(data)
+                    data["tool_retry_policy"] = {
+                        "max_attempts": policy.max_attempts,
+                        "delay": policy.initial_delay_ms / 1000.0,
+                        "backoff_factor": policy.backoff_factor,
+                        "max_delay": policy.max_delay_ms / 1000.0,
+                    }
+            except ImportError:
+                pass
+        return data
+
+    @model_validator(mode='before')
+    @classmethod
     def normalize_stream_alias(cls, data):
         """Map legacy 'stream' into canonical 'streaming'."""
         if isinstance(data, dict) and 'streaming' not in data and 'stream' in data:
@@ -141,6 +164,21 @@ class AgentConfig(BaseModel):
         # Convert tool_retry_policy dict to ToolRetryPolicy
         if isinstance(self.tool_retry_policy, dict):
             self.tool_retry_policy = ToolRetryPolicy(**self.tool_retry_policy)
+        elif self.tool_retry_policy is not None and not isinstance(
+            self.tool_retry_policy, ToolRetryPolicy
+        ):
+            try:
+                from praisonaiagents.tools.retry import RetryPolicy as AgentRetryPolicy
+
+                if isinstance(self.tool_retry_policy, AgentRetryPolicy):
+                    self.tool_retry_policy = ToolRetryPolicy(
+                        max_attempts=self.tool_retry_policy.max_attempts,
+                        delay=self.tool_retry_policy.initial_delay_ms / 1000.0,
+                        backoff_factor=self.tool_retry_policy.backoff_factor,
+                        max_delay=self.tool_retry_policy.max_delay_ms / 1000.0,
+                    )
+            except ImportError:
+                pass
         
         # Convert approval dict/bool to ApprovalConfig
         if isinstance(self.approval, bool):

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -109,7 +109,7 @@ langgraph = [
     "langgraph>=0.2.0,<2",
     "langgraph-prebuilt>=0.2.0,<2",
     "langchain-core>=0.3.0,<2",
-    "langchain-openai>=0.2.0",
+    "langchain-openai>=0.2.0,<2",
     "praisonai-tools>=0.1.0",
 ]
 acp = [

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -105,6 +105,13 @@ autogen-v4 = [
     "praisonai-tools>=0.1.0", 
     "crewai"
 ]
+langgraph = [
+    "langgraph>=0.2.0,<2",
+    "langgraph-prebuilt>=0.2.0,<2",
+    "langchain-core>=0.3.0,<2",
+    "langchain-openai>=0.2.0",
+    "praisonai-tools>=0.1.0",
+]
 acp = [
     "agent-client-protocol>=0.7.0",
 ]

--- a/src/praisonai/tests/e2e/langgraph_e2e/test_langgraph_real.py
+++ b/src/praisonai/tests/e2e/langgraph_e2e/test_langgraph_real.py
@@ -7,12 +7,9 @@ WARNING: Live tests make real API calls and may incur costs.
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../src"))
 
 
 def _write_yaml(content: str) -> str:
@@ -27,6 +24,8 @@ class TestLangGraphReal:
     """Real LangGraph tests with actual API calls."""
 
     def test_langgraph_simple_setup(self):
+        pytest.importorskip("langgraph")
+        pytest.importorskip("praisonai_frameworks")
         try:
             from praisonai import PraisonAI
         except ImportError as exc:
@@ -148,6 +147,7 @@ roles:
     @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
     def test_langgraph_adapter_direct_run(self):
         pytest.importorskip("langgraph")
+        pytest.importorskip("praisonai_frameworks")
         from praisonai_frameworks.langgraph.adapter import LangGraphAdapter
 
         config = {

--- a/src/praisonai/tests/e2e/langgraph_e2e/test_langgraph_real.py
+++ b/src/praisonai/tests/e2e/langgraph_e2e/test_langgraph_real.py
@@ -1,0 +1,173 @@
+"""
+LangGraph Real End-to-End Test
+
+WARNING: Live tests make real API calls and may incur costs.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../src"))
+
+
+def _write_yaml(content: str) -> str:
+    handle = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+    handle.write(content)
+    handle.close()
+    return handle.name
+
+
+@pytest.mark.real
+class TestLangGraphReal:
+    """Real LangGraph tests with actual API calls."""
+
+    def test_langgraph_simple_setup(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        yaml_content = """
+framework: langgraph
+topic: Simple Question Answer
+roles:
+  researcher:
+    role: Helper
+    goal: Answer simple questions accurately
+    backstory: I am a helpful assistant
+    tasks:
+      answer:
+        description: What is the capital of France? Reply with just the city name.
+        expected_output: Paris
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="langgraph")
+            assert praisonai is not None
+            assert praisonai.framework == "langgraph"
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)
+
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_langgraph_environment_check(self):
+        pytest.importorskip("langgraph")
+        pytest.importorskip("praisonai_frameworks")
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_langgraph_full_execution_single_task(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("langgraph")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: langgraph
+topic: Quick Math Test
+roles:
+  helper:
+    role: Calculator
+    goal: Do simple math quickly
+    backstory: I give brief numeric answers
+    tasks:
+      math:
+        description: Calculate 3+3. Answer with just the number, nothing else.
+        expected_output: "6"
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="langgraph")
+            result = praisonai.run()
+            text = str(result)
+            assert text.strip()
+            assert "6" in text
+            assert "LangGraph Output" in text or "langgraph" in text.lower()
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_langgraph_full_execution_sequential_context(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("langgraph")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: langgraph
+topic: Planet facts
+roles:
+  researcher:
+    role: Research_Analyst
+    goal: Gather concise facts
+    backstory: Expert researcher
+    tasks:
+      research:
+        description: Name one planet in our solar system. Reply with only the planet name.
+        expected_output: A planet name
+      summarise:
+        description: Write one short sentence describing that planet.
+        expected_output: One sentence
+        context:
+          - research
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="langgraph")
+            result = praisonai.run()
+            text = str(result)
+            assert text.strip()
+            assert len(text.split()) >= 3
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_langgraph_adapter_direct_run(self):
+        pytest.importorskip("langgraph")
+        from praisonai_frameworks.langgraph.adapter import LangGraphAdapter
+
+        config = {
+            "framework": "langgraph",
+            "topic": "Quick test",
+            "roles": {
+                "helper": {
+                    "role": "Assistant",
+                    "goal": "Answer briefly",
+                    "backstory": "Helpful assistant",
+                    "tasks": {
+                        "answer": {
+                            "description": "Reply with exactly the word OK.",
+                            "expected_output": "OK",
+                        }
+                    },
+                }
+            },
+        }
+        llm_config = [{"model": "gpt-4o-mini", "api_key": os.environ["OPENAI_API_KEY"]}]
+        result = LangGraphAdapter().run(config, llm_config, "Quick test", tools_dict={})
+        assert "### LangGraph Output ###" in result
+        assert "OK" in result.upper()

--- a/src/praisonai/tests/unit/test_langgraph_frameworks_integration.py
+++ b/src/praisonai/tests/unit/test_langgraph_frameworks_integration.py
@@ -1,0 +1,121 @@
+"""LangGraph via praisonai-frameworks entry point — integration tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("praisonaiagents.frameworks")
+
+pytest.importorskip("langgraph")
+frameworks = pytest.importorskip("praisonai_frameworks")
+
+from praisonai.framework_adapters.registry import (
+    FrameworkAdapterRegistry,
+    get_default_registry,
+    get_install_hint,
+    list_available_frameworks,
+    list_framework_choices,
+)
+from praisonai.framework_adapters import registry as registry_module
+from praisonai.framework_adapters.validators import assert_framework_available
+
+
+_LANGGRAPH_YAML = """
+framework: langgraph
+topic: AI trends
+roles:
+  researcher:
+    role: Research_Analyst
+    goal: Find accurate information on {topic}
+    backstory: Expert researcher
+    tasks:
+      research:
+        description: Research {topic}
+        expected_output: A concise summary
+"""
+
+
+def test_langgraph_adapter_resolves_from_frameworks_package():
+    adapter = get_default_registry().create("langgraph")
+    assert type(adapter).__module__.startswith("praisonai_frameworks")
+
+
+def test_langgraph_entry_point_only_registry():
+    registry = FrameworkAdapterRegistry()
+    assert "langgraph" in registry.list_names()
+    adapter = registry.create("langgraph")
+    assert type(adapter).__module__.startswith("praisonai_frameworks")
+
+
+def test_langgraph_install_hint_points_to_frameworks():
+    hint = get_install_hint("langgraph")
+    assert "praisonai-frameworks" in hint
+
+
+def test_langgraph_in_registry_discovery_lists():
+    names = list_framework_choices(include_unavailable=True)
+    assert "langgraph" in names
+    if get_default_registry().is_available("langgraph"):
+        assert "langgraph" in list_available_frameworks()
+
+
+def test_assert_framework_available_langgraph_when_installed():
+    if not get_default_registry().is_available("langgraph"):
+        pytest.skip("langgraph adapter not available in this environment")
+    assert_framework_available("langgraph")
+
+
+@patch("litellm.completion")
+def test_agents_generator_langgraph_via_frameworks_adapter(mock_completion):
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message = MagicMock()
+    mock_response.choices[0].message.content = "Done"
+    mock_completion.return_value = mock_response
+
+    registry = FrameworkAdapterRegistry()
+    adapter = registry.create("langgraph")
+
+    from praisonai.agents_generator import AgentsGenerator
+
+    gen = AgentsGenerator(
+        agent_file="agents.yaml",
+        framework="langgraph",
+        config_list=[{"model": "openai/gpt-4o-mini", "api_key": "test-key"}],
+        agent_yaml=_LANGGRAPH_YAML,
+        adapter_registry=registry,
+    )
+
+    mock_run = MagicMock(return_value="### LangGraph Output ###\nFrameworks langgraph output")
+    adapter.run = mock_run
+
+    def _fake_prepare(_config):
+        return {
+            "adapter": adapter,
+            "config": {
+                "framework": "langgraph",
+                "topic": "AI trends",
+                "roles": gen._load_config()["roles"],
+            },
+            "topic": "AI trends",
+            "tools_dict": {},
+        }
+
+    with patch.object(gen, "_prepare_for_run", side_effect=_fake_prepare):
+        result = gen.generate_crew_and_kickoff()
+
+    assert "Frameworks langgraph output" in result
+    mock_run.assert_called_once()
+
+
+def test_entry_point_metadata_registers_frameworks_langgraph():
+    import importlib.metadata
+
+    eps = {
+        ep.name: ep.value
+        for ep in importlib.metadata.entry_points(group="praisonai.framework_adapters")
+    }
+    assert "langgraph" in eps
+    assert eps["langgraph"].startswith("praisonai_frameworks")


### PR DESCRIPTION
## Summary

- Adds `praisonai[langgraph]` optional extra with LangGraph/LangChain dependencies
- Registers LangGraph in doctor runtime checks and `_framework_availability` probes (requires `langgraph.prebuilt`)
- Adds entry-point integration tests mirroring the CrewAI frameworks pattern
- Adds live e2e tests (`PRAISONAI_LIVE_TESTS=1`) for single-task, sequential context, and direct adapter runs
- Fixes CLI `RetryPolicy` → YAML validation by serialising retry policy to dict before agent config merge (unblocks `praisonai.run()` for all external frameworks)

## Adapter PR (PraisonAI-Frameworks)

The LangGraph adapter implementation lives in **PraisonAI-Frameworks** (already implemented locally):

https://github.com/MervinPraison/PraisonAI-Frameworks/pull/10

Install both for end-to-end use:

```bash
pip install -e praisonai -e "praisonai-frameworks[langgraph]"
```

## Validation

- `pytest tests/unit/test_langgraph_frameworks_integration.py` — 7 passed
- Live API (`PRAISONAI_LIVE_TESTS=1`, `OPENAI_API_KEY`) — 5/5 e2e passed including `praisonai.run()` and sequential `context` chains
- Branch rebased on latest `origin/main`

## Test plan

- [x] Unit integration tests pass locally
- [x] Live e2e with real OpenAI calls
- [ ] CI green on PR
- [ ] Merge with PraisonAI-Frameworks #10 and verify `framework: langgraph` agents.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LangGraph support as an optional install path, with discovery and runtime checks so it shows up when available.
  * Improved CLI configuration handling to accept retry policy settings more consistently.

* **Bug Fixes**
  * Retry policy values are now normalized more reliably, including converting delay values to seconds when needed.

* **Tests**
  * Added broader integration and end-to-end coverage for LangGraph setup and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->