### PR TITLE
Fix OpenAI Agents YAML validation and expand live e2e coverage

### DIFF
--- a/src/praisonai/praisonai/config/schema.py
+++ b/src/praisonai/praisonai/config/schema.py
@@ -153,9 +153,10 @@ class AgentConfig(BaseModel):
             normalized_tasks = {}
             for task_name, task_config in self.tasks.items():
                 if isinstance(task_config, dict):
-                    # Add the agent field if not present (use self.role)
+                    # Add the agent field if not present (validator-safe identifier)
                     if 'agent' not in task_config:
-                        task_config['agent'] = self.role
+                        safe_name = re.sub(r'[^a-zA-Z0-9_-]+', '_', self.role.strip()).strip('_')
+                        task_config['agent'] = safe_name or 'agent'
                     normalized_tasks[task_name] = TaskConfig(**task_config)
                 else:
                     normalized_tasks[task_name] = task_config

--- a/src/praisonai/tests/e2e/README.md
+++ b/src/praisonai/tests/e2e/README.md
@@ -25,6 +25,10 @@ tests/e2e/
 │   └── test_autogen_real.py    # Real AutoGen tests
 ├── crewai/
 │   └── test_crewai_real.py     # Real CrewAI tests
+├── langgraph_e2e/
+│   └── test_langgraph_real.py  # Real LangGraph tests
+├── openai_agents_e2e/
+│   └── test_openai_agents_real.py  # Real OpenAI Agents SDK tests
 ├── README.md                   # This file
 └── __init__.py
 ```

--- a/src/praisonai/tests/e2e/openai_agents_e2e/test_openai_agents_real.py
+++ b/src/praisonai/tests/e2e/openai_agents_e2e/test_openai_agents_real.py
@@ -128,3 +128,89 @@ roles:
         result = OpenAIAgentsAdapter().run(config, llm_config, "Quick test", tools_dict={})
         assert "### OpenAI Agents Output ###" in result
         assert "OK" in result.upper()
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_openai_agents_full_execution_sequential_context(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("agents")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: openai_agents
+topic: text processing
+roles:
+  writer:
+    role: Writer
+    goal: Transform text
+    backstory: Professional writer
+    tasks:
+      draft:
+        description: Write one word hello
+        expected_output: hello
+      polish:
+        description: Uppercase the prior draft word only.
+        expected_output: HELLO
+        context:
+          - draft
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="openai_agents")
+            result = praisonai.run()
+            text = str(result)
+            assert text.strip()
+            assert "HELLO" in text.upper()
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_openai_agents_full_execution_handoff_yaml(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("agents")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: openai_agents
+topic: greeting
+roles:
+  triage:
+    role: Triage Agent
+    goal: Route English requests to English Agent
+    backstory: Delegate English to the English Agent.
+    handoff:
+      to:
+        - English Agent
+    tasks:
+      route:
+        description: User says hello in English. Delegate appropriately.
+        expected_output: A friendly English reply
+  english:
+    role: English Agent
+    goal: Reply in English only
+    backstory: English specialist.
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="openai_agents")
+            result = praisonai.run()
+            assert str(result).strip()
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)

--- a/src/praisonai/tests/unit/test_framework_registry_helpers.py
+++ b/src/praisonai/tests/unit/test_framework_registry_helpers.py
@@ -47,7 +47,6 @@ def test_autogen_family_is_router_skips_run_validation():
 
 
 def test_ag2_not_in_default_builtins():
-    from praisonai.framework_adapters.registry import get_default_registry
+    from praisonai.framework_adapters import registry as registry_module
 
-    registry = get_default_registry()
-    assert "ag2" not in registry.list_names()
+    assert "ag2" not in registry_module._BUILTIN_ADAPTERS

--- a/src/praisonai/tests/unit/test_workflow_framework_validation.py
+++ b/src/praisonai/tests/unit/test_workflow_framework_validation.py
@@ -20,6 +20,16 @@ def test_validate_workflow_framework_rejects_crewai(caplog):
     assert any("crewai" in r.message for r in caplog.records)
 
 
+def test_validate_workflow_framework_rejects_openai_agents(caplog):
+    import logging
+    from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError, match="not supported for workflow execution"):
+            validate_workflow_framework("openai_agents", source="workflow.yaml")
+    assert any("openai_agents" in r.message for r in caplog.records)
+
+
 def test_framework_from_config_defaults_praisonai():
     from praisonai.framework_adapters.workflow_framework import framework_from_config
 


### PR DESCRIPTION
## Summary
- Sanitise auto-filled task agent names when role titles contain spaces (fixes handoff YAML through PraisonAI.run).
- Expand openai_agents e2e live tests for sequential multi-task and handoff flows.
- Align framework registry helper tests and reject openai_agents in workflow validation.

## Dependency
Merge and publish **PraisonAI-Frameworks** PR #20 (`praisonai-frameworks>=0.1.3`) before relying on live handoff/sequential adapter behaviour in CI.

## Test plan
- [x] `pytest src/praisonai/tests/unit/test_framework_registry_helpers.py -q`
- [x] `pytest src/praisonai/tests/unit/test_workflow_framework_validation.py -q`
- [x] Live: `PRAISONAI_LIVE_TESTS=1 pytest src/praisonai/tests/e2e/openai_agents_e2e/ -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real end-to-end coverage for additional agent workflows, including sequential task context and agent handoffs.

* **Bug Fixes**
  * Improved automatic task configuration so agent names are cleaned and standardized before use, reducing issues with unusual characters or empty names.
  * Added clearer validation for unsupported workflow frameworks, with a warning when an invalid option is used.

* **Documentation**
  * Updated E2E test documentation to include the newly added real test directories.

* **Tests**
  * Expanded unit and end-to-end test coverage for framework validation and live agent execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->