### PR TITLE
Add Agno framework integration to PraisonAI wrapper

### DIFF
--- a/src/praisonai/examples/python/frameworks/agno/agents.yaml
+++ b/src/praisonai/examples/python/frameworks/agno/agents.yaml
@@ -1,0 +1,11 @@
+framework: agno
+topic: math
+roles:
+  calculator:
+    role: Calculator
+    goal: Compute exactly
+    backstory: Return only the numeric answer.
+    tasks:
+      add:
+        description: What is 3 + 3?
+        expected_output: "6"

--- a/src/praisonai/praisonai/_framework_availability.py
+++ b/src/praisonai/praisonai/_framework_availability.py
@@ -43,6 +43,19 @@ def _openai_agents_probe() -> bool:
     except ImportError:
         return False
 
+def _agno_probe() -> bool:
+    try:
+        importlib.metadata.distribution("agno")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    if importlib.util.find_spec("agno") is None:
+        return False
+    try:
+        from agno.agent import Agent  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
 _PROBES: dict[str, Callable[[], bool]] = {
     "crewai":            lambda: importlib.util.find_spec("crewai") is not None,
     "autogen":           lambda: importlib.util.find_spec("autogen") is not None,
@@ -65,6 +78,7 @@ _PROBES: dict[str, Callable[[], bool]] = {
     "weaviate":          lambda: importlib.util.find_spec("weaviate") is not None,
     "langgraph":         _langgraph_probe,
     "openai_agents":     _openai_agents_probe,
+    "agno":              _agno_probe,
 }
 
 def is_available(name: str) -> bool:

--- a/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
+++ b/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
@@ -178,6 +178,19 @@ class RuntimeCompatibilityChecker:
             supports_handoff=True,
             supports_tool_loop=True
         )
+
+        runtimes['agno'] = RuntimeInfo(
+            id='agno',
+            name='Agno',
+            available=_runtime_usable('agno', 'agno'),
+            capabilities=[
+                RuntimeCapability('agent_creation', 'Create and manage agents'),
+                RuntimeCapability('tool_execution', 'Execute tools and functions'),
+                RuntimeCapability('sequential_execution', 'Sequential task execution'),
+            ],
+            supports_handoff=False,
+            supports_tool_loop=True
+        )
         
         return runtimes
     

--- a/src/praisonai/praisonai/cli/main.py
+++ b/src/praisonai/praisonai/cli/main.py
@@ -1997,14 +1997,17 @@ class PraisonAI:
                     print("\npip install praisonaiagents  # native PraisonAI")
                     print("pip install \"praisonai-frameworks[crewai]\"  # CrewAI")
                     print("pip install \"praisonai-frameworks[autogen]\"  # AutoGen")
-                    print("pip install \"praisonai-frameworks[openai-agents]\"  # OpenAI Agents SDK\n")
+                    print("pip install \"praisonai-frameworks[openai-agents]\"  # OpenAI Agents SDK")
+                    print("pip install \"praisonai-frameworks[agno]\"  # Agno\n")
                     sys.exit(1)
             except ImportError:
                 if not CREWAI_AVAILABLE and not AUTOGEN_AVAILABLE and not PRAISONAI_AVAILABLE:
                     print("[red]ERROR: No framework is installed. Please install at least one framework:[/red]")
                     print("\npip install \"praisonai-frameworks\\[crewai]\"  # For CrewAI")
                     print("pip install \"praisonai-frameworks\\[autogen]\"  # For AutoGen")
-                    print("pip install \"praisonai-frameworks\\[crewai,autogen]\"  # For both frameworks\n")
+                    print("pip install \"praisonai-frameworks\\[openai-agents]\"  # OpenAI Agents SDK")
+                    print("pip install \"praisonai-frameworks\\[agno]\"  # Agno")
+                    print("pip install \"praisonai-frameworks\\[crewai,autogen]\"  # Multiple frameworks\n")
                     print("pip install praisonaiagents # For Agents\n")
                     sys.exit(1)
 
@@ -5314,7 +5317,9 @@ Now, {final_instruction.lower()}:"""
             print("[red]ERROR: No framework is installed. Please install at least one framework:[/red]")
             print("\npip install \"praisonai-frameworks\\[crewai]\"  # For CrewAI")
             print("pip install \"praisonai-frameworks\\[autogen]\"  # For AutoGen")
-            print("pip install \"praisonai-frameworks\\[crewai,autogen]\"  # For both frameworks\n")
+            print("pip install \"praisonai-frameworks\\[openai-agents]\"  # OpenAI Agents SDK")
+            print("pip install \"praisonai-frameworks\\[agno]\"  # Agno")
+            print("pip install \"praisonai-frameworks\\[crewai,autogen]\"  # Multiple frameworks\n")
             print("pip install praisonaiagents # For Agents\n")  
             sys.exit(1)
 

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -116,6 +116,10 @@ openai-agents = [
     "praisonai-frameworks[openai-agents]>=0.1.3",
     "praisonai-tools>=0.1.0",
 ]
+agno = [
+    "praisonai-frameworks[agno]>=0.1.6",
+    "praisonai-tools>=0.1.0",
+]
 acp = [
     "agent-client-protocol>=0.7.0",
 ]

--- a/src/praisonai/tests/e2e/README.md
+++ b/src/praisonai/tests/e2e/README.md
@@ -29,6 +29,8 @@ tests/e2e/
 │   └── test_langgraph_real.py  # Real LangGraph tests
 ├── openai_agents_e2e/
 │   └── test_openai_agents_real.py  # Real OpenAI Agents SDK tests
+├── agno_e2e/
+│   └── test_agno_real.py           # Real Agno tests
 ├── README.md                   # This file
 └── __init__.py
 ```
@@ -80,6 +82,16 @@ export PRAISONAI_RUN_FULL_TESTS=true
 
 # Run with real-time output to see actual execution
 python -m pytest tests/e2e/autogen/ -v -m real -s
+```
+
+**Run OpenAI Agents real tests only:**
+```bash
+python -m pytest tests/e2e/openai_agents_e2e/ -v -m real
+```
+
+**Run Agno real tests only:**
+```bash
+python -m pytest tests/e2e/agno_e2e/ -v -m real
 ```
 
 **Skip real tests (default behavior without API keys):**

--- a/src/praisonai/tests/e2e/agno_e2e/test_agno_real.py
+++ b/src/praisonai/tests/e2e/agno_e2e/test_agno_real.py
@@ -1,0 +1,178 @@
+"""
+Agno Real End-to-End Test
+
+WARNING: Live tests make real API calls and may incur costs.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+
+def _write_yaml(content: str) -> str:
+    handle = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+    handle.write(content)
+    handle.close()
+    return handle.name
+
+
+@pytest.mark.real
+class TestAgnoReal:
+    """Real Agno tests with actual API calls."""
+
+    def test_agno_simple_setup(self):
+        pytest.importorskip("agno")
+        pytest.importorskip("praisonai_frameworks")
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        yaml_content = """
+framework: agno
+topic: Simple Question Answer
+roles:
+  researcher:
+    role: Helper
+    goal: Answer simple questions accurately
+    backstory: I am a helpful assistant
+    tasks:
+      answer:
+        description: What is the capital of France? Reply with just the city name.
+        expected_output: Paris
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="agno")
+            assert praisonai is not None
+            assert praisonai.framework == "agno"
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)
+
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_agno_environment_check(self):
+        pytest.importorskip("agno")
+        pytest.importorskip("praisonai_frameworks")
+        from praisonai_frameworks._availability import is_available
+        from praisonai_frameworks.agno.adapter import AgnoAdapter
+
+        assert is_available("agno") is True
+        assert AgnoAdapter().is_available() is True
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_agno_full_execution_single_task(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("agno")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: agno
+topic: Quick Math Test
+roles:
+  helper:
+    role: Calculator
+    goal: Do simple math quickly
+    backstory: I give brief numeric answers
+    tasks:
+      math:
+        description: Calculate 3+3. Answer with just the number, nothing else.
+        expected_output: "6"
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="agno")
+            result = praisonai.run()
+            text = str(result)
+            assert text.strip()
+            assert "6" in text
+            assert "Agno Output" in text or "agno" in text.lower()
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_agno_adapter_direct_run(self):
+        pytest.importorskip("agno")
+        pytest.importorskip("praisonai_frameworks")
+        from praisonai_frameworks.agno.adapter import AgnoAdapter
+
+        config = {
+            "framework": "agno",
+            "topic": "Quick test",
+            "roles": {
+                "helper": {
+                    "role": "Assistant",
+                    "goal": "Answer briefly",
+                    "backstory": "Helpful assistant",
+                    "tasks": {
+                        "answer": {
+                            "description": "Reply with exactly the word OK.",
+                            "expected_output": "OK",
+                        }
+                    },
+                }
+            },
+        }
+        llm_config = [{"model": "gpt-4o-mini", "api_key": os.environ["OPENAI_API_KEY"]}]
+        result = AgnoAdapter().run(config, llm_config, "Quick test", tools_dict={})
+        assert "### Agno Output ###" in result
+        assert "OK" in result.upper()
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_agno_full_execution_sequential_context(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("agno")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: agno
+topic: numbers
+roles:
+  writer:
+    role: Writer
+    goal: Write numbers only
+    backstory: Concise writer
+    tasks:
+      draft:
+        description: Reply with only the number 3.
+        expected_output: "3"
+      polish:
+        description: Add 3 to the previous result. Reply with only the number.
+        expected_output: "6"
+        context:
+          - draft
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="agno")
+            result = praisonai.run()
+            text = str(result)
+            assert "6" in text
+            assert "Agno Output" in text
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)

--- a/src/praisonai/tests/unit/test_agno_frameworks_integration.py
+++ b/src/praisonai/tests/unit/test_agno_frameworks_integration.py
@@ -1,0 +1,120 @@
+"""Agno via praisonai-frameworks entry point — integration tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("praisonaiagents.frameworks")
+pytest.importorskip("agno", reason="agno optional extra not installed")
+pytest.importorskip("praisonai_frameworks")
+
+from praisonai.framework_adapters.registry import (
+    FrameworkAdapterRegistry,
+    get_default_registry,
+    get_install_hint,
+    list_available_frameworks,
+    list_framework_choices,
+)
+from praisonai.framework_adapters.validators import assert_framework_available
+
+
+_AGNO_YAML = """
+framework: agno
+topic: AI trends
+roles:
+  researcher:
+    role: Research_Analyst
+    goal: Find accurate information on {topic}
+    backstory: Expert researcher
+    tasks:
+      research:
+        description: Research {topic}
+        expected_output: A concise summary
+"""
+
+
+def test_agno_adapter_resolves_from_frameworks_package():
+    adapter = get_default_registry().create("agno")
+    assert type(adapter).__module__.startswith("praisonai_frameworks")
+
+
+def test_agno_entry_point_only_registry():
+    registry = FrameworkAdapterRegistry()
+    assert "agno" in registry.list_names()
+    adapter = registry.create("agno")
+    assert type(adapter).__module__.startswith("praisonai_frameworks")
+
+
+def test_agno_install_hint_points_to_frameworks():
+    hint = get_install_hint("agno")
+    assert "agno" in hint
+    assert "praisonai-frameworks" in hint
+
+
+def test_agno_in_registry_discovery_lists():
+    names = list_framework_choices(include_unavailable=True)
+    assert "agno" in names
+    if get_default_registry().is_available("agno"):
+        assert "agno" in list_available_frameworks()
+
+
+def test_assert_framework_available_agno_when_installed():
+    if not get_default_registry().is_available("agno"):
+        pytest.skip("agno adapter not available in this environment")
+    assert_framework_available("agno")
+
+
+@patch("litellm.completion")
+def test_agents_generator_agno_via_frameworks_adapter(mock_completion):
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message = MagicMock()
+    mock_response.choices[0].message.content = "Done"
+    mock_completion.return_value = mock_response
+
+    registry = FrameworkAdapterRegistry()
+    adapter = registry.create("agno")
+
+    from praisonai.agents_generator import AgentsGenerator
+
+    gen = AgentsGenerator(
+        agent_file="agents.yaml",
+        framework="agno",
+        config_list=[{"model": "openai/gpt-4o-mini", "api_key": "test-key"}],
+        agent_yaml=_AGNO_YAML,
+        adapter_registry=registry,
+    )
+
+    mock_run = MagicMock(return_value="### Agno Output ###\nFrameworks output")
+    adapter.run = mock_run
+
+    def _fake_prepare(_config):
+        return {
+            "adapter": adapter,
+            "config": {
+                "framework": "agno",
+                "topic": "AI trends",
+                "roles": gen._load_config()["roles"],
+            },
+            "topic": "AI trends",
+            "tools_dict": {},
+        }
+
+    with patch.object(gen, "_prepare_for_run", side_effect=_fake_prepare):
+        result = gen.generate_crew_and_kickoff()
+
+    assert "Frameworks output" in result
+    mock_run.assert_called_once()
+
+
+def test_entry_point_metadata_registers_frameworks_agno():
+    import importlib.metadata
+
+    eps = {
+        ep.name: ep.value
+        for ep in importlib.metadata.entry_points(group="praisonai.framework_adapters")
+    }
+    assert "agno" in eps
+    assert eps["agno"].startswith("praisonai_frameworks")

--- a/src/praisonai/tests/unit/test_framework_registry_helpers.py
+++ b/src/praisonai/tests/unit/test_framework_registry_helpers.py
@@ -38,6 +38,13 @@ def test_get_install_hint_openai_agents_extra():
     assert "openai-agents" in hint
 
 
+def test_get_install_hint_agno_extra():
+    from praisonai.framework_adapters.registry import get_install_hint
+
+    hint = get_install_hint("agno")
+    assert "agno" in hint
+
+
 def test_autogen_family_is_router_skips_run_validation():
     from praisonai.framework_adapters.registry import FrameworkAdapterRegistry
 

--- a/src/praisonai/tests/unit/test_workflow_framework_validation.py
+++ b/src/praisonai/tests/unit/test_workflow_framework_validation.py
@@ -30,6 +30,16 @@ def test_validate_workflow_framework_rejects_openai_agents(caplog):
     assert any("openai_agents" in r.message for r in caplog.records)
 
 
+def test_validate_workflow_framework_rejects_agno(caplog):
+    import logging
+    from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError, match="not supported for workflow execution"):
+            validate_workflow_framework("agno", source="workflow.yaml")
+    assert any("agno" in r.message for r in caplog.records)
+
+
 def test_framework_from_config_defaults_praisonai():
     from praisonai.framework_adapters.workflow_framework import framework_from_config
 


### PR DESCRIPTION
## Summary
- Wires Agno into the PraisonAI wrapper: availability probe, `praisonai[agno]` extra (`praisonai-frameworks[agno]>=0.1.6`), doctor runtime card, CLI install hints, and workflow validation rejection.
- Adds unit integration tests, example YAML, and live e2e coverage for single-task and sequential-context flows via `PraisonAI.run()` and direct `AgnoAdapter.run()`.

## Test plan
- [x] Unit tests: `python -m pytest tests/unit/test_agno_frameworks_integration.py tests/unit/test_framework_registry_helpers.py tests/unit/test_workflow_framework_validation.py -q` (20 passed)
- [x] Live e2e: `PRAISONAI_LIVE_TESTS=1 OPENAI_API_KEY=... python -m pytest tests/e2e/agno_e2e/test_agno_real.py -m real -v` (5/5 passed)
- [ ] Merge after **PraisonAI-Frameworks 0.1.6** is published to PyPI

## Depends on
- https://github.com/MervinPraison/PraisonAI-Frameworks/pull/21 (merge + PyPI release first)

## Install (after both land)
```bash
pip install "praisonai[agno]"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Agno framework, including a new optional install extra and framework availability detection.
  * Expanded runtime compatibility to recognize Agno and surface its supported capabilities.
* **Bug Fixes**
  * Updated setup guidance when no framework is installed to include Agno-related install options.
  * Clarified that Agno is not supported for workflow execution, with an explicit warning.
* **Documentation**
  * Added examples and docs for running Agno real end-to-end tests.
* **Tests**
  * Added unit and end-to-end coverage for Agno framework discovery, installation hints, adapter behavior, and execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->