### PR TITLE
feat: Phase 3 handoff doctor + e2e for Agno and Google ADK

### DIFF
--- a/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
+++ b/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
@@ -187,8 +187,9 @@ class RuntimeCompatibilityChecker:
                 RuntimeCapability('agent_creation', 'Create and manage agents'),
                 RuntimeCapability('tool_execution', 'Execute tools and functions'),
                 RuntimeCapability('sequential_execution', 'Sequential task execution'),
+                RuntimeCapability('handoff_support', 'Agent-to-agent handoffs via Team route', required=False),
             ],
-            supports_handoff=False,
+            supports_handoff=True,
             supports_tool_loop=True
         )
 
@@ -200,8 +201,9 @@ class RuntimeCompatibilityChecker:
                 RuntimeCapability('agent_creation', 'Create and manage agents'),
                 RuntimeCapability('tool_execution', 'Execute tools and functions'),
                 RuntimeCapability('sequential_execution', 'Sequential task execution'),
+                RuntimeCapability('handoff_support', 'Agent-to-agent handoffs via sub_agents', required=False),
             ],
-            supports_handoff=False,
+            supports_handoff=True,
             supports_tool_loop=True
         )
         
@@ -482,7 +484,13 @@ class RuntimeCompatibilityChecker:
         handoff_agents = [a for a in agents if a.handoff_targets]
         if handoff_agents:
             handoff_runtimes = {a.resolved_runtime for a in handoff_agents}
-            incompatible_handoff_runtimes = handoff_runtimes - {'praisonai', 'autogen_v4', 'openai_agents'}
+            incompatible_handoff_runtimes = handoff_runtimes - {
+                'praisonai',
+                'autogen_v4',
+                'openai_agents',
+                'agno',
+                'google_adk',
+            }
             
             if incompatible_handoff_runtimes:
                 yield CheckResult(
@@ -491,8 +499,8 @@ class RuntimeCompatibilityChecker:
                     category=CheckCategory.CONFIG,
                     status=CheckStatus.FAIL,
                     message=f"Handoffs configured with incompatible runtimes: {', '.join(incompatible_handoff_runtimes)}",
-                    details="Only praisonai, autogen_v4, and openai_agents runtimes support handoffs",
-                    remediation="Use praisonai, autogen_v4, or openai_agents for agents that need handoff capabilities",
+                    details="Only praisonai, autogen_v4, openai_agents, agno, and google_adk runtimes support handoffs",
+                    remediation="Use praisonai, autogen_v4, openai_agents, agno, or google_adk for agents that need handoff capabilities",
                     severity=CheckSeverity.HIGH
                 )
 

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -117,11 +117,11 @@ openai-agents = [
     "praisonai-tools>=0.1.0",
 ]
 agno = [
-    "praisonai-frameworks[agno]>=0.1.7",
+    "praisonai-frameworks[agno]>=0.1.8",
     "praisonai-tools>=0.1.0",
 ]
 google-adk = [
-    "praisonai-frameworks[google-adk]>=0.1.7",
+    "praisonai-frameworks[google-adk]>=0.1.8",
     "praisonai-tools>=0.1.0",
 ]
 acp = [

--- a/src/praisonai/tests/e2e/agno_e2e/test_agno_real.py
+++ b/src/praisonai/tests/e2e/agno_e2e/test_agno_real.py
@@ -176,3 +176,46 @@ roles:
         finally:
             if os.path.exists(test_file):
                 os.unlink(test_file)
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_agno_full_execution_handoff_yaml(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("agno")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: agno
+topic: greeting
+roles:
+  triage:
+    role: Triage Agent
+    goal: Route English requests to English Agent
+    backstory: Delegate English to the English Agent.
+    handoff:
+      to:
+        - English Agent
+    tasks:
+      route:
+        description: User says hello in English. Delegate appropriately.
+        expected_output: A friendly English reply
+  english:
+    role: English Agent
+    goal: Reply in English only
+    backstory: English specialist.
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="agno")
+            result = praisonai.run()
+            assert str(result).strip()
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)

--- a/src/praisonai/tests/e2e/google_adk_e2e/test_google_adk_real.py
+++ b/src/praisonai/tests/e2e/google_adk_e2e/test_google_adk_real.py
@@ -180,3 +180,46 @@ roles:
         finally:
             if os.path.exists(test_file):
                 os.unlink(test_file)
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not _google_key(), reason="GOOGLE_API_KEY or GEMINI_API_KEY not set")
+    def test_google_adk_full_execution_handoff_yaml(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("google.adk")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: google_adk
+topic: greeting
+roles:
+  triage:
+    role: Triage Agent
+    goal: Route English requests to English Agent
+    backstory: Delegate English to the English Agent.
+    handoff:
+      to:
+        - English Agent
+    tasks:
+      route:
+        description: User says hello in English. Delegate appropriately.
+        expected_output: A friendly English reply
+  english:
+    role: English Agent
+    goal: Reply in English only
+    backstory: English specialist.
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="google_adk")
+            result = praisonai.run()
+            assert str(result).strip()
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)

--- a/src/praisonai/tests/unit/test_agno_frameworks_integration.py
+++ b/src/praisonai/tests/unit/test_agno_frameworks_integration.py
@@ -117,7 +117,7 @@ def test_agents_generator_agno_via_frameworks_adapter(mock_completion):
         tools_dict={},
         agent_callback=None,
         task_callback=None,
-        cli_config=None,
+        cli_config={},
     )
 
 

--- a/src/praisonai/tests/unit/test_google_adk_frameworks_integration.py
+++ b/src/praisonai/tests/unit/test_google_adk_frameworks_integration.py
@@ -117,7 +117,7 @@ def test_agents_generator_google_adk_via_frameworks_adapter(mock_completion):
         tools_dict={},
         agent_callback=None,
         task_callback=None,
-        cli_config=None,
+        cli_config={},
     )
 
 


### PR DESCRIPTION
## Summary
- Set `supports_handoff=True` for `agno` and `google_adk` in doctor runtime checks
- Include both runtimes in handoff-compatible remediation strings
- Pin `praisonai-frameworks[agno|google-adk]>=0.1.8`
- Add wrapper e2e handoff tests for Agno and Google ADK

Depends on: MervinPraison/PraisonAI-Frameworks#24

## Test plan
- [x] `pytest tests/e2e/agno_e2e/test_agno_real.py` with `PRAISONAI_LIVE_TESTS=1`
- [x] `pytest tests/e2e/google_adk_e2e/test_google_adk_real.py` with `PRAISONAI_LIVE_TESTS=1` and `PRAISONAI_TEST_PROVIDERS=all`
- [x] Handoff YAML e2e tests pass with real API keys


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added handoff support for AG2 and Google ADK runtimes, expanding compatible workflow options.
  * Added live end-to-end coverage for handoff-based execution in both runtimes.

* **Bug Fixes**
  * Improved mixed-runtime compatibility checks and updated guidance when handoff-capable runtimes are used.

* **Tests**
  * Updated integration expectations to reflect the current runtime configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->