### PR TITLE
feat: Pydantic AI wrapper integration

### DIFF
--- a/src/praisonai/examples/python/frameworks/pydantic_ai/agents.yaml
+++ b/src/praisonai/examples/python/frameworks/pydantic_ai/agents.yaml
@@ -1,0 +1,11 @@
+framework: pydantic_ai
+topic: math
+roles:
+  calculator:
+    role: Calculator
+    goal: Compute exactly
+    backstory: Return only the numeric answer.
+    tasks:
+      add:
+        description: What is 3 + 3?
+        expected_output: "6"

--- a/src/praisonai/praisonai/_framework_availability.py
+++ b/src/praisonai/praisonai/_framework_availability.py
@@ -73,6 +73,19 @@ def _google_adk_probe() -> bool:
         except ImportError:
             return False
 
+def _pydantic_ai_probe() -> bool:
+    try:
+        importlib.metadata.distribution("pydantic-ai")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    if importlib.util.find_spec("pydantic_ai") is None:
+        return False
+    try:
+        from pydantic_ai import Agent  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
 _PROBES: dict[str, Callable[[], bool]] = {
     "crewai":            lambda: importlib.util.find_spec("crewai") is not None,
     "autogen":           lambda: importlib.util.find_spec("autogen") is not None,
@@ -97,6 +110,7 @@ _PROBES: dict[str, Callable[[], bool]] = {
     "openai_agents":     _openai_agents_probe,
     "agno":              _agno_probe,
     "google_adk":        _google_adk_probe,
+    "pydantic_ai":       _pydantic_ai_probe,
 }
 
 def is_available(name: str) -> bool:

--- a/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
+++ b/src/praisonai/praisonai/cli/features/doctor/checks/runtime_checks.py
@@ -206,6 +206,20 @@ class RuntimeCompatibilityChecker:
             supports_handoff=True,
             supports_tool_loop=True
         )
+
+        runtimes['pydantic_ai'] = RuntimeInfo(
+            id='pydantic_ai',
+            name='Pydantic AI',
+            available=_runtime_usable('pydantic_ai', 'pydantic_ai'),
+            capabilities=[
+                RuntimeCapability('agent_creation', 'Create and manage agents'),
+                RuntimeCapability('tool_execution', 'Execute tools and functions'),
+                RuntimeCapability('sequential_execution', 'Sequential task execution'),
+                RuntimeCapability('handoff_support', 'Agent-to-agent handoffs via delegation tools', required=False),
+            ],
+            supports_handoff=True,
+            supports_tool_loop=True
+        )
         
         return runtimes
     
@@ -490,6 +504,7 @@ class RuntimeCompatibilityChecker:
                 'openai_agents',
                 'agno',
                 'google_adk',
+                'pydantic_ai',
             }
             
             if incompatible_handoff_runtimes:
@@ -499,8 +514,8 @@ class RuntimeCompatibilityChecker:
                     category=CheckCategory.CONFIG,
                     status=CheckStatus.FAIL,
                     message=f"Handoffs configured with incompatible runtimes: {', '.join(incompatible_handoff_runtimes)}",
-                    details="Only praisonai, autogen_v4, openai_agents, agno, and google_adk runtimes support handoffs",
-                    remediation="Use praisonai, autogen_v4, openai_agents, agno, or google_adk for agents that need handoff capabilities",
+                    details="Only praisonai, autogen_v4, openai_agents, agno, google_adk, and pydantic_ai runtimes support handoffs",
+                    remediation="Use praisonai, autogen_v4, openai_agents, agno, google_adk, or pydantic_ai for agents that need handoff capabilities",
                     severity=CheckSeverity.HIGH
                 )
 

--- a/src/praisonai/praisonai/cli/features/migrate.py
+++ b/src/praisonai/praisonai/cli/features/migrate.py
@@ -640,6 +640,21 @@ class CodeConverter:
             if re.search(pattern, converted, flags):
                 converted = re.sub(pattern, replacement, converted, flags=flags)
                 imports_to_add.add("from praisonaiagents import Agent, AgentTeam")
+
+        pydantic_ai_replacements = [
+            (r'^from\s+pydantic_ai\s+import\s+Agent\b.*$', 'from praisonaiagents import Agent', re.MULTILINE),
+            (r'\.run_sync\s*\(', '.start('),
+        ]
+
+        for item in pydantic_ai_replacements:
+            if len(item) == 3:
+                pattern, replacement, flags = item
+            else:
+                pattern, replacement = item
+                flags = 0
+            if re.search(pattern, converted, flags):
+                converted = re.sub(pattern, replacement, converted, flags=flags)
+                imports_to_add.add("from praisonaiagents import Agent")
         
         # Add imports if not already present
         if imports_to_add and "from praisonaiagents import" not in converted:

--- a/src/praisonai/praisonai/framework_adapters/registry.py
+++ b/src/praisonai/praisonai/framework_adapters/registry.py
@@ -230,6 +230,7 @@ def get_install_hint(name: str) -> str:
         "autogen_v4": "autogen-v4",
         "openai_agents": "openai-agents",
         "google_adk": "google-adk",
+        "pydantic_ai": "pydantic-ai",
     }.get(name, name)
     return f"pip install 'praisonai-frameworks[{extra_name}]'"
 

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -124,6 +124,10 @@ google-adk = [
     "praisonai-frameworks[google-adk]>=0.1.8",
     "praisonai-tools>=0.1.0",
 ]
+pydantic-ai = [
+    "praisonai-frameworks[pydantic-ai]>=0.1.9",
+    "praisonai-tools>=0.1.0",
+]
 acp = [
     "agent-client-protocol>=0.7.0",
 ]

--- a/src/praisonai/tests/e2e/README.md
+++ b/src/praisonai/tests/e2e/README.md
@@ -33,6 +33,8 @@ tests/e2e/
 │   └── test_agno_real.py           # Real Agno tests
 ├── google_adk_e2e/
 │   └── test_google_adk_real.py     # Real Google ADK tests
+├── pydantic_ai_e2e/
+│   └── test_pydantic_ai_real.py    # Real Pydantic AI tests
 ├── README.md                   # This file
 └── __init__.py
 ```
@@ -99,6 +101,11 @@ PRAISONAI_LIVE_TESTS=1 OPENAI_API_KEY="your-key" python -m pytest tests/e2e/agno
 **Run Google ADK real tests only:**
 ```bash
 PRAISONAI_LIVE_TESTS=1 GOOGLE_API_KEY="your-key" PRAISONAI_TEST_PROVIDERS=all python -m pytest tests/e2e/google_adk_e2e/ -v -m real
+```
+
+**Run Pydantic AI real tests only:**
+```bash
+PRAISONAI_LIVE_TESTS=1 OPENAI_API_KEY="your-key" python -m pytest tests/e2e/pydantic_ai_e2e/ -v -m real
 ```
 
 **Skip real tests (default behavior without API keys):**

--- a/src/praisonai/tests/e2e/pydantic_ai_e2e/test_pydantic_ai_real.py
+++ b/src/praisonai/tests/e2e/pydantic_ai_e2e/test_pydantic_ai_real.py
@@ -1,0 +1,225 @@
+"""
+Pydantic AI Real End-to-End Test
+
+WARNING: Live tests make real API calls and may incur costs.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+
+def _write_yaml(content: str) -> str:
+    handle = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+    handle.write(content)
+    handle.close()
+    return handle.name
+
+
+def _openai_key() -> str | None:
+    return os.getenv("OPENAI_API_KEY")
+
+
+@pytest.mark.real
+class TestPydanticAiReal:
+    """Real Pydantic AI tests with actual API calls."""
+
+    def test_pydantic_ai_simple_setup(self):
+        pytest.importorskip("pydantic_ai")
+        pytest.importorskip("praisonai_frameworks")
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        yaml_content = """
+framework: pydantic_ai
+topic: Simple Question Answer
+roles:
+  researcher:
+    role: Helper
+    goal: Answer simple questions accurately
+    backstory: I am a helpful assistant
+    tasks:
+      answer:
+        description: What is the capital of France? Reply with just the city name.
+        expected_output: Paris
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="pydantic_ai")
+            assert praisonai is not None
+            assert praisonai.framework == "pydantic_ai"
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)
+
+    @pytest.mark.skipif(not _openai_key(), reason="OPENAI_API_KEY not set")
+    def test_pydantic_ai_environment_check(self):
+        pytest.importorskip("pydantic_ai")
+        pytest.importorskip("praisonai_frameworks")
+        from praisonai_frameworks._availability import is_available
+        from praisonai_frameworks.pydantic_ai.adapter import PydanticAiAdapter
+
+        assert is_available("pydantic_ai") is True
+        assert PydanticAiAdapter().is_available() is True
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not _openai_key(), reason="OPENAI_API_KEY not set")
+    def test_pydantic_ai_full_execution_single_task(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("pydantic_ai")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: pydantic_ai
+topic: Quick Math Test
+roles:
+  helper:
+    role: Calculator
+    goal: Do simple math quickly
+    backstory: I give brief numeric answers
+    tasks:
+      math:
+        description: Calculate 3+3. Answer with just the number, nothing else.
+        expected_output: "6"
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="pydantic_ai")
+            result = praisonai.run()
+            text = str(result)
+            assert text.strip()
+            assert "6" in text
+            assert "Pydantic AI Output" in text
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not _openai_key(), reason="OPENAI_API_KEY not set")
+    def test_pydantic_ai_adapter_direct_run(self):
+        pytest.importorskip("pydantic_ai")
+        pytest.importorskip("praisonai_frameworks")
+        from praisonai_frameworks.pydantic_ai.adapter import PydanticAiAdapter
+
+        config = {
+            "framework": "pydantic_ai",
+            "topic": "Quick test",
+            "roles": {
+                "helper": {
+                    "role": "Assistant",
+                    "goal": "Answer briefly",
+                    "backstory": "Helpful assistant",
+                    "tasks": {
+                        "answer": {
+                            "description": "Reply with exactly the word OK.",
+                            "expected_output": "OK",
+                        }
+                    },
+                }
+            },
+        }
+        llm_config = [{"model": "openai/gpt-4o-mini", "api_key": _openai_key()}]
+        result = PydanticAiAdapter().run(config, llm_config, "Quick test", tools_dict={})
+        assert "### Pydantic AI Output ###" in result
+        assert "OK" in result.upper()
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not _openai_key(), reason="OPENAI_API_KEY not set")
+    def test_pydantic_ai_full_execution_sequential_context(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("pydantic_ai")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: pydantic_ai
+topic: numbers
+roles:
+  writer:
+    role: Writer
+    goal: Write numbers only
+    backstory: Concise writer
+    tasks:
+      draft:
+        description: Reply with only the number 3.
+        expected_output: "3"
+      polish:
+        description: Add 3 to the previous result. Reply with only the number.
+        expected_output: "6"
+        context:
+          - draft
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="pydantic_ai")
+            result = praisonai.run()
+            text = str(result)
+            assert "6" in text
+            assert "Pydantic AI Output" in text
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)
+
+    @pytest.mark.skipif(
+        not os.getenv("PRAISONAI_LIVE_TESTS"),
+        reason="Set PRAISONAI_LIVE_TESTS=1 to run real API calls",
+    )
+    @pytest.mark.skipif(not _openai_key(), reason="OPENAI_API_KEY not set")
+    def test_pydantic_ai_full_execution_handoff_yaml(self):
+        try:
+            from praisonai import PraisonAI
+        except ImportError as exc:
+            pytest.skip(f"PraisonAI not available: {exc}")
+
+        pytest.importorskip("pydantic_ai")
+        pytest.importorskip("praisonai_frameworks")
+
+        yaml_content = """
+framework: pydantic_ai
+topic: greeting
+roles:
+  triage:
+    role: Triage Agent
+    goal: Route English requests to English Agent
+    backstory: Delegate English to the English Agent.
+    handoff:
+      to:
+        - English Agent
+    tasks:
+      route:
+        description: User says hello in English. Delegate appropriately.
+        expected_output: A friendly English reply
+  english:
+    role: English Agent
+    goal: Reply in English only
+    backstory: English specialist.
+"""
+        test_file = _write_yaml(yaml_content)
+        try:
+            praisonai = PraisonAI(agent_file=test_file, framework="pydantic_ai")
+            result = praisonai.run()
+            assert str(result).strip()
+        finally:
+            if os.path.exists(test_file):
+                os.unlink(test_file)

--- a/src/praisonai/tests/unit/test_framework_registry_helpers.py
+++ b/src/praisonai/tests/unit/test_framework_registry_helpers.py
@@ -52,6 +52,13 @@ def test_get_install_hint_google_adk_extra():
     assert "google-adk" in hint
 
 
+def test_get_install_hint_pydantic_ai_extra():
+    from praisonai.framework_adapters.registry import get_install_hint
+
+    hint = get_install_hint("pydantic_ai")
+    assert "pydantic" in hint.lower()
+
+
 def test_autogen_family_is_router_skips_run_validation():
     from praisonai.framework_adapters.registry import FrameworkAdapterRegistry
 

--- a/src/praisonai/tests/unit/test_pydantic_ai_frameworks_integration.py
+++ b/src/praisonai/tests/unit/test_pydantic_ai_frameworks_integration.py
@@ -1,0 +1,132 @@
+"""Pydantic AI via praisonai-frameworks entry point — integration tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("praisonaiagents.frameworks")
+pytest.importorskip("pydantic_ai", reason="pydantic-ai optional extra not installed")
+pytest.importorskip("praisonai_frameworks")
+
+from praisonai.framework_adapters.registry import (
+    FrameworkAdapterRegistry,
+    get_default_registry,
+    get_install_hint,
+    list_available_frameworks,
+    list_framework_choices,
+)
+from praisonai.framework_adapters.validators import assert_framework_available
+
+
+_PYDANTIC_AI_YAML = """
+framework: pydantic_ai
+topic: AI trends
+roles:
+  researcher:
+    role: Research_Analyst
+    goal: Find accurate information on {topic}
+    backstory: Expert researcher
+    tasks:
+      research:
+        description: Research {topic}
+        expected_output: A concise summary
+"""
+
+
+def test_pydantic_ai_adapter_resolves_from_frameworks_package():
+    adapter = get_default_registry().create("pydantic_ai")
+    assert type(adapter).__module__.startswith("praisonai_frameworks")
+
+
+def test_pydantic_ai_entry_point_only_registry():
+    registry = FrameworkAdapterRegistry()
+    assert "pydantic_ai" in registry.list_names()
+    adapter = registry.create("pydantic_ai")
+    assert type(adapter).__module__.startswith("praisonai_frameworks")
+
+
+def test_pydantic_ai_install_hint_points_to_frameworks():
+    hint = get_install_hint("pydantic_ai")
+    assert "pydantic" in hint.lower()
+    assert "praisonai-frameworks" in hint
+
+
+def test_pydantic_ai_in_registry_discovery_lists():
+    names = list_framework_choices(include_unavailable=True)
+    assert "pydantic_ai" in names
+    if get_default_registry().is_available("pydantic_ai"):
+        assert "pydantic_ai" in list_available_frameworks()
+
+
+def test_assert_framework_available_pydantic_ai_when_installed():
+    if not get_default_registry().is_available("pydantic_ai"):
+        pytest.skip("pydantic_ai adapter not available in this environment")
+    assert_framework_available("pydantic_ai")
+
+
+@patch("litellm.completion")
+def test_agents_generator_pydantic_ai_via_frameworks_adapter(mock_completion):
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message = MagicMock()
+    mock_response.choices[0].message.content = "Done"
+    mock_completion.return_value = mock_response
+
+    registry = FrameworkAdapterRegistry()
+    adapter = registry.create("pydantic_ai")
+
+    from praisonai.agents_generator import AgentsGenerator
+
+    gen = AgentsGenerator(
+        agent_file="agents.yaml",
+        framework="pydantic_ai",
+        config_list=[{"model": "openai/gpt-4o-mini", "api_key": "test-key"}],
+        agent_yaml=_PYDANTIC_AI_YAML,
+        adapter_registry=registry,
+    )
+
+    mock_run = MagicMock(return_value="### Pydantic AI Output ###\nFrameworks output")
+    adapter.run = mock_run
+
+    def _fake_prepare(_config):
+        return {
+            "adapter": adapter,
+            "config": {
+                "framework": "pydantic_ai",
+                "topic": "AI trends",
+                "roles": gen._load_config()["roles"],
+            },
+            "topic": "AI trends",
+            "tools_dict": {},
+        }
+
+    with patch.object(gen, "_prepare_for_run", side_effect=_fake_prepare):
+        result = gen.generate_crew_and_kickoff()
+
+    assert "Frameworks output" in result
+    mock_run.assert_called_once_with(
+        {
+            "framework": "pydantic_ai",
+            "topic": "AI trends",
+            "roles": gen._load_config()["roles"],
+        },
+        [{"model": "openai/gpt-4o-mini", "api_key": "test-key"}],
+        "AI trends",
+        tools_dict={},
+        agent_callback=None,
+        task_callback=None,
+        cli_config={},
+    )
+
+
+def test_entry_point_metadata_registers_frameworks_pydantic_ai():
+    import importlib.metadata
+
+    eps = {
+        ep.name: ep.value
+        for ep in importlib.metadata.entry_points(group="praisonai.framework_adapters")
+    }
+    assert "pydantic_ai" in eps
+    assert eps["pydantic_ai"].startswith("praisonai_frameworks")

--- a/src/praisonai/tests/unit/test_workflow_framework_validation.py
+++ b/src/praisonai/tests/unit/test_workflow_framework_validation.py
@@ -50,6 +50,16 @@ def test_validate_workflow_framework_rejects_google_adk(caplog):
     assert any("google_adk" in r.message for r in caplog.records)
 
 
+def test_validate_workflow_framework_rejects_pydantic_ai(caplog):
+    import logging
+    from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError, match="not supported for workflow execution"):
+            validate_workflow_framework("pydantic_ai", source="workflow.yaml")
+    assert any("pydantic_ai" in r.message for r in caplog.records)
+
+
 def test_framework_from_config_defaults_praisonai():
     from praisonai.framework_adapters.workflow_framework import framework_from_config
 


### PR DESCRIPTION
## Summary
- Add `praisonai[pydantic-ai]` extra pinning `praisonai-frameworks[pydantic-ai]>=0.1.9`
- Doctor runtime: `pydantic_ai` with handoff support; workflow YAML rejection test
- Availability probe, registry install hint, migrate patterns, example YAML, integration + e2e live tests

## Notes
- Depends on praisonai-frameworks 0.1.9 (#25)
- Builds on Phase 3 wrapper changes in #2507 — merge that first for a cleaner diff

## Test plan
- [x] `python -m pytest src/praisonai/tests/unit/test_pydantic_ai_frameworks_integration.py`
- [x] `PRAISONAI_LIVE_TESTS=1 python -m pytest src/praisonai/tests/e2e/pydantic_ai_e2e/ -m real`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `pydantic_ai` framework, including availability detection, install guidance, and runtime recognition.
  * Added migration support to help convert Pydantic AI-based code to the PraisonAI format.

* **Bug Fixes**
  * Improved mixed-runtime handoff handling so Pydantic AI is treated as handoff-compatible where supported.

* **Documentation**
  * Updated end-to-end testing docs with a dedicated Pydantic AI test command.

* **Tests**
  * Added unit and real end-to-end coverage for framework discovery, install hints, workflow validation, and live execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->