### PR TITLE
fix(praisonai-code): 0.0.2 standalone deps and C5 backward-compat tests

### DIFF
--- a/src/praisonai-code/praisonai_code/__init__.py
+++ b/src/praisonai-code/praisonai_code/__init__.py
@@ -12,6 +12,6 @@ the remaining terminal-agent modules, with PEP 562 shims left behind at the
 old ``praisonai.*`` paths for backward compatibility.
 """
 
-__version__ = "0.0.0"
+__version__ = "0.0.2"
 
 __all__ = ["__version__"]

--- a/src/praisonai-code/pyproject.toml
+++ b/src/praisonai-code/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "praisonai-code"
-version = "0.0.1"
+version = "0.0.2"
 description = "Agentic terminal CLI for PraisonAI — the terminal-native agent (run, chat, code, runtime, cli backends) extracted from the praisonai wrapper."
 readme = "README.md"
 license = {text = "MIT"}
@@ -19,6 +19,7 @@ dependencies = [
     "litellm>=1.83.14,<2",
     "mcp>=1.20.0",
     "pydantic>=2.0.0",
+    "toml>=0.10.2",
 ]
 
 [project.urls]

--- a/src/praisonai-code/uv.lock
+++ b/src/praisonai-code/uv.lock
@@ -516,7 +516,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1358,7 +1358,7 @@ wheels = [
 
 [[package]]
 name = "praisonai-code"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1370,6 +1370,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "textual" },
+    { name = "toml" },
     { name = "typer" },
 ]
 
@@ -1384,6 +1385,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.7" },
     { name = "textual", specifier = ">=0.47.0" },
+    { name = "toml", specifier = ">=0.10.2" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
 
@@ -2409,6 +2411,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
     { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
     { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "textual>=0.47.0",
     "pydantic>=2.0.0",
     "toml>=0.10.2",
-    "praisonai-code",
 ]
 
 [project.scripts]

--- a/src/praisonai/tests/unit/test_c5_backward_compat.py
+++ b/src/praisonai/tests/unit/test_c5_backward_compat.py
@@ -1,0 +1,127 @@
+"""Backward-compatibility gate for praisonai-code C5 extraction.
+
+Verifies old ``praisonai.*`` import paths, module identity for patching,
+CLI entry points, and bot-layer modules that must remain in the wrapper.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _run_legacy_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = {k: v for k, v in __import__("os").environ.items() if not k.startswith("PYTEST_")}
+    env["PYTHONPATH"] = str(REPO_ROOT / "src" / "praisonai-agents") + ":" + str(
+        REPO_ROOT / "src" / "praisonai"
+    )
+    return subprocess.run(
+        [sys.executable, "-m", "praisonai.cli.main", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+
+
+class TestImportPathAliases:
+    """Old import paths must resolve to the same module objects as praisonai_code."""
+
+    @pytest.mark.parametrize(
+        "old_path,new_path",
+        [
+            ("praisonai.cli.main", "praisonai_code.cli.main"),
+            ("praisonai.cli.app", "praisonai_code.cli.app"),
+            ("praisonai.cli.commands.run", "praisonai_code.cli.commands.run"),
+            ("praisonai.cli.commands.doctor", "praisonai_code.cli.commands.doctor"),
+            ("praisonai.cli.output.console", "praisonai_code.cli.output.console"),
+            ("praisonai.cli.configuration.resolver", "praisonai_code.cli.configuration.resolver"),
+            ("praisonai.runtime.descriptor", "praisonai_code.runtime.descriptor"),
+            ("praisonai.cli_backends.registry", "praisonai_code.cli_backends.registry"),
+        ],
+    )
+    def test_module_identity(self, old_path: str, new_path: str):
+        old_mod = importlib.import_module(old_path)
+        new_mod = importlib.import_module(new_path)
+        assert old_mod is new_mod, f"{old_path} and {new_path} must be the same module object"
+
+    def test_praisonai_class_importable_from_old_path(self):
+        from praisonai.cli.main import PraisonAI as OldPraisonAI
+        from praisonai_code.cli.main import PraisonAI as NewPraisonAI
+
+        assert OldPraisonAI is NewPraisonAI
+
+    def test_feature_handler_lazy_import(self):
+        from praisonai.cli.features import MCPHandler
+
+        from praisonai_code.cli.features.mcp import MCPHandler as CodeMCPHandler
+
+        assert MCPHandler is CodeMCPHandler
+
+    def test_config_schema_at_legacy_path(self):
+        import praisonai.cli.configuration as configuration
+
+        schema_path = Path(configuration.__file__).parent / "config.schema.json"
+        assert schema_path.exists()
+
+
+class TestPatchTargetCompatibility:
+    """unittest.mock.patch on old dotted paths must hit moved implementation."""
+
+    def test_patch_run_module(self):
+        with patch("praisonai.cli.commands.run.app") as mocked:
+            import praisonai.cli.commands.run as run_mod
+
+            run_mod.app  # noqa: B018 — trigger attribute access
+            mocked  # patched object registered
+
+    def test_patch_main_praisonai(self):
+        with patch("praisonai.cli.main.PraisonAI") as mocked:
+            from praisonai.cli.main import PraisonAI
+
+            assert PraisonAI is mocked
+
+
+class TestCliEntryPoints:
+    def test_python_m_praisonai_cli_main_help(self):
+        result = _run_legacy_cli("--help")
+        assert result.returncode == 0
+        assert "--cli-backend" in result.stdout
+
+    def test_praisonai_main_import(self):
+        from praisonai.__main__ import main
+
+        assert callable(main)
+
+
+class TestBotLayerUnchanged:
+    """Bot/channel modules must remain real wrapper implementations, not shims."""
+
+    @pytest.mark.parametrize(
+        "module_path,marker",
+        [
+            ("praisonai.cli.commands.gateway", "Manage the PraisonAI Gateway"),
+            ("praisonai.cli.commands.bot", "messaging bots"),
+            ("praisonai.cli.features.gateway", "gateway"),
+            ("praisonai.cli.features.bots_cli", "BotHandler"),
+        ],
+    )
+    def test_bot_modules_are_wrapper_local(self, module_path: str, marker: str):
+        mod = importlib.import_module(module_path)
+        source = inspect.getsourcefile(mod) or ""
+        assert "/praisonai/praisonai/" in source.replace("\\", "/")
+        assert "praisonai-code" not in source.replace("\\", "/")
+        assert marker.lower() in inspect.getsource(mod).lower() or hasattr(mod, marker)
+
+    def test_no_nested_praisonai_code_package(self):
+        nested = REPO_ROOT / "src" / "praisonai" / "praisonai_code"
+        assert not nested.exists(), "nested praisonai_code must not shadow praisonai-code package"


### PR DESCRIPTION
## Summary
- Bump `praisonai-code` to **0.0.2** and sync `__version__` in `praisonai_code/__init__.py` (was `0.0.0` in source while PyPI metadata said `0.0.1`)
- Add missing `toml>=0.10.2` dependency so standalone `pip install praisonai-code` can load the config resolver
- Remove duplicate `praisonai-code` entry from wrapper `pyproject.toml`
- Add `tests/unit/test_c5_backward_compat.py` — import-path identity, patch targets, legacy CLI entry points, and bot-layer locality checks

## Test plan
- [x] `pytest tests/unit/test_c5_backward_compat.py` — 20 passed
- [ ] CI smoke / test-core (cli) on PR
- [ ] After merge: publish `praisonai-code==0.0.2` to PyPI and verify `import praisonai_code; praisonai_code.__version__ == "0.0.2"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the package version to **0.0.2**.
  * Updated install requirements.

* **Bug Fixes**
  * Improved compatibility for existing import paths and CLI entry points.
  * Ensured legacy commands and module references continue to work as expected.

* **Tests**
  * Added coverage for backward compatibility across imports, CLI behavior, and key module wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->