### PR TITLE
fix(c6): wrapper Typer commands, schema shims, and compat CI gate

### DIFF
--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -79,6 +79,8 @@ jobs:
       run: |
         set -euo pipefail
         cd src/praisonai
+        python -m pytest tests/unit/test_c5_backward_compat.py \
+          -q --tb=line --timeout=30 --maxfail=5
         python -m pytest tests/unit/cli/ \
           -m "not slow and not network" \
           -q --tb=line \
@@ -86,6 +88,20 @@ jobs:
           --ignore=tests/fixtures \
           --ignore=tests/unit/cli/test_message_queue.py \
           --maxfail=5
+
+    - name: Standalone praisonai-code import smoke
+      shell: bash
+      run: |
+        set -euo pipefail
+        python -m venv /tmp/praisonai-code-standalone
+        /tmp/praisonai-code-standalone/bin/pip install -q -e src/praisonai-agents -e src/praisonai-code
+        /tmp/praisonai-code-standalone/bin/python -c "
+        import praisonai_code
+        from praisonai_code.cli.configuration.resolver import ConfigResolver
+        import toml
+        assert hasattr(ConfigResolver, '__name__')
+        print('standalone ok', praisonai_code.__version__, 'toml', toml.__version__)
+        "
     
     - name: Smoke Test Summary
       if: always()

--- a/src/praisonai-code/praisonai_code/cli/app.py
+++ b/src/praisonai-code/praisonai_code/cli/app.py
@@ -256,6 +256,9 @@ class LazyCommandGroup(TyperGroup):
             module_path, attr_name, _ = _LAZY_COMMANDS[name]
             try:
                 if name in _WRAPPER_COMMANDS:
+                    import importlib.util as _importlib_util
+                    if _importlib_util.find_spec("praisonai") is None:
+                        return None
                     module = importlib.import_module(f"praisonai.cli.commands.{name}")
                 else:
                     module = importlib.import_module(module_path, __package__)

--- a/src/praisonai-code/praisonai_code/cli/app.py
+++ b/src/praisonai-code/praisonai_code/cli/app.py
@@ -202,6 +202,18 @@ _LAZY_COMMANDS: Dict[str, Tuple[str, str, str]] = {
     "up": (".commands.up", "app", "🚀 Start unified PraisonAI stack (Langfuse + Langflow)"),
 }
 
+# Bot/channel commands that remain in the ``praisonai`` wrapper (not ``praisonai_code``).
+_WRAPPER_COMMANDS = frozenset({
+    "bot",
+    "gateway",
+    "pairing",
+    "identity",
+    "onboard",
+    "kanban",
+    "dashboard",
+    "claw",
+})
+
 # Special commands that need custom handling
 _SPECIAL_COMMANDS = {
     "tui": (".features.tui.debug", "create_debug_app", "Interactive TUI and simulation"),
@@ -243,7 +255,10 @@ class LazyCommandGroup(TyperGroup):
         if name in _LAZY_COMMANDS:
             module_path, attr_name, _ = _LAZY_COMMANDS[name]
             try:
-                module = importlib.import_module(module_path, __package__)
+                if name in _WRAPPER_COMMANDS:
+                    module = importlib.import_module(f"praisonai.cli.commands.{name}")
+                else:
+                    module = importlib.import_module(module_path, __package__)
                 sub_app = getattr(module, attr_name)
                 if isinstance(sub_app, click.Command):
                     return sub_app

--- a/src/praisonai/praisonai/cli/_warnings.py
+++ b/src/praisonai/praisonai/cli/_warnings.py
@@ -1,0 +1,7 @@
+"""Backward-compatibility shim for :mod:`praisonai.cli._warnings`."""
+
+import sys as _sys
+
+import praisonai_code.cli._warnings as _impl
+
+_sys.modules[__name__] = _impl

--- a/src/praisonai/praisonai/cli/_warnings.py
+++ b/src/praisonai/praisonai/cli/_warnings.py
@@ -5,3 +5,7 @@ import sys as _sys
 import praisonai_code.cli._warnings as _impl
 
 _sys.modules[__name__] = _impl
+
+_parent_name, _, _child_name = __name__.rpartition(".")
+if _parent_name and _parent_name in _sys.modules:
+    setattr(_sys.modules[_parent_name], _child_name, _impl)

--- a/src/praisonai/praisonai/cli/fallback_schema.py
+++ b/src/praisonai/praisonai/cli/fallback_schema.py
@@ -5,3 +5,7 @@ import sys as _sys
 import praisonai_code.cli.fallback_schema as _impl
 
 _sys.modules[__name__] = _impl
+
+_parent_name, _, _child_name = __name__.rpartition(".")
+if _parent_name and _parent_name in _sys.modules:
+    setattr(_sys.modules[_parent_name], _child_name, _impl)

--- a/src/praisonai/praisonai/cli/fallback_schema.py
+++ b/src/praisonai/praisonai/cli/fallback_schema.py
@@ -1,0 +1,7 @@
+"""Backward-compatibility shim for :mod:`praisonai.cli.fallback_schema`."""
+
+import sys as _sys
+
+import praisonai_code.cli.fallback_schema as _impl
+
+_sys.modules[__name__] = _impl

--- a/src/praisonai/praisonai/cli/schema_provider.py
+++ b/src/praisonai/praisonai/cli/schema_provider.py
@@ -5,3 +5,7 @@ import sys as _sys
 import praisonai_code.cli.schema_provider as _impl
 
 _sys.modules[__name__] = _impl
+
+_parent_name, _, _child_name = __name__.rpartition(".")
+if _parent_name and _parent_name in _sys.modules:
+    setattr(_sys.modules[_parent_name], _child_name, _impl)

--- a/src/praisonai/praisonai/cli/schema_provider.py
+++ b/src/praisonai/praisonai/cli/schema_provider.py
@@ -1,0 +1,7 @@
+"""Backward-compatibility shim for :mod:`praisonai.cli.schema_provider`."""
+
+import sys as _sys
+
+import praisonai_code.cli.schema_provider as _impl
+
+_sys.modules[__name__] = _impl

--- a/src/praisonai/praisonai/cli/unified_schema.py
+++ b/src/praisonai/praisonai/cli/unified_schema.py
@@ -5,3 +5,7 @@ import sys as _sys
 import praisonai_code.cli.unified_schema as _impl
 
 _sys.modules[__name__] = _impl
+
+_parent_name, _, _child_name = __name__.rpartition(".")
+if _parent_name and _parent_name in _sys.modules:
+    setattr(_sys.modules[_parent_name], _child_name, _impl)

--- a/src/praisonai/praisonai/cli/unified_schema.py
+++ b/src/praisonai/praisonai/cli/unified_schema.py
@@ -1,0 +1,7 @@
+"""Backward-compatibility shim for :mod:`praisonai.cli.unified_schema`."""
+
+import sys as _sys
+
+import praisonai_code.cli.unified_schema as _impl
+
+_sys.modules[__name__] = _impl

--- a/src/praisonai/tests/unit/test_c5_backward_compat.py
+++ b/src/praisonai/tests/unit/test_c5_backward_compat.py
@@ -17,8 +17,11 @@ from unittest.mock import patch
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
-_LEGACY_PYTHONPATH = (
-    str(REPO_ROOT / "src" / "praisonai-agents") + ":" + str(REPO_ROOT / "src" / "praisonai")
+_LEGACY_PYTHONPATH = os.pathsep.join(
+    [
+        str(REPO_ROOT / "src" / "praisonai-agents"),
+        str(REPO_ROOT / "src" / "praisonai"),
+    ]
 )
 
 
@@ -44,7 +47,7 @@ def _run_typer_cli(*args: str) -> subprocess.CompletedProcess[str]:
         [sys.executable, "-m", "praisonai", *args],
         capture_output=True,
         text=True,
-        timeout=45,
+        timeout=25,
         cwd=str(REPO_ROOT),
         env=_legacy_env(),
     )

--- a/src/praisonai/tests/unit/test_c5_backward_compat.py
+++ b/src/praisonai/tests/unit/test_c5_backward_compat.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -16,20 +17,47 @@ from unittest.mock import patch
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
+_LEGACY_PYTHONPATH = (
+    str(REPO_ROOT / "src" / "praisonai-agents") + ":" + str(REPO_ROOT / "src" / "praisonai")
+)
+
+
+def _legacy_env() -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("PYTEST_")}
+    env["PYTHONPATH"] = _LEGACY_PYTHONPATH
+    return env
 
 
 def _run_legacy_cli(*args: str) -> subprocess.CompletedProcess[str]:
-    env = {k: v for k, v in __import__("os").environ.items() if not k.startswith("PYTEST_")}
-    env["PYTHONPATH"] = str(REPO_ROOT / "src" / "praisonai-agents") + ":" + str(
-        REPO_ROOT / "src" / "praisonai"
-    )
     return subprocess.run(
         [sys.executable, "-m", "praisonai.cli.main", *args],
         capture_output=True,
         text=True,
         timeout=30,
         cwd=str(REPO_ROOT),
-        env=env,
+        env=_legacy_env(),
+    )
+
+
+def _run_typer_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "praisonai", *args],
+        capture_output=True,
+        text=True,
+        timeout=45,
+        cwd=str(REPO_ROOT),
+        env=_legacy_env(),
+    )
+
+
+def _run_runtime_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "praisonai.runtime", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(REPO_ROOT),
+        env=_legacy_env(),
     )
 
 
@@ -45,6 +73,10 @@ class TestImportPathAliases:
             ("praisonai.cli.commands.doctor", "praisonai_code.cli.commands.doctor"),
             ("praisonai.cli.output.console", "praisonai_code.cli.output.console"),
             ("praisonai.cli.configuration.resolver", "praisonai_code.cli.configuration.resolver"),
+            ("praisonai.cli.unified_schema", "praisonai_code.cli.unified_schema"),
+            ("praisonai.cli.schema_provider", "praisonai_code.cli.schema_provider"),
+            ("praisonai.cli.fallback_schema", "praisonai_code.cli.fallback_schema"),
+            ("praisonai.cli._warnings", "praisonai_code.cli._warnings"),
             ("praisonai.runtime.descriptor", "praisonai_code.runtime.descriptor"),
             ("praisonai.cli_backends.registry", "praisonai_code.cli_backends.registry"),
         ],
@@ -101,6 +133,36 @@ class TestCliEntryPoints:
         from praisonai.__main__ import main
 
         assert callable(main)
+
+    @pytest.mark.parametrize("command,marker", [("gateway", "Gateway"), ("bot", "bot")])
+    def test_typer_wrapper_commands_help(self, command: str, marker: str):
+        result = _run_typer_cli(command, "--help")
+        assert result.returncode == 0, result.stderr
+        assert marker.lower() in (result.stdout + result.stderr).lower()
+
+    def test_python_m_praisonai_runtime_help(self):
+        result = _run_runtime_cli("--help")
+        assert result.returncode == 0
+        assert "--host" in result.stdout or "host" in result.stdout.lower()
+
+    def test_bootstrap_resolves_praisonai_code_on_legacy_pythonpath(self):
+        script = (
+            "import praisonai; "
+            "from praisonai.cli.unified_schema import rag_schema_provider; "
+            "import praisonai_code; "
+            "assert rag_schema_provider is not None; "
+            "print(praisonai_code.__version__)"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=str(REPO_ROOT),
+            env=_legacy_env(),
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip()
 
 
 class TestBotLayerUnchanged:


### PR DESCRIPTION
## Summary
- Fix Typer lazy-load for **wrapper-local commands** (`bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, `claw`) by resolving `praisonai.cli.commands.*` instead of non-existent `praisonai_code.cli.commands.*`
- Add missing C5 backward-compat shims: `unified_schema`, `schema_provider`, `fallback_schema`, `_warnings`
- Extend `test_c5_backward_compat.py` (28 tests): schema module identity, `praisonai gateway/bot --help`, `python -m praisonai.runtime --help`, bootstrap + schema import on legacy `PYTHONPATH`
- Add C5 compat gate and standalone `praisonai-code` venv smoke to optimised CI workflow

## Test plan
- [x] `pytest tests/unit/test_c5_backward_compat.py` — 28 passed
- [x] `praisonai gateway --help` / `praisonai bot --help` — OK locally
- [ ] CI smoke (C5 gate + CLI suite + standalone venv check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional backward-compatibility validation for legacy `praisonai` wrapper CLI and module imports.
* **Bug Fixes**
  * Improved command resolution to ensure specific CLI commands load from the correct wrapper entrypoint.
  * Added compatibility shims so older `praisonai.cli.*` import paths continue to work by redirecting to the backend implementation.
* **Tests**
  * Expanded legacy backward-compatibility test coverage (CLI help, runtime help, and import/version checks).
  * Updated the smoke workflow to run the new legacy test and added a standalone import smoke step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->