### PR TITLE
feat(release): three-package PyPI flow + C6 backcompat

### DIFF
--- a/.github/scripts/release-gate-selftest.js
+++ b/.github/scripts/release-gate-selftest.js
@@ -3,9 +3,18 @@ const rg = require('./release-gate.js');
 
 assert.strictEqual(rg.bumpPatch('1.6.80'), '1.6.81');
 assert.strictEqual(rg.bumpPatch('4.6.80'), '4.6.81');
+assert.strictEqual(rg.bumpPatch('0.0.2'), '0.0.3');
+
+const versions = rg.readVersionsFromTree();
+assert.ok(versions.currentAgents);
+assert.ok(versions.currentCode);
+assert.ok(versions.currentWrapper);
+assert.ok(versions.targetCode);
+assert.ok(rg.PACKAGE_PATHS.includes('src/praisonai-code'));
 
 (async () => {
   assert.strictEqual(await rg.pypiVersionExists('praisonaiagents', '0.0.0'), false);
   console.log('ok: bumpPatch');
+  console.log('ok: readVersionsFromTree');
   console.log('ok: pypiVersionExists missing version');
 })();

--- a/.github/scripts/release-gate.js
+++ b/.github/scripts/release-gate.js
@@ -4,7 +4,7 @@
 
 const https = require('https');
 
-const PACKAGE_PATHS = ['src/praisonai', 'src/praisonai-agents'];
+const PACKAGE_PATHS = ['src/praisonai', 'src/praisonai-agents', 'src/praisonai-code'];
 const ACTIVE_RELEASE_STATUSES = new Set([
   'queued', 'in_progress', 'waiting', 'pending', 'requested',
 ]);
@@ -23,6 +23,13 @@ function readVersionsFromTree(root = '.') {
   );
   const agentsMatch = agentsToml.match(/^version\s*=\s*"([^"]+)"/m);
   if (!agentsMatch) throw new Error('Could not read agents version');
+
+  const codeToml = fs.readFileSync(
+    path.join(root, 'src/praisonai-code/pyproject.toml'), 'utf8'
+  );
+  const codeMatch = codeToml.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!codeMatch) throw new Error('Could not read praisonai-code version');
+
   const wrapperPy = fs.readFileSync(
     path.join(root, 'src/praisonai/praisonai/version.py'), 'utf8'
   );
@@ -30,8 +37,10 @@ function readVersionsFromTree(root = '.') {
   if (!wrapperMatch) throw new Error('Could not read wrapper version');
   return {
     currentAgents: agentsMatch[1],
+    currentCode: codeMatch[1],
     currentWrapper: wrapperMatch[1],
     targetAgents: bumpPatch(agentsMatch[1]),
+    targetCode: bumpPatch(codeMatch[1]),
     targetWrapper: bumpPatch(wrapperMatch[1]),
   };
 }
@@ -93,6 +102,7 @@ async function evaluateReleasePreflight(github, owner, repo, options, core) {
     headSha: headSha || '',
     lastTag: '',
     targetAgents: '',
+    targetCode: '',
     targetWrapper: '',
   };
 
@@ -114,12 +124,17 @@ async function evaluateReleasePreflight(github, owner, repo, options, core) {
     return out;
   }
   out.targetAgents = versions.targetAgents;
+  out.targetCode = versions.targetCode;
   out.targetWrapper = versions.targetWrapper;
 
   const agentsOnPypi = await pypiVersionExists('praisonaiagents', versions.targetAgents);
+  const codeOnPypi = await pypiVersionExists('praisonai-code', versions.targetCode);
   const wrapperOnPypi = await pypiVersionExists('praisonai', versions.targetWrapper);
-  if (agentsOnPypi && wrapperOnPypi) {
-    reasons.push(`already published: praisonaiagents==${versions.targetAgents}, praisonai==${versions.targetWrapper}`);
+  if (agentsOnPypi && codeOnPypi && wrapperOnPypi) {
+    reasons.push(
+      `already published: praisonaiagents==${versions.targetAgents}, `
+      + `praisonai-code==${versions.targetCode}, praisonai==${versions.targetWrapper}`
+    );
     return out;
   }
 
@@ -184,4 +199,5 @@ module.exports = {
   pypiVersionExists,
   evaluateReleasePreflight,
   ACTIVE_RELEASE_STATUSES,
+  PACKAGE_PATHS,
 };

--- a/.github/workflows/nightly-release-gate.yml
+++ b/.github/workflows/nightly-release-gate.yml
@@ -94,13 +94,17 @@ jobs:
             core.setOutput('head_sha', result.headSha || headSha);
             core.setOutput('last_tag', result.lastTag || '');
             core.setOutput('target_agents', result.targetAgents || '');
+            core.setOutput('target_code', result.targetCode || '');
             core.setOutput('target_wrapper', result.targetWrapper || '');
 
             core.summary.addRaw('## Release gate preflight\n');
             core.summary.addRaw(`Ready: ${result.ready}\n`);
             core.summary.addRaw(`Reason: ${result.reasons.join('; ')}\n`);
             if (result.targetAgents) {
-              core.summary.addRaw(`Targets: praisonaiagents==${result.targetAgents}, praisonai==${result.targetWrapper}\n`);
+              core.summary.addRaw(
+                `Targets: praisonaiagents==${result.targetAgents}, `
+                + `praisonai-code==${result.targetCode}, praisonai==${result.targetWrapper}\n`
+              );
             }
             await core.summary.write();
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: 'Version bump type for both packages'
+        description: 'Version bump type for all packages (agents, code, wrapper)'
         required: true
         default: patch
         type: choice
@@ -27,7 +27,12 @@ on:
         default: false
         type: boolean
       skip_wrapper:
-        description: 'Publish agents only'
+        description: 'Skip wrapper publish (agents and/or code only)'
+        required: false
+        default: false
+        type: boolean
+      skip_code:
+        description: 'Skip praisonai-code publish (recovery if already on PyPI)'
         required: false
         default: false
         type: boolean
@@ -38,6 +43,11 @@ on:
         type: string
       wrapper_version:
         description: 'Override wrapper version (empty = auto bump from version.py)'
+        required: false
+        default: ''
+        type: string
+      code_version:
+        description: 'Override praisonai-code version (empty = auto bump from pyproject.toml)'
         required: false
         default: ''
         type: string
@@ -112,7 +122,9 @@ jobs:
           BUMP: ${{ inputs.bump }}
           AGENTS_OVERRIDE: ${{ inputs.agents_version }}
           WRAPPER_OVERRIDE: ${{ inputs.wrapper_version }}
+          CODE_OVERRIDE: ${{ inputs.code_version }}
           SKIP_AGENTS: ${{ inputs.skip_agents }}
+          SKIP_CODE: ${{ inputs.skip_code }}
         run: |
           python <<'PY'
           import os
@@ -143,8 +155,10 @@ jobs:
 
           agents_override = os.environ.get("AGENTS_OVERRIDE", "").strip()
           wrapper_override = os.environ.get("WRAPPER_OVERRIDE", "").strip()
+          code_override = os.environ.get("CODE_OVERRIDE", "").strip()
           validate_version("agents_version", agents_override)
           validate_version("wrapper_version", wrapper_override)
+          validate_version("code_version", code_override)
 
           agents_pyproject = root / "src/praisonai-agents/pyproject.toml"
           agents_content = agents_pyproject.read_text()
@@ -153,9 +167,14 @@ jobs:
               print("Could not read agents version from pyproject.toml", file=sys.stderr)
               sys.exit(1)
           current_agents = agents_match.group(1)
-          if not SEMVER.match(current_agents):
-              print(f"Invalid current agents version: {current_agents}", file=sys.stderr)
+
+          code_pyproject = root / "src/praisonai-code/pyproject.toml"
+          code_content = code_pyproject.read_text()
+          code_match = re.search(r'^version\s*=\s*"([^"]+)"', code_content, re.MULTILINE)
+          if not code_match:
+              print("Could not read praisonai-code version from pyproject.toml", file=sys.stderr)
               sys.exit(1)
+          current_code = code_match.group(1)
 
           wrapper_version_py = root / "src/praisonai/praisonai/version.py"
           wrapper_content = wrapper_version_py.read_text()
@@ -164,11 +183,18 @@ jobs:
               print("Could not read wrapper version from version.py", file=sys.stderr)
               sys.exit(1)
           current_wrapper = wrapper_match.group(1)
-          if not SEMVER.match(current_wrapper):
-              print(f"Invalid current wrapper version: {current_wrapper}", file=sys.stderr)
-              sys.exit(1)
+
+          for label, value in (
+              ("agents", current_agents),
+              ("code", current_code),
+              ("wrapper", current_wrapper),
+          ):
+              if not SEMVER.match(value):
+                  print(f"Invalid current {label} version: {value}", file=sys.stderr)
+                  sys.exit(1)
 
           skip_agents = os.environ.get("SKIP_AGENTS", "false").lower() == "true"
+          skip_code = os.environ.get("SKIP_CODE", "false").lower() == "true"
 
           if agents_override:
               agents_version = agents_override
@@ -176,6 +202,13 @@ jobs:
               agents_version = current_agents
           else:
               agents_version = bump_version(current_agents)
+
+          if code_override:
+              code_version = code_override
+          elif skip_code:
+              code_version = current_code
+          else:
+              code_version = bump_version(current_code)
 
           if wrapper_override:
               wrapper_version = wrapper_override
@@ -185,11 +218,14 @@ jobs:
           github_output = os.environ["GITHUB_OUTPUT"]
           with open(github_output, "a", encoding="utf-8") as fh:
               fh.write(f"agents_version={agents_version}\n")
+              fh.write(f"code_version={code_version}\n")
               fh.write(f"wrapper_version={wrapper_version}\n")
               fh.write(f"current_agents={current_agents}\n")
+              fh.write(f"current_code={current_code}\n")
               fh.write(f"current_wrapper={current_wrapper}\n")
 
           print(f"Agents:  {current_agents} -> {agents_version}")
+          print(f"Code:    {current_code} -> {code_version}")
           print(f"Wrapper: {current_wrapper} -> {wrapper_version}")
           PY
 
@@ -198,29 +234,37 @@ jobs:
         if: inputs.dry_run != true
         env:
           AGENTS_VERSION: ${{ steps.versions.outputs.agents_version }}
+          CODE_VERSION: ${{ steps.versions.outputs.code_version }}
           WRAPPER_VERSION: ${{ steps.versions.outputs.wrapper_version }}
           INPUT_SKIP_AGENTS: ${{ inputs.skip_agents }}
+          INPUT_SKIP_CODE: ${{ inputs.skip_code }}
           INPUT_SKIP_WRAPPER: ${{ inputs.skip_wrapper }}
         run: |
           set -euo pipefail
           skip_agents="${INPUT_SKIP_AGENTS}"
+          skip_code="${INPUT_SKIP_CODE}"
           skip_wrapper="${INPUT_SKIP_WRAPPER}"
           if [ "$skip_agents" != "true" ]; then
             curl -fsSL "https://pypi.org/pypi/praisonaiagents/${AGENTS_VERSION}/json" >/dev/null && skip_agents=true || true
+          fi
+          if [ "$skip_code" != "true" ]; then
+            curl -fsSL "https://pypi.org/pypi/praisonai-code/${CODE_VERSION}/json" >/dev/null && skip_code=true || true
           fi
           if [ "$skip_wrapper" != "true" ]; then
             curl -fsSL "https://pypi.org/pypi/praisonai/${WRAPPER_VERSION}/json" >/dev/null && skip_wrapper=true || true
           fi
           echo "skip_agents=${skip_agents}" >> "$GITHUB_OUTPUT"
+          echo "skip_code=${skip_code}" >> "$GITHUB_OUTPUT"
           echo "skip_wrapper=${skip_wrapper}" >> "$GITHUB_OUTPUT"
-          if [ "$skip_agents" = "true" ] && [ "$skip_wrapper" = "true" ]; then
-            echo "Both target versions already on PyPI — nothing to publish."
+          if [ "$skip_agents" = "true" ] && [ "$skip_code" = "true" ] && [ "$skip_wrapper" = "true" ]; then
+            echo "All target versions already on PyPI — nothing to publish."
           fi
 
       - name: Exit if already published
         if: >-
           inputs.dry_run != true &&
           steps.pypi_exists.outputs.skip_agents == 'true' &&
+          steps.pypi_exists.outputs.skip_code == 'true' &&
           steps.pypi_exists.outputs.skip_wrapper == 'true'
         run: echo "Idempotent skip — target versions already on PyPI."
 
@@ -229,14 +273,17 @@ jobs:
         run: |
           echo "Dry run — no publish, commit, or push."
           echo "Agents version:  ${{ steps.versions.outputs.agents_version }}"
+          echo "Code version:    ${{ steps.versions.outputs.code_version }}"
           echo "Wrapper version: ${{ steps.versions.outputs.wrapper_version }}"
           echo ""
           if [ "${{ inputs.skip_agents }}" != "true" ]; then
             echo "Would publish praisonaiagents ${{ steps.versions.outputs.agents_version }}"
-            echo "Would commit src/praisonai-agents/pyproject.toml and uv.lock"
+          fi
+          if [ "${{ inputs.skip_code }}" != "true" ]; then
+            echo "Would publish praisonai-code ${{ steps.versions.outputs.code_version }}"
           fi
           if [ "${{ inputs.skip_wrapper }}" != "true" ]; then
-            echo "Would run bump_and_release.py ${{ steps.versions.outputs.wrapper_version }} --agents ${{ steps.versions.outputs.agents_version }}"
+            echo "Would run bump_and_release.py ${{ steps.versions.outputs.wrapper_version }} --agents ${{ steps.versions.outputs.agents_version }} --code-pin ${{ steps.versions.outputs.code_version }}"
             echo "Would uv publish praisonai ${{ steps.versions.outputs.wrapper_version }}"
           fi
 
@@ -306,6 +353,76 @@ jobs:
           git pull --rebase origin main
           git push origin main
 
+      - name: Publish praisonai-code
+        if: >-
+          inputs.dry_run != true &&
+          inputs.skip_code != true &&
+          steps.pypi_exists.outputs.skip_code != 'true'
+        working-directory: src/praisonai-code
+        env:
+          NEW_VERSION: ${{ steps.versions.outputs.code_version }}
+          CURRENT: ${{ steps.versions.outputs.current_code }}
+        run: |
+          set -euo pipefail
+          python <<'PY'
+          import os
+          import re
+          from pathlib import Path
+          new = os.environ["NEW_VERSION"]
+          current = os.environ["CURRENT"]
+          pyproject = Path("pyproject.toml")
+          content = pyproject.read_text()
+          pyproject.write_text(content.replace(f'version = "{current}"', f'version = "{new}"', 1))
+          init_py = Path("praisonai_code/__init__.py")
+          init_content = init_py.read_text()
+          init_py.write_text(re.sub(r'__version__ = "[^"]+"', f'__version__ = "{new}"', init_content, count=1))
+          PY
+
+          rm -rf dist
+          uv lock
+          uv build
+          uv publish
+
+      - name: Wait for praisonai-code on PyPI
+        if: >-
+          inputs.dry_run != true &&
+          inputs.skip_code != true &&
+          steps.pypi_exists.outputs.skip_code != 'true'
+        run: |
+          set -euo pipefail
+          PACKAGE="praisonai-code"
+          VERSION="${{ steps.versions.outputs.code_version }}"
+          MAX_WAIT=600
+          INTERVAL=30
+          START=$(date +%s)
+
+          while true; do
+            if curl -fsSL "https://pypi.org/pypi/${PACKAGE}/${VERSION}/json" >/dev/null; then
+              echo "✅ ${PACKAGE}==${VERSION} is available on PyPI"
+              exit 0
+            fi
+            ELAPSED=$(( $(date +%s) - START ))
+            if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
+              echo "❌ Timeout waiting for ${PACKAGE}==${VERSION} on PyPI"
+              exit 1
+            fi
+            echo "⏳ Waiting for ${PACKAGE}==${VERSION} ($(( MAX_WAIT - ELAPSED ))s remaining...)"
+            sleep "$INTERVAL"
+          done
+
+      - name: Commit praisonai-code version bump
+        if: >-
+          inputs.dry_run != true &&
+          inputs.skip_code != true &&
+          steps.pypi_exists.outputs.skip_code != 'true'
+        run: |
+          set -euo pipefail
+          git add src/praisonai-code/pyproject.toml src/praisonai-code/uv.lock src/praisonai-code/praisonai_code/__init__.py
+          git diff --cached --quiet && { echo "No code files to commit"; exit 0; }
+          git commit -m "Bump praisonai-code to ${{ steps.versions.outputs.code_version }}"
+          git pull --rebase origin main
+          git push origin main
+
       - name: Bump and release wrapper
         if: >-
           inputs.dry_run != true &&
@@ -315,6 +432,7 @@ jobs:
           set -euo pipefail
           python src/praisonai/scripts/bump_and_release.py "${{ steps.versions.outputs.wrapper_version }}" \
             --agents "${{ steps.versions.outputs.agents_version }}" \
+            --code-pin "${{ steps.versions.outputs.code_version }}" \
             --wait --max-wait 600 --no-add-all
 
       - name: Publish praisonai wrapper to PyPI
@@ -357,10 +475,15 @@ jobs:
         run: |
           set -euo pipefail
           AGENTS="${{ steps.versions.outputs.agents_version }}"
+          CODE="${{ steps.versions.outputs.code_version }}"
           WRAPPER="${{ steps.versions.outputs.wrapper_version }}"
 
           if [ "${{ inputs.skip_agents }}" != "true" ]; then
             echo "✅ praisonaiagents==${AGENTS}"
+          fi
+
+          if [ "${{ inputs.skip_code }}" != "true" ]; then
+            echo "✅ praisonai-code==${CODE}"
           fi
 
           if [ "${{ inputs.skip_wrapper }}" != "true" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,4 +7,5 @@ You are working on the PraisonAI project.
 - Be concise and helpful in responses  
 - Test implementation thoroughly
 - Ensure backward compatibility with existing APIs
-- Follow protocol-driven design: core protocols in praisonaiagents/, heavy implementations in praisonai/
+- Follow protocol-driven design: core protocols in `praisonaiagents/`, agentic terminal CLI in `praisonai-code/`, bot/channel and heavy implementations in `praisonai/`
+- Preserve old `praisonai.cli.*` import paths via shims when changing moved CLI code (see §2.3 in `src/praisonai-agents/AGENTS.md`)

--- a/src/praisonai-agents/AGENTS.md
+++ b/src/praisonai-agents/AGENTS.md
@@ -42,7 +42,11 @@ Each feature runs 3 ways: **CLI, YAML, Python**.
 │   │   └── pyproject.toml         # Package config
 │   │
 │   ├── praisonai/                 # Wrapper (praisonai)
-│   │   ├── praisonai/             # CLI, integrations, heavy impls
+│   │   ├── praisonai/             # Bot/channel CLI, integrations, heavy impls
+│   │   └── pyproject.toml
+│   │
+│   ├── praisonai-code/            # Agentic terminal CLI (praisonai_code)
+│   │   ├── praisonai_code/        # run, chat, code, runtime, cli_backends
 │   │   └── pyproject.toml
 │   │
 │   └── praisonai-ts/              # TypeScript SDK
@@ -80,7 +84,10 @@ Each feature runs 3 ways: **CLI, YAML, Python**.
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                      praisonai (Wrapper)                        │
-│  CLI • Integrations • Heavy Implementations • Optional Deps     │
+│  Bot/channel CLI • Gateway • Integrations • Heavy impls         │
+├─────────────────────────────────────────────────────────────────┤
+│                    praisonai-code (Terminal agent)              │
+│  run • chat • code • doctor • runtime • cli_backends • Typer    │
 ├─────────────────────────────────────────────────────────────────┤
 │                    praisonaiagents (Core SDK)                   │
 │  Protocols • Hooks • Adapters • Base Classes • Decorators       │
@@ -89,6 +96,75 @@ Each feature runs 3 ways: **CLI, YAML, Python**.
 │  Optional Tools • Plugins • Community Extensions                │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+### 2.3 `praisonai-code` — Agentic Terminal CLI Split (C5/C6)
+
+The **agentic terminal CLI** (`run`, `chat`, `code`, warm runtime, CLI backends, Typer app) lives in the separate **`praisonai-code`** PyPI package (`praisonai_code`). The **`praisonai`** wrapper keeps bot/channel orchestration, gateway, and heavy integrations. **`pip install praisonai`** still installs everything; old import paths are preserved via shims.
+
+| Product | Location | Stays out of |
+|---------|----------|--------------|
+| Agentic terminal CLI | `src/praisonai-code/praisonai_code/` | Must **not** depend on `praisonai` (PyPI cycle) |
+| Bot/channel runtime | `src/praisonai/praisonai/` | Gateway, BotOS, onboarding, dashboard |
+| Core SDK | `src/praisonai-agents/praisonaiagents/` | Heavy CLI / integrations |
+
+**Moved into `praisonai_code` (~304 modules):**
+
+| Step | Content |
+|------|---------|
+| C1 | `runtime/`, `cli_backends/` |
+| C2 | `cli/interactive/`, `execution/`, `ui/`, `output/`, `state/` |
+| C3 | `cli/commands/*` (80 Typer command modules) |
+| C4 | `cli/features/*` (158 feature handlers; bot features excepted) |
+| C5 | `cli/main.py`, `app.py`, `configuration/`, `session/`, `utils/`, schema modules |
+
+**Intentionally retained in the wrapper (not shims):**
+
+- **Commands:** `gateway`, `bot`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, `claw`
+- **Features:** `gateway`, `bots_cli`, `onboard`, `approval`, `serve`
+- **Domains:** `praisonai.gateway.*`, `praisonai.bots.*`, integrations, endpoints
+
+**Backward-compat shim patterns** (old `praisonai.*` paths must keep working):
+
+| Pattern | Used for | Module identity |
+|---------|----------|-----------------|
+| `sys.modules[__name__] = _impl` | `cli/main`, `cli/app`, each moved `cli/commands/*`, schema modules | Same object as `praisonai_code.*` |
+| `alias_package()` + `_AliasFinder` | `cli/output`, `interactive`, `execution`, `ui`, `state`, `session`, `configuration`, `utils` | Same submodule objects |
+| Package `__getattr__` + submodule alias | `runtime/`, `cli_backends/` | Submodules identical; package object differs |
+| `features/__init__.py` `__path__` extension | Extracted features; five bot features stay local | Handler imports via `__getattr__` |
+
+**Typer lazy-load:** `praisonai_code.cli.app._WRAPPER_COMMANDS` lists bot/channel commands that resolve via **`praisonai.cli.commands.*`** (wrapper), not `praisonai_code.cli.commands.*`.
+
+**Monorepo bootstrap:** `praisonai._bootstrap.ensure_praisonai_code()` adds sibling `src/praisonai-code` to `sys.path` so `PYTHONPATH=src/praisonai-agents:src/praisonai` works without an explicit code entry.
+
+**Install order (CI and local dev):** `praisonai-agents` → `praisonai-code` → `praisonai` (see `.github/actions/install-monorepo-packages`).
+
+**Invocation paths that must remain valid:**
+
+```bash
+praisonai …                          # console script → praisonai.__main__
+python -m praisonai …
+python -m praisonai.cli.main …
+python -m praisonai.runtime …
+from praisonai.cli.main import PraisonAI
+from praisonai.cli.commands.run import …
+unittest.mock.patch("praisonai.cli.commands.run.X")   # same module object
+```
+
+**Regression gate:** `src/praisonai/tests/unit/test_c5_backward_compat.py` (also run in optimised CI smoke). Standalone `pip install praisonai-code` requires declared deps (e.g. `toml` for config resolver).
+
+**Key files:**
+
+| What | Where |
+|------|-------|
+| Typer app + lazy commands | `praisonai_code/cli/app.py` |
+| Shim helper | `praisonai/cli/_shim.py` |
+| Bootstrap | `praisonai/_bootstrap.py` |
+| CLI main shim | `praisonai/cli/main.py` |
+| Runtime / backends shims | `praisonai/runtime/`, `praisonai/cli_backends/` |
+
+**Do not** recreate `src/praisonai/praisonai_code/` — it shadows the real package.
+
+**PyPI publish order:** `praisonaiagents` → `praisonai-code` → `praisonai` (see `src/praisonai/scripts/bump_and_release.py` and `.github/workflows/pypi-release.yml`). Gateway/bots changes release via wrapper only; agentic CLI changes also bump `praisonai-code`.
 
 ---
 
@@ -178,15 +254,14 @@ mongodb = ["pymongo>=4.6.3", "motor>=3.4.0"]
 ### 4.1 Protocol-Driven Core (MUST)
 
 ```
-Core SDK (praisonaiagents)          Wrapper (praisonai)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━         ━━━━━━━━━━━━━━━━━━━
-✅ Protocols                        ✅ Heavy implementations
-✅ Hooks                            ✅ CLI commands
-✅ Adapters                         ✅ External integrations
-✅ Base classes                     ✅ Optional deps
-✅ Decorators                       ✅ UI components
-✅ Dataclasses                      ✅ Database adapters
-❌ Heavy implementations            ❌ Core logic
+Core SDK (praisonaiagents)     praisonai-code (terminal CLI)    Wrapper (praisonai)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━    ━━━━━━━━━━━━━━━━━━━
+✅ Protocols                   ✅ run/chat/code/doctor/setup      ✅ Bot/gateway CLI
+✅ Hooks                        ✅ runtime, cli_backends           ✅ Integrations
+✅ Adapters                     ✅ Typer app, moved commands       ✅ Heavy implementations
+✅ Base classes                 ✅ Depends on agents only           ✅ Optional deps
+✅ Decorators                   ❌ Must not import praisonai        ✅ UI, DB adapters
+❌ Heavy implementations        ❌ Bot/channel commands             ❌ Core logic
 ```
 
 ### 4.2 No Performance Impact (MUST)
@@ -739,6 +814,12 @@ from praisonaiagents import Workflow, Route, Parallel, Loop
 | Policy engine | `praisonaiagents/policy/engine.py` |
 | Scheduler module | `praisonaiagents/scheduler/` |
 | Schedule tools | `praisonaiagents/tools/schedule_tools.py` |
+| Agentic CLI (Typer) | `praisonai_code/cli/app.py` |
+| CLI main / run | `praisonai_code/cli/main.py` |
+| Warm runtime | `praisonai_code/runtime/` |
+| CLI backends | `praisonai_code/cli_backends/` |
+| Back-compat shims | `praisonai/cli/_shim.py`, `praisonai/cli/main.py` |
+| C5 regression tests | `praisonai/tests/unit/test_c5_backward_compat.py` |
 
 ---
 

--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "markdown>=3.5",
     "pyparsing>=3.0.0",
     "praisonaiagents>=1.6.104",
-    "praisonai-code",
+    "praisonai-code>=0.0.2",
     "python-dotenv>=0.19.0",
     "litellm>=1.83.14,<2",
     "PyYAML>=6.0",

--- a/src/praisonai/scripts/bump_and_release.py
+++ b/src/praisonai/scripts/bump_and_release.py
@@ -46,6 +46,11 @@ def get_praisonai_dir() -> Path:
     return get_project_root() / "src/praisonai"
 
 
+def get_praisonai_code_dir() -> Path:
+    """Get the praisonai-code package directory."""
+    return get_project_root() / "src/praisonai-code"
+
+
 def run(cmd: list[str], cwd: Optional[Path] = None, check: bool = True, silent: bool = False) -> subprocess.CompletedProcess:
     """Run a command and print it."""
     if not silent:
@@ -124,10 +129,16 @@ def update_file(filepath: Path, patterns: list[tuple[str, str]], root: Path) -> 
         return False
 
 
-def bump_version(new_version: str, agents_version: Optional[str] = None):
+def bump_version(
+    new_version: str,
+    agents_version: Optional[str] = None,
+    code_version: Optional[str] = None,
+    code_pin_only: bool = False,
+):
     """Bump version in all required files."""
     root = get_project_root()
     praisonai_dir = get_praisonai_dir()
+    code_dir = get_praisonai_code_dir()
     
     print(f"\n🚀 Bumping PraisonAI version to {new_version}\n")
     
@@ -180,6 +191,32 @@ def bump_version(new_version: str, agents_version: Optional[str] = None):
         update_file(
             praisonai_dir / "pyproject.toml",
             [(r'praisonaiagents>=[0-9.]+', f'praisonaiagents>={agents_version}')],
+            root
+        )
+
+    if code_version:
+        if code_pin_only:
+            print(f"\n📦 Pinning praisonai-code dependency to >={code_version}:")
+        else:
+            print(f"\n📦 Bumping praisonai-code to {code_version}:")
+            update_file(
+                code_dir / "pyproject.toml",
+                [(r'^version = "[^"]+"', f'version = "{code_version}"')],
+                root
+            )
+            update_file(
+                code_dir / "praisonai_code/__init__.py",
+                [(r'__version__ = "[^"]+"', f'__version__ = "{code_version}"')],
+                root
+            )
+        update_file(
+            praisonai_dir / "pyproject.toml",
+            [
+                (
+                    r'"praisonai-code(?:>=[0-9.]+)?"',
+                    f'"praisonai-code>={code_version}"',
+                )
+            ],
             root
         )
     
@@ -281,7 +318,10 @@ def release(version: str, use_frozen_lock: bool = False, no_add_all: bool = Fals
         "src/praisonai/uv.lock",
         "src/praisonai/README.md",
         "src/praisonai-agents/pyproject.toml",
-        "src/praisonai-agents/uv.lock"
+        "src/praisonai-agents/uv.lock",
+        "src/praisonai-code/pyproject.toml",
+        "src/praisonai-code/praisonai_code/__init__.py",
+        "src/praisonai-code/uv.lock",
     ]
     
     # Filter to only existing files to avoid git errors
@@ -378,6 +418,16 @@ Examples:
         help="Number of retries for dependency validation (default: 3)"
     )
     parser.add_argument(
+        "--code", "-c",
+        help="Bump praisonai-code version (pyproject + __init__) and pin wrapper dep",
+        default=None
+    )
+    parser.add_argument(
+        "--code-pin",
+        help="Pin praisonai-code>= in wrapper pyproject only (after CI code publish)",
+        default=None
+    )
+    parser.add_argument(
         "--force", "-f",
         action="store_true",
         help="Skip pre-flight checks (use with caution)"
@@ -412,6 +462,16 @@ Examples:
         print("   Expected format: X.Y.Z (e.g., 0.11.8)")
         sys.exit(1)
     
+    if args.code and args.code_pin:
+        print("❌ Use only one of --code or --code-pin")
+        sys.exit(1)
+
+    code_version = args.code or args.code_pin
+    if code_version and not re.match(r'^\d+\.\d+\.\d+$', code_version):
+        print(f"❌ Invalid code version format: {code_version}")
+        print("   Expected format: X.Y.Z (e.g., 0.0.3)")
+        sys.exit(1)
+    
     # Pre-flight checks
     print("\n🔍 Pre-flight checks...")
     
@@ -434,7 +494,12 @@ Examples:
             sys.exit(1)
     
     # Run bump version
-    bump_version(args.version, args.agents)
+    bump_version(
+        args.version,
+        args.agents,
+        code_version=code_version,
+        code_pin_only=bool(args.code_pin and not args.code),
+    )
     
     # Patch releases (--agents set): frozen targeted upgrade only.
     # Full releases: regenerate lock from scratch.

--- a/src/praisonai/scripts/bump_version.py
+++ b/src/praisonai/scripts/bump_version.py
@@ -48,7 +48,7 @@ def update_file(filepath: Path, patterns: list[tuple[str, str]]) -> bool:
         return False
 
 
-def bump_version(new_version: str, agents_version: str | None = None):
+def bump_version(new_version: str, agents_version: str | None = None, code_version: str | None = None, code_pin_only: bool = False):
     """Bump version in all required files."""
     root = get_project_root()
     
@@ -102,6 +102,30 @@ def bump_version(new_version: str, agents_version: str | None = None):
             praisonai_dir / "pyproject.toml",
             [(r'praisonaiagents>=[0-9.]+', f'praisonaiagents>={agents_version}')]
         )
+
+    if code_version:
+        code_dir = root / "src/praisonai-code"
+        if code_pin_only:
+            print(f"\n📦 Pinning praisonai-code dependency to >={code_version}:")
+        else:
+            print(f"\n📦 Bumping praisonai-code to {code_version}:")
+            update_file(
+                code_dir / "pyproject.toml",
+                [(r'^version = "[^"]+"', f'version = "{code_version}"')]
+            )
+            update_file(
+                code_dir / "praisonai_code/__init__.py",
+                [(r'__version__ = "[^"]+"', f'__version__ = "{code_version}"')]
+            )
+        update_file(
+            praisonai_dir / "pyproject.toml",
+            [
+                (
+                    r'"praisonai-code(?:>=[0-9.]+)?"',
+                    f'"praisonai-code>={code_version}"',
+                )
+            ],
+        )
     
     print("\n✨ Version bump complete!")
     print("\nNext steps:")
@@ -126,6 +150,17 @@ def main():
         default=None
     )
     
+    parser.add_argument(
+        "--code", "-c",
+        help="Bump praisonai-code version and pin wrapper dependency",
+        default=None
+    )
+    parser.add_argument(
+        "--code-pin",
+        help="Pin praisonai-code>= in wrapper pyproject only",
+        default=None
+    )
+    
     args = parser.parse_args()
     
     # Validate version format
@@ -139,7 +174,21 @@ def main():
         print("   Expected format: X.Y.Z (e.g., 0.0.167)")
         sys.exit(1)
     
-    bump_version(args.version, args.agents)
+    if args.code and args.code_pin:
+        print("❌ Use only one of --code or --code-pin")
+        sys.exit(1)
+
+    code_version = args.code or args.code_pin
+    if code_version and not re.match(r'^\d+\.\d+\.\d+$', code_version):
+        print(f"❌ Invalid code version format: {code_version}")
+        sys.exit(1)
+    
+    bump_version(
+        args.version,
+        args.agents,
+        code_version=code_version,
+        code_pin_only=bool(args.code_pin and not args.code),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **C6 backcompat:** wrapper Typer commands (`gateway`, `bot`, …) route via `_WRAPPER_COMMANDS`; schema shims; 28 compat tests; CI smoke gate
- **Three-package release:** `pypi-release.yml` publishes `praisonaiagents` → `praisonai-code` → `praisonai`
- **Bump scripts:** `--code` / `--code-pin` in `bump_and_release.py` and `bump_version.py`
- **Release gate:** `src/praisonai-code` in `PACKAGE_PATHS`; nightly summary includes code version
- **Wrapper pin:** `praisonai-code>=0.0.2` in wrapper pyproject
- **Docs:** AGENTS.md §2.3 architecture + publish order

## Test plan
- [x] `pytest tests/unit/test_c5_backward_compat.py` — 28 passed
- [x] `node .github/scripts/release-gate-selftest.js`
- [x] `praisonai gateway --help` works
- [ ] CI smoke + test-core on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for publishing and versioning an additional package alongside the existing releases.
  * Release flows now track and report all three package versions, including the new code package.

* **Bug Fixes**
  * Improved release checks to prevent incomplete publishes when one of the required package versions is missing.
  * Added stronger version validation and dependency pinning so releases stay consistent across components.

* **Documentation**
  * Updated project guidance to reflect the revised package layout and compatibility expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->