### PR TITLE
chore(c6): integration gate sign-off for praisonai-code extraction

### DIFF
--- a/.github/actions/install-monorepo-packages/action.yml
+++ b/.github/actions/install-monorepo-packages/action.yml
@@ -1,5 +1,5 @@
 name: Install PraisonAI monorepo packages
-description: Install praisonai-agents, praisonai-code, and praisonai wrapper from local paths (praisonai-code is not on PyPI yet).
+description: Install praisonai-agents, praisonai-code, and praisonai wrapper from local paths (mirrors PyPI three-package install order).
 
 inputs:
   repo-root:

--- a/src/praisonai-agents/AGENTS.md
+++ b/src/praisonai-agents/AGENTS.md
@@ -166,6 +166,30 @@ unittest.mock.patch("praisonai.cli.commands.run.X")   # same module object
 
 **PyPI publish order:** `praisonaiagents` → `praisonai-code` → `praisonai` (see `src/praisonai/scripts/bump_and_release.py` and `.github/workflows/pypi-release.yml`). Gateway/bots changes release via wrapper only; agentic CLI changes also bump `praisonai-code`.
 
+#### C6 integration gate (#2519)
+
+C6 is the **sign-off step** after C0–C5 file moves: no further moves, only regression verification and release wiring.
+
+| Check | Command / artefact |
+|-------|-------------------|
+| Smoke `--help` | `praisonai`, `praisonai run/chat/code/daemon/attach/gateway/bot/doctor --help` |
+| Compat regression | `pytest src/praisonai/tests/unit/test_c5_backward_compat.py` |
+| CLI shard | `pytest src/praisonai/tests/unit/cli/` |
+| Warm runtime | `pytest src/praisonai/tests/unit/test_warm_runtime.py` |
+| Doctor shard | `pytest src/praisonai/tests/unit/doctor/` |
+| Import perf | `pytest src/praisonai/tests/unit/test_performance_benchmarks.py` (< 500ms) |
+| Real LLM smoke | `RUN_REAL_KEY_TESTS=1 PRAISONAI_ALLOW_NETWORK=1 PRAISONAI_TEST_PROVIDERS=all pytest src/praisonai/tests/integration/test_real_key_smoke.py` |
+| Verification log | `src/praisonai/tests/C6_VERIFICATION.md` |
+
+**Command split (wrapper vs code):**
+
+| Install target | Agentic CLI (`run`, `chat`, `code`, …) | Bot/gateway (`bot`, `gateway`, `pairing`, …) |
+|----------------|----------------------------------------|---------------------------------------------|
+| `pip install praisonai` | Yes (via `praisonai-code` dep + shims) | Yes |
+| `pip install praisonai-code` only | Partial — requires wrapper for ~170 reverse imports | No — wrapper-only commands hidden when `praisonai` absent |
+
+**v1 decision:** Wrapper-required install is acceptable. Standalone `praisonai-code` without `praisonai` is deferred to **C7** (reverse-import elimination).
+
 ---
 
 ## 3. Core SDK Architecture (praisonaiagents)

--- a/src/praisonai-code/.gitignore
+++ b/src/praisonai-code/.gitignore
@@ -1,0 +1,5 @@
+build/
+dist/
+*.egg-info/
+.venv/
+__pycache__/

--- a/src/praisonai-code/README.md
+++ b/src/praisonai-code/README.md
@@ -8,19 +8,18 @@ Agentic terminal CLI for PraisonAI — the terminal-native agent product
 
 ## Status
 
-Migration in progress. `runtime/` and `cli_backends/` have moved into
-`praisonai_code` (step C1); the remaining terminal-agent modules follow
-incrementally in steps C2–C6 (see issue #2512):
+**C0–C5 complete.** C6 integration gate verified — see
+`src/praisonai/tests/C6_VERIFICATION.md`.
 
-| Step | Scope |
-|------|-------|
-| C0 | Scaffold |
-| C1 | `runtime/` + `cli_backends/` |
-| C2 | `interactive/`, `execution/`, `ui/`, `output/`, `state/` |
-| C3 | Agentic commands |
-| C4 | Agentic features |
-| C5 | `main.py`, `app.py`, config/session/utils + shims |
-| C6 | Integration gate |
+| Step | Scope | Status |
+|------|-------|--------|
+| C0 | Scaffold | Done |
+| C1 | `runtime/` + `cli_backends/` | Done |
+| C2 | `interactive/`, `execution/`, `ui/`, `output/`, `state/` | Done |
+| C3 | Agentic commands | Done |
+| C4 | Agentic features | Done |
+| C5 | `main.py`, `app.py`, config/session/utils + shims | Done |
+| C6 | Integration gate + sign-off | Done |
 
 - `praisonai_code.runtime` — warm local runtime (daemon + thin client).
 - `praisonai_code.cli_backends` — CLI backend implementations (e.g. Claude Code).
@@ -36,24 +35,32 @@ praisonai-code    →  depends on  praisonaiagents (core SDK)
 click, textual, PyYAML, python-dotenv, litellm, mcp, pydantic — see
 `pyproject.toml`). The rules above govern the **inter-package** direction.
 
-> **Migration note (C1):** `cli_backends/registry.py` still imports
-> `PluginRegistry` from the `praisonai` main package (same "keep main-package
-> import" pattern as `runtime/descriptor.py`'s `from praisonai.version`).
-> `praisonai-code` is wired via an editable path dependency and `praisonai` is
-> always present at runtime during migration, so this residual back-import is a
-> deliberate C1 tradeoff to be removed in a later step — not a standalone-publish
-> guarantee yet.
+> **C7 note:** Some modules still import the `praisonai` wrapper at runtime
+> (~170 files). **Standalone `pip install praisonai-code` without `praisonai`
+> is not fully supported yet.** Use `pip install praisonai` for production.
+> Residual C1 back-imports: `runtime/descriptor.py` → `praisonai.version`;
+> `cli_backends/registry.py` → `praisonai._registry`.
 
 Backward compatibility is preserved via PEP 562 shims at the old
 `praisonai.*` import paths, so `pip install praisonai` and
 `from praisonai.cli.main import PraisonAI` keep working unchanged.
 
-## Install (development)
+## Install
+
+**Recommended (includes wrapper + bots/gateway):**
 
 ```bash
+pip install praisonai
+```
+
+**Development / monorepo:**
+
+```bash
+pip install -e src/praisonai-agents
 pip install -e src/praisonai-code
+pip install -e src/praisonai
 python -c "import praisonai_code; print(praisonai_code.__version__)"
 ```
 
-`praisonai-code` is **not** published standalone to PyPI during migration;
-`praisonai` remains the user-facing install.
+**PyPI:** Published as `praisonai-code` after `praisonaiagents` in the
+three-package release order (see `pypi-release.yml`).

--- a/src/praisonai-code/praisonai_code/cli/app.py
+++ b/src/praisonai-code/praisonai_code/cli/app.py
@@ -221,6 +221,12 @@ _SPECIAL_COMMANDS = {
 }
 
 
+def _wrapper_available() -> bool:
+    """Return True when the ``praisonai`` wrapper package is importable."""
+    import importlib.util as _importlib_util
+    return _importlib_util.find_spec("praisonai") is not None
+
+
 class LazyCommandGroup(TyperGroup):
     """Click Group that lazily loads subcommands from registry."""
     
@@ -229,8 +235,14 @@ class LazyCommandGroup(TyperGroup):
         # Start with commands from parent (already registered commands)
         commands = set(super().list_commands(ctx))
         
-        # Add lazy-loaded commands
-        commands.update(_LAZY_COMMANDS.keys())
+        # Add lazy-loaded commands. Wrapper-only commands are advertised only when
+        # the ``praisonai`` wrapper is installed, so a standalone ``praisonai-code``
+        # install does not surface commands it cannot resolve.
+        wrapper_ok = _wrapper_available()
+        commands.update(
+            name for name in _LAZY_COMMANDS
+            if wrapper_ok or name not in _WRAPPER_COMMANDS
+        )
         commands.update(_SPECIAL_COMMANDS.keys())
         
         # Add special inline commands
@@ -256,8 +268,7 @@ class LazyCommandGroup(TyperGroup):
             module_path, attr_name, _ = _LAZY_COMMANDS[name]
             try:
                 if name in _WRAPPER_COMMANDS:
-                    import importlib.util as _importlib_util
-                    if _importlib_util.find_spec("praisonai") is None:
+                    if not _wrapper_available():
                         return None
                     module = importlib.import_module(f"praisonai.cli.commands.{name}")
                 else:

--- a/src/praisonai/praisonai/profiler.py
+++ b/src/praisonai/praisonai/profiler.py
@@ -437,6 +437,16 @@ class _ProfilerImpl:
         with self._lock:
             return list(self._api_calls)
 
+    @asynccontextmanager
+    async def streaming_async(self, name: str):
+        """Async context manager for profiling streaming operations."""
+        tracker = StreamingTracker(name)
+        tracker.start()
+        try:
+            yield tracker
+        finally:
+            tracker.end()
+
     def get_streaming_records(self) -> List[StreamingRecord]:
         """Get streaming records."""
         with self._lock:
@@ -555,12 +565,15 @@ class _ProfilerImpl:
         """Profile memory usage for a block when tracemalloc is available."""
         import tracemalloc
 
-        tracemalloc.start()
+        was_tracing = tracemalloc.is_tracing()
+        if not was_tracing:
+            tracemalloc.start()
         try:
             yield
         finally:
             current, peak = tracemalloc.get_traced_memory()
-            tracemalloc.stop()
+            if not was_tracing:
+                tracemalloc.stop()
             self.record_memory(
                 name=name,
                 current_kb=current / 1024.0,
@@ -571,18 +584,21 @@ class _ProfilerImpl:
         """Return current process memory snapshot in KB."""
         import tracemalloc
 
-        tracemalloc.start()
+        was_tracing = tracemalloc.is_tracing()
+        if not was_tracing:
+            tracemalloc.start()
         try:
             current, peak = tracemalloc.get_traced_memory()
         finally:
-            tracemalloc.stop()
+            if not was_tracing:
+                tracemalloc.stop()
         return {"current_kb": current / 1024.0, "peak_kb": peak / 1024.0}
 
     def export_json(self) -> str:
         """Export profiling summary as JSON."""
         import json
 
-        return json.dumps(self.get_summary(), default=str)
+        return json.dumps({"summary": self.get_summary()}, default=str)
 
     def export_html(self) -> str:
         """Export a minimal HTML profiling report."""
@@ -824,6 +840,11 @@ class ProfilerCompat:
     def streaming(name: str):
         """Context manager for profiling streaming operations."""
         return get_profiler().streaming(name)
+
+    @staticmethod
+    def streaming_async(name: str):
+        """Async context manager for profiling streaming operations."""
+        return get_profiler().streaming_async(name)
     
     @staticmethod
     def api_call(endpoint: str, method: str = "GET"):

--- a/src/praisonai/praisonai/profiler.py
+++ b/src/praisonai/praisonai/profiler.py
@@ -63,6 +63,7 @@ import cProfile
 import pstats
 import io
 import statistics
+from pathlib import Path
 from collections import OrderedDict
 from collections import deque
 from contextvars import ContextVar
@@ -430,7 +431,186 @@ class _ProfilerImpl:
         """Get flow records."""
         with self._lock:
             return list(self._flow)
-    
+
+    def get_api_calls(self) -> List[APICallRecord]:
+        """Get API call records."""
+        with self._lock:
+            return list(self._api_calls)
+
+    def get_streaming_records(self) -> List[StreamingRecord]:
+        """Get streaming records."""
+        with self._lock:
+            return list(self._streaming)
+
+    def get_memory_records(self) -> List[MemoryRecord]:
+        """Get memory records."""
+        with self._lock:
+            return list(self._memory)
+
+    def get_line_profile_data(self) -> Dict[str, Any]:
+        """Get line-level profiling data."""
+        with self._lock:
+            return dict(self._line_profile_data)
+
+    def set_line_profile_data(self, name: str, data: Any) -> None:
+        """Store line-level profiling output for a function."""
+        with self._lock:
+            self._line_profile_data[name] = data
+
+    def record_streaming(
+        self,
+        name: str,
+        ttft_ms: float,
+        total_ms: float,
+        chunk_count: int = 0,
+        total_tokens: int = 0,
+    ) -> None:
+        """Record a streaming operation."""
+        if not self.is_enabled():
+            return
+        with self._lock:
+            self._streaming.append(
+                StreamingRecord(
+                    name=name,
+                    ttft_ms=ttft_ms,
+                    total_ms=total_ms,
+                    chunk_count=chunk_count,
+                    total_tokens=total_tokens,
+                )
+            )
+
+    def record_memory(self, name: str, current_kb: float, peak_kb: float) -> None:
+        """Record memory usage snapshot."""
+        if not self.is_enabled():
+            return
+        with self._lock:
+            self._memory.append(
+                MemoryRecord(name=name, current_kb=current_kb, peak_kb=peak_kb)
+            )
+
+    def get_statistics(self, category: Optional[str] = None) -> Dict[str, float]:
+        """Return percentile statistics for timing records."""
+        import statistics
+
+        timings = self.get_timings(category=category)
+        values = [t.duration_ms for t in timings]
+        if not values:
+            return {
+                "p50": 0.0,
+                "p95": 0.0,
+                "p99": 0.0,
+                "mean": 0.0,
+                "std_dev": 0.0,
+                "min": 0.0,
+                "max": 0.0,
+            }
+        values.sort()
+        n = len(values)
+
+        def _pct(p: float) -> float:
+            idx = min(n - 1, max(0, int(round((p / 100.0) * (n - 1)))))
+            return float(values[idx])
+
+        return {
+            "p50": _pct(50),
+            "p95": _pct(95),
+            "p99": _pct(99),
+            "mean": float(statistics.mean(values)),
+            "std_dev": float(statistics.pstdev(values)) if n > 1 else 0.0,
+            "min": float(values[0]),
+            "max": float(values[-1]),
+        }
+
+    def get_flamegraph_data(self) -> List[Dict[str, Any]]:
+        """Return simplified flamegraph nodes from flow records."""
+        with self._lock:
+            return [
+                {
+                    "name": record.name,
+                    "value": record.duration_ms,
+                    "file": record.file,
+                    "line": record.line,
+                }
+                for record in self._flow
+            ]
+
+    @contextmanager
+    def cprofile(self, name: str):
+        """Profile a block with cProfile when available."""
+        import cProfile
+        import pstats
+
+        profiler = cProfile.Profile()
+        profiler.enable()
+        try:
+            yield profiler
+        finally:
+            profiler.disable()
+            stats = pstats.Stats(profiler)
+            with self._lock:
+                self._cprofile_stats.append((name, stats))
+
+    @contextmanager
+    def memory(self, name: str):
+        """Profile memory usage for a block when tracemalloc is available."""
+        import tracemalloc
+
+        tracemalloc.start()
+        try:
+            yield
+        finally:
+            current, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            self.record_memory(
+                name=name,
+                current_kb=current / 1024.0,
+                peak_kb=peak / 1024.0,
+            )
+
+    def memory_snapshot(self) -> Dict[str, float]:
+        """Return current process memory snapshot in KB."""
+        import tracemalloc
+
+        tracemalloc.start()
+        try:
+            current, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        return {"current_kb": current / 1024.0, "peak_kb": peak / 1024.0}
+
+    def export_json(self) -> str:
+        """Export profiling summary as JSON."""
+        import json
+
+        return json.dumps(self.get_summary(), default=str)
+
+    def export_html(self) -> str:
+        """Export a minimal HTML profiling report."""
+        summary = self.get_summary()
+        rows = "".join(
+            f"<tr><td>{name}</td><td>{duration:.2f}</td></tr>"
+            for name, duration in summary.get("slowest_operations", [])
+        )
+        return (
+            "<html><body><h1>PraisonAI Profiler</h1>"
+            f"<p>Total time: {summary.get('total_time_ms', 0):.2f}ms</p>"
+            f"<table>{rows}</table></body></html>"
+        )
+
+    def export_to_file(self, filepath: str, format: str = "json") -> None:
+        """Export report to a file."""
+        content = self.export_json() if format == "json" else self.export_html()
+        Path(filepath).write_text(content, encoding="utf-8")
+
+    def export_flamegraph(self, filepath: str) -> None:
+        """Export a minimal SVG flamegraph placeholder from flow data."""
+        data = self.get_flamegraph_data()
+        svg = (
+            '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg">'
+            f'<text x="10" y="20">nodes={len(data)}</text></svg>'
+        )
+        Path(filepath).write_text(svg, encoding="utf-8")
+
     def get_files_accessed(self) -> Dict[str, int]:
         """Get files accessed with counts."""
         with self._lock:
@@ -554,6 +734,12 @@ class ProfilerCompat:
     Delegates all calls to the current profiler instance via get_profiler().
     This maintains backward compatibility while enabling per-agent isolation.
     """
+    _instance: Optional["ProfilerCompat"] = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
     
     @staticmethod
     def enable() -> None:
@@ -643,6 +829,90 @@ class ProfilerCompat:
     def api_call(endpoint: str, method: str = "GET"):
         """Context manager for profiling API calls."""
         return get_profiler().api_call(endpoint, method)
+
+    @staticmethod
+    def get_api_calls():
+        """Get API call records."""
+        return get_profiler().get_api_calls()
+
+    @staticmethod
+    def get_streaming_records():
+        """Get streaming records."""
+        return get_profiler().get_streaming_records()
+
+    @staticmethod
+    def get_memory_records():
+        """Get memory records."""
+        return get_profiler().get_memory_records()
+
+    @staticmethod
+    def get_statistics(category: Optional[str] = None):
+        """Get timing statistics."""
+        return get_profiler().get_statistics(category=category)
+
+    @staticmethod
+    def get_flamegraph_data():
+        """Get flamegraph-compatible data."""
+        return get_profiler().get_flamegraph_data()
+
+    @staticmethod
+    def get_line_profile_data():
+        """Get line-level profiling data."""
+        return get_profiler().get_line_profile_data()
+
+    @staticmethod
+    def set_line_profile_data(name: str, data: Any) -> None:
+        """Store line-level profiling output."""
+        get_profiler().set_line_profile_data(name, data)
+
+    @staticmethod
+    def record_streaming(
+        name: str,
+        ttft_ms: float,
+        total_ms: float,
+        chunk_count: int = 0,
+        total_tokens: int = 0,
+    ) -> None:
+        """Record a streaming operation."""
+        get_profiler().record_streaming(
+            name, ttft_ms, total_ms, chunk_count=chunk_count, total_tokens=total_tokens
+        )
+
+    @staticmethod
+    def record_memory(name: str, current_kb: float, peak_kb: float) -> None:
+        """Record memory usage."""
+        get_profiler().record_memory(name, current_kb, peak_kb)
+
+    @staticmethod
+    def cprofile(name: str):
+        """Context manager for cProfile."""
+        return get_profiler().cprofile(name)
+
+    @staticmethod
+    def memory(name: str):
+        """Context manager for memory profiling."""
+        return get_profiler().memory(name)
+
+    @staticmethod
+    def memory_snapshot():
+        """Return current memory snapshot."""
+        return get_profiler().memory_snapshot()
+
+    @staticmethod
+    def export_json() -> str:
+        return get_profiler().export_json()
+
+    @staticmethod
+    def export_html() -> str:
+        return get_profiler().export_html()
+
+    @staticmethod
+    def export_to_file(filepath: str, format: str = "json") -> None:
+        get_profiler().export_to_file(filepath, format=format)
+
+    @staticmethod
+    def export_flamegraph(filepath: str) -> None:
+        get_profiler().export_flamegraph(filepath)
 
 # Create compatibility instance that acts like old singleton
 # This allows existing code to work: Profiler.enable(), etc.

--- a/src/praisonai/scripts/bump_and_release.py
+++ b/src/praisonai/scripts/bump_and_release.py
@@ -14,14 +14,18 @@ Usage:
 
 This script:
 1. Validates pre-flight conditions (clean git state, versions)
-2. Optionally waits for praisonaiagents to be available on PyPI
-3. Bumps version in all required files
+2. Optionally waits for praisonaiagents and/or praisonai-code on PyPI
+3. Bumps version in all required files (agents, code, wrapper)
 4. Copies root README.md to package dir
 5. Runs uv lock & uv build
 6. Commits changes
 7. Creates git tag
 8. Pushes to GitHub (with rebase if needed)
 9. Creates GitHub release (latest)
+
+Three-package publish order: praisonaiagents → praisonai-code → praisonai
+Use --code to bump code package; --code-pin to pin wrapper after code publish.
+Use --wait for agents PyPI propagation; --wait-code for praisonai-code.
 """
 
 import re
@@ -228,19 +232,19 @@ def validate_dependencies(
     retry_interval: int = 60,
     use_frozen: bool = False,
     agents_version: Optional[str] = None,
+    code_version: Optional[str] = None,
 ) -> bool:
     """Validate release dependency resolution, with retry logic for PyPI propagation."""
     praisonai_dir = get_praisonai_dir()
 
     if use_frozen:
         lock_cmd = ["uv", "lock", "--frozen"]
-    elif agents_version:
-        # Patch releases only bump praisonaiagents — avoid re-resolving every optional
-        # extra together (crewai/flow/langfuse have known cross-extra conflicts).
-        # --dry-run still universal-resolves all requires-python splits (e.g. py3.14
-        # win32) and fails even when the wheel is on PyPI; --frozen --upgrade-package
-        # validates the targeted bump without a full lock regeneration.
-        lock_cmd = ["uv", "lock", "--frozen", "--upgrade-package", f"praisonaiagents=={agents_version}"]
+    elif agents_version or code_version:
+        lock_cmd = ["uv", "lock", "--frozen"]
+        if agents_version:
+            lock_cmd.extend(["--upgrade-package", f"praisonaiagents=={agents_version}"])
+        if code_version:
+            lock_cmd.extend(["--upgrade-package", f"praisonai-code=={code_version}"])
     else:
         lock_cmd = ["uv", "lock", "--dry-run"]
 
@@ -406,6 +410,11 @@ Examples:
         help="Wait for the specified agents version to be available on PyPI"
     )
     parser.add_argument(
+        "--wait-code",
+        action="store_true",
+        help="Wait for the specified praisonai-code version to be available on PyPI"
+    )
+    parser.add_argument(
         "--max-wait",
         type=int,
         default=300,
@@ -492,6 +501,11 @@ Examples:
             print("\n💡 Tip: Check if the package was published successfully")
             print("💡 Tip: You can retry without --wait if the package is confirmed published")
             sys.exit(1)
+
+    if args.wait_code and code_version:
+        if not wait_for_pypi_version("praisonai-code", code_version, max_wait=args.max_wait):
+            print("\n💡 Tip: Check if praisonai-code was published successfully")
+            sys.exit(1)
     
     # Run bump version
     bump_version(
@@ -508,6 +522,7 @@ Examples:
         max_retries=args.retries,
         use_frozen=not patch_release,
         agents_version=args.agents,
+        code_version=code_version if args.code and not args.code_pin else None,
     ):
         print("\n💡 Tip: Revert changes with 'git checkout .' if needed")
         print("💡 Tip: The package may need more time to propagate to PyPI")

--- a/src/praisonai/scripts/bump_and_release.py
+++ b/src/praisonai/scripts/bump_and_release.py
@@ -237,14 +237,14 @@ def validate_dependencies(
     """Validate release dependency resolution, with retry logic for PyPI propagation."""
     praisonai_dir = get_praisonai_dir()
 
-    if use_frozen:
-        lock_cmd = ["uv", "lock", "--frozen"]
-    elif agents_version or code_version:
+    if agents_version or code_version:
         lock_cmd = ["uv", "lock", "--frozen"]
         if agents_version:
             lock_cmd.extend(["--upgrade-package", f"praisonaiagents=={agents_version}"])
         if code_version:
             lock_cmd.extend(["--upgrade-package", f"praisonai-code=={code_version}"])
+    elif use_frozen:
+        lock_cmd = ["uv", "lock", "--frozen"]
     else:
         lock_cmd = ["uv", "lock", "--dry-run"]
 
@@ -520,9 +520,9 @@ Examples:
     patch_release = args.agents is not None
     if not validate_dependencies(
         max_retries=args.retries,
-        use_frozen=not patch_release,
+        use_frozen=patch_release,
         agents_version=args.agents,
-        code_version=code_version if args.code and not args.code_pin else None,
+        code_version=code_version,
     ):
         print("\n💡 Tip: Revert changes with 'git checkout .' if needed")
         print("💡 Tip: The package may need more time to propagate to PyPI")

--- a/src/praisonai/scripts/bump_and_release.py
+++ b/src/praisonai/scripts/bump_and_release.py
@@ -201,7 +201,7 @@ def bump_version(
             print(f"\n📦 Bumping praisonai-code to {code_version}:")
             update_file(
                 code_dir / "pyproject.toml",
-                [(r'^version = "[^"]+"', f'version = "{code_version}"')],
+                [(r'(?m)^version = "[^"]+"', f'version = "{code_version}"')],
                 root
             )
             update_file(

--- a/src/praisonai/scripts/bump_version.py
+++ b/src/praisonai/scripts/bump_version.py
@@ -111,7 +111,7 @@ def bump_version(new_version: str, agents_version: str | None = None, code_versi
             print(f"\n📦 Bumping praisonai-code to {code_version}:")
             update_file(
                 code_dir / "pyproject.toml",
-                [(r'^version = "[^"]+"', f'version = "{code_version}"')]
+                [(r'(?m)^version = "[^"]+"', f'version = "{code_version}"')]
             )
             update_file(
                 code_dir / "praisonai_code/__init__.py",

--- a/src/praisonai/tests/C6_VERIFICATION.md
+++ b/src/praisonai/tests/C6_VERIFICATION.md
@@ -2,6 +2,9 @@
 
 Run on `main` after C0–C5 merge. Date: 2026-07-01.
 
+> All `pytest` commands below are run from the `src/praisonai/` package root
+> (i.e. `cd src/praisonai && pytest tests/...`).
+
 ## Smoke commands
 
 | Command | Result |

--- a/src/praisonai/tests/C6_VERIFICATION.md
+++ b/src/praisonai/tests/C6_VERIFICATION.md
@@ -1,0 +1,76 @@
+# C6 Integration Gate Verification (#2519)
+
+Run on `main` after C0–C5 merge. Date: 2026-07-01.
+
+## Smoke commands
+
+| Command | Result |
+|---------|--------|
+| `praisonai --help` | PASS |
+| `praisonai run/chat/code/daemon/attach/gateway/bot/doctor --help` | PASS |
+| `praisonai "Say hello in one word"` (real LLM) | PASS (~3s) |
+
+## Test shards
+
+| Shard | Result |
+|-------|--------|
+| `pytest tests/unit/cli/` | 1634 passed |
+| `pytest tests/unit/test_c5_backward_compat.py` | PASS |
+| `pytest tests/unit/test_warm_runtime.py` | 21 passed |
+| `pytest tests/unit/doctor/` | PASS (in CLI shard) |
+| `pytest tests/unit/test_wrapper_layer_regression.py` | PASS |
+| `pytest tests/unit/test_performance_benchmarks.py` | 11 passed |
+| `pytest tests/unit/gateway/` | unchanged (bot layer) |
+
+## Real agentic / API key
+
+| Test | Result |
+|------|--------|
+| `test_real_key_smoke.py` (9 tests, gated) | 9/9 PASS |
+
+Env: `RUN_REAL_KEY_TESTS=1 PRAISONAI_ALLOW_NETWORK=1 PRAISONAI_TEST_PROVIDERS=all`
+
+## Import graph (#2519 grep assertions)
+
+| Assertion | Result |
+|-----------|--------|
+| No `from praisonai.gateway` in `praisonai_code/cli/commands/run.py` | 0 matches |
+| No `from praisonai.gateway` in `praisonai_code/cli/interactive/` | 0 matches |
+| `praisonai-code/pyproject.toml` has no `praisonai` wrapper dep | PASS (only `praisonaiagents`) |
+
+## Import performance
+
+| Metric | Result |
+|--------|--------|
+| `import praisonai` | ~2ms (well under 500ms gate) |
+
+## Legacy unit tests (re-enabled post-C6)
+
+Removed blanket `@pytest.mark.skip("Legacy unit test pending Core Tests gate update")` from 27 files.
+
+| Metric | Result |
+|--------|--------|
+| Tests in re-enabled files | 431 collected |
+| Passed | 376 |
+| Failed | 55 (API drift — CLI backend resolver, bot session asyncio, training mocks) |
+| Critical #2519 shards | warm_runtime, gateway_gaps, profiler: green |
+
+Follow-up: fix or rewrite remaining 55 tests in a post-C6 maintenance pass.
+
+## Release
+
+| Item | Result |
+|------|--------|
+| Cherry-pick `81b954571` (code bump regex + standalone wrapper cmd gate) | Applied on `chore/c6-sign-off` |
+| Three-package PyPI workflow | Merged (#2543) |
+
+## Sign-off
+
+- [x] Smoke commands pass
+- [x] CLI + doctor + warm runtime shards pass
+- [x] `import praisonai` < 500ms
+- [x] Real agentic LLM E2E passes
+- [x] Zero gateway imports on agentic hot path
+- [x] Wrapper-required install documented (C7 defers standalone `praisonai-code`)
+
+Closes #2519, Closes #2512.

--- a/src/praisonai/tests/integration/test_real_key_smoke.py
+++ b/src/praisonai/tests/integration/test_real_key_smoke.py
@@ -4,12 +4,15 @@ Real API Key Smoke Tests for PraisonAI.
 These tests validate end-to-end behavior using real API keys.
 They are gated by environment variables and use minimal tokens.
 
-Run with:
-    RUN_REAL_KEY_TESTS=1 pytest tests/integration/test_real_key_smoke.py -v
+Run with (source ~/.bashrc or ~/.zshrc for API keys first):
+    RUN_REAL_KEY_TESTS=1 PRAISONAI_ALLOW_NETWORK=1 PRAISONAI_TEST_PROVIDERS=all \\
+        pytest tests/integration/test_real_key_smoke.py -v
 
 Required environment variables:
     - OPENAI_API_KEY: For OpenAI provider tests
     - RUN_REAL_KEY_TESTS=1: Gate to enable these tests
+    - PRAISONAI_ALLOW_NETWORK=1: Allow network calls (conftest gating)
+    - PRAISONAI_TEST_PROVIDERS=all: File mentions multiple providers
 """
 
 import os
@@ -65,7 +68,6 @@ from praisonaiagents import Agent
 agent = Agent(
     instructions="Reply with exactly one word: OK",
     llm="gpt-4o-mini",
-    verbose=False
 )
 
 # Minimal prompt
@@ -93,7 +95,6 @@ agent = Agent(
     instructions="You have access to get_time tool. Use it and report the time briefly.",
     llm="gpt-4o-mini",
     tools=[get_time],
-    verbose=False
 )
 
 response = agent.chat("What time is it?")
@@ -191,7 +192,6 @@ from praisonaiagents import Agent
 agent = Agent(
     instructions="Reply with exactly: ANTHROPIC_OK",
     llm="claude-3-haiku-20240307",
-    verbose=False
 )
 response = agent.chat("Respond")
 print("SUCCESS" if "ANTHROPIC_OK" in response or response else "FAIL")
@@ -213,7 +213,6 @@ from praisonaiagents import Agent
 agent = Agent(
     instructions="Reply with exactly: GOOGLE_OK",
     llm="gemini/gemini-1.5-flash",
-    verbose=False
 )
 response = agent.chat("Respond")
 print("SUCCESS" if response else "FAIL")

--- a/src/praisonai/tests/unit/test_agent_os_wrapper.py
+++ b/src/praisonai/tests/unit/test_agent_os_wrapper.py
@@ -4,7 +4,6 @@ TDD tests for AgentOS exports from praisonai wrapper.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 
 
 class TestAgentOSWrapperExports:

--- a/src/praisonai/tests/unit/test_agents_yaml_validation.py
+++ b/src/praisonai/tests/unit/test_agents_yaml_validation.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 """
 Test agents.yaml field validation functionality.
 

--- a/src/praisonai/tests/unit/test_approval_agent_integration.py
+++ b/src/praisonai/tests/unit/test_approval_agent_integration.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 """
 Agent Integration Test for Human Approval System
 

--- a/src/praisonai/tests/unit/test_approval_interactive.py
+++ b/src/praisonai/tests/unit/test_approval_interactive.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 """
 Interactive test for the human approval system.
 

--- a/src/praisonai/tests/unit/test_async_daemon_deployment.py
+++ b/src/praisonai/tests/unit/test_async_daemon_deployment.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 """
 Unit tests for async daemon and deployment methods.
 

--- a/src/praisonai/tests/unit/test_auto_lazy_loading.py
+++ b/src/praisonai/tests/unit/test_auto_lazy_loading.py
@@ -9,7 +9,6 @@ These tests verify that:
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import sys
 import time
 

--- a/src/praisonai/tests/unit/test_bot_fixes.py
+++ b/src/praisonai/tests/unit/test_bot_fixes.py
@@ -11,7 +11,6 @@ Tests cover:
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import time
 
 

--- a/src/praisonai/tests/unit/test_bot_history.py
+++ b/src/praisonai/tests/unit/test_bot_history.py
@@ -7,7 +7,6 @@ so agents automatically get conversation context across turns.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 class TestBotHistoryInjection:
     """Tests for Bot._apply_smart_defaults() history wiring."""
 

--- a/src/praisonai/tests/unit/test_bot_wiring.py
+++ b/src/praisonai/tests/unit/test_bot_wiring.py
@@ -5,7 +5,6 @@ are properly wired into the bot adapters (not just tested in isolation).
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import time
 
 import pytest

--- a/src/praisonai/tests/unit/test_db_adapter_tracing_init.py
+++ b/src/praisonai/tests/unit/test_db_adapter_tracing_init.py
@@ -7,7 +7,6 @@ by ensuring stores are initialized before any write operations.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import unittest
 from unittest.mock import Mock, patch
 import time

--- a/src/praisonai/tests/unit/test_decorator_simple.py
+++ b/src/praisonai/tests/unit/test_decorator_simple.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 """
 Simple test to verify the improved require_approval decorator.
 """

--- a/src/praisonai/tests/unit/test_discord_approval.py
+++ b/src/praisonai/tests/unit/test_discord_approval.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 
 import asyncio
 

--- a/src/praisonai/tests/unit/test_gateway_gaps.py
+++ b/src/praisonai/tests/unit/test_gateway_gaps.py
@@ -6,7 +6,6 @@ Tests the fixes for PraisonAIUI gateway integration gaps.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch

--- a/src/praisonai/tests/unit/test_gateway_session.py
+++ b/src/praisonai/tests/unit/test_gateway_session.py
@@ -8,7 +8,6 @@ command handlers, and wires debouncer/ack support.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest

--- a/src/praisonai/tests/unit/test_hybrid_workflow.py
+++ b/src/praisonai/tests/unit/test_hybrid_workflow.py
@@ -6,7 +6,6 @@ Tests the HybridWorkflowExecutor that combines job and agent workflow capabiliti
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch

--- a/src/praisonai/tests/unit/test_job_workflow_agent_steps.py
+++ b/src/praisonai/tests/unit/test_job_workflow_agent_steps.py
@@ -6,7 +6,6 @@ Tests the new step types: agent:, judge:, approve:
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch

--- a/src/praisonai/tests/unit/test_kanban_sqlite_store.py
+++ b/src/praisonai/tests/unit/test_kanban_sqlite_store.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import tempfile
 import shutil
 import sqlite3

--- a/src/praisonai/tests/unit/test_lazy_imports.py
+++ b/src/praisonai/tests/unit/test_lazy_imports.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 """
 Unit tests for lazy import behavior in architectural fixes.
 
@@ -25,7 +24,7 @@ class TestLazyImports(unittest.TestCase):
         """Smoke test: trainer module imports quickly without heavy deps."""
         # Remove any cached imports to get fresh import time
         modules_to_remove = [
-            'praisonai.praisonai.train.llm.trainer',
+            'praisonai.train.llm.trainer',
             'torch', 'transformers', 'unsloth', 'trl', 'datasets', 'psutil'
         ]
         for module in modules_to_remove:
@@ -35,7 +34,7 @@ class TestLazyImports(unittest.TestCase):
         start_time = time.time()
         
         # Import should be fast without triggering heavy deps
-        from praisonai.praisonai.train.llm.trainer import TrainModel
+        from praisonai.train.llm.trainer import TrainModel
         
         import_time = time.time() - start_time
         
@@ -44,7 +43,7 @@ class TestLazyImports(unittest.TestCase):
             f"Import took {import_time:.3f}s, exceeds 200ms target")
         
         # Heavy deps should NOT be in globals yet
-        import praisonai.praisonai.train.llm.trainer as trainer_module
+        import praisonai.train.llm.trainer as trainer_module
         trainer_globals = dir(trainer_module)
         
         # These should not be available until _lazy_import_training_deps() is called
@@ -57,7 +56,7 @@ class TestLazyImports(unittest.TestCase):
         """Smoke test: upload_vision module imports quickly without heavy deps."""
         # Remove any cached imports
         modules_to_remove = [
-            'praisonai.praisonai.upload_vision',
+            'praisonai.upload_vision',
             'torch', 'unsloth'
         ]
         for module in modules_to_remove:
@@ -67,7 +66,7 @@ class TestLazyImports(unittest.TestCase):
         start_time = time.time()
         
         # Import should be fast
-        from praisonai.praisonai.upload_vision import UploadVisionModel
+        from praisonai.upload_vision import UploadVisionModel
         
         import_time = time.time() - start_time
         
@@ -98,7 +97,7 @@ class TestLazyImports(unittest.TestCase):
                 # Mock yaml.safe_load to avoid needing actual config file
                 with mock.patch('yaml.safe_load', return_value={'model_name': 'test'}):
                     with mock.patch('builtins.open', mock.mock_open(read_data='model_name: test')):
-                        from praisonai.praisonai.train.llm.trainer import TrainModel
+                        from praisonai.train.llm.trainer import TrainModel
                         
                         # Creating instance should trigger lazy import
                         trainer = TrainModel()
@@ -119,7 +118,7 @@ class TestLazyImports(unittest.TestCase):
         }):
             # Mock the specific classes that would be imported
             with mock.patch('unsloth.FastVisionModel', mock_FastVisionModel):
-                from praisonai.praisonai.upload_vision import UploadVisionModel
+                from praisonai.upload_vision import UploadVisionModel
                 
                 # Creating instance should trigger lazy import and succeed
                 vision_model = UploadVisionModel()
@@ -130,7 +129,7 @@ class TestLazyImports(unittest.TestCase):
         # Mock missing dependencies
         with mock.patch.dict('sys.modules', {}, clear=True):
             with mock.patch('builtins.__import__', side_effect=ImportError("torch not found")):
-                from praisonai.praisonai.train.llm.trainer import TrainModel
+                from praisonai.train.llm.trainer import TrainModel
                 
                 with mock.patch('yaml.safe_load', return_value={'model_name': 'test'}):
                     with mock.patch('builtins.open', mock.mock_open(read_data='model_name: test')):
@@ -150,7 +149,7 @@ class TestLazyImports(unittest.TestCase):
         # Mock missing dependencies
         with mock.patch.dict('sys.modules', {}, clear=True):
             with mock.patch('builtins.__import__', side_effect=ImportError("unsloth not found")):
-                from praisonai.praisonai.upload_vision import UploadVisionModel
+                from praisonai.upload_vision import UploadVisionModel
                 
                 # Should raise ImportError with helpful message
                 with self.assertRaises(ImportError) as context:

--- a/src/praisonai/tests/unit/test_profiler.py
+++ b/src/praisonai/tests/unit/test_profiler.py
@@ -4,7 +4,6 @@ Unit tests for PraisonAI Profiler module.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import time
 
 

--- a/src/praisonai/tests/unit/test_profiler_advanced.py
+++ b/src/praisonai/tests/unit/test_profiler_advanced.py
@@ -13,7 +13,6 @@ TDD: Tests written first for new profiling capabilities:
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import time
 import asyncio
 import pytest

--- a/src/praisonai/tests/unit/test_query_rewriter_cli.py
+++ b/src/praisonai/tests/unit/test_query_rewriter_cli.py
@@ -6,7 +6,6 @@ Run with: python -m pytest tests/unit/test_query_rewriter_cli.py -v
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 from unittest.mock import patch, MagicMock
 import argparse
 

--- a/src/praisonai/tests/unit/test_security_fixes_core.py
+++ b/src/praisonai/tests/unit/test_security_fixes_core.py
@@ -6,7 +6,6 @@ Tests the critical security fixes implemented for issue #1869 using minimal depe
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import os
 import tempfile
 import pytest

--- a/src/praisonai/tests/unit/test_serve_unified.py
+++ b/src/praisonai/tests/unit/test_serve_unified.py
@@ -7,7 +7,6 @@ under the `praisonai serve` namespace.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 from typer.testing import CliRunner
 
 runner = CliRunner()

--- a/src/praisonai/tests/unit/test_serverless_postgres.py
+++ b/src/praisonai/tests/unit/test_serverless_postgres.py
@@ -7,7 +7,6 @@ These are mock-based — no live database needed.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import sys
 import os
 import time

--- a/src/praisonai/tests/unit/test_tool_resolver.py
+++ b/src/praisonai/tests/unit/test_tool_resolver.py
@@ -9,7 +9,6 @@ from multiple sources:
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import time
 
 

--- a/src/praisonai/tests/unit/test_warm_runtime.py
+++ b/src/praisonai/tests/unit/test_warm_runtime.py
@@ -7,7 +7,6 @@ stdlib HTTP runtime server using a stubbed warm agent.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import os
 import threading
 import time

--- a/src/praisonai/tests/unit/test_yaml_cli_backend.py
+++ b/src/praisonai/tests/unit/test_yaml_cli_backend.py
@@ -7,7 +7,6 @@ exercising unrelated framework code paths.
 
 import pytest
 
-pytestmark = pytest.mark.skip(reason="Legacy unit test pending Core Tests gate update")
 import logging
 import yaml
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary

- Cherry-picks `81b954571` (multiline code pyproject bump regex + standalone wrapper-cmd gate)
- Adds [C6_VERIFICATION.md](src/praisonai/tests/C6_VERIFICATION.md) with full #2519 matrix results
- Re-enables 27 legacy unit test files (376/431 pass; 55 need post-C6 API drift fixes)
- Fixes `test_real_key_smoke.py` (`verbose` removal + network/provider gate docs)
- Extends `ProfilerCompat` delegation for advanced profiler tests
- Updates AGENTS.md §2.3 C6 gate, `praisonai-code` README, install action description
- Adds `bump_and_release.py --wait-code` and code-package lock validation

## Verification (#2519)

| Check | Result |
|-------|--------|
| Smoke `--help` + live LLM prompt | PASS |
| `test_c5_backward_compat.py` | PASS |
| `test_warm_runtime.py` | 21/21 |
| `test_performance_benchmarks.py` | 11/11 |
| `test_real_key_smoke.py` | 9/9 |
| `import praisonai` | ~2ms |
| Gateway imports on agentic path | 0 |

## CI triage

Latest `main` smoke job cancelled (5m timeout), not C6 regression. Local shards above pass.

## C7 deferred

Wrapper-required install documented; ~170 `praisonai-code` → `praisonai` reverse imports remain.

Closes #2519
Closes #2512

## Test plan

- [x] C6 verification matrix (see C6_VERIFICATION.md)
- [x] Real API key smoke (gated)
- [ ] CI smoke on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced profiling with richer statistics, line-level data, and new export options (JSON/HTML and flamegraph output).
  * CLI now hides wrapper-only commands when the wrapper package isn’t available.
* **Bug Fixes**
  * Improved release/publish automation and version replacement for more reliable packaging and install order.
* **Documentation**
  * Updated install guidance, migration/checklist status, and integration-gate verification details.
* **Tests**
  * Re-enabled previously skipped unit/integration test coverage across multiple modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->