### PR TITLE
fix(parity): apply Python doc aliases only for Python parity

### DIFF
--- a/src/praisonai-agents/DOCS_PARITY.md
+++ b/src/praisonai-agents/DOCS_PARITY.md
@@ -21,13 +21,13 @@ This report compares **Python SDK feature categories** against **Python document
 | ✅ Agent | 21 | 43 | 11893 |
 | ✅ Agent-to-Agent (A2A) | 1 | 7 | 2927 |
 | ✅ Agent-to-User (A2U) | 1 | 3 | 573 |
-| ✅ Approval | 1 | 4 | 1856 |
+| ✅ Approval | 1 | 5 | 2055 |
 | ✅ Audio | 2 | 10 | 645 |
 | ✅ Auto Generation | 5 | 7 | 2032 |
 | ✅ Autonomy | 3 | 6 | 2148 |
-| ✅ Bots | 7 | 24 | 8439 |
+| ✅ Bots | 7 | 24 | 8449 |
 | ✅ Budget | 1 | 1 | 287 |
-| ✅ CLI | 5 | 111 | 28209 |
+| ✅ CLI | 5 | 111 | 28280 |
 | ✅ Chunking | 2 | 2 | 339 |
 | ✅ Citations | 2 | 1 | 202 |
 | ✅ Code Execution | 2 | 13 | 3739 |
@@ -44,13 +44,13 @@ This report compares **Python SDK feature categories** against **Python document
 | ✅ Failover | 2 | 1 | 398 |
 | ✅ Files | 2 | 6 | 1801 |
 | ✅ Flow | 1 | 3 | 777 |
-| ✅ Gateway | 7 | 36 | 12924 |
+| ✅ Gateway | 7 | 36 | 12942 |
 | ✅ Guardrails | 4 | 4 | 1634 |
 | ✅ Handoffs | 11 | 6 | 2596 |
-| ✅ Hooks | 2 | 9 | 3475 |
+| ✅ Hooks | 2 | 9 | 3484 |
 | ✅ Image | 1 | 11 | 1103 |
 | ✅ Knowledge | 4 | 12 | 3643 |
-| ✅ LLM | 3 | 11 | 4026 |
+| ✅ LLM | 3 | 12 | 4229 |
 | ✅ Loops | 4 | 3 | 774 |
 | ✅ MCP | 1 | 52 | 11137 |
 | ✅ Memory | 6 | 17 | 6136 |
@@ -76,9 +76,9 @@ This report compares **Python SDK feature categories** against **Python document
 | ✅ Tasks | 2 | 6 | 2703 |
 | ✅ Telemetry | 1 | 2 | 572 |
 | ✅ Templates | 1 | 8 | 1653 |
-| ✅ Tools | 12 | 123 | 30337 |
+| ✅ Tools | 12 | 125 | 30756 |
 | ✅ Tracing | 3 | 2 | 139 |
-| ✅ Vector Store | 1 | 12 | 1114 |
+| ✅ Vector Store | 1 | 12 | 1137 |
 | ✅ Video | 2 | 6 | 510 |
 | ✅ Vision | 2 | 1 | 283 |
 | ✅ Web | 3 | 8 | 1897 |

--- a/src/praisonai-rust/DOCS_PARITY.md
+++ b/src/praisonai-rust/DOCS_PARITY.md
@@ -1,6 +1,6 @@
 # Documentation Parity Tracker (Rust)
 
-> **Categories:** 68 | **Documented:** 64 | **Parity:** 94.1%
+> **Categories:** 68 | **Documented:** 68 | **Parity:** 100.0%
 
 This report compares **Rust SDK feature categories** against **Rust documentation** (docs/rust/).
 
@@ -9,9 +9,9 @@ This report compares **Rust SDK feature categories** against **Rust documentatio
 | Metric | Count |
 |--------|-------|
 | Feature Categories | 68 |
-| **Documented Categories** | **64** |
-| **Undocumented Categories** | **4** |
-| **Parity** | **94.1%** |
+| **Documented Categories** | **68** |
+| **Undocumented Categories** | **0** |
+| **Parity** | **100.0%** |
 
 ## Documented Categories
 
@@ -26,12 +26,13 @@ This report compares **Rust SDK feature categories** against **Rust documentatio
 | ✅ Autonomy | 4 | 1 | 161 |
 | ✅ Bots | 10 | 1 | 66 |
 | ✅ Budget | 2 | 1 | 76 |
+| ✅ Callbacks | 1 | 1 | 178 |
 | ✅ Chunking | 3 | 1 | 103 |
 | ✅ Citations | 2 | 1 | 71 |
 | ✅ Code Execution | 5 | 1 | 104 |
 | ✅ Conditions | 1 | 1 | 132 |
 | ✅ Configuration | 2 | 1 | 130 |
-| ✅ Context Management | 21 | 2 | 272 |
+| ✅ Context Management | 21 | 1 | 83 |
 | ✅ Criteria | 4 | 1 | 70 |
 | ✅ Database | 2 | 1 | 198 |
 | ✅ Display | 12 | 1 | 64 |
@@ -46,10 +47,10 @@ This report compares **Rust SDK feature categories** against **Rust documentatio
 | ✅ Gateway | 8 | 1 | 76 |
 | ✅ Guardrails | 10 | 1 | 291 |
 | ✅ Handoffs | 13 | 1 | 276 |
-| ✅ Hooks | 12 | 2 | 517 |
+| ✅ Hooks | 12 | 1 | 339 |
 | ✅ Image | 4 | 1 | 85 |
 | ✅ Knowledge | 12 | 1 | 146 |
-| ✅ LLM | 10 | 2 | 279 |
+| ✅ LLM | 10 | 1 | 151 |
 | ✅ Loops | 7 | 1 | 134 |
 | ✅ MCP | 11 | 1 | 196 |
 | ✅ Memory | 11 | 1 | 273 |
@@ -59,6 +60,7 @@ This report compares **Rust SDK feature categories** against **Rust documentatio
 | ✅ Parallel Execution | 4 | 1 | 115 |
 | ✅ Planning | 10 | 1 | 193 |
 | ✅ Plugins | 11 | 1 | 62 |
+| ✅ Process | 2 | 1 | 257 |
 | ✅ Prompts | 4 | 1 | 80 |
 | ✅ Providers | 3 | 1 | 74 |
 | ✅ Query | 5 | 1 | 57 |
@@ -71,25 +73,18 @@ This report compares **Rust SDK feature categories** against **Rust documentatio
 | ✅ Security | 2 | 1 | 74 |
 | ✅ Sessions | 7 | 1 | 169 |
 | ✅ Skills | 5 | 1 | 66 |
+| ✅ Streaming | 6 | 1 | 128 |
 | ✅ Tasks | 8 | 1 | 68 |
 | ✅ Telemetry | 4 | 1 | 104 |
 | ✅ Templates | 1 | 1 | 66 |
+| ✅ Token Management | 2 | 1 | 189 |
 | ✅ Tools | 16 | 1 | 334 |
 | ✅ Tracing | 8 | 1 | 310 |
 | ✅ Vector Store | 2 | 1 | 222 |
 | ✅ Video | 5 | 1 | 60 |
 | ✅ Vision | 3 | 1 | 65 |
 | ✅ Web | 5 | 2 | 185 |
-| ✅ Workflows | 5 | 2 | 326 |
-
-## Undocumented Categories (Need Documentation)
-
-| Category | Features |
-|----------|----------|
-| ❌ Callbacks | 1 |
-| ❌ Process | 2 |
-| ❌ Streaming | 6 |
-| ❌ Token Management | 2 |
+| ✅ Workflows | 5 | 1 | 69 |
 
 ## Documentation Without Features
 

--- a/src/praisonai-ts/DOCS_PARITY.md
+++ b/src/praisonai-ts/DOCS_PARITY.md
@@ -1,6 +1,6 @@
 # Documentation Parity Tracker (TypeScript/JavaScript)
 
-> **Categories:** 75 | **Documented:** 69 | **Parity:** 92.0%
+> **Categories:** 75 | **Documented:** 75 | **Parity:** 100.0%
 
 This report compares **TypeScript/JavaScript SDK feature categories** against **TypeScript/JavaScript documentation** (docs/js/).
 
@@ -9,15 +9,16 @@ This report compares **TypeScript/JavaScript SDK feature categories** against **
 | Metric | Count |
 |--------|-------|
 | Feature Categories | 75 |
-| **Documented Categories** | **69** |
-| **Undocumented Categories** | **6** |
-| **Parity** | **92.0%** |
+| **Documented Categories** | **75** |
+| **Undocumented Categories** | **0** |
+| **Parity** | **100.0%** |
 
 ## Documented Categories
 
 | Category | Features | Docs | Lines |
 |----------|----------|------|-------|
 | ✅ AGUI | 1 | 1 | 195 |
+| ✅ AI SDK | 38 | 8 | 1112 |
 | ✅ Agent | 66 | 7 | 2084 |
 | ✅ Agent-to-Agent (A2A) | 15 | 1 | 342 |
 | ✅ Approval | 9 | 1 | 165 |
@@ -33,7 +34,7 @@ This report compares **TypeScript/JavaScript SDK feature categories** against **
 | ✅ Code Execution | 6 | 4 | 464 |
 | ✅ Conditions | 1 | 1 | 372 |
 | ✅ Configuration | 3 | 1 | 272 |
-| ✅ Context Management | 17 | 3 | 504 |
+| ✅ Context Management | 17 | 2 | 345 |
 | ✅ Criteria | 1 | 1 | 162 |
 | ✅ Database | 14 | 2 | 469 |
 | ✅ Display | 20 | 1 | 342 |
@@ -47,13 +48,15 @@ This report compares **TypeScript/JavaScript SDK feature categories** against **
 | ✅ Gateway | 6 | 1 | 401 |
 | ✅ Guardrails | 6 | 3 | 744 |
 | ✅ Handoffs | 12 | 1 | 179 |
-| ✅ Hooks | 8 | 3 | 572 |
+| ✅ Hooks | 8 | 1 | 199 |
 | ✅ Image | 4 | 2 | 282 |
+| ✅ Jobs | 8 | 1 | 156 |
 | ✅ Knowledge | 3 | 2 | 312 |
-| ✅ LLM | 6 | 4 | 668 |
+| ✅ LLM | 6 | 2 | 279 |
 | ✅ Loops | 11 | 1 | 180 |
 | ✅ MCP | 17 | 4 | 828 |
 | ✅ Memory | 17 | 4 | 779 |
+| ✅ Middleware | 2 | 1 | 162 |
 | ✅ OCR | 2 | 1 | 162 |
 | ✅ Observability | 6 | 28 | 2277 |
 | ✅ Optimizer | 1 | 1 | 162 |
@@ -71,37 +74,30 @@ This report compares **TypeScript/JavaScript SDK feature categories** against **
 | ✅ Retrieval | 5 | 1 | 150 |
 | ✅ Routing | 1 | 1 | 153 |
 | ✅ Sandbox | 8 | 2 | 134 |
+| ✅ Scheduler | 2 | 2 | 398 |
 | ✅ Security | 2 | 1 | 157 |
 | ✅ Sessions | 3 | 2 | 429 |
 | ✅ Skills | 7 | 2 | 380 |
+| ✅ Streaming | 2 | 2 | 389 |
 | ✅ Tasks | 4 | 1 | 165 |
 | ✅ Teams | 1 | 1 | 170 |
 | ✅ Telemetry | 6 | 2 | 269 |
 | ✅ Templates | 1 | 2 | 598 |
-| ✅ Tools | 34 | 17 | 3598 |
+| ✅ Token Management | 1 | 1 | 159 |
+| ✅ Tools | 34 | 15 | 3200 |
 | ✅ Tracing | 8 | 3 | 477 |
 | ✅ Vector Store | 6 | 2 | 530 |
 | ✅ Video | 2 | 1 | 150 |
 | ✅ Vision | 2 | 1 | 155 |
 | ✅ Voice | 1 | 2 | 515 |
 | ✅ Web | 4 | 1 | 150 |
-| ✅ Workflows | 7 | 4 | 876 |
-
-## Undocumented Categories (Need Documentation)
-
-| Category | Features |
-|----------|----------|
-| ❌ AI SDK | 38 |
-| ❌ Jobs | 8 |
-| ❌ Middleware | 2 |
-| ❌ Scheduler | 2 |
-| ❌ Streaming | 2 |
-| ❌ Token Management | 1 |
+| ✅ Workflows | 7 | 3 | 720 |
 
 ## Documentation Without Features
 
 These docs exist but don't match any implemented feature category:
 
+- ℹ️ Callbacks (1 docs, 211 lines)
 - ℹ️ Deep Research (2 docs, 292 lines)
 
 ---

--- a/src/praisonai/praisonai/_dev/parity/docs_generator.py
+++ b/src/praisonai/praisonai/_dev/parity/docs_generator.py
@@ -376,7 +376,9 @@ class DocsParityGenerator:
     def _calculate_category_parity(
         self,
         feature_groups: Dict[str, List[str]],
-        doc_groups: Dict[str, tuple[List[str], int]]
+        doc_groups: Dict[str, tuple[List[str], int]],
+        *,
+        apply_python_doc_rules: bool = False,
     ) -> tuple[DocsParitySummary, List[CategoryParity]]:
         """Calculate parity at category level, grouped by display name."""
         # Convert prefix-based groups to display-name-based groups
@@ -397,9 +399,10 @@ class DocsParityGenerator:
                 if prefix == 'other':
                     continue
                 display_name = FEATURE_CATEGORIES.get(prefix, prefix.title())
-                if display_name in PYTHON_DOC_ORPHAN_EXCLUSIONS:
-                    continue
-                display_name = DOC_FEATURE_CATEGORY_ALIASES.get(display_name, display_name)
+                if apply_python_doc_rules:
+                    if display_name in PYTHON_DOC_ORPHAN_EXCLUSIONS:
+                        continue
+                    display_name = DOC_FEATURE_CATEGORY_ALIASES.get(display_name, display_name)
                 if display_name not in result:
                     result[display_name] = ([], 0)
                 existing_names, existing_lines = result[display_name]
@@ -465,7 +468,9 @@ class DocsParityGenerator:
         doc_groups = self._group_docs(docs)
         
         # Calculate parity
-        summary, categories = self._calculate_category_parity(feature_groups, doc_groups)
+        summary, categories = self._calculate_category_parity(
+            feature_groups, doc_groups, apply_python_doc_rules=True
+        )
         
         # Build category lists - stubs are separate from documented
         documented = [c for c in categories if c.has_features and c.has_docs and not c.is_stub]


### PR DESCRIPTION
## Summary

- Scope `DOC_FEATURE_CATEGORY_ALIASES` and `PYTHON_DOC_ORPHAN_EXCLUSIONS` to Python parity only so TypeScript/Rust doc pages match their own feature categories.
- Regenerate in-repo `DOCS_PARITY.md` files for agents, praisonai-ts, and praisonai-rust.

Fixes false negatives reported in PraisonAIDocs #1374 (pages exist but trackers marked categories undocumented).

## Test plan

- [x] `python3 src/praisonai/scripts/generate_docs_parity.py --docs-root ~/PraisonAIDocs/docs --repo-root . --copy-docs`
- [x] JS/Rust trackers show 100% parity; Python remains 100%


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation parity reports to show full coverage across Python, Rust, and TypeScript.
  * Several category counts and line totals were refreshed to match the latest documentation status.

* **Bug Fixes**
  * Improved parity calculations so language-specific documentation rules are applied consistently.
  * Removed outdated “missing documentation” sections where coverage is now complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->