### PR TITLE
C7.1: formalise package boundaries and wrapper bridge hardening

### DIFF
--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -80,6 +80,7 @@ jobs:
         set -euo pipefail
         cd src/praisonai
         python -m pytest tests/unit/test_c5_backward_compat.py \
+          tests/unit/test_c7_1_boundaries.py \
           -q --tb=line --timeout=30 --maxfail=5
         python -m pytest tests/unit/cli/ \
           -m "not slow and not network" \

--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -124,7 +124,7 @@ jobs:
           fi
         done
         echo "C7 hot-path import gate ok"
-        bash scripts/check_c7_imports.sh
+        bash "$GITHUB_WORKSPACE/scripts/check_c7_imports.sh"
         # Standalone run must not fail on wrapper ImportError (API auth failure is OK)
         set +e
         RUN_OUT=$(/tmp/praisonai-code-standalone/bin/praisonai-code run "Say hello in one word" 2>&1)

--- a/scripts/c7_wrapper_import_allowlist.txt
+++ b/scripts/c7_wrapper_import_allowlist.txt
@@ -1,0 +1,59 @@
+# Files allowed to contain lazy ``from praisonai.*`` imports in praisonai-code.
+# New direct imports require review; prefer praisonai_code._wrapper_bridge.
+# Regenerate counts: bash scripts/check_c7_imports.sh
+#
+# Format: path  # reason (approx line count after C7.1)
+
+cli/main.py  # legacy argparse, auto, agents_generator (wrapper-enhanced)
+cli/features/capabilities.py  # bridged via _cap(); wrapper capabilities endpoints
+cli/features/recipe.py  # recipe runner (wrapper integrations)
+cli/features/templates.py  # template store in wrapper
+cli/commands/serve.py  # hybrid; gateway serve subpaths need wrapper
+cli/commands/train.py  # training uses wrapper capabilities
+cli/commands/docs.py  # docs server wrapper paths
+cli/commands/replay.py  # trace replay wrapper
+cli/features/deploy.py  # deployment integrations
+cli/commands/standardise.py  # migration tooling
+cli/commands/schedule.py  # scheduler wrapper
+cli/commands/n8n.py  # n8n integration
+cli/commands/examples.py  # example runners
+cli/features/persistence.py  # persistence backends
+cli/commands/langfuse.py  # observability
+cli/commands/flow.py  # Langflow
+cli/features/doctor/checks/gateway_checks.py  # bridged; bot/gateway doctor
+cli/features/doctor/checks/bot_checks.py  # bridged; bot doctor
+cli/features/doctor/checks/serve_checks.py  # serve doctor
+cli/features/doctor/checks/runtime_checks.py  # bridged framework registry
+cli/features/doctor/checks/config_checks.py  # bridged framework registry
+cli/features/recipe_creator.py  # bridged auto constants
+cli/features/recipe_optimizer.py  # recipe tooling
+cli/interactive/async_tui.py  # interactive wrapper hooks
+cli/commands/replay.py  # context trace writer
+cli/commands/mcp.py  # MCP server management
+cli/commands/validate.py  # validation against wrapper schemas
+cli/commands/context.py  # context features
+cli/commands/batch.py  # batch runner
+cli/features/agent_scheduler.py  # scheduler integration
+cli/features/eval.py  # eval harness
+cli/features/tools.py  # tool discovery
+cli/features/sandbox_cli.py  # sandbox wrapper
+cli/features/registry.py  # plugin registry wrapper
+cli/features/ollama.py  # ollama wrapper
+cli/features/workflow.py  # workflow wrapper
+cli/features/tui/app.py  # TUI wrapper hooks
+cli/features/interactive_runtime.py  # runtime bridge
+cli/features/endpoints.py  # API endpoints
+cli/features/background.py  # background jobs
+cli/features/agent_tools.py  # agent tools wrapper
+cli/features/acp.py  # ACP wrapper
+cli/commands/rag.py  # RAG server
+cli/commands/realtime.py  # realtime API
+cli/commands/knowledge.py  # knowledge CLI
+cli/commands/langextract.py  # langextract
+cli/commands/profile.py  # profiler
+cli/commands/recipe.py  # recipe command
+cli/commands/audit.py  # audit
+cli/interactive/core.py  # interactive core
+cli/commands/batch.py  # batch
+_version.py  # optional wrapper version fallback
+cli/langfuse_client.py  # langfuse shim path

--- a/scripts/c7_wrapper_import_allowlist.txt
+++ b/scripts/c7_wrapper_import_allowlist.txt
@@ -46,5 +46,8 @@ cli/commands/profile.py  # profiler
 cli/commands/recipe.py  # recipe command
 cli/commands/audit.py  # audit
 cli/interactive/core.py  # interactive core
+cli/commands/managed.py  # managed deployment (wrapper integrations)
+cli/commands/app.py  # legacy app launcher (wrapper-enhanced)
+cli/features/doctor/checks/performance_checks.py  # perf checks probe wrapper import cost
 _version.py  # optional wrapper version fallback
 cli/langfuse_client.py  # langfuse shim path

--- a/scripts/c7_wrapper_import_allowlist.txt
+++ b/scripts/c7_wrapper_import_allowlist.txt
@@ -5,7 +5,6 @@
 # Format: path  # reason (approx line count after C7.1)
 
 cli/main.py  # legacy argparse, auto, agents_generator (wrapper-enhanced)
-cli/features/capabilities.py  # bridged via _cap(); wrapper capabilities endpoints
 cli/features/recipe.py  # recipe runner (wrapper integrations)
 cli/features/templates.py  # template store in wrapper
 cli/commands/serve.py  # hybrid; gateway serve subpaths need wrapper
@@ -20,15 +19,8 @@ cli/commands/examples.py  # example runners
 cli/features/persistence.py  # persistence backends
 cli/commands/langfuse.py  # observability
 cli/commands/flow.py  # Langflow
-cli/features/doctor/checks/gateway_checks.py  # bridged; bot/gateway doctor
-cli/features/doctor/checks/bot_checks.py  # bridged; bot doctor
-cli/features/doctor/checks/serve_checks.py  # serve doctor
-cli/features/doctor/checks/runtime_checks.py  # bridged framework registry
-cli/features/doctor/checks/config_checks.py  # bridged framework registry
-cli/features/recipe_creator.py  # bridged auto constants
 cli/features/recipe_optimizer.py  # recipe tooling
 cli/interactive/async_tui.py  # interactive wrapper hooks
-cli/commands/replay.py  # context trace writer
 cli/commands/mcp.py  # MCP server management
 cli/commands/validate.py  # validation against wrapper schemas
 cli/commands/context.py  # context features
@@ -54,6 +46,5 @@ cli/commands/profile.py  # profiler
 cli/commands/recipe.py  # recipe command
 cli/commands/audit.py  # audit
 cli/interactive/core.py  # interactive core
-cli/commands/batch.py  # batch
 _version.py  # optional wrapper version fallback
 cli/langfuse_client.py  # langfuse shim path

--- a/scripts/check_c7_imports.sh
+++ b/scripts/check_c7_imports.sh
@@ -3,12 +3,12 @@
 set -euo pipefail
 
 ROOT="${1:-src/praisonai-code/praisonai_code}"
-cd "$(dirname "$0")/.."
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Module-level hot path: praisonai wrapper only (not praisonaiagents / praisonai_code).
 HOT_PATH_RE='^from praisonai([[:space:]]|\.|$)|^import praisonai([[:space:]]|\.|$)'
 # Line-level wrapper imports (exclude praisonaiagents, praisonai_code, praisonai-tools).
-ANY_WRAPPER_RE='(^\s*from praisonai\.|^import praisonai($|\.))'
+ANY_WRAPPER_RE='(^[[:space:]]*from praisonai([[:space:]]|\.)|^import praisonai($|\.))'
 ALLOWLIST="scripts/c7_wrapper_import_allowlist.txt"
 
 echo "== C7 hot-path module-level gate =="
@@ -41,7 +41,7 @@ done
 echo "strict hot-path gate ok"
 
 echo "== C7 regression baseline (total wrapper import lines) =="
-BASELINE="${C7_WRAPPER_IMPORT_BASELINE:-211}"
+BASELINE="${C7_WRAPPER_IMPORT_BASELINE:-225}"
 # Count wrapper import lines with a portable tool. Prefer ripgrep when present
 # (fast, respects the same regex) and fall back to POSIX grep -r otherwise, so
 # the gate does not exit 127 on runners without rg. The `|| true` keeps a

--- a/scripts/check_c7_imports.sh
+++ b/scripts/check_c7_imports.sh
@@ -42,7 +42,15 @@ echo "strict hot-path gate ok"
 
 echo "== C7 regression baseline (total wrapper import lines) =="
 BASELINE="${C7_WRAPPER_IMPORT_BASELINE:-211}"
-COUNT="$(rg -c "$ANY_WRAPPER_RE" "$ROOT" --glob '*.py' 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')"
+# Count wrapper import lines with a portable tool. Prefer ripgrep when present
+# (fast, respects the same regex) and fall back to POSIX grep -r otherwise, so
+# the gate does not exit 127 on runners without rg. The `|| true` keeps a
+# no-match (grep/rg exit 1) from aborting the script under `set -o pipefail`.
+if command -v rg >/dev/null 2>&1; then
+  COUNT="$( { rg -c "$ANY_WRAPPER_RE" "$ROOT" --glob '*.py' 2>/dev/null || true; } | awk -F: '{s+=$2} END {print s+0}')"
+else
+  COUNT="$( { grep -rEc --include='*.py' "$ANY_WRAPPER_RE" "$ROOT" 2>/dev/null || true; } | awk -F: '{s+=$2} END {print s+0}')"
+fi
 echo "wrapper import lines: $COUNT (baseline $BASELINE)"
 if [ "$COUNT" -gt "$BASELINE" ]; then
   echo "FAIL: wrapper import count regressed above baseline ($COUNT > $BASELINE)"

--- a/scripts/check_c7_imports.sh
+++ b/scripts/check_c7_imports.sh
@@ -58,6 +58,29 @@ if [ "$COUNT" -gt "$BASELINE" ]; then
 fi
 echo "regression baseline ok"
 
+echo "== C7 allowlist enforcement =="
 if [ -f "$ALLOWLIST" ]; then
-  echo "== C7 allowlist present: $ALLOWLIST =="
+  # Files (relative to $ROOT) that carry wrapper imports.
+  if command -v rg >/dev/null 2>&1; then
+    OFFENDERS="$( { rg -l "$ANY_WRAPPER_RE" "$ROOT" --glob '*.py' 2>/dev/null || true; } )"
+  else
+    OFFENDERS="$( { grep -rlE --include='*.py' "$ANY_WRAPPER_RE" "$ROOT" 2>/dev/null || true; } )"
+  fi
+  # Strip the reasons/comments and blank/comment lines from the allowlist.
+  ALLOWED="$(sed -E 's/[[:space:]]*#.*$//; /^[[:space:]]*$/d' "$ALLOWLIST" | sed -E 's/[[:space:]]+$//')"
+  FAIL=0
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    rel="${f#"$ROOT/"}"
+    if ! printf '%s\n' "$ALLOWED" | grep -Fxq "$rel"; then
+      echo "FAIL: non-allowlisted wrapper import in $rel (add to $ALLOWLIST after review)"
+      FAIL=1
+    fi
+  done <<< "$OFFENDERS"
+  if [ "$FAIL" -ne 0 ]; then
+    exit 1
+  fi
+  echo "allowlist enforcement ok"
+else
+  echo "allowlist file missing: $ALLOWLIST (skipping enforcement)"
 fi

--- a/scripts/check_c7_imports.sh
+++ b/scripts/check_c7_imports.sh
@@ -5,8 +5,11 @@ set -euo pipefail
 ROOT="${1:-src/praisonai-code/praisonai_code}"
 cd "$(dirname "$0")/.."
 
+# Module-level hot path: praisonai wrapper only (not praisonaiagents / praisonai_code).
 HOT_PATH_RE='^from praisonai([[:space:]]|\.|$)|^import praisonai([[:space:]]|\.|$)'
-ANY_WRAPPER_RE='from praisonai\.|import praisonai[^_]'
+# Line-level wrapper imports (exclude praisonaiagents, praisonai_code, praisonai-tools).
+ANY_WRAPPER_RE='(^\s*from praisonai\.|^import praisonai($|\.))'
+ALLOWLIST="scripts/c7_wrapper_import_allowlist.txt"
 
 echo "== C7 hot-path module-level gate =="
 for f in \
@@ -38,7 +41,7 @@ done
 echo "strict hot-path gate ok"
 
 echo "== C7 regression baseline (total wrapper import lines) =="
-BASELINE="${C7_WRAPPER_IMPORT_BASELINE:-310}"
+BASELINE="${C7_WRAPPER_IMPORT_BASELINE:-211}"
 COUNT="$(rg -c "$ANY_WRAPPER_RE" "$ROOT" --glob '*.py' 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')"
 echo "wrapper import lines: $COUNT (baseline $BASELINE)"
 if [ "$COUNT" -gt "$BASELINE" ]; then
@@ -46,3 +49,7 @@ if [ "$COUNT" -gt "$BASELINE" ]; then
   exit 1
 fi
 echo "regression baseline ok"
+
+if [ -f "$ALLOWLIST" ]; then
+  echo "== C7 allowlist present: $ALLOWLIST =="
+fi

--- a/src/praisonai-agents/AGENTS.md
+++ b/src/praisonai-agents/AGENTS.md
@@ -189,7 +189,7 @@ C6 is the **sign-off step** after C0–C5 file moves: no further moves, only reg
 | `pip install praisonai-code` only | Yes — agentic hot path (`run`, `chat`, `code`, warm runtime) without wrapper import | No — wrapper-only commands hidden when `praisonai` absent |
 
 **C7 (hot path complete):** Core agentic CLI imports no longer require the `praisonai`
-wrapper at module level. Remaining lazy wrapper imports (~300+) are optional commands
+wrapper at module level. Remaining lazy wrapper imports (~211, regression-gated) are optional commands
 and features (train, capabilities, bots, framework adapters) — use
 `praisonai_code._wrapper_bridge` or `pip install praisonai`. See
 `src/praisonai/tests/C7_VERIFICATION.md`. CI gate: `scripts/check_c7_imports.sh`.

--- a/src/praisonai-agents/AGENTS.md
+++ b/src/praisonai-agents/AGENTS.md
@@ -194,6 +194,26 @@ and features (train, capabilities, bots, framework adapters) — use
 `praisonai_code._wrapper_bridge` or `pip install praisonai`. See
 `src/praisonai/tests/C7_VERIFICATION.md`. CI gate: `scripts/check_c7_imports.sh`.
 
+### 2.4 Package ownership (C7.1)
+
+| Tier | Package | Owns |
+|------|---------|------|
+| 1 | `praisonaiagents` | Agent, tools, memory, hooks, `frameworks/` protocols |
+| 2 | `praisonai-code` | `run`/`chat`/`code`, Typer, runtime, llm, tool resolution |
+| 3 | `praisonai` | Gateway, bots, `framework_adapters/`, capabilities, train, serve orchestration |
+
+**Cross-tier rule:** `praisonai-code` must not declare a PyPI dependency on `praisonai`. Use
+[`praisonai_code._wrapper_bridge`](../praisonai-code/praisonai_code/_wrapper_bridge.py) for lazy wrapper access.
+
+**framework_adapters:** protocols in SDK; registry + CrewAI/AutoGen/PraisonAI bodies stay in
+[`praisonai/framework_adapters/`](../praisonai/praisonai/framework_adapters/). Do not move to `praisonai-code`.
+
+**Typer `_WRAPPER_COMMANDS`:** only for commands whose implementation lives in the wrapper
+(`bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, `claw`). Commands
+implemented in `praisonai_code` (`train`, `serve`) stay local; bridge internal wrapper imports.
+
+Full boundary doc: [`src/praisonai/tests/C7.1_BOUNDARIES.md`](../praisonai/tests/C7.1_BOUNDARIES.md).
+
 ---
 
 ## 3. Core SDK Architecture (praisonaiagents)

--- a/src/praisonai-code/praisonai_code/_wrapper_bridge.py
+++ b/src/praisonai-code/praisonai_code/_wrapper_bridge.py
@@ -39,10 +39,15 @@ def get_wrapper_attr(module_name: str, attr: str) -> Any:
 
 
 def optional_wrapper_attr(module_name: str, attr: str, default: T | None = None) -> Any | T | None:
-    """Return a wrapper attribute when installed, else ``default``."""
+    """Return a wrapper attribute when installed, else ``default``.
+
+    Falls back to ``default`` when the wrapper package is missing (ImportError)
+    or when an installed wrapper module lacks the requested attribute
+    (AttributeError), so callers degrade gracefully in both cases.
+    """
     if not wrapper_available():
         return default
     try:
         return get_wrapper_attr(module_name, attr)
-    except ImportError:
+    except (ImportError, AttributeError):
         return default

--- a/src/praisonai-code/praisonai_code/cli/app.py
+++ b/src/praisonai-code/praisonai_code/cli/app.py
@@ -223,6 +223,9 @@ _LAZY_COMMANDS: Dict[str, Tuple[str, str, str]] = {
 # relative ``.commands.*`` path would resolve to ``praisonai_code`` where the
 # modules do not live. The import happens lazily at invocation time only, so
 # ``praisonai_code`` keeps no static dependency on ``praisonai``.
+# C7.1 audit: wrapper-resident Typer modules only (no praisonai_code.cli.commands.*
+# copy). Do NOT add train/serve here — their impl lives in praisonai_code; bridge
+# internal wrapper imports instead. mint_link is wrapper-only but not in Typer registry.
 _WRAPPER_COMMANDS = frozenset({
     "bot",
     "gateway",

--- a/src/praisonai-code/praisonai_code/cli/app.py
+++ b/src/praisonai-code/praisonai_code/cli/app.py
@@ -458,7 +458,8 @@ class LazyCommandGroup(TyperGroup):
             console = Console()
             
             try:
-                from praisonai import AgentOS
+                from praisonai_code._wrapper_bridge import get_wrapper_attr
+                AgentOS = get_wrapper_attr("praisonai", "AgentOS")
                 from praisonaiagents import AgentOSConfig
             except ImportError as e:
                 console.print(f"[red]Error importing AgentOS: {e}[/red]")

--- a/src/praisonai-code/praisonai_code/cli/features/capabilities.py
+++ b/src/praisonai-code/praisonai_code/cli/features/capabilities.py
@@ -9,6 +9,12 @@ import sys
 from typing import Optional, List
 
 
+def _cap(submodule: str, attr: str):
+    """Load a wrapper capabilities symbol (requires pip install praisonai)."""
+    from praisonai_code._wrapper_bridge import get_wrapper_attr
+    return get_wrapper_attr(f"praisonai.capabilities.{submodule}", attr)
+
+
 class CapabilitiesHandler:
     """Handler for capabilities CLI commands."""
     
@@ -50,9 +56,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.audio import transcribe
-        
+        transcribe = _cap("audio", "transcribe")
         try:
             result = transcribe(
                 audio=parsed.file,
@@ -93,9 +97,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.audio import speech
-        
+        speech = _cap("audio", "speech")
         try:
             result = speech(
                 text=parsed.text,
@@ -149,9 +151,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.images import image_generate
-        
+        image_generate = _cap("images", "image_generate")
         try:
             results = image_generate(
                 prompt=parsed.prompt,
@@ -184,9 +184,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.images import image_edit
-        
+        image_edit = _cap("images", "image_edit")
         try:
             results = image_edit(
                 image=parsed.image,
@@ -244,9 +242,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.files import file_create
-        
+        file_create = _cap("files", "file_create")
         try:
             result = file_create(
                 file=parsed.file,
@@ -273,9 +269,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.files import file_list
-        
+        file_list = _cap("files", "file_list")
         try:
             results = file_list(purpose=parsed.purpose)
             
@@ -300,9 +294,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.files import file_retrieve
-        
+        file_retrieve = _cap("files", "file_retrieve")
         try:
             result = file_retrieve(file_id=parsed.file_id)
             
@@ -327,9 +319,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.files import file_delete
-        
+        file_delete = _cap("files", "file_delete")
         try:
             result = file_delete(file_id=parsed.file_id)
             
@@ -389,9 +379,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.rerank import rerank
-        
+        rerank = _cap("rerank", "rerank")
         try:
             result = rerank(
                 query=parsed.query,
@@ -420,9 +408,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.moderations import moderate
-        
+        moderate = _cap("moderations", "moderate")
         try:
             text_input = " ".join(parsed.text)
             results = moderate(
@@ -454,9 +440,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.ocr import ocr
-        
+        ocr = _cap("ocr", "ocr")
         try:
             result = ocr(
                 document=parsed.document,
@@ -514,9 +498,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.batches import batch_create
-        
+        batch_create = _cap("batches", "batch_create")
         try:
             result = batch_create(
                 input_file_id=parsed.file_id,
@@ -534,8 +516,7 @@ class CapabilitiesHandler:
     @staticmethod
     def _handle_batches_list(args, remaining_args):
         """Handle: praisonai batches list"""
-        from praisonai.capabilities.batches import batch_list
-        
+        batch_list = _cap("batches", "batch_list")
         try:
             results = batch_list()
             
@@ -560,9 +541,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.batches import batch_retrieve
-        
+        batch_retrieve = _cap("batches", "batch_retrieve")
         try:
             result = batch_retrieve(batch_id=parsed.batch_id)
             
@@ -587,9 +566,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.batches import batch_cancel
-        
+        batch_cancel = _cap("batches", "batch_cancel")
         try:
             result = batch_cancel(batch_id=parsed.batch_id)
             
@@ -633,9 +610,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.vector_stores import vector_store_create
-        
+        vector_store_create = _cap("vector_stores", "vector_store_create")
         try:
             result = vector_store_create(
                 name=parsed.name,
@@ -663,9 +638,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.vector_stores import vector_store_search
-        
+        vector_store_search = _cap("vector_stores", "vector_store_search")
         try:
             result = vector_store_search(
                 vector_store_id=parsed.store_id,
@@ -719,9 +692,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.assistants import assistant_create
-        
+        assistant_create = _cap("assistants", "assistant_create")
         try:
             result = assistant_create(
                 name=parsed.name,
@@ -741,8 +712,7 @@ class CapabilitiesHandler:
     @staticmethod
     def _handle_assistants_list(args, remaining_args):
         """Handle: praisonai assistants list"""
-        from praisonai.capabilities.assistants import assistant_list
-        
+        assistant_list = _cap("assistants", "assistant_list")
         try:
             results = assistant_list()
             
@@ -790,9 +760,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.fine_tuning import fine_tuning_create
-        
+        fine_tuning_create = _cap("fine_tuning", "fine_tuning_create")
         try:
             result = fine_tuning_create(
                 training_file=parsed.file_id,
@@ -812,8 +780,7 @@ class CapabilitiesHandler:
     @staticmethod
     def _handle_fine_tuning_list(args, remaining_args):
         """Handle: praisonai fine-tuning list"""
-        from praisonai.capabilities.fine_tuning import fine_tuning_list
-        
+        fine_tuning_list = _cap("fine_tuning", "fine_tuning_list")
         try:
             results = fine_tuning_list()
             
@@ -846,9 +813,7 @@ class CapabilitiesHandler:
         if not parsed.prompt:
             print("Usage: praisonai completions <prompt> [options]")
             return 1
-        
-        from praisonai.capabilities.completions import chat_completion
-        
+        chat_completion = _cap("completions", "chat_completion")
         try:
             messages = []
             if parsed.system:
@@ -899,9 +864,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.messages import messages_create
-        
+        messages_create = _cap("messages", "messages_create")
         try:
             result = messages_create(
                 messages=[{"role": "user", "content": parsed.prompt}],
@@ -931,9 +894,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.messages import count_tokens
-        
+        count_tokens = _cap("messages", "count_tokens")
         try:
             result = count_tokens(
                 messages=[{"role": "user", "content": parsed.text}],
@@ -958,9 +919,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.guardrails import apply_guardrail
-        
+        apply_guardrail = _cap("guardrails", "apply_guardrail")
         try:
             result = apply_guardrail(
                 content=parsed.content,
@@ -994,9 +953,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.rag import rag_query
-        
+        rag_query = _cap("rag", "rag_query")
         try:
             result = rag_query(
                 query=parsed.query,
@@ -1028,9 +985,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.realtime import realtime_connect
-        
+        realtime_connect = _cap("realtime", "realtime_connect")
         try:
             if parsed.action == "connect":
                 session = realtime_connect(model=parsed.model)
@@ -1059,9 +1014,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.videos import video_generate
-        
+        video_generate = _cap("videos", "video_generate")
         try:
             result = video_generate(
                 prompt=parsed.prompt,
@@ -1089,9 +1042,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.a2a import a2a_send
-        
+        a2a_send = _cap("a2a", "a2a_send")
         try:
             result = a2a_send(
                 message=parsed.message,
@@ -1137,9 +1088,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(remaining_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.containers import container_create
-        
+        container_create = _cap("containers", "container_create")
         try:
             result = container_create(
                 image=parsed.image,
@@ -1173,9 +1122,7 @@ class CapabilitiesHandler:
                 parsed = parser.parse_args(action_args)
             except SystemExit:
                 return 1
-            
-            from praisonai.capabilities.container_files import container_file_read
-            
+            container_file_read = _cap("container_files", "container_file_read")
             try:
                 result = container_file_read(
                     container_id=parsed.container_id,
@@ -1201,9 +1148,7 @@ class CapabilitiesHandler:
                 parsed = parser.parse_args(action_args)
             except SystemExit:
                 return 1
-            
-            from praisonai.capabilities.container_files import container_file_list
-            
+            container_file_list = _cap("container_files", "container_file_list")
             try:
                 results = container_file_list(
                     container_id=parsed.container_id,
@@ -1238,8 +1183,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.passthrough import passthrough
+        passthrough = _cap("passthrough", "passthrough")
         import json
         
         try:
@@ -1273,9 +1217,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.responses import responses_create
-        
+        responses_create = _cap("responses", "responses_create")
         try:
             result = responses_create(
                 input=parsed.input,
@@ -1301,9 +1243,7 @@ class CapabilitiesHandler:
             parsed = parser.parse_args(unknown_args)
         except SystemExit:
             return 1
-        
-        from praisonai.capabilities.search import search
-        
+        search = _cap("search", "search")
         try:
             result = search(
                 query=parsed.query,

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/_wrapper_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/_wrapper_checks.py
@@ -29,3 +29,10 @@ def skip_if_no_wrapper(
         message="Install full wrapper: pip install praisonai",
         duration_ms=duration_ms,
     )
+
+
+def bots_config_schema():
+    """Load ``praisonai.bots._config_schema`` via the wrapper bridge."""
+    from praisonai_code._wrapper_bridge import import_wrapper_module
+
+    return import_wrapper_module("praisonai.bots._config_schema")

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/_wrapper_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/_wrapper_checks.py
@@ -1,0 +1,31 @@
+"""Shared helpers for doctor checks that require the praisonai wrapper."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from ..models import CheckResult, CheckStatus, CheckCategory
+
+
+def skip_if_no_wrapper(
+    check_id: str,
+    title: str,
+    *,
+    start: Optional[float] = None,
+    category: CheckCategory = CheckCategory.BOTS,
+) -> Optional[CheckResult]:
+    """Return a SKIP result when the full wrapper is not installed."""
+    from praisonai_code._wrapper_bridge import wrapper_available
+
+    if wrapper_available():
+        return None
+    duration_ms = (time.time() - start) * 1000 if start is not None else None
+    return CheckResult(
+        id=check_id,
+        title=title,
+        category=category,
+        status=CheckStatus.SKIP,
+        message="Install full wrapper: pip install praisonai",
+        duration_ms=duration_ms,
+    )

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/acp_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/acp_checks.py
@@ -8,6 +8,7 @@ import os
 
 from ..models import CheckCategory, CheckResult, CheckStatus
 from ..registry import register_check
+from ._wrapper_checks import skip_if_no_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -102,8 +103,12 @@ def check_acp_sdk(config=None) -> CheckResult:
 )
 def check_acp_server(config=None) -> CheckResult:
     """Check if ACP server can be imported."""
+    skipped = skip_if_no_wrapper("acp_server", "ACP Server Import", category=CheckCategory.TOOLS)
+    if skipped:
+        return skipped
     try:
-        from praisonai.acp import ACPServer  # noqa: F401
+        from praisonai_code._wrapper_bridge import get_wrapper_attr
+        get_wrapper_attr("praisonai.acp", "ACPServer")
         
         return CheckResult(
             id="acp_server",

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/bot_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/bot_checks.py
@@ -12,12 +12,7 @@ from typing import List
 
 from ..models import CheckResult, CheckStatus, CheckCategory, CheckSeverity, DoctorConfig
 from ..registry import register_check
-from ._wrapper_checks import skip_if_no_wrapper
-
-
-def _bots_config_schema():
-    from praisonai_code._wrapper_bridge import import_wrapper_module
-    return import_wrapper_module("praisonai.bots._config_schema")
+from ._wrapper_checks import skip_if_no_wrapper, bots_config_schema as _bots_config_schema
 
 
 @register_check(

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/bot_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/bot_checks.py
@@ -12,6 +12,12 @@ from typing import List
 
 from ..models import CheckResult, CheckStatus, CheckCategory, CheckSeverity, DoctorConfig
 from ..registry import register_check
+from ._wrapper_checks import skip_if_no_wrapper
+
+
+def _bots_config_schema():
+    from praisonai_code._wrapper_bridge import import_wrapper_module
+    return import_wrapper_module("praisonai.bots._config_schema")
 
 
 @register_check(
@@ -23,7 +29,7 @@ from ..registry import register_check
 )
 def check_bot_tokens(config: DoctorConfig) -> CheckResult:
     """Check bot token environment variables."""
-    from praisonai.cli._paths import resolve_bot_config_path
+    from praisonai_code.cli._paths import resolve_bot_config_path
     config_path = getattr(config, 'config_file', None) or resolve_bot_config_path("bot.yaml")
     token_vars = {
         "TELEGRAM_BOT_TOKEN": "Telegram",
@@ -64,7 +70,10 @@ def check_bot_tokens(config: DoctorConfig) -> CheckResult:
 def check_bot_config(config: DoctorConfig) -> CheckResult:
     """Check bot.yaml exists and is valid."""
     start = time.time()
-    from praisonai.cli._paths import resolve_bot_config_path
+    skipped = skip_if_no_wrapper("bot_config", "Bot Config", start=start)
+    if skipped:
+        return skipped
+    from praisonai_code.cli._paths import resolve_bot_config_path
     config_path = getattr(config, 'config_file', None) or resolve_bot_config_path("bot.yaml")
     if not os.path.exists(config_path):
         return CheckResult(
@@ -77,7 +86,7 @@ def check_bot_config(config: DoctorConfig) -> CheckResult:
             duration_ms=(time.time() - start) * 1000,
         )
     try:
-        from praisonai.bots._config_schema import load_and_validate_bot_yaml
+        load_and_validate_bot_yaml = _bots_config_schema().load_and_validate_bot_yaml
         load_and_validate_bot_yaml(config_path)
         return CheckResult(
             id="bot_config",
@@ -109,7 +118,10 @@ def check_bot_config(config: DoctorConfig) -> CheckResult:
 def check_bot_security(config: DoctorConfig) -> CheckResult:
     """Check bot security configuration for safe defaults."""
     start = time.time()
-    from praisonai.cli._paths import resolve_bot_config_path
+    skipped = skip_if_no_wrapper("bot_security", "Bot Security Config", start=start)
+    if skipped:
+        return skipped
+    from praisonai_code.cli._paths import resolve_bot_config_path
     config_path = getattr(config, 'config_file', None) or resolve_bot_config_path("bot.yaml")
     channel_warnings = []
     global_warnings = []
@@ -126,8 +138,7 @@ def check_bot_security(config: DoctorConfig) -> CheckResult:
         )
     
     try:
-        from praisonai.bots._config_schema import load_and_validate_bot_yaml
-        config = load_and_validate_bot_yaml(config_path)
+        config = _bots_config_schema().load_and_validate_bot_yaml(config_path)
         
         # Check for risky configurations across channels
         for channel_name, channel_config in config.channels.items():
@@ -210,7 +221,10 @@ def check_bot_security(config: DoctorConfig) -> CheckResult:
 def check_multi_channel_tokens(config: DoctorConfig) -> CheckResult:
     """Check multi-channel token configuration for duplicates and naming conventions."""
     start = time.time()
-    from praisonai.cli._paths import resolve_bot_config_path
+    skipped = skip_if_no_wrapper("multi_channel_tokens", "Multi-Channel Token Configuration", start=start)
+    if skipped:
+        return skipped
+    from praisonai_code.cli._paths import resolve_bot_config_path
     config_path = getattr(config, 'config_file', None) or resolve_bot_config_path("bot.yaml")
     
     # Check if bot.yaml exists
@@ -225,8 +239,7 @@ def check_multi_channel_tokens(config: DoctorConfig) -> CheckResult:
         )
     
     try:
-        from praisonai.bots._config_schema import load_and_validate_bot_yaml
-        config_data = load_and_validate_bot_yaml(config_path)
+        config_data = _bots_config_schema().load_and_validate_bot_yaml(config_path)
         
         warnings = []
         errors = []

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/config_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/config_checks.py
@@ -169,7 +169,10 @@ def check_agents_yaml_schema(config: DoctorConfig) -> CheckResult:
     if "framework" in data:
         framework = data["framework"]
         try:
-            from praisonai.framework_adapters.registry import get_default_registry
+            from praisonai_code._wrapper_bridge import import_wrapper_module
+            get_default_registry = import_wrapper_module(
+                "praisonai.framework_adapters.registry"
+            ).get_default_registry
             registered = get_default_registry().list_names()
             if framework not in registered:
                 warnings.append(f"Unknown framework: {framework} (registered: {', '.join(sorted(registered))})")

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/gateway_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/gateway_checks.py
@@ -12,6 +12,12 @@ from typing import List, Optional
 
 from ..models import CheckResult, CheckStatus, CheckCategory, CheckSeverity, DoctorConfig
 from ..registry import register_check
+from ._wrapper_checks import skip_if_no_wrapper
+
+
+def _bots_config_schema():
+    from praisonai_code._wrapper_bridge import import_wrapper_module
+    return import_wrapper_module("praisonai.bots._config_schema")
 
 
 @register_check(
@@ -24,6 +30,9 @@ from ..registry import register_check
 def check_gateway_config_validation(config: DoctorConfig) -> CheckResult:
     """Validate gateway/bot configuration using canonical schema."""
     start = time.time()
+    skipped = skip_if_no_wrapper("gateway_config_validation", "Gateway Config Validation", start=start)
+    if skipped:
+        return skipped
     
     # Check multiple possible config locations
     config_paths = []
@@ -31,7 +40,7 @@ def check_gateway_config_validation(config: DoctorConfig) -> CheckResult:
         config_paths.append(config.config_file)
     
     # Check common locations
-    from praisonai.cli._paths import resolve_bot_config_path
+    from praisonai_code.cli._paths import resolve_bot_config_path
     config_paths.extend([
         resolve_bot_config_path("gateway.yaml"),
         resolve_bot_config_path("bot.yaml"),
@@ -58,7 +67,7 @@ def check_gateway_config_validation(config: DoctorConfig) -> CheckResult:
         )
         
     try:
-        from praisonai.bots._config_schema import load_and_validate_gateway_yaml
+        load_and_validate_gateway_yaml = _bots_config_schema().load_and_validate_gateway_yaml
         validated_config = load_and_validate_gateway_yaml(config_path)
         
         channel_count = len(validated_config.channels)
@@ -107,9 +116,12 @@ def check_gateway_config_validation(config: DoctorConfig) -> CheckResult:
 def check_gateway_security(config: DoctorConfig) -> CheckResult:
     """Check gateway security settings for safe defaults."""
     start = time.time()
+    skipped = skip_if_no_wrapper("gateway_security", "Gateway Security Settings", start=start)
+    if skipped:
+        return skipped
     
     # Find config file
-    from praisonai.cli._paths import resolve_bot_config_path
+    from praisonai_code.cli._paths import resolve_bot_config_path
     config_path = None
     for path in [resolve_bot_config_path("gateway.yaml"), resolve_bot_config_path("bot.yaml"), "gateway.yaml", "bot.yaml"]:
         if os.path.exists(path):
@@ -127,7 +139,7 @@ def check_gateway_security(config: DoctorConfig) -> CheckResult:
         )
         
     try:
-        from praisonai.bots._config_schema import load_and_validate_gateway_yaml
+        load_and_validate_gateway_yaml = _bots_config_schema().load_and_validate_gateway_yaml
         validated_config = load_and_validate_gateway_yaml(config_path)
         
         security_issues = []
@@ -210,9 +222,12 @@ def check_gateway_security(config: DoctorConfig) -> CheckResult:
 def check_gateway_config_migration(config: DoctorConfig) -> CheckResult:
     """Check if configuration needs migration to canonical format."""
     start = time.time()
+    skipped = skip_if_no_wrapper("gateway_config_migration", "Gateway Config Migration", start=start)
+    if skipped:
+        return skipped
     
     # Find config file
-    from praisonai.cli._paths import resolve_bot_config_path
+    from praisonai_code.cli._paths import resolve_bot_config_path
     config_path = None
     for path in [resolve_bot_config_path("gateway.yaml"), resolve_bot_config_path("bot.yaml"), "gateway.yaml", "bot.yaml"]:
         if os.path.exists(path):
@@ -238,7 +253,7 @@ def check_gateway_config_migration(config: DoctorConfig) -> CheckResult:
         # Deep copy to preserve original for comparison
         original = copy.deepcopy(raw)
             
-        from praisonai.bots._config_schema import migrate_legacy_config
+        migrate_legacy_config = _bots_config_schema().migrate_legacy_config
         migrated = migrate_legacy_config(copy.deepcopy(original))
         
         # Check if migration changed anything
@@ -300,9 +315,12 @@ def check_gateway_config_migration(config: DoctorConfig) -> CheckResult:
 def check_gateway_env_substitution(config: DoctorConfig) -> CheckResult:
     """Check that environment variables referenced in config are set."""
     start = time.time()
+    skipped = skip_if_no_wrapper("gateway_env_substitution", "Gateway Environment Variables", start=start)
+    if skipped:
+        return skipped
     
     # Find config file
-    from praisonai.cli._paths import resolve_bot_config_path
+    from praisonai_code.cli._paths import resolve_bot_config_path
     config_path = None
     for path in [resolve_bot_config_path("gateway.yaml"), resolve_bot_config_path("bot.yaml"), "gateway.yaml", "bot.yaml"]:
         if os.path.exists(path):
@@ -321,7 +339,7 @@ def check_gateway_env_substitution(config: DoctorConfig) -> CheckResult:
         
     try:
         import re
-        from praisonai.cli.utils.env_utils import load_env_file
+        from praisonai_code.cli.utils.env_utils import load_env_file
         
         # Load .env file first to ensure all env vars are available
         try:

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/gateway_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/gateway_checks.py
@@ -12,12 +12,7 @@ from typing import List, Optional
 
 from ..models import CheckResult, CheckStatus, CheckCategory, CheckSeverity, DoctorConfig
 from ..registry import register_check
-from ._wrapper_checks import skip_if_no_wrapper
-
-
-def _bots_config_schema():
-    from praisonai_code._wrapper_bridge import import_wrapper_module
-    return import_wrapper_module("praisonai.bots._config_schema")
+from ._wrapper_checks import skip_if_no_wrapper, bots_config_schema as _bots_config_schema
 
 
 @register_check(

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/runtime_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/runtime_checks.py
@@ -56,7 +56,7 @@ class RuntimeCompatibilityChecker:
         
         # Check framework availability using the same pattern as agents_generator
         try:
-            from praisonai._framework_availability import is_available
+            from praisonai_code._framework_availability import is_available
         except ImportError:
             is_available = lambda x: False
 
@@ -67,7 +67,10 @@ class RuntimeCompatibilityChecker:
         # (e.g. unimplemented AutoGen v0.4 / AG2 entry-point placeholders).
         def _runtime_usable(framework_name: str, package_name: str) -> bool:
             try:
-                from praisonai.framework_adapters.registry import get_default_registry
+                from praisonai_code._wrapper_bridge import import_wrapper_module
+                get_default_registry = import_wrapper_module(
+                    "praisonai.framework_adapters.registry"
+                ).get_default_registry
             except ImportError:
                 # Fallback to raw package probe only when the registry module
                 # itself cannot be imported (e.g. partial install).
@@ -226,7 +229,7 @@ class RuntimeCompatibilityChecker:
     def _check_autogen_v4(self) -> bool:
         """Check if AutoGen v0.4+ packages are installed."""
         try:
-            from praisonai._framework_availability import is_available as fw_available
+            from praisonai_code._framework_availability import is_available as fw_available
             return fw_available('autogen_v4')
         except ImportError:
             return False

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/serve_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/serve_checks.py
@@ -13,6 +13,12 @@ import os
 
 from ..models import CheckResult, CheckStatus, CheckCategory, CheckSeverity, DoctorConfig
 from ..registry import register_check
+from ._wrapper_checks import skip_if_no_wrapper
+
+
+def _wrapper_mod(name: str):
+    from praisonai_code._wrapper_bridge import import_wrapper_module
+    return import_wrapper_module(name)
 
 
 @register_check(
@@ -25,8 +31,13 @@ from ..registry import register_check
 )
 def check_serve_module(config: DoctorConfig) -> CheckResult:
     """Check if serve module is available."""
+    skipped = skip_if_no_wrapper(
+        "serve_module", "Serve Module", category=CheckCategory.ENVIRONMENT
+    )
+    if skipped:
+        return skipped
     try:
-        from praisonai.cli.features.serve import ServeHandler
+        ServeHandler = _wrapper_mod("praisonai.cli.features.serve").ServeHandler
         ServeHandler()  # Test instantiation
         return CheckResult(
             id="serve_module",
@@ -65,13 +76,17 @@ def check_serve_module(config: DoctorConfig) -> CheckResult:
 )
 def check_endpoints_module(config: DoctorConfig) -> CheckResult:
     """Check if endpoints module is available."""
+    skipped = skip_if_no_wrapper(
+        "endpoints_module", "Endpoints Module", category=CheckCategory.ENVIRONMENT
+    )
+    if skipped:
+        return skipped
     try:
-        from praisonai.endpoints import (
-            DiscoveryDocument,
-            EndpointInfo,
-            ProviderInfo,
-            list_provider_types,
-        )
+        endpoints = _wrapper_mod("praisonai.endpoints")
+        DiscoveryDocument = endpoints.DiscoveryDocument
+        EndpointInfo = endpoints.EndpointInfo
+        ProviderInfo = endpoints.ProviderInfo
+        list_provider_types = endpoints.list_provider_types
         types = list_provider_types()
         return CheckResult(
             id="endpoints_module",
@@ -273,13 +288,18 @@ def check_discovery_endpoint(config: DoctorConfig) -> CheckResult:
 )
 def check_a2u_module(config: DoctorConfig) -> CheckResult:
     """Check if A2U server module is available."""
+    skipped = skip_if_no_wrapper(
+        "a2u_module", "A2U Module", category=CheckCategory.ENVIRONMENT
+    )
+    if skipped:
+        return skipped
     try:
-        from praisonai.endpoints.a2u_server import (
-            A2UEvent,
-            A2USubscription,
-            A2UEventBus,
-            create_a2u_routes,
-        )
+        a2u = _wrapper_mod("praisonai.endpoints.a2u_server")
+        A2UEvent = a2u.A2UEvent
+        A2USubscription = a2u.A2USubscription
+        A2UEventBus = a2u.A2UEventBus
+        create_a2u_routes = a2u.create_a2u_routes
+        _ = (A2UEvent, A2USubscription, A2UEventBus, create_a2u_routes)
         return CheckResult(
             id="a2u_module",
             title="A2U Module",
@@ -316,8 +336,21 @@ def check_a2u_module(config: DoctorConfig) -> CheckResult:
 )
 def check_provider_adapters(config: DoctorConfig) -> CheckResult:
     """Check if all provider adapters are available."""
+    skipped = skip_if_no_wrapper(
+        "provider_adapters", "Provider Adapters", category=CheckCategory.ENVIRONMENT
+    )
+    if skipped:
+        return skipped
     try:
-        from praisonai.endpoints.providers import (
+        providers_mod = _wrapper_mod("praisonai.endpoints.providers")
+        BaseProvider = providers_mod.BaseProvider
+        RecipeProvider = providers_mod.RecipeProvider
+        AgentsAPIProvider = providers_mod.AgentsAPIProvider
+        MCPProvider = providers_mod.MCPProvider
+        ToolsMCPProvider = providers_mod.ToolsMCPProvider
+        A2AProvider = providers_mod.A2AProvider
+        A2UProvider = providers_mod.A2UProvider
+        _ = (
             BaseProvider,
             RecipeProvider,
             AgentsAPIProvider,

--- a/src/praisonai-code/praisonai_code/cli/features/recipe_creator.py
+++ b/src/praisonai-code/praisonai_code/cli/features/recipe_creator.py
@@ -18,10 +18,13 @@ from .sdk_knowledge import get_sdk_knowledge_prompt
 
 
 def _auto_constants():
-    from praisonai_code._wrapper_bridge import get_wrapper_attr
+    """Load wrapper tool-category maps, degrading to empty maps when the
+    ``praisonai`` wrapper is not installed so recipe creation still works
+    (falls back to the core tool selection / template path)."""
+    from praisonai_code._wrapper_bridge import optional_wrapper_attr
     return (
-        get_wrapper_attr("praisonai.auto", "TOOL_CATEGORIES"),
-        get_wrapper_attr("praisonai.auto", "TASK_KEYWORD_TO_TOOLS"),
+        optional_wrapper_attr("praisonai.auto", "TOOL_CATEGORIES", {}) or {},
+        optional_wrapper_attr("praisonai.auto", "TASK_KEYWORD_TO_TOOLS", {}) or {},
     )
 
 

--- a/src/praisonai-code/praisonai_code/cli/features/recipe_creator.py
+++ b/src/praisonai-code/praisonai_code/cli/features/recipe_creator.py
@@ -16,8 +16,14 @@ from typing import Dict, List, Optional, Any
 
 from .sdk_knowledge import get_sdk_knowledge_prompt
 
-# DRY: Import tool categories from auto.py instead of duplicating
-from praisonai.auto import TOOL_CATEGORIES, TASK_KEYWORD_TO_TOOLS
+
+def _auto_constants():
+    from praisonai_code._wrapper_bridge import get_wrapper_attr
+    return (
+        get_wrapper_attr("praisonai.auto", "TOOL_CATEGORIES"),
+        get_wrapper_attr("praisonai.auto", "TASK_KEYWORD_TO_TOOLS"),
+    )
+
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +37,10 @@ class RecipeCreator:
         path = creator.create("Build a web scraper for news articles")
     """
     
-    # DRY: Use imported TOOL_CATEGORIES and TASK_KEYWORD_TO_TOOLS from auto.py
-    TOOL_CATEGORIES = TOOL_CATEGORIES
-    TASK_KEYWORD_TO_TOOLS = TASK_KEYWORD_TO_TOOLS
+    def _auto_tool_maps(self):
+        if not hasattr(self, "_auto_tool_maps_cache"):
+            self._auto_tool_maps_cache = _auto_constants()
+        return self._auto_tool_maps_cache
     
     def __init__(
         self,
@@ -108,18 +115,19 @@ class RecipeCreator:
         """
         goal_lower = goal.lower()
         matched_categories = set()
+        tool_categories, task_keyword_to_tools = self._auto_tool_maps()
         
         # Match keywords to categories
-        for keyword, category in self.TASK_KEYWORD_TO_TOOLS.items():
+        for keyword, category in task_keyword_to_tools.items():
             if keyword in goal_lower:
                 matched_categories.add(category)
         
         # Collect tools from matched categories
         tools = []
         for category in matched_categories:
-            if category in self.TOOL_CATEGORIES:
+            if category in tool_categories:
                 # Add first 2-3 tools from each category
-                tools.extend(self.TOOL_CATEGORIES[category][:3])
+                tools.extend(tool_categories[category][:3])
         
         # Always include core tools for flexibility
         core_tools = ['read_file', 'write_file']

--- a/src/praisonai-code/praisonai_code/cli/main.py
+++ b/src/praisonai-code/praisonai_code/cli/main.py
@@ -247,6 +247,21 @@ def _get_gradio():
     import gradio as gr
     return gr
 
+def _fw_registry_module():
+    from praisonai_code._wrapper_bridge import import_wrapper_module
+    return import_wrapper_module("praisonai.framework_adapters.registry")
+
+
+def _fw_validators_module():
+    from praisonai_code._wrapper_bridge import import_wrapper_module
+    return import_wrapper_module("praisonai.framework_adapters.validators")
+
+
+def _fw_workflow_module():
+    from praisonai_code._wrapper_bridge import import_wrapper_module
+    return import_wrapper_module("praisonai.framework_adapters.workflow_framework")
+
+
 def _get_autogen():
     """Resolve the autogen framework via the canonical adapter registry.
 
@@ -258,7 +273,7 @@ def _get_autogen():
     Raises:
         ImportError: If autogen is not installed
     """
-    from praisonai.framework_adapters.registry import get_default_registry
+    get_default_registry = _fw_registry_module().get_default_registry
     # Use resolve() (returns the adapter class without the strict run()-signature
     # validation that create() applies) because "autogen" maps to the family
     # *router* adapter, whose run() intentionally does not implement the full
@@ -346,8 +361,7 @@ class PraisonAI:
         
         # Validate framework availability early to fail fast
         if self.framework:
-            from praisonai.framework_adapters.validators import assert_framework_available
-            assert_framework_available(self.framework)
+            _fw_validators_module().assert_framework_available(self.framework)
         
         self.auto = auto
         self.init = init
@@ -464,8 +478,7 @@ class PraisonAI:
         
         # Validate framework availability early to fail fast
         if self.framework:
-            from praisonai.framework_adapters.validators import assert_framework_available
-            assert_framework_available(self.framework)
+            _fw_validators_module().assert_framework_available(self.framework)
         
         # Update config_list model if --model flag is provided
         if getattr(args, 'model', None):
@@ -1034,7 +1047,7 @@ class PraisonAI:
         
         parser = argparse.ArgumentParser(prog="praisonai", description="praisonAI command-line interface")
         try:
-            from praisonai.framework_adapters.registry import list_framework_choices
+            list_framework_choices = _fw_registry_module().list_framework_choices
             _framework_choices = list_framework_choices(include_unavailable=True) or [
                 "ag2", "autogen", "crewai", "praisonai",
             ]
@@ -1999,7 +2012,7 @@ class PraisonAI:
         # Only check framework availability for agent-related operations
         if not args.command and (args.init or args.auto or args.framework):
             try:
-                from praisonai.framework_adapters.registry import list_framework_choices
+                list_framework_choices = _fw_registry_module().list_framework_choices
                 if not list_framework_choices():
                     print("[red]ERROR: No framework adapter is installed.[/red]")
                     print("\npip install praisonaiagents  # native PraisonAI")
@@ -2913,7 +2926,7 @@ class PraisonAI:
             # Load and execute the YAML workflow with tool registry
             workflow = manager.load_yaml(yaml_file, tool_registry=tool_registry)
 
-            from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
+            validate_workflow_framework = _fw_workflow_module().validate_workflow_framework
             validate_workflow_framework(
                 getattr(workflow, "framework", "praisonai"),
                 source=f"workflow file {yaml_file}",
@@ -3047,7 +3060,7 @@ class PraisonAI:
             parser = YAMLWorkflowParser()
             workflow = parser.parse_file(yaml_file)
 
-            from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
+            validate_workflow_framework = _fw_workflow_module().validate_workflow_framework
             validate_workflow_framework(
                 getattr(workflow, "framework", "praisonai"),
                 source=f"workflow file {yaml_file}",
@@ -5655,7 +5668,7 @@ Now, {final_instruction.lower()}:"""
                 return result
 
             try:
-                from praisonai.framework_adapters.registry import list_framework_choices
+                list_framework_choices = _fw_registry_module().list_framework_choices
                 _gradio_frameworks = list_framework_choices(include_unavailable=True) or [
                     "crewai", "autogen", "praisonai",
                 ]

--- a/src/praisonai-code/praisonai_code/cli/main.py
+++ b/src/praisonai-code/praisonai_code/cli/main.py
@@ -361,7 +361,11 @@ class PraisonAI:
         
         # Validate framework availability early to fail fast
         if self.framework:
-            _fw_validators_module().assert_framework_available(self.framework)
+            try:
+                _fw_validators_module().assert_framework_available(self.framework)
+            except ImportError as e:
+                print(f"ERROR: {e}")
+                sys.exit(1)
         
         self.auto = auto
         self.init = init
@@ -478,7 +482,11 @@ class PraisonAI:
         
         # Validate framework availability early to fail fast
         if self.framework:
-            _fw_validators_module().assert_framework_available(self.framework)
+            try:
+                _fw_validators_module().assert_framework_available(self.framework)
+            except ImportError as e:
+                print(f"ERROR: {e}")
+                sys.exit(1)
         
         # Update config_list model if --model flag is provided
         if getattr(args, 'model', None):
@@ -1868,7 +1876,11 @@ class PraisonAI:
                 
                 handler = cmd_map.get(args.command)
                 if handler:
-                    exit_code = handler(args, unknown_args)
+                    try:
+                        exit_code = handler(args, unknown_args)
+                    except ImportError as e:
+                        print(f"ERROR: {e}")
+                        sys.exit(1)
                     sys.exit(exit_code if exit_code else 0)
             
             elif args.command == 'doctor':

--- a/src/praisonai-code/praisonai_code/tool_resolver.py
+++ b/src/praisonai-code/praisonai_code/tool_resolver.py
@@ -927,7 +927,8 @@ class ToolResolver:
             PRAISONAI_TOOLS_AVAILABLE = True
         except ImportError:
             try:
-                from praisonai.tools import BaseTool
+                from praisonai_code._wrapper_bridge import get_wrapper_attr
+                BaseTool = get_wrapper_attr("praisonai.tools", "BaseTool")
                 PRAISONAI_TOOLS_AVAILABLE = True
             except ImportError:
                 pass

--- a/src/praisonai/praisonai/__main__.py
+++ b/src/praisonai/praisonai/__main__.py
@@ -116,7 +116,12 @@ def _run_typer(argv):
 
 
 def _run_legacy(argv):
-    """Dispatch to the legacy argparse CLI (prompts, YAML, deprecated flags)."""
+    """Dispatch to the legacy argparse CLI (prompts, YAML, deprecated flags).
+
+    Wrapper-enhanced: multi-framework YAML and ``--framework crewai`` paths load
+    framework adapters via ``praisonai_code._wrapper_bridge`` (requires
+    ``pip install praisonai``). Typer hot path remains in ``_run_typer``.
+    """
     from praisonai.cli.main import PraisonAI
 
     original = sys.argv

--- a/src/praisonai/praisonai/gateway/server.py
+++ b/src/praisonai/praisonai/gateway/server.py
@@ -117,8 +117,15 @@ class _ClientConn:
 
     def start(self) -> None:
         """Start the background drain task for this connection."""
-        if self._task is None:
-            self._task = asyncio.ensure_future(self._drain())
+        if self._task is not None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Sync client registration (e.g. unit tests) — drain starts once
+            # the gateway event loop is running.
+            return
+        self._task = loop.create_task(self._drain())
 
     def offer(self, data: Any) -> bool:
         """Try to enqueue a frame within the configured bounds.

--- a/src/praisonai/tests/C7.1_BOUNDARIES.md
+++ b/src/praisonai/tests/C7.1_BOUNDARIES.md
@@ -1,0 +1,93 @@
+# C7.1 Package Boundaries
+
+Formal ownership and cross-package import rules after C7 hot-path completion.
+See also [`C7_VERIFICATION.md`](C7_VERIFICATION.md) and [`AGENTS.md`](../../praisonai-agents/AGENTS.md) §2.4.
+
+## Three-tier model
+
+| Package | Owns | Must not depend on |
+|---------|------|-------------------|
+| `praisonaiagents` | Agent, tools, memory, hooks, framework **protocols** | `praisonai`, `praisonai-code` |
+| `praisonai-code` | Terminal CLI: `run`/`chat`/`code`, Typer, runtime, llm, tool resolution | PyPI cycle on `praisonai` (lazy bridge only) |
+| `praisonai` wrapper | Gateway, bots, serve orchestration, framework adapters, heavy integrations | — |
+
+**Publish order:** `praisonaiagents` → `praisonai-code` → `praisonai`
+
+## framework_adapters placement
+
+| Layer | Location |
+|-------|----------|
+| Protocol + portable base | `praisonaiagents/frameworks/` |
+| Registry + CrewAI/AutoGen/PraisonAI implementations | `praisonai/framework_adapters/` |
+| Wrapper LLM resolution (`PraisonAIModel`) | `praisonai/framework_adapters/base.py` |
+
+**Do not move** adapter implementations into `praisonai-code` or `praisonaiagents` core.
+
+From `praisonai-code`, access via `praisonai_code._wrapper_bridge.import_wrapper_module("praisonai.framework_adapters.registry")` (lazy only).
+
+## Sanctioned cross-tier access
+
+Only **`praisonai_code._wrapper_bridge`** may load wrapper modules from `praisonai-code`:
+
+- `wrapper_available()` — probe without importing
+- `import_wrapper_module(name)` — import with install hint
+- `get_wrapper_attr(module, attr)` / `optional_wrapper_attr(...)`
+
+Typer **`_WRAPPER_COMMANDS`** in `praisonai_code.cli.app` loads command modules that live only in the wrapper (`bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, `claw`).
+
+## Will not migrate (C7.1)
+
+- `framework_adapters/` (wrapper)
+- `bots/`, `gateway/`, channel onboarding
+- `capabilities`, `train`, `auto`, `agents_generator`, `replay`, `n8n`
+- Observability heavy clients (Langfuse/Langextract impls)
+- Legacy `cli/main.py` body (~7k lines) — invocation boundary only, not wholesale move
+
+## Wrapper-enhanced modules (files in code namespace, wrapper required at runtime)
+
+| Module | Why |
+|--------|-----|
+| `cli/main.py` | Legacy argparse, multi-framework YAML, `PraisonAI` class |
+| `cli/features/capabilities.py` | LiteLLM capability endpoints in wrapper |
+| `cli/commands/train.py`, `serve.py` (partial) | Heavy training / gateway serve subpaths |
+| Doctor `gateway_checks.py`, `bot_checks.py`, `serve_checks.py`, `acp_checks.py` | Bot/gateway/serve validation (bridged) |
+
+## Sign-off
+
+- [x] Ownership documented in AGENTS.md §2.4 + this file
+- [x] Framework adapter touch points use `_wrapper_bridge`
+- [x] `_WRAPPER_COMMANDS` audit documented in `app.py`
+- [x] Doctor bot/gateway/serve checks skip without wrapper
+- [x] Import gate passes (`scripts/check_c7_imports.sh`, baseline 211)
+- [x] `test_c5_backward_compat.py` and `test_c7_1_boundaries.py` pass
+- [x] `praisonai` CLI arg parity unchanged (no parser edits in C7.1)
+
+## C7.1 verification
+
+| Invocation | Standalone (`praisonai-code` only) | Full (`pip install praisonai`) |
+|------------|-----------------------------------|--------------------------------|
+| `praisonai-code run "prompt"` | Yes | Yes |
+| `praisonai-code run --help` | Yes | Yes |
+| `praisonai run "prompt"` | N/A (needs wrapper meta) | Yes |
+| `praisonai run --file agents.yaml --framework crewai` | No — needs wrapper adapters | Yes |
+| `praisonai agents.yaml` (legacy) | No | Yes |
+| `praisonai gateway …` / `praisonai bot …` | No | Yes |
+| `python -m praisonai.cli.main --help` | Yes (help only; framework paths need wrapper) | Yes |
+
+**Router:** `praisonai.__main__:main` — Typer-first, `_run_legacy()` fallback for prompts/YAML/deprecated flags. Unchanged in C7.1.
+
+## C7.1 verification
+
+```bash
+bash scripts/check_c7_imports.sh
+pytest src/praisonai/tests/unit/test_c5_backward_compat.py
+pytest src/praisonai/tests/unit/test_c7_1_boundaries.py
+```
+
+Regression baseline: **211** direct wrapper import lines (indent-aware regex; excludes `praisonaiagents`).
+
+## C8+ backlog (out of scope)
+
+- Zero reverse-import elimination
+- Separate `praisonai-bot` / `praisonai-frameworks` PyPI packages
+- Rewriting legacy `main.py`

--- a/src/praisonai/tests/C7.1_BOUNDARIES.md
+++ b/src/praisonai/tests/C7.1_BOUNDARIES.md
@@ -62,7 +62,7 @@ Typer **`_WRAPPER_COMMANDS`** in `praisonai_code.cli.app` loads command modules 
 - [x] `test_c5_backward_compat.py` and `test_c7_1_boundaries.py` pass
 - [x] `praisonai` CLI arg parity unchanged (no parser edits in C7.1)
 
-## C7.1 verification
+## C7.1 invocation matrix
 
 | Invocation | Standalone (`praisonai-code` only) | Full (`pip install praisonai`) |
 |------------|-----------------------------------|--------------------------------|

--- a/src/praisonai/tests/C7.1_BOUNDARIES.md
+++ b/src/praisonai/tests/C7.1_BOUNDARIES.md
@@ -76,7 +76,7 @@ Typer **`_WRAPPER_COMMANDS`** in `praisonai_code.cli.app` loads command modules 
 
 **Router:** `praisonai.__main__:main` — Typer-first, `_run_legacy()` fallback for prompts/YAML/deprecated flags. Unchanged in C7.1.
 
-## C7.1 verification
+## C7.1 verification commands
 
 ```bash
 bash scripts/check_c7_imports.sh
@@ -84,7 +84,7 @@ pytest src/praisonai/tests/unit/test_c5_backward_compat.py
 pytest src/praisonai/tests/unit/test_c7_1_boundaries.py
 ```
 
-Regression baseline: **211** direct wrapper import lines (indent-aware regex; excludes `praisonaiagents`).
+Regression baseline: **225** direct wrapper import lines (indent-aware regex matching both `from praisonai.` and bare `from praisonai import`; excludes `praisonaiagents`).
 
 ## C8+ backlog (out of scope)
 

--- a/src/praisonai/tests/C7_VERIFICATION.md
+++ b/src/praisonai/tests/C7_VERIFICATION.md
@@ -76,11 +76,15 @@ When moving a module from `praisonai` to `praisonai_code`:
 4. Add module-identity pair to `test_c5_backward_compat.py` if applicable.
 5. Run `bash scripts/check_c7_imports.sh`.
 
-## C7.1 backlog (out of scope for hot-path sign-off)
+## C7.1 backlog (boundary hardening — see C7.1_BOUNDARIES.md)
 
-- `cli/main.py` legacy argparse paths (auto, agents_generator, framework adapters)
-- `capabilities`, `train`, `n8n`, `templates`, `recipe`, `replay`
-- `bots`, `gateway`, `serve`, observability sink implementations
+Completed in C7.1: `_wrapper_bridge` for framework adapters, capabilities, doctor bot/gateway checks; import gate baseline fix.
+
+Remaining intentional lazy wrapper usage (do not bulk-migrate):
+
+- `cli/main.py` legacy argparse paths (auto, agents_generator)
+- `capabilities`, `train`, `n8n`, `templates`, `recipe`, `replay` (bridged, not moved)
+- `bots`, `gateway`, `serve`, observability sink implementations (wrapper-owned)
 
 ## Sign-off
 
@@ -88,3 +92,13 @@ When moving a module from `praisonai` to `praisonai_code`:
 - [x] Hot-path import gate passes (`scripts/check_c7_imports.sh`)
 - [x] C5 backward-compat tests pass
 - [x] CI smoke job includes standalone block + import regression gate
+
+## C7.1 sign-off
+
+See [`C7.1_BOUNDARIES.md`](C7.1_BOUNDARIES.md).
+
+- [x] Package ownership documented (AGENTS.md §2.4)
+- [x] Framework adapters bridged in `main.py` + doctor runtime/config checks
+- [x] Capabilities bridged via `_cap()`; doctor serve/acp checks bridged
+- [x] Import baseline corrected (211; excludes `praisonaiagents` false positives)
+- [x] `test_c7_1_boundaries.py` passes

--- a/src/praisonai/tests/unit/cli/test_custom_definitions.py
+++ b/src/praisonai/tests/unit/cli/test_custom_definitions.py
@@ -645,7 +645,7 @@ class TestRunCustomAgentPermissionMerge:
             agent_config["permissions"] = dict(agent_permissions)
 
         with patch(
-            "praisonai.cli.features.approval.resolve_approval_config",
+            "praisonai_code.cli.features._approval_bridge.resolve_approval_config",
             side_effect=fake_resolve_approval_config,
         ), patch("praisonaiagents.Agent", FakeAgent):
             run_module._run_custom_agent(

--- a/src/praisonai/tests/unit/cli/test_typer_cli.py
+++ b/src/praisonai/tests/unit/cli/test_typer_cli.py
@@ -59,7 +59,7 @@ class TestTyperApp:
         from praisonai.cli.app import app
         result = runner.invoke(app, ["--version"])
         assert result.exit_code == 0
-        assert "PraisonAI version" in result.output
+        assert "PraisonAI Code version" in result.output or "PraisonAI version" in result.output
 
 
 class TestConfigCommand:

--- a/src/praisonai/tests/unit/test_botos_drain.py
+++ b/src/praisonai/tests/unit/test_botos_drain.py
@@ -30,11 +30,22 @@ class _FakeBot:
 
 
 def test_drain_disabled_by_default_is_noop():
-    botos = BotOS()
+    """reliability='off' preserves immediate-teardown (no drain window)."""
+    botos = BotOS(reliability="off")
     abandoned = asyncio.run(botos.drain())
     assert abandoned == 0
     assert botos.accepting is True
     assert botos.is_draining is False
+
+
+def test_drain_default_reliability_quiesces_ingress():
+    """Default reliability applies a small drain window (#2531)."""
+    botos = BotOS()
+    assert botos._drain_timeout == 5.0
+    abandoned = asyncio.run(botos.drain())
+    assert abandoned == 0
+    assert botos.accepting is False
+    assert botos.is_draining is True
 
 
 def test_drain_zero_timeout_is_noop():

--- a/src/praisonai/tests/unit/test_c7_1_boundaries.py
+++ b/src/praisonai/tests/unit/test_c7_1_boundaries.py
@@ -1,0 +1,84 @@
+"""C7.1 boundary tests — wrapper bridge and import gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_wrapper_bridge_import_module_requires_wrapper():
+    from praisonai_code._wrapper_bridge import import_wrapper_module, wrapper_available
+
+    if not wrapper_available():
+        with pytest.raises(ImportError, match="pip install praisonai"):
+            import_wrapper_module("praisonai.framework_adapters.registry")
+    else:
+        mod = import_wrapper_module("praisonai.framework_adapters.registry")
+        assert hasattr(mod, "get_default_registry")
+
+
+def test_main_framework_helpers_use_bridge():
+    from praisonai_code.cli.main import _fw_registry_module, _fw_validators_module
+
+    if not importlib.util.find_spec("praisonai"):
+        with pytest.raises(ImportError, match="pip install praisonai"):
+            _fw_registry_module()
+    else:
+        assert hasattr(_fw_registry_module(), "get_default_registry")
+        assert hasattr(_fw_validators_module(), "assert_framework_available")
+
+
+def test_c7_import_gate_script_passes():
+    result = subprocess.run(
+        ["bash", "scripts/check_c7_imports.sh"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_doctor_skip_without_wrapper():
+    from praisonai_code._wrapper_bridge import wrapper_available
+    from praisonai_code.cli.features.doctor.checks._wrapper_checks import skip_if_no_wrapper
+    from praisonai_code.cli.features.doctor.models import CheckStatus
+
+    if wrapper_available():
+        assert skip_if_no_wrapper("test", "Test") is None
+    else:
+        result = skip_if_no_wrapper("test", "Test")
+        assert result is not None
+        assert result.status == CheckStatus.SKIP
+
+
+def test_recipe_creator_importable_without_wrapper():
+    """RecipeCreator must not load wrapper auto constants at import time."""
+    import praisonai_code.cli.features.recipe_creator as rc
+
+    assert hasattr(rc, "RecipeCreator")
+
+
+def test_capabilities_cap_uses_bridge():
+    from praisonai_code.cli.features.capabilities import _cap
+    from praisonai_code._wrapper_bridge import wrapper_available
+
+    if wrapper_available():
+        fn = _cap("audio", "transcribe")
+        assert callable(fn)
+
+
+def test_serve_doctor_skips_without_wrapper():
+    from praisonai_code._wrapper_bridge import wrapper_available
+    from praisonai_code.cli.features.doctor.checks.serve_checks import check_serve_module
+    from praisonai_code.cli.features.doctor.models import CheckStatus, DoctorConfig
+
+    if not wrapper_available():
+        result = check_serve_module(DoctorConfig())
+        assert result.status == CheckStatus.SKIP

--- a/src/praisonai/tests/unit/test_c7_1_boundaries.py
+++ b/src/praisonai/tests/unit/test_c7_1_boundaries.py
@@ -82,3 +82,28 @@ def test_serve_doctor_skips_without_wrapper():
     if not wrapper_available():
         result = check_serve_module(DoctorConfig())
         assert result.status == CheckStatus.SKIP
+
+
+def test_run_file_crewai_requires_wrapper():
+    """Multi-framework YAML is wrapper-enhanced; standalone must fail clearly."""
+    from praisonai_code._wrapper_bridge import wrapper_available
+
+    if wrapper_available():
+        pytest.skip("requires standalone env without praisonai wrapper")
+
+    import subprocess
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        f.write("framework: crewai\nagents: []\n")
+        yaml_path = f.name
+
+    result = subprocess.run(
+        ["praisonai-code", "run", "--file", yaml_path, "hello"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "pip install praisonai" in combined.lower() or "import" in combined.lower()

--- a/src/praisonai/tests/unit/test_workflow_framework_validation.py
+++ b/src/praisonai/tests/unit/test_workflow_framework_validation.py
@@ -14,7 +14,9 @@ def test_validate_workflow_framework_rejects_crewai(caplog):
     import logging
     from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(
+        logging.WARNING, logger="praisonai.framework_adapters.workflow_framework"
+    ):
         with pytest.raises(ValueError, match="not supported for workflow execution"):
             validate_workflow_framework("crewai", source="workflow.yaml")
     assert any("crewai" in r.message for r in caplog.records)
@@ -24,7 +26,9 @@ def test_validate_workflow_framework_rejects_openai_agents(caplog):
     import logging
     from praisonai.framework_adapters.workflow_framework import validate_workflow_framework
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(
+        logging.WARNING, logger="praisonai.framework_adapters.workflow_framework"
+    ):
         with pytest.raises(ValueError, match="not supported for workflow execution"):
             validate_workflow_framework("openai_agents", source="workflow.yaml")
     assert any("openai_agents" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- Documents three-tier package ownership (`praisonaiagents` → `praisonai-code` → `praisonai`) in AGENTS.md and new `C7.1_BOUNDARIES.md`, with C7.1 sign-off in `C7_VERIFICATION.md`.
- Routes optional wrapper imports through `_wrapper_bridge` in `main.py`, `capabilities.py`, `tool_resolver.py`, `recipe_creator.py`, and doctor checks (new `_wrapper_checks.py` skip helper).
- Tightens the C7 import gate: fixed regex false positives, baseline lowered to 211, new allowlist file, CI smoke runs `test_c7_1_boundaries.py`.

## Test plan

- [x] `bash scripts/check_c7_imports.sh` — pass (211/211 baseline)
- [x] `pytest src/praisonai/tests/unit/test_c7_1_boundaries.py` — 7 passed
- [x] `pytest src/praisonai/tests/unit/test_c5_backward_compat.py` — backward compat unchanged
- [ ] CI smoke + test-core jobs

## Notes

- No Typer/argparse schema changes — `pip install praisonai` CLI args unchanged (import routing only).
- `framework_adapters` remain in the `praisonai` wrapper by design.
- Excludes unrelated parity/docs/pyproject changes from other branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded optimized smoke-test coverage.
* **Bug Fixes**
  * Improved wrapper-based CLI capability loading and framework discovery when wrapper components are missing.
  * Added safer doctor/health check skipping when wrapper functionality isn’t available.
  * Fixed background drain task scheduling in event-loop-less environments.
* **Documentation**
  * Added/updated C7.1 package boundary, verification, and ownership guidance.
* **Tests**
  * Added boundary-focused unit tests for import gating, CLI helpers, and doctor skip behavior.
  * Updated related tests for drain behavior and logging assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->