### PR TITLE
test: re-enable history injection regression tests

### DIFF
--- a/src/praisonai-agents/tests/unit/test_history_parameter.py
+++ b/src/praisonai-agents/tests/unit/test_history_parameter.py
@@ -119,7 +119,6 @@ class TestMemoryConfigHistoryFields:
         assert agent._history_limit == 15
 
 
-@pytest.mark.skip(reason="History injection implementation differs from test expectations - needs API alignment")
 class TestHistoryInjection:
     """Test that history is actually injected into messages."""
     


### PR DESCRIPTION
## Summary

Removes an obsolete `pytest.mark.skip` from the history injection regression tests.

The history injection implementation now correctly injects session history into messages and respects the configured history limit, so these tests no longer require being skipped.

## Changes

* Removed the outdated skip marker from `TestHistoryInjection`
* Re-enabled execution of:

  * `test_history_injected_into_messages`
  * `test_history_respects_limit`

## Validation

Executed the full test module:

```bash
pytest src/praisonai-agents/tests/unit/test_history_parameter.py -vv
```

Result:

* **13 passed**

Executed the history injection tests directly:

```bash
pytest src/praisonai-agents/tests/unit/test_history_parameter.py::TestHistoryInjection -vv
```

Result:

* **2 passed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled history-related unit tests so they now run as part of the test suite instead of being skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->