### PR TITLE
feat(memory): add Dakera memory adapter

### DIFF
--- a/src/praisonai-agents/praisonaiagents/memory/adapters/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/memory/adapters/__init__.py
@@ -9,6 +9,7 @@ Adapters:
 - in_memory_adapter: Lightweight in-memory storage (core, for testing/dev)
 - chromadb_adapter: ChromaDB vector memory storage (wrapper)
 - mongodb_adapter: MongoDB document storage (wrapper)
+- dakera_adapter: Dakera decay-weighted memory server (wrapper)
 - redis_adapter: Redis in-memory storage (wrapper)
 - postgres_adapter: PostgreSQL storage (wrapper)
 
@@ -30,6 +31,7 @@ from .factories import (
     create_mem0_memory_adapter,
     create_chroma_memory_adapter,
     create_mongodb_memory_adapter,
+    create_dakera_memory_adapter,
 )
 
 # Register core adapters
@@ -40,6 +42,7 @@ register_memory_adapter("in_memory", InMemoryAdapter)
 register_memory_factory("mem0", create_mem0_memory_adapter)
 register_memory_factory("chroma", create_chroma_memory_adapter)
 register_memory_factory("mongodb", create_mongodb_memory_adapter)
+register_memory_factory("dakera", create_dakera_memory_adapter)
 
 __all__ = [
     'SqliteMemoryAdapter',

--- a/src/praisonai-agents/praisonaiagents/memory/adapters/factories.py
+++ b/src/praisonai-agents/praisonaiagents/memory/adapters/factories.py
@@ -101,6 +101,47 @@ def create_mongodb_memory_adapter(**kwargs) -> MemoryProtocol:
     return MongoDBMemoryAdapter(pymongo=pymongo, mongo_client=MongoClient, **kwargs)
 
 
+def create_dakera_memory_adapter(**kwargs) -> MemoryProtocol:
+    """
+    Factory function to create a Dakera memory adapter.
+
+    Lazy imports the ``dakera`` SDK and creates an adapter that wraps a
+    ``DakeraClient`` to implement ``MemoryProtocol``. Dakera is a self-hosted
+    memory server providing decay-weighted vector recall scoped by ``agent_id``.
+
+    Args:
+        **kwargs: Configuration passed to the adapter. Recognised keys (either
+            at the top level or nested under a ``"config"`` dict, mirroring the
+            mem0 adapter):
+
+            - ``url`` / ``base_url``: Dakera server URL
+              (falls back to ``DAKERA_URL`` / ``DAKERA_API_URL`` env, then
+              ``http://localhost:3000``).
+            - ``api_key``: API key (falls back to ``DAKERA_API_KEY`` env).
+            - ``agent_id``: Namespace for the agent's memories
+              (falls back to ``DAKERA_AGENT_ID`` env, then ``"praisonai"``).
+            - ``short_term_type`` / ``long_term_type``: Dakera memory types to
+              use for the two tiers (default ``"working"`` and ``"episodic"``).
+            - ``default_importance``: Importance score for stored memories
+              when none is supplied (default ``0.5``).
+
+    Returns:
+        MemoryProtocol adapter instance.
+
+    Raises:
+        ImportError: If the ``dakera`` SDK is not installed.
+    """
+    try:
+        import dakera  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "dakera is required for the dakera adapter. "
+            "Install with: pip install 'praisonaiagents[dakera]' (or: pip install dakera)"
+        )
+
+    return DakeraMemoryAdapter(dakera_config=kwargs)
+
+
 class Mem0MemoryAdapter:
     """
     Memory adapter that wraps mem0.Memory to implement MemoryProtocol.
@@ -511,3 +552,165 @@ class MongoDBMemoryAdapter:
                 logging.warning(f"MongoDB cleanup failed: {e}")
             finally:
                 self.client = None
+
+
+class DakeraMemoryAdapter:
+    """
+    Memory adapter that wraps the Dakera SDK to implement ``MemoryProtocol``.
+
+    Dakera (https://dakera.ai) is a self-hosted memory server that provides
+    persistent, decay-weighted vector recall across sessions: memories are
+    importance-scored and decay over time, so stale context stops competing
+    with fresh, relevant facts. All memories are scoped by ``agent_id``.
+
+    Unlike a flat vector store, Dakera has a first-class ``memory_type`` field,
+    so this adapter maps PraisonAI's two tiers onto distinct Dakera types
+    (short-term -> ``"working"``, long-term -> ``"episodic"`` by default),
+    keeping recency-heavy scratch context separate from durable knowledge.
+
+    Also implements the optional ``DeletableMemoryProtocol`` (``delete_memory`` /
+    ``delete_memories``) and ``ResettableMemoryProtocol`` (``reset_short_term`` /
+    ``reset_long_term``).
+    """
+
+    def __init__(self, dakera_config: Dict[str, Any]):
+        """Initialise the Dakera memory adapter."""
+        from dakera import DakeraClient
+
+        # Support both a flat config and a nested {"config": {...}} form,
+        # mirroring Mem0MemoryAdapter.
+        config = dakera_config.get("config", dakera_config) or {}
+
+        url = (
+            config.get("url")
+            or config.get("base_url")
+            or os.getenv("DAKERA_URL")
+            or os.getenv("DAKERA_API_URL")
+            or "http://localhost:3000"
+        )
+        api_key = config.get("api_key") or os.getenv("DAKERA_API_KEY")
+
+        self.agent_id = (
+            config.get("agent_id")
+            or os.getenv("DAKERA_AGENT_ID")
+            or "praisonai"
+        )
+        self.short_term_type = config.get("short_term_type", "working")
+        self.long_term_type = config.get("long_term_type", "episodic")
+        self.default_importance = config.get("default_importance", 0.5)
+
+        self.client = DakeraClient(base_url=url, api_key=api_key)
+
+    # -- helpers ------------------------------------------------------------
+
+    def _store(self, text: str, memory_type: str,
+               metadata: Optional[Dict[str, Any]], kwargs: Dict[str, Any]) -> str:
+        """Store a memory of ``memory_type`` and return its id."""
+        meta = dict(metadata or {})
+        importance = kwargs.get("importance", meta.pop("importance", self.default_importance))
+        session_id = kwargs.get("session_id") or meta.pop("session_id", None)
+        tags = kwargs.get("tags") or meta.pop("tags", None)
+
+        result = self.client.store_memory(
+            agent_id=self.agent_id,
+            content=text,
+            memory_type=memory_type,
+            importance=importance,
+            metadata=meta or None,
+            session_id=session_id,
+            tags=tags,
+        )
+        # store_memory returns the stored memory dict.
+        return str(result.get("id", "")) if isinstance(result, dict) else str(result)
+
+    def _search(self, query: str, memory_type: str,
+                limit: int, kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Recall memories of ``memory_type`` matching ``query``."""
+        response = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            top_k=limit,
+            memory_type=memory_type,
+            min_importance=kwargs.get("min_importance"),
+        )
+        return [self._to_result(m) for m in response.memories]
+
+    @staticmethod
+    def _to_result(memory: Any) -> Dict[str, Any]:
+        """Normalise a Dakera memory object into PraisonAI's result dict shape."""
+        return {
+            "id": str(getattr(memory, "id", "")),
+            "text": getattr(memory, "content", ""),
+            "metadata": getattr(memory, "metadata", None) or {},
+            "score": getattr(memory, "score", None),
+            "memory_type": getattr(memory, "memory_type", None),
+        }
+
+    # -- MemoryProtocol -----------------------------------------------------
+
+    def store_short_term(self, text: str, metadata: Optional[Dict[str, Any]] = None,
+                         **kwargs) -> str:
+        """Store content in short-term (``working``) memory."""
+        return self._store(text, self.short_term_type, metadata, kwargs)
+
+    def search_short_term(self, query: str, limit: int = 5,
+                          **kwargs) -> List[Dict[str, Any]]:
+        """Search short-term (``working``) memory."""
+        return self._search(query, self.short_term_type, limit, kwargs)
+
+    def store_long_term(self, text: str, metadata: Optional[Dict[str, Any]] = None,
+                        **kwargs) -> str:
+        """Store content in long-term (``episodic``) memory."""
+        return self._store(text, self.long_term_type, metadata, kwargs)
+
+    def search_long_term(self, query: str, limit: int = 5,
+                         **kwargs) -> List[Dict[str, Any]]:
+        """Search long-term (``episodic``) memory."""
+        return self._search(query, self.long_term_type, limit, kwargs)
+
+    def get_all_memories(self, **kwargs) -> List[Dict[str, Any]]:
+        """Return all memories for the agent (no embedding required)."""
+        from dakera import BatchRecallRequest
+
+        limit = kwargs.get("limit", 1000)
+        response = self.client.batch_recall(
+            BatchRecallRequest(agent_id=self.agent_id, limit=limit)
+        )
+        return [self._to_result(m) for m in response.memories]
+
+    # -- DeletableMemoryProtocol -------------------------------------------
+
+    def delete_memory(self, memory_id: str,
+                      memory_type: Optional[str] = None) -> bool:
+        """Delete a specific memory by id. Returns True on success."""
+        try:
+            self.client.forget(agent_id=self.agent_id, memory_id=memory_id)
+            return True
+        except Exception as e:
+            import logging
+            logging.warning(f"Dakera delete_memory({memory_id}) failed: {e}")
+            return False
+
+    def delete_memories(self, memory_ids: List[str]) -> int:
+        """Delete multiple memories by id. Returns the number deleted."""
+        return sum(1 for mid in memory_ids if self.delete_memory(mid))
+
+    # -- ResettableMemoryProtocol ------------------------------------------
+
+    def _reset_type(self, memory_type: str) -> None:
+        from dakera import BatchForgetRequest, BatchMemoryFilter
+
+        self.client.batch_forget(
+            BatchForgetRequest(
+                agent_id=self.agent_id,
+                filter=BatchMemoryFilter(memory_type=memory_type),
+            )
+        )
+
+    def reset_short_term(self) -> None:
+        """Clear all short-term (``working``) memory for the agent."""
+        self._reset_type(self.short_term_type)
+
+    def reset_long_term(self) -> None:
+        """Clear all long-term (``episodic``) memory for the agent."""
+        self._reset_type(self.long_term_type)

--- a/src/praisonai-agents/praisonaiagents/memory/adapters/factories.py
+++ b/src/praisonai-agents/praisonaiagents/memory/adapters/factories.py
@@ -133,11 +133,11 @@ def create_dakera_memory_adapter(**kwargs) -> MemoryProtocol:
     """
     try:
         import dakera  # noqa: F401
-    except ImportError:
+    except ImportError as exc:
         raise ImportError(
             "dakera is required for the dakera adapter. "
             "Install with: pip install 'praisonaiagents[dakera]' (or: pip install dakera)"
-        )
+        ) from exc
 
     return DakeraMemoryAdapter(dakera_config=kwargs)
 
@@ -607,9 +607,19 @@ class DakeraMemoryAdapter:
                metadata: Optional[Dict[str, Any]], kwargs: Dict[str, Any]) -> str:
         """Store a memory of ``memory_type`` and return its id."""
         meta = dict(metadata or {})
-        importance = kwargs.get("importance", meta.pop("importance", self.default_importance))
-        session_id = kwargs.get("session_id") or meta.pop("session_id", None)
-        tags = kwargs.get("tags") or meta.pop("tags", None)
+        # Always strip reserved keys from metadata so they never leak into the
+        # stored payload, then let explicit kwargs take precedence over them.
+        meta_importance = meta.pop("importance", None)
+        meta_session_id = meta.pop("session_id", None)
+        meta_tags = meta.pop("tags", None)
+
+        importance = kwargs.get("importance")
+        if importance is None:
+            importance = (
+                meta_importance if meta_importance is not None else self.default_importance
+            )
+        session_id = kwargs.get("session_id") or meta_session_id
+        tags = kwargs.get("tags") or meta_tags
 
         result = self.client.store_memory(
             agent_id=self.agent_id,
@@ -688,7 +698,10 @@ class DakeraMemoryAdapter:
             return True
         except Exception as e:
             import logging
-            logging.warning(f"Dakera delete_memory({memory_id}) failed: {e}")
+            logging.warning(
+                f"Dakera delete_memory({memory_id}) failed for agent "
+                f"'{self.agent_id}': {e}"
+            )
             return False
 
     def delete_memories(self, memory_ids: List[str]) -> int:

--- a/src/praisonai-agents/praisonaiagents/memory/memory.py
+++ b/src/praisonai-agents/praisonaiagents/memory/memory.py
@@ -169,11 +169,13 @@ class Memory(SearchMixin, MemoryCoreMixin):
                         create_mem0_memory_adapter,
                         create_chroma_memory_adapter,
                         create_mongodb_memory_adapter,
+                        create_dakera_memory_adapter,
                     )
                     factory_map = {
                         "mem0": create_mem0_memory_adapter,
-                        "chroma": create_chroma_memory_adapter, 
+                        "chroma": create_chroma_memory_adapter,
                         "mongodb": create_mongodb_memory_adapter,
+                        "dakera": create_dakera_memory_adapter,
                     }
                     if adapter_name in factory_map:
                         # Call the factory to get ImportError with installation hint

--- a/src/praisonai-agents/pyproject.toml
+++ b/src/praisonai-agents/pyproject.toml
@@ -76,6 +76,11 @@ mongodb = [
     "motor>=3.4.0"
 ]
 
+# Dakera decay-weighted memory server
+dakera = [
+    "dakera>=0.12.8",
+]
+
 # Authentication dependencies
 auth = [
     "PyJWT>=2.8.0",

--- a/src/praisonai-agents/tests/unit/memory/test_dakera_adapter.py
+++ b/src/praisonai-agents/tests/unit/memory/test_dakera_adapter.py
@@ -1,0 +1,322 @@
+"""
+Unit tests for the Dakera memory adapter (``DakeraMemoryAdapter``).
+
+These tests inject a fake ``dakera`` module into ``sys.modules`` so the adapter
+can be exercised end-to-end without a running Dakera server or the real SDK,
+mirroring how the other wrapper adapters (mem0/chroma/mongodb) are unit tested.
+"""
+
+import sys
+import types
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake dakera SDK
+# ---------------------------------------------------------------------------
+
+class _FakeRecalledMemory:
+    def __init__(self, id, content, memory_type, importance=0.5, score=0.9,
+                 metadata=None):
+        self.id = id
+        self.content = content
+        self.memory_type = memory_type
+        self.importance = importance
+        self.score = score
+        self.metadata = metadata or {}
+
+
+class _FakeRecallResponse:
+    def __init__(self, memories):
+        self.memories = memories
+
+
+class _FakeBatchResponse:
+    def __init__(self, memories):
+        self.memories = memories
+        self.total = len(memories)
+        self.filtered = len(memories)
+
+
+class _FakeBatchRecallRequest:
+    def __init__(self, agent_id, filter=None, limit=100, min_importance=None):
+        self.agent_id = agent_id
+        self.filter = filter
+        self.limit = limit
+        self.min_importance = min_importance
+
+
+class _FakeBatchForgetRequest:
+    def __init__(self, agent_id, filter=None):
+        self.agent_id = agent_id
+        self.filter = filter
+
+
+class _FakeBatchMemoryFilter:
+    def __init__(self, memory_type=None, **kwargs):
+        self.memory_type = memory_type
+        self.kwargs = kwargs
+
+
+class _FakeDakeraClient:
+    """Records calls and returns canned responses."""
+
+    instances = []
+
+    def __init__(self, base_url=None, api_key=None):
+        self.base_url = base_url
+        self.api_key = api_key
+        self.stored = []
+        self.recall_calls = []
+        self.batch_recall_calls = []
+        self.forgotten = []
+        self.batch_forget_calls = []
+        self._counter = 0
+        _FakeDakeraClient.instances.append(self)
+
+    def store_memory(self, agent_id, content, memory_type="episodic",
+                     importance=None, metadata=None, session_id=None, tags=None,
+                     **kwargs):
+        self._counter += 1
+        mem = {
+            "id": f"mem-{self._counter}",
+            "content": content,
+            "memory_type": memory_type,
+            "importance": importance,
+            "metadata": metadata,
+            "session_id": session_id,
+            "tags": tags,
+        }
+        self.stored.append(mem)
+        return mem
+
+    def recall(self, agent_id, query, top_k=5, memory_type=None,
+               min_importance=None, **kwargs):
+        self.recall_calls.append({
+            "agent_id": agent_id, "query": query, "top_k": top_k,
+            "memory_type": memory_type, "min_importance": min_importance,
+        })
+        mems = [
+            m for m in self.stored
+            if memory_type is None or m["memory_type"] == memory_type
+        ][:top_k]
+        return _FakeRecallResponse([
+            _FakeRecalledMemory(m["id"], m["content"], m["memory_type"],
+                                metadata=m["metadata"])
+            for m in mems
+        ])
+
+    def batch_recall(self, request):
+        self.batch_recall_calls.append(request)
+        return _FakeBatchResponse([
+            _FakeRecalledMemory(m["id"], m["content"], m["memory_type"],
+                                metadata=m["metadata"])
+            for m in self.stored[:request.limit]
+        ])
+
+    def forget(self, agent_id, memory_id):
+        self.forgotten.append(memory_id)
+        return {"deleted": 1}
+
+    def batch_forget(self, request):
+        self.batch_forget_calls.append(request)
+        return {"deleted": 0}
+
+
+def _make_fake_dakera():
+    mod = types.ModuleType("dakera")
+    mod.DakeraClient = _FakeDakeraClient
+    mod.BatchRecallRequest = _FakeBatchRecallRequest
+    mod.BatchForgetRequest = _FakeBatchForgetRequest
+    mod.BatchMemoryFilter = _FakeBatchMemoryFilter
+    return mod
+
+
+@pytest.fixture
+def fake_dakera(monkeypatch):
+    """Install a fake ``dakera`` module for the duration of a test."""
+    _FakeDakeraClient.instances = []
+    monkeypatch.setitem(sys.modules, "dakera", _make_fake_dakera())
+    # Ensure adapter config is not polluted by ambient env.
+    for var in ("DAKERA_URL", "DAKERA_API_URL", "DAKERA_API_KEY", "DAKERA_AGENT_ID"):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def _make_adapter(**config):
+    from praisonaiagents.memory.adapters.factories import create_dakera_memory_adapter
+    return create_dakera_memory_adapter(config=config)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+class TestDakeraRegistration:
+    def test_factory_is_registered(self):
+        from praisonaiagents.memory.adapters.registry import (
+            list_memory_adapters, has_memory_adapter,
+        )
+        assert "dakera" in list_memory_adapters()
+        assert has_memory_adapter("dakera")
+
+    def test_factory_missing_dependency_raises_importerror(self, monkeypatch):
+        # Block the import so the factory's ImportError branch is exercised.
+        monkeypatch.setitem(sys.modules, "dakera", None)
+        from praisonaiagents.memory.adapters.factories import (
+            create_dakera_memory_adapter,
+        )
+        with pytest.raises(ImportError) as exc:
+            create_dakera_memory_adapter()
+        assert "dakera" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class TestDakeraConfig:
+    def test_defaults(self, fake_dakera):
+        adapter = _make_adapter()
+        assert adapter.agent_id == "praisonai"
+        assert adapter.short_term_type == "working"
+        assert adapter.long_term_type == "episodic"
+        assert adapter.client.base_url == "http://localhost:3000"
+
+    def test_explicit_config(self, fake_dakera):
+        adapter = _make_adapter(
+            url="http://dakera.internal:3000",
+            api_key="dk-secret",
+            agent_id="agent-42",
+            short_term_type="working",
+            long_term_type="semantic",
+        )
+        assert adapter.client.base_url == "http://dakera.internal:3000"
+        assert adapter.client.api_key == "dk-secret"
+        assert adapter.agent_id == "agent-42"
+        assert adapter.long_term_type == "semantic"
+
+    def test_env_fallback(self, fake_dakera, monkeypatch):
+        monkeypatch.setenv("DAKERA_URL", "http://env-host:3000")
+        monkeypatch.setenv("DAKERA_API_KEY", "dk-env")
+        monkeypatch.setenv("DAKERA_AGENT_ID", "env-agent")
+        adapter = _make_adapter()
+        assert adapter.client.base_url == "http://env-host:3000"
+        assert adapter.client.api_key == "dk-env"
+        assert adapter.agent_id == "env-agent"
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+class TestDakeraProtocol:
+    def test_implements_memory_protocol(self, fake_dakera):
+        from praisonaiagents.memory.protocols import (
+            MemoryProtocol, DeletableMemoryProtocol, ResettableMemoryProtocol,
+        )
+        adapter = _make_adapter()
+        assert isinstance(adapter, MemoryProtocol)
+        assert isinstance(adapter, DeletableMemoryProtocol)
+        assert isinstance(adapter, ResettableMemoryProtocol)
+
+
+# ---------------------------------------------------------------------------
+# Store / search
+# ---------------------------------------------------------------------------
+
+class TestDakeraStoreSearch:
+    def test_store_short_term_uses_working_type(self, fake_dakera):
+        adapter = _make_adapter()
+        mem_id = adapter.store_short_term("scratch note")
+        assert mem_id == "mem-1"
+        assert adapter.client.stored[0]["memory_type"] == "working"
+        assert adapter.client.stored[0]["content"] == "scratch note"
+
+    def test_store_long_term_uses_episodic_type(self, fake_dakera):
+        adapter = _make_adapter()
+        adapter.store_long_term("durable fact")
+        assert adapter.client.stored[0]["memory_type"] == "episodic"
+
+    def test_store_extracts_importance_and_tags(self, fake_dakera):
+        adapter = _make_adapter()
+        adapter.store_long_term(
+            "important fact",
+            metadata={"importance": 0.95, "tags": ["pref"], "topic": "food"},
+        )
+        stored = adapter.client.stored[0]
+        assert stored["importance"] == 0.95
+        assert stored["tags"] == ["pref"]
+        # Non-reserved metadata keys survive.
+        assert stored["metadata"] == {"topic": "food"}
+
+    def test_store_uses_default_importance(self, fake_dakera):
+        adapter = _make_adapter(default_importance=0.3)
+        adapter.store_short_term("note")
+        assert adapter.client.stored[0]["importance"] == 0.3
+
+    def test_search_short_term_filters_working(self, fake_dakera):
+        adapter = _make_adapter()
+        adapter.store_short_term("short one")
+        adapter.store_long_term("long one")
+        results = adapter.search_short_term("one", limit=3)
+        assert adapter.client.recall_calls[-1]["memory_type"] == "working"
+        assert len(results) == 1
+        assert results[0]["text"] == "short one"
+        assert results[0]["memory_type"] == "working"
+        # Normalised result dict shape.
+        assert set(results[0]) >= {"id", "text", "metadata", "score"}
+
+    def test_search_long_term_filters_episodic(self, fake_dakera):
+        adapter = _make_adapter()
+        adapter.store_short_term("short one")
+        adapter.store_long_term("long one")
+        results = adapter.search_long_term("one")
+        assert adapter.client.recall_calls[-1]["memory_type"] == "episodic"
+        assert [r["text"] for r in results] == ["long one"]
+
+    def test_get_all_memories_uses_batch_recall(self, fake_dakera):
+        adapter = _make_adapter()
+        adapter.store_short_term("a")
+        adapter.store_long_term("b")
+        results = adapter.get_all_memories()
+        assert len(adapter.client.batch_recall_calls) == 1
+        assert {r["text"] for r in results} == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# Delete / reset
+# ---------------------------------------------------------------------------
+
+class TestDakeraDeleteReset:
+    def test_delete_memory_success(self, fake_dakera):
+        adapter = _make_adapter()
+        assert adapter.delete_memory("mem-1") is True
+        assert adapter.client.forgotten == ["mem-1"]
+
+    def test_delete_memory_failure_returns_false(self, fake_dakera):
+        adapter = _make_adapter()
+
+        def boom(agent_id, memory_id):
+            raise RuntimeError("network down")
+
+        adapter.client.forget = boom
+        assert adapter.delete_memory("mem-x") is False
+
+    def test_delete_memories_counts(self, fake_dakera):
+        adapter = _make_adapter()
+        assert adapter.delete_memories(["a", "b", "c"]) == 3
+        assert adapter.client.forgotten == ["a", "b", "c"]
+
+    def test_reset_short_term_filters_working(self, fake_dakera):
+        adapter = _make_adapter()
+        adapter.reset_short_term()
+        req = adapter.client.batch_forget_calls[-1]
+        assert req.filter.memory_type == "working"
+
+    def test_reset_long_term_filters_episodic(self, fake_dakera):
+        adapter = _make_adapter()
+        adapter.reset_long_term()
+        req = adapter.client.batch_forget_calls[-1]
+        assert req.filter.memory_type == "episodic"

--- a/src/praisonai-agents/tests/unit/memory/test_dakera_adapter.py
+++ b/src/praisonai-agents/tests/unit/memory/test_dakera_adapter.py
@@ -172,6 +172,17 @@ class TestDakeraRegistration:
             create_dakera_memory_adapter()
         assert "dakera" in str(exc.value).lower()
 
+    def test_memory_explicit_dakera_surfaces_install_hint(self, monkeypatch):
+        # Full Memory(config={"provider": "dakera"}) path: when the SDK is
+        # missing, the explicit-provider branch must re-raise the factory's
+        # ImportError (with the install hint) rather than silently falling back
+        # to sqlite/in_memory.
+        monkeypatch.setitem(sys.modules, "dakera", None)
+        from praisonaiagents.memory.memory import Memory
+        with pytest.raises(ImportError) as exc:
+            Memory(config={"provider": "dakera"})
+        assert "dakera" in str(exc.value).lower()
+
 
 # ---------------------------------------------------------------------------
 # Configuration

--- a/src/praisonai-agents/tests/unit/memory/test_dakera_adapter.py
+++ b/src/praisonai-agents/tests/unit/memory/test_dakera_adapter.py
@@ -6,6 +6,7 @@ can be exercised end-to-end without a running Dakera server or the real SDK,
 mirroring how the other wrapper adapters (mem0/chroma/mongodb) are unit tested.
 """
 
+import os
 import sys
 import types
 
@@ -251,6 +252,26 @@ class TestDakeraStoreSearch:
         # Non-reserved metadata keys survive.
         assert stored["metadata"] == {"topic": "food"}
 
+    def test_store_kwargs_reserved_keys_do_not_leak_into_metadata(self, fake_dakera):
+        # Reserved keys passed via kwargs must win over metadata AND be stripped
+        # from the metadata copy, so they never leak into the stored payload.
+        # Regression for the short-circuit `or` that skipped meta.pop() whenever
+        # the kwarg was truthy, leaving a stale session_id/tags in metadata.
+        adapter = _make_adapter()
+        adapter.store_long_term(
+            "fact",
+            metadata={"session_id": "meta-sess", "tags": ["from-meta"], "topic": "food"},
+            session_id="kw-sess",
+            tags=["from-kwargs"],
+            importance=0.8,
+        )
+        stored = adapter.client.stored[0]
+        assert stored["session_id"] == "kw-sess"
+        assert stored["tags"] == ["from-kwargs"]
+        assert stored["importance"] == 0.8
+        # Reserved keys stripped from metadata regardless of their source.
+        assert stored["metadata"] == {"topic": "food"}
+
     def test_store_uses_default_importance(self, fake_dakera):
         adapter = _make_adapter(default_importance=0.3)
         adapter.store_short_term("note")
@@ -320,3 +341,34 @@ class TestDakeraDeleteReset:
         adapter.reset_long_term()
         req = adapter.client.batch_forget_calls[-1]
         assert req.filter.memory_type == "episodic"
+
+
+# ---------------------------------------------------------------------------
+# Real-SDK integration (gated) — exercises the actual `dakera` client against a
+# live self-hosted server. Skipped unless DAKERA_URL is set (e.g. a local
+# `dakera-ai/dakera-deploy` compose), so CI stays hermetic while the real
+# round-trip can be verified on demand:  DAKERA_URL=http://localhost:3000 pytest
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not os.getenv("DAKERA_URL"),
+    reason="requires a running Dakera server (set DAKERA_URL to enable)",
+)
+class TestDakeraRealSDK:
+    def test_store_then_recall_roundtrip(self):
+        pytest.importorskip("dakera")
+        from praisonaiagents.memory.adapters.factories import (
+            create_dakera_memory_adapter,
+        )
+
+        adapter = create_dakera_memory_adapter(
+            config={"agent_id": "praisonai-itest", "default_importance": 0.9}
+        )
+        adapter.reset_long_term()
+        adapter.store_long_term(
+            "The user's favourite programming language is Rust.",
+            metadata={"topic": "preferences"},
+        )
+        results = adapter.search_long_term("what language does the user like?", limit=5)
+        assert any("Rust" in r["text"] for r in results)
+        adapter.reset_long_term()


### PR DESCRIPTION
## Summary

Adds a **`dakera`** memory provider that lets PraisonAI agents use [Dakera](https://dakera.ai) as a memory backend, mirroring the existing `mem0` / `chroma` / `mongodb` factory adapters.

Dakera is a self-hosted memory server that provides **persistent, decay-weighted vector recall** across sessions: memories are importance-scored and decay over time, so stale context stops competing with fresh, relevant facts. It runs beside the app (Docker/Helm) and is driven entirely through its Python SDK — no changes to core `Memory` are required beyond registering the adapter.

## Design

Follows the protocol-driven adapter pattern added in the memory refactor:

- **`create_dakera_memory_adapter(**kwargs)`** — lazy-imports the `dakera` SDK and raises a clear `ImportError` with install instructions if it's missing (same shape as the mem0/chroma/mongodb factories).
- **`DakeraMemoryAdapter`** — implements `MemoryProtocol`, plus the optional `DeletableMemoryProtocol` (`delete_memory` / `delete_memories`) and `ResettableMemoryProtocol` (`reset_short_term` / `reset_long_term`).

Because Dakera has a first-class `memory_type` field, the adapter maps PraisonAI's two tiers onto **distinct** Dakera types instead of collapsing them:

| PraisonAI tier | Dakera `memory_type` |
| --- | --- |
| short-term | `working` (default) |
| long-term  | `episodic` (default) |

Both are overridable via config. Implementation notes:

- `store_*` → `client.store_memory(...)`; importance/tags/session_id are lifted from `kwargs`/`metadata` (falling back to a configurable `default_importance`).
- `search_*` → `client.recall(..., memory_type=...)`, normalised to PraisonAI's `{"id", "text", "metadata", "score", ...}` result dicts (matching the sqlite/in-memory adapters).
- `get_all_memories()` → `client.batch_recall(...)` (filter-based, **no embedding required**).
- `delete_*` → `client.forget(...)`; `reset_*` → `client.batch_forget(...)` scoped by `memory_type`.

Config is read from the nested `config` dict (like the mem0 adapter), with env fallbacks — `DAKERA_URL` / `DAKERA_API_URL`, `DAKERA_API_KEY`, `DAKERA_AGENT_ID` — and a `http://localhost:3000` default.

## Usage

```python
from praisonaiagents.memory import Memory

memory = Memory(config={
    "provider": "dakera",
    "config": {
        "url": "http://localhost:3000",   # or DAKERA_URL
        "api_key": "dk-...",              # or DAKERA_API_KEY
        "agent_id": "my-agent",           # namespaces this agent's memories
    },
})

memory.store_long_term("The user prefers concise answers.")
hits = memory.search_long_term("what does the user prefer?", limit=5)
```

Self-hosting Dakera is a `docker compose` away via [`dakera-ai/dakera-deploy`](https://github.com/dakera-ai/dakera-deploy).

## Testing

- **18 new unit tests** (`tests/unit/memory/test_dakera_adapter.py`) covering registration, config/env resolution, protocol conformance, tier→`memory_type` mapping, store/search/get-all, delete, and reset. They inject a fake `dakera` module via `sys.modules`, so **no running server or real SDK is needed in CI** (same approach as the other wrapper adapters).
- Full local run: `56 passed` (`tests/unit/test_adapter_registry.py` + the new file).
- Smoke-tested the adapter construction and every SDK call signature against the **real** `dakera==0.12.8` package; `ruff check` is clean on the added code.

## Dependency

`dakera` is an **optional** dependency, added as a `dakera` extra:

```bash
pip install "praisonaiagents[dakera]"   # or: pip install dakera
```

The core package and existing adapters are unaffected.

## Checklist

- [x] New provider follows the existing factory/adapter pattern
- [x] Lazy import with a helpful `ImportError`
- [x] Optional extra in `pyproject.toml`; no new hard dependency
- [x] Unit tests added and passing (no server required)
- [x] `ruff` clean on the new code
- [x] Conventional commit message


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “dakera” memory backend option with support for storing, searching/recalling, deleting, and resetting memories.
  * Added a `dakera>=0.12.8` optional dependency extra to enable the backend.
* **Tests**
  * Added unit tests covering factory registration, configuration defaults/overrides, memory typing, metadata handling, delete/reset behavior, and hermetic SDK mocking.
  * Added a gated real-SDK integration test when required environment variables are set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->