### PR TITLE
fix(c8): bridge repatriated tools, workflow, and interactive modules

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/_wrapper_reexport.py
+++ b/src/praisonai-code/praisonai_code/cli/_wrapper_reexport.py
@@ -12,7 +12,25 @@ def load_wrapper_module(wrapper_name: str) -> ModuleType:
 
 
 def populate_from_module(target_globals: dict, source: ModuleType) -> None:
+    """Re-export ``source``'s public attributes into ``target_globals``.
+
+    A snapshot of current attributes is copied so ``from bridge import Name``
+    keeps working, and a live PEP 562 ``__getattr__`` proxy is installed so
+    later reassignments on ``source`` (e.g. test monkeypatching) stay visible
+    through the bridge.
+    """
     for name, value in vars(source).items():
         if name.startswith("__"):
             continue
         target_globals[name] = value
+
+    def __getattr__(name: str):
+        try:
+            return getattr(source, name)
+        except AttributeError as exc:  # pragma: no cover - defensive
+            raise AttributeError(
+                f"module {target_globals.get('__name__', '?')!r} "
+                f"has no attribute {name!r}"
+            ) from exc
+
+    target_globals["__getattr__"] = __getattr__

--- a/src/praisonai-code/praisonai_code/cli/_wrapper_reexport.py
+++ b/src/praisonai-code/praisonai_code/cli/_wrapper_reexport.py
@@ -1,0 +1,18 @@
+"""Re-export a wrapper submodule into a praisonai-code bridge module."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+
+def load_wrapper_module(wrapper_name: str) -> ModuleType:
+    from praisonai_code._wrapper_bridge import import_wrapper_module
+
+    return import_wrapper_module(wrapper_name)
+
+
+def populate_from_module(target_globals: dict, source: ModuleType) -> None:
+    for name, value in vars(source).items():
+        if name.startswith("__"):
+            continue
+        target_globals[name] = value

--- a/src/praisonai-code/praisonai_code/cli/features/tools.py
+++ b/src/praisonai-code/praisonai_code/cli/features/tools.py
@@ -1,0 +1,6 @@
+"""C8 bridge: tools handler lives in the praisonai wrapper."""
+
+from praisonai_code.cli._wrapper_reexport import load_wrapper_module, populate_from_module
+
+_mod = load_wrapper_module("praisonai.cli.features.tools")
+populate_from_module(globals(), _mod)

--- a/src/praisonai-code/praisonai_code/cli/features/workflow.py
+++ b/src/praisonai-code/praisonai_code/cli/features/workflow.py
@@ -1,0 +1,6 @@
+"""C8 bridge: workflow handler lives in the praisonai wrapper."""
+
+from praisonai_code.cli._wrapper_reexport import load_wrapper_module, populate_from_module
+
+_mod = load_wrapper_module("praisonai.cli.features.workflow")
+populate_from_module(globals(), _mod)

--- a/src/praisonai-code/praisonai_code/cli/interactive/async_tui.py
+++ b/src/praisonai-code/praisonai_code/cli/interactive/async_tui.py
@@ -1,0 +1,6 @@
+"""C8 bridge: async TUI lives in the praisonai wrapper."""
+
+from praisonai_code.cli._wrapper_reexport import load_wrapper_module, populate_from_module
+
+_mod = load_wrapper_module("praisonai.cli.interactive.async_tui")
+populate_from_module(globals(), _mod)

--- a/src/praisonai-code/praisonai_code/cli/interactive/core.py
+++ b/src/praisonai-code/praisonai_code/cli/interactive/core.py
@@ -1,0 +1,6 @@
+"""C8 bridge: InteractiveCore lives in the praisonai wrapper."""
+
+from praisonai_code.cli._wrapper_reexport import load_wrapper_module, populate_from_module
+
+_mod = load_wrapper_module("praisonai.cli.interactive.core")
+populate_from_module(globals(), _mod)

--- a/src/praisonai/praisonai/cli/features/__init__.py
+++ b/src/praisonai/praisonai/cli/features/__init__.py
@@ -91,8 +91,20 @@ __all__ = [
 ]
 
 
+_WRAPPER_LOCAL_HANDLERS = {
+    "ToolsHandler": "tools",
+    "WorkflowHandler": "workflow",
+}
+
+
 def __getattr__(name):
-    """Delegate handler/attribute access to ``praisonai_code.cli.features``."""
+    """Resolve repatriated handlers locally, then delegate to code features."""
+    submodule = _WRAPPER_LOCAL_HANDLERS.get(name)
+    if submodule is not None:
+        import importlib
+
+        mod = importlib.import_module(f"{__name__}.{submodule}")
+        return getattr(mod, name)
     if _code_features is not None:
         try:
             return getattr(_code_features, name)

--- a/src/praisonai/praisonai/cli/features/__init__.py
+++ b/src/praisonai/praisonai/cli/features/__init__.py
@@ -30,8 +30,7 @@ try:  # pragma: no cover - defensive
     for _code_dir in getattr(_code_features, "__path__", []):
         if _code_dir not in __path__:
             __path__.append(_code_dir)
-    del _code_dir
-except Exception:  # pragma: no cover - code package optional at import time
+except ImportError:  # pragma: no cover - code package optional at import time
     _code_features = None
 
 

--- a/src/praisonai/praisonai/cli/interactive/__init__.py
+++ b/src/praisonai/praisonai/cli/interactive/__init__.py
@@ -1,10 +1,45 @@
-"""Backward-compatibility shim: ``praisonai.cli.interactive`` moved to
-``praisonai_code.cli.interactive``.
+"""Hybrid CLI interactive package: wrapper core/TUI + code runtime modules.
 
-This module aliases the moved package so all existing imports such as
-``from praisonai.cli.interactive.async_tui import AsyncTUI`` continue to work.
+After C8 repatriation, ``core`` and ``async_tui`` live under this package.
+Config, events, REPL, and frontends remain in ``praisonai_code.cli.interactive``.
 """
 
-from praisonai.cli._shim import alias_package as _alias_package
+try:  # pragma: no cover - defensive
+    import praisonai_code.cli.interactive as _code_interactive
 
-_alias_package(__name__, "praisonai_code.cli.interactive")
+    for _code_dir in getattr(_code_interactive, "__path__", []):
+        if _code_dir not in __path__:
+            __path__.append(_code_dir)
+    del _code_dir
+except Exception:  # pragma: no cover - code package optional at import time
+    _code_interactive = None
+
+__all__ = [
+    "InteractiveCore",
+    "InteractiveConfig",
+    "InteractiveEvent",
+    "InteractiveEventType",
+    "ApprovalRequest",
+    "ApprovalResponse",
+    "ApprovalDecision",
+]
+
+
+def __getattr__(name: str):
+    if name == "InteractiveCore":
+        from .core import InteractiveCore
+
+        return InteractiveCore
+    if _code_interactive is not None:
+        try:
+            return getattr(_code_interactive, name)
+        except AttributeError:
+            pass
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    base = set(globals().keys()) | set(__all__)
+    if _code_interactive is not None:
+        base |= set(dir(_code_interactive))
+    return sorted(base)

--- a/src/praisonai/praisonai/cli/interactive/__init__.py
+++ b/src/praisonai/praisonai/cli/interactive/__init__.py
@@ -10,8 +10,7 @@ try:  # pragma: no cover - defensive
     for _code_dir in getattr(_code_interactive, "__path__", []):
         if _code_dir not in __path__:
             __path__.append(_code_dir)
-    del _code_dir
-except Exception:  # pragma: no cover - code package optional at import time
+except ImportError:  # pragma: no cover - code package optional at import time
     _code_interactive = None
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Fixes Core Tests and Optimized Test Suite failures after C8 repatriation where tools, workflow, interactive.core, and interactive.async_tui moved to the wrapper but import paths still resolved under praisonai_code.
- Adds thin wrapper re-export bridge modules in praisonai-code for code-side imports (app.py, main.py, code unit tests).
- Updates praisonai.cli.features and praisonai.cli.interactive shims to resolve repatriated modules locally before delegating to code.

## Root cause
C8 moved wrapper-heavy modules out of praisonai-code, but lazy loaders and package shims still pointed at the old code paths, causing ModuleNotFoundError in CI.

## Test plan
- [x] pytest test_cli_features.py::TestToolsHandler::test_tools_handler_import
- [x] pytest test_workflow_cli.py::TestWorkflowHandler::test_workflow_handler_import
- [x] pytest tests/unit/cli/interactive/test_approval.py (11 passed)
- [x] pytest tests/unit/cli/test_async_tui.py (70 passed)
- [x] pytest praisonai-code/tests/unit/test_chat_auth_exit_code.py (13 passed)
- [x] bash scripts/check_c7_imports.sh (0 wrapper import lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded CLI feature availability across tools, workflow, and interactive commands via improved re-exporting of public command functionality.
* **Bug Fixes**
  * Improved command discovery and attribute resolution for interactive and feature-related CLI components.
  * Enhanced compatibility when the code-backed feature set is optionally present, ensuring missing features fail gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->