### PR TITLE
test: make default tool directory test platform independent

### DIFF
--- a/src/praisonai/tests/unit/test_templates.py
+++ b/src/praisonai/tests/unit/test_templates.py
@@ -1416,17 +1416,21 @@ def custom_search(query: str) -> str:
         # After context, original state should be restored
         # (implementation detail - registry should be isolated)
     
+
     def test_default_custom_dirs(self):
         """Test that default custom tool directories are defined."""
         from praisonai.templates.tool_override import ToolOverrideLoader
-        
+
         loader = ToolOverrideLoader()
         default_dirs = loader.get_default_tool_dirs()
-        
+
         assert len(default_dirs) >= 2
-        assert any(".praison/tools" in str(d) for d in default_dirs)
-        assert any(".config/praison/tools" in str(d) or ".praison/tools" in str(d) for d in default_dirs)
-    
+        assert any(".praison/tools" in Path(d).as_posix() for d in default_dirs)
+        assert any(
+            ".config/praison/tools" in Path(d).as_posix()
+            or ".praison/tools" in Path(d).as_posix()
+            for d in default_dirs
+        )
     def test_no_scanning_on_import(self):
         """Test that no filesystem scanning occurs on import."""
         import sys


### PR DESCRIPTION
## Summary

This PR fixes a platform-specific test failure in `TestToolsOverride.test_default_custom_dirs`.

### What changed

The original test compared paths using `str(d)` and assumed POSIX-style path separators (`.praison/tools`). On Windows, `Path` objects use backslashes (`.praison\tools`), causing the assertions to fail even though the implementation returned the correct directories.

The test now normalizes paths with `Path(...).as_posix()` before performing the string assertions, making the test platform-independent while preserving its original intent.

### Verification

Executed the targeted test:

```bash
pytest tests/unit/test_templates.py::TestToolsOverride::test_default_custom_dirs -vv
```

Result:

* ✅ 1 passed

Executed the full template test suite:

```bash
pytest tests/unit/test_templates.py -vv
```

Result:

* ✅ 78 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved path-handling checks in automated tests to make directory matching more reliable across platforms.
  * Updated expectations for default custom tool directory detection using normalized paths, reducing false failures on different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->