### PR TITLE
fix(c8): complete validation follow-ups — bridge, audit, doc sign-off

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,10 +114,11 @@ flowchart LR
 ### Import gates (CI enforced)
 
 - **Hot path:** no module-level `from praisonai` in `main.py`, `app.py`, `run.py`, `chat.py`, `code.py`
-- **Regression baseline:** 225 wrapper import lines max (`scripts/check_c7_imports.sh`)
-- **Allowlist:** reviewed files only (`scripts/c7_wrapper_import_allowlist.txt`)
+- **Regression baseline:** 50 direct wrapper import lines max (`scripts/check_c7_imports.sh`; C8 achieved **0**)
+- **Allowlist:** reviewed files only (`scripts/c7_wrapper_import_allowlist.txt`; empty post-C8)
+- **Hybrid audit:** `scripts/audit_hybrid_modules.py` — repatriated cross-tier import paths
 
-### C7 / C7.1 status
+### C7 / C7.1 / C8 status
 
 | Milestone | Status |
 |-----------|--------|
@@ -125,7 +126,9 @@ flowchart LR
 | `_wrapper_bridge` hardening | **Complete** |
 | Import gate + allowlist | **Complete** |
 | Boundary tests + CI smoke | **Complete** |
-| C8+ (zero lazy imports, package splits) | **Future** — see [`C8_BACKLOG.md`](src/praisonai/tests/C8_BACKLOG.md) |
+| C8 reverse import elimination (225 → 0 direct imports) | **Complete** — see [`C8_BACKLOG.md`](src/praisonai/tests/C8_BACKLOG.md) |
+| C8.4 main.py physical decomposition | **Deferred** (separate epic) |
+| PyPI package splits (`praisonai-bot`, etc.) | **Out of scope** |
 
 ---
 

--- a/scripts/audit_hybrid_modules.py
+++ b/scripts/audit_hybrid_modules.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Assert critical C8 hybrid import paths resolve (wrapper + code tiers)."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def _check(label: str, import_fn) -> None:
+    try:
+        import_fn()
+    except Exception as exc:
+        print(f"FAIL {label}: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print(f"OK   {label}")
+
+
+def main() -> None:
+    _check(
+        "praisonai.cli.features.tui.app.TUIApp",
+        lambda: importlib.import_module("praisonai.cli.features.tui.app").TUIApp,
+    )
+    _check(
+        "praisonai.cli.features.tools.ToolsHandler",
+        lambda: importlib.import_module("praisonai.cli.features.tools").ToolsHandler,
+    )
+    _check(
+        "praisonai.cli.features.workflow.WorkflowHandler",
+        lambda: importlib.import_module("praisonai.cli.features.workflow").WorkflowHandler,
+    )
+    _check(
+        "praisonai.cli.interactive.core.InteractiveCore",
+        lambda: importlib.import_module("praisonai.cli.interactive.core").InteractiveCore,
+    )
+    _check(
+        "praisonai_code.cli.interactive.async_tui.AsyncTUI",
+        lambda: importlib.import_module("praisonai_code.cli.interactive.async_tui").AsyncTUI,
+    )
+    _check(
+        "praisonai_code.cli.features.workflow.WorkflowHandler",
+        lambda: importlib.import_module("praisonai_code.cli.features.workflow").WorkflowHandler,
+    )
+    print("All hybrid module paths importable.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/praisonai-code/praisonai_code/cli/interactive/frontends/textual_frontend.py
+++ b/src/praisonai-code/praisonai_code/cli/interactive/frontends/textual_frontend.py
@@ -57,7 +57,9 @@ class TextualFrontend:
     async def run(self) -> None:
         """Run the Textual TUI."""
         try:
-            from ..features.tui.app import TUIApp
+            from praisonai_code._wrapper_bridge import import_wrapper_module
+
+            TUIApp = import_wrapper_module("praisonai.cli.features.tui.app").TUIApp
             
             # Create app with our core
             self._app = TUIApp(

--- a/src/praisonai/tests/C7.1_BOUNDARIES.md
+++ b/src/praisonai/tests/C7.1_BOUNDARIES.md
@@ -33,34 +33,59 @@ Only **`praisonai_code._wrapper_bridge`** may load wrapper modules from `praison
 - `import_wrapper_module(name)` — import with install hint
 - `get_wrapper_attr(module, attr)` / `optional_wrapper_attr(...)`
 
-Typer **`_WRAPPER_COMMANDS`** in `praisonai_code.cli.app` loads command modules that live only in the wrapper (`bot`, `gateway`, `pairing`, `identity`, `onboard`, `kanban`, `dashboard`, `claw`).
+Typer **`_WRAPPER_RESIDENT_COMMANDS`** in `praisonai_code.cli.app` loads command modules that live only in the wrapper (33 commands including `bot`, `gateway`, `langfuse`, `train`, `docs`, `mcp`, etc.).
 
-## Will not migrate (C7.1)
+## Will not migrate (C7.1 + C8 floor)
 
 - `framework_adapters/` (wrapper)
 - `bots/`, `gateway/`, channel onboarding
-- `capabilities`, `train`, `auto`, `agents_generator`, `replay`, `n8n`
-- Observability heavy clients (Langfuse/Langextract impls)
-- Legacy `cli/main.py` body (~7k lines) — invocation boundary only, not wholesale move
+- Doctor bridge checks (`gateway_checks`, `bot_checks`, `serve_checks`, …)
+- Bridge call sites in `main.py` via `import_wrapper_module()` (~45 sites — sanctioned, not direct imports)
 
-## Wrapper-enhanced modules (files in code namespace, wrapper required at runtime)
+## C8 sign-off (2026-07-03)
 
-| Module | Why |
-|--------|-----|
-| `cli/main.py` | Legacy argparse, multi-framework YAML, `PraisonAI` class |
-| `cli/features/capabilities.py` | LiteLLM capability endpoints in wrapper |
-| `cli/commands/train.py`, `serve.py` (partial) | Heavy training / gateway serve subpaths |
-| Doctor `gateway_checks.py`, `bot_checks.py`, `serve_checks.py`, `acp_checks.py` | Bot/gateway/serve validation (bridged) |
+C8 reverse import elimination is **complete on main** (PRs #2590, #2592, #2605).
+
+| Metric | Before C8 | After C8 |
+|--------|-----------|----------|
+| Direct `from praisonai` / `import praisonai` lines in `praisonai-code` | 225 | **0** |
+| Allowlisted import files | 47 | **0** |
+| Regression baseline (`check_c7_imports.sh`) | 225 | **50** (actual: 0) |
+| Wrapper-resident Typer commands | 8 | **33** |
+
+**Distinction:** The import gate counts **direct import statements** only. Wrapper coupling via `import_wrapper_module("praisonai...")` remains in legacy paths (`main.py`, `serve.py`, doctor) and is **sanctioned** — not a C8 regression.
+
+**Hybrid bridges:** Repatriated modules that both tiers import use re-export shims (`_wrapper_reexport.py`) or hybrid `__path__` packages (`praisonai.cli.features.tui`). Verified by `scripts/audit_hybrid_modules.py` and `test_c8_hybrid_module_imports`.
+
+**Deferred:** C8.4 full `main.py` decomposition (`praison_class.py`, ≤300-line dispatcher) — separate epic; does not block C8 import goals.
+
+- [x] Zero direct wrapper imports in `praisonai-code` (gate enforced)
+- [x] Hot path standalone (`run`/`chat`/`code`/`app`)
+- [x] No PyPI dependency cycle on `praisonai`
+- [x] `_WRAPPER_RESIDENT_COMMANDS` routing for repatriated commands
+- [x] SDK protocols in `praisonaiagents/cli/protocols.py`
+- [x] Hybrid module audit + boundary tests extended
+- [ ] Legacy `main.py` physical decomposition (deferred)
+
+## Wrapper-enhanced modules (historical — pre-C8; most repatriated)
+
+| Module | Status post-C8 |
+|--------|----------------|
+| `cli/main.py` | Bridge-only access; body still ~7k lines (deferred) |
+| `cli/features/capabilities.py` | Bridge via `_cap()` |
+| `cli/commands/serve.py` | Split — SDK subcommands in code, gateway in wrapper |
+| Doctor checks | Bridged; skip without wrapper |
 
 ## Sign-off
 
 - [x] Ownership documented in AGENTS.md §2.4 + this file
 - [x] Framework adapter touch points use `_wrapper_bridge`
-- [x] `_WRAPPER_COMMANDS` audit documented in `app.py`
+- [x] `_WRAPPER_RESIDENT_COMMANDS` audit documented in `app.py`
 - [x] Doctor bot/gateway/serve checks skip without wrapper
-- [x] Import gate passes (`scripts/check_c7_imports.sh`, baseline 211)
+- [x] Import gate passes (`scripts/check_c7_imports.sh`, baseline 50, actual 0)
 - [x] `test_c5_backward_compat.py` and `test_c7_1_boundaries.py` pass
-- [x] `praisonai` CLI arg parity unchanged (no parser edits in C7.1)
+- [x] C8 hybrid import audit (`scripts/audit_hybrid_modules.py`)
+- [x] `praisonai` CLI arg parity unchanged
 
 ## C7.1 invocation matrix
 
@@ -84,12 +109,11 @@ pytest src/praisonai/tests/unit/test_c5_backward_compat.py
 pytest src/praisonai/tests/unit/test_c7_1_boundaries.py
 ```
 
-Regression baseline: **225** direct wrapper import lines (indent-aware regex matching both `from praisonai.` and bare `from praisonai import`; excludes `praisonaiagents`).
+Regression baseline: **50** direct wrapper import lines (C8 achieved **0**). Gate matches `from praisonai.` and bare `import praisonai`; excludes `praisonaiagents` and bridge string literals.
 
-## C8+ backlog (out of scope)
+## C8+ backlog
 
-See [`C8_BACKLOG.md`](C8_BACKLOG.md) for the full planning document.
+See [`C8_BACKLOG.md`](C8_BACKLOG.md) — **C8 complete on main**. Remaining:
 
-- Zero reverse-import elimination
-- Separate `praisonai-bot` / `praisonai-frameworks` PyPI packages
-- Rewriting legacy `main.py`
+- C8.4 follow-up: `praison_class.py` extraction (optional epic)
+- Separate `praisonai-bot` / `praisonai-frameworks` PyPI packages (out of scope)

--- a/src/praisonai/tests/C8_BACKLOG.md
+++ b/src/praisonai/tests/C8_BACKLOG.md
@@ -4,7 +4,7 @@ Planning document for **C8**: reduce lazy wrapper imports in `praisonai-code` fr
 225 → ~40–60 without new PyPI packages. See [`C7.1_BOUNDARIES.md`](C7.1_BOUNDARIES.md)
 and [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) §2.
 
-**Status:** Complete on branch `feat/c8-reverse-import-elimination` — **0** reverse import lines (baseline 50).
+**Status:** **Complete on main** (merged PR #2590, #2592, #2605) — **0** direct reverse import lines (regression baseline 50).
 
 ---
 
@@ -15,10 +15,12 @@ and [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) §2.
 | C8.1 | `_WRAPPER_RESIDENT_COMMANDS`, import gate regex, tests | 50 | Done |
 | C8.2A–E | Command repatriation + serve bridge | 0 | Done |
 | C8.3 | cli/features/* repatriation | 0 | Done |
-| C8.4 | legacy/ modules (inbuilt_tools, prompt_dispatch) | 0 | Done |
+| C8.4 | legacy/ modules (inbuilt_tools, prompt_dispatch) | 0 | Done (partial — see deferred) |
 | C8.5 | Bridge normalisation + SDK protocols | 0 | Done |
 
 **Out of scope:** `praisonai-bot`, `praisonai-frameworks` PyPI splits.
+
+**Deferred (C8.4 follow-up epic):** Physical move of ~6k-line `PraisonAI` class to `praisonai/cli/legacy/praison_class.py`; thin code `main.py` (≤300 lines).
 
 ---
 
@@ -26,10 +28,24 @@ and [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) §2.
 
 | Item | Value |
 |------|-------|
-| Lazy wrapper import lines | 0 (regression-gated; baseline 50) |
+| Direct wrapper import lines | 0 (regression-gated; baseline 50) |
+| Bridge call sites (`import_wrapper_module`) | ~45 (by design — not counted by gate) |
 | Allowlisted files | 0 (empty — add only after review) |
+| Wrapper-resident commands | 33 in `_WRAPPER_RESIDENT_COMMANDS` |
 | Agentic hot path | Standalone — no module-level `praisonai` import |
-| Cross-tier access | `praisonai_code._wrapper_bridge` only |
+| Cross-tier access | `praisonai_code._wrapper_bridge` + hybrid re-export shims |
+
+---
+
+## Hybrid module patterns (post-C8)
+
+| Pattern | Example | Resolution |
+|---------|---------|------------|
+| Code-only | `mcp`, `doctor`, TUI widgets | `praisonai.cli.features` extends `__path__` to code |
+| Wrapper-only + code bridge | `tools`, `workflow`, `core`, `async_tui` | Wrapper impl; code `_wrapper_reexport` shim |
+| Split hybrid | `tui` (app in wrapper, widgets in code) | Wrapper `tui/__init__.py` extends `__path__` to code |
+
+Audit: `python scripts/audit_hybrid_modules.py` or `pytest test_c7_1_boundaries.py::test_c8_hybrid_module_imports`.
 
 ---
 
@@ -38,7 +54,7 @@ and [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) §2.
 1. Move impl from `praisonai_code/...` → `praisonai/...` (replace C5 shim).
 2. Delete code copy; add command name to `_WRAPPER_RESIDENT_COMMANDS`.
 3. Remove path from allowlist; lower baseline in `check_c7_imports.sh`.
-4. Run gates: `check_c7_imports.sh`, `test_c7_1_boundaries.py`, `test_c5_backward_compat.py`.
+4. Run gates: `check_c7_imports.sh`, `audit_hybrid_modules.py`, `test_c7_1_boundaries.py`, `test_c5_backward_compat.py`.
 
 ---
 
@@ -61,6 +77,7 @@ flowchart TB
 
 ```bash
 bash scripts/check_c7_imports.sh
+python scripts/audit_hybrid_modules.py
 pytest src/praisonai/tests/unit/test_c7_1_boundaries.py
 pytest src/praisonai/tests/unit/test_c5_backward_compat.py
 ```

--- a/src/praisonai/tests/unit/test_c7_1_boundaries.py
+++ b/src/praisonai/tests/unit/test_c7_1_boundaries.py
@@ -126,3 +126,42 @@ def test_run_file_crewai_requires_wrapper():
     combined = result.stdout + result.stderr
     assert result.returncode != 0
     assert "pip install praisonai" in combined.lower() or "import" in combined.lower()
+
+
+def test_c8_hybrid_module_imports():
+    """Critical repatriated / hybrid paths must resolve when wrapper is installed."""
+    import importlib
+
+    from praisonai_code._wrapper_bridge import wrapper_available
+
+    if not wrapper_available():
+        pytest.skip("requires praisonai wrapper installed")
+
+    paths = [
+        ("praisonai.cli.features.tui.app", "TUIApp"),
+        ("praisonai.cli.features.tools", "ToolsHandler"),
+        ("praisonai.cli.features.workflow", "WorkflowHandler"),
+        ("praisonai.cli.interactive.core", "InteractiveCore"),
+        ("praisonai_code.cli.interactive.async_tui", "AsyncTUI"),
+        ("praisonai_code.cli.features.workflow", "WorkflowHandler"),
+    ]
+    for module_name, attr in paths:
+        mod = importlib.import_module(module_name)
+        assert hasattr(mod, attr), f"{module_name} missing {attr}"
+
+
+def test_textual_frontend_tui_app_import():
+    """TextualFrontend.run() must resolve TUIApp via hybrid wrapper package."""
+    import importlib
+
+    from praisonai_code._wrapper_bridge import wrapper_available
+
+    if not wrapper_available():
+        pytest.skip("requires praisonai wrapper installed")
+
+    mod = importlib.import_module(
+        "praisonai_code.cli.interactive.frontends.textual_frontend"
+    )
+    source = importlib.import_module("inspect").getsource(mod.TextualFrontend.run)
+    assert "import_wrapper_module" in source
+    assert "praisonai.cli.features.tui.app" in source


### PR DESCRIPTION
## Summary
- Fixes TextualFrontend runtime TUIApp load via `_wrapper_bridge` (0 direct import regression)
- Adds `scripts/audit_hybrid_modules.py` and boundary tests for C8 hybrid paths
- C8 sign-off in C7.1_BOUNDARIES.md, C8_BACKLOG.md, and ARCHITECTURE.md

## Test plan
- [x] bash scripts/check_c7_imports.sh (0 lines)
- [x] python scripts/audit_hybrid_modules.py
- [x] pytest src/praisonai/tests/unit/test_c7_1_boundaries.py (10 passed, 1 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broader support for hybrid app entry points, improving command and UI loading paths.
  * Introduced a new runtime check to verify key module paths remain importable.

* **Bug Fixes**
  * Reduced import-boundary regressions and tightened cross-package loading behavior.
  * Improved fallback handling for interactive UI startup.

* **Documentation**
  * Updated architecture and boundary notes with refreshed migration status, baselines, and remaining follow-ups.

* **Tests**
  * Added coverage for hybrid imports and wrapper-based UI resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->