### PR TITLE
docs: add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,20 @@ You are working on the PraisonAI project.
 - Ensure backward compatibility with existing APIs
 - Follow protocol-driven design: core protocols in `praisonaiagents/`, agentic terminal CLI in `praisonai-code/`, bot/channel and heavy implementations in `praisonai/`
 - Preserve old `praisonai.cli.*` import paths via shims when changing moved CLI code (see §2.3 in `src/praisonai-agents/AGENTS.md`)
+
+## Cursor Cloud specific instructions
+
+Scope: the core Python product (three-package monorepo `praisonaiagents` → `praisonai-code` → `praisonai`). The TypeScript (`src/praisonai-ts`) and Rust (`src/praisonai-rust`) SDKs are separate optional products and are not part of this setup.
+
+Environment (the update script installs all three packages editable, plus test tooling):
+- Use `python3` — there is no `python` on PATH. No conda is available; packages are system pip user installs.
+- The `praisonai` console script lives in `~/.local/bin`; if it is not on PATH, run `python3 -m praisonai …` instead.
+- Set `PYTHONPATH=src/praisonai-agents` for CLI/tests (mirrors CI's `.github/workflows/test-core.yml`).
+
+Running/testing:
+- Run the CLI: `praisonai version`, `praisonai --help`, `praisonai doctor` (doctor "failures" for unset API keys / bot tokens are expected). CLI `run` takes options *before* the prompt, e.g. `praisonai run --model gpt-4o-mini "Say hello"`.
+- Unit tests (from `src/praisonai-agents` or `src/praisonai`): `OPENAI_API_KEY=sk-test OPENAI_MODEL_NAME=gpt-4o-mini PRAISONAI_ALLOW_NETWORK=0 python3 -m pytest tests/unit -m "not network and not slow"`. A fake key is fine for unit tests.
+- No Python linter (ruff/flake8/black) is configured; there is no lint command.
+- Some unit tests in the current snapshot are pre-existing failures from test/source drift (e.g. `tests/unit/config/test_precedence_ladder.py`, `tests/unit/sandbox/test_security.py`, `tests/unit/test_error_classification.py`) — not environment problems. The full wrapper suite additionally expects heavy extras (`crewai`, `autogen`, etc.) that the minimal setup omits.
+
+Running an agent without a paid key: point `OPENAI_API_BASE` and `OPENAI_BASE_URL` at a local OpenAI-compatible mock. Note the core SDK `Agent` uses the Chat Completions API (`/v1/chat/completions`), while the terminal CLI `praisonai run` uses the OpenAI **Responses API** (`/v1/responses`) — a mock must implement both to satisfy both paths.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the core Python product (three-package monorepo `praisonaiagents` → `praisonai-code` → `praisonai`) and records durable, non-obvious setup notes in `AGENTS.md`.

The only code change is documentation (`AGENTS.md`). The VM update script (dependency refresh) is configured separately.

## Environment

- Installed the three packages editable (mirrors `.github/actions/install-monorepo-packages`) plus `praisonaiagents[knowledge]` and pytest tooling.
- `python3` only (no `python`); `praisonai` console script in `~/.local/bin`; tests use `PYTHONPATH=src/praisonai-agents`.

## Verification

- `praisonai version` / `--help` / `doctor` run correctly.
- `praisonai-agents` unit tests: 5922 passed (pre-existing test/source drift accounts for the remaining failures, not the environment).
- Wrapper regression gate + doctor tests: 122 passed.
- Ran an agent end-to-end (both the core SDK `Agent` and the flagship `praisonai run` CLI) against a local OpenAI-compatible mock; both returned the expected reply.

[Hello-world evidence](https://cursor.com/agents/bc-1c74606a-23ab-4249-a224-5359158bc02e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpraisonai_env_setup_evidence.log)

Notes captured in `AGENTS.md` under `## Cursor Cloud specific instructions`: no Python linter is configured; the CLI `run` uses the OpenAI Responses API while the core SDK `Agent` uses Chat Completions (a local mock must support both).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c74606a-23ab-4249-a224-5359158bc02e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c74606a-23ab-4249-a224-5359158bc02e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer environment and workflow guidance for working in the core Python monorepo.
  * Included updated instructions for running key CLI commands and unit tests, including expected network/key behavior and known test issues.
  * Documented how to run a local OpenAI-compatible mock service with support for both chat and responses endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->