### PR TITLE
fix(ci): unblock review chain when Gemini posts pull reviews only

### DIFF
--- a/.github/scripts/pr-review-chain-selftest.js
+++ b/.github/scripts/pr-review-chain-selftest.js
@@ -56,4 +56,18 @@ assert(
   !chain.claudeFinalReady([coderabbit, greptile], [], { allowCopilotTimeout: true }).ready
 );
 
+const geminiReview = {
+  user: { login: 'gemini-code-assist[bot]' },
+  body: '## Code Review\n\nThis pull request decomposes the large main.py file',
+  submitted_at: '2026-07-03T08:08:00Z',
+};
+assert(
+  'gemini pull review counts as prior reviewer',
+  chain.hasGeminiReview([], [geminiReview])
+);
+assert(
+  'prior ready with gemini review only (no gemini comment)',
+  chain.priorReviewersReady([coderabbit, greptile], [geminiReview], { optionalWaitMs: 0 }).ready
+);
+
 process.exit(failed ? 1 : 0);

--- a/.github/scripts/pr-review-chain.js
+++ b/.github/scripts/pr-review-chain.js
@@ -39,7 +39,8 @@ function hasQodoReview(comments, reviews = []) {
   return reviews.some((r) => loginOf(r).includes('qodo'));
 }
 
-function hasGeminiReview(comments) {
+function hasGeminiReview(comments, reviews = []) {
+  if (reviews.some((r) => loginOf(r).includes('gemini'))) return true;
   return comments.some((c) => {
     if (loginOf(c).includes('gemini')) return true;
     const body = bodyOf(c);
@@ -54,7 +55,7 @@ const PRIOR_CHECKS = {
   coderabbit: (comments) => hasCoderabbitSummary(comments),
   greptile: (comments) => hasGreptileReview(comments),
   qodo: (comments, reviews) => hasQodoReview(comments, reviews),
-  gemini: (comments) => hasGeminiReview(comments),
+  gemini: (comments, reviews) => hasGeminiReview(comments, reviews),
 };
 
 function priorReviewerStatus(comments, reviews = []) {
@@ -157,6 +158,23 @@ function claudeFinalReady(comments, reviews = [], options = {}) {
     return { ready: true, reason: 'copilot timeout fallback', copilotSkipped: true };
   }
   return { ready: false, reason: copilot.reason };
+}
+
+/** Post @copilot when prior reviewers are ready, then @claude FINAL when Copilot done (or timeout). */
+async function advanceReviewChain(github, owner, repo, prNumber, finalBody, core, options = {}) {
+  const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+  const chainOpts = {
+    prCreatedAt: pr.created_at,
+    optionalWaitMs: options.optionalWaitMs ?? 0,
+  };
+  const copilot = options.skipCopilot
+    ? { triggered: false, reason: 'skipped' }
+    : await maybeTriggerCopilot(github, owner, repo, prNumber, core, chainOpts);
+  const claude = await maybeTriggerClaudeFinal(
+    github, owner, repo, prNumber, finalBody, core,
+    { ...options, ...chainOpts }
+  );
+  return { copilot, claude };
 }
 
 async function maybeTriggerClaudeFinal(github, owner, repo, prNumber, finalBody, core, options = {}) {
@@ -262,6 +280,8 @@ module.exports = {
   isFinalClaudeTriggerComment,
   maybeTriggerCopilot,
   maybeTriggerClaudeFinal,
+  advanceReviewChain,
   pollCopilotResponse,
+  hasGeminiReview,
   listCommentsAndReviews,
 };

--- a/.github/workflows/auto-pr-comment.yml
+++ b/.github/workflows/auto-pr-comment.yml
@@ -42,7 +42,10 @@ jobs:
          contains(github.event.comment.user.login, 'qodo-code-review')
        )) ||
       (github.event_name == 'pull_request_review' &&
-       contains(github.event.review.user.login, 'qodo-code-review'))
+       (
+         contains(github.event.review.user.login, 'qodo-code-review') ||
+         contains(github.event.review.user.login, 'gemini-code-assist')
+       ))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -97,7 +100,7 @@ jobs:
       - name: Wait for review chain (25 min)
         run: sleep 1500
 
-      - name: Post Claude FINAL (prior reviewers + Copilot timeout OK)
+      - name: Advance review chain (Copilot then Claude FINAL)
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_TOKEN }}
@@ -106,11 +109,27 @@ jobs:
             const chain = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/pr-review-chain.js'));
             const mergeGate = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/merge-gate.js'));
             const pr = context.payload.pull_request.number;
-            await chain.maybeTriggerClaudeFinal(
-              github, context.repo.owner, context.repo.repo, pr,
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const result = await chain.advanceReviewChain(
+              github, owner, repo, pr,
               mergeGate.FINAL_CLAUDE_REVIEW_BODY, core,
               { allowCopilotTimeout: true, optionalWaitMs: 0 }
             );
+            if (result.copilot.triggered) {
+              const poll = await chain.pollCopilotResponse(github, owner, repo, pr, {
+                maxAttempts: parseInt(process.env.MAX_POLL_ATTEMPTS, 10),
+                delayMs: parseInt(process.env.POLL_DELAY_MS, 10),
+              });
+              core.info(`Copilot poll after fallback trigger: ${poll.ready ? 'ready' : poll.reason}`);
+            }
+            if (!result.claude.posted) {
+              await chain.maybeTriggerClaudeFinal(
+                github, owner, repo, pr,
+                mergeGate.FINAL_CLAUDE_REVIEW_BODY, core,
+                { allowCopilotTimeout: true, optionalWaitMs: 0 }
+              );
+            }
 
   # ================================================================
   # Claude FINAL — only after Copilot responds (prior reviewers already done)
@@ -315,14 +334,16 @@ jobs:
                 }
               }
 
-              const result = await chain.maybeTriggerClaudeFinal(
+              const result = await chain.advanceReviewChain(
                 github, owner, repo, pr.number,
                 mergeGate.FINAL_CLAUDE_REVIEW_BODY, core,
                 { allowCopilotTimeout: true, optionalWaitMs: 0 }
               );
-              if (result.posted) {
+              if (result.copilot.triggered || result.claude.posted) {
                 posted++;
-                core.info(`Posted Claude FINAL on PR #${pr.number}`);
+                core.info(
+                  `PR #${pr.number}: copilot=${result.copilot.triggered}, claude=${result.claude.posted}`
+                );
               }
               if (posted >= 10) break;
             }


### PR DESCRIPTION
## Summary
- Detect Gemini reviews from `pulls/{n}/reviews` (Gemini posts PR reviews, not issue comments), fixing false "waiting for optional gemini" stalls on PRs like #2604 and #2607
- Re-trigger the Copilot job on `pull_request_review` events from `gemini-code-assist[bot]`
- Add `advanceReviewChain()` so the 25-min fallback and scheduled sweep post `@copilot` before `@claude`, with Copilot polling in the fallback path

## Test plan
- [x] `node .github/scripts/pr-review-chain-selftest.js` passes (incl. new Gemini review cases)
- [ ] Merge to main and confirm next PR with Gemini review-only gets `@copilot` after Greptile without manual intervention
- [ ] Confirm `claude-fallback-timeout` posts `@copilot` then `@claude` when the event-driven chain stalls


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review handling now recognizes Gemini activity from both comments and review submissions, improving automated workflow coordination.
  * The review flow can now advance more consistently between Copilot and Claude FINAL responses during fallback and sweep runs.

* **Bug Fixes**
  * Fixed cases where Gemini reviews were not counted toward prior-review readiness.
  * Improved fallback logic so Claude FINAL is posted only when needed, reducing duplicate or missed automated replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->