### PR TITLE
test(c8.4): patch _get_agents_generator at praison_ai module after de…

### DIFF
--- a/src/praisonai/tests/unit/test_cli_agent_integration.py
+++ b/src/praisonai/tests/unit/test_cli_agent_integration.py
@@ -185,7 +185,7 @@ class TestBarePositionalPrompt:
         with patch.object(PraisonAI, "parse_args", return_value=(base_args, [])), \
              patch.object(PraisonAI, "read_stdin_if_available", return_value=None), \
              patch.object(PraisonAI, "read_file_if_provided", return_value=None), \
-             patch("praisonai.cli.main._get_agents_generator", return_value=lambda *a, **k: mock_generator), \
+             patch("praisonai_code.cli.legacy.praison_ai._get_agents_generator", return_value=lambda *a, **k: mock_generator), \
              patch.object(PraisonAI, "handle_direct_prompt", return_value="OK") as mock_prompt:
             result = instance.run()
         return instance, mock_prompt, result, mock_generator


### PR DESCRIPTION
…composition

C8.4 moved AgentsGenerator loading to praison_ai.py; unit test mock target must follow the implementation path for agent-file routing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an integration test to match the current location of the agent generator, helping keep CLI behavior checks accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->