### PR TITLE
fix(c9): standalone bot registry and publish token mapping

### DIFF
--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -143,10 +143,16 @@ jobs:
         python -m venv /tmp/praisonai-bot-standalone
         /tmp/praisonai-bot-standalone/bin/pip install -q -e src/praisonai-agents -e src/praisonai-bot
         /tmp/praisonai-bot-standalone/bin/python -c "
+        from praisonai_bot._version import __version__ as pkg_version
         import praisonai_bot
         from praisonai_bot.bots import Bot
+        from praisonai_bot.bots._registry import resolve_adapter
         from praisonai_bot.gateway import WebSocketGateway
-        print('bot standalone ok', Bot, WebSocketGateway)
+        assert praisonai_bot.__version__ == pkg_version
+        telegram = resolve_adapter('telegram')
+        assert telegram.__name__ == 'TelegramBot'
+        assert telegram.__module__.startswith('praisonai_bot.bots.')
+        print('bot standalone ok', praisonai_bot.__version__, telegram.__name__)
         "
         /tmp/praisonai-bot-standalone/bin/praisonai-bot --help
         bash "$GITHUB_WORKSPACE/scripts/check_c9_bot_imports.sh"

--- a/src/praisonai-agents/praisonaiagents/bots/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/bots/__init__.py
@@ -2,7 +2,8 @@
 Bot Protocols and Configuration for PraisonAI Agents.
 
 Defines the interfaces and configuration for messaging bot implementations.
-All implementations live in the praisonai wrapper package.
+All implementations live in the ``praisonai-bot`` package (``praisonai_bot.bots``).
+Backward-compatible imports: ``from praisonai.bots import Bot`` via wrapper shims.
 """
 
 from typing import TYPE_CHECKING

--- a/src/praisonai-agents/praisonaiagents/bots/agent_reply.py
+++ b/src/praisonai-agents/praisonaiagents/bots/agent_reply.py
@@ -7,7 +7,7 @@ Channels render the presentation via the existing per-platform renderers and
 fall back to text where rich UI is unsupported.
 
 This is a core protocol with no heavy implementations: channel rendering and
-session wiring live in the wrapper (praisonai). Producers return one of:
+session wiring live in ``praisonai-bot`` (``praisonai_bot.bots``). Producers return one of:
 
 * ``str``                     -> plain text (unchanged, fully backward compatible)
 * ``MessagePresentation``     -> interactive UI (text fallback derived from text blocks)

--- a/src/praisonai-agents/praisonaiagents/bots/interactive.py
+++ b/src/praisonai-agents/praisonaiagents/bots/interactive.py
@@ -6,7 +6,7 @@ interactive UI elements (buttons, select menus) across all messaging platforms.
 This complements the presentation.py render side with symmetric inbound handling.
 
 This is a core protocol with no heavy implementations - channel-specific
-callback decoding belongs in the wrapper (praisonai).
+callback decoding belongs in ``praisonai-bot`` (``praisonai_bot.bots``).
 """
 
 from __future__ import annotations

--- a/src/praisonai-agents/praisonaiagents/bots/pairing_types.py
+++ b/src/praisonai-agents/praisonaiagents/bots/pairing_types.py
@@ -2,7 +2,7 @@
 Pairing types and protocols for bot user approval.
 
 Contains lightweight types and protocols for the pairing approval system.
-Heavy implementations are in the wrapper package.
+Heavy implementations are in the ``praisonai-bot`` package.
 """
 
 from dataclasses import dataclass

--- a/src/praisonai-agents/praisonaiagents/bots/presentation.py
+++ b/src/praisonai-agents/praisonaiagents/bots/presentation.py
@@ -6,7 +6,7 @@ that channel adapters render as native widgets. Enables structured
 interactive UI across Telegram, Slack, Discord, and other platforms.
 
 This is a core protocol with no heavy implementations - channel-specific
-rendering belongs in the wrapper (praisonai).
+rendering belongs in ``praisonai-bot`` (``praisonai_bot.bots``).
 """
 
 from __future__ import annotations

--- a/src/praisonai-agents/praisonaiagents/bots/protocols.py
+++ b/src/praisonai-agents/praisonaiagents/bots/protocols.py
@@ -5,7 +5,8 @@ Defines the interfaces for messaging bot implementations.
 These protocols enable agents to communicate through messaging platforms
 like Telegram, Discord, Slack, etc.
 
-All implementations should live in the praisonai wrapper package.
+All implementations live in the ``praisonai-bot`` package (``praisonai_bot.bots``).
+Backward-compatible imports: ``from praisonai.bots import Bot`` via wrapper shims.
 """
 
 from __future__ import annotations
@@ -179,7 +180,7 @@ class WebhookVerifierProtocol(Protocol):
     ``PlatformCapabilities.accepts_webhooks`` must expose a verifier and that
     verifier must pass before dispatch.
 
-    Implementations live in the ``praisonai`` wrapper package and typically
+    Implementations live in the ``praisonai-bot`` package (``praisonai_bot.bots``) and
     wrap an HMAC comparison over the raw request body.
 
     Example:
@@ -668,8 +669,10 @@ class BotProtocol(Protocol):
     - Webhook/polling management
     - User and channel management
     
-    Example usage (implementation in praisonai wrapper):
-        from praisonai.bots import TelegramBot
+    Example usage (implementation in praisonai-bot):
+
+        from praisonai_bot.bots.telegram import TelegramBot
+        # or: from praisonai.bots import TelegramBot  # wrapper shim
         
         bot = TelegramBot(token="...", agent=my_agent)
         await bot.start()
@@ -1118,7 +1121,7 @@ class BotOSProtocol(Protocol):
         └── Bot  (single platform)
             └── Agent / AgentTeam / AgentFlow  (AI brain)
 
-    Implementations live in the ``praisonai`` wrapper package.
+    Implementations live in the ``praisonai-bot`` package (``praisonai_bot.bots``).
     """
 
     @property

--- a/src/praisonai-bot/praisonai_bot/__init__.py
+++ b/src/praisonai-bot/praisonai_bot/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.0.1"
+from praisonai_bot._version import __version__
 
 _LAZY_EXPORTS = {
     "Bot": ("praisonai_bot.bots.bot", "Bot"),

--- a/src/praisonai-bot/praisonai_bot/bots/_registry.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_registry.py
@@ -14,40 +14,39 @@ from .._registry import PluginRegistry
 from praisonaiagents.bots.protocols import PlatformCapabilities
 
 
-def _telegram_loader():
+def _load_bot_class(module: str, class_name: str):
     import importlib
-    mod = importlib.import_module("praisonai.bots.telegram")
-    return getattr(mod, "TelegramBot")
+
+    mod = importlib.import_module(f"praisonai_bot.bots.{module}")
+    return getattr(mod, class_name)
+
+
+def _telegram_loader():
+    return _load_bot_class("telegram", "TelegramBot")
+
 
 def _discord_loader():
-    import importlib
-    mod = importlib.import_module("praisonai.bots.discord")
-    return getattr(mod, "DiscordBot")
+    return _load_bot_class("discord", "DiscordBot")
+
 
 def _slack_loader():
-    import importlib
-    mod = importlib.import_module("praisonai.bots.slack")
-    return getattr(mod, "SlackBot")
+    return _load_bot_class("slack", "SlackBot")
+
 
 def _whatsapp_loader():
-    import importlib
-    mod = importlib.import_module("praisonai.bots.whatsapp")
-    return getattr(mod, "WhatsAppBot")
+    return _load_bot_class("whatsapp", "WhatsAppBot")
+
 
 def _linear_loader():
-    import importlib
-    mod = importlib.import_module("praisonai.bots.linear")
-    return getattr(mod, "LinearBot")
+    return _load_bot_class("linear", "LinearBot")
+
 
 def _email_loader():
-    import importlib
-    mod = importlib.import_module("praisonai.bots.email")
-    return getattr(mod, "EmailBot")
+    return _load_bot_class("email", "EmailBot")
+
 
 def _agentmail_loader():
-    import importlib
-    mod = importlib.import_module("praisonai.bots.agentmail")
-    return getattr(mod, "AgentMailBot")
+    return _load_bot_class("agentmail", "AgentMailBot")
 
 # Built-in bot platforms with lazy loading
 _BUILTIN_PLATFORMS = {
@@ -66,11 +65,11 @@ class BotPlatformRegistry(PluginRegistry):
     
     def __init__(self):
         super().__init__(
-            entry_point_group="praisonai.bots",
-            builtins=_BUILTIN_PLATFORMS
+            entry_point_group="praisonai.channels",
+            builtins=_BUILTIN_PLATFORMS,
+            discover_entry_points=False,
         )
-        # Also discover the idiomatic ``praisonai.channels`` entry-point group
-        # so a ``pip install``ed channel connector registers itself with no code.
+        # Discover third-party channel connectors without shadowing builtins.
         self._discover_channel_entry_points()
         # Store capabilities for each platform
         self._capabilities: Dict[str, PlatformCapabilities] = {}

--- a/src/praisonai-bot/praisonai_bot/bots/_registry.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_registry.py
@@ -69,26 +69,38 @@ class BotPlatformRegistry(PluginRegistry):
             builtins=_BUILTIN_PLATFORMS,
             discover_entry_points=False,
         )
-        # Discover third-party channel connectors without shadowing builtins.
-        self._discover_channel_entry_points()
-        # Store capabilities for each platform
+        # Store capabilities for each platform (initialised before entry-point
+        # discovery so any future capability-aware discovery is safe).
         self._capabilities: Dict[str, PlatformCapabilities] = {}
         self._capabilities_lock = threading.Lock()
+        # Discover third-party channel connectors without shadowing builtins.
+        self._discover_channel_entry_points()
 
     def _discover_channel_entry_points(self) -> None:
         """Discover channel connectors from the ``praisonai.channels`` group."""
         import logging
         from importlib.metadata import entry_points
         logger = logging.getLogger(__name__)
+        # Names this package ships as builtins are also declared as entry points
+        # (for external discoverability), so a duplicate here is expected and not
+        # a conflict — log those at DEBUG and only warn for genuine third-party
+        # shadowing attempts.
+        builtin_names = set(_BUILTIN_PLATFORMS)
         try:
             for ep in entry_points(group="praisonai.channels"):
                 # Do not let a third-party entry point silently shadow a
                 # built-in (or already-registered) channel loader.
                 if ep.name.lower() in self._loaders:
-                    logger.warning(
-                        "Skipping duplicate channel entry point %r; a loader "
-                        "with that name is already registered.", ep.name
-                    )
+                    if ep.name.lower() in builtin_names:
+                        logger.debug(
+                            "Channel entry point %r matches a built-in loader; "
+                            "keeping the built-in.", ep.name
+                        )
+                    else:
+                        logger.warning(
+                            "Skipping duplicate channel entry point %r; a loader "
+                            "with that name is already registered.", ep.name
+                        )
                     continue
                 self._add_loader(ep.name, ep.load)
         except Exception:

--- a/src/praisonai-bot/pyproject.toml
+++ b/src/praisonai-bot/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Mervin Praison" }
 ]
 dependencies = [
-    "praisonaiagents>=1.6.117",
+    "praisonaiagents>=1.6.123",
     "rich>=13.7",
     "typer>=0.12.0",
     "click>=8.4.2",

--- a/src/praisonai-bot/tests/unit/test_bot_fixes.py
+++ b/src/praisonai-bot/tests/unit/test_bot_fixes.py
@@ -224,12 +224,18 @@ class TestLegacyApprovalDeprecation:
         import sys
         import importlib
         
-        # Skip if loaded via bot package or wrapper shim (deprecation only on first import)
-        if (
-            "praisonai.bots._approval" in sys.modules
-            or "praisonai_bot.bots._approval" in sys.modules
-        ):
-            pytest.skip("Module already imported in this process; deprecation emitted earlier")
+        # Drop any prior imports so the module-level DeprecationWarning fires on
+        # a fresh re-import (the wrapper shim re-exports the bot package module).
+        sys.modules.pop("praisonai.bots._approval", None)
+        sys.modules.pop("praisonai_bot.bots._approval", None)
+        # warn_deprecated_param() dedupes once per process via a module-level
+        # set; clear our key so the re-import reliably re-emits the warning.
+        try:
+            from praisonaiagents.utils import deprecation as _dep
+
+            _dep._warned_params.discard("BotApprovalBackend module:1.0.0")
+        except Exception:
+            pass
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/src/praisonai-bot/tests/unit/test_bot_fixes.py
+++ b/src/praisonai-bot/tests/unit/test_bot_fixes.py
@@ -224,8 +224,11 @@ class TestLegacyApprovalDeprecation:
         import sys
         import importlib
         
-        # Remove from cache to force re-import when not already loaded
-        if 'praisonai.bots._approval' in sys.modules:
+        # Skip if loaded via bot package or wrapper shim (deprecation only on first import)
+        if (
+            "praisonai.bots._approval" in sys.modules
+            or "praisonai_bot.bots._approval" in sys.modules
+        ):
             pytest.skip("Module already imported in this process; deprecation emitted earlier")
 
         with warnings.catch_warnings(record=True) as w:

--- a/src/praisonai/scripts/_release_lib.py
+++ b/src/praisonai/scripts/_release_lib.py
@@ -173,7 +173,7 @@ def publish_package(package_dir: Path) -> None:
     if dist.exists():
         import shutil
         shutil.rmtree(dist)
-    run(["uv", "lock", "--frozen"], cwd=package_dir, check=False)
+    run(["uv", "lock", "--frozen"], cwd=package_dir)
     run(["uv", "build"], cwd=package_dir)
     run(["uv", "publish", "--trusted-publishing", "never"], cwd=package_dir)
 

--- a/src/praisonai/scripts/_release_lib.py
+++ b/src/praisonai/scripts/_release_lib.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import urllib.error
@@ -145,14 +146,36 @@ def bump_bot_files(new_version: str) -> None:
     )
 
 
+def resolve_pypi_token() -> str | None:
+    """Return PyPI token from env (UV_PUBLISH_TOKEN, PYPI_TOKEN, or PYPI_API_TOKEN)."""
+    return (
+        os.environ.get("UV_PUBLISH_TOKEN")
+        or os.environ.get("PYPI_TOKEN")
+        or os.environ.get("PYPI_API_TOKEN")
+    )
+
+
+def ensure_uv_publish_token() -> None:
+    """Map PYPI_TOKEN / PYPI_API_TOKEN into UV_PUBLISH_TOKEN for uv publish."""
+    if os.environ.get("UV_PUBLISH_TOKEN"):
+        return
+    token = os.environ.get("PYPI_TOKEN") or os.environ.get("PYPI_API_TOKEN")
+    if token:
+        os.environ["UV_PUBLISH_TOKEN"] = token
+
+
 def publish_package(package_dir: Path) -> None:
+    token = resolve_pypi_token()
+    if not token:
+        raise RuntimeError("Missing PyPI credentials. Set UV_PUBLISH_TOKEN or PYPI_TOKEN.")
+    ensure_uv_publish_token()
     dist = package_dir / "dist"
     if dist.exists():
         import shutil
         shutil.rmtree(dist)
     run(["uv", "lock", "--frozen"], cwd=package_dir, check=False)
     run(["uv", "build"], cwd=package_dir)
-    run(["uv", "publish"], cwd=package_dir)
+    run(["uv", "publish", "--trusted-publishing", "never"], cwd=package_dir)
 
 
 def git_commit_files(message: str, rel_paths: list[str], root: Optional[Path] = None) -> bool:

--- a/src/praisonai/scripts/publish_all.py
+++ b/src/praisonai/scripts/publish_all.py
@@ -105,10 +105,11 @@ def main() -> None:
         print("Dry run — no changes made.")
         return
 
-    token = os.environ.get("UV_PUBLISH_TOKEN") or os.environ.get("PYPI_TOKEN") or os.environ.get("PYPI_API_TOKEN")
+    token = lib.resolve_pypi_token()
     if not token:
         print("❌ Set UV_PUBLISH_TOKEN or PYPI_TOKEN before publishing.")
         sys.exit(1)
+    lib.ensure_uv_publish_token()
 
     if bump.check_git_status() and not args.force:
         print("❌ Working tree has uncommitted changes. Commit/stash or use --force.")

--- a/src/praisonai/tests/C9.1_BOUNDARIES.md
+++ b/src/praisonai/tests/C9.1_BOUNDARIES.md
@@ -40,5 +40,6 @@ praisonaiagents → praisonai-code + praisonai-bot → praisonai (wrapper)
 - [x] Wrapper import lines in `praisonai_bot`: **0** (via bridges)
 - [x] Integration moved modules shimmed (`gateway_host`, `host_app`, `context_files`, `kanban_bridge`, `bot_health`)
 - [x] Standalone `praisonai-bot --help` works (agents + bot only install)
+- [x] Standalone `resolve_adapter('telegram')` without wrapper (registry loaders)
 - [x] `test-core.yml` bots-gateway shard → `src/praisonai-bot/tests/`
 - [x] `tests/conftest.py` in praisonai-bot package

--- a/src/praisonai/tests/C9_BACKLOG.md
+++ b/src/praisonai/tests/C9_BACKLOG.md
@@ -7,19 +7,34 @@ Epic branch: `feat/c9-praisonai-bot`
 | Phase | Status | Scope |
 |-------|--------|-------|
 | C9.0 | done | Package shell, gates, bootstrap |
+| C9.0b | done | 4-package CI install, standalone smoke, Windows bot help |
 | C9.1 | done | `bots/` move + shims + tests |
 | C9.2 | done | `gateway/` move + shims + tests |
 | C9.3 | done | `daemon/`, `integration/` partial |
 | C9.4 | done | CLI commands/features, `_BOT_RESIDENT_COMMANDS` |
 | C9.5 | done | pyproject extras, wrapper dep |
-| C9.5b | partial | kanban/claw/tools/audio moved; scheduler via bridge |
+| C9.5b | partial | kanban/claw/tools/audio moved; scheduler via `_wrapper_bridge` |
 | C9.6 | done | `_bot_bridge`, SDK lazy re-export, doctor/approval |
-| C9.6b | partial | approval via bot bridge; serve split deferred |
-| C9.7 | done | test_c9_backward_compat, install action |
-| C9.7b | pending | pypi-release 4th package |
-| C9.8 | done | entry-points praisonai.channels |
-| C9.9 | partial | ARCHITECTURE note in boundaries doc |
-| C9.10 | partial | sign-off pending CI green |
+| C9.6b | partial | serve gateway/recipe retarget done; HTTP serve stays in wrapper |
+| C9.7 | done | test_c9_backward_compat, install action, boundary tests |
+| C9.7b | done | pypi-release 4th package, `publish_all.py`, wrapper pin |
+| C9.8 | done | entry-points `praisonai.channels` |
+| C9.9 | partial | ARCHITECTURE/AGENTS updated; Mintlify standalone install TBD |
+| C9.10 | done | registry standalone fix, backlog/manifest reconciliation |
+
+## Post-C9 gap fixes (2026-07-03)
+
+- [x] `_registry.py` builtin loaders → `praisonai_bot.bots.*` (standalone without wrapper)
+- [x] `entry_point_group` → `praisonai.channels`
+- [x] `praisonai_bot.__init__.__version__` synced from `_version.py`
+- [x] SDK docstrings → canonical `praisonai-bot` home
+- [x] Standalone CI smoke + `test_bot_registry_resolves_without_wrapper`
+
+## Deferred (optional follow-on)
+
+- [ ] Move gateway scheduler subset out of wrapper bridge (`praisonai.scheduler.executor`)
+- [ ] Mintlify + examples: first-class `pip install praisonai-bot[gateway,bot]`
+- [ ] C9.11 gateway `server.py` thinning (optional)
 
 ## Gates
 
@@ -27,4 +42,5 @@ Epic branch: `feat/c9-praisonai-bot`
 bash scripts/check_c9_bot_imports.sh
 bash scripts/audit_bot_wrapper_imports.sh
 pytest src/praisonai/tests/unit/test_c9_backward_compat.py -q
+pytest src/praisonai/tests/unit/test_c9_1_boundaries.py -q
 ```

--- a/src/praisonai/tests/PRAISONAI_BOT_MANIFEST.md
+++ b/src/praisonai/tests/PRAISONAI_BOT_MANIFEST.md
@@ -1,60 +1,85 @@
-# praisonai-bot Boundary Manifest (C8.4 Phase 9)
+# praisonai-bot Boundary Manifest (C9 — implemented)
 
-> Future PyPI package split — **not implemented in C8.4**. This document defines ownership for extraction.
+> **Status:** Implemented in C9. PyPI package `praisonai-bot` (currently 0.0.4+). Wrapper shims preserve `praisonai.bots.*` / `praisonai.gateway.*` imports.
+
+## Four-tier stack
+
+```
+praisonaiagents → praisonai-code + praisonai-bot → praisonai (wrapper)
+```
 
 ## Two daemon concepts (do not merge)
 
 | Name | Location | Purpose |
 |------|----------|---------|
 | `praisonai daemon` | `praisonai_code/cli/commands/daemon.py` | Warm runtime (code tier) |
-| `praisonai.daemon` | `praisonai/daemon/{systemd,launchd,windows}.py` | OS bot service install (`praisonai-bot` unit) |
+| `praisonai-bot` OS service | `praisonai_bot/daemon/{systemd,launchd,windows}.py` | Bot/gateway systemd unit |
 
-## Modules to move to `praisonai-bot`
+## Owned by `praisonai-bot` (`praisonai_bot/`)
 
 ### Runtime
 
 | Path | Notes |
 |------|-------|
-| `praisonai/gateway/*` | WebSocket gateway server, pairing, push |
-| `praisonai/bots/*` | Platform adapters, BotOS, registry |
-| `praisonai/daemon/*` | systemd/launchd/Windows service generators |
-| `praisonai/integration/{gateway_host,host_app,bridges/}` | UI gateway, dashboard bridges |
+| `praisonai_bot/bots/*` | Platform adapters, BotOS, registry |
+| `praisonai_bot/gateway/*` | WebSocket gateway, pairing, push |
+| `praisonai_bot/daemon/*` | OS service generators |
+| `praisonai_bot/integration/*` | gateway_host, host_app, kanban_bridge |
+| `praisonai_bot/kanban/*` | SQLite store for kanban dispatcher |
+| `praisonai_bot/claw/*` | Claw default app |
+| `praisonai_bot/tools/audio.py` | Telegram STT/TTS |
 
 ### CLI
 
 | Path | Notes |
 |------|-------|
-| `praisonai/cli/features/{gateway,bots_cli,onboard,approval,serve}.py` | Feature handlers |
-| `praisonai/cli/commands/{bot,gateway,pairing,identity,onboard,kanban,claw,dashboard,mint_link}` | Typer commands |
+| `praisonai_bot/cli/commands/*` | bot, gateway, pairing, identity, onboard, kanban, claw, mint_link |
+| `praisonai_bot/cli/features/*` | gateway, bots_cli, onboard, approval, recipe_gateway |
 
-### SDK protocols (stay in `praisonaiagents`)
+Console script: `praisonai-bot`
 
-| Protocol | Location |
-|----------|----------|
-| `GatewayProtocol` | `praisonaiagents/gateway/protocols.py` |
-| `BotOSProtocol` | `praisonaiagents/bots/protocols.py` |
+## Wrapper shims (backward compat)
+
+| Shim | Target |
+|------|--------|
+| `praisonai.bots` | `alias_package` → `praisonai_bot.bots` |
+| `praisonai.gateway` | `alias_package` → `praisonai_bot.gateway` |
+| `praisonai.daemon` | `alias_package` → `praisonai_bot.daemon` |
+| `praisonai.cli.commands.{bot,gateway,...}` | `sys.modules` → `praisonai_bot.cli.commands.*` |
+
+## Stays in `praisonaiagents` (protocols only)
+
+| Module | Location |
+|--------|----------|
+| `BotOSProtocol`, `BotProtocol` | `praisonaiagents/bots/protocols.py` |
+| `GatewayProtocol`, `GatewayConfig` | `praisonaiagents/gateway/` |
 | `BotGatewayFacadeProtocol` | `praisonaiagents/cli/protocols.py` |
 
 ## Stays in `praisonai-code`
 
 - `cli/commands/daemon.py` (warm runtime)
-- Doctor bridge checks (`gateway_checks`, `bot_checks`)
-- `_paths.resolve_bot_config_path`
-- `_WRAPPER_RESIDENT_COMMANDS` routing (until entry-point generalisation)
+- Doctor checks via `_bot_bridge`
+- `_BOT_RESIDENT_COMMANDS` routing to `praisonai_bot.cli.commands.*`
+- `serve gateway` / `serve ui-gateway` / `serve recipe` bridges to bot package
 
-## Stays in `praisonai` wrapper (until split)
+## Stays in `praisonai` wrapper
 
-- All modules listed above remain wrapper-resident in C8.4
-- Wrapper `pyproject.toml` extras: `[gateway]`, `[bot]`, `[claw]`
+- `cli/commands/dashboard.py` (unified flow+claw+ui launcher)
+- `cli/features/serve.py` (HTTP agents/mcp/a2a serve — not gateway recipe)
+- `scheduler/*` (gateway polls via `_wrapper_bridge` when co-installed)
+- Framework adapters, train, deploy
 
-## Post-split changes required
+## Install matrix
 
-1. Retarget `praisonaiagents.gateway` lazy re-exports to `praisonai_bot.gateway`
-2. Update `systemd.py` ExecStart from `python -m praisonai gateway` to `praisonai-bot`
-3. Generalise `LazyCommandGroup.get_command()` beyond hardcoded `praisonai.cli.commands.*`
-4. Add `[project.entry-points."praisonai.channels"]` in bot pyproject
-5. Bridge doctor/approval checks to new package namespace
+| Install | Bots/Gateway |
+|---------|--------------|
+| `pip install praisonaiagents` | Protocols only |
+| `pip install praisonai-bot[gateway,bot]` | Standalone (`praisonai-bot gateway start`) |
+| `pip install praisonai` | Full stack via dep + shims |
+| `pip install praisonai[bot]` | Alias → `praisonai-bot[bot]` |
 
-## C8.4 routing (interim)
+## Publish order
 
-Legacy `parse_args` gateway/bot branches use `legacy_dispatch.py` bridge to wrapper features — no direct `.features.gateway` import from code namespace.
+`praisonaiagents` → `praisonai-code` + `praisonai-bot` → `praisonai`
+
+See `src/praisonai/scripts/publish_all.py` and `.github/workflows/pypi-release.yml`.

--- a/src/praisonai/tests/unit/test_c9_1_boundaries.py
+++ b/src/praisonai/tests/unit/test_c9_1_boundaries.py
@@ -54,3 +54,12 @@ def test_sdk_gateway_lazy_resolves_bot_first():
 def test_no_nested_praisonai_bot_under_wrapper():
     wrapper_pkg = REPO_ROOT / "src" / "praisonai" / "praisonai"
     assert not (wrapper_pkg / "praisonai_bot").exists()
+
+
+def test_bot_registry_resolves_without_wrapper():
+    """Built-in platform loaders must not require the praisonai wrapper."""
+    from praisonai_bot.bots._registry import resolve_adapter
+
+    telegram = resolve_adapter("telegram")
+    assert telegram.__name__ == "TelegramBot"
+    assert telegram.__module__.startswith("praisonai_bot.bots.")


### PR DESCRIPTION
## Summary
- Fix praisonai_bot.bots._registry builtin loaders to import praisonai_bot.bots.* instead of praisonai.bots.*, enabling true standalone pip install praisonai-bot channel resolution without the wrapper.
- Align entry-point group to praisonai.channels, sync __version__ from _version.py, and bump praisonaiagents>=1.6.123 in bot pyproject.
- Extend standalone CI smoke and add test_bot_registry_resolves_without_wrapper; update SDK docstrings and C9 backlog/manifest docs.
- Map PYPI_TOKEN / PYPI_API_TOKEN to UV_PUBLISH_TOKEN for uv publish in release scripts.
- Fix flaky deprecation test in test_bot_fixes.py when _approval is pre-imported via bot package.

## Test plan
- [x] bash scripts/check_c9_bot_imports.sh
- [x] bash scripts/audit_bot_wrapper_imports.sh
- [x] pytest src/praisonai/tests/unit/test_c9_1_boundaries.py src/praisonai/tests/unit/test_c9_backward_compat.py — 12/12
- [x] pytest src/praisonai-bot/tests/unit — 1103 passed, 3 skipped
- [x] Standalone venv: resolve_adapter('telegram') → praisonai_bot.bots.telegram.TelegramBot
- [x] Real API: smoke_w1_botos_real.py — PASS (gpt-4o-mini)
- [x] Real API: test_real_key_smoke.py with RUN_REAL_KEY_TESTS=1 — 7 passed, 2 skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved standalone bot adapter resolution validation (including Telegram) without requiring the wrapper.

* **Bug Fixes**
  * Enhanced bot adapter/registry loading with clearer built-in vs third-party duplicate handling.
  * Updated version exposure to be sourced consistently from the package.

* **Documentation**
  * Refreshed bot/package location guidance and compatibility import wrapper wording.

* **Tests**
  * Strengthened C9 boundary and deprecation-warning tests to reliably assert expected behavior.

* **Chores**
  * Publishing scripts/workflow now resolve credentials more robustly and use a safer, stricter publish flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->