### PR TITLE
Fix four-tier bridge wiring and standalone tier boundaries

### DIFF
--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -129,17 +129,35 @@ jobs:
         done
         echo "C7 hot-path import gate ok"
         bash "$GITHUB_WORKSPACE/scripts/check_c7_imports.sh"
-        # Standalone run must not fail on wrapper ImportError (API auth failure is OK)
+        # Standalone actions run (no wrapper); default run/chat require praisonai
         set +e
-        RUN_OUT=$(timeout 90 /tmp/praisonai-code-standalone/bin/praisonai-code run "Say hello in one word" 2>&1)
+        RUN_OUT=$(timeout 90 /tmp/praisonai-code-standalone/bin/praisonai-code run --output actions "Say hello in one word" 2>&1)
         RUN_CODE=$?
         set -e
         echo "$RUN_OUT" | tail -20
         if echo "$RUN_OUT" | grep -qE 'ImportError|ModuleNotFoundError: No module named .praisonai'; then
-          echo "FAIL: standalone run hit wrapper import error"
+          echo "FAIL: standalone actions run hit wrapper import error"
           exit 1
         fi
-        echo "standalone run import gate ok (exit $RUN_CODE)"
+        echo "standalone actions run import gate ok (exit $RUN_CODE)"
+        set +e
+        DEFAULT_RUN=$(timeout 15 /tmp/praisonai-code-standalone/bin/praisonai-code run "hi" 2>&1)
+        set -e
+        echo "$DEFAULT_RUN" | tail -10
+        if ! echo "$DEFAULT_RUN" | grep -qi 'pip install praisonai'; then
+          echo "FAIL: default run should prompt for praisonai wrapper install"
+          exit 1
+        fi
+        echo "default run wrapper gate ok"
+        set +e
+        CHAT_RUN=$(timeout 10 /tmp/praisonai-code-standalone/bin/praisonai-code chat 2>&1)
+        set -e
+        echo "$CHAT_RUN" | tail -10
+        if ! echo "$CHAT_RUN" | grep -qi 'pip install praisonai'; then
+          echo "FAIL: chat should prompt for praisonai wrapper install"
+          exit 1
+        fi
+        echo "chat wrapper gate ok"
 
     - name: Standalone praisonai-bot smoke (C9)
       run: |
@@ -162,6 +180,12 @@ jobs:
         "
         /tmp/praisonai-bot-standalone/bin/praisonai-bot --help
         bash "$GITHUB_WORKSPACE/scripts/check_c9_bot_imports.sh"
+        bash "$GITHUB_WORKSPACE/scripts/check_bot_code_imports.sh"
+        /tmp/praisonai-bot-standalone/bin/python -c "
+        import praisonai_bot.cli.commands.bot as bot_cmd
+        import praisonai_bot.cli.commands.gateway as gw_cmd
+        print('bot command modules import ok', bot_cmd.app, gw_cmd.app)
+        "
     
     - name: Smoke Test Summary
       if: always()

--- a/scripts/c9_code_import_allowlist.txt
+++ b/scripts/c9_code_import_allowlist.txt
@@ -1,0 +1,4 @@
+# Files allowed to reference praisonai_code directly (bridges / bootstrap only).
+_code_bridge.py
+_bootstrap.py
+_registry.py

--- a/scripts/check_bot_code_imports.sh
+++ b/scripts/check_bot_code_imports.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT="src/praisonai-bot/praisonai_bot"
 ALLOWLIST="scripts/c9_code_import_allowlist.txt"
-RE='(^from praisonai_code|^import praisonai_code)'
+RE='(from praisonai_code|import praisonai_code)'
 FAIL=0
 
 allowed_line() {

--- a/scripts/check_bot_code_imports.sh
+++ b/scripts/check_bot_code_imports.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# C9 bot→code gate: production code must not hard-import praisonai_code (use _code_bridge).
+set -euo pipefail
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="src/praisonai-bot/praisonai_bot"
+ALLOWLIST="scripts/c9_code_import_allowlist.txt"
+RE='(^from praisonai_code|^import praisonai_code)'
+FAIL=0
+
+allowed_line() {
+  local rel="$1"
+  if [ ! -f "$ALLOWLIST" ]; then
+    return 1
+  fi
+  sed -E 's/[[:space:]]*#.*$//;/^[[:space:]]*$/d' "$ALLOWLIST" | grep -Fxq "$rel"
+}
+
+while IFS= read -r f; do
+  rel="${f#"$ROOT/"}"
+  if allowed_line "$rel"; then
+    continue
+  fi
+  if grep -E "$RE" "$f" 2>/dev/null | grep -v '^[[:space:]]*#'; then
+    echo "FAIL: direct praisonai_code import in $rel (use praisonai_bot._code_bridge)"
+    FAIL=1
+  fi
+done < <(find "$ROOT" -name '*.py' -type f)
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "check_bot_code_imports ok"
+else
+  exit 1
+fi

--- a/src/praisonai-agents/praisonaiagents/gateway/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/gateway/__init__.py
@@ -5,10 +5,11 @@ Provides protocols and base classes for building gateway/control plane
 implementations that coordinate multi-agent deployments.
 
 This module contains only protocols and lightweight utilities.
-Heavy implementations live in the praisonai wrapper package.
+Heavy implementations live in the ``praisonai-bot`` package (C9); the
+``praisonai`` wrapper re-exports them for full-stack installs.
 
 Gap S2: WebSocketGateway is re-exported here for convenience but requires
-the praisonai wrapper package to be installed.
+``praisonai-bot`` (or ``pip install praisonai``) to be installed.
 """
 
 from .protocols import (
@@ -119,11 +120,10 @@ _lazy_cache = {}
 
 
 def __getattr__(name: str):
-    """Lazy load heavy gateway implementations from praisonai wrapper.
-    
-    Gap S2: Re-export WebSocketGateway from praisonai wrapper for convenience.
-    This allows downstream packages to import from praisonaiagents.gateway
-    without needing to know about the praisonai wrapper.
+    """Lazy load heavy gateway implementations from praisonai-bot (C9).
+
+    Gap S2: Re-export WebSocketGateway for convenience. Prefer
+    ``praisonai_bot.gateway`` or ``pip install praisonai`` for full stack.
     """
     if name in _lazy_cache:
         return _lazy_cache[name]

--- a/src/praisonai-agents/praisonaiagents/gateway/protocols.py
+++ b/src/praisonai-agents/praisonaiagents/gateway/protocols.py
@@ -5,7 +5,8 @@ Defines the interfaces for gateway/control plane implementations.
 These protocols enable multi-agent coordination, session management,
 and real-time communication.
 
-All implementations should live in the praisonai wrapper package.
+All implementations live in the ``praisonai-bot`` package (``praisonai_bot.gateway``).
+The ``praisonai`` wrapper provides backward-compatible shims.
 """
 
 from __future__ import annotations
@@ -507,7 +508,7 @@ class GatewayProtocol(Protocol):
     The gateway coordinates communication between clients and agents,
     manages sessions, and provides health/presence tracking.
     
-    Example usage (implementation in praisonai wrapper):
+    Example usage (implementation in praisonai_bot.gateway):
         from praisonai.gateway import WebSocketGateway
         
         gateway = WebSocketGateway(port=8765)
@@ -917,7 +918,7 @@ class OutboundDeliveryProtocol(Protocol):
     are persisted before sending and can be retried on failure. This provides
     crash-safe at-least-once delivery for channel replies.
     
-    Example usage (implementation in praisonai wrapper):
+    Example usage (implementation in praisonai_bot.gateway):
         from praisonai.bots import OutboundQueue
         
         outbox = OutboundQueue(path="~/.praisonai/state/outbox.sqlite")
@@ -1737,7 +1738,7 @@ class OutboundMessengerProtocol(Protocol):
     built-in ``send_message`` tool can resolve it. It bridges to the existing
     delivery stack (DeliveryRouter, HomeChannelRegistry, outbox, mirroring).
 
-    Example usage (implementation in praisonai wrapper)::
+    Example usage (implementation in praisonai_bot.gateway)::
 
         messenger = BotOutboundMessenger(bot, resolver, router)
         token = register_outbound_messenger(messenger)

--- a/src/praisonai-bot/praisonai_bot/bots/_approval_base.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_approval_base.py
@@ -139,7 +139,9 @@ async def classify_with_llm(
     )
 
     try:
-        from praisonai_code.llm.env import resolve_llm_endpoint
+        from praisonai_bot._code_bridge import import_code_module
+
+        resolve_llm_endpoint = import_code_module("praisonai_code.llm.env").resolve_llm_endpoint
         ep = resolve_llm_endpoint()
         
         client = OpenAI(

--- a/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
@@ -457,7 +457,9 @@ def validate_gateway_config(raw: Dict[str, Any], apply_env_substitution: bool = 
     """
     # Apply environment variable substitution if requested
     if apply_env_substitution:
-        from praisonai_code.cli.utils.env_utils import substitute_env_vars
+        from praisonai_bot._code_bridge import import_code_module
+
+        substitute_env_vars = import_code_module("praisonai_code.cli.utils.env_utils").substitute_env_vars
         raw = substitute_env_vars(raw)
         
     try:
@@ -515,7 +517,9 @@ def load_and_validate_gateway_yaml(path: str, apply_env_substitution: bool = Tru
         )
     
     # Load env file if not already loaded
-    from praisonai_code.cli.utils.env_utils import load_env_file
+    from praisonai_bot._code_bridge import import_code_module
+
+    load_env_file = import_code_module("praisonai_code.cli.utils.env_utils").load_env_file
     load_env_file()
     
     with open(path) as f:

--- a/src/praisonai-bot/praisonai_bot/bots/_defaults.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_defaults.py
@@ -161,7 +161,9 @@ def _resolve_tool_names_with_workspace(tool_names: List[str], workspace=None) ->
     """Resolve tool names to actual tool instances with workspace support."""
     try:
         from praisonaiagents.tools.profiles import resolve_profiles
-        from praisonai_code.tool_resolver import ToolResolver
+        from praisonai_bot._code_bridge import import_code_module
+
+        ToolResolver = import_code_module("praisonai_code.tool_resolver").ToolResolver
         
         # Split into workspace-aware and regular tools
         workspace_tools = {

--- a/src/praisonai-bot/praisonai_bot/bots/botos.py
+++ b/src/praisonai-bot/praisonai_bot/bots/botos.py
@@ -1293,7 +1293,9 @@ class BotOS:
                     try:
                         # Go through the praisonai.tool_resolver shim so the
                         # praisonai_code bootstrap runs in lean installs.
-                        from praisonai_code.tool_resolver import ToolResolver
+                        from praisonai_bot._code_bridge import import_code_module
+
+                        ToolResolver = import_code_module("praisonai_code.tool_resolver").ToolResolver
 
                         # Point the resolver at the config directory's tools.py so
                         # config-local tools are found regardless of process cwd

--- a/src/praisonai-bot/praisonai_bot/cli/commands/bot.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/bot.py
@@ -106,8 +106,10 @@ def bot_start(
         praisonai bot start --config ~/.praisonai/bot.yaml
         praisonai bot start -c my-telegram-bot.yaml
     """
-    from praisonai_code.cli._paths import resolve_bot_config_path
+    from praisonai_bot._code_bridge import import_code_module
     from ..features.bots_cli import BotHandler
+
+    resolve_bot_config_path = import_code_module("praisonai_code.cli._paths").resolve_bot_config_path
 
     resolved = resolve_bot_config_path(config)
     handler = BotHandler()
@@ -613,8 +615,10 @@ def bot_install_daemon(
         praisonai bot install-daemon --config my-bot.yaml --no-start
     """
     from praisonai_bot.daemon import install_daemon
-    from praisonai_code.cli._paths import resolve_bot_config_path
+    from praisonai_bot._code_bridge import import_code_module
     from ..output.console import get_output_controller
+
+    resolve_bot_config_path = import_code_module("praisonai_code.cli._paths").resolve_bot_config_path
     
     output = get_output_controller()
     config = resolve_bot_config_path(config)

--- a/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
@@ -541,8 +541,10 @@ def gateway_install(
         praisonai gateway install --config my-bot.yaml --no-start
     """
     from praisonai_bot.daemon import install_daemon
-    from praisonai_code.cli._paths import resolve_bot_config_path
+    from praisonai_bot._code_bridge import import_code_module
     from ..output.console import get_output_controller
+
+    resolve_bot_config_path = import_code_module("praisonai_code.cli._paths").resolve_bot_config_path
     
     output = get_output_controller()
     config = resolve_bot_config_path(config)

--- a/src/praisonai-bot/praisonai_bot/cli/features/bots_cli.py
+++ b/src/praisonai-bot/praisonai_bot/cli/features/bots_cli.py
@@ -1037,7 +1037,9 @@ class BotHandler:
     
     def _resolve_tool_by_name(self, name: str):
         """Resolve a tool by name using the canonical ToolResolver."""
-        from praisonai_code.tool_resolver import ToolResolver
+        from praisonai_bot._code_bridge import import_code_module
+
+        ToolResolver = import_code_module("praisonai_code.tool_resolver").ToolResolver
         resolver = ToolResolver()
         tool = resolver.resolve(name, instantiate=True)
         if tool is None:

--- a/src/praisonai-bot/praisonai_bot/cli/features/onboard.py
+++ b/src/praisonai-bot/praisonai_bot/cli/features/onboard.py
@@ -522,7 +522,9 @@ class OnboardWizard:
             agent_instructions=self.agent_instructions,
         )
 
-        from praisonai_code.cli._paths import default_bot_config_path
+        from praisonai_bot._code_bridge import import_code_module
+
+        default_bot_config_path = import_code_module("praisonai_code.cli._paths").default_bot_config_path
         self.config_path = str(default_bot_config_path())
         os.makedirs(os.path.dirname(os.path.abspath(self.config_path)) or ".", exist_ok=True)
 
@@ -912,7 +914,9 @@ class OnboardWizard:
 
         env_file = _save_env_vars(env_to_save)
         yaml_content = _generate_bot_yaml(self.selected_platforms)
-        from praisonai_code.cli._paths import default_bot_config_path
+        from praisonai_bot._code_bridge import import_code_module
+
+        default_bot_config_path = import_code_module("praisonai_code.cli._paths").default_bot_config_path
         cfg_path = default_bot_config_path()
         os.makedirs(cfg_path.parent, exist_ok=True)
         with open(cfg_path, "w") as f:

--- a/src/praisonai-bot/praisonai_bot/gateway/server.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/server.py
@@ -3740,7 +3740,9 @@ class WebSocketGateway:
         # Resolve tool names to callables (same pattern as agents_generator)
         tool_resolver = None
         try:
-            from praisonai_code.tool_resolver import ToolResolver
+            from praisonai_bot._code_bridge import import_code_module
+
+            ToolResolver = import_code_module("praisonai_code.tool_resolver").ToolResolver
             tool_resolver = ToolResolver()
         except ImportError:
             logger.debug("ToolResolver not available, agents will have no tools")

--- a/src/praisonai-bot/praisonai_bot/integration/bridges/kanban_bridge.py
+++ b/src/praisonai-bot/praisonai_bot/integration/bridges/kanban_bridge.py
@@ -25,7 +25,7 @@ def get_jobs_store():
     try:
         from praisonai_bot._wrapper_bridge import import_wrapper_module
 
-        jobs = import_wrapper_module("praisonai.jobs.store")
+        jobs = import_wrapper_module("praisonai.jobs.server")
         return jobs.get_store
     except ImportError:
         return None
@@ -36,7 +36,7 @@ def get_jobs_executor():
     try:
         from praisonai_bot._wrapper_bridge import import_wrapper_module
 
-        jobs = import_wrapper_module("praisonai.jobs.executor")
+        jobs = import_wrapper_module("praisonai.jobs.server")
         return jobs.get_executor
     except ImportError:
         return None

--- a/src/praisonai-bot/praisonai_bot/integration/host_app.py
+++ b/src/praisonai-bot/praisonai_bot/integration/host_app.py
@@ -202,22 +202,23 @@ def setup_bridges() -> None:
     """Register optional L1→L2 bridge hooks (usage sink, schedules, aiui backends)."""
     import logging
 
+    from praisonai_bot._wrapper_bridge import import_wrapper_module
+
     log = logging.getLogger(__name__)
     sink = None
+    usage_bridge = None
 
     try:
-        from praisonai_bot.integration.bridges.usage_bridge import register_usage_sink
-
-        sink = register_usage_sink()
+        usage_bridge = import_wrapper_module("praisonai.integration.bridges.usage_bridge")
+        sink = usage_bridge.register_usage_sink()
     except ImportError as exc:
         log.debug("usage bridge unavailable: %s", exc)
     except Exception as exc:
         log.warning("usage bridge unavailable: %s", exc)
 
     try:
-        from praisonai_bot.integration.bridges.schedules_runner import ensure_schedule_runner
-
-        ensure_schedule_runner()
+        schedules_runner = import_wrapper_module("praisonai.integration.bridges.schedules_runner")
+        schedules_runner.ensure_schedule_runner()
     except ImportError as exc:
         log.debug("schedule runner unavailable: %s", exc)
     except Exception as exc:
@@ -225,34 +226,32 @@ def setup_bridges() -> None:
 
     try:
         import praisonaiui.backends as backends
-        from praisonai_bot.integration.bridges.hooks_query import list_hooks_for_api
-        from praisonai_bot.integration.bridges.workflows_service import run_workflow as svc_run
+
+        hooks_query = import_wrapper_module("praisonai.integration.bridges.hooks_query")
+        workflows_service = import_wrapper_module("praisonai.integration.bridges.workflows_service")
+        approvals_bridge = import_wrapper_module("praisonai.integration.bridges.approvals_bridge")
 
         def _workflow_backend(wf_id, *, workflow, input_data):
             text = (input_data or {}).get("text") or (input_data or {}).get("message") or ""
-            return svc_run(wf_id, input_text=text, workflow_config=workflow)
+            return workflows_service.run_workflow(
+                wf_id, input_text=text, workflow_config=workflow
+            )
 
-        backends.set_backend("hooks", list_hooks_for_api)
+        backends.set_backend("hooks", hooks_query.list_hooks_for_api)
         backends.set_backend("workflows", _workflow_backend)
         if sink is not None:
             backends.set_backend("usage_sink", sink)
-        from praisonai_bot.integration.bridges.usage_bridge import get_usage_query
+        if usage_bridge is not None:
+            query = usage_bridge.get_usage_query()
+            if query is not None:
+                backends.set_backend("usage_query", query)
+        backends.set_backend("approvals_pending", approvals_bridge.list_pending_approvals)
+        backends.set_backend("approvals_policies", approvals_bridge.get_approval_policies)
 
-        query = get_usage_query()
-        if query is not None:
-            backends.set_backend("usage_query", query)
-        from praisonai_bot.integration.bridges.approvals_bridge import (
-            get_approval_policies,
-            list_pending_approvals,
-        )
-
-        backends.set_backend("approvals_pending", list_pending_approvals)
-        backends.set_backend("approvals_policies", get_approval_policies)
-        
-        # Kanban and jobs backends
         from praisonai_bot.integration.bridges.kanban_bridge import register_kanban_backends
+
         register_kanban_backends()
-        
+
     except Exception as exc:
         log.warning("aiui backend injection failed: %s", exc)
 

--- a/src/praisonai-bot/pyproject.toml
+++ b/src/praisonai-bot/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Mervin Praison" }
 ]
 dependencies = [
-    "praisonaiagents>=1.6.123",
+    "praisonaiagents>=1.6.126",
     "rich>=13.7",
     "typer>=0.12.0",
     "click>=8.4.2",

--- a/src/praisonai-code/README.md
+++ b/src/praisonai-code/README.md
@@ -41,11 +41,25 @@ click, textual, PyYAML, python-dotenv, litellm, mcp, pydantic — see
 `pyproject.toml`). The rules above govern the **inter-package** direction.
 
 > **C7 (hot path complete):** Standalone `pip install praisonai-code` supports
-> agentic terminal commands (`run`, `chat`, `code`, warm runtime) without importing
-> the wrapper on the hot path. Approval backends resolve locally via
+> core agentic terminal commands without importing the wrapper on the hot path.
+> Approval backends resolve locally via
 > `praisonai_code.cli.features._approval_bridge` (channel bots delegate to the
 > wrapper). Optional features (observability sinks, framework adapters,
 > bots/gateway) remain wrapper-only via `praisonai_code._wrapper_bridge`.
+
+### Standalone limits (`pip install praisonai-code` only)
+
+| Command | Works standalone? | Notes |
+|---------|-------------------|-------|
+| `run --help`, `config`, `doctor` | Yes | |
+| `run --output actions "…"` | Yes | In-process `Agent` |
+| `run "…"` (default) | No | Requires `pip install praisonai` |
+| `chat`, `code` | No | TUI / interactive legacy live in wrapper |
+| `daemon start` (foreground) | Yes | |
+| `daemon start --background` | Yes | Spawns `python -m praisonai_code.runtime` |
+
+For full terminal UX (`chat`, `code`, default `run`), install the wrapper:
+`pip install praisonai`.
 
 Completed C7 steps:
 - `praisonai_code._registry` — vendored plugin registry (no wrapper import)

--- a/src/praisonai-code/praisonai_code/cli/commands/chat.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/chat.py
@@ -204,6 +204,16 @@ def chat_main(
             raise typer.Exit(1)
     
     # Use the async TUI (non-blocking, scrollable output)
+    from praisonai_code._wrapper_bridge import wrapper_available
+
+    if not wrapper_available():
+        typer.echo(
+            "Error: chat requires the praisonai wrapper. "
+            "Install the full wrapper: pip install praisonai",
+            err=True,
+        )
+        raise typer.Exit(1)
+
     from praisonai_code.cli.interactive.async_tui import AsyncTUI, AsyncTUIConfig
 
     # Resolve a provider-aware default when no model was given:

--- a/src/praisonai-code/praisonai_code/cli/commands/code.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/code.py
@@ -162,6 +162,16 @@ def code_main(
             args.llm = agent_profile["llm"]
     
     # Import and run the terminal-native interactive mode
+    from praisonai_code._wrapper_bridge import wrapper_available
+
+    if not wrapper_available():
+        typer.echo(
+            "Error: code requires the praisonai wrapper. "
+            "Install the full wrapper: pip install praisonai",
+            err=True,
+        )
+        raise typer.Exit(1)
+
     from praisonai_code.cli.main import PraisonAI
     
     praison = PraisonAI()

--- a/src/praisonai-code/praisonai_code/cli/commands/daemon.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/daemon.py
@@ -68,7 +68,7 @@ def daemon_start(
         import sys
 
         cmd = [
-            sys.executable, "-m", "praisonai.runtime",
+            sys.executable, "-m", "praisonai_code.runtime",
             "--host", host,
             "--port", str(port),
             "--idle-timeout", str(idle_timeout),

--- a/src/praisonai-code/praisonai_code/cli/commands/run.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/run.py
@@ -1161,6 +1161,16 @@ def _run_prompt(
         args.thinking_budget = thinking_budget
         
         praison.args = args
+
+        from praisonai_code._wrapper_bridge import wrapper_available
+
+        if not wrapper_available():
+            output.print_error(
+                "Default run mode requires the praisonai wrapper. "
+                "Install with: pip install praisonai\n"
+                "Standalone alternative: praisonai run --output actions \"your prompt\""
+            )
+            raise typer.Exit(1)
         
         result = praison.handle_direct_prompt(prompt)
         

--- a/src/praisonai-code/praisonai_code/runtime/__main__.py
+++ b/src/praisonai-code/praisonai_code/runtime/__main__.py
@@ -1,7 +1,8 @@
 """
-Entrypoint so ``python -m praisonai.runtime`` boots a warm runtime.
+Entrypoint so ``python -m praisonai_code.runtime`` boots a warm runtime.
 
 Used by ``praisonai daemon start --background`` to spawn a detached process.
+The wrapper shim ``python -m praisonai.runtime`` remains for full-stack installs.
 """
 
 from __future__ import annotations

--- a/src/praisonai-code/pyproject.toml
+++ b/src/praisonai-code/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Mervin Praison" }
 ]
 dependencies = [
-    "praisonaiagents>=1.6.101",
+    "praisonaiagents>=1.6.126",
     "rich>=13.7",
     "typer>=0.12.0",
     "click>=8.4.2",

--- a/src/praisonai/tests/C7_VERIFICATION.md
+++ b/src/praisonai/tests/C7_VERIFICATION.md
@@ -50,8 +50,22 @@ echo "hot-path gate ok"
 ## Real agentic (optional, requires API key)
 
 ```bash
-OPENAI_API_KEY=... praisonai-code run "Say hello in one word"
+# Standalone (actions mode — no wrapper required)
+OPENAI_API_KEY=... praisonai-code run --output actions "Say hello in one word"
+
+# Full stack (default run mode, chat, code)
+OPENAI_API_KEY=... pip install praisonai
+OPENAI_API_KEY=... praisonai run "Say hello in one word"
 ```
+
+## Standalone command matrix
+
+| Command | Standalone? |
+|---------|-------------|
+| `run --output actions` | Yes |
+| `run` (default) | No — needs wrapper |
+| `chat`, `code` | No — needs wrapper |
+| `daemon start --background` | Yes (`praisonai_code.runtime`) |
 
 ## Moved modules (C7)
 

--- a/src/praisonai/tests/C9_BACKLOG.md
+++ b/src/praisonai/tests/C9_BACKLOG.md
@@ -33,6 +33,13 @@ Epic branch: `feat/c9-praisonai-bot`
 - [x] `[claw]` extra composes `praisonai-bot[gateway,bot]`
 - [x] CI legacy paths + `test_c9_*` smoke; duplicate onboard tests removed
 
+## Four-tier validation fixes (2026-07-04)
+
+- [x] `host_app.setup_bridges()` → wrapper bridges via `_wrapper_bridge` (not missing bot copies)
+- [x] `kanban_bridge` jobs helpers → `praisonai.jobs.server`
+- [x] Bot production `praisonai_code` imports → `_code_bridge` (`check_bot_code_imports.sh`)
+- [x] C7 standalone truth: `chat`/`code`/default `run` require wrapper; daemon `--background` uses `praisonai_code.runtime`
+
 ## Deferred (optional follow-on)
 
 - [ ] `praisonai.jobs/*` move — stays wrapper-owned (lazy `praisonai` + recipe deps)
@@ -43,6 +50,7 @@ Epic branch: `feat/c9-praisonai-bot`
 ```bash
 bash scripts/check_c9_bot_imports.sh
 bash scripts/audit_bot_wrapper_imports.sh
+bash scripts/check_bot_code_imports.sh
 pytest src/praisonai/tests/unit/test_c9_backward_compat.py -q
 pytest src/praisonai/tests/unit/test_c9_1_boundaries.py -q
 ```


### PR DESCRIPTION
## Summary
- **P0:** Fix `host_app.setup_bridges()` to load wrapper-resident bridges via `_wrapper_bridge`; point `kanban_bridge` jobs helpers at `praisonai.jobs.server` (restores AIUI backend injection and kanban integration tests).
- **P1:** Route 9 bot production `praisonai_code` imports through `_code_bridge`; add `scripts/check_bot_code_imports.sh` gate.
- **P2:** Fix `daemon start --background` to spawn `praisonai_code.runtime`; add clear wrapper-required errors for default `run`, `chat`, and `code`; document C7 standalone limits; extend CI smoke for actions run + wrapper gates.
- **P3:** Align `praisonaiagents>=1.6.126` in code/bot pyprojects; update SDK gateway docstrings and C9/C7 backlog.

## Test plan
- [x] `bash scripts/check_bot_code_imports.sh`
- [x] `bash scripts/check_c7_imports.sh`
- [x] `bash scripts/audit_bot_wrapper_imports.sh`
- [x] `bash scripts/check_c9_bot_imports.sh`
- [x] `pytest src/praisonai/tests/integration/test_kanban_host_injection.py` (6/6)
- [x] `pytest src/praisonai/tests/integration/test_aiui_backends_injection.py test_aiui_gateway_parity.py` (8/8)
- [x] `pytest src/praisonai/tests/unit/test_c5_backward_compat.py test_c9_backward_compat.py test_c9_1_boundaries.py test_c7_1_boundaries.py` (55+ passed)
- [x] Standalone smoke: default `run`/`chat` emit `pip install praisonai` hint (not raw ImportError)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved wrapper-aware behavior for CLI flows (including `run`, `chat`, `code`, `bot`, and `gateway`) with clearer install guidance when the full wrapper isn’t present.

* **Bug Fixes**
  * More reliable runtime/module resolution for background, bot, and gateway operations.
  * Corrected kanban backend job wiring and improved fallback behavior when optional components aren’t available.

* **Documentation**
  * Updated standalone command matrices and limits across the product docs and verification guides.

* **Tests/CI**
  * Added a production import gate for bot code and expanded smoke workflow checks for wrapper-gated commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->