### PR TITLE
Close four-tier CI blind spots (stacked on #2650)

### DIFF
--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -186,6 +186,12 @@ jobs:
         import praisonai_bot.cli.commands.gateway as gw_cmd
         print('bot command modules import ok', bot_cmd.app, gw_cmd.app)
         "
+
+    - name: Audit hybrid module imports (C8 full stack)
+      run: |
+        set -euo pipefail
+        pip install -q -e src/praisonai-agents -e src/praisonai-code -e src/praisonai-bot -e src/praisonai
+        python scripts/audit_hybrid_modules.py
     
     - name: Smoke Test Summary
       if: always()

--- a/src/praisonai-code/tests/unit/test_daemon_background.py
+++ b/src/praisonai-code/tests/unit/test_daemon_background.py
@@ -1,0 +1,33 @@
+"""Daemon CLI background spawn uses code-tier runtime module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+
+def test_daemon_start_background_spawns_code_runtime_module():
+    """Background daemon must spawn praisonai_code.runtime, not praisonai.runtime."""
+    from praisonai_code.cli.commands import daemon as daemon_cmd
+
+    ready = MagicMock(base_url="http://127.0.0.1:9999", pid=12345)
+
+    with patch(
+        "praisonai_code.runtime.get_runtime_descriptor",
+        side_effect=[None, ready],
+    ), patch("subprocess.Popen") as popen, patch("time.sleep"):
+        popen.return_value = MagicMock()
+        with pytest.raises(typer.Exit) as exc:
+            daemon_cmd.daemon_start(
+                host="127.0.0.1",
+                port=0,
+                model=None,
+                idle_timeout=1800.0,
+                background=True,
+            )
+        assert exc.value.exit_code == 0
+        cmd = popen.call_args[0][0]
+        assert "-m" in cmd
+        assert cmd[cmd.index("-m") + 1] == "praisonai_code.runtime"

--- a/src/praisonai/tests/C9_BACKLOG.md
+++ b/src/praisonai/tests/C9_BACKLOG.md
@@ -39,6 +39,7 @@ Epic branch: `feat/c9-praisonai-bot`
 - [x] `kanban_bridge` jobs helpers → `praisonai.jobs.server`
 - [x] Bot production `praisonai_code` imports → `_code_bridge` (`check_bot_code_imports.sh`)
 - [x] C7 standalone truth: `chat`/`code`/default `run` require wrapper; daemon `--background` uses `praisonai_code.runtime`
+- [x] `scripts/audit_hybrid_modules.py` in CI smoke (C8 hybrid path gate)
 
 ## Deferred (optional follow-on)
 

--- a/src/praisonai/tests/integration/test_kanban_host_injection.py
+++ b/src/praisonai/tests/integration/test_kanban_host_injection.py
@@ -116,7 +116,8 @@ def test_missing_dependencies_graceful_degradation():
 def test_jobs_store_bridge():
     """Test jobs store bridge resolves praisonai.jobs.server helpers."""
     from praisonai.integration.bridges.kanban_bridge import get_jobs_store, get_jobs_executor
-    from praisonai_bot._wrapper_bridge import wrapper_available
+
+    bridge = pytest.importorskip("praisonai_bot._wrapper_bridge")
 
     jobs_store = get_jobs_store()
     jobs_executor = get_jobs_executor()
@@ -124,7 +125,7 @@ def test_jobs_store_bridge():
     assert jobs_store is None or callable(jobs_store)
     assert jobs_executor is None or callable(jobs_executor)
 
-    if wrapper_available():
+    if bridge.wrapper_available():
         from praisonai.jobs import server as jobs_server
 
         assert jobs_store is jobs_server.get_store

--- a/src/praisonai/tests/integration/test_kanban_host_injection.py
+++ b/src/praisonai/tests/integration/test_kanban_host_injection.py
@@ -114,14 +114,18 @@ def test_missing_dependencies_graceful_degradation():
 
 
 def test_jobs_store_bridge():
-    """Test jobs store bridge functionality."""
+    """Test jobs store bridge resolves praisonai.jobs.server helpers."""
     from praisonai.integration.bridges.kanban_bridge import get_jobs_store, get_jobs_executor
-    
-    # These may return None if jobs module isn't available, which is fine
+    from praisonai_bot._wrapper_bridge import wrapper_available
+
     jobs_store = get_jobs_store()
     jobs_executor = get_jobs_executor()
-    
-    # Just test that the functions don't raise exceptions
-    # Actual functionality depends on jobs module implementation
+
     assert jobs_store is None or callable(jobs_store)
     assert jobs_executor is None or callable(jobs_executor)
+
+    if wrapper_available():
+        from praisonai.jobs import server as jobs_server
+
+        assert jobs_store is jobs_server.get_store
+        assert jobs_executor is jobs_server.get_executor


### PR DESCRIPTION
## Summary
Stacked on #2650. Multi-agent gap review found no further production bridge bugs; remaining actionable item was CI coverage for C8 hybrid import paths plus stronger regression tests.

- Add `scripts/audit_hybrid_modules.py` to smoke CI (full-stack editable install)
- Strengthen `test_jobs_store_bridge` to assert `praisonai.jobs.server.get_store/get_executor` when wrapper is present
- Add `test_daemon_background.py` regression: `daemon start --background` spawns `-m praisonai_code.runtime`

## Multi-agent gap review
- **Code tier agent:** No remaining direct-import or bridge-path violations after #2650
- **CI agent:** Primary blind spot was `audit_hybrid_modules.py` not wired into workflows (now fixed)
- **Deferred (unchanged):** async_tui repatriation, gateway thinning, jobs API move — documented/intentional per plan

## Test plan
- [x] `python scripts/audit_hybrid_modules.py`
- [x] `pytest src/praisonai-code/tests/unit/test_daemon_background.py`
- [x] `pytest src/praisonai/tests/integration/test_kanban_host_injection.py::test_jobs_store_bridge`


Made with [Cursor](https://cursor.com)