### PR TITLE
fix: restore CI smoke wrapper gate for default run

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/commands/run.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/run.py
@@ -70,6 +70,7 @@ def _require_wrapper_for_default_run(
     )
     raise typer.Exit(1)
 
+
 def _parse_permissions(allow: Optional[List[str]], deny: Optional[List[str]], permissions_file: Optional[str], default: Optional[str]) -> Optional[dict]:
     """Parse permission flags into a config dict.
     
@@ -1229,10 +1230,6 @@ def _run_prompt(
         
         praison.args = args
 
-        _require_wrapper_for_default_run(
-            prompt, agent=None, command=None, output_mode=output_mode
-        )
-        
         result = praison.handle_direct_prompt(prompt)
         
         _record_session_usage(session_id or auto_save_name, model, output)

--- a/src/praisonai-code/praisonai_code/cli/commands/run.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/run.py
@@ -33,6 +33,43 @@ def _is_yaml_file(target: Optional[str]) -> bool:
     )
 
 
+def _direct_prompt_needs_wrapper(
+    target: Optional[str],
+    *,
+    agent: Optional[str],
+    command: Optional[str],
+    output_mode: Optional[str],
+) -> bool:
+    """True when a text prompt run uses wrapper-only handle_direct_prompt path."""
+    if agent or command or not target or _is_yaml_file(target):
+        return False
+    return output_mode not in ("actions", "json", "stream", "stream-json")
+
+
+def _require_wrapper_for_default_run(
+    target: Optional[str],
+    *,
+    agent: Optional[str],
+    command: Optional[str],
+    output_mode: Optional[str],
+) -> None:
+    """Fail fast with install hint before credential/setup checks."""
+    if not _direct_prompt_needs_wrapper(
+        target, agent=agent, command=command, output_mode=output_mode
+    ):
+        return
+    from praisonai_code._wrapper_bridge import wrapper_available
+
+    if wrapper_available():
+        return
+    output = get_output_controller()
+    output.print_error(
+        "Default run mode requires the praisonai wrapper. "
+        "Install with: pip install praisonai\n"
+        "Standalone alternative: praisonai run --output actions \"your prompt\""
+    )
+    raise typer.Exit(1)
+
 def _parse_permissions(allow: Optional[List[str]], deny: Optional[List[str]], permissions_file: Optional[str], default: Optional[str]) -> Optional[dict]:
     """Parse permission flags into a config dict.
     
@@ -543,6 +580,10 @@ def run_main(
     except ValueError as exc:
         output.print_error(str(exc))
         raise typer.Exit(1)
+
+    _require_wrapper_for_default_run(
+        target, agent=agent, command=command, output_mode=output_mode
+    )
 
     # Early credential check before any processing
     if target:  # Only check if we actually have something to run
@@ -1091,7 +1132,6 @@ def _run_prompt(
                 )
             
             # Add session support to Agent if needed
-            from ..utils.project import build_cli_memory_config, apply_cli_session_continuity
             memory_cfg = build_cli_memory_config(session_id=session_id, auto_save=auto_save_name)
             if memory_cfg is not None:
                 agent_config["memory"] = memory_cfg
@@ -1189,15 +1229,9 @@ def _run_prompt(
         
         praison.args = args
 
-        from praisonai_code._wrapper_bridge import wrapper_available
-
-        if not wrapper_available():
-            output.print_error(
-                "Default run mode requires the praisonai wrapper. "
-                "Install with: pip install praisonai\n"
-                "Standalone alternative: praisonai run --output actions \"your prompt\""
-            )
-            raise typer.Exit(1)
+        _require_wrapper_for_default_run(
+            prompt, agent=None, command=None, output_mode=output_mode
+        )
         
         result = praison.handle_direct_prompt(prompt)
         


### PR DESCRIPTION
## Root cause
Optimized Test Suite **smoke** job fails on:
```
FAIL: default run should prompt for praisonai wrapper install
```

`run_main()` runs the API-key credential check **before** the wrapper-required path, so standalone `praisonai-code run "hi"` prints "No API key configured" instead of `pip install praisonai`.

## Fix
- Add `_require_wrapper_for_default_run()` and call it in `run_main()` before credential checks
- Remove shadowed `apply_cli_session_continuity` import from `utils.project` in actions mode (fixes `unexpected keyword argument 'auto_save'`)

## Test plan
- [x] Standalone `run "hi"` → wrapper install hint (matches CI grep)
- [x] Standalone `run --output actions` → no TypeError on session continuity
- [x] `pytest src/praisonai/tests/unit/test_c7_1_boundaries.py`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `run` command behavior so wrapper-only direct-prompt requirements are validated earlier, with a clearer install/alternative hint when missing.
  * Enhanced default direct-prompt handling to fail fast when the selected prompt/output combination requires wrapper support.
  * Kept `--output actions` runs working by aligning session continuity behavior with the updated execution flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->