### PR TITLE
fix: smoke CI wrapper grep survives Rich panel wrap

### DIFF
--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -144,7 +144,7 @@ jobs:
         DEFAULT_RUN=$(timeout 15 /tmp/praisonai-code-standalone/bin/praisonai-code run "hi" 2>&1)
         set -e
         echo "$DEFAULT_RUN" | tail -10
-        if ! echo "$DEFAULT_RUN" | grep -qi 'pip install praisonai'; then
+        if ! echo "$DEFAULT_RUN" | grep -qi 'install praisonai'; then
           echo "FAIL: default run should prompt for praisonai wrapper install"
           exit 1
         fi
@@ -153,7 +153,7 @@ jobs:
         CHAT_RUN=$(timeout 10 /tmp/praisonai-code-standalone/bin/praisonai-code chat 2>&1)
         set -e
         echo "$CHAT_RUN" | tail -10
-        if ! echo "$CHAT_RUN" | grep -qi 'pip install praisonai'; then
+        if ! echo "$CHAT_RUN" | grep -qi 'install praisonai'; then
           echo "FAIL: chat should prompt for praisonai wrapper install"
           exit 1
         fi


### PR DESCRIPTION
## Root cause
#2706 fixed the runtime behaviour, but smoke CI still fails because Rich wraps the error panel:

```
│ Install with: pip        │
│ install praisonai        │
```

The grep for `pip install praisonai` never matches as a single line.

## Fix
Match on `install praisonai` for default `run` and `chat` wrapper gates.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated checks to accept broader install guidance text when validating command startup messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->