### PR TITLE
fix: init guard test CI failure (wrong mock target)

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
+++ b/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
@@ -454,7 +454,7 @@ class PraisonAI:
                     result = self.handle_direct_prompt(combined_prompt)
                     # Result already printed by handle_direct_prompt, don't print again
                     return result
-                elif os.path.isfile(args.command) or args.command.lower().endswith((".yaml", ".yml")):
+                elif os.path.isfile(args.command) or (args.command or "").lower().endswith((".yaml", ".yml")):
                     # Treat as an agent file when it is an existing file or a YAML path
                     self.agent_file = args.command
                 else:
@@ -1639,7 +1639,7 @@ class PraisonAI:
             and args.command
             and args.command not in special_commands
             and not os.path.isfile(args.command)
-            and not args.command.lower().endswith((".yaml", ".yml"))
+            and not (args.command or "").lower().endswith((".yaml", ".yml"))
         ):
             args.direct_prompt = args.command
             args.command = None

--- a/src/praisonai-code/praisonai_code/llm/credentials.py
+++ b/src/praisonai-code/praisonai_code/llm/credentials.py
@@ -99,6 +99,8 @@ def inject_credentials_into_env() -> bool:
 
 def _provider_key_vars_for_model(model: str) -> tuple[str, ...]:
     """Map a model id to the environment variable(s) for its provider."""
+    if not model:
+        return ()
     m = model.lower()
     if m.startswith("anthropic/") or m.startswith("claude"):
         return ("ANTHROPIC_API_KEY",)

--- a/src/praisonai/tests/unit/cli/test_init_provider_guard.py
+++ b/src/praisonai/tests/unit/cli/test_init_provider_guard.py
@@ -104,16 +104,17 @@ class TestInitGuardWiring:
             merge=False,
         )
 
-        with patch.object(instance, "parse_args", return_value=(args, [])), patch.object(
-            cli_main, "_load_env_once"
+        with patch.object(instance, "parse_args", return_value=(args, [])), patch(
+            "praisonai_code.cli.legacy.env_security._load_env_once"
         ), patch.object(
             instance, "read_stdin_if_available", return_value=None
         ), patch.object(
             instance, "read_file_if_provided", return_value=None
-        ), patch.object(
-            cli_main, "_provider_preflight_message", return_value="SETUP GUIDANCE"
-        ), patch.object(
-            cli_main, "_get_auto_generator"
+        ), patch(
+            "praisonai_code.cli.main._provider_preflight_message",
+            return_value="SETUP GUIDANCE",
+        ), patch(
+            "praisonai_code.cli.legacy.praison_ai._get_auto_generator"
         ) as get_gen, patch("builtins.print"):
             result = instance.main()
 


### PR DESCRIPTION
## Root cause
`main (3.11)` failed on `test_init_returns_early_without_calling_generator` with `AttributeError: 'NoneType' object has no attribute 'lower'`.

The test patched `cli_main._get_auto_generator`, but `--init` calls `praisonai_code.cli.legacy.praison_ai._get_auto_generator`. When the preflight mock was bypassed (CI sets `OPENAI_API_KEY`), the real generator import path ran and blew up.

## Fix
- Patch `praisonai_code.cli.legacy.praison_ai._get_auto_generator` and `praisonai_code.cli.main._provider_preflight_message`
- Guard `_provider_key_vars_for_model` and YAML path checks against empty/None command strings

## Test plan
- [x] `pytest tests/unit/cli/test_init_provider_guard.py -n 2 --dist loadfile`
- [x] With `OPENAI_API_KEY=test-key` (CI env)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI stability when commands are empty or missing, preventing crashes in edge cases.
  * Made prompt and file-type detection safer for command-line input that isn’t a string.
  * Fixed model handling so empty values no longer trigger unnecessary provider lookup logic.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->