### PR TITLE
fix: isolate project session continuity tests under xdist

### DIFF
--- a/src/praisonai/tests/unit/cli/test_project_session_continuity.py
+++ b/src/praisonai/tests/unit/cli/test_project_session_continuity.py
@@ -8,7 +8,7 @@ from praisonaiagents.session.store import DefaultSessionStore
 
 
 @pytest.fixture(autouse=True)
-def _isolated_session_stores(monkeypatch, tmp_path):
+def isolated_session_stores(monkeypatch, tmp_path):
     """Keep session I/O off shared CI dirs when pytest-xdist runs workers in parallel."""
     project_store = DefaultSessionStore(session_dir=str(tmp_path / "project"))
     global_store = DefaultSessionStore(session_dir=str(tmp_path / "global"))
@@ -78,21 +78,17 @@ def test_injected_session_store_not_overwritten():
     store.clear_session(session_id)
 
 
-def test_find_last_session_sees_global_agent_session(monkeypatch, tmp_path):
+def test_find_last_session_sees_global_agent_session(isolated_session_stores):
     """A session created via the core global store (e.g. Agent(session_id=...))
     must be visible to `--continue`/find_last_session and to the merged
     listing, not only project-scoped run sessions (Issue #2655).
 
-    Both stores are redirected to isolated temp dirs so the assertion that the
+    Both stores are redirected to isolated temp dirs (via the autouse
+    ``isolated_session_stores`` fixture) so the assertion that the
     freshly-created session is *the* most-recent one is deterministic and never
     contends with pre-existing sessions on the machine or parallel test runs.
     """
-    project_store = DefaultSessionStore(session_dir=str(tmp_path / "project"))
-    global_store = DefaultSessionStore(session_dir=str(tmp_path / "global"))
-    monkeypatch.setattr(
-        project_sessions, "get_project_session_store", lambda *a, **k: project_store
-    )
-    monkeypatch.setattr(project_sessions, "_get_default_store", lambda: global_store)
+    _project_store, global_store = isolated_session_stores
 
     session_id = "issue-2655-global-session"
     global_store.add_user_message(session_id, "created by core Agent")
@@ -103,20 +99,16 @@ def test_find_last_session_sees_global_agent_session(monkeypatch, tmp_path):
     assert session_id in listed
 
 
-def test_find_last_session_skips_sub_agent_child(monkeypatch, tmp_path):
+def test_find_last_session_skips_sub_agent_child(isolated_session_stores):
     """`--continue` resolves to the last root session, never a sub-agent child
     marked with a parent_id in metadata (Issue #2655).
 
-    Stores are redirected to isolated temp dirs so the child (written last, and
+    Stores are redirected to isolated temp dirs (via the autouse
+    ``isolated_session_stores`` fixture) so the child (written last, and
     thus most-recent) never wins over the root purely because of a pre-existing
     session elsewhere on the machine.
     """
-    store = DefaultSessionStore(session_dir=str(tmp_path / "project"))
-    empty_global = DefaultSessionStore(session_dir=str(tmp_path / "global"))
-    monkeypatch.setattr(
-        project_sessions, "get_project_session_store", lambda *a, **k: store
-    )
-    monkeypatch.setattr(project_sessions, "_get_default_store", lambda: empty_global)
+    store, _empty_global = isolated_session_stores
 
     root_id = "issue-2655-root"
     child_id = "issue-2655-child"

--- a/src/praisonai/tests/unit/cli/test_project_session_continuity.py
+++ b/src/praisonai/tests/unit/cli/test_project_session_continuity.py
@@ -1,18 +1,30 @@
 """Tests for praison run project-scoped session continuity."""
 
-from praisonai.cli.state.project_sessions import (
-    apply_cli_session_continuity,
-    build_cli_memory_config,
-    find_last_session,
-    get_project_session_store,
-    list_project_sessions,
-)
+import pytest
+
+import praisonai.cli.state.project_sessions as project_sessions
 from praisonaiagents import Agent
-from praisonaiagents.session.store import get_default_session_store
+from praisonaiagents.session.store import DefaultSessionStore
+
+
+@pytest.fixture(autouse=True)
+def _isolated_session_stores(monkeypatch, tmp_path):
+    """Keep session I/O off shared CI dirs when pytest-xdist runs workers in parallel."""
+    project_store = DefaultSessionStore(session_dir=str(tmp_path / "project"))
+    global_store = DefaultSessionStore(session_dir=str(tmp_path / "global"))
+    monkeypatch.setattr(
+        project_sessions, "get_project_session_store", lambda *a, **k: project_store
+    )
+    monkeypatch.setattr(project_sessions, "_get_default_store", lambda: global_store)
+    monkeypatch.setattr(
+        "praisonaiagents.session.store.get_default_session_store",
+        lambda: global_store,
+    )
+    return project_store, global_store
 
 
 def test_build_cli_memory_config_enables_history():
-    cfg = build_cli_memory_config(session_id="sess-1", auto_save="sess-1")
+    cfg = project_sessions.build_cli_memory_config(session_id="sess-1", auto_save="sess-1")
     assert cfg is not None
     assert cfg.session_id == "sess-1"
     assert cfg.auto_save == "sess-1"
@@ -20,14 +32,17 @@ def test_build_cli_memory_config_enables_history():
 
 
 def test_apply_cli_session_continuity_restores_project_history():
-    store = get_project_session_store()
+    store = project_sessions.get_project_session_store()
     session_id = "continuity-unit-test"
     store.clear_session(session_id)
     store.add_user_message(session_id, "remember this")
     store.add_assistant_message(session_id, "acknowledged")
 
-    agent = Agent(name="RunAgent", memory=build_cli_memory_config(session_id, session_id))
-    apply_cli_session_continuity(agent, session_id)
+    agent = Agent(
+        name="RunAgent",
+        memory=project_sessions.build_cli_memory_config(session_id, session_id),
+    )
+    project_sessions.apply_cli_session_continuity(agent, session_id)
 
     assert agent._session_store.session_dir == store.session_dir
     assert agent._session_id == session_id
@@ -46,12 +61,15 @@ def test_apply_cli_session_continuity_restores_project_history():
 
 
 def test_injected_session_store_not_overwritten():
-    store = get_project_session_store()
+    store = project_sessions.get_project_session_store()
     session_id = "store-injection-test"
     store.clear_session(session_id)
 
-    agent = Agent(name="RunAgent", memory=build_cli_memory_config(session_id, session_id))
-    apply_cli_session_continuity(agent, session_id)
+    agent = Agent(
+        name="RunAgent",
+        memory=project_sessions.build_cli_memory_config(session_id, session_id),
+    )
+    project_sessions.apply_cli_session_continuity(agent, session_id)
     injected_dir = agent._session_store.session_dir
 
     agent._init_session_store()
@@ -69,20 +87,19 @@ def test_find_last_session_sees_global_agent_session(monkeypatch, tmp_path):
     freshly-created session is *the* most-recent one is deterministic and never
     contends with pre-existing sessions on the machine or parallel test runs.
     """
-    from praisonaiagents.session.store import DefaultSessionStore
-    import praisonai.cli.state.project_sessions as ps
-
     project_store = DefaultSessionStore(session_dir=str(tmp_path / "project"))
     global_store = DefaultSessionStore(session_dir=str(tmp_path / "global"))
-    monkeypatch.setattr(ps, "get_project_session_store", lambda *a, **k: project_store)
-    monkeypatch.setattr(ps, "_get_default_store", lambda: global_store)
+    monkeypatch.setattr(
+        project_sessions, "get_project_session_store", lambda *a, **k: project_store
+    )
+    monkeypatch.setattr(project_sessions, "_get_default_store", lambda: global_store)
 
     session_id = "issue-2655-global-session"
     global_store.add_user_message(session_id, "created by core Agent")
 
-    assert find_last_session() == session_id
+    assert project_sessions.find_last_session() == session_id
 
-    listed = {s.get("session_id") for s in list_project_sessions()}
+    listed = {s.get("session_id") for s in project_sessions.list_project_sessions()}
     assert session_id in listed
 
 
@@ -94,13 +111,12 @@ def test_find_last_session_skips_sub_agent_child(monkeypatch, tmp_path):
     thus most-recent) never wins over the root purely because of a pre-existing
     session elsewhere on the machine.
     """
-    from praisonaiagents.session.store import DefaultSessionStore
-    import praisonai.cli.state.project_sessions as ps
-
     store = DefaultSessionStore(session_dir=str(tmp_path / "project"))
     empty_global = DefaultSessionStore(session_dir=str(tmp_path / "global"))
-    monkeypatch.setattr(ps, "get_project_session_store", lambda *a, **k: store)
-    monkeypatch.setattr(ps, "_get_default_store", lambda: empty_global)
+    monkeypatch.setattr(
+        project_sessions, "get_project_session_store", lambda *a, **k: store
+    )
+    monkeypatch.setattr(project_sessions, "_get_default_store", lambda: empty_global)
 
     root_id = "issue-2655-root"
     child_id = "issue-2655-child"
@@ -109,4 +125,4 @@ def test_find_last_session_skips_sub_agent_child(monkeypatch, tmp_path):
     store.add_user_message(child_id, "sub-agent work")
     store.update_session_metadata(child_id, parent_id=root_id)
 
-    assert find_last_session() == root_id
+    assert project_sessions.find_last_session() == root_id


### PR DESCRIPTION
## Summary
- Add autouse fixture that redirects project/global session stores to isolated temp dirs for every test in `test_project_session_continuity.py`
- Resolve helpers via `project_sessions` module namespace so monkeypatch applies correctly (direct imports kept stale references)
- Fixes flaky `main (3.11)` failures on release CI where parallel workers polluted shared `~/.praisonai/sessions`

## Test plan
- [x] `pytest tests/unit/cli/test_project_session_continuity.py -n 2` (5 consecutive passes locally)
- [ ] Optimized Test Suite smoke + main (3.11) green on PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved session-continuity test coverage with isolated temporary session storage for safer parallel test runs.
  * Updated session-related tests to use the shared session APIs consistently.
  * Simplified test setup for session visibility and child-session handling by reusing common fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->