### PR TITLE
fix: harden session continuity test against xdist auto_save flake

### DIFF
--- a/src/praisonai/tests/unit/cli/test_project_session_continuity.py
+++ b/src/praisonai/tests/unit/cli/test_project_session_continuity.py
@@ -1,7 +1,11 @@
 """Tests for praison run project-scoped session continuity."""
 
+import pytest
+
 import praisonai.cli.state.project_sessions as project_sessions
 from praisonaiagents import Agent
+
+pytestmark = pytest.mark.xdist_group("cli-session-store")
 
 
 def test_build_cli_memory_config_enables_history():
@@ -23,16 +27,20 @@ def test_apply_cli_session_continuity_restores_project_history():
         name="RunAgent",
         memory=project_sessions.build_cli_memory_config(session_id, session_id),
     )
-    project_sessions.apply_cli_session_continuity(agent, session_id)
+    project_sessions.apply_cli_session_continuity(
+        agent, session_id, auto_save=session_id
+    )
 
     assert agent._session_store.session_dir == store.session_dir
     assert agent._session_id == session_id
+    assert agent.auto_save == session_id
     assert len(agent.chat_history) == 2
     assert agent.chat_history[0]["content"] == "remember this"
 
     agent.chat_history.append({"role": "user", "content": "follow-up"})
     agent.chat_history.append({"role": "assistant", "content": "reply"})
     agent._auto_save_session()
+    assert agent._auto_save_last_index == len(agent.chat_history)
 
     saved = store.get_chat_history(session_id)
     assert len(saved) == 4


### PR DESCRIPTION
## Summary
- Pass `auto_save=session_id` explicitly in `apply_cli_session_continuity` so `_auto_save_session()` always persists under xdist
- Assert `agent.auto_save` and `_auto_save_last_index` before checking saved history
- Serialise `test_project_session_continuity.py` via `xdist_group` to avoid cross-worker session dir races in full `tests/unit/` runs

Fixes intermittent `assert 2 == 4` failures on PR branches (e.g. #2724, #2725, #2704).

## Test plan
- [x] `pytest tests/unit/cli/test_project_session_continuity.py -n 2` (15x stress pass)
- [ ] Optimized Test Suite smoke + main (3.11) green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened session continuity coverage for CLI workflows.
  * Added checks for restored session state, auto-save behavior, and chat history preservation.
  * Improved test isolation when running in parallel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->