### PR TITLE
fix(ci): unblock merge gate after rebase and cancelled conflict scans

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -27,6 +27,19 @@ const withRecovery = [
 ];
 assert('not stale when @claude after head', !mg.isStaleFinalAfterPush(withRecovery, '2026-06-12T09:00:00Z'));
 
+const withClaudeReply = [
+  ...finals,
+  {
+    user: { login: 'praisonai-triage-agent[bot]' },
+    body: "**Claude finished @MervinPraison's task** —— [View job](https://github.com/)",
+    created_at: '2026-06-12T08:30:00Z',
+  },
+];
+assert('not stale when Claude replied after FINAL', !mg.isStaleFinalAfterPush(withClaudeReply, '2026-06-12T09:00:00Z'));
+assert('claude final reply detected', mg.isClaudeFinalReplyComment(withClaudeReply[1]));
+
+assert('cancelled detect-and-trigger does not block', mg.OPTIONAL_CANCELLED_CHECKS.has('detect-and-trigger'));
+
 // Stale-FINAL recovery guards (PR #2560 push loop)
 const nowMs = Date.now();
 const iso = (ms) => new Date(ms).toISOString();

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -41,6 +41,8 @@ const BLOCK_LABELS = new Set([
   'no-auto-merge',
   'auto-merged-by-gate',
 ]);
+/** Superseded concurrency runs; must not block merge when real tests passed. */
+const OPTIONAL_CANCELLED_CHECKS = new Set(['detect-and-trigger']);
 const BOT_REVIEWER_PATTERNS = [
   'coderabbit',
   'qodo',
@@ -65,6 +67,12 @@ function isClaudeTriggerNoise(c) {
   if (body.includes('MERGE_GATE_VERDICT')) return true;
   if (body.includes('Merged by **Claude PR merge gate**')) return true;
   return false;
+}
+
+function isClaudeFinalReplyComment(c) {
+  const login = (c.user?.login || '').toLowerCase();
+  if (!login.includes('praisonai-triage')) return false;
+  return (c.body || '').includes('Claude finished');
 }
 
 function hasRecentClaudeTrigger(comments, minutes = 35) {
@@ -175,6 +183,11 @@ function isStaleFinalAfterPush(comments, headPushedAt) {
   );
   const finalTime = new Date(latestFinal.created_at).getTime();
   if (headTime <= finalTime + 60000) return false;
+  const claudeRepliedAfterFinal = comments.some((c) => {
+    if (!isClaudeFinalReplyComment(c)) return false;
+    return new Date(c.created_at).getTime() >= finalTime - 60000;
+  });
+  if (claudeRepliedAfterFinal) return false;
   const claudeSinceHead = comments.some((c) => {
     if (!CLAUDE_TRIGGER_LOGINS.includes(c.user.login)) return false;
     if (isClaudeTriggerNoise(c)) return false;
@@ -311,7 +324,9 @@ async function allChecksGreenOnSha(github, owner, repo, sha, core) {
       core?.info?.(`Check pending: ${run.name} (${run.status})`);
       return false;
     }
-    const ok = ['success', 'neutral', 'skipped'].includes(run.conclusion);
+    const ok =
+      ['success', 'neutral', 'skipped'].includes(run.conclusion) ||
+      (run.conclusion === 'cancelled' && OPTIONAL_CANCELLED_CHECKS.has(run.name));
     if (!ok) {
       core?.info?.(`Check failed: ${run.name} (${run.conclusion})`);
       return false;
@@ -751,6 +766,7 @@ module.exports = {
   AUTO_ACTORS,
   isFinalClaudeTriggerComment,
   isClaudeTriggerNoise,
+  isClaudeFinalReplyComment,
   hasRecentClaudeTrigger,
   hasRecentConflictComment,
   isConflictRebaseTriggerComment,
@@ -761,6 +777,7 @@ module.exports = {
   hasFinalClaudeReviewTrigger,
   finalClaudeCompletedOnSha,
   getMergeState,
+  OPTIONAL_CANCELLED_CHECKS,
   allChecksGreenOnSha,
   hasInProgressClaudeAssistant,
   claudeRunBlocksPr,

--- a/.github/workflows/merge-conflict-claude.yml
+++ b/.github/workflows/merge-conflict-claude.yml
@@ -12,7 +12,7 @@ on:
     - cron: '0 */6 * * *'
 
 concurrency:
-  group: merge-conflict-scan-${{ github.repository }}
+  group: merge-conflict-scan-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary
- Stop marking FINAL reviews stale when Claude has already replied (`Claude finished` from triage agent), so rebase-only updates do not require another `@claude` trigger
- Ignore superseded `detect-and-trigger` cancellations in merge-gate CI checks — these were blocking otherwise green PRs like #2730 after bulk rebases
- Scope merge-conflict workflow concurrency per PR so parallel rebases no longer cancel each other's conflict scans

## Test plan
- [x] `node .github/scripts/merge-gate-selftest.js`
- [ ] Merge to `main` and run **Pipeline Status Sync**
- [ ] Confirm green PRs (e.g. #2730) drop `pipeline/blocked:stale-final` and `pipeline/blocked:ci`
- [ ] Confirm merge gate can proceed to `APPROVE` where other blockers are clear


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge eligibility checks so certain expected cancelled runs no longer block progress.
  * Better recognizes when a final response has already been posted, reducing false “stale” merge warnings.

* **Chores**
  * Updated workflow run grouping to avoid collisions between concurrent checks for different pull requests.
  * Expanded automated self-tests to cover the updated merge-gate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->