### PR TITLE
Merge gate throughput: App token, MAX_CANDIDATES=3, merge-ready-first scan

### DIFF
--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -41,6 +41,7 @@ const BLOCK_LABELS = new Set([
   'no-auto-merge',
   'auto-merged-by-gate',
 ]);
+const MERGE_READY_LABEL = 'pipeline/merge-ready';
 /** Superseded concurrency runs; must not block merge when real tests passed. */
 const OPTIONAL_CANCELLED_CHECKS = new Set(['detect-and-trigger']);
 const BOT_REVIEWER_PATTERNS = [
@@ -724,10 +725,67 @@ async function evaluatePipelineQuiescent(github, owner, repo, prNumber, core, op
   };
 }
 
+async function listPrNumbersForMergeGateScan(github, owner, repo, core) {
+  let mergeReadyIssues;
+  if (typeof github.paginate === 'function') {
+    mergeReadyIssues = await github.paginate(github.rest.issues.listForRepo, {
+      owner,
+      repo,
+      state: 'open',
+      labels: MERGE_READY_LABEL,
+      per_page: 100,
+    });
+  } else {
+    ({ data: mergeReadyIssues } = await github.rest.issues.listForRepo({
+      owner,
+      repo,
+      state: 'open',
+      labels: MERGE_READY_LABEL,
+      per_page: 100,
+    }));
+  }
+  const mergeReady = mergeReadyIssues
+    .filter((issue) => issue.pull_request)
+    .map((issue) => issue.number)
+    .sort((a, b) => a - b);
+
+  if (mergeReady.length > 0) {
+    core?.info?.(
+      `Merge gate scan: ${mergeReady.length} ${MERGE_READY_LABEL} PR(s) (skipping unlabelled open PRs)`
+    );
+    return mergeReady;
+  }
+
+  core?.info?.(`No ${MERGE_READY_LABEL} PRs — scanning oldest open PRs`);
+  const prs =
+    typeof github.paginate === 'function'
+      ? await github.paginate(github.rest.pulls.list, {
+          owner,
+          repo,
+          state: 'open',
+          per_page: 100,
+          sort: 'created',
+          direction: 'asc',
+        })
+      : (await github.rest.pulls.list({
+          owner,
+          repo,
+          state: 'open',
+          per_page: 100,
+          sort: 'created',
+          direction: 'asc',
+        })).data;
+  return prs.map((pr) => pr.number);
+}
+
 async function selectMergeGateCandidates(github, owner, repo, prNumbers, maxCandidates, core) {
   const readyList = [];
   const skipped = [];
   for (const num of prNumbers) {
+    if (readyList.length >= maxCandidates) {
+      core?.info?.(`Found ${maxCandidates} candidate(s) — skipping remaining PR scans`);
+      break;
+    }
     const result = await evaluatePipelineQuiescent(github, owner, repo, num, core);
     if (result.ready) {
       readyList.push({ pr_number: num, head_sha: result.headSha });
@@ -814,6 +872,8 @@ module.exports = {
   FINAL_CLAUDE_REVIEW_BODY,
   loadPrContext,
   evaluatePipelineQuiescent,
+  MERGE_READY_LABEL,
+  listPrNumbersForMergeGateScan,
   selectMergeGateCandidates,
   findMergeGateVerdict,
 };

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -38,7 +38,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-  MAX_CANDIDATES: 1
+  MAX_CANDIDATES: 3
   DISPATCH_PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.client_payload.pr_number || '' }}
 
 permissions:
@@ -56,26 +56,28 @@ jobs:
       pull-requests: read
       issues: read
       actions: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Dispatch merge gate when PR pipeline is ready
         uses: actions/github-script@v7
-        env:
-          PAT: ${{ secrets.GH_TOKEN }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const path = require('path');
             const mergeGate = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/merge-gate.js'));
             const wr = context.payload.workflow_run;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-
-            if (!process.env.PAT) {
-              core.setFailed('GH_TOKEN secret is required for merge gate auto-dispatch (needs repo + workflow scope).');
-              return;
-            }
 
             if (wr.conclusion !== 'success') {
               core.info(`Skip dispatch: ${wr.name} conclusion=${wr.conclusion}`);
@@ -121,17 +123,26 @@ jobs:
       pull-requests: read
       issues: write
       actions: read
+      id-token: write
     outputs:
       matrix: ${{ steps.scan.outputs.matrix }}
       has_candidates: ${{ steps.scan.outputs.has_candidates }}
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Scan open PRs for merge gate eligibility
         id: scan
         uses: actions/github-script@v7
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const path = require('path');
             const mergeGate = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/merge-gate.js'));
@@ -156,10 +167,9 @@ jobs:
                 skipped.push({ pr: n, reasons: result.reasons });
               }
             } else {
-              const prs = await github.paginate(github.rest.pulls.list, {
-                owner, repo, state: 'open', per_page: 100, sort: 'created', direction: 'asc',
-              });
-              const prNumbers = prs.map((p) => p.number);
+              const prNumbers = await mergeGate.listPrNumbersForMergeGateScan(
+                github, owner, repo, core
+              );
               const selected = await mergeGate.selectMergeGateCandidates(
                 github, owner, repo, prNumbers, maxCandidates, core
               );
@@ -196,7 +206,7 @@ jobs:
               });
             }
 
-            await ps.syncOpenPullRequests(github, owner, repo, { maxPrs: 20 }, core);
+            await ps.syncOpenPullRequests(github, owner, repo, { maxPrs: 10 }, core);
 
   claude-assess:
     needs: scan-candidates
@@ -230,7 +240,7 @@ jobs:
         id: mark_active
         uses: actions/github-script@v7
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             core.setOutput('started_at', new Date().toISOString());
             await github.rest.issues.addLabels({
@@ -303,7 +313,7 @@ jobs:
         id: fallback_verdict
         uses: actions/github-script@v7
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const mergeGate = require('/tmp/merge-gate.js');
             const owner = context.repo.owner;
@@ -344,7 +354,7 @@ jobs:
         id: verdict
         uses: actions/github-script@v7
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const mergeGate = require('/tmp/merge-gate.js');
             const comments = await mergeGate.listAllComments(
@@ -362,7 +372,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const prNumber = ${{ matrix.pr_number }};
             try {
@@ -396,8 +406,17 @@ jobs:
       pull-requests: write
       issues: write
       actions: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Re-check gates and merge
         uses: actions/github-script@v7
@@ -405,7 +424,7 @@ jobs:
           MERGE_METHOD: ${{ github.event.inputs.merge_method || 'merge' }}
           SCAN_HEAD_SHA: ${{ matrix.head_sha }}
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const path = require('path');
             const mergeGate = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/merge-gate.js'));

--- a/.github/workflows/pipeline-status-sync.yml
+++ b/.github/workflows/pipeline-status-sync.yml
@@ -11,6 +11,7 @@ permissions:
   pull-requests: read
   issues: write
   actions: write
+  id-token: write
 
 jobs:
   sync:
@@ -20,10 +21,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Sync pipeline labels on open PRs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const path = require('path');
             const ps = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/pipeline-status.js'));


### PR DESCRIPTION
## Summary
- **A:** Route API-heavy merge-gate jobs (auto-dispatch, scan, assess helpers, merge-only) and pipeline-status-sync through the GitHub App token instead of the user PAT — avoids 5000/hr PAT exhaustion during bulk scans/rebases.
- **B:** Raise MAX_CANDIDATES from 1 to 3 so each scheduled run can assess/merge up to three PRs (~3x throughput).
- **C:** Scan only pipeline/merge-ready labelled PRs when any exist; stop scanning once maxCandidates ready PRs are found.

## Test plan
- [x] merge-gate-selftest.js — all 31 tests pass
- [ ] Merge gate scheduled run picks merge-ready PRs and dispatches up to 3 candidates
- [ ] Pipeline Status Sync completes without PAT rate-limit errors
- [ ] Auto-dispatch still fires after Claude Assistant / Core Tests success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merge checks now prioritize pull requests marked as ready, helping the queue focus on work that’s prepared to merge.
  * More pull requests are considered during merge readiness checks, improving coverage when several PRs are open.

* **Bug Fixes**
  * Merge-gate and status-sync workflows now use a more reliable authentication flow, reducing failures caused by token issues.
  * Open pull request syncing now uses a smaller, more focused set of candidates for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->