### PR TITLE
Require Opus verdict in merge gate (no automated APPROVE fallback)

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -110,6 +110,25 @@ assert(
   mg.findMergeGateVerdict(fallbackApprove, null, '2026-06-12T09:00:00Z') === 'APPROVE'
 );
 
+const fallbackBlockNewFormat = [
+  {
+    body: 'MERGE_GATE_VERDICT: BLOCK\n\nAutomated fallback — Opus merge gate assessment did not complete.',
+    created_at: '2026-06-12T10:00:00Z',
+  },
+];
+assert(
+  'new-format fallback BLOCK ignored when Opus required',
+  mg.findMergeGateVerdict(fallbackBlockNewFormat, null, '2026-06-12T09:00:00Z', { excludeAutomatedFallback: true }) === null
+);
+assert(
+  'new-format fallback BLOCK detected by marker helper',
+  mg.isAutomatedFallbackVerdict(fallbackBlockNewFormat[0].body)
+);
+assert(
+  'findMergeGateVerdict null-safe with explicit null options',
+  mg.findMergeGateVerdict(fallbackApprove, null, '2026-06-12T09:00:00Z', null) === 'APPROVE'
+);
+
 const noise = [{ user: { login: 'MervinPraison' }, body: '**Merge gate scan** — wait for `@claude`', created_at: new Date().toISOString() }];
 assert('diagnostic comment not a trigger', !mg.hasRecentClaudeTrigger(noise, 35));
 

--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -95,6 +95,21 @@ assert('verdict after head accepted', mg.findMergeGateVerdict(
   '2026-06-12T09:00:00Z'
 ) === 'APPROVE');
 
+const fallbackApprove = [
+  {
+    body: 'MERGE_GATE_VERDICT: APPROVE\n\nAutomated fallback — Claude assess did not post a verdict comment.',
+    created_at: '2026-06-12T10:00:00Z',
+  },
+];
+assert(
+  'automated fallback APPROVE ignored when Opus required',
+  mg.findMergeGateVerdict(fallbackApprove, null, '2026-06-12T09:00:00Z', { excludeAutomatedFallback: true }) === null
+);
+assert(
+  'automated fallback APPROVE still visible without Opus-only filter',
+  mg.findMergeGateVerdict(fallbackApprove, null, '2026-06-12T09:00:00Z') === 'APPROVE'
+);
+
 const noise = [{ user: { login: 'MervinPraison' }, body: '**Merge gate scan** — wait for `@claude`', created_at: new Date().toISOString() }];
 assert('diagnostic comment not a trigger', !mg.hasRecentClaudeTrigger(noise, 35));
 

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -800,12 +800,14 @@ async function selectMergeGateCandidates(github, owner, repo, prNumbers, maxCand
   };
 }
 
+const AUTOMATED_FALLBACK_MARKER = 'Automated fallback —';
+
 function isAutomatedFallbackVerdict(body) {
-  return (body || '').includes('Automated fallback — Claude assess did not post');
+  return (body || '').includes(AUTOMATED_FALLBACK_MARKER);
 }
 
 function findMergeGateVerdict(comments, minCreatedAt = null, headPushedAt = null, options = {}) {
-  const { excludeAutomatedFallback = false } = options;
+  const { excludeAutomatedFallback = false } = options || {};
   const minTime = minCreatedAt ? new Date(minCreatedAt).getTime() : 0;
   const headTime = headPushedAt ? new Date(headPushedAt).getTime() - 60000 : 0;
   const gateComments = comments
@@ -882,5 +884,6 @@ module.exports = {
   listPrNumbersForMergeGateScan,
   selectMergeGateCandidates,
   isAutomatedFallbackVerdict,
+  AUTOMATED_FALLBACK_MARKER,
   findMergeGateVerdict,
 };

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -800,12 +800,18 @@ async function selectMergeGateCandidates(github, owner, repo, prNumbers, maxCand
   };
 }
 
-function findMergeGateVerdict(comments, minCreatedAt = null, headPushedAt = null) {
+function isAutomatedFallbackVerdict(body) {
+  return (body || '').includes('Automated fallback — Claude assess did not post');
+}
+
+function findMergeGateVerdict(comments, minCreatedAt = null, headPushedAt = null, options = {}) {
+  const { excludeAutomatedFallback = false } = options;
   const minTime = minCreatedAt ? new Date(minCreatedAt).getTime() : 0;
   const headTime = headPushedAt ? new Date(headPushedAt).getTime() - 60000 : 0;
   const gateComments = comments
     .filter((c) => {
       if (!(c.body || '').includes('MERGE_GATE_VERDICT:')) return false;
+      if (excludeAutomatedFallback && isAutomatedFallbackVerdict(c.body)) return false;
       const created = new Date(c.created_at).getTime();
       if (minTime && created < minTime) return false;
       if (headTime && created < headTime) return false;
@@ -875,5 +881,6 @@ module.exports = {
   MERGE_READY_LABEL,
   listPrNumbersForMergeGateScan,
   selectMergeGateCandidates,
+  isAutomatedFallbackVerdict,
   findMergeGateVerdict,
 };

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -262,7 +262,6 @@ jobs:
 
       - name: Claude merge gate assessment (read-only)
         id: assess
-        continue-on-error: true
         uses: ./.github/actions/claude-code-action
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -309,8 +308,9 @@ jobs:
             Read
           timeout_minutes: 15
 
-      - name: Post fallback verdict if Claude did not comment
+      - name: Post fallback BLOCK if Opus did not comment
         id: fallback_verdict
+        if: steps.assess.outcome != 'success'
         uses: actions/github-script@v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -322,24 +322,24 @@ jobs:
 
             const ctx = await mergeGate.loadPrContext(github, owner, repo, prNumber);
             const minCreatedAt = new Date(Date.now() - 25 * 60 * 1000).toISOString();
-            const existing = mergeGate.findMergeGateVerdict(ctx.comments, minCreatedAt, ctx.headPushedAt);
+            const existing = mergeGate.findMergeGateVerdict(
+              ctx.comments, minCreatedAt, ctx.headPushedAt, { excludeAutomatedFallback: true }
+            );
             if (existing) {
-              core.info(`Verdict already posted: ${existing}`);
-              core.setOutput('verdict', existing);
+              core.info(`Opus verdict already posted: ${existing}`);
               return;
             }
 
             const check = await mergeGate.evaluatePipelineQuiescent(
               github, owner, repo, prNumber, core, { forMergeStep: true }
             );
-            const verdict = check.ready ? 'APPROVE' : 'BLOCK';
             const lines = [
-              `MERGE_GATE_VERDICT: ${verdict}`,
+              'MERGE_GATE_VERDICT: BLOCK',
               '',
-              'Automated fallback — Claude assess did not post a verdict comment (e.g. GitHub MCP unavailable).',
+              'Automated fallback — Opus merge gate assessment did not complete.',
             ];
             if (check.ready) {
-              lines.push('All deterministic merge gates passed.');
+              lines.push('Deterministic gates passed, but Opus MERGE_GATE_VERDICT is required before merge.');
             } else {
               lines.push('Blockers:', ...check.reasons.map((r) => `- ${r}`));
             }
@@ -347,11 +347,9 @@ jobs:
               owner, repo, issue_number: prNumber,
               body: lines.join('\n'),
             });
-            core.info(`Posted fallback verdict: ${verdict}`);
-            core.setOutput('verdict', verdict);
+            core.info('Posted fallback BLOCK — Opus verdict required');
 
-      - name: Verify verdict posted
-        id: verdict
+      - name: Require Opus MERGE_GATE_VERDICT
         uses: actions/github-script@v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -364,9 +362,17 @@ jobs:
               github, context.repo.owner, context.repo.repo, ${{ matrix.pr_number }}
             );
             const minCreatedAt = new Date(Date.now() - 25 * 60 * 1000).toISOString();
-            const verdict = mergeGate.findMergeGateVerdict(comments, minCreatedAt, ctx.headPushedAt);
-            core.setOutput('verdict', verdict || 'NONE');
-            if (!verdict) core.warning('No recent MERGE_GATE_VERDICT comment found after assessment');
+            const verdict = mergeGate.findMergeGateVerdict(
+              comments, minCreatedAt, ctx.headPushedAt, { excludeAutomatedFallback: true }
+            );
+            if (!verdict) {
+              core.setFailed(
+                'Opus merge gate assessment must post MERGE_GATE_VERDICT on this PR (automated fallback APPROVE is not accepted).'
+              );
+              return;
+            }
+            core.info(`Opus merge gate verdict: ${verdict}`);
+            core.setOutput('verdict', verdict);
 
       - name: Remove merge gate active label
         if: always()
@@ -447,7 +453,9 @@ jobs:
               const ctx = await mergeGate.loadPrContext(github, owner, repo, prNumber);
               const comments = ctx.comments;
               const verdictMin = new Date(Date.now() - 25 * 60 * 1000).toISOString();
-              const verdict = mergeGate.findMergeGateVerdict(comments, verdictMin, ctx.headPushedAt);
+              const verdict = mergeGate.findMergeGateVerdict(
+                comments, verdictMin, ctx.headPushedAt, { excludeAutomatedFallback: true }
+              );
               if (verdict !== 'APPROVE') {
                 core.info(`Skip merge: verdict=${verdict || 'NONE'}`);
                 await removeLabels();


### PR DESCRIPTION
## Summary
- Opus merge gate assessment is now mandatory — no deterministic fast path and no automated APPROVE fallback.
- Fallback only posts BLOCK when assess fails; merge proceeds only on a real Opus MERGE_GATE_VERDICT comment.
- merge-only and assess steps ignore automated fallback comments via excludeAutomatedFallback.

## Test plan
- [x] merge-gate-selftest.js — 33 tests pass (incl. fallback APPROVE rejection)
- [ ] Merge gate run on a merge-ready PR: Opus posts APPROVE → merge succeeds
- [ ] If Opus assess fails without verdict: job fails, no merge, fallback BLOCK only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying and optionally ignoring automated fallback merge-gate verdict comments.

* **Bug Fixes**
  * Merge-gate enforcement now requires an explicit Claude (Opus) `MERGE_GATE_VERDICT` comment; fallback automated verdicts no longer satisfy approval.
  * Automated fallback verdicts are treated as **BLOCK-only** when a real verdict is required.
  * The workflow now fails if the expected non-automated verdict isn’t found.

* **Tests**
  * Expanded self-test coverage for automated fallback verdict detection and option handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->