### PR TITLE
feat(docs): add --dry-run to docs run (repatriate #2602)

### DIFF
--- a/src/praisonai/praisonai/cli/commands/docs.py
+++ b/src/praisonai/praisonai/cli/commands/docs.py
@@ -137,6 +137,11 @@ def docs_run(
         "--python",
         help="Python executable to use (default: current interpreter)",
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Extract code blocks without executing them",
+    ),
     quiet: bool = typer.Option(
         False,
         "--quiet", "-q",
@@ -190,6 +195,8 @@ def docs_run(
         timeout=timeout,
         fail_fast=fail_fast,
         stream_output=not no_stream,
+        dry_run=dry_run,
+
         max_items=max_snippets,
         require_env=list(require_env) if require_env else None,
         report_dir=output_dir,
@@ -834,11 +841,6 @@ def docs_generate(
         "--output", "-o",
         help="Output directory for MDX files (default: ~/PraisonAIDocs/docs/sdk/reference/praisonaiagents)",
     ),
-    dry_run: bool = typer.Option(
-        False,
-        "--dry-run",
-        help="Preview without writing files",
-    ),
     force: bool = typer.Option(
         False,
         "--force",
@@ -1149,6 +1151,7 @@ def cli_run_all(
         "--quiet", "-q",
         help="Minimal output",
     ),
+      
     ci: bool = typer.Option(
         False,
         "--ci",

--- a/src/praisonai/praisonai/cli/commands/docs.py
+++ b/src/praisonai/praisonai/cli/commands/docs.py
@@ -196,7 +196,6 @@ def docs_run(
         fail_fast=fail_fast,
         stream_output=not no_stream,
         dry_run=dry_run,
-
         max_items=max_snippets,
         require_env=list(require_env) if require_env else None,
         report_dir=output_dir,
@@ -841,6 +840,11 @@ def docs_generate(
         "--output", "-o",
         help="Output directory for MDX files (default: ~/PraisonAIDocs/docs/sdk/reference/praisonaiagents)",
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview without writing files",
+    ),
     force: bool = typer.Option(
         False,
         "--force",
@@ -1151,7 +1155,6 @@ def cli_run_all(
         "--quiet", "-q",
         help="Minimal output",
     ),
-      
     ci: bool = typer.Option(
         False,
         "--ci",

--- a/src/praisonai/praisonai/suite_runner/executor.py
+++ b/src/praisonai/praisonai/suite_runner/executor.py
@@ -180,7 +180,6 @@ class SuiteExecutor:
                         on_item_end(result, idx, total)
                     continue
             if self.dry_run:
-                
                 result = RunResult(
                     item_id=item.item_id,
                     suite=item.suite,

--- a/src/praisonai/praisonai/suite_runner/executor.py
+++ b/src/praisonai/praisonai/suite_runner/executor.py
@@ -30,6 +30,7 @@ class SuiteExecutor:
         timeout: int = 60,
         fail_fast: bool = False,
         stream_output: bool = True,
+        dry_run: bool = False,
         max_items: Optional[int] = None,
         require_env: Optional[List[str]] = None,
         env_overrides: Optional[dict] = None,
@@ -50,6 +51,7 @@ class SuiteExecutor:
             timeout: Per-item timeout in seconds.
             fail_fast: Stop on first failure.
             stream_output: Stream output to terminal.
+            dry_run: Detect runnable items without executing them.
             max_items: Maximum items to process.
             require_env: Global required env vars.
             env_overrides: Environment variable overrides.
@@ -66,6 +68,7 @@ class SuiteExecutor:
         self.timeout = timeout
         self.fail_fast = fail_fast
         self.stream_output = stream_output
+        self.dry_run = dry_run
         self.max_items = max_items
         self.require_env = require_env or []
         self.env_overrides = env_overrides or {}
@@ -176,7 +179,28 @@ class SuiteExecutor:
                     if on_item_end:
                         on_item_end(result, idx, total)
                     continue
-            
+            if self.dry_run:
+                
+                result = RunResult(
+                    item_id=item.item_id,
+                    suite=item.suite,
+                    group=item.group,
+                    source_path=item.source_path,
+                    block_index=item.block_index,
+                    language=item.language,
+                    line_start=item.line_start,
+                    line_end=item.line_end,
+                    runnable_decision=item.runnable_decision,
+                    status="not_run",
+                    skip_reason="Dry run",
+                    code_hash=item.code_hash,
+                )
+                results.append(result)
+
+                if on_item_end:
+                    on_item_end(result, idx, total)
+
+                continue
             # Execute
             result = runner.run(
                 item,

--- a/src/praisonai/tests/unit/cli/test_docs_cli.py
+++ b/src/praisonai/tests/unit/cli/test_docs_cli.py
@@ -1,0 +1,61 @@
+"""CLI integration tests for praisonai docs commands."""
+
+
+class TestCLIIntegration:
+    """Tests for CLI command integration."""
+
+    def test_docs_list_command(self, tmp_path):
+        """Test 'praisonai docs list' command."""
+        from typer.testing import CliRunner
+
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "test.mdx").write_text("# Test\n```python\nprint(1)\n```")
+
+        from praisonai.cli.commands.docs import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["list", "--docs-path", str(docs_dir)])
+
+        assert result.exit_code == 0
+        assert "test.mdx" in result.stdout
+
+    def test_docs_run_dry_run(self, tmp_path):
+        """Test 'praisonai docs run --dry-run' command."""
+        from typer.testing import CliRunner
+
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "test.mdx").write_text("""# Test
+```python
+from os import getcwd
+print(getcwd())
+```
+""")
+
+        from praisonai.cli.commands.docs import app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                "--docs-path",
+                str(docs_dir),
+                "--dry-run",
+                "--report-dir",
+                str(tmp_path / "reports"),
+            ],
+        )
+        assert result.exit_code == 0
+
+        report_path = tmp_path / "reports" / "report.json"
+        assert report_path.exists()
+        import json
+
+        report = json.loads(report_path.read_text())
+        dry_run_results = [
+            r for r in report["results"] if r.get("skip_reason") == "Dry run"
+        ]
+        assert dry_run_results
+        assert all(r["status"] == "not_run" for r in dry_run_results)


### PR DESCRIPTION
## Summary

Repatriates external fork PR #2602 with contributor credit preserved.

- Adds `--dry-run` to `praisonai docs run` so code blocks are discovered and classified without execution
- Implements `SuiteExecutor(dry_run=True)` with `not_run` / `Dry run` results for runnable items
- Adds focused CLI integration tests in `test_docs_cli.py` (replaces obsolete `test_docs_runner.py` from the fork)

## Contributor credit

Thanks **@Iyanuoluwa007** for the original work in #2602. This branch cherry-picks their commit (`e783ad17c`) and adapts tests for the current `suite_runner` architecture on `main`.

## Closes

Closes #2602

## Test plan

- [x] `pytest src/praisonai/tests/unit/cli/test_docs_cli.py`
- [ ] CI green on internal PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `praisonai docs run` now supports a `--dry-run` mode that extracts/discovers documentation code blocks without executing them.
  * Dry-run outcomes are surfaced in the generated `report.json` as skipped items (not marked as run).

* **Tests**
  * Added CLI integration tests covering the `docs list` command output and validating `docs run --dry-run` reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->