### PR TITLE
fix(rag): avoid panic when truncating context on a UTF-8 char boundary

### DIFF
--- a/src/praisonai-rust/praisonai/src/rag/mod.rs
+++ b/src/praisonai-rust/praisonai/src/rag/mod.rs
@@ -549,7 +549,13 @@ impl RAG {
             return context.to_string();
         }
 
-        format!("{}...", &context[..char_limit])
+        // `char_limit` is a byte count; walk back to the nearest char boundary
+        // so we never slice through a multi-byte UTF-8 character (would panic).
+        let mut end = char_limit.min(context.len());
+        while end > 0 && !context.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &context[..end])
     }
 }
 
@@ -616,7 +622,13 @@ pub fn truncate_context(context: &str, max_tokens: usize) -> String {
         return context.to_string();
     }
 
-    format!("{}...", &context[..char_limit])
+    // `char_limit` is a byte count; walk back to the nearest char boundary so
+    // we never slice through a multi-byte UTF-8 character (which would panic).
+    let mut end = char_limit.min(context.len());
+    while end > 0 && !context.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &context[..end])
 }
 
 /// Deduplicate chunks by content similarity.
@@ -758,6 +770,16 @@ mod tests {
         let truncated = truncate_context(&long_text, 100);
         assert!(truncated.len() < long_text.len());
         assert!(truncated.ends_with("..."));
+    }
+
+    #[test]
+    fn test_truncate_context_multibyte_no_panic() {
+        // A byte-based char_limit can land inside a multi-byte character;
+        // truncation must not panic and must cut on a char boundary.
+        let text = "日本語テキストです".repeat(50); // multi-byte, well over the limit
+        let truncated = truncate_context(&text, 1);
+        assert!(truncated.ends_with("..."));
+        assert!(truncated.len() < text.len());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`truncate_context` (in `src/praisonai-rust/praisonai/src/rag/mod.rs`, both the free function and the `RAG::truncate_context` method) computes a cut point as a **byte** count (`max_tokens * 4`) and then slices the string directly:

```rust
let char_limit = max_tokens * 4;
if context.len() <= char_limit { return context.to_string(); }
format!("{}...", &context[..char_limit])   // panics on non-ASCII
```

`&context[..char_limit]` requires `char_limit` to fall on a UTF-8 character boundary. For any context containing multi-byte characters (CJK, accented Latin, emoji), the byte index can land **inside** a character, and Rust panics:

```
thread 'main' panicked: byte index 4 is not a char boundary; it is inside 'é' (bytes 3..5 of `aaaé`)
```

`truncate_context` is public (re-exported in `lib.rs`) and is the RAG context-trimming path, so any non-English document large enough to be truncated can crash it.

## Fix

Walk the cut point back to the nearest character boundary before slicing (applied at both sites):

```rust
let mut end = char_limit.min(context.len());
while end > 0 && !context.is_char_boundary(end) {
    end -= 1;
}
format!("{}...", &context[..end])
```

ASCII inputs are unaffected (the boundary is already valid).

## Tests

Added `test_truncate_context_multibyte_no_panic` (the existing `test_truncate_context` only covered ASCII `"a".repeat(...)`). Before the fix it panics; after, it truncates on a char boundary.

```
$ cargo test -p praisonai truncate_context
test rag::tests::test_truncate_context_multibyte_no_panic ... ok
test rag::tests::test_truncate_context ... ok
test result: ok. 2 passed; 0 failed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation to safely handle multi-byte characters, preventing crashes when shortening context strings.
  * Added coverage for truncation with non-ASCII text to ensure results remain stable and end with an ellipsis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->