### PR TITLE
fix(ci): default secret sync target to PraisonAIUI

### DIFF
--- a/.github/workflows/sync-secrets-to-aiui.yml
+++ b/.github/workflows/sync-secrets-to-aiui.yml
@@ -6,7 +6,7 @@ on:
       target_repo:
         description: 'Destination repo (owner/name)'
         required: true
-        default: 'MervinPraison/PraisonAI-Plugins'
+        default: 'MervinPraison/PraisonAIUI'
         type: string
 
 permissions:


### PR DESCRIPTION
## Summary

Updates `sync-secrets-to-aiui.yml` default `target_repo` from `PraisonAI-Plugins` to `MervinPraison/PraisonAIUI` so the AIUI gate stack receives Claude secrets by default.

PraisonAIUI `sync-secrets-from-praisonai.yml` now passes `-f target_repo=MervinPraison/PraisonAIUI`.

## Test plan

- [ ] `workflow_dispatch` Sync Claude Secrets on PraisonAI with default target
- [ ] `workflow_dispatch` Sync Claude Secrets from PraisonAI on PraisonAIUI