### PR TITLE
fix(sandbox): resolve plugin backends via praisonai.sandbox registry

### DIFF
--- a/src/praisonai-agents/praisonaiagents/sandbox/config.py
+++ b/src/praisonai-agents/praisonaiagents/sandbox/config.py
@@ -153,6 +153,18 @@ class SandboxConfig:
         return cls(
             sandbox_type="e2b",
         )
+
+    @classmethod
+    def capsule(cls) -> "SandboxConfig":
+        """Create a Capsule sandbox configuration.
+
+        Requires a plugin that registers ``capsule`` under the
+        ``praisonai.sandbox`` entry-point group (e.g. praisonai-plugins[capsule]).
+        """
+        return cls(
+            sandbox_type="capsule",
+            security_policy=SecurityPolicy.strict(),
+        )
     
     @classmethod
     def native(

--- a/src/praisonai-agents/praisonaiagents/sandbox/manager.py
+++ b/src/praisonai-agents/praisonaiagents/sandbox/manager.py
@@ -123,21 +123,24 @@ class SandboxManager:
                 f"Unknown sandbox type: {sandbox_type!r}. "
                 f"Supported built-ins: 'docker', 'subprocess', 'e2b', 'sandlock', "
                 f"'ssh', 'modal', 'daytona'. "
-                f"Install praisonai-plugins[capsule] or another plugin package "
-                f"that registers '{sandbox_type}'."
+                f"Install a plugin package that registers '{sandbox_type}' "
+                f"under the 'praisonai.sandbox' entry-point group."
             ) from e
 
+        registry = SandboxRegistry.default()
         try:
-            sandbox_cls = SandboxRegistry.default().resolve(sandbox_type)
+            sandbox_cls = registry.resolve(sandbox_type)
         except ValueError as e:
             raise ValueError(
                 f"Unknown sandbox type: {sandbox_type!r}. "
-                f"Available: {SandboxRegistry.default().list_names()}"
+                f"Available: {registry.list_names()}"
             ) from e
 
         sandbox = sandbox_cls(config=self.config)
         is_available = getattr(sandbox, "is_available", True)
-        if is_available is False:
+        if callable(is_available):
+            is_available = is_available()
+        if not is_available:
             raise RuntimeError(
                 f"Sandbox {sandbox_type!r} is not available. "
                 f"Install the plugin package that provides this backend."

--- a/src/praisonai-agents/praisonaiagents/sandbox/manager.py
+++ b/src/praisonai-agents/praisonaiagents/sandbox/manager.py
@@ -112,10 +112,39 @@ class SandboxManager:
         elif sandbox_type == "daytona":
             return await self._create_daytona_sandbox()
         else:
+            return await self._create_registry_sandbox(sandbox_type)
+    
+    async def _create_registry_sandbox(self, sandbox_type: str) -> SandboxProtocol:
+        """Create a sandbox registered via praisonai.sandbox entry points."""
+        try:
+            from praisonai.sandbox._registry import SandboxRegistry
+        except ImportError as e:
             raise ValueError(
                 f"Unknown sandbox type: {sandbox_type!r}. "
-                f"Supported: 'docker', 'subprocess', 'e2b', 'sandlock', 'ssh', 'modal', 'daytona'"
+                f"Supported built-ins: 'docker', 'subprocess', 'e2b', 'sandlock', "
+                f"'ssh', 'modal', 'daytona'. "
+                f"Install praisonai-plugins[capsule] or another plugin package "
+                f"that registers '{sandbox_type}'."
+            ) from e
+
+        try:
+            sandbox_cls = SandboxRegistry.default().resolve(sandbox_type)
+        except ValueError as e:
+            raise ValueError(
+                f"Unknown sandbox type: {sandbox_type!r}. "
+                f"Available: {SandboxRegistry.default().list_names()}"
+            ) from e
+
+        sandbox = sandbox_cls(config=self.config)
+        is_available = getattr(sandbox, "is_available", True)
+        if is_available is False:
+            raise RuntimeError(
+                f"Sandbox {sandbox_type!r} is not available. "
+                f"Install the plugin package that provides this backend."
             )
+
+        await sandbox.start()
+        return sandbox
     
     async def _create_docker_sandbox(self) -> SandboxProtocol:
         """Create Docker sandbox."""

--- a/src/praisonai-agents/tests/unit/sandbox/test_sandbox_manager.py
+++ b/src/praisonai-agents/tests/unit/sandbox/test_sandbox_manager.py
@@ -117,12 +117,39 @@ class TestSandboxManager:
             assert sandbox == mock_instance
 
     async def test_create_sandbox_unknown_type(self):
-        """Test creating sandbox with unknown type."""
-        config = SandboxConfig(sandbox_type="unknown")
+        """Test creating sandbox with unknown type fails via registry."""
+        config = SandboxConfig(sandbox_type="totally_unknown_backend")
         manager = SandboxManager(config)
-        
-        with pytest.raises(ValueError, match="Unknown sandbox type"):
-            await manager._create_sandbox()
+
+        mock_registry = Mock()
+        mock_registry.resolve.side_effect = ValueError(
+            "Unknown praisonai.sandbox plugin: 'totally_unknown_backend'"
+        )
+        mock_registry.list_names.return_value = ["docker", "subprocess"]
+
+        with patch("praisonai.sandbox._registry.SandboxRegistry.default", return_value=mock_registry):
+            with pytest.raises(ValueError, match="Unknown sandbox type"):
+                await manager._create_sandbox()
+
+    async def test_create_sandbox_registry_plugin(self):
+        """Test plugin sandbox types resolve via praisonai.sandbox registry."""
+        config = SandboxConfig.capsule()
+        manager = SandboxManager(config)
+
+        mock_instance = AsyncMock()
+        mock_instance.is_available = True
+        mock_cls = Mock(return_value=mock_instance)
+
+        mock_registry = Mock()
+        mock_registry.resolve.return_value = mock_cls
+
+        with patch("praisonai.sandbox._registry.SandboxRegistry.default", return_value=mock_registry):
+            sandbox = await manager._create_sandbox()
+
+        mock_registry.resolve.assert_called_once_with("capsule")
+        mock_cls.assert_called_once_with(config=config)
+        mock_instance.start.assert_called_once()
+        assert sandbox is mock_instance
 
     async def test_create_sandbox_unavailable(self):
         """Test creating sandbox when not available."""

--- a/src/praisonai-agents/tests/unit/sandbox/test_sandbox_manager.py
+++ b/src/praisonai-agents/tests/unit/sandbox/test_sandbox_manager.py
@@ -2,11 +2,26 @@
 Unit tests for SandboxManager.
 """
 
+import sys
+import types
+from contextlib import contextmanager
+
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 from praisonaiagents.sandbox.manager import SandboxManager
 from praisonaiagents.sandbox.config import SandboxConfig
 from praisonaiagents.sandbox.protocols import SandboxResult, SandboxStatus
+
+
+@contextmanager
+def _patch_registry(mock_registry):
+    """Inject a fake praisonai.sandbox._registry so tests run without praisonai."""
+    module = types.ModuleType("praisonai.sandbox._registry")
+    registry_cls = Mock()
+    registry_cls.default.return_value = mock_registry
+    module.SandboxRegistry = registry_cls
+    with patch.dict(sys.modules, {"praisonai.sandbox._registry": module}):
+        yield
 
 
 class TestSandboxManager:
@@ -127,7 +142,7 @@ class TestSandboxManager:
         )
         mock_registry.list_names.return_value = ["docker", "subprocess"]
 
-        with patch("praisonai.sandbox._registry.SandboxRegistry.default", return_value=mock_registry):
+        with _patch_registry(mock_registry):
             with pytest.raises(ValueError, match="Unknown sandbox type"):
                 await manager._create_sandbox()
 
@@ -143,13 +158,29 @@ class TestSandboxManager:
         mock_registry = Mock()
         mock_registry.resolve.return_value = mock_cls
 
-        with patch("praisonai.sandbox._registry.SandboxRegistry.default", return_value=mock_registry):
+        with _patch_registry(mock_registry):
             sandbox = await manager._create_sandbox()
 
         mock_registry.resolve.assert_called_once_with("capsule")
         mock_cls.assert_called_once_with(config=config)
         mock_instance.start.assert_called_once()
         assert sandbox is mock_instance
+
+    async def test_create_sandbox_registry_import_error(self):
+        """Test unknown type fails clearly when praisonai wrapper is absent."""
+        config = SandboxConfig(sandbox_type="totally_unknown_backend")
+        manager = SandboxManager(config)
+
+        real_import = __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "praisonai.sandbox._registry":
+                raise ImportError("No module named 'praisonai'")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            with pytest.raises(ValueError, match="Unknown sandbox type"):
+                await manager._create_sandbox()
 
     async def test_create_sandbox_unavailable(self):
         """Test creating sandbox when not available."""


### PR DESCRIPTION
Fixes routing for #2773 / #2804

## Summary
- SandboxManager falls back to SandboxRegistry for entry-point backends (e.g. capsule from praisonai-plugins)
- Adds SandboxConfig.capsule() factory only — no wrapper implementation

## Test plan
- [x] test_create_sandbox_registry_plugin
- [x] test_create_sandbox_unknown_type


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capsule-based sandbox configuration support with stricter security controls.
  * Sandboxes can now be created from externally registered backend plugins.
* **Bug Fixes**
  * Unrecognized or unavailable sandbox backends now report clearer, plugin-aware error messages and available options.
* **Tests**
  * Expanded unit coverage for plugin-based backend resolution, sandbox startup, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->