### PR TITLE
fix(sdk): close extension routing gaps for tools, plugins, and sandbox

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -705,6 +705,13 @@ class Agent(SteeringMixin, SandboxMixin, SkillReviewMixin, UnifiedExecutionMixin
             Agent._configure_logging()
             Agent._logging_configured = True
 
+        # Auto-enable entry-point plugins when PRAISONAI_PLUGINS / config.toml requests it
+        try:
+            from ..plugins import maybe_enable_from_config
+            maybe_enable_from_config()
+        except Exception:
+            pass
+
         # ============================================================
         # CONFIG-DRIVEN DEFAULTS (apply before parameter resolution)
         # Precedence: Explicit params > Config file > Built-in defaults

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -709,8 +709,9 @@ class Agent(SteeringMixin, SandboxMixin, SkillReviewMixin, UnifiedExecutionMixin
         try:
             from ..plugins import maybe_enable_from_config
             maybe_enable_from_config()
-        except Exception:
-            pass
+        except Exception as _plugin_exc:
+            import logging as _logging
+            _logging.getLogger(__name__).debug("Plugin auto-enable failed: %s", _plugin_exc)
 
         # ============================================================
         # CONFIG-DRIVEN DEFAULTS (apply before parameter resolution)

--- a/src/praisonai-agents/praisonaiagents/agent/tool_execution.py
+++ b/src/praisonai-agents/praisonaiagents/agent/tool_execution.py
@@ -331,29 +331,10 @@ class ToolExecutionMixin:
         return None
 
     def _resolve_tool_names(self, tool_names):
-        """Resolve tool names to actual tool instances from registry.
-        
-        Args:
-            tool_names: List of tool name strings
-            
-        Returns:
-            List of resolved tool instances
-        """
-        resolved = []
-        try:
-            from ..tools.registry import get_registry
-            registry = get_registry()
-            
-            for name in tool_names:
-                tool = registry.get(name)
-                if tool is not None:
-                    resolved.append(tool)
-                else:
-                    logging.warning(f"Tool '{name}' not found in registry")
-        except ImportError:
-            logging.warning("Tool registry not available, cannot resolve tool names")
-        
-        return resolved
+        """Resolve tool names via the canonical resolver chain."""
+        from ..tools.resolver import resolve_tool_names
+
+        return resolve_tool_names(tool_names)
 
     def _cast_arguments(self, func, arguments):
         """Cast arguments to their expected types based on function signature."""

--- a/src/praisonai-agents/praisonaiagents/plugins/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/plugins/__init__.py
@@ -85,26 +85,33 @@ _plugins_lock = threading.Lock()
 _plugins_enabled: bool = False
 _enabled_plugin_names: list = None  # None = all, list = specific
 _auto_enable_attempted: bool = False
+_auto_enable_lock = threading.Lock()
 
 
 def maybe_enable_from_config() -> None:
     """Enable plugins once per process when config or env requests it."""
     global _auto_enable_attempted
 
-    with _plugins_lock:
+    # Fast path: avoid taking the lock once initialization has been attempted.
+    if _auto_enable_attempted or _plugins_enabled:
+        return
+
+    # Hold a dedicated lock across the whole init so concurrent callers block
+    # until enable() has finished (rather than returning early on the flag).
+    with _auto_enable_lock:
         if _auto_enable_attempted or _plugins_enabled:
             return
         _auto_enable_attempted = True
 
-    try:
-        from praisonaiagents.config.loader import get_enabled_plugins, is_plugins_enabled
+        try:
+            from praisonaiagents.config.loader import get_enabled_plugins, is_plugins_enabled
 
-        if is_plugins_enabled():
-            enable(get_enabled_plugins())
-    except Exception as exc:
-        import logging
+            if is_plugins_enabled():
+                enable(get_enabled_plugins())
+        except Exception as exc:
+            import logging
 
-        logging.getLogger(__name__).debug("Plugin auto-enable skipped: %s", exc)
+            logging.getLogger(__name__).debug("Plugin auto-enable skipped: %s", exc)
 
 
 def enable(plugins: list = None) -> None:

--- a/src/praisonai-agents/praisonaiagents/plugins/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/plugins/__init__.py
@@ -40,6 +40,7 @@ __all__ = [
     # Easy enable API
     "enable",
     "disable",
+    "maybe_enable_from_config",
     "list_plugins",
     "is_enabled",
     # Core
@@ -83,6 +84,27 @@ import threading
 _plugins_lock = threading.Lock()
 _plugins_enabled: bool = False
 _enabled_plugin_names: list = None  # None = all, list = specific
+_auto_enable_attempted: bool = False
+
+
+def maybe_enable_from_config() -> None:
+    """Enable plugins once per process when config or env requests it."""
+    global _auto_enable_attempted
+
+    with _plugins_lock:
+        if _auto_enable_attempted or _plugins_enabled:
+            return
+        _auto_enable_attempted = True
+
+    try:
+        from praisonaiagents.config.loader import get_enabled_plugins, is_plugins_enabled
+
+        if is_plugins_enabled():
+            enable(get_enabled_plugins())
+    except Exception as exc:
+        import logging
+
+        logging.getLogger(__name__).debug("Plugin auto-enable skipped: %s", exc)
 
 
 def enable(plugins: list = None) -> None:

--- a/src/praisonai-agents/praisonaiagents/sandbox/config.py
+++ b/src/praisonai-agents/praisonaiagents/sandbox/config.py
@@ -165,7 +165,7 @@ class SandboxConfig:
             sandbox_type="capsule",
             security_policy=SecurityPolicy.strict(),
         )
-    
+
     @classmethod
     def native(
         cls,

--- a/src/praisonai-agents/praisonaiagents/sandbox/manager.py
+++ b/src/praisonai-agents/praisonaiagents/sandbox/manager.py
@@ -124,7 +124,8 @@ class SandboxManager:
                 f"Supported built-ins: 'docker', 'subprocess', 'e2b', 'sandlock', "
                 f"'ssh', 'modal', 'daytona'. "
                 f"Install a plugin package that registers '{sandbox_type}' "
-                f"under the 'praisonai.sandbox' entry-point group."
+                f"under the 'praisonai.sandbox' entry-point group "
+                f"(e.g. pip install praisonai-plugins[capsule])."
             ) from e
 
         registry = SandboxRegistry.default()

--- a/src/praisonai-agents/praisonaiagents/tools/resolver.py
+++ b/src/praisonai-agents/praisonaiagents/tools/resolver.py
@@ -55,7 +55,9 @@ def resolve_tool_name(name: str) -> Optional[Any]:
             tool = getattr(praisonai_tools, name, None)
             if tool is not None:
                 return tool
-        except ImportError:
+        except Exception:
+            # A partially installed / broken praisonai_tools can raise more than
+            # ImportError (AttributeError, SyntaxError, ...). Never crash resolution.
             _praisonai_tools_available = False
 
     return None

--- a/src/praisonai-agents/praisonaiagents/tools/resolver.py
+++ b/src/praisonai-agents/praisonaiagents/tools/resolver.py
@@ -1,0 +1,73 @@
+"""Canonical tool name resolution for the core SDK.
+
+Resolution order (first match wins):
+1. Tool registry (explicitly registered tools)
+2. praisonaiagents.tools.TOOL_MAPPINGS (built-in lazy tools)
+3. praisonai-tools package (external integrations, optional)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_praisonai_tools_available: Optional[bool] = None
+
+
+def resolve_tool_name(name: str) -> Optional[Any]:
+    """Resolve a single tool name to a callable or tool instance."""
+    # 1. Registry
+    try:
+        from .registry import get_registry
+
+        tool = get_registry().get(name)
+        if tool is not None:
+            return tool
+    except ImportError:
+        pass
+
+    # 2. Built-in TOOL_MAPPINGS
+    try:
+        from . import TOOL_MAPPINGS
+
+        if name in TOOL_MAPPINGS:
+            import praisonaiagents.tools as agent_tools
+
+            return getattr(agent_tools, name)
+    except AttributeError as exc:
+        logger.warning("Tool %r exists in TOOL_MAPPINGS but failed to load: %s", name, exc)
+        return None
+    except ImportError:
+        pass
+
+    # 3. praisonai-tools (optional)
+    global _praisonai_tools_available
+    if _praisonai_tools_available is None:
+        _praisonai_tools_available = importlib.util.find_spec("praisonai_tools") is not None
+
+    if _praisonai_tools_available:
+        try:
+            import praisonai_tools
+
+            tool = getattr(praisonai_tools, name, None)
+            if tool is not None:
+                return tool
+        except ImportError:
+            _praisonai_tools_available = False
+
+    return None
+
+
+def resolve_tool_names(names: List[str]) -> List[Any]:
+    """Resolve tool name strings to callables/instances."""
+    resolved = []
+    for name in names:
+        tool = resolve_tool_name(name)
+        if tool is not None:
+            resolved.append(tool)
+        else:
+            logger.warning("Tool %r not found (registry, TOOL_MAPPINGS, praisonai-tools)", name)
+    return resolved

--- a/src/praisonai-agents/tests/unit/plugins/test_plugins_enable.py
+++ b/src/praisonai-agents/tests/unit/plugins/test_plugins_enable.py
@@ -185,6 +185,49 @@ backend = "file"
                 os.unlink(f.name)
 
 
+class TestMaybeEnableFromConfig:
+    """Test automatic plugin enablement from env/config."""
+
+    def setup_method(self):
+        import praisonaiagents.plugins as plugins_mod
+
+        with plugins_mod._plugins_lock:
+            plugins_mod._plugins_enabled = False
+            plugins_mod._enabled_plugin_names = None
+            plugins_mod._auto_enable_attempted = False
+
+    def teardown_method(self):
+        import praisonaiagents.plugins as plugins_mod
+
+        with plugins_mod._plugins_lock:
+            plugins_mod._plugins_enabled = False
+            plugins_mod._enabled_plugin_names = None
+            plugins_mod._auto_enable_attempted = False
+
+    def test_auto_enables_when_env_set(self):
+        import praisonaiagents.plugins as plugins_mod
+
+        with patch.dict(os.environ, {"PRAISONAI_PLUGINS": "true"}, clear=False):
+            plugins_mod.maybe_enable_from_config()
+            assert plugins_mod.is_enabled() is True
+
+    def test_skips_when_env_disabled(self):
+        import praisonaiagents.plugins as plugins_mod
+
+        with patch.dict(os.environ, {"PRAISONAI_PLUGINS": "false"}, clear=False):
+            plugins_mod.maybe_enable_from_config()
+            assert plugins_mod.is_enabled() is False
+
+    def test_runs_once_per_process(self):
+        import praisonaiagents.plugins as plugins_mod
+
+        with patch.object(plugins_mod, "enable") as mock_enable:
+            with patch.dict(os.environ, {"PRAISONAI_PLUGINS": "true"}, clear=False):
+                plugins_mod.maybe_enable_from_config()
+                plugins_mod.maybe_enable_from_config()
+        mock_enable.assert_called_once()
+
+
 class TestConfigDrivenDefaults:
     """Test config-driven defaults for Agent parameters."""
     

--- a/src/praisonai-agents/tests/unit/sandbox/test_sandbox_manager.py
+++ b/src/praisonai-agents/tests/unit/sandbox/test_sandbox_manager.py
@@ -182,6 +182,12 @@ class TestSandboxManager:
             with pytest.raises(ValueError, match="Unknown sandbox type"):
                 await manager._create_sandbox()
 
+    def test_config_capsule_factory(self):
+        """Test Capsule config factory."""
+        config = SandboxConfig.capsule()
+        assert config.sandbox_type == "capsule"
+        assert config.security_policy.allow_network is False
+
     async def test_create_sandbox_unavailable(self):
         """Test creating sandbox when not available."""
         config = SandboxConfig.docker("python:3.11")

--- a/src/praisonai-agents/tests/unit/tools/test_tool_resolver.py
+++ b/src/praisonai-agents/tests/unit/tools/test_tool_resolver.py
@@ -1,0 +1,46 @@
+"""Unit tests for canonical tool name resolution."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from praisonaiagents.tools.resolver import resolve_tool_name, resolve_tool_names
+
+
+class TestResolveToolName:
+    def test_registry_takes_precedence(self):
+        mock_tool = MagicMock()
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = mock_tool
+
+        with patch("praisonaiagents.tools.registry.get_registry", return_value=mock_registry):
+            assert resolve_tool_name("my_tool") is mock_tool
+
+    def test_falls_back_to_tool_mappings(self):
+        sentinel = MagicMock()
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = None
+
+        with patch("praisonaiagents.tools.registry.get_registry", return_value=mock_registry):
+            with patch("praisonaiagents.tools.TOOL_MAPPINGS", {"schedule_add": (".schedule_tools", None)}):
+                with patch("praisonaiagents.tools.__getattr__", return_value=sentinel):
+                    assert resolve_tool_name("schedule_add") is sentinel
+
+    def test_returns_none_when_unresolved(self):
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = None
+
+        with patch("praisonaiagents.tools.registry.get_registry", return_value=mock_registry):
+            with patch("praisonaiagents.tools.TOOL_MAPPINGS", {}):
+                with patch("praisonaiagents.tools.resolver._praisonai_tools_available", False):
+                    assert resolve_tool_name("nonexistent_tool_xyz") is None
+
+
+class TestResolveToolNames:
+    def test_resolve_tool_names_skips_missing(self):
+        with patch(
+            "praisonaiagents.tools.resolver.resolve_tool_name",
+            side_effect=[MagicMock(), None, MagicMock()],
+        ):
+            resolved = resolve_tool_names(["a", "b", "c"])
+        assert len(resolved) == 2


### PR DESCRIPTION
## Summary
- Unify Agent tool name resolution: registry → TOOL_MAPPINGS → praisonai-tools (new `tools/resolver.py`)
- Auto-enable plugins on Agent init when `PRAISONAI_PLUGINS` or config.toml requests it (`maybe_enable_from_config`)
- SandboxManager falls back to `praisonai.sandbox` entry points for plugin backends (e.g. Capsule)
- Add `SandboxConfig.capsule()` factory

## Related
- Closes routing gaps from architecture review (Capsule/Composio follow-up)
- Works with PraisonAI-Plugins PR #4 (Capsule backend)
- Complements issue #2804 (remaining hook bridge events deferred)

## Test plan
- [x] `pytest tests/unit/tools/test_tool_resolver.py -v`
- [x] `pytest tests/unit/sandbox/test_sandbox_manager.py` (registry + capsule factory tests)
- [x] `pytest tests/unit/plugins/test_plugins_enable.py::TestMaybeEnableFromConfig -v`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **capsule** sandbox option with a stricter security policy.
  * Plugins can now be **auto-enabled on startup** based on configuration/environment settings.
* **Bug Fixes**
  * Improved canonical **tool name resolution** by applying a consistent precedence order.
  * Unresolvable or unavailable tools are handled more gracefully, with missing items **skipped** instead of causing failure.
* **Tests**
  * Added unit test coverage for plugin auto-enable behavior, capsule config creation, and canonical tool resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->