### PR TITLE
Fix release gate: max one patch release per UTC day

### DIFF
--- a/.github/scripts/release-gate-selftest.js
+++ b/.github/scripts/release-gate-selftest.js
@@ -12,9 +12,46 @@ assert.ok(versions.currentWrapper);
 assert.ok(versions.targetCode);
 assert.ok(rg.PACKAGE_PATHS.includes('src/praisonai-code'));
 
+const noonUtc = new Date('2026-07-08T12:00:00Z');
+const dayStart = rg.utcDayStart(noonUtc);
+assert.strictEqual(dayStart.toISOString(), '2026-07-08T00:00:00.000Z');
+
 (async () => {
   assert.strictEqual(await rg.pypiVersionExists('praisonaiagents', '0.0.0'), false);
+
+  const mockGithub = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async () => ({
+          data: {
+            workflow_runs: [
+              {
+                conclusion: 'success',
+                created_at: '2026-07-08T09:00:00Z',
+                status: 'completed',
+              },
+            ],
+          },
+        }),
+      },
+    },
+  };
+  assert.strictEqual(
+    await rg.hasSuccessfulReleaseToday(mockGithub, 'o', 'r', noonUtc),
+    true
+  );
+
+  const result = await rg.evaluateReleasePreflight(
+    mockGithub, 'o', 'r',
+    { headSha: 'abc', isCiTrigger: false, bump: 'patch', now: noonUtc },
+    null
+  );
+  assert.ok(result.reasons.some((r) => r.includes('already released today')));
+
   console.log('ok: bumpPatch');
   console.log('ok: readVersionsFromTree');
   console.log('ok: pypiVersionExists missing version');
+  console.log('ok: utcDayStart');
+  console.log('ok: hasSuccessfulReleaseToday');
+  console.log('ok: daily dedupe blocks second release');
 })();

--- a/.github/scripts/release-gate.js
+++ b/.github/scripts/release-gate.js
@@ -75,6 +75,24 @@ async function hasActiveReleaseRun(github, owner, repo) {
   );
 }
 
+function utcDayStart(now = new Date()) {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+async function hasSuccessfulReleaseToday(github, owner, repo, now = new Date()) {
+  const dayStart = utcDayStart(now);
+  const runs = await github.rest.actions.listWorkflowRuns({
+    owner,
+    repo,
+    workflow_id: 'pypi-release.yml',
+    status: 'completed',
+    per_page: 30,
+  });
+  return runs.data.workflow_runs.some(
+    (r) => r.conclusion === 'success' && new Date(r.created_at) >= dayStart
+  );
+}
+
 async function lastGreenCoreTestsSha(github, owner, repo) {
   const runs = await github.rest.actions.listWorkflowRuns({
     owner,
@@ -113,6 +131,13 @@ async function evaluateReleasePreflight(github, owner, repo, options, core) {
 
   if (await hasActiveReleaseRun(github, owner, repo)) {
     reasons.push('PyPI Release already in progress or awaiting approval');
+    return out;
+  }
+
+  const referenceTime = options.now instanceof Date ? options.now : new Date();
+  if (await hasSuccessfulReleaseToday(github, owner, repo, referenceTime)) {
+    const day = referenceTime.toISOString().slice(0, 10);
+    reasons.push(`already released today (UTC ${day}); max one patch release per day`);
     return out;
   }
 
@@ -197,6 +222,8 @@ module.exports = {
   bumpPatch,
   readVersionsFromTree,
   pypiVersionExists,
+  hasSuccessfulReleaseToday,
+  utcDayStart,
   evaluateReleasePreflight,
   ACTIVE_RELEASE_STATUSES,
   PACKAGE_PATHS,

--- a/.github/workflows/nightly-release-gate.yml
+++ b/.github/workflows/nightly-release-gate.yml
@@ -1,8 +1,8 @@
 name: Nightly Release Gate
 
 # Preflight before PyPI Release (patch bump).
-# Primary: Core Tests success on main (workflow_run).
-# Backstop: nightly cron at 00:00 UTC.
+# Triggers: Core Tests success on main (workflow_run) or nightly cron at 00:00 UTC.
+# Dedupe: max one successful patch release per UTC day (see release-gate.js).
 
 on:
   schedule:
@@ -39,7 +39,9 @@ jobs:
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_branch == 'main' &&
-        github.event.workflow_run.event == 'push'
+        github.event.workflow_run.event == 'push' &&
+        !startsWith(github.event.workflow_run.head_commit.message, 'Release v') &&
+        !startsWith(github.event.workflow_run.head_commit.message, 'Bump praisonai')
       )
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Problem

Today **4 patch releases** shipped in ~1 hour (v4.6.137 → v4.6.140) because the release gate fired on **every** successful Core Tests push to `main`.

PraisonAIUI already had `hasSuccessfulReleaseToday` in `release-gate.js`; the monorepo copy was missing it.

## Fix

- Add **max one successful patch release per UTC day** (same logic as PraisonAIUI)
- Skip release-gate `workflow_run` when the triggering commit is a `Release v*` or `Bump praisonai*` bot commit (avoids cascade after publish)
- Selftests for daily dedupe

## Behaviour after merge

| Event | Result |
|-------|--------|
| First green Core Tests on `main` each UTC day (with package changes) | Patch release |
| Further merges same UTC day | Skipped — `already released today` |
| Nightly cron 00:00 UTC | Runs only if no release yet that day **and** changes since last tag |

## Test plan
- [x] `node .github/scripts/release-gate-selftest.js`
- [ ] Merge and verify next Core Tests push does not release if one already succeeded today

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a daily release check so a successful patch release won’t run more than once per UTC day.
  * Improved workflow filtering to avoid duplicate nightly release-gate runs in common release scenarios.
* **Documentation**
  * Updated workflow comments to better reflect when release gating runs and how duplicate releases are prevented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->