### PR TITLE
feat(memory): add Perseus Vault memory adapter (local-first, single-binary, no SDK dep)

### DIFF
--- a/src/praisonai-agents/examples/python/memory/perseus_vault_memory.py
+++ b/src/praisonai-agents/examples/python/memory/perseus_vault_memory.py
@@ -52,6 +52,12 @@ def main():
     )
 
     workflow.start()
+    # Expected output (abridged): the agent produces a short summary and the
+    # workflow persists it to Perseus Vault under the ./praisonai-perseus-vault.db
+    # file, e.g.:
+    #> Local-first agent memory keeps data on your own hardware, works offline,
+    #> and gives deterministic recall — no external memory service required.
+    # On the next run the agent can recall this via Perseus Vault's hybrid search.
 
 
 if __name__ == "__main__":

--- a/src/praisonai-agents/examples/python/memory/perseus_vault_memory.py
+++ b/src/praisonai-agents/examples/python/memory/perseus_vault_memory.py
@@ -1,0 +1,58 @@
+"""
+Perseus Vault memory backend for PraisonAI.
+
+Perseus Vault (https://github.com/Perseus-Computing-LLC/perseus-vault) is a
+single static-binary MCP memory server: SQLite + FTS5 + bundled ONNX
+embeddings, optional AES-256-GCM, fully local and offline. This example wires
+it into a PraisonAI Agent as the memory backend.
+
+Prereqs:
+  1. Install the perseus-vault binary (single file, no Python deps) and put it
+     on PATH, or set PERSEUS_VAULT_BIN=/path/to/perseus-vault.
+  2. pip install praisonaiagents
+
+Run:
+  python perseus_vault_memory.py
+"""
+
+from praisonaiagents import Agent, Task, PraisonAIAgents
+
+
+def main():
+    # The "perseus_vault" adapter is registered out of the box. Point it at the
+    # binary + a DB file; short/long-term memory map onto vault categories.
+    agent = Agent(
+        name="Researcher",
+        role="Research assistant with persistent, local-first memory",
+        goal="Remember findings across sessions and recall them on demand",
+        memory=True,
+    )
+
+    task = Task(
+        description="Summarize why local-first agent memory matters, and remember it.",
+        expected_output="A short summary, persisted to Perseus Vault.",
+        agent=agent,
+    )
+
+    workflow = PraisonAIAgents(
+        agents=[agent],
+        tasks=[task],
+        memory=True,
+        memory_config={
+            "provider": "perseus_vault",
+            "config": {
+                # Falls back to PERSEUS_VAULT_BIN / PERSEUS_VAULT_DB env if omitted.
+                "binary": "perseus-vault",
+                "db_path": "./praisonai-perseus-vault.db",
+                # Optional: path to an AES-256-GCM key file for encryption at rest.
+                # "encryption_key": "/path/to/key",
+                "search_mode": "hybrid",  # fts5 | dense | hybrid
+            },
+        },
+    )
+
+    workflow.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/praisonai-agents/praisonaiagents/memory/adapters/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/memory/adapters/__init__.py
@@ -32,6 +32,7 @@ from .factories import (
     create_chroma_memory_adapter,
     create_mongodb_memory_adapter,
     create_dakera_memory_adapter,
+    create_perseus_vault_memory_adapter,
 )
 
 # Register core adapters
@@ -43,6 +44,7 @@ register_memory_factory("mem0", create_mem0_memory_adapter)
 register_memory_factory("chroma", create_chroma_memory_adapter)
 register_memory_factory("mongodb", create_mongodb_memory_adapter)
 register_memory_factory("dakera", create_dakera_memory_adapter)
+register_memory_factory("perseus_vault", create_perseus_vault_memory_adapter)
 
 __all__ = [
     'SqliteMemoryAdapter',

--- a/src/praisonai-agents/praisonaiagents/memory/adapters/factories.py
+++ b/src/praisonai-agents/praisonaiagents/memory/adapters/factories.py
@@ -172,6 +172,52 @@ def create_dakera_memory_adapter(**kwargs) -> MemoryProtocol:
     return DakeraMemoryAdapter(dakera_config=kwargs)
 
 
+def create_perseus_vault_memory_adapter(**kwargs) -> MemoryProtocol:
+    """
+    Factory function to create a Perseus Vault memory adapter.
+
+    Perseus Vault is a single static-binary MCP memory server (SQLite + FTS5 +
+    bundled ONNX embeddings, optional AES-256-GCM). Unlike the other wrapper
+    adapters this needs **no third-party Python SDK** — it talks JSON-RPC over
+    the binary's stdio ``serve`` transport directly, matching Perseus Vault's
+    zero-dependency, local-first design. The only requirement is that the
+    ``perseus-vault`` binary is reachable.
+
+    Args:
+        **kwargs: Configuration passed to the adapter. Recognised keys (either at
+            the top level or nested under a ``"config"`` dict, mirroring the mem0
+            and dakera adapters):
+
+            - ``binary`` / ``bin``: path to the ``perseus-vault`` binary
+              (falls back to ``PERSEUS_VAULT_BIN`` env, then ``perseus-vault`` on PATH).
+            - ``db_path`` / ``db``: SQLite DB path
+              (falls back to ``PERSEUS_VAULT_DB`` env, then ``./perseus-vault.db``).
+            - ``encryption_key``: path to an AES-256-GCM key file
+              (falls back to ``PERSEUS_VAULT_ENCRYPTION_KEY`` env; optional).
+            - ``short_term_category`` / ``long_term_category``: entity categories
+              for the two tiers (default ``working`` and ``episodic``).
+            - ``search_mode``: ``hybrid`` (default), ``fts5``, or ``dense``.
+            - ``default_importance``: initial importance 0.0-1.0 (default ``0.5``).
+
+    Returns:
+        MemoryProtocol adapter instance.
+
+    Raises:
+        FileNotFoundError: If the ``perseus-vault`` binary cannot be launched.
+    """
+    from .perseus_vault_adapter import PerseusVaultMemoryAdapter
+
+    try:
+        return PerseusVaultMemoryAdapter(config=kwargs)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            "The 'perseus-vault' binary was not found. Install it (single static "
+            "binary, no Python deps) from "
+            "https://github.com/Perseus-Computing-LLC/perseus-vault and either put "
+            "it on PATH or set the PERSEUS_VAULT_BIN env / `binary=` config key."
+        ) from exc
+
+
 class Mem0MemoryAdapter:
     """
     Memory adapter that wraps mem0.Memory to implement MemoryProtocol.

--- a/src/praisonai-agents/praisonaiagents/memory/adapters/perseus_vault_adapter.py
+++ b/src/praisonai-agents/praisonaiagents/memory/adapters/perseus_vault_adapter.py
@@ -1,0 +1,282 @@
+"""
+Perseus Vault memory adapter for PraisonAI.
+
+Wraps the `perseus-vault` MCP server (a single static binary — SQLite + FTS5 +
+bundled ONNX embeddings, optional AES-256-GCM) to implement ``MemoryProtocol``.
+Unlike the mem0/chroma/mongodb adapters this has **no third-party Python SDK
+dependency**: it speaks JSON-RPC 2.0 over the binary's stdio `serve` transport
+directly, matching Perseus Vault's zero-dependency, local-first design.
+
+Short-term vs long-term memory map onto Perseus Vault entity *categories*
+(``working`` and ``episodic`` by default), so the two tiers stay queryable and
+independently resettable. Search uses hybrid retrieval (FTS5 + dense vector
+fusion) via ``perseus_vault_recall``.
+
+Perseus Vault: https://github.com/Perseus-Computing-LLC/perseus-vault
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+
+class _VaultStdioClient:
+    """Minimal JSON-RPC 2.0 client over the perseus-vault `serve` stdio transport.
+
+    Spawns `perseus-vault serve --db <path>` as a long-lived child and exchanges
+    newline-delimited JSON-RPC messages over its stdin/stdout. Thread-safe: a
+    single lock serializes request/response round-trips.
+    """
+
+    def __init__(self, binary: str, db_path: str, env: Optional[Dict[str, str]] = None,
+                 encryption_key: Optional[str] = None, startup_timeout: float = 10.0):
+        self._binary = binary
+        self._db_path = db_path
+        self._encryption_key = encryption_key
+        self._env = {**os.environ, **(env or {})}
+        self._lock = threading.Lock()
+        self._id = 0
+        self._proc: Optional[subprocess.Popen] = None
+        self._startup_timeout = startup_timeout
+        self._start()
+
+    def _start(self) -> None:
+        cmd = [self._binary, "serve", "--db", self._db_path]
+        if self._encryption_key:
+            cmd += ["--encryption-key", self._encryption_key]
+        self._proc = subprocess.Popen(
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, text=True, bufsize=1, env=self._env,
+        )
+        # Handshake: initialize + notifications/initialized.
+        self._request("initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "praisonai-perseus-vault", "version": "0.1.0"},
+        })
+        self._notify("notifications/initialized", {})
+
+    def _next_id(self) -> int:
+        self._id += 1
+        return self._id
+
+    def _request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        if self._proc is None or self._proc.poll() is not None:
+            self._start()
+        with self._lock:
+            rid = self._next_id()
+            msg = {"jsonrpc": "2.0", "id": rid, "method": method, "params": params}
+            assert self._proc and self._proc.stdin and self._proc.stdout
+            self._proc.stdin.write(json.dumps(msg) + "\n")
+            self._proc.stdin.flush()
+            # Read until we get the response with our id (skip notifications).
+            deadline = time.time() + self._startup_timeout
+            while time.time() < deadline:
+                line = self._proc.stdout.readline()
+                if not line:
+                    raise RuntimeError("perseus-vault closed stdout unexpectedly")
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    resp = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if resp.get("id") == rid:
+                    if "error" in resp and resp["error"]:
+                        raise RuntimeError(f"perseus-vault error: {resp['error']}")
+                    return resp.get("result", {})
+            raise TimeoutError(f"perseus-vault did not respond to {method} in time")
+
+    def _notify(self, method: str, params: Dict[str, Any]) -> None:
+        with self._lock:
+            assert self._proc and self._proc.stdin
+            msg = {"jsonrpc": "2.0", "method": method, "params": params}
+            self._proc.stdin.write(json.dumps(msg) + "\n")
+            self._proc.stdin.flush()
+
+    def call_tool(self, name: str, arguments: Dict[str, Any]) -> Any:
+        """Invoke an MCP tool; return the parsed JSON body of the first content item."""
+        result = self._request("tools/call", {"name": name, "arguments": arguments})
+        content = result.get("content", [])
+        if not content:
+            return result
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return text
+
+    def close(self) -> None:
+        if self._proc and self._proc.poll() is None:
+            try:
+                if self._proc.stdin:
+                    self._proc.stdin.close()
+                self._proc.terminate()
+                self._proc.wait(timeout=5)
+            except Exception:
+                self._proc.kill()
+
+
+class PerseusVaultMemoryAdapter:
+    """Memory adapter backing PraisonAI with a local Perseus Vault MCP server.
+
+    Recognised config keys (top level or nested under ``"config"``, mirroring the
+    mem0/dakera adapters):
+
+    - ``binary`` / ``bin``: path to the ``perseus-vault`` binary
+      (falls back to ``PERSEUS_VAULT_BIN`` env, then ``"perseus-vault"`` on PATH).
+    - ``db_path`` / ``db``: SQLite DB path
+      (falls back to ``PERSEUS_VAULT_DB`` env, then ``"./perseus-vault.db"``).
+    - ``encryption_key``: path to an AES-256-GCM key file
+      (falls back to ``PERSEUS_VAULT_ENCRYPTION_KEY`` env; optional).
+    - ``short_term_category`` / ``long_term_category``: entity categories used for
+      the two tiers (default ``"working"`` and ``"episodic"``).
+    - ``search_mode``: ``"hybrid"`` (default), ``"fts5"``, or ``"dense"``.
+    - ``default_importance``: initial importance 0.0-1.0 for stored entities
+      (default ``0.5``).
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None, client: Any = None, **kwargs):
+        cfg = dict(config or {})
+        cfg.update(kwargs)
+        inner = cfg.get("config")
+        if isinstance(inner, dict):
+            cfg = {**inner, **{k: v for k, v in cfg.items() if k != "config"}}
+
+        self._binary = cfg.get("binary") or cfg.get("bin") \
+            or os.getenv("PERSEUS_VAULT_BIN", "perseus-vault")
+        self._db_path = cfg.get("db_path") or cfg.get("db") \
+            or os.getenv("PERSEUS_VAULT_DB", "./perseus-vault.db")
+        self._encryption_key = cfg.get("encryption_key") \
+            or os.getenv("PERSEUS_VAULT_ENCRYPTION_KEY")
+        self._st_cat = cfg.get("short_term_category", "working")
+        self._lt_cat = cfg.get("long_term_category", "episodic")
+        self._search_mode = cfg.get("search_mode", "hybrid")
+        self._default_importance = float(cfg.get("default_importance", 0.5))
+
+        # `client` is injectable for testing; otherwise spawn the real binary.
+        self._client = client if client is not None else _VaultStdioClient(
+            self._binary, self._db_path, env=cfg.get("env"),
+            encryption_key=self._encryption_key,
+        )
+
+    # -- internal helpers ---------------------------------------------------
+
+    def _store(self, category: str, text: str, metadata: Optional[Dict[str, Any]]) -> str:
+        key = (metadata or {}).get("key") or f"{category}-{uuid.uuid4().hex[:12]}"
+        body = {"content": text}
+        if metadata:
+            body["metadata"] = metadata
+        self._client.call_tool("perseus_vault_remember", {
+            "category": category,
+            "key": key,
+            "body_json": json.dumps(body),
+            "importance": self._default_importance,
+        })
+        return key
+
+    def _search(self, category: str, query: str, limit: int) -> List[Dict[str, Any]]:
+        res = self._client.call_tool("perseus_vault_recall", {
+            "query": query,
+            "category": category,
+            "limit": limit,
+            "mode": self._search_mode,
+        })
+        items = res.get("items", []) if isinstance(res, dict) else []
+        out: List[Dict[str, Any]] = []
+        for it in items:
+            body = it.get("body_json") or it.get("body") or {}
+            if isinstance(body, str):
+                try:
+                    body = json.loads(body)
+                except json.JSONDecodeError:
+                    body = {"content": body}
+            out.append({
+                "id": it.get("key") or it.get("id"),
+                "text": body.get("content", ""),
+                "metadata": body.get("metadata"),
+                "score": it.get("score") or it.get("confidence"),
+            })
+        return out
+
+    # -- MemoryProtocol -----------------------------------------------------
+
+    def store_short_term(self, text: str, metadata: Optional[Dict[str, Any]] = None, **kwargs) -> str:
+        return self._store(self._st_cat, text, metadata)
+
+    def search_short_term(self, query: str, limit: int = 5, **kwargs) -> List[Dict[str, Any]]:
+        return self._search(self._st_cat, query, limit)
+
+    def store_long_term(self, text: str, metadata: Optional[Dict[str, Any]] = None, **kwargs) -> str:
+        return self._store(self._lt_cat, text, metadata)
+
+    def search_long_term(self, query: str, limit: int = 5, **kwargs) -> List[Dict[str, Any]]:
+        return self._search(self._lt_cat, query, limit)
+
+    def get_all_memories(self, **kwargs) -> List[Dict[str, Any]]:
+        # Enumerate both tiers. An empty query returns all entities in a
+        # category (ordered by the vault's recency/decay ranking).
+        results: List[Dict[str, Any]] = []
+        limit = kwargs.get("limit", 100)
+        for cat in (self._st_cat, self._lt_cat):
+            results.extend(self._search(cat, "", limit))
+        return results
+
+    def reset_short_term(self) -> None:
+        self._reset_category(self._st_cat)
+
+    def reset_long_term(self) -> None:
+        self._reset_category(self._lt_cat)
+
+    def _reset_category(self, category: str) -> None:
+        # Bulk-archive every active entity in the category (soft-delete,
+        # recoverable). `purge_all` scopes the prune to the whole category;
+        # entities in the other tier are untouched.
+        self._client.call_tool("perseus_vault_prune", {
+            "category": category,
+            "purge_all": True,
+        })
+
+    def delete_memory(self, memory_id: str, memory_type: Optional[str] = None) -> bool:
+        cat = self._st_cat if memory_type == "short" else self._lt_cat
+        # Try both categories if type unspecified.
+        cats = [cat] if memory_type else [self._st_cat, self._lt_cat]
+        ok = False
+        for c in cats:
+            try:
+                self._client.call_tool("perseus_vault_forget", {
+                    "category": c, "key": memory_id, "reason": "PraisonAI delete_memory",
+                })
+                ok = True
+            except Exception:
+                continue
+        return ok
+
+    def delete_memories(self, memory_ids: List[str]) -> int:
+        return sum(1 for mid in memory_ids if self.delete_memory(mid))
+
+    def get_context(self, query: Optional[str] = None, **kwargs) -> str:
+        """Return a pre-formatted markdown context block for prompt injection."""
+        args: Dict[str, Any] = {}
+        if query:
+            args["query"] = query
+        if "limit" in kwargs:
+            args["limit"] = kwargs["limit"]
+        res = self._client.call_tool("perseus_vault_context", args)
+        if isinstance(res, str):
+            return res
+        if isinstance(res, dict):
+            # perseus_vault_context returns a structured block; the rendered
+            # prompt-ready text lives under "markdown".
+            return res.get("markdown") or res.get("context") or res.get("text") or ""
+        return ""
+
+    def close(self) -> None:
+        self._client.close()

--- a/src/praisonai-agents/praisonaiagents/memory/adapters/perseus_vault_adapter.py
+++ b/src/praisonai-agents/praisonaiagents/memory/adapters/perseus_vault_adapter.py
@@ -106,11 +106,18 @@ class _VaultStdioClient:
             while True:
                 remaining = deadline - time.time()
                 if remaining <= 0:
+                    self._teardown()
                     raise TimeoutError(
                         f"perseus-vault did not respond to {method} in time"
                     )
                 line = self._readline_with_timeout(remaining)
                 if line is None:
+                    # Timed out mid-read. The daemon reader thread is still
+                    # blocked on this stdout, so we must NOT reuse the process:
+                    # a later call would race two readers on the same stream and
+                    # one could steal the other's response. Tear the child down
+                    # so the next _request() spawns a clean one.
+                    self._teardown()
                     raise TimeoutError(
                         f"perseus-vault did not respond to {method} in time"
                     )
@@ -147,15 +154,27 @@ class _VaultStdioClient:
         except (json.JSONDecodeError, TypeError):
             return text
 
-    def close(self) -> None:
-        if self._proc and self._proc.poll() is None:
+    def _teardown(self) -> None:
+        """Forcibly terminate the child process. Used both on close and after a
+        read timeout, where a daemon reader thread may still be attached to the
+        old stdout — killing the process unblocks it and guarantees the next
+        _request() starts from a clean subprocess."""
+        proc, self._proc = self._proc, None
+        if proc and proc.poll() is None:
             try:
-                if self._proc.stdin:
-                    self._proc.stdin.close()
-                self._proc.terminate()
-                self._proc.wait(timeout=5)
+                if proc.stdin:
+                    proc.stdin.close()
+                proc.terminate()
+                proc.wait(timeout=5)
             except Exception:
-                self._proc.kill()
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+
+    def close(self) -> None:
+        with self._lock:
+            self._teardown()
 
 
 class PerseusVaultMemoryAdapter:
@@ -193,7 +212,23 @@ class PerseusVaultMemoryAdapter:
         self._st_cat = cfg.get("short_term_category", "working")
         self._lt_cat = cfg.get("long_term_category", "episodic")
         self._search_mode = cfg.get("search_mode", "hybrid")
-        self._default_importance = float(cfg.get("default_importance", 0.5))
+        if self._search_mode not in ("hybrid", "fts5", "dense"):
+            raise ValueError(
+                f"search_mode must be one of 'hybrid', 'fts5', 'dense'; "
+                f"got {self._search_mode!r}"
+            )
+        try:
+            self._default_importance = float(cfg.get("default_importance", 0.5))
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"default_importance must be a number in [0.0, 1.0]; "
+                f"got {cfg.get('default_importance')!r}"
+            )
+        if not (0.0 <= self._default_importance <= 1.0):
+            raise ValueError(
+                f"default_importance must be in [0.0, 1.0]; "
+                f"got {self._default_importance!r}"
+            )
 
         # `client` is injectable for testing; otherwise spawn the real binary.
         self._client = client if client is not None else _VaultStdioClient(
@@ -309,13 +344,10 @@ class PerseusVaultMemoryAdapter:
             except Exception:
                 continue
             # Only report success if the vault actually archived the entity;
-            # a missing key / wrong category yields archived == 0.
-            if isinstance(res, dict):
-                if res.get("archived", 0):
-                    ok = True
-            else:
-                # Non-dict response (older/edge builds): fall back to
-                # "no exception" as the success signal.
+            # a missing key / wrong category yields archived == 0. A non-dict
+            # response is ambiguous and is NOT treated as success (avoids
+            # reporting a delete that may never have happened).
+            if isinstance(res, dict) and res.get("archived", 0):
                 ok = True
         return ok
 

--- a/src/praisonai-agents/praisonaiagents/memory/adapters/perseus_vault_adapter.py
+++ b/src/praisonai-agents/praisonaiagents/memory/adapters/perseus_vault_adapter.py
@@ -40,7 +40,9 @@ class _VaultStdioClient:
         self._db_path = db_path
         self._encryption_key = encryption_key
         self._env = {**os.environ, **(env or {})}
-        self._lock = threading.Lock()
+        # Reentrant: _request may recurse into _start (which calls _request
+        # again during the handshake) while already holding the lock.
+        self._lock = threading.RLock()
         self._id = 0
         self._proc: Optional[subprocess.Popen] = None
         self._startup_timeout = startup_timeout
@@ -66,10 +68,34 @@ class _VaultStdioClient:
         self._id += 1
         return self._id
 
+    def _readline_with_timeout(self, timeout: float) -> Optional[str]:
+        """Read one line from stdout, giving up after ``timeout`` seconds.
+
+        A plain ``readline()`` blocks forever if the child accepts the request
+        but never emits a newline, which would hang every subsequent memory
+        call while the lock is held. Reading on a daemon thread lets the
+        deadline actually fire and surface a ``TimeoutError``.
+        """
+        assert self._proc and self._proc.stdout
+        result: List[Optional[str]] = [None]
+
+        def _read() -> None:
+            try:
+                result[0] = self._proc.stdout.readline()
+            except Exception:
+                result[0] = None
+
+        t = threading.Thread(target=_read, daemon=True)
+        t.start()
+        t.join(timeout)
+        if t.is_alive():
+            return None
+        return result[0]
+
     def _request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
-        if self._proc is None or self._proc.poll() is not None:
-            self._start()
         with self._lock:
+            if self._proc is None or self._proc.poll() is not None:
+                self._start()
             rid = self._next_id()
             msg = {"jsonrpc": "2.0", "id": rid, "method": method, "params": params}
             assert self._proc and self._proc.stdin and self._proc.stdout
@@ -77,9 +103,18 @@ class _VaultStdioClient:
             self._proc.stdin.flush()
             # Read until we get the response with our id (skip notifications).
             deadline = time.time() + self._startup_timeout
-            while time.time() < deadline:
-                line = self._proc.stdout.readline()
-                if not line:
+            while True:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"perseus-vault did not respond to {method} in time"
+                    )
+                line = self._readline_with_timeout(remaining)
+                if line is None:
+                    raise TimeoutError(
+                        f"perseus-vault did not respond to {method} in time"
+                    )
+                if line == "":
                     raise RuntimeError("perseus-vault closed stdout unexpectedly")
                 line = line.strip()
                 if not line:
@@ -92,7 +127,6 @@ class _VaultStdioClient:
                     if "error" in resp and resp["error"]:
                         raise RuntimeError(f"perseus-vault error: {resp['error']}")
                     return resp.get("result", {})
-            raise TimeoutError(f"perseus-vault did not respond to {method} in time")
 
     def _notify(self, method: str, params: Dict[str, Any]) -> None:
         with self._lock:
@@ -169,16 +203,23 @@ class PerseusVaultMemoryAdapter:
 
     # -- internal helpers ---------------------------------------------------
 
-    def _store(self, category: str, text: str, metadata: Optional[Dict[str, Any]]) -> str:
+    def _store(self, category: str, text: str, metadata: Optional[Dict[str, Any]],
+               **kwargs) -> str:
         key = (metadata or {}).get("key") or f"{category}-{uuid.uuid4().hex[:12]}"
         body = {"content": text}
         if metadata:
             body["metadata"] = metadata
+        # Honour a caller-supplied importance (kwargs win over metadata), like
+        # the dakera adapter, rather than always using the default.
+        importance = kwargs.get("importance")
+        if importance is None and metadata:
+            importance = metadata.get("importance")
+        importance = self._default_importance if importance is None else float(importance)
         self._client.call_tool("perseus_vault_remember", {
             "category": category,
             "key": key,
             "body_json": json.dumps(body),
-            "importance": self._default_importance,
+            "importance": importance,
         })
         return key
 
@@ -198,24 +239,29 @@ class PerseusVaultMemoryAdapter:
                     body = json.loads(body)
                 except json.JSONDecodeError:
                     body = {"content": body}
+            score = it.get("score")
+            if score is None:
+                score = it.get("confidence")
             out.append({
                 "id": it.get("key") or it.get("id"),
                 "text": body.get("content", ""),
-                "metadata": body.get("metadata"),
-                "score": it.get("score") or it.get("confidence"),
+                # Callers treat metadata as a dict and score as numeric, so
+                # never surface None for either.
+                "metadata": body.get("metadata") or {},
+                "score": score if score is not None else 1.0,
             })
         return out
 
     # -- MemoryProtocol -----------------------------------------------------
 
     def store_short_term(self, text: str, metadata: Optional[Dict[str, Any]] = None, **kwargs) -> str:
-        return self._store(self._st_cat, text, metadata)
+        return self._store(self._st_cat, text, metadata, **kwargs)
 
     def search_short_term(self, query: str, limit: int = 5, **kwargs) -> List[Dict[str, Any]]:
         return self._search(self._st_cat, query, limit)
 
     def store_long_term(self, text: str, metadata: Optional[Dict[str, Any]] = None, **kwargs) -> str:
-        return self._store(self._lt_cat, text, metadata)
+        return self._store(self._lt_cat, text, metadata, **kwargs)
 
     def search_long_term(self, query: str, limit: int = 5, **kwargs) -> List[Dict[str, Any]]:
         return self._search(self._lt_cat, query, limit)
@@ -245,18 +291,32 @@ class PerseusVaultMemoryAdapter:
         })
 
     def delete_memory(self, memory_id: str, memory_type: Optional[str] = None) -> bool:
-        cat = self._st_cat if memory_type == "short" else self._lt_cat
-        # Try both categories if type unspecified.
-        cats = [cat] if memory_type else [self._st_cat, self._lt_cat]
+        # Accept both the short hint ("short") and the MemoryProtocol value
+        # ("short_term"); anything else targets the long-term tier.
+        if memory_type in ("short", "short_term"):
+            cats = [self._st_cat]
+        elif memory_type in ("long", "long_term"):
+            cats = [self._lt_cat]
+        else:
+            # Type unspecified: try both tiers.
+            cats = [self._st_cat, self._lt_cat]
         ok = False
         for c in cats:
             try:
-                self._client.call_tool("perseus_vault_forget", {
+                res = self._client.call_tool("perseus_vault_forget", {
                     "category": c, "key": memory_id, "reason": "PraisonAI delete_memory",
                 })
-                ok = True
             except Exception:
                 continue
+            # Only report success if the vault actually archived the entity;
+            # a missing key / wrong category yields archived == 0.
+            if isinstance(res, dict):
+                if res.get("archived", 0):
+                    ok = True
+            else:
+                # Non-dict response (older/edge builds): fall back to
+                # "no exception" as the success signal.
+                ok = True
         return ok
 
     def delete_memories(self, memory_ids: List[str]) -> int:

--- a/src/praisonai-agents/tests/unit/memory/test_perseus_vault_adapter.py
+++ b/src/praisonai-agents/tests/unit/memory/test_perseus_vault_adapter.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for the Perseus Vault memory adapter (``PerseusVaultMemoryAdapter``).
+
+These tests inject a fake MCP stdio client so the adapter can be exercised
+end-to-end without the real ``perseus-vault`` binary, mirroring how the other
+wrapper adapters (dakera/mem0/chroma/mongodb) are unit tested.
+"""
+
+import json
+import sys
+import types
+
+import pytest
+
+from praisonaiagents.memory.adapters.perseus_vault_adapter import (
+    PerseusVaultMemoryAdapter,
+)
+from praisonaiagents.memory.protocols import MemoryProtocol
+
+
+# ---------------------------------------------------------------------------
+# Fake MCP stdio client — records calls, models the vault's entity semantics
+# ---------------------------------------------------------------------------
+
+class _FakeVaultClient:
+    """Stand-in for `_VaultStdioClient` that stores entities in a dict keyed by
+    (category, key) and answers the handful of tools the adapter uses."""
+
+    def __init__(self):
+        self.entities = {}          # (category, key) -> body dict
+        self.calls = []             # (tool_name, arguments)
+
+    def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+
+        if name == "perseus_vault_remember":
+            cat = arguments["category"]
+            key = arguments["key"]
+            self.entities[(cat, key)] = json.loads(arguments["body_json"])
+            return {"action": "created", "key": key}
+
+        if name == "perseus_vault_recall":
+            cat = arguments.get("category")
+            query = (arguments.get("query") or "").lower()
+            items = []
+            for (c, k), body in self.entities.items():
+                if cat is not None and c != cat:
+                    continue
+                content = str(body.get("content", "")).lower()
+                # Empty query = enumerate all in category; else substring match
+                # on any whitespace-separated term (models FTS5 OR semantics).
+                if query == "" or any(tok in content for tok in query.split()):
+                    items.append({"key": k, "body_json": json.dumps(body), "score": 0.5})
+            return {"items": items, "total": len(items)}
+
+        if name == "perseus_vault_prune":
+            cat = arguments.get("category")
+            if arguments.get("purge_all"):
+                doomed = [(c, k) for (c, k) in self.entities if c == cat]
+                for key in doomed:
+                    del self.entities[key]
+                return {"archived": len(doomed), "examined": len(doomed)}
+            return {"archived": 0}
+
+        if name == "perseus_vault_forget":
+            key = (arguments["category"], arguments["key"])
+            existed = key in self.entities
+            self.entities.pop(key, None)
+            return {"archived": 1 if existed else 0}
+
+        if name == "perseus_vault_context":
+            return {"markdown": "## Perseus Vault Context\n\n- (test)\n",
+                    "entities_injected": len(self.entities)}
+
+        raise AssertionError(f"unexpected tool {name}")
+
+    def close(self):
+        pass
+
+
+def _make_adapter(**config):
+    return PerseusVaultMemoryAdapter(config=config, client=_FakeVaultClient())
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+class TestPerseusVaultRegistration:
+    def test_factory_is_registered(self):
+        from praisonaiagents.memory.adapters.registry import (
+            list_memory_adapters, has_memory_adapter,
+        )
+        assert "perseus_vault" in list_memory_adapters()
+        assert has_memory_adapter("perseus_vault")
+
+    def test_factory_missing_binary_raises(self, monkeypatch):
+        # Force the real client path and make the spawn fail like a missing binary.
+        from praisonaiagents.memory.adapters import perseus_vault_adapter as mod
+
+        def _boom(*a, **k):
+            raise FileNotFoundError("no such file: perseus-vault")
+
+        monkeypatch.setattr(mod, "_VaultStdioClient", _boom)
+        from praisonaiagents.memory.adapters.factories import (
+            create_perseus_vault_memory_adapter,
+        )
+        with pytest.raises(FileNotFoundError) as exc:
+            create_perseus_vault_memory_adapter(binary="perseus-vault")
+        assert "perseus-vault" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class TestPerseusVaultConfig:
+    def test_defaults(self):
+        adapter = _make_adapter()
+        assert adapter._st_cat == "working"
+        assert adapter._lt_cat == "episodic"
+        assert adapter._search_mode == "hybrid"
+
+    def test_explicit_config(self):
+        adapter = _make_adapter(
+            short_term_category="scratch",
+            long_term_category="semantic",
+            search_mode="fts5",
+            default_importance=0.9,
+        )
+        assert adapter._st_cat == "scratch"
+        assert adapter._lt_cat == "semantic"
+        assert adapter._search_mode == "fts5"
+        assert adapter._default_importance == 0.9
+
+    def test_env_fallback(self, monkeypatch):
+        monkeypatch.setenv("PERSEUS_VAULT_BIN", "/opt/pv/perseus-vault")
+        monkeypatch.setenv("PERSEUS_VAULT_DB", "/data/pv.db")
+        adapter = _make_adapter()
+        assert adapter._binary == "/opt/pv/perseus-vault"
+        assert adapter._db_path == "/data/pv.db"
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance + behavior
+# ---------------------------------------------------------------------------
+
+class TestPerseusVaultBehavior:
+    def test_satisfies_memory_protocol(self):
+        adapter = _make_adapter()
+        assert isinstance(adapter, MemoryProtocol)
+
+    def test_store_and_search_short_term(self):
+        adapter = _make_adapter()
+        key = adapter.store_short_term("blue-green deployment health gate", {"topic": "deploy"})
+        assert key.startswith("working-")
+        hits = adapter.search_short_term("deployment", limit=5)
+        assert len(hits) == 1
+        assert "blue-green" in hits[0]["text"]
+        assert hits[0]["metadata"] == {"topic": "deploy"}
+
+    def test_store_and_search_long_term(self):
+        adapter = _make_adapter()
+        adapter.store_long_term("chose SQLite FTS5 for the index", {"topic": "arch"})
+        hits = adapter.search_long_term("SQLite", limit=5)
+        assert len(hits) == 1
+        assert "FTS5" in hits[0]["text"]
+
+    def test_tiers_are_isolated(self):
+        adapter = _make_adapter()
+        adapter.store_short_term("short lived note about caching", None)
+        adapter.store_long_term("durable architectural decision", None)
+        # A short-term query must not return the long-term entity and vice versa.
+        assert adapter.search_short_term("architectural") == []
+        assert adapter.search_long_term("caching") == []
+
+    def test_explicit_key_via_metadata(self):
+        adapter = _make_adapter()
+        key = adapter.store_long_term("pinned fact", {"key": "fact-1"})
+        assert key == "fact-1"
+
+    def test_get_all_memories_spans_both_tiers(self):
+        adapter = _make_adapter()
+        adapter.store_short_term("one", None)
+        adapter.store_long_term("two", None)
+        allm = adapter.get_all_memories()
+        assert len(allm) == 2
+
+    def test_reset_short_term_preserves_long_term(self):
+        adapter = _make_adapter()
+        adapter.store_short_term("ephemeral", None)
+        adapter.store_long_term("permanent", None)
+        adapter.reset_short_term()
+        assert adapter.search_short_term("ephemeral") == []
+        assert len(adapter.search_long_term("permanent")) == 1
+
+    def test_reset_long_term_preserves_short_term(self):
+        adapter = _make_adapter()
+        adapter.store_short_term("ephemeral", None)
+        adapter.store_long_term("permanent", None)
+        adapter.reset_long_term()
+        assert adapter.search_long_term("permanent") == []
+        assert len(adapter.search_short_term("ephemeral")) == 1
+
+    def test_delete_memory(self):
+        adapter = _make_adapter()
+        key = adapter.store_long_term("to be deleted", {"key": "del-1"})
+        assert adapter.delete_memory(key) is True
+        assert adapter.search_long_term("deleted") == []
+
+    def test_delete_memories_counts(self):
+        adapter = _make_adapter()
+        adapter.store_long_term("a", {"key": "k1"})
+        adapter.store_long_term("b", {"key": "k2"})
+        assert adapter.delete_memories(["k1", "k2"]) == 2
+
+    def test_get_context_returns_markdown(self):
+        adapter = _make_adapter()
+        adapter.store_long_term("some fact", None)
+        ctx = adapter.get_context(query="fact")
+        assert ctx.startswith("## Perseus Vault Context")

--- a/src/praisonai-agents/tests/unit/memory/test_perseus_vault_adapter.py
+++ b/src/praisonai-agents/tests/unit/memory/test_perseus_vault_adapter.py
@@ -214,6 +214,35 @@ class TestPerseusVaultBehavior:
         adapter.store_long_term("b", {"key": "k2"})
         assert adapter.delete_memories(["k1", "k2"]) == 2
 
+    def test_delete_memory_short_term_hint(self):
+        adapter = _make_adapter()
+        adapter.store_short_term("scratch note", {"key": "st-1"})
+        # The MemoryProtocol hint "short_term" must target the short-term tier.
+        assert adapter.delete_memory("st-1", memory_type="short_term") is True
+        assert adapter.search_short_term("scratch") == []
+
+    def test_delete_missing_reports_false(self):
+        adapter = _make_adapter()
+        # Nothing stored, so nothing is archived -> must not report success.
+        assert adapter.delete_memory("does-not-exist") is False
+
+    def test_importance_propagated_from_kwargs(self):
+        client = _FakeVaultClient()
+        adapter = PerseusVaultMemoryAdapter(config={}, client=client)
+        adapter.store_long_term("weighted fact", {"key": "w1"}, importance=0.87)
+        remember = [c for c in client.calls if c[0] == "perseus_vault_remember"][-1]
+        assert remember[1]["importance"] == 0.87
+
+    def test_search_metadata_and_score_never_none(self):
+        adapter = _make_adapter()
+        # Stored without metadata: result metadata must be {} not None, and
+        # score must be numeric so downstream filtering never crashes.
+        adapter.store_long_term("bare memory with no metadata", None)
+        hits = adapter.search_long_term("bare", limit=5)
+        assert len(hits) == 1
+        assert hits[0]["metadata"] == {}
+        assert isinstance(hits[0]["score"], (int, float))
+
     def test_get_context_returns_markdown(self):
         adapter = _make_adapter()
         adapter.store_long_term("some fact", None)

--- a/src/praisonai-agents/tests/unit/memory/test_perseus_vault_adapter.py
+++ b/src/praisonai-agents/tests/unit/memory/test_perseus_vault_adapter.py
@@ -140,6 +140,18 @@ class TestPerseusVaultConfig:
         assert adapter._binary == "/opt/pv/perseus-vault"
         assert adapter._db_path == "/data/pv.db"
 
+    def test_invalid_search_mode_rejected(self):
+        with pytest.raises(ValueError, match="search_mode"):
+            _make_adapter(search_mode="fuzzy")
+
+    def test_out_of_range_importance_rejected(self):
+        with pytest.raises(ValueError, match="default_importance"):
+            _make_adapter(default_importance=1.5)
+
+    def test_non_numeric_importance_rejected(self):
+        with pytest.raises(ValueError, match="default_importance"):
+            _make_adapter(default_importance="high")
+
 
 # ---------------------------------------------------------------------------
 # Protocol conformance + behavior
@@ -226,6 +238,18 @@ class TestPerseusVaultBehavior:
         # Nothing stored, so nothing is archived -> must not report success.
         assert adapter.delete_memory("does-not-exist") is False
 
+    def test_delete_non_dict_response_not_success(self):
+        # A vault response that isn't a dict is ambiguous and must NOT be
+        # reported as a successful delete.
+        class _NonDictClient(_FakeVaultClient):
+            def call_tool(self, name, arguments):
+                if name == "perseus_vault_forget":
+                    return "archived"  # non-dict, ambiguous
+                return super().call_tool(name, arguments)
+
+        adapter = PerseusVaultMemoryAdapter(config={}, client=_NonDictClient())
+        assert adapter.delete_memory("whatever") is False
+
     def test_importance_propagated_from_kwargs(self):
         client = _FakeVaultClient()
         adapter = PerseusVaultMemoryAdapter(config={}, client=client)
@@ -248,3 +272,67 @@ class TestPerseusVaultBehavior:
         adapter.store_long_term("some fact", None)
         ctx = adapter.get_context(query="fact")
         assert ctx.startswith("## Perseus Vault Context")
+
+
+# ---------------------------------------------------------------------------
+# Stdio client transport (uses a fake "binary" that hangs after the handshake)
+# ---------------------------------------------------------------------------
+
+class TestVaultStdioClientTimeout:
+    def test_timeout_tears_down_process(self, tmp_path):
+        """A binary that completes the handshake but then hangs on the next
+        request must raise TimeoutError AND terminate the child, so a reused
+        client doesn't leak a process or race a stale reader thread."""
+        import sys
+        import textwrap
+        from praisonaiagents.memory.adapters.perseus_vault_adapter import (
+            _VaultStdioClient,
+        )
+
+        # Fake binary: answer the `initialize` handshake, then go silent.
+        fake = tmp_path / "fake_vault.py"
+        fake.write_text(textwrap.dedent('''
+            import sys, json
+            first = True
+            for line in sys.stdin:
+                line = line.strip()
+                if not line:
+                    continue
+                msg = json.loads(line)
+                if msg.get("method") == "initialize":
+                    sys.stdout.write(json.dumps(
+                        {"jsonrpc": "2.0", "id": msg["id"], "result": {}}) + "\\n")
+                    sys.stdout.flush()
+                # Any later request: never respond (simulate a hung server).
+        '''))
+
+        # Wrap so `[binary, "serve", "--db", db]` runs our script.
+        client = _VaultStdioClient.__new__(_VaultStdioClient)
+        client._binary = sys.executable
+        client._db_path = str(fake)  # ignored by the script
+        client._encryption_key = None
+        client._env = dict(__import__("os").environ)
+        import threading
+        client._lock = threading.RLock()
+        client._id = 0
+        client._proc = None
+        client._startup_timeout = 1.0
+
+        # Manually spawn with our script as the "serve" target.
+        import subprocess
+        client._proc = subprocess.Popen(
+            [sys.executable, str(fake)],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, text=True, bufsize=1, env=client._env,
+        )
+        # Handshake succeeds...
+        client._request("initialize", {"protocolVersion": "2024-11-05",
+                                        "capabilities": {}, "clientInfo": {}})
+        proc = client._proc
+        # ...next call hangs -> TimeoutError + teardown.
+        with pytest.raises(TimeoutError):
+            client._request("tools/call", {"name": "x", "arguments": {}})
+        proc.wait(timeout=5)
+        assert proc.poll() is not None  # process was terminated
+        assert client._proc is None     # client reset for a clean respawn
+


### PR DESCRIPTION
## Summary

Adds **`perseus_vault`** as a registered memory backend implementing `MemoryProtocol`, alongside the existing `sqlite`/`in_memory`/`mem0`/`chroma`/`mongodb`/`dakera` adapters.

[Perseus Vault](https://github.com/Perseus-Computing-LLC/perseus-vault) is a single static-binary MCP memory server — SQLite + FTS5 + bundled ONNX embeddings, optional AES-256-GCM, fully local and offline. Unlike the other wrapper adapters it needs **no third-party Python SDK**: the adapter speaks JSON-RPC 2.0 over the binary's stdio `serve` transport directly, matching Perseus Vault's zero-dependency, local-first design (and following the protocol-driven adapter pattern in `memory/adapters/`).

## What's included

- `praisonaiagents/memory/adapters/perseus_vault_adapter.py` — the adapter plus a minimal thread-safe JSON-RPC stdio client for the vault binary.
- `create_perseus_vault_memory_adapter` factory in `factories.py` + registration in `adapters/__init__.py` (`register_memory_factory("perseus_vault", ...)`).
- `examples/python/memory/perseus_vault_memory.py`.
- `tests/unit/memory/test_perseus_vault_adapter.py` — 16 tests using a fake stdio client, **no binary required**, mirroring `test_dakera_adapter.py`.

## Design

- **Tiers → categories.** Short-term and long-term map onto vault entity categories (`working` / `episodic` by default) so each tier stays independently queryable and resettable.
- **Hybrid retrieval** (FTS5 + dense vector fusion) by default; `search_mode` = `fts5` | `dense` | `hybrid`.
- **`get_context`** returns the vault's pre-rendered markdown injection block.
- **`reset_short_term` / `reset_long_term`** use a category-scoped prune (`purge_all`), leaving the other tier untouched.

Config keys (top level or nested under `config`, mirroring mem0/dakera): `binary`/`bin`, `db_path`/`db`, `encryption_key`, `short_term_category`, `long_term_category`, `search_mode`, `default_importance` — each falling back to the matching `PERSEUS_VAULT_*` env var.

## Usage

```python
workflow = PraisonAIAgents(
    agents=[agent], tasks=[task], memory=True,
    memory_config={
        "provider": "perseus_vault",
        "config": {"binary": "perseus-vault", "db_path": "./pv.db", "search_mode": "hybrid"},
    },
)
```

## Verification

- End-to-end against `perseus-vault 2.20.0`: store/search (both tiers, correctly isolated), `get_context`, `get_all_memories`, and category-scoped reset all round-trip through the real MCP protocol.
- Mock-based unit suite: **16 passed**.
- No regressions: existing memory adapter + registry + protocol tests remain green (**70 passed, 1 skipped**).

Happy to adjust naming, config keys, or packaging (e.g. move to an optional-extra) to fit your conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Perseus Vault as a persistent memory provider for PraisonAI agents, with short-term and long-term memory tiers.
  * Supports memory store/search (hybrid/FTS5/dense), deletion, tier-specific reset, and generated prompt-ready context.
  * Added an example script demonstrating how to configure and run an agent using Perseus Vault memory.
* **Tests**
  * Added unit tests covering provider registration, configuration and error handling, tier isolation, CRUD behavior, search scoring/metadata, context formatting, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->