### PR TITLE
fix(bot): pre-trim history before compaction to avoid CI timeout

### DIFF
--- a/src/praisonai-bot/praisonai_bot/bots/_session.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_session.py
@@ -575,7 +575,12 @@ class BotSessionManager:
         if compactor is not None and self._max_history > 0:
             hard_cap = self._max_history * 4
             if len(history) > hard_cap:
-                history = history[-hard_cap:]
+                # Preserve system messages (e.g. an existing compaction summary)
+                # so trimming the oldest turns never erases long-term memory the
+                # compactor would otherwise keep. Cap only the non-system tail.
+                sys_msgs = [m for m in history if m.get("role") == "system"]
+                non_sys = [m for m in history if m.get("role") != "system"]
+                history = sys_msgs + non_sys[-hard_cap:]
         if compactor is not None:
             try:
                 if compactor.needs_compaction(history):
@@ -587,15 +592,6 @@ class BotSessionManager:
                 )
                 if self._max_history > 0 and len(history) > self._max_history:
                     history = history[-self._max_history:]
-            else:
-                # Hard cap safety valve: even when the token-based compactor
-                # hasn't triggered (e.g. short messages under-shoot the token
-                # estimate), never let history grow unbounded. Allow headroom
-                # so the cap doesn't fight compaction's recent-tail + summary.
-                if self._max_history > 0:
-                    hard_cap = self._max_history * 4
-                    if len(history) > hard_cap:
-                        history = history[-hard_cap:]
         elif self._max_history > 0 and len(history) > self._max_history:
             history = history[-self._max_history:]
 

--- a/src/praisonai-bot/praisonai_bot/bots/_session.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_session.py
@@ -568,6 +568,14 @@ class BotSessionManager:
             if self._compaction_enabled
             else None
         )
+        # Hard cap before compaction: short messages can under-shoot the token
+        # budget yet still arrive in huge batches. Trimming first avoids running
+        # token counting / summarisation over thousands of turns (and prevents
+        # offline CI hangs when tiktoken tries a first-use network download).
+        if compactor is not None and self._max_history > 0:
+            hard_cap = self._max_history * 4
+            if len(history) > hard_cap:
+                history = history[-hard_cap:]
         if compactor is not None:
             try:
                 if compactor.needs_compaction(history):


### PR DESCRIPTION
## Summary
- Apply the max_history hard cap before compaction in BotSessionManager._save_history, so large short-message batches are trimmed to max_history * 4 turns first.
- Fixes Core Tests test-core (bots-gateway) timeouts on test_max_history_hard_cap_in_compaction_mode, where offline CI could hang while tiktoken attempted a first-use network download during token counting over 1000 messages.

## Test plan
- [x] pytest src/praisonai-bot/tests/unit/bots/test_session_compaction.py -n 2 --dist loadfile (10 passed)
- [ ] Verify Core Tests test-core (bots-gateway) passes on CI for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history handling when context compaction is enabled by applying the hard-cap limit earlier.
  * Preserves system-role messages while trimming only the older non-system portion before compaction, reducing unnecessary context processing.
  * Keeps behavior the same when context compaction is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->