### PR TITLE
fix(embedding): match model dimension keys case-insensitively (all-MiniLM-L6-v2)

### DIFF
--- a/src/praisonai-agents/praisonaiagents/embedding/dimensions.py
+++ b/src/praisonai-agents/praisonaiagents/embedding/dimensions.py
@@ -68,8 +68,12 @@ def get_dimensions(model_name: str) -> int:
     if model_lower in MODEL_DIMENSIONS:
         return MODEL_DIMENSIONS[model_lower]
     
-    # Check if model name contains known model identifiers
-    for model_key, dimensions in MODEL_DIMENSIONS.items():
+    # Check if model name contains known model identifiers.
+    # Sort by key length (longest first) so more specific keys like
+    # "voyage-3-lite" match before shorter prefixes like "voyage-3".
+    for model_key, dimensions in sorted(
+        MODEL_DIMENSIONS.items(), key=lambda item: len(item[0]), reverse=True
+    ):
         if model_key.lower() in model_lower:
             return dimensions
     

--- a/src/praisonai-agents/praisonaiagents/embedding/dimensions.py
+++ b/src/praisonai-agents/praisonaiagents/embedding/dimensions.py
@@ -70,7 +70,7 @@ def get_dimensions(model_name: str) -> int:
     
     # Check if model name contains known model identifiers
     for model_key, dimensions in MODEL_DIMENSIONS.items():
-        if model_key in model_lower:
+        if model_key.lower() in model_lower:
             return dimensions
     
     # Default to 1536 for unknown models (OpenAI standard)

--- a/src/praisonai-agents/praisonaiagents/embedding/dimensions.py
+++ b/src/praisonai-agents/praisonaiagents/embedding/dimensions.py
@@ -40,6 +40,17 @@ MODEL_DIMENSIONS: Dict[str, int] = {
 # Default dimension for unknown models
 DEFAULT_DIMENSION = 1536
 
+# Precomputed lowercased lookup so mixed-case keys (e.g. "all-MiniLM-L6-v2")
+# resolve on the exact-match path, and precomputed length-descending entries
+# so specific keys ("voyage-3-lite") win over prefixes ("voyage-3") without
+# sorting/lowercasing on every call.
+_LOWER_MODEL_DIMENSIONS: Dict[str, int] = {
+    key.lower(): value for key, value in MODEL_DIMENSIONS.items()
+}
+_SORTED_MODEL_DIMENSIONS = sorted(
+    _LOWER_MODEL_DIMENSIONS.items(), key=lambda item: len(item[0]), reverse=True
+)
+
 
 def get_dimensions(model_name: str) -> int:
     """Get embedding dimensions based on model name.
@@ -64,17 +75,15 @@ def get_dimensions(model_name: str) -> int:
     """
     model_lower = model_name.lower()
     
-    # Check for exact match first
-    if model_lower in MODEL_DIMENSIONS:
-        return MODEL_DIMENSIONS[model_lower]
+    # Check for exact match first (lowercased lookup handles mixed-case keys)
+    if model_lower in _LOWER_MODEL_DIMENSIONS:
+        return _LOWER_MODEL_DIMENSIONS[model_lower]
     
     # Check if model name contains known model identifiers.
-    # Sort by key length (longest first) so more specific keys like
-    # "voyage-3-lite" match before shorter prefixes like "voyage-3".
-    for model_key, dimensions in sorted(
-        MODEL_DIMENSIONS.items(), key=lambda item: len(item[0]), reverse=True
-    ):
-        if model_key.lower() in model_lower:
+    # Entries are pre-sorted by key length (longest first) so more specific
+    # keys like "voyage-3-lite" match before shorter prefixes like "voyage-3".
+    for model_key, dimensions in _SORTED_MODEL_DIMENSIONS:
+        if model_key in model_lower:
             return dimensions
     
     # Default to 1536 for unknown models (OpenAI standard)

--- a/src/praisonai-agents/tests/unit/embedding/test_embedding.py
+++ b/src/praisonai-agents/tests/unit/embedding/test_embedding.py
@@ -162,8 +162,20 @@ class TestGetDimensions:
     def test_get_dimensions_unknown_model(self):
         """Test get_dimensions() returns default for unknown models."""
         from praisonaiagents.embedding import get_dimensions
-        
+
         assert get_dimensions("unknown-model") == 1536  # Default
+
+    def test_get_dimensions_mixed_case_key(self):
+        """Model keys with uppercase letters must still match (case-insensitive).
+
+        all-MiniLM-L6-v2 is the only mixed-case key in MODEL_DIMENSIONS; the
+        substring lookup lowercases the input, so it must lowercase the key too
+        or this common local model wrongly falls back to the 1536 default.
+        """
+        from praisonaiagents.embedding import get_dimensions
+
+        assert get_dimensions("all-MiniLM-L6-v2") == 384
+        assert get_dimensions("sentence-transformers/all-MiniLM-L6-v2") == 384
 
 
 class TestAliases:

--- a/src/praisonai-agents/tests/unit/embedding/test_embedding.py
+++ b/src/praisonai-agents/tests/unit/embedding/test_embedding.py
@@ -177,6 +177,17 @@ class TestGetDimensions:
         assert get_dimensions("all-MiniLM-L6-v2") == 384
         assert get_dimensions("sentence-transformers/all-MiniLM-L6-v2") == 384
 
+    def test_get_dimensions_prefers_longer_key(self):
+        """More specific (longer) keys must win over shorter prefixes.
+
+        "voyage-3" (1024) is a substring of "voyage-3-lite" (512); without
+        matching longest-key-first, "voyage/voyage-3-lite" wrongly returns 1024.
+        """
+        from praisonaiagents.embedding import get_dimensions
+
+        assert get_dimensions("voyage/voyage-3-lite") == 512
+        assert get_dimensions("voyage-3") == 1024
+
 
 class TestAliases:
     """Tests for function aliases."""


### PR DESCRIPTION
## Problem

`get_dimensions()` in `praisonaiagents/embedding/dimensions.py` lowercases the input model name but compares it against the raw `MODEL_DIMENSIONS` keys:

```python
model_lower = model_name.lower()
if model_lower in MODEL_DIMENSIONS:          # exact match against lowercased input
    return MODEL_DIMENSIONS[model_lower]
for model_key, dimensions in MODEL_DIMENSIONS.items():
    if model_key in model_lower:             # key is NOT lowercased
        return dimensions
return DEFAULT_DIMENSION                       # 1536
```

Every key is lowercase except one: `"all-MiniLM-L6-v2": 384`. Because the input is lowercased to `all-minilm-l6-v2`, that mixed-case key matches neither the exact check (`"all-minilm-l6-v2" in MODEL_DIMENSIONS` → False) nor the substring check (`"all-MiniLM-L6-v2" in "all-minilm-l6-v2"` → False), so it falls through to the 1536 default.

`all-MiniLM-L6-v2` is the most common local sentence-transformers model — it's even the default in `knowledge/chunking.py`. `memory.py` calls `get_dimensions(embedding_model)` to size the vector store, so a user on this model gets a **1536-dim collection while the model emits 384-dim vectors** — a dimension mismatch on store/query.

## Reproduction

| call | before | after |
|---|---|---|
| `get_dimensions("all-MiniLM-L6-v2")` | **1536** ❌ | **384** ✅ |
| `get_dimensions("sentence-transformers/all-MiniLM-L6-v2")` | **1536** ❌ | **384** ✅ |
| `get_dimensions("all-mpnet-base-v2")` | 768 | 768 |
| `get_dimensions("text-embedding-3-small")` | 1536 | 1536 |

## Fix

Lowercase the key in the substring comparison:

```python
for model_key, dimensions in MODEL_DIMENSIONS.items():
    if model_key.lower() in model_lower:
        return dimensions
```

## Test

Added `test_get_dimensions_mixed_case_key` to `TestGetDimensions`. It fails on the current code (`assert 1536 == 384`) and passes after the fix; the full `TestGetDimensions` class stays green (4 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model dimension detection by making lookups case-insensitive.
  * Ensures correct dimension resolution for mixed-case and `sentence-transformers/`-prefixed model names.
* **Tests**
  * Added a unit test covering mixed-case model keys and expected dimension values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->