### PR TITLE
fix(ci): post FINAL @claude after 30m when required reviewers are silent

### DIFF
--- a/.github/scripts/pr-review-chain-selftest.js
+++ b/.github/scripts/pr-review-chain-selftest.js
@@ -81,4 +81,27 @@ assert(
   chain.priorReviewersReady([coderabbit, greptile], [geminiReview], { optionalWaitMs: 0 }).ready
 );
 
+const oldPr = new Date(Date.now() - 31 * 60 * 1000).toISOString();
+assert(
+  'prior not ready without coderabbit before timeout',
+  !chain.priorReviewersReady([greptile], [], { prCreatedAt: new Date().toISOString(), requiredWaitMs: 30 * 60 * 1000 }).ready
+);
+assert(
+  'prior timeout when coderabbit silent after 30m',
+  chain.priorReviewersReady([greptile], [], { prCreatedAt: oldPr, requiredWaitMs: 30 * 60 * 1000 }).ready
+);
+assert(
+  'claude FINAL timeout when required reviewer silent and no prior FINAL',
+  chain.claudeFinalReady([greptile], [], { prCreatedAt: oldPr, skipCopilot: true, requiredWaitMs: 30 * 60 * 1000 }).ready
+);
+const finalClaude = {
+  user: { login: 'github-actions[bot]' },
+  body: '@claude You are the FINAL architecture reviewer for this PR.',
+  created_at: '2026-07-02T07:25:00Z',
+};
+assert(
+  'claude FINAL not re-posted when already triggered',
+  !chain.claudeFinalReady([greptile, finalClaude], [], { prCreatedAt: oldPr, skipCopilot: true, requiredWaitMs: 0 }).ready
+);
+
 process.exit(failed ? 1 : 0);

--- a/.github/scripts/pr-review-chain-selftest.js
+++ b/.github/scripts/pr-review-chain-selftest.js
@@ -92,7 +92,11 @@ assert(
 );
 assert(
   'claude FINAL timeout when required reviewer silent and no prior FINAL',
-  chain.claudeFinalReady([greptile], [], { prCreatedAt: oldPr, skipCopilot: true, requiredWaitMs: 30 * 60 * 1000 }).ready
+  chain.claudeFinalReady([greptile], [], { prCreatedAt: oldPr, requiredWaitMs: 30 * 60 * 1000 }).ready
+);
+assert(
+  'claude FINAL timeout auto-skips copilot without explicit skipCopilot',
+  chain.claudeFinalReady([greptile], [], { prCreatedAt: oldPr, requiredWaitMs: 30 * 60 * 1000 }).copilotSkipped
 );
 const finalClaude = {
   user: { login: 'github-actions[bot]' },
@@ -101,7 +105,7 @@ const finalClaude = {
 };
 assert(
   'claude FINAL not re-posted when already triggered',
-  !chain.claudeFinalReady([greptile, finalClaude], [], { prCreatedAt: oldPr, skipCopilot: true, requiredWaitMs: 0 }).ready
+  !chain.claudeFinalReady([greptile, finalClaude], [], { prCreatedAt: oldPr, requiredWaitMs: 0 }).ready
 );
 
 process.exit(failed ? 1 : 0);

--- a/.github/scripts/pr-review-chain.js
+++ b/.github/scripts/pr-review-chain.js
@@ -170,7 +170,7 @@ function claudeFinalReady(comments, reviews = [], options = {}) {
   if (!prior.ready) {
     return { ready: false, reason: prior.reason };
   }
-  if (isSkipCopilot(options)) {
+  if (isSkipCopilot(options) || prior.requiredTimeout) {
     return {
       ready: true,
       reason: prior.requiredTimeout ? prior.reason : 'copilot skipped',
@@ -209,6 +209,7 @@ async function maybeTriggerClaudeFinal(github, owner, repo, prNumber, finalBody,
   const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
   const { comments, reviews } = await listCommentsAndReviews(github, owner, repo, prNumber);
   const gate = claudeFinalReady(comments, reviews, {
+    ...options,
     prCreatedAt: pr.created_at,
     optionalWaitMs: options.optionalWaitMs,
     allowCopilotTimeout: options.allowCopilotTimeout !== false,

--- a/.github/scripts/pr-review-chain.js
+++ b/.github/scripts/pr-review-chain.js
@@ -16,6 +16,7 @@ const CLAUDE_TRIGGER_LOGINS = new Set(['MervinPraison', 'github-actions[bot]']);
 const REQUIRED_PRIOR = ['coderabbit', 'greptile'];
 const OPTIONAL_PRIOR = ['qodo', 'gemini'];
 const OPTIONAL_PRIOR_WAIT_MS = 20 * 60 * 1000;
+const REQUIRED_PRIOR_WAIT_MS = 30 * 60 * 1000;
 
 function loginOf(item) {
   return (item?.user?.login || '').toLowerCase();
@@ -75,11 +76,23 @@ function priorReviewerStatus(comments, reviews = []) {
 
 function priorReviewersReady(comments, reviews = [], options = {}) {
   const waitMs = options.optionalWaitMs ?? OPTIONAL_PRIOR_WAIT_MS;
+  const requiredWaitMs = options.requiredWaitMs ?? REQUIRED_PRIOR_WAIT_MS;
   const prCreatedAt = options.prCreatedAt || null;
   const status = priorReviewerStatus(comments, reviews);
 
   const missingRequired = REQUIRED_PRIOR.filter((id) => !status[id]);
   if (missingRequired.length) {
+    if (prCreatedAt) {
+      const age = Date.now() - new Date(prCreatedAt).getTime();
+      if (age >= requiredWaitMs) {
+        return {
+          ready: true,
+          reason: `required reviewer timeout (${missingRequired.join(', ')} silent after ${Math.round(requiredWaitMs / 60000)}m)`,
+          status,
+          requiredTimeout: true,
+        };
+      }
+    }
     return { ready: false, reason: `waiting for ${missingRequired.join(', ')}`, status };
   }
 
@@ -158,7 +171,12 @@ function claudeFinalReady(comments, reviews = [], options = {}) {
     return { ready: false, reason: prior.reason };
   }
   if (isSkipCopilot(options)) {
-    return { ready: true, reason: 'copilot skipped', copilotSkipped: true };
+    return {
+      ready: true,
+      reason: prior.requiredTimeout ? prior.reason : 'copilot skipped',
+      copilotSkipped: true,
+      requiredTimeout: prior.requiredTimeout,
+    };
   }
   const copilot = copilotReviewReady(comments, reviews);
   if (copilot.ready) {
@@ -205,7 +223,11 @@ async function maybeTriggerClaudeFinal(github, owner, repo, prNumber, finalBody,
     issue_number: prNumber,
     body: finalBody,
   });
-  const note = gate.copilotSkipped ? ' (Copilot timeout fallback)' : '';
+  const note = gate.requiredTimeout
+    ? ' (required reviewer timeout fallback)'
+    : gate.copilotSkipped
+      ? ' (Copilot timeout fallback)'
+      : '';
   core?.info?.(`Posted Claude FINAL on PR #${prNumber}${note}`);
   return { posted: true, reason: '' };
 }
@@ -281,6 +303,7 @@ module.exports = {
   isSkipCopilot,
   REQUIRED_PRIOR,
   OPTIONAL_PRIOR,
+  REQUIRED_PRIOR_WAIT_MS,
   COPILOT_REVIEW_BODY,
   priorReviewerStatus,
   priorReviewersReady,

--- a/.github/workflows/auto-pr-comment.yml
+++ b/.github/workflows/auto-pr-comment.yml
@@ -91,8 +91,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Wait for prior reviewers (25 min)
-        run: sleep 1500
+      - name: Wait for prior reviewers (30 min)
+        run: sleep 1800
 
       - name: Post Claude FINAL (skip Copilot)
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- Add a 30-minute timeout in `pr-review-chain.js` so FINAL `@claude` is posted when CodeRabbit or Greptile never respond
- Align the `claude-fallback-timeout` job sleep to 30 minutes
- Skip posting if a FINAL `@claude` comment already exists

Fixes stuck PRs like #3029 where Greptile reviewed but CodeRabbit stayed silent.

## Test plan
- [x] `node .github/scripts/pr-review-chain-selftest.js` (16/16 pass)
- [ ] Merge and confirm `post-missing-claude-final` or fallback posts FINAL `@claude` on #3029
- [ ] Confirm young PRs still wait for required reviewers before 30m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced review-chain timeout handling with a 30-minute required-prior reviewer fallback when prior reviewers are unresponsive.
  * After the fallback elapses, “Claude FINAL” can proceed, bypassing Copilot automatically and avoiding duplicate final reviews if a final trigger already exists.
  * Increased the fallback wait for prior reviewers from 25 to 30 minutes in the relevant timeout workflow.
* **Tests**
  * Added expanded self-test assertions to cover the new timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->