### PR TITLE
fix(ci): stop merge-gate scan comments retriggering Claude Assistant

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -118,19 +118,30 @@ jobs:
   # Triggers on: labeled 'claude', @claude comments, assignments
   # ================================================================
   claude-response:
-    # Allow: human users, github-actions[bot] (auto-comments/labels)
-    # Block: dependabot, cursor, renovate, other bots
+    # Allow: human users, github-actions[bot] (FINAL @claude / CI-fix comments only)
+    # Block: praisonai-triage-agent (merge-gate scan mentions @claude as status text)
     # Skip 'opened' events — triage job handles those above
     if: |
       github.event.action != 'opened' &&
       (github.event.action != 'labeled' || github.event.label.name == 'claude') &&
-      (github.event_name != 'issue_comment' || contains(github.event.comment.body, '@claude')) &&
+      (github.event_name != 'issue_comment' || (
+        contains(github.event.comment.body, '@claude') &&
+        !contains(github.event.comment.body, 'Merge gate scan') &&
+        !contains(github.event.comment.body, 'MERGE_GATE_VERDICT') &&
+        !contains(github.event.comment.body, 'Merged by **Claude PR merge gate**') &&
+        (
+          !contains(github.actor, '[bot]') ||
+          contains(github.event.comment.body, 'FINAL architecture reviewer') ||
+          contains(github.event.comment.body, 'lead engineer') ||
+          contains(github.event.comment.body, 'merge conflict') ||
+          contains(github.event.comment.body, 'CI failed on HEAD')
+        )
+      )) &&
       (github.event_name != 'pull_request_review' || contains(github.event.review.body, '@claude')) &&
       (github.event_name != 'pull_request_review_comment' || contains(github.event.comment.body, '@claude')) &&
       (
         !contains(github.actor, '[bot]') ||
-        github.actor == 'github-actions[bot]' ||
-        github.actor == 'praisonai-triage-agent[bot]'
+        github.actor == 'github-actions[bot]'
       ) &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'cursor[bot]' &&


### PR DESCRIPTION
## Summary
- Stop `praisonai-triage-agent[bot]` merge-gate scan comments from retriggering `claude-response` when they mention `` `@claude` `` as status text (e.g. `recent @claude within 35min`)
- Ignore known pipeline noise comment types (`Merge gate scan`, `MERGE_GATE_VERDICT`, merge-gate merge notices)
- Restrict bot-triggered `@claude` comments to intentional phrases: FINAL review, merge conflict, or CI-failure fix

Fixes the feedback loop seen on #3029 where each Claude run dispatched merge gate, which posted another `@claude` mention and started Claude again.

## Test plan
- [ ] Merge and confirm merge-gate scan comments on a PR no longer start `Claude Assistant`
- [ ] Confirm manual `@claude` from `MervinPraison` still triggers
- [ ] Confirm `github-actions[bot]` FINAL architecture reviewer comments still trigger
- [ ] Confirm CI-failure and merge-conflict auto-comments still trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automated code-fix workflows from responding to merge-gate scan, verdict, and status messages.
  * Restricted bot-triggered workflow runs to the intended automation account, reducing unintended activations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->