### PR TITLE
fix(ci): deploy install scripts

### DIFF
--- a/.github/workflows/deploy-install-scripts.yml
+++ b/.github/workflows/deploy-install-scripts.yml
@@ -1,7 +1,7 @@
 name: Deploy install scripts to praison.ai
 
-# Production praison.ai runs on Hestia (185.249.73.167), not Azure AKS.
-# Sync install.sh / install.ps1 to /home/hestiaadmin/web/praison.ai/pa/web/
+# Production praison.ai runs on Hestia (migration-target), not Azure AKS.
+# Uses scoped deploy user (praison-deploy) — not root.
 
 on:
   push:
@@ -21,23 +21,25 @@ permissions:
 jobs:
   deploy-to-hestia:
     runs-on: ubuntu-latest
+    environment: production-hestia
     steps:
       - uses: actions/checkout@v4
 
       - name: Sync install scripts to Hestia
         env:
           SSH_PRIVATE_KEY: ${{ secrets.MIGRATION_TARGET_SSH_KEY }}
+          HESTIA_HOST: ${{ secrets.MIGRATION_TARGET_HOST }}
+          HESTIA_USER: ${{ secrets.MIGRATION_TARGET_USER }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ -z "${SSH_PRIVATE_KEY:-}" ]; then
-            echo "MIGRATION_TARGET_SSH_KEY is not configured on this repository"
-            echo "Add the migration-target (185.249.73.167) SSH private key as a GitHub secret"
-            exit 1
-          fi
+          for var in SSH_PRIVATE_KEY HESTIA_HOST HESTIA_USER; do
+            if [ -z "${!var:-}" ]; then
+              echo "Missing secret for deploy (need MIGRATION_TARGET_SSH_KEY, MIGRATION_TARGET_HOST, MIGRATION_TARGET_USER)"
+              exit 1
+            fi
+          done
 
-          HESTIA_HOST="185.249.73.167"
-          HESTIA_USER="root"
           REMOTE_WEB="/home/hestiaadmin/web/praison.ai/pa/web"
 
           mkdir -p ~/.ssh
@@ -51,8 +53,8 @@ jobs:
           done
 
           ssh "${HESTIA_USER}@${HESTIA_HOST}" \
-            "chown hestiaadmin:hestiaadmin ${REMOTE_WEB}/install.sh ${REMOTE_WEB}/install.ps1 && \
-             chmod 644 ${REMOTE_WEB}/install.sh ${REMOTE_WEB}/install.ps1"
+            "sudo chown hestiaadmin:hestiaadmin ${REMOTE_WEB}/install.sh ${REMOTE_WEB}/install.ps1 && \
+             sudo chmod 644 ${REMOTE_WEB}/install.sh ${REMOTE_WEB}/install.ps1"
 
           echo "Deployed install scripts for commit ${SOURCE_SHA}"
           echo "Verify: curl -fsSL https://praison.ai/install.ps1 | head -5"

--- a/.github/workflows/deploy-install-scripts.yml
+++ b/.github/workflows/deploy-install-scripts.yml
@@ -1,7 +1,7 @@
 name: Deploy install scripts to praison.ai
 
-# When install.sh or install.ps1 change on main, trigger praison.ai CI which
-# syncs scripts at build time and deploys to Azure AKS (existing azure-pipeline.yaml).
+# Production praison.ai runs on Hestia (185.249.73.167), not Azure AKS.
+# Sync install.sh / install.ps1 to /home/hestiaadmin/web/praison.ai/pa/web/
 
 on:
   push:
@@ -19,34 +19,40 @@ permissions:
   contents: read
 
 jobs:
-  trigger-website-deploy:
+  deploy-to-hestia:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger praison.ai CI
+      - uses: actions/checkout@v4
+
+      - name: Sync install scripts to Hestia
         env:
-          GH_TOKEN: ${{ secrets.SECRETS_ADMIN_PAT }}
+          SSH_PRIVATE_KEY: ${{ secrets.MIGRATION_TARGET_SSH_KEY }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "SECRETS_ADMIN_PAT is not configured in this repository"
+          if [ -z "${SSH_PRIVATE_KEY:-}" ]; then
+            echo "MIGRATION_TARGET_SSH_KEY is not configured on this repository"
+            echo "Add the migration-target (185.249.73.167) SSH private key as a GitHub secret"
             exit 1
           fi
 
-          gh workflow run CI \
-            --repo MervinPraison/praison.ai \
-            --ref master
+          HESTIA_HOST="185.249.73.167"
+          HESTIA_USER="root"
+          REMOTE_WEB="/home/hestiaadmin/web/praison.ai/pa/web"
 
-          echo "Triggered praison.ai CI for PraisonAI commit ${SOURCE_SHA}"
-          echo "Monitor: https://github.com/MervinPraison/praison.ai/actions/workflows/azure-pipeline.yaml"
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$HESTIA_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
-          sleep 10
-          RUN_URL=$(gh run list \
-            --repo MervinPraison/praison.ai \
-            --workflow CI \
-            --limit 1 \
-            --json url,status,createdAt \
-            --jq '.[0].url' 2>/dev/null || true)
-          if [ -n "${RUN_URL}" ]; then
-            echo "Latest praison.ai CI run: ${RUN_URL}"
-          fi
+          for f in install.sh install.ps1; do
+            echo "Syncing $f..."
+            scp "src/praisonai/scripts/$f" "${HESTIA_USER}@${HESTIA_HOST}:${REMOTE_WEB}/${f}"
+          done
+
+          ssh "${HESTIA_USER}@${HESTIA_HOST}" \
+            "chown hestiaadmin:hestiaadmin ${REMOTE_WEB}/install.sh ${REMOTE_WEB}/install.ps1 && \
+             chmod 644 ${REMOTE_WEB}/install.sh ${REMOTE_WEB}/install.ps1"
+
+          echo "Deployed install scripts for commit ${SOURCE_SHA}"
+          echo "Verify: curl -fsSL https://praison.ai/install.ps1 | head -5"

--- a/.github/workflows/deploy-install-scripts.yml
+++ b/.github/workflows/deploy-install-scripts.yml
@@ -24,12 +24,16 @@ jobs:
     environment: production-hestia
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
 
       - name: Sync install scripts to Hestia
         env:
           SSH_PRIVATE_KEY: ${{ secrets.MIGRATION_TARGET_SSH_KEY }}
           HESTIA_HOST: ${{ secrets.MIGRATION_TARGET_HOST }}
           HESTIA_USER: ${{ secrets.MIGRATION_TARGET_USER }}
+          HESTIA_KNOWN_HOSTS: ${{ secrets.MIGRATION_TARGET_KNOWN_HOSTS }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -41,19 +45,32 @@ jobs:
           done
 
           REMOTE_WEB="/home/hestiaadmin/web/praison.ai/pa/web"
+          SSH_OPTS="-o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=yes"
 
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "$HESTIA_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          trap 'rm -f ~/.ssh/id_ed25519' EXIT
 
+          # Pin host identity via an out-of-band secret (no TOFU/ssh-keyscan).
+          if [ -z "${HESTIA_KNOWN_HOSTS:-}" ]; then
+            echo "Missing secret MIGRATION_TARGET_KNOWN_HOSTS (pinned host key). Refusing to deploy without a verified host identity."
+            exit 1
+          fi
+          echo "$HESTIA_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+          # Upload to temp files, then atomically move both into place in a
+          # single remote step to avoid serving truncated or mixed-commit files.
           for f in install.sh install.ps1; do
             echo "Syncing $f..."
-            scp "src/praisonai/scripts/$f" "${HESTIA_USER}@${HESTIA_HOST}:${REMOTE_WEB}/${f}"
+            scp $SSH_OPTS "src/praisonai/scripts/$f" "${HESTIA_USER}@${HESTIA_HOST}:${REMOTE_WEB}/.${f}.tmp"
           done
 
-          ssh "${HESTIA_USER}@${HESTIA_HOST}" \
-            "sudo chown hestiaadmin:hestiaadmin ${REMOTE_WEB}/install.sh ${REMOTE_WEB}/install.ps1 && \
+          ssh $SSH_OPTS "${HESTIA_USER}@${HESTIA_HOST}" \
+            "mv -f ${REMOTE_WEB}/.install.sh.tmp ${REMOTE_WEB}/install.sh && \
+             mv -f ${REMOTE_WEB}/.install.ps1.tmp ${REMOTE_WEB}/install.ps1 && \
+             sudo chown hestiaadmin:hestiaadmin ${REMOTE_WEB}/install.sh ${REMOTE_WEB}/install.ps1 && \
              sudo chmod 644 ${REMOTE_WEB}/install.sh ${REMOTE_WEB}/install.ps1"
 
           echo "Deployed install scripts for commit ${SOURCE_SHA}"


### PR DESCRIPTION
## Summary
- Deploy `install.sh` / `install.ps1` to Hestia (`migration-target`) instead of retired Azure AKS pipeline
- **Scoped `praison-deploy` user** — not root; ACL write on install files only; sudo limited to chown/chmod those two files
- **Dedicated CI SSH key** — separate from personal `id_ed25519`
- Host/user moved to secrets (`MIGRATION_TARGET_HOST`, `MIGRATION_TARGET_USER`)
- `production-hestia` environment gate (enable required reviewers in repo Settings → Environments)

## Secrets (configured)
- `MIGRATION_TARGET_SSH_KEY` — dedicated `praison-ci-install-deploy` key
- `MIGRATION_TARGET_HOST` — Hestia IP
- `MIGRATION_TARGET_USER` — `praison-deploy`

## Test plan
- [x] `praison-deploy` scp + scoped sudo tested on server
- [x] Local live sync — `install.ps1` serves `praisonai[all]`
- [ ] Merge and run `workflow_dispatch` to confirm CI deploy
- [ ] Optional: add required reviewers on `production-hestia` environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the installation script deployment workflow to deploy directly to the Hestia production host on changes to the install scripts.
  * Replaced the prior upstream-trigger approach with a dedicated deploy job that securely transfers both scripts over SSH.
  * Ensures required migration secrets are present, pins the remote host identity for safer connections, applies correct ownership/permissions, and outputs the deployed commit SHA plus a curl-based verification command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->