### PR TITLE
fix(ci): unblock Claude auto-trigger on issue open and labeled events

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -104,7 +104,9 @@ jobs:
             }
 
             // --- Auto-trigger Claude for owner issues and actionable external bug/enhancement reports ---
-            const autoClaude = isOwner || labels.includes('bug') || labels.includes('enhancement');
+            const titleLower = (issue.title || '').toLowerCase();
+            const hasActionableTitle = /^(bug:|fix[:(]|feat:|ux:|enhancement:)/.test(titleLower);
+            const autoClaude = isOwner || (hasActionableTitle && (labels.includes('bug') || labels.includes('enhancement')));
             if (autoClaude) {
               await github.rest.issues.addLabels({
                 issue_number: issue.number,
@@ -119,8 +121,9 @@ jobs:
   # Triggers on: labeled 'claude', @claude comments, assignments
   # ================================================================
   claude-response:
-    # Allow: human users, github-actions[bot] (FINAL @claude / CI-fix comments only)
-    # Block: praisonai-triage-agent (merge-gate scan mentions @claude as status text)
+    # Allow: human users, github-actions[bot] (FINAL @claude / CI-fix comments)
+    # Allow: praisonai-triage-agent[bot] only for issues labeled 'claude' (auto-triage)
+    # Block: praisonai-triage-agent on issue_comment (merge-gate scan mentions @claude)
     # Skip 'opened' events — triage job handles those above
     if: |
       github.event.action != 'opened' &&
@@ -141,9 +144,9 @@ jobs:
       (github.event_name != 'pull_request_review' || contains(github.event.review.body, '@claude')) &&
       (github.event_name != 'pull_request_review_comment' || contains(github.event.comment.body, '@claude')) &&
       (
-        (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
         !contains(github.actor, '[bot]') ||
-        github.actor == 'github-actions[bot]'
+        github.actor == 'github-actions[bot]' ||
+        (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude' && github.actor == 'praisonai-triage-agent[bot]')
       ) &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'cursor[bot]' &&

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -96,15 +96,16 @@ jobs:
                   '- Check [existing issues](https://github.com/MervinPraison/PraisonAI/issues) for duplicates',
                   '- Review the [documentation](https://docs.praison.ai) for related guides',
                   '',
-                  '_A maintainer can trigger deeper analysis by commenting `@claude` on this issue._',
+                  '_Bug and enhancement reports are auto-triaged with Claude. Questions and other issues: a maintainer can comment `@claude` to trigger analysis._',
                   '',
                   '**Routing:** Agent-callable tools → [PraisonAI-Tools](https://github.com/MervinPraison/PraisonAI-Tools); lifecycle plugins (tracing/hooks/guardrails) → [PraisonAI-Plugins](https://github.com/MervinPraison/PraisonAI-Plugins).'
                 ].join('\n')
               });
             }
 
-            // --- For owner: add 'claude' label to trigger the code-fix job ---
-            if (isOwner) {
+            // --- Auto-trigger Claude for owner issues and actionable external bug/enhancement reports ---
+            const autoClaude = isOwner || labels.includes('bug') || labels.includes('enhancement');
+            if (autoClaude) {
               await github.rest.issues.addLabels({
                 issue_number: issue.number,
                 owner: context.repo.owner,
@@ -114,7 +115,7 @@ jobs:
             }
 
   # ================================================================
-  # Job 2: Full Claude code-fix (owner/collaborator only)
+  # Job 2: Full Claude code-fix
   # Triggers on: labeled 'claude', @claude comments, assignments
   # ================================================================
   claude-response:
@@ -140,6 +141,7 @@ jobs:
       (github.event_name != 'pull_request_review' || contains(github.event.review.body, '@claude')) &&
       (github.event_name != 'pull_request_review_comment' || contains(github.event.comment.body, '@claude')) &&
       (
+        (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
         !contains(github.actor, '[bot]') ||
         github.actor == 'github-actions[bot]'
       ) &&


### PR DESCRIPTION
## Summary
- Auto-add `claude` label for external **bug** and **enhancement** issues (not only owner/collaborator)
- Allow `issues: labeled` + `claude` events through the actor filter so triage-bot label application triggers `claude-response`
- Update external-user welcome copy to reflect auto-triage on bugs

## Root cause
Two gaps in `claude.yml` blocked Claude on issues like #3040–#3043:

1. **No `claude` label for external reporters** — `issue-triage` only labeled owner issues, so Dhivya-Bharathy bug reports got welcome text but never started Claude.
2. **Actor filter blocked labeled events** — when triage added `claude`, `claude-response` skipped because `praisonai-triage-agent[bot]` was not in the allowed bot list (only `github-actions[bot]` was).

## Test plan
- [ ] Merge and open a test external bug issue → should get `claude` label + `claude-response` run
- [ ] Owner issue open → `claude` label + `claude-response` still fires on labeled event
- [ ] Merge-gate / triage welcome comments mentioning `@claude` still do **not** retrigger Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated issue triage messaging to clarify when Claude will handle bug/enhancement reports versus when maintainers should step in for questions and other issue types.
  * Improved the Claude auto-routing logic to better determine which newly filed issues are eligible (including bug/enhancement title and labels).
  * Expanded when Claude responses can start, including cases where issues receive the `claude` label via the triage agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->