### PR TITLE
fix(ci): accept [BUG] title prefix for external Claude auto-trigger

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -105,7 +105,7 @@ jobs:
 
             // --- Auto-trigger Claude for owner issues and actionable external bug/enhancement reports ---
             const titleLower = (issue.title || '').toLowerCase();
-            const hasActionableTitle = /^(bug:|fix[:(]|feat:|ux:|enhancement:)/.test(titleLower);
+            const hasActionableTitle = /^(\[bug\]|bug:|fix[:(]|feat:|ux:|enhancement:)/i.test(titleLower);
             const autoClaude = isOwner || (hasActionableTitle && (labels.includes('bug') || labels.includes('enhancement')));
             if (autoClaude) {
               await github.rest.issues.addLabels({


### PR DESCRIPTION
## Summary
- Extend external-issue title gate to recognise `[BUG]` prefix (e.g. #3073), in addition to `Bug:`, `fix(`, `feat:`, etc.

## Test plan
- [ ] External issue titled `[BUG] ...` gets `claude` label on open
- [ ] Existing `Bug:` / `fix(` titles still auto-trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Issue triage now recognizes titles beginning with `[bug]` as actionable.
  * Bug title matching is now case-insensitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->