### PR TITLE
fix: accept bracket-prefixed titles for Claude auto-triage

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,9 +52,11 @@ jobs:
             // Kind labels
             if (content.includes('feature request') || content.includes('[feature')) {
               labels.push('enhancement');
+            } else if (title.includes('[question]') || content.includes('how do i') || content.includes('how to')) {
+              labels.push('question');
             } else if (content.includes('bug') || content.includes('error') || content.includes('crash') || content.includes('traceback')) {
               labels.push('bug');
-            } else if (content.includes('question') || content.includes('how do i') || content.includes('how to')) {
+            } else if (content.includes('question')) {
               labels.push('question');
             }
 
@@ -106,7 +108,7 @@ jobs:
             // --- Auto-trigger Claude for owner issues and actionable external bug/enhancement reports ---
             const titleLower = (issue.title || '').toLowerCase();
             const hasActionableTitle = /^(\[[^\]]+\]|bug:|fix[:(]|feat:|ux:|enhancement:)/i.test(titleLower);
-            const autoClaude = isOwner || (hasActionableTitle && (labels.includes('bug') || labels.includes('enhancement')));
+            const autoClaude = isOwner || (hasActionableTitle && (labels.includes('bug') || labels.includes('enhancement')) && !labels.includes('question'));
             if (autoClaude) {
               await github.rest.issues.addLabels({
                 issue_number: issue.number,

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -105,7 +105,7 @@ jobs:
 
             // --- Auto-trigger Claude for owner issues and actionable external bug/enhancement reports ---
             const titleLower = (issue.title || '').toLowerCase();
-            const hasActionableTitle = /^(\[bug\]|bug:|fix[:(]|feat:|ux:|enhancement:)/i.test(titleLower);
+            const hasActionableTitle = /^(\[[^\]]+\]|bug:|fix[:(]|feat:|ux:|enhancement:)/i.test(titleLower);
             const autoClaude = isOwner || (hasActionableTitle && (labels.includes('bug') || labels.includes('enhancement')));
             if (autoClaude) {
               await github.rest.issues.addLabels({


### PR DESCRIPTION
## Summary
- Extend the external-issue title gate to match any leading `[...]` prefix (e.g. `[praisonai-mcp]`, `[praisonai-browser]`), not only `[bug]`
- Keeps the existing requirement that the issue has `bug` or `enhancement` labels before auto-adding `claude`

## Context
Dhivya issues #3094–#3098 and #3110–#3111 were opened with package-scoped titles and never received the `claude` label. Manually re-triggered those seven issues after adding labels.

## Test plan
- [x] Regex covers `[bug]`, `[praisonai-mcp]`, `[praisonai-browser]`
- [x] Manual `claude` label added to #3094–#3098, #3110–#3111
- [ ] Merge and confirm future external `[package]` bug reports auto-triage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue triage so “question” detection triggers earlier, including bracket-tagged titles and common “how do I/how to” phrasing.
  * Refined automation for actionable, bracket-prefixed titles and adjusted labeling so non-owner issues receive the correct auto-labels without overriding question items.
  * Expanded support for non-bug bracket prefixes while keeping bug/enhancement labeling behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->