### PR TITLE
fix: close C13 post-merge gaps — CLI, Daytona, live tests

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -183,6 +183,9 @@ jobs:
         if [ "$WORKDIR" = "src/praisonai-sandbox" ]; then
           bash "$GITHUB_WORKSPACE/scripts/check_c13_sandbox_imports.sh"
         fi
+        if [ "$WORKDIR" = "src/praisonai-mcp" ]; then
+          bash "$GITHUB_WORKSPACE/scripts/check_c12_mcp_imports.sh"
+        fi
         cd "$WORKDIR"
         if [ -n "${{ matrix.pythonpath || '' }}" ]; then
           export PYTHONPATH="${{ matrix.pythonpath }}:${PYTHONPATH:-}"

--- a/examples/python/sandbox_example.py
+++ b/examples/python/sandbox_example.py
@@ -132,6 +132,7 @@ if __name__ == "__main__":
     demonstrate_result_handling()
     
     print("To run code in sandbox via CLI:")
-    print("  praisonai sandbox run \"print('Hello, World!')\"")
-    print("  praisonai sandbox run --file script.py")
+    print("  praisonai sandbox run --code \"print('Hello, World!')\"")
+    print("  praisonai sandbox run --file script.py --type docker")
     print("  praisonai sandbox shell")
+    print("  praisonai sandbox backends")

--- a/src/praisonai-agents/uv.lock
+++ b/src/praisonai-agents/uv.lock
@@ -974,68 +974,12 @@ wheels = [
 ]
 
 [[package]]
-name = "docker"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
-]
-
-[[package]]
-name = "dockerfile-parse"
-version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
-]
-
-[[package]]
 name = "durationpy"
 version = "0.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/e9/f49c4e7fccb77fa5c43c2480e09a857a78b41e7331a75e128ed5df45c56b/durationpy-0.9.tar.gz", hash = "sha256:fd3feb0a69a0057d582ef643c355c40d2fa1c942191f914d12203b1a01ac722a", size = 3186, upload-time = "2024-10-02T17:59:00.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a3/ac312faeceffd2d8f86bc6dcb5c401188ba5a01bc88e69bed97578a0dfcd/durationpy-0.9-py3-none-any.whl", hash = "sha256:e65359a7af5cedad07fb77a2dd3f390f8eb0b74cb845589fa6c057086834dd38", size = 3461, upload-time = "2024-10-02T17:58:59.349Z" },
-]
-
-[[package]]
-name = "e2b"
-version = "2.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "dockerfile-parse" },
-    { name = "httpcore" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "python-dateutil" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/1b/d11119f70ada7d8f0d3a79e6cd60c9180f614ddcd99afa436d89b81739bc/e2b-2.2.3.tar.gz", hash = "sha256:6e28655b1dc3753005e48e7268c02b29314d4b7907cf8617ba777a7096b471d9", size = 89414, upload-time = "2025-10-09T08:44:36.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/d1/ab9dec3e4abc9f932a9ef4a9a57900332a3c6df31db454d2d8ef0b6d1944/e2b-2.2.3-py3-none-any.whl", hash = "sha256:c6949b7c17ab66a5c56c187b473a7f5d5f367e22cf2bd8e3c5e376117003dc56", size = 165490, upload-time = "2025-10-09T08:44:35.196Z" },
-]
-
-[[package]]
-name = "e2b-code-interpreter"
-version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "e2b" },
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/d0/116900ce07bef1cf2068a0c6da6df4eebcb78b22c037ccb3360613ac1d47/e2b_code_interpreter-2.1.1.tar.gz", hash = "sha256:a51af42d30cbeca158168cee11e362254467b508a0ab578760248f0e97779dd8", size = 10114, upload-time = "2025-10-08T00:18:19.086Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/c0/774e3e37ba818e27496d2a483a2d679a56b6427562f6e94af862eefc9a9f/e2b_code_interpreter-2.1.1-py3-none-any.whl", hash = "sha256:f7d561ae0bc6f0ae755d09afaa636d3ba935af1b11e6e31d5dbd5988da5a4101", size = 12983, upload-time = "2025-10-08T00:18:17.424Z" },
 ]
 
 [[package]]
@@ -1064,7 +1008,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -3162,7 +3106,6 @@ all = [
     { name = "chromadb" },
     { name = "crawl4ai" },
     { name = "ddgs" },
-    { name = "e2b-code-interpreter" },
     { name = "fastapi" },
     { name = "litellm" },
     { name = "markitdown", extra = ["all"] },
@@ -3233,12 +3176,6 @@ os = [
     { name = "pyjwt" },
     { name = "uvicorn" },
 ]
-sandbox = [
-    { name = "e2b-code-interpreter" },
-]
-sandbox-docker = [
-    { name = "docker" },
-]
 search = [
     { name = "ddgs" },
 ]
@@ -3259,8 +3196,6 @@ requires-dist = [
     { name = "crawl4ai", marker = "extra == 'crawl'", specifier = ">=0.4.0" },
     { name = "dakera", marker = "extra == 'dakera'", specifier = ">=0.12.8" },
     { name = "ddgs", marker = "extra == 'search'", specifier = ">=9.0.0" },
-    { name = "docker", marker = "extra == 'sandbox-docker'", specifier = ">=7.0.0" },
-    { name = "e2b-code-interpreter", marker = "extra == 'sandbox'", specifier = ">=1.0.0" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.115.0" },
     { name = "fastapi", marker = "extra == 'mcp'", specifier = ">=0.115.0" },
     { name = "fastapi", marker = "extra == 'os'", specifier = ">=0.115.0" },
@@ -3288,7 +3223,6 @@ requires-dist = [
     { name = "praisonaiagents", extras = ["memory"], marker = "extra == 'all'" },
     { name = "praisonaiagents", extras = ["mongodb"], marker = "extra == 'all'" },
     { name = "praisonaiagents", extras = ["os"], marker = "extra == 'all'" },
-    { name = "praisonaiagents", extras = ["sandbox"], marker = "extra == 'all'" },
     { name = "praisonaiagents", extras = ["search"], marker = "extra == 'all'" },
     { name = "praisonaiagents", extras = ["telemetry"], marker = "extra == 'all'" },
     { name = "pydantic", specifier = ">=2.10.0" },
@@ -3305,7 +3239,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'os'", specifier = ">=0.34.0" },
     { name = "websockets", marker = "extra == 'mcp'", specifier = ">=12.0" },
 ]
-provides-extras = ["mcp", "memory", "knowledge", "graph", "llm", "api", "os", "telemetry", "mongodb", "dakera", "auth", "autonomy", "search", "crawl", "sandbox", "a2ui", "sandbox-docker", "all"]
+provides-extras = ["mcp", "memory", "knowledge", "graph", "llm", "api", "os", "telemetry", "mongodb", "dakera", "auth", "autonomy", "search", "crawl", "a2ui", "all"]
 
 [[package]]
 name = "primp"
@@ -4398,7 +4332,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4461,7 +4395,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4725,8 +4659,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts" },
-    { name = "standard-chunk" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [

--- a/src/praisonai-code/praisonai_code/cli/commands/sandbox.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/sandbox.py
@@ -14,7 +14,7 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-_SandboxType = Literal["subprocess", "docker"]
+_SandboxType = Literal["subprocess", "docker", "daytona"]
 
 
 def _sandbox_handler():
@@ -29,7 +29,7 @@ def sandbox_run(
     code: Optional[str] = typer.Option(None, "--code", "-c", help="Code to execute"),
     file: Optional[str] = typer.Option(None, "--file", "-f", help="File to execute"),
     sandbox_type: _SandboxType = typer.Option(
-        "subprocess", "--type", "-t", help="Sandbox backend (subprocess or docker)"
+        "subprocess", "--type", "-t", help="Sandbox backend (subprocess, docker, or daytona)"
     ),
     image: str = typer.Option("python:3.11-slim", "--image", help="Docker image"),
     timeout: int = typer.Option(60, "--timeout", help="Timeout in seconds"),
@@ -47,7 +47,7 @@ def sandbox_run(
 @app.command("shell")
 def sandbox_shell(
     sandbox_type: _SandboxType = typer.Option(
-        "subprocess", "--type", "-t", help="Sandbox backend (subprocess or docker)"
+        "subprocess", "--type", "-t", help="Sandbox backend (subprocess, docker, or daytona)"
     ),
     image: str = typer.Option("python:3.11-slim", "--image", help="Docker image"),
 ):

--- a/src/praisonai-code/praisonai_code/cli/commands/sandbox.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/sandbox.py
@@ -5,14 +5,60 @@ Provides sandbox management commands inspired by moltbot's sandbox CLI.
 Supports listing, explaining, and recreating sandbox containers.
 """
 
-from typing import Optional
+from typing import Literal, Optional
 
 import typer
 
 app = typer.Typer(
-    help="Sandbox container management",
+    help="Sandbox: code execution (run/shell/backends) and container management",
     no_args_is_help=True,
 )
+
+_SandboxType = Literal["subprocess", "docker"]
+
+
+def _sandbox_handler():
+    """Lazy wrapper bridge to code-exec handler (manifest: stays in praisonai wrapper)."""
+    from praisonai_code._wrapper_bridge import import_wrapper_module
+
+    return import_wrapper_module("praisonai.cli.features.sandbox_cli").SandboxHandler()
+
+
+@app.command("run")
+def sandbox_run(
+    code: Optional[str] = typer.Option(None, "--code", "-c", help="Code to execute"),
+    file: Optional[str] = typer.Option(None, "--file", "-f", help="File to execute"),
+    sandbox_type: _SandboxType = typer.Option(
+        "subprocess", "--type", "-t", help="Sandbox backend (subprocess or docker)"
+    ),
+    image: str = typer.Option("python:3.11-slim", "--image", help="Docker image"),
+    timeout: int = typer.Option(60, "--timeout", help="Timeout in seconds"),
+):
+    """Run code in an isolated sandbox backend."""
+    _sandbox_handler().run(
+        code=code,
+        file=file,
+        sandbox_type=sandbox_type,
+        image=image,
+        timeout=timeout,
+    )
+
+
+@app.command("shell")
+def sandbox_shell(
+    sandbox_type: _SandboxType = typer.Option(
+        "subprocess", "--type", "-t", help="Sandbox backend (subprocess or docker)"
+    ),
+    image: str = typer.Option("python:3.11-slim", "--image", help="Docker image"),
+):
+    """Start an interactive sandbox REPL."""
+    _sandbox_handler().shell(sandbox_type=sandbox_type, image=image)
+
+
+@app.command("backends")
+def sandbox_backends():
+    """Show availability of sandbox execution backends."""
+    _sandbox_handler().status()
 
 
 @app.command("status")
@@ -346,17 +392,22 @@ def sandbox_callback(ctx: typer.Context):
     """Show sandbox help if no subcommand provided."""
     if ctx.invoked_subcommand is None:
         help_text = """
-[bold cyan]PraisonAI Sandbox - Container Management[/bold cyan]
+[bold cyan]PraisonAI Sandbox[/bold cyan]
 
-Manage sandbox containers with: praisonai sandbox <command>
+Code execution and container management: praisonai sandbox <command>
 
 [bold]Commands:[/bold]
-  [green]status[/green]      Show sandbox status
+  [green]run[/green]        Run code in a sandbox backend
+  [green]shell[/green]      Interactive sandbox REPL
+  [green]backends[/green]    Show backend availability
+  [green]status[/green]      Show container status
   [green]explain[/green]     Explain effective sandbox policy
   [green]list[/green]        List sandbox containers
   [green]recreate[/green]    Recreate containers
 
 [bold]Examples:[/bold]
+  praisonai sandbox run --code "print('hello')"
+  praisonai sandbox backends
   praisonai sandbox status
   praisonai sandbox explain --agent work
   praisonai sandbox list --browser

--- a/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
+++ b/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
@@ -1582,10 +1582,15 @@ class PraisonAI:
                 sys.exit(exit_code if exit_code is not None else 1)
             
             elif args.command == 'sandbox':
-                from praisonai_code._wrapper_bridge import import_wrapper_module
-                mod = import_wrapper_module("praisonai.cli.features.sandbox_cli")
-                exit_code = mod.handle_sandbox_command(unknown_args)
-                sys.exit(exit_code)
+                from ..app import app as typer_app, register_commands
+                register_commands()
+                import sys as _sys
+                _sys.argv = ['praisonai', 'sandbox'] + unknown_args
+                try:
+                    typer_app()
+                except SystemExit as e:
+                    sys.exit(e.code if e.code else 0)
+                sys.exit(0)
             
             elif args.command == 'wizard':
                 # Wizard command - interactive project setup

--- a/src/praisonai-sandbox/praisonai_sandbox/__main__.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/__main__.py
@@ -7,12 +7,26 @@ import sys
 
 def main(argv: list[str] | None = None) -> None:
     args = argv if argv is not None else sys.argv[1:]
-    if not args:
-        args = ["--help"]
-    print("praisonai-sandbox: use praisonaiagents SandboxManager or import praisonai_sandbox backends.")
-    print("Install extras: pip install praisonai-sandbox[docker,e2b,sandlock,ssh,modal]")
-    if args[0] in ("--help", "-h"):
+    if not args or args[0] in ("--help", "-h"):
+        print("praisonai-sandbox — isolated agent code execution backends")
+        print("Use: praisonai sandbox run | praisonaiagents SandboxManager | import praisonai_sandbox")
+        print("Extras: pip install praisonai-sandbox[docker,e2b,daytona,modal,sandlock,ssh]")
         raise SystemExit(0)
+
+    if args[0] == "backends":
+        try:
+            from praisonaiagents.sandbox import SandboxConfig, SandboxManager
+
+            manager = SandboxManager(SandboxConfig.subprocess())
+            for name, info in sorted(manager.get_available_types().items()):
+                flag = "available" if info.get("available") else "unavailable"
+                print(f"{name}: {flag}")
+            raise SystemExit(0)
+        except ImportError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            raise SystemExit(1) from exc
+
+    print("Unknown command. Try: praisonai-sandbox --help")
     raise SystemExit(1)
 
 

--- a/src/praisonai-sandbox/praisonai_sandbox/daytona.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/daytona.py
@@ -108,9 +108,10 @@ class DaytonaSandbox:
         from daytona_sdk import CreateSandboxFromImageParams, Resources
 
         client = self._get_client()
+        memory_gib = max(1, round(self.memory_mb / 1024))
         params = CreateSandboxFromImageParams(
             image=self.image,
-            resources=Resources(cpu=self.cpu, memory=self.memory_mb),
+            resources=Resources(cpu=self.cpu, memory=memory_gib),
         )
         return client.create(params, timeout=max(self.timeout, 60))
 
@@ -245,19 +246,28 @@ class DaytonaSandbox:
                     error=f"Could not read {file_path}: {exc}",
                 )
             language = "bash" if file_path.endswith((".sh", ".bash")) else "python"
+            if args:
+                interpreter = "bash" if language == "bash" else "python"
+                remote_path = f"/tmp/{uuid.uuid4().hex}_{os.path.basename(file_path)}"
+                if not await self.write_file(remote_path, code):
+                    return SandboxResult(
+                        execution_id=str(uuid.uuid4()),
+                        status=SandboxStatus.FAILED,
+                        error=f"Could not upload {file_path} to sandbox",
+                    )
+                parts = [interpreter, remote_path] + list(args)
+                return await self.run_command(parts, limits=limits, env=env)
             return await self.execute(code, language=language, limits=limits, env=env)
 
-        parts = [file_path] + (args or [])
-        return await self.run_command(
-            " ".join(shlex.quote(p) for p in parts), limits=limits, env=env
-        )
+        parts = [file_path] + list(args or [])
+        return await self.run_command(parts, limits=limits, env=env)
 
     async def write_file(self, path: str, content: Union[str, bytes]) -> bool:
         if not self._is_running:
             await self.start()
         try:
             payload = content if isinstance(content, bytes) else content.encode("utf-8")
-            await asyncio.to_thread(self._sandbox.fs.upload_file, path, payload)
+            await asyncio.to_thread(self._sandbox.fs.upload_file, payload, path)
             return True
         except Exception as exc:
             logger.error("Daytona write_file failed: %s", exc)

--- a/src/praisonai-sandbox/praisonai_sandbox/daytona.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/daytona.py
@@ -14,7 +14,12 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional, Union
 
-from praisonaiagents.sandbox import SandboxResult, SandboxStatus, ResourceLimits
+from praisonaiagents.sandbox import (
+    SandboxConfig,
+    SandboxResult,
+    SandboxStatus,
+    ResourceLimits,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,23 +31,37 @@ class DaytonaSandbox:
 
     def __init__(
         self,
-        image: str = "python:3.12-slim",
+        config: Optional[SandboxConfig] = None,
+        image: Optional[str] = None,
         api_key: Optional[str] = None,
         api_url: Optional[str] = None,
         target: Optional[str] = None,
-        timeout: int = 300,
-        cpu: int = 1,
-        memory_mb: int = 512,
+        timeout: Optional[int] = None,
+        cpu: Optional[int] = None,
+        memory_mb: Optional[int] = None,
     ):
-        self.image = image
+        self.config = config or SandboxConfig(sandbox_type="daytona")
+        limits = self.config.resource_limits
+
+        if image is not None:
+            self.image = image
+        elif config is not None and config.image:
+            self.image = config.image
+        else:
+            self.image = "python:3.12-slim"
         self._api_key = api_key or os.environ.get("DAYTONA_API_KEY", "")
         self._api_url = api_url or os.environ.get(
             "DAYTONA_API_URL", "https://app.daytona.io/api"
         )
         self._target = target or os.environ.get("DAYTONA_TARGET", "us")
-        self.timeout = timeout
-        self.cpu = cpu
-        self.memory_mb = memory_mb
+        if timeout is not None:
+            self.timeout = timeout
+        elif config is not None:
+            self.timeout = limits.timeout_seconds
+        else:
+            self.timeout = 300
+        self.cpu = cpu if cpu is not None else max(1, limits.cpu_percent // 100)
+        self.memory_mb = memory_mb if memory_mb is not None else limits.memory_mb
         self._sandbox = None
         self._client = None
         self._is_running = False
@@ -168,22 +187,19 @@ class DaytonaSandbox:
         started_at: float,
     ) -> SandboxResult:
         try:
+            cmd_parts: List[str] = []
+            if working_dir:
+                cmd_parts.append(f"cd {shlex.quote(working_dir)}")
             if env:
                 for key, value in env.items():
-                    await asyncio.to_thread(
-                        self._sandbox.process.exec,
-                        f"export {shlex.quote(key)}={shlex.quote(value)}",
-                        timeout=10,
+                    cmd_parts.append(
+                        f"export {shlex.quote(key)}={shlex.quote(value)}"
                     )
-            if working_dir:
-                await asyncio.to_thread(
-                    self._sandbox.process.exec,
-                    f"cd {shlex.quote(working_dir)}",
-                    timeout=10,
-                )
+            cmd_parts.append(command)
+            full_command = " && ".join(cmd_parts)
             response = await asyncio.to_thread(
                 self._sandbox.process.exec,
-                command,
+                full_command,
                 timeout=limits.timeout_seconds,
             )
             stdout = getattr(response, "result", "") or ""
@@ -218,8 +234,23 @@ class DaytonaSandbox:
         limits: Optional[ResourceLimits] = None,
         env: Optional[Dict[str, str]] = None,
     ) -> SandboxResult:
+        if os.path.isfile(file_path):
+            try:
+                with open(file_path, "r", encoding="utf-8") as handle:
+                    code = handle.read()
+            except OSError as exc:
+                return SandboxResult(
+                    execution_id=str(uuid.uuid4()),
+                    status=SandboxStatus.FAILED,
+                    error=f"Could not read {file_path}: {exc}",
+                )
+            language = "bash" if file_path.endswith((".sh", ".bash")) else "python"
+            return await self.execute(code, language=language, limits=limits, env=env)
+
         parts = [file_path] + (args or [])
-        return await self.run_command(" ".join(shlex.quote(p) for p in parts), limits=limits, env=env)
+        return await self.run_command(
+            " ".join(shlex.quote(p) for p in parts), limits=limits, env=env
+        )
 
     async def write_file(self, path: str, content: Union[str, bytes]) -> bool:
         if not self._is_running:

--- a/src/praisonai-sandbox/praisonai_sandbox/daytona.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/daytona.py
@@ -1,106 +1,113 @@
 """
 Daytona Sandbox implementation for PraisonAI.
 
-Provides code execution in Daytona cloud development environments.
+Provides code execution in Daytona cloud sandboxes via daytona-sdk.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
+import shlex
 import time
 import uuid
 from typing import Any, Dict, List, Optional, Union
 
-from praisonaiagents.sandbox import (
-    SandboxResult,
-    SandboxStatus,
-    ResourceLimits,
-)
+from praisonaiagents.sandbox import SandboxResult, SandboxStatus, ResourceLimits
 
 logger = logging.getLogger(__name__)
 
+_INSTALL_HINT = "pip install praisonai-sandbox[daytona]"
+
 
 class DaytonaSandbox:
-    """Daytona-based sandbox for cloud development environment execution.
-    
-    Executes code in Daytona cloud development environments with 
-    pre-configured tooling and dependencies.
-    
-    Example:
-        from praisonai_sandbox import DaytonaSandbox
-        
-        sandbox = DaytonaSandbox(
-            workspace_template="python-dev",
-            provider="aws"
-        )
-        result = await sandbox.execute("python -c 'import numpy; print(numpy.__version__)'")
-        print(result.stdout)
-    
-    Requires: daytona package (install with pip install praisonai[daytona])
-    """
-    
+    """Daytona cloud sandbox for isolated code execution."""
+
     def __init__(
         self,
-        workspace_template: str = "python",
-        provider: str = "local",
-        workspace_name: Optional[str] = None,
+        image: str = "python:3.12-slim",
         api_key: Optional[str] = None,
-        server_url: Optional[str] = None,
+        api_url: Optional[str] = None,
+        target: Optional[str] = None,
         timeout: int = 300,
+        cpu: int = 1,
+        memory_mb: int = 512,
     ):
-        """Initialize the Daytona sandbox.
-        
-        Args:
-            workspace_template: Daytona workspace template to use
-            provider: Cloud provider (aws, gcp, azure, local)
-            workspace_name: Optional workspace name
-            api_key: Daytona API key
-            server_url: Daytona server URL
-            timeout: Maximum execution time in seconds
-        """
-        self.workspace_template = workspace_template
-        self.provider = provider
-        self.workspace_name = workspace_name or f"praisonai-{uuid.uuid4().hex[:8]}"
-        self.api_key = api_key
-        self.server_url = server_url or "http://localhost:3000"
+        self.image = image
+        self._api_key = api_key or os.environ.get("DAYTONA_API_KEY", "")
+        self._api_url = api_url or os.environ.get(
+            "DAYTONA_API_URL", "https://app.daytona.io/api"
+        )
+        self._target = target or os.environ.get("DAYTONA_TARGET", "us")
         self.timeout = timeout
-        
-        self._workspace = None
+        self.cpu = cpu
+        self.memory_mb = memory_mb
+        self._sandbox = None
         self._client = None
         self._is_running = False
-    
+
     @property
     def is_available(self) -> bool:
-        """Check if Daytona backend is available."""
-        # Disabled until real implementation is ready
-        return False
-    
+        if not self._api_key.strip():
+            return False
+        try:
+            import daytona_sdk  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
     @property
     def sandbox_type(self) -> str:
         return "daytona"
-    
+
+    def _get_client(self):
+        if self._client is None:
+            from daytona_sdk import Daytona, DaytonaConfig
+
+            self._client = Daytona(
+                DaytonaConfig(
+                    api_key=self._api_key,
+                    api_url=self._api_url,
+                    target=self._target,
+                )
+            )
+        return self._client
+
     async def start(self) -> None:
-        """Start/initialize the Daytona workspace."""
         if self._is_running:
             return
-        
-        # Directly raise NotImplementedError to make the fail-loud contract clear
-        raise NotImplementedError(
-            "Daytona backend not yet implemented. "
-            "Use 'subprocess', 'docker', or 'e2b' sandbox instead."
+        if not self.is_available:
+            raise RuntimeError(
+                f"Daytona not available. Install daytona-sdk and set DAYTONA_API_KEY. {_INSTALL_HINT}"
+            )
+        self._sandbox = await asyncio.to_thread(self._create_sandbox_sync)
+        self._is_running = True
+        logger.info("Daytona sandbox started")
+
+    def _create_sandbox_sync(self):
+        from daytona_sdk import CreateSandboxFromImageParams, Resources
+
+        client = self._get_client()
+        params = CreateSandboxFromImageParams(
+            image=self.image,
+            resources=Resources(cpu=self.cpu, memory=self.memory_mb),
         )
-    
+        return client.create(params, timeout=max(self.timeout, 60))
+
     async def stop(self) -> None:
-        """Stop/cleanup the Daytona workspace."""
-        if self._workspace:
-            logger.info(f"Stopping Daytona workspace: {self.workspace_name}")
-            # In practice, call Daytona API to stop workspace
-            self._workspace = None
-        
-        self._client = None
+        if not self._is_running:
+            return
+        sandbox = self._sandbox
+        self._sandbox = None
         self._is_running = False
+        if sandbox is not None:
+            try:
+                await asyncio.to_thread(sandbox.delete)
+            except Exception as exc:
+                logger.warning("Daytona sandbox delete failed: %s", exc)
         logger.info("Daytona sandbox stopped")
-    
+
     async def execute(
         self,
         code: str,
@@ -109,132 +116,26 @@ class DaytonaSandbox:
         env: Optional[Dict[str, str]] = None,
         working_dir: Optional[str] = None,
     ) -> SandboxResult:
-        """Execute code in Daytona workspace.
-        
-        Args:
-            code: Code to execute
-            language: Programming language (python, bash, etc.)
-            limits: Resource limits for execution
-            env: Environment variables
-            working_dir: Working directory for execution
-            
-        Returns:
-            Execution result
-        """
         if not self._is_running:
             await self.start()
-        
+        limits = limits or ResourceLimits(timeout_seconds=self.timeout)
         execution_id = str(uuid.uuid4())
         started_at = time.time()
-        
-        try:
-            # Simulate code execution in Daytona workspace
-            # In practice, this would make API calls to Daytona workspace
-            
-            result = await self._execute_in_workspace(
-                code, language, limits, env, working_dir
-            )
-            
-            completed_at = time.time()
-            duration = completed_at - started_at
-            
-            return SandboxResult(
-                execution_id=execution_id,
-                status=SandboxStatus.COMPLETED if result["exit_code"] == 0 else SandboxStatus.FAILED,
-                exit_code=result["exit_code"],
-                stdout=result["stdout"],
-                stderr=result["stderr"],
-                duration_seconds=duration,
-                started_at=started_at,
-                completed_at=completed_at,
-                metadata={
-                    "platform": "daytona",
-                    "workspace": self.workspace_name,
-                    "template": self.workspace_template,
-                    "provider": self.provider,
-                    "language": language,
-                }
-            )
-            
-        except Exception as e:
-            error_msg = str(e)
-            status = SandboxStatus.TIMEOUT if "timeout" in error_msg.lower() else SandboxStatus.FAILED
-            
-            return SandboxResult(
-                execution_id=execution_id,
-                status=status,
-                error=error_msg,
-                started_at=started_at,
-                completed_at=time.time(),
-                duration_seconds=time.time() - started_at,
-                metadata={
-                    "platform": "daytona",
-                    "workspace": self.workspace_name,
-                    "template": self.workspace_template,
-                    "provider": self.provider,
-                    "language": language,
-                }
-            )
-    
-    async def execute_file(
-        self,
-        file_path: str,
-        args: Optional[List[str]] = None,
-        limits: Optional[ResourceLimits] = None,
-        env: Optional[Dict[str, str]] = None,
-    ) -> SandboxResult:
-        """Execute a file in Daytona workspace."""
-        if not self._is_running:
-            await self.start()
-        
-        execution_id = str(uuid.uuid4())
-        started_at = time.time()
-        
-        try:
-            # Build command to execute file
-            command_parts = [file_path]
-            if args:
-                command_parts.extend(args)
-            command = " ".join(command_parts)
-            
-            result = await self._execute_command_in_workspace(
-                command, limits, env
-            )
-            
-            completed_at = time.time()
-            duration = completed_at - started_at
-            
-            return SandboxResult(
-                execution_id=execution_id,
-                status=SandboxStatus.COMPLETED if result["exit_code"] == 0 else SandboxStatus.FAILED,
-                exit_code=result["exit_code"],
-                stdout=result["stdout"],
-                stderr=result["stderr"],
-                duration_seconds=duration,
-                started_at=started_at,
-                completed_at=completed_at,
-                metadata={
-                    "platform": "daytona",
-                    "workspace": self.workspace_name,
-                    "file": file_path,
-                }
-            )
-            
-        except Exception as e:
-            return SandboxResult(
-                execution_id=execution_id,
-                status=SandboxStatus.FAILED,
-                error=str(e),
-                started_at=started_at,
-                completed_at=time.time(),
-                duration_seconds=time.time() - started_at,
-                metadata={
-                    "platform": "daytona",
-                    "workspace": self.workspace_name,
-                    "file": file_path,
-                }
-            )
-    
+        if language == "python":
+            command = f"python -c {shlex.quote(code)}"
+        elif language == "bash":
+            command = code
+        else:
+            command = f"python -c {shlex.quote(code)}"
+        return await self._run_command(
+            command,
+            limits=limits,
+            env=env,
+            working_dir=working_dir,
+            execution_id=execution_id,
+            started_at=started_at,
+        )
+
     async def run_command(
         self,
         command: Union[str, List[str]],
@@ -242,199 +143,125 @@ class DaytonaSandbox:
         env: Optional[Dict[str, str]] = None,
         working_dir: Optional[str] = None,
     ) -> SandboxResult:
-        """Run a shell command in Daytona workspace."""
         if not self._is_running:
             await self.start()
-        
-        execution_id = str(uuid.uuid4())
-        started_at = time.time()
-        
+        if isinstance(command, list):
+            command = shlex.join(command)
+        limits = limits or ResourceLimits(timeout_seconds=self.timeout)
+        return await self._run_command(
+            command,
+            limits=limits,
+            env=env,
+            working_dir=working_dir,
+            execution_id=str(uuid.uuid4()),
+            started_at=time.time(),
+        )
+
+    async def _run_command(
+        self,
+        command: str,
+        *,
+        limits: ResourceLimits,
+        env: Optional[Dict[str, str]],
+        working_dir: Optional[str],
+        execution_id: str,
+        started_at: float,
+    ) -> SandboxResult:
         try:
-            # Convert command to string if needed
-            if isinstance(command, list):
-                command = " ".join(command)
-            
-            result = await self._execute_command_in_workspace(
-                command, limits, env, working_dir
+            if env:
+                for key, value in env.items():
+                    await asyncio.to_thread(
+                        self._sandbox.process.exec,
+                        f"export {shlex.quote(key)}={shlex.quote(value)}",
+                        timeout=10,
+                    )
+            if working_dir:
+                await asyncio.to_thread(
+                    self._sandbox.process.exec,
+                    f"cd {shlex.quote(working_dir)}",
+                    timeout=10,
+                )
+            response = await asyncio.to_thread(
+                self._sandbox.process.exec,
+                command,
+                timeout=limits.timeout_seconds,
             )
-            
-            completed_at = time.time()
-            duration = completed_at - started_at
-            
+            stdout = getattr(response, "result", "") or ""
+            exit_code = getattr(response, "exit_code", 0)
+            status = SandboxStatus.COMPLETED if exit_code == 0 else SandboxStatus.FAILED
             return SandboxResult(
                 execution_id=execution_id,
-                status=SandboxStatus.COMPLETED if result["exit_code"] == 0 else SandboxStatus.FAILED,
-                exit_code=result["exit_code"],
-                stdout=result["stdout"],
-                stderr=result["stderr"],
-                duration_seconds=duration,
-                started_at=started_at,
-                completed_at=completed_at,
-                metadata={
-                    "platform": "daytona",
-                    "workspace": self.workspace_name,
-                    "command": command,
-                }
-            )
-            
-        except Exception as e:
-            return SandboxResult(
-                execution_id=execution_id,
-                status=SandboxStatus.FAILED,
-                error=str(e),
+                status=status,
+                exit_code=exit_code,
+                stdout=stdout,
+                stderr="",
+                duration_seconds=time.time() - started_at,
                 started_at=started_at,
                 completed_at=time.time(),
-                duration_seconds=time.time() - started_at,
-                metadata={
-                    "platform": "daytona",
-                    "workspace": self.workspace_name,
-                    "command": command,
-                }
             )
-    
-    async def write_file(
+        except Exception as exc:
+            error = str(exc)
+            status = SandboxStatus.TIMEOUT if "timeout" in error.lower() else SandboxStatus.FAILED
+            return SandboxResult(
+                execution_id=execution_id,
+                status=status,
+                error=error,
+                duration_seconds=time.time() - started_at,
+                started_at=started_at,
+                completed_at=time.time(),
+            )
+
+    async def execute_file(
         self,
-        path: str,
-        content: Union[str, bytes],
-    ) -> bool:
-        """Write a file to the Daytona workspace."""
+        file_path: str,
+        args: Optional[List[str]] = None,
+        limits: Optional[ResourceLimits] = None,
+        env: Optional[Dict[str, str]] = None,
+    ) -> SandboxResult:
+        parts = [file_path] + (args or [])
+        return await self.run_command(" ".join(shlex.quote(p) for p in parts), limits=limits, env=env)
+
+    async def write_file(self, path: str, content: Union[str, bytes]) -> bool:
         if not self._is_running:
             await self.start()
-        
         try:
-            # In practice, this would use Daytona API to write files
-            logger.info(f"Writing file to Daytona workspace: {path}")
-            
-            # Simulate file write
+            payload = content if isinstance(content, bytes) else content.encode("utf-8")
+            await asyncio.to_thread(self._sandbox.fs.upload_file, path, payload)
             return True
-            
-        except Exception as e:
-            logger.error(f"Failed to write file {path}: {e}")
+        except Exception as exc:
+            logger.error("Daytona write_file failed: %s", exc)
             return False
-    
-    async def read_file(
-        self,
-        path: str,
-    ) -> Optional[Union[str, bytes]]:
-        """Read a file from the Daytona workspace."""
+
+    async def read_file(self, path: str) -> Optional[Union[str, bytes]]:
         if not self._is_running:
             await self.start()
-        
         try:
-            # In practice, this would use Daytona API to read files
-            logger.info(f"Reading file from Daytona workspace: {path}")
-            
-            # Simulate file read
-            return "# Simulated file content"
-            
-        except Exception as e:
-            logger.error(f"Failed to read file {path}: {e}")
+            content = await asyncio.to_thread(self._sandbox.fs.download_file, path)
+            if isinstance(content, bytes):
+                return content.decode("utf-8", errors="replace")
+            return content
+        except Exception as exc:
+            logger.warning("Daytona read_file failed: %s", exc)
             return None
-    
-    async def list_files(
-        self,
-        path: str = "/",
-    ) -> List[str]:
-        """List files in a Daytona workspace directory."""
-        if not self._is_running:
-            await self.start()
-        
-        try:
-            # In practice, this would use Daytona API to list files
-            logger.info(f"Listing files in Daytona workspace: {path}")
-            
-            # Simulate file listing
-            return ["/workspace/main.py", "/workspace/requirements.txt"]
-            
-        except Exception as e:
-            logger.error(f"Failed to list files in {path}: {e}")
+
+    async def list_files(self, path: str = "/") -> List[str]:
+        result = await self.run_command(f"find {shlex.quote(path)} -type f 2>/dev/null | head -100")
+        if not result.success:
             return []
-    
+        return [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+
     def get_status(self) -> Dict[str, Any]:
-        """Get Daytona sandbox status information."""
         return {
             "available": self.is_available,
             "type": self.sandbox_type,
             "running": self._is_running,
-            "workspace": self.workspace_name,
-            "template": self.workspace_template,
-            "provider": self.provider,
-            "server_url": self.server_url,
-            "workspace_info": self._workspace,
+            "image": self.image,
+            "api_key_set": bool(self._api_key),
         }
-    
+
     async def cleanup(self) -> None:
-        """Clean up Daytona workspace resources."""
-        if not self._is_running:
-            return
-        
-        try:
-            # In practice, clean up workspace files via Daytona API
-            logger.info(f"Cleaning up Daytona workspace: {self.workspace_name}")
-            
-        except Exception as e:
-            logger.warning(f"Failed to cleanup workspace: {e}")
-    
+        await self.stop()
+
     async def reset(self) -> None:
-        """Reset Daytona workspace to initial state."""
-        if not self._is_running:
-            return
-        
-        try:
-            # In practice, reset workspace via Daytona API
-            logger.info(f"Resetting Daytona workspace: {self.workspace_name}")
-            
-        except Exception as e:
-            logger.warning(f"Failed to reset workspace: {e}")
-    
-    async def _execute_in_workspace(
-        self,
-        code: str,
-        language: str,
-        limits: Optional[ResourceLimits],
-        env: Optional[Dict[str, str]],
-        working_dir: Optional[str]
-    ) -> Dict[str, Any]:
-        """Execute code in the Daytona workspace."""
-        # This is a simplified simulation
-        # In practice, this would make API calls to the Daytona workspace
-        
-        if language.lower() == "python":
-            # Simulate Python execution
-            if "import" in code and "numpy" in code:
-                return {
-                    "exit_code": 0,
-                    "stdout": "1.24.3",  # Simulated numpy version
-                    "stderr": "",
-                }
-            elif "print" in code:
-                # Extract print statement content
-                return {
-                    "exit_code": 0,
-                    "stdout": "Hello from Daytona!",
-                    "stderr": "",
-                }
-        
-        # Default simulation
-        return {
-            "exit_code": 0,
-            "stdout": f"Executed {language} code in Daytona workspace",
-            "stderr": "",
-        }
-    
-    async def _execute_command_in_workspace(
-        self,
-        command: str,
-        limits: Optional[ResourceLimits],
-        env: Optional[Dict[str, str]],
-        working_dir: Optional[str] = None
-    ) -> Dict[str, Any]:
-        """Execute a command in the Daytona workspace."""
-        # This is a simplified simulation
-        # In practice, this would execute commands via Daytona workspace API
-        
-        return {
-            "exit_code": 0,
-            "stdout": f"Command '{command}' executed in Daytona workspace",
-            "stderr": "",
-        }
+        await self.stop()
+        await self.start()

--- a/src/praisonai-sandbox/pyproject.toml
+++ b/src/praisonai-sandbox/pyproject.toml
@@ -31,9 +31,11 @@ ssh = [
 modal = [
     "modal>=0.64.0",
 ]
-daytona = []
+daytona = [
+    "daytona-sdk>=0.1.0",
+]
 all = [
-    "praisonai-sandbox[docker,e2b,sandlock,ssh,modal]",
+    "praisonai-sandbox[docker,e2b,sandlock,ssh,modal,daytona]",
 ]
 
 [project.urls]

--- a/src/praisonai-sandbox/tests/test_daytona.py
+++ b/src/praisonai-sandbox/tests/test_daytona.py
@@ -1,83 +1,109 @@
-"""
-Unit tests for Daytona Sandbox implementation.
+"""Unit tests for Daytona Sandbox (daytona-sdk backend)."""
 
-The Daytona backend is a deliberate fail-loud stub until a real Daytona client
-ships: ``is_available`` is ``False`` and lifecycle/execution raise (or surface)
-``NotImplementedError``. These tests lock in that contract plus the
-dependency-free initialization and status behaviour.
-"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
 from praisonai_sandbox.daytona import DaytonaSandbox
+from praisonaiagents.sandbox import SandboxStatus
+
+
+def _daytona_sdk_module():
+    mod = MagicMock()
+    mod.Daytona = Mock()
+    mod.DaytonaConfig = Mock()
+    mod.CreateSandboxFromImageParams = Mock()
+    mod.Resources = Mock()
+    return mod
 
 
 class TestDaytonaSandbox:
-    """Test Daytona sandbox stub contract."""
-
-    def test_init(self):
-        """Test Daytona sandbox initialization with explicit args."""
-        sandbox = DaytonaSandbox(
-            workspace_template="python-dev",
-            provider="aws",
-            api_key="test-key",
-        )
-
-        assert sandbox.workspace_template == "python-dev"
-        assert sandbox.provider == "aws"
-        assert sandbox.api_key == "test-key"
+    def test_init_defaults(self):
+        sandbox = DaytonaSandbox()
+        assert sandbox.image == "python:3.12-slim"
         assert sandbox.sandbox_type == "daytona"
         assert not sandbox._is_running
 
-    def test_init_with_defaults(self):
-        """Test initialization with default values."""
+    def test_is_available_without_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            sandbox = DaytonaSandbox()
+            assert sandbox.is_available is False
+
+    @patch.dict(os.environ, {"DAYTONA_API_KEY": "test-key"})
+    def test_is_available_with_key_and_sdk(self):
         sandbox = DaytonaSandbox()
+        with patch.dict(sys.modules, {"daytona_sdk": _daytona_sdk_module()}):
+            assert sandbox.is_available is True
 
-        assert sandbox.workspace_template == "python"
-        assert sandbox.provider == "local"
-        assert sandbox.api_key is None
-        assert sandbox.server_url == "http://localhost:3000"
-        assert sandbox.timeout == 300
-        assert sandbox.workspace_name.startswith("praisonai-")
-
-    def test_init_with_custom_workspace_name(self):
-        """Test initialization with a custom workspace name."""
-        custom_name = "my-workspace"
-        sandbox = DaytonaSandbox(workspace_name=custom_name)
-        assert sandbox.workspace_name == custom_name
-
-    def test_is_available_is_false(self):
-        """Daytona backend advertises itself as unavailable until implemented."""
+    @patch.dict(os.environ, {"DAYTONA_API_KEY": "test-key"})
+    def test_is_available_without_sdk(self):
         sandbox = DaytonaSandbox()
-        assert sandbox.is_available is False
+        with patch.dict(sys.modules, {"daytona_sdk": None}):
+            with patch(
+                "builtins.__import__",
+                side_effect=lambda name, *a, **k: (_ for _ in ()).throw(ImportError())
+                if name == "daytona_sdk"
+                else __import__(name, *a, **k),
+            ):
+                assert sandbox.is_available is False
 
     @pytest.mark.asyncio
-    async def test_start_raises_not_implemented(self):
-        """start() fails loud with NotImplementedError."""
+    @patch.dict(os.environ, {"DAYTONA_API_KEY": "test-key"})
+    async def test_start_success(self):
+        sandbox = DaytonaSandbox(api_key="test-key")
+        mock_sandbox = Mock()
+        mock_client = Mock()
+        mock_client.create.return_value = mock_sandbox
+
+        with patch.dict(sys.modules, {"daytona_sdk": _daytona_sdk_module()}):
+            with patch.object(sandbox, "_get_client", return_value=mock_client):
+                await sandbox.start()
+
+        assert sandbox._is_running
+        assert sandbox._sandbox is mock_sandbox
+        mock_client.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_start_not_available(self):
         sandbox = DaytonaSandbox()
-        with pytest.raises(NotImplementedError, match="not yet implemented"):
+        with pytest.raises(RuntimeError, match="Daytona not available"):
             await sandbox.start()
 
     @pytest.mark.asyncio
-    async def test_execute_fails_loud(self):
-        """execute() fails loud because start() is not implemented."""
-        sandbox = DaytonaSandbox()
-        with pytest.raises(NotImplementedError, match="not yet implemented"):
-            await sandbox.execute("print('Hello')", "python")
+    @patch.dict(os.environ, {"DAYTONA_API_KEY": "test-key"})
+    async def test_execute_python(self):
+        sandbox = DaytonaSandbox(api_key="test-key")
+        sandbox._is_running = True
+        mock_response = Mock(result="daytona-ok", exit_code=0)
+        mock_sandbox = Mock()
+        mock_sandbox.process.exec.return_value = mock_response
+        sandbox._sandbox = mock_sandbox
+
+        result = await sandbox.execute("print('daytona-ok')", language="python")
+
+        assert result.status == SandboxStatus.COMPLETED
+        assert "daytona-ok" in (result.stdout or "")
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"DAYTONA_API_KEY": "test-key"})
+    async def test_stop_deletes_sandbox(self):
+        sandbox = DaytonaSandbox(api_key="test-key")
+        mock_sandbox = Mock()
+        sandbox._sandbox = mock_sandbox
+        sandbox._is_running = True
+
+        await sandbox.stop()
+
+        mock_sandbox.delete.assert_called_once()
+        assert not sandbox._is_running
 
     def test_get_status(self):
-        """Test getting sandbox status without touching the workspace."""
-        sandbox = DaytonaSandbox(
-            workspace_template="python-dev",
-            provider="aws",
-            api_key="test-key",
-        )
-
+        sandbox = DaytonaSandbox(api_key="secret")
         status = sandbox.get_status()
-
         assert status["type"] == "daytona"
-        assert status["workspace"] == sandbox.workspace_name
-        assert status["template"] == "python-dev"
-        assert status["provider"] == "aws"
-        assert not status["running"]
-        assert status["workspace_info"] is None
+        assert status["api_key_set"] is True
+        assert status["running"] is False

--- a/src/praisonai-sandbox/tests/test_live_sandbox.py
+++ b/src/praisonai-sandbox/tests/test_live_sandbox.py
@@ -3,15 +3,26 @@
 from __future__ import annotations
 
 import os
+import shutil
 
 import pytest
 
 pytestmark = pytest.mark.network
 
 
+def _docker_available() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        from praisonai_sandbox.docker import DockerSandbox
+
+        return DockerSandbox().is_available
+    except Exception:
+        return False
+
+
 @pytest.mark.asyncio
 async def test_subprocess_live_execute():
-    """Subprocess sandbox always works without external deps."""
     from praisonai_sandbox import SubprocessSandbox
 
     sandbox = SubprocessSandbox()
@@ -20,6 +31,21 @@ async def test_subprocess_live_execute():
         result = await sandbox.execute("print('c13-live-ok')")
         assert result.status.value in ("completed", "success")
         assert "c13-live-ok" in (result.stdout or "")
+    finally:
+        await sandbox.stop()
+        await sandbox.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _docker_available(), reason="Docker not available")
+async def test_docker_live_execute():
+    from praisonai_sandbox import DockerSandbox
+
+    sandbox = DockerSandbox(image="python:3.11-slim")
+    await sandbox.start()
+    try:
+        result = await sandbox.execute("print('docker-live-ok')")
+        assert "docker-live-ok" in (result.stdout or "")
     finally:
         await sandbox.stop()
         await sandbox.cleanup()
@@ -44,8 +70,25 @@ async def test_e2b_live_execute():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not os.getenv("DAYTONA_API_KEY"), reason="DAYTONA_API_KEY not set")
+async def test_daytona_live_execute():
+    from praisonai_sandbox import DaytonaSandbox
+
+    sandbox = DaytonaSandbox()
+    if not sandbox.is_available:
+        pytest.skip("Daytona not available (missing daytona-sdk or API key)")
+
+    await sandbox.start()
+    try:
+        result = await sandbox.execute("print('daytona-live-ok')")
+        assert "daytona-live-ok" in (result.stdout or "")
+    finally:
+        await sandbox.stop()
+        await sandbox.cleanup()
+
+
+@pytest.mark.asyncio
 async def test_sandbox_manager_subprocess_live():
-    """End-to-end via agents SandboxManager bridge."""
     from praisonaiagents.sandbox import SandboxConfig, SandboxManager
 
     manager = SandboxManager(SandboxConfig.subprocess())
@@ -54,8 +97,17 @@ async def test_sandbox_manager_subprocess_live():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not _docker_available(), reason="Docker not available")
+async def test_sandbox_manager_docker_live():
+    from praisonaiagents.sandbox import SandboxConfig, SandboxManager
+
+    manager = SandboxManager(SandboxConfig.docker("python:3.11-slim"))
+    result = await manager.run_code("print('manager-docker-ok')")
+    assert "manager-docker-ok" in (result.stdout or "")
+
+
+@pytest.mark.asyncio
 async def test_backward_compat_shim_live():
-    """praisonai.sandbox shim resolves to praisonai_sandbox at runtime."""
     from praisonai._bootstrap import ensure_praisonai_sandbox
 
     ensure_praisonai_sandbox()

--- a/src/praisonai-sandbox/uv.lock
+++ b/src/praisonai-sandbox/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "24.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -153,6 +162,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-retry"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981, upload-time = "2024-11-06T10:44:52.917Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -235,6 +256,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
+name = "bidict"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093, upload-time = "2024-02-18T19:09:05.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764, upload-time = "2024-02-18T19:09:04.156Z" },
 ]
 
 [[package]]
@@ -563,6 +593,145 @@ wheels = [
 ]
 
 [[package]]
+name = "daytona-analytics-api-client"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/fc/92666cf4cfbd72b1ef866ce9e481114616d9435daa40d8644c620bc8ebb1/daytona_analytics_api_client-0.198.0.tar.gz", hash = "sha256:8c0d05f5711042ef7524a00696dd4d375274d005689d56823264b4099be4e75c", size = 30034, upload-time = "2026-07-16T09:17:10.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/58/1bc386dd3e617ed17596f0b98983c0d585722ffa39e59dde317fa04f5808/daytona_analytics_api_client-0.198.0-py3-none-any.whl", hash = "sha256:3fc92faf102f0affcbdd81157ea7f88bb7c92e3651d940f59ffd532ca22c40cd", size = 45004, upload-time = "2026-07-16T09:17:11.293Z" },
+]
+
+[[package]]
+name = "daytona-analytics-api-client-async"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/28/ac54bc290aeea7cf434a998a6c55e92956a31c18ce7ffffadb81b5439a99/daytona_analytics_api_client_async-0.198.0.tar.gz", hash = "sha256:b7863766be03dda2d268d999d8fb02247b48f78803529d074067a983bc3c7308", size = 30046, upload-time = "2026-07-16T09:17:01.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/39/1bd663fd1f7f00f9a4ed7bc3fa7cebcd0c0d36cf87ce36ab9df31668fe97/daytona_analytics_api_client_async-0.198.0-py3-none-any.whl", hash = "sha256:e189c37406e1d8f9a9e5c11fb8c8ed27f8a5c6c27f40728975a014205691e329", size = 45276, upload-time = "2026-07-16T09:17:02.066Z" },
+]
+
+[[package]]
+name = "daytona-api-client"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/2f/9dbfdc70ccfe5de1a335c35dedf7b2714ca9fbf7aa7b4589a4db48d77c1f/daytona_api_client-0.198.0.tar.gz", hash = "sha256:0daf3dd33a21bbf3291bf2d93bb5c916afac7abeaa227012bf0f51b504b2f33b", size = 124346, upload-time = "2026-07-16T09:17:20.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/b0/7cf252e2d680c960f4915a0a66b7eb8027e5b8a02255db28346343b40853/daytona_api_client-0.198.0-py3-none-any.whl", hash = "sha256:1b30649218fe6e1307387de81d041c66e19a4947a88eec4caea6d9c518d15b00", size = 315467, upload-time = "2026-07-16T09:17:21.397Z" },
+]
+
+[[package]]
+name = "daytona-api-client-async"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/53/27d056246593c552023c836ae5c2d8629100c328d78efea043b712a6a171/daytona_api_client_async-0.198.0.tar.gz", hash = "sha256:c76c42c08b350729eb938551df11f6e3193b5bb2d12a11488aea441fed865a1d", size = 124869, upload-time = "2026-07-16T09:17:01.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/0c/c6fd85b80561bb3fca5a9e706385544000e1eb6a8ed67dab0b8407c7bfae/daytona_api_client_async-0.198.0-py3-none-any.whl", hash = "sha256:522d0c2235c7125a02c45a55905fed6a6583d6fc0f2bd911f5fd62bfccb356f5", size = 318067, upload-time = "2026-07-16T09:17:03.751Z" },
+]
+
+[[package]]
+name = "daytona-sdk"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "daytona-analytics-api-client" },
+    { name = "daytona-analytics-api-client-async" },
+    { name = "daytona-api-client" },
+    { name = "daytona-api-client-async" },
+    { name = "daytona-toolbox-api-client" },
+    { name = "daytona-toolbox-api-client-async" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "httpx-ws" },
+    { name = "obstore" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-aiohttp-client" },
+    { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "python-socketio", extra = ["asyncio-client", "client"] },
+    { name = "toml" },
+    { name = "urllib3" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/f0/0893c121ed8dae065da258990317bad9c09965e90136c8a0ff7983f89834/daytona_sdk-0.198.0.tar.gz", hash = "sha256:db167fca6d9e133c3bf8d6af454cbeb9df92567120c83f0008615458fc12c06c", size = 173451, upload-time = "2026-07-16T09:17:57.634Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/a6/0a08d827d940ba4f1b911d93533ed05642fd3c9755d7f081a2b97f329f07/daytona_sdk-0.198.0-py3-none-any.whl", hash = "sha256:24cbb6b6da132f83167450dde3e2bfde675a9caadf167a43688c90ec1ec6f673", size = 210956, upload-time = "2026-07-16T09:17:59.006Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/f1/e933c40e1320b2bff173d4254c6757870f929ecd4f2447d1a09b9139361d/daytona_toolbox_api_client-0.198.0.tar.gz", hash = "sha256:75624bccda97346019453129c89d9fcc5979847ee249eec36aba8b7ce22d2a26", size = 86297, upload-time = "2026-07-16T09:17:11.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/4d/0ab80c2d97eb7e11129e9069729c56e216f3e979a4f889b788af07b2598d/daytona_toolbox_api_client-0.198.0-py3-none-any.whl", hash = "sha256:179d82ed726e2508e4833ef8605988400e521552df5195d9ca53e28422974dd3", size = 247056, upload-time = "2026-07-16T09:17:13.051Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client-async"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/0d/5b4211851b5fc6467b5b73c25536d7575583aa511c093c5ccc774b235b47/daytona_toolbox_api_client_async-0.198.0.tar.gz", hash = "sha256:89a70ca15b6a1b6ec3bb3beec13488c05d30db1cf27f935ce732283bbc3c352c", size = 80151, upload-time = "2026-07-16T09:17:01.567Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/7b/d3dcf6a88fbb45bce0dbad570ff466d32d8b4431d3f8efc0da49626c7988/daytona_toolbox_api_client_async-0.198.0-py3-none-any.whl", hash = "sha256:2ce23b3c464e009b09f02c398a24aa8a558edd8ef02a77de2415c05905296b8b", size = 245525, upload-time = "2026-07-16T09:17:02.904Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -764,6 +933,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "grpclib"
 version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -833,6 +1014,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-ws"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
 ]
 
 [[package]]
@@ -1136,6 +1332,93 @@ wheels = [
 ]
 
 [[package]]
+name = "obstore"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/8c/9ec984edd0f3b72226adfaa19b1c61b15823b35b52f311ca4af36d009d15/obstore-0.8.2.tar.gz", hash = "sha256:a467bc4e97169e2ba749981b4fd0936015428d9b8f3fb83a5528536b1b6f377f", size = 168852, upload-time = "2025-09-16T15:34:55.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e9/0a1e340ef262f225ad71f556ccba257896f85ca197f02cd228fe5e20b45a/obstore-0.8.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:49104c0d72688c180af015b02c691fbb6cf6a45b03a9d71b84059ed92dbec704", size = 3622821, upload-time = "2025-09-16T15:32:53.79Z" },
+    { url = "https://files.pythonhosted.org/packages/24/86/2b53e8b0a838dbbf89ef5dfddde888770bc1a993c691698dae411a407228/obstore-0.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c49776abd416e4d80d003213522d82ad48ed3517bee27a6cf8ce0f0cf4e6337e", size = 3356349, upload-time = "2025-09-16T15:32:55.715Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/79/1ba6dc854d7de7704a2c474d723ffeb01b6884f72eea7cbe128efc472f4a/obstore-0.8.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1636372b5e171a98369612d122ea20b955661daafa6519ed8322f4f0cb43ff74", size = 3454842, upload-time = "2025-09-16T15:32:57.072Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/03/ca67ccc9b9e63cfc0cd069b84437807fed4ef880be1e445b3f29d11518e0/obstore-0.8.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2efed0d86ad4ebffcbe3d0c4d84f26c2c6b20287484a0a748499c169a8e1f2c4", size = 3688363, upload-time = "2025-09-16T15:32:58.164Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/2f/c78eb4352d8be64a072934fe3ff2af79a1d06f4571af7c70d96f9741766b/obstore-0.8.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00c5542616dc5608de82ab6f6820633c9dbab6ff048e770fb8a5fcd1d30cd656", size = 3960133, upload-time = "2025-09-16T15:32:59.614Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/34/9e828d19194e227fd9f1d2dd70710da99c2bd2cd728686d59ea80be10b7c/obstore-0.8.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d9df46aaf25ce80fff48c53382572adc67b6410611660b798024450281a3129", size = 3925493, upload-time = "2025-09-16T15:33:00.923Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7d/9ec5967f3e2915fbc441f72c3892a7f0fb3618e3ae5c8a44181ce4aa641c/obstore-0.8.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ccf0f03a7fe453fb8640611c922bce19f021c6aaeee6ee44d6d8fb57db6be48", size = 3769401, upload-time = "2025-09-16T15:33:02.373Z" },
+    { url = "https://files.pythonhosted.org/packages/85/bf/00b65013068bde630a7369610a2dae4579315cd6ce82d30e3d23315cf308/obstore-0.8.2-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:ddfbfadc88c5e9740b687ef0833384329a56cea07b34f44e1c4b00a0e97d94a9", size = 3534383, upload-time = "2025-09-16T15:33:03.903Z" },
+    { url = "https://files.pythonhosted.org/packages/52/39/1b684fd96c9a33974fc52f417c52b42c1d50df40b44e588853c4a14d9ab1/obstore-0.8.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:53ad53bb16e64102f39559ec470efd78a5272b5e3b84c53aa0423993ac5575c1", size = 3697939, upload-time = "2025-09-16T15:33:05.355Z" },
+    { url = "https://files.pythonhosted.org/packages/85/58/93a2c78935f17fde7e22842598a6373e46a9c32d0243ec3b26b5da92df27/obstore-0.8.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:b0b905b46354db0961ab818cad762b9c1ac154333ae5d341934c90635a6bd7ab", size = 3681746, upload-time = "2025-09-16T15:33:09.344Z" },
+    { url = "https://files.pythonhosted.org/packages/38/90/225c2972338d18f92e7a56f71e34df6935b0b1bd7458bb6a0d2bd4d48f92/obstore-0.8.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fee235694406ebb2dc4178752cf5587f471d6662659b082e9786c716a0a9465c", size = 3765156, upload-time = "2025-09-16T15:33:10.457Z" },
+    { url = "https://files.pythonhosted.org/packages/79/eb/aca27e895bfcbbcd2bf05ea6a2538a94b718e6f6d72986e16ab158b753ec/obstore-0.8.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6c36faf7ace17dd0832aa454118a63ea21862e3d34f71b9297d0c788d00f4985", size = 3941190, upload-time = "2025-09-16T15:33:11.59Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ce/c8251a397e7507521768f05bc355b132a0daaff3739e861e51fa6abd821e/obstore-0.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:948a1db1d34f88cfc7ab7e0cccdcfd84cf3977365634599c95ba03b4ef80d1c4", size = 3970041, upload-time = "2025-09-16T15:33:13.035Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c4/018f90701f1e5ea3fbd57f61463f42e1ef5218e548d3adcf12b6be021c34/obstore-0.8.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:2edaa97687c191c5324bb939d72f6fe86a7aa8191c410f1648c14e8296d05c1c", size = 3622568, upload-time = "2025-09-16T15:33:14.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/62/72dd1e7d52fc554bb1fdb1a9499bda219cf3facea5865a1d97fdc00b3a1b/obstore-0.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c4fb7ef8108f08d14edc8bec9e9a6a2e5c4d14eddb8819f5d0da498aff6e8888", size = 3356109, upload-time = "2025-09-16T15:33:15.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ae/089fe5b9207091252fe5ce352551214f04560f85eb8f2cc4f716a6a1a57e/obstore-0.8.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fda8f658c0edf799ab1e264f9b12c7c184cd09a5272dc645d42e987810ff2772", size = 3454588, upload-time = "2025-09-16T15:33:16.421Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/10/1865ae2d1ba45e8ae85fb0c1aada2dc9533baf60c4dfe74dab905348d74a/obstore-0.8.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87fe2bc15ce4051ecb56abd484feca323c2416628beb62c1c7b6712114564d6e", size = 3688627, upload-time = "2025-09-16T15:33:17.604Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/09/5d7ba6d0aeac563ea5f5586401c677bace4f782af83522b1fdf15430e152/obstore-0.8.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2482aa2562ab6a4ca40250b26bea33f8375b59898a9b5615fd412cab81098123", size = 3959896, upload-time = "2025-09-16T15:33:18.789Z" },
+    { url = "https://files.pythonhosted.org/packages/16/15/2b3eda59914761a9ff4d840e2daec5697fd29b293bd18d3dc11c593aed06/obstore-0.8.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4153b928f5d2e9c6cb645e83668a53e0b42253d1e8bcb4e16571fc0a1434599a", size = 3933162, upload-time = "2025-09-16T15:33:19.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7a/5fc63b41526587067537fb1498c59a210884664c65ccf0d1f8f823b0875a/obstore-0.8.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbfa9c38620cc191be98c8b5558c62071e495dc6b1cc724f38293ee439aa9f92", size = 3769605, upload-time = "2025-09-16T15:33:21.389Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4e/2208ab6e1fc021bf8b7e117249a10ab75d0ed24e0f2de1a8d7cd67d885b5/obstore-0.8.2-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:0822836eae8d52499f10daef17f26855b4c123119c6eb984aa4f2d525ec2678d", size = 3534396, upload-time = "2025-09-16T15:33:22.574Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/8f/a0e2882edd6bd285c82b8a5851c4ecf386c93fe75b6e340d5d9d30e809fc/obstore-0.8.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ef6435dfd586d83b4f778e7927a5d5b0d8b771e9ba914bc809a13d7805410e6", size = 3697777, upload-time = "2025-09-16T15:33:23.723Z" },
+    { url = "https://files.pythonhosted.org/packages/94/78/ebf0c33bed5c9a8eed3b00eefafbcc0a687eeb1e05451c76fcf199d29ff8/obstore-0.8.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0f2cba91f4271ca95a932a51aa8dda1537160342b33f7836c75e1eb9d40621a2", size = 3681546, upload-time = "2025-09-16T15:33:24.935Z" },
+    { url = "https://files.pythonhosted.org/packages/af/21/9bf4fb9e53fd5f01af580b6538de2eae857e31d24b0ebfc4d916c306a1e4/obstore-0.8.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:23c876d603af0627627808d19a58d43eb5d8bfd02eecd29460bc9a58030fed55", size = 3765336, upload-time = "2025-09-16T15:33:26.069Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3c/7f6895c23719482d231b2d6ed328e3223fdf99785f6850fba8d2fc5a86ee/obstore-0.8.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ff3c4b5d07629b70b9dee494cd6b94fff8465c3864752181a1cb81a77190fe42", size = 3941142, upload-time = "2025-09-16T15:33:27.275Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a4/56ccdb756161595680a28f4b0def2c04f7048ffacf128029be8394367b26/obstore-0.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:aadb2cb72de7227d07f4570f82729625ffc77522fadca5cf13c3a37fbe8c8de9", size = 3970172, upload-time = "2025-09-16T15:33:28.393Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/dc/60fefbb5736e69eab56657bca04ca64dc07fdeccb3814164a31b62ad066b/obstore-0.8.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bb70ce297a47392b1d9a3e310f18d59cd5ebbb9453428210fef02ed60e4d75d1", size = 3612955, upload-time = "2025-09-16T15:33:29.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/844e8f382e5a12b8a3796a05d76a03e12c7aedc13d6900419e39207d7868/obstore-0.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1619bf618428abf1f607e0b219b2e230a966dcf697b717deccfa0983dd91f646", size = 3346564, upload-time = "2025-09-16T15:33:30.698Z" },
+    { url = "https://files.pythonhosted.org/packages/89/73/8537f99e09a38a54a6a15ede907aa25d4da089f767a808f0b2edd9c03cec/obstore-0.8.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a4605c3ed7c9515aeb4c619b5f7f2c9986ed4a79fe6045e536b5e59b804b1476", size = 3460809, upload-time = "2025-09-16T15:33:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/99/7714dec721e43f521d6325a82303a002cddad089437640f92542b84e9cc8/obstore-0.8.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce42670417876dd8668cbb8659e860e9725e5f26bbc86449fd259970e2dd9d18", size = 3692081, upload-time = "2025-09-16T15:33:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/4ac4175fe95a24c220a96021c25c432bcc0c0212f618be0737184eebbaad/obstore-0.8.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4a3e893b2a06585f651c541c1972fe1e3bf999ae2a5fda052ee55eb7e6516f5", size = 3957466, upload-time = "2025-09-16T15:33:34.528Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/04/caa288fb735484fc5cb019bdf3d896eaccfae0ac4622e520d05692c46790/obstore-0.8.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08462b32f95a9948ed56ed63e88406e2e5a4cae1fde198f9682e0fb8487100ed", size = 3951293, upload-time = "2025-09-16T15:33:35.733Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2f/d380239da2d6a1fda82e17df5dae600a404e8a93a065784518ff8325d5f6/obstore-0.8.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a0bf7763292a8fc47d01cd66e6f19002c5c6ad4b3ed4e6b2729f5e190fa8a0d", size = 3766199, upload-time = "2025-09-16T15:33:36.904Z" },
+    { url = "https://files.pythonhosted.org/packages/28/41/d391be069d3da82969b54266948b2582aeca5dd735abeda4d63dba36e07b/obstore-0.8.2-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:bcd47f8126cb192cbe86942b8f73b1c45a651ce7e14c9a82c5641dfbf8be7603", size = 3529678, upload-time = "2025-09-16T15:33:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/4c/4862fdd1a3abde459ee8eea699b1797df638a460af235b18ca82c8fffb72/obstore-0.8.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:57eda9fd8c757c3b4fe36cf3918d7e589cc1286591295cc10b34122fa36dd3fd", size = 3698079, upload-time = "2025-09-16T15:33:39.696Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ca/014e747bc53b570059c27e3565b2316fbe5c107d4134551f4cd3e24aa667/obstore-0.8.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ea44442aad8992166baa69f5069750979e4c5d9ffce772e61565945eea5774b9", size = 3687154, upload-time = "2025-09-16T15:33:40.92Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/6db5f8edd93028e5b8bfbeee15e6bd3e56f72106107d31cb208b57659de4/obstore-0.8.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:41496a3ab8527402db4142aaaf0d42df9d7d354b13ba10d9c33e0e48dd49dd96", size = 3773444, upload-time = "2025-09-16T15:33:42.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e5/c9e2cc540689c873beb61246e1615d6e38301e6a34dec424f5a5c63c1afd/obstore-0.8.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43da209803f052df96c7c3cbec512d310982efd2407e4a435632841a51143170", size = 3939315, upload-time = "2025-09-16T15:33:43.252Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c9/bb53280ca50103c1ffda373cdc9b0f835431060039c2897cbc87ddd92e42/obstore-0.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:1836f5dcd49f9f2950c75889ab5c51fb290d3ea93cdc39a514541e0be3af016e", size = 3978234, upload-time = "2025-09-16T15:33:44.393Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/5d/8c3316cc958d386d5e6ab03e9db9ddc27f8e2141cee4a6777ae5b92f3aac/obstore-0.8.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:212f033e53fe6e53d64957923c5c88949a400e9027f7038c705ec2e9038be563", size = 3612027, upload-time = "2025-09-16T15:33:45.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/4d/699359774ce6330130536d008bfc32827fab0c25a00238d015a5974a3d1d/obstore-0.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bee21fa4ba148d08fa90e47a96df11161661ed31e09c056a373cb2154b0f2852", size = 3344686, upload-time = "2025-09-16T15:33:47.185Z" },
+    { url = "https://files.pythonhosted.org/packages/82/37/55437341f10512906e02fd9fa69a8a95ad3f2f6a916d3233fda01763d110/obstore-0.8.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4c66594b59832ff1ced4c72575d9beb8b5f9b4e404ac1150a42bfb226617fd50", size = 3459860, upload-time = "2025-09-16T15:33:48.382Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/51/4245a616c94ee4851965e33f7a563ab4090cc81f52cc73227ff9ceca2e46/obstore-0.8.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:089f33af5c2fe132d00214a0c1f40601b28f23a38e24ef9f79fb0576f2730b74", size = 3691648, upload-time = "2025-09-16T15:33:49.524Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f1/4e2fb24171e3ca3641a4653f006be826e7e17634b11688a5190553b00b83/obstore-0.8.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d87f658dfd340d5d9ea2d86a7c90d44da77a0db9e00c034367dca335735110cf", size = 3956867, upload-time = "2025-09-16T15:33:51.082Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f5/b703115361c798c9c1744e1e700d5908d904a8c2e2bd38bec759c9ffb469/obstore-0.8.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e2e4fa92828c4fbc2d487f3da2d3588701a1b67d9f6ca3c97cc2afc912e9c63", size = 3950599, upload-time = "2025-09-16T15:33:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/53/20/08c6dc0f20c1394e2324b9344838e4e7af770cdcb52c30757a475f50daeb/obstore-0.8.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab440e89c5c37a8ec230857dd65147d4b923e0cada33297135d05e0f937d696a", size = 3765865, upload-time = "2025-09-16T15:33:53.291Z" },
+    { url = "https://files.pythonhosted.org/packages/77/20/77907765e29b2eba6bd8821872284d91170d7084f670855b2dfcb249ea14/obstore-0.8.2-cp313-cp313-manylinux_2_24_aarch64.whl", hash = "sha256:b9beed107c5c9cd995d4a73263861fcfbc414d58773ed65c14f80eb18258a932", size = 3529807, upload-time = "2025-09-16T15:33:54.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f5/f629d39cc30d050f52b1bf927e4d65c1cc7d7ffbb8a635cd546b5c5219a0/obstore-0.8.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b75b4e7746292c785e31edcd5aadc8b758238372a19d4c5e394db5c305d7d175", size = 3693629, upload-time = "2025-09-16T15:33:56.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ff/106763fd10f2a1cb47f2ef1162293c78ad52f4e73223d8d43fc6b755445d/obstore-0.8.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:f33e6c366869d05ab0b7f12efe63269e631c5450d95d6b4ba4c5faf63f69de70", size = 3686176, upload-time = "2025-09-16T15:33:57.247Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0c/d2ccb6f32feeca906d5a7c4255340df5262af8838441ca06c9e4e37b67d5/obstore-0.8.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:12c885a9ce5ceb09d13cc186586c0c10b62597eff21b985f6ce8ff9dab963ad3", size = 3773081, upload-time = "2025-09-16T15:33:58.475Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/79/40d1cc504cefc89c9b3dd8874287f3fddc7d963a8748d6dffc5880222013/obstore-0.8.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4accc883b93349a81c9931e15dd318cc703b02bbef2805d964724c73d006d00e", size = 3938589, upload-time = "2025-09-16T15:33:59.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/916c6777222db3271e9fb3cf9a97ed92b3a9b3e465bdeec96de9ab809d53/obstore-0.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:ec850adf9980e5788a826ccfd5819989724e2a2f712bfa3258e85966c8d9981e", size = 3977768, upload-time = "2025-09-16T15:34:01.25Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/61/66f8dc98bbf5613bbfe5bf21747b4c8091442977f4bd897945895ab7325c/obstore-0.8.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1431e40e9bb4773a261e51b192ea6489d0799b9d4d7dbdf175cdf813eb8c0503", size = 3623364, upload-time = "2025-09-16T15:34:02.957Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/66/6d527b3027e42f625c8fc816ac7d19b0d6228f95bfe7666e4d6b081d2348/obstore-0.8.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ddb39d4da303f50b959da000aa42734f6da7ac0cc0be2d5a7838b62c97055bb9", size = 3347764, upload-time = "2025-09-16T15:34:04.236Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/79/c00103302b620192ea447a948921ad3fed031ce3d19e989f038e1183f607/obstore-0.8.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e01f4e13783db453e17e005a4a3ceff09c41c262e44649ba169d253098c775e8", size = 3460981, upload-time = "2025-09-16T15:34:05.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d9/bfe4ed4b1aebc45b56644dd5b943cf8e1673505cccb352e66878a457e807/obstore-0.8.2-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df0fc2d0bc17caff9b538564ddc26d7616f7e8b7c65b1a3c90b5048a8ad2e797", size = 3692711, upload-time = "2025-09-16T15:34:06.796Z" },
+    { url = "https://files.pythonhosted.org/packages/13/47/cd6c2cbb18e1f40c77e7957a4a03d2d83f1859a2e876a408f1ece81cad4c/obstore-0.8.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e439d06c99a140348f046c9f598ee349cc2dcd9105c15540a4b231f9cc48bbae", size = 3958362, upload-time = "2025-09-16T15:34:08.277Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ea/5ee82bf23abd71c7d6a3f2d008197ae8f8f569d41314c26a8f75318245be/obstore-0.8.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e37d9046669fcc59522d0faf1d105fcbfd09c84cccaaa1e809227d8e030f32c", size = 3957082, upload-time = "2025-09-16T15:34:09.477Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ee/46650405e50fdaa8d95f30375491f9c91fac9517980e8a28a4a6af66927f/obstore-0.8.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2646fdcc4bbe92dc2bb5bcdff15574da1211f5806c002b66d514cee2a23c7cb8", size = 3775539, upload-time = "2025-09-16T15:34:10.726Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/348a7ebebe2ca3d94dfc75344ea19675ae45472823e372c1852844078307/obstore-0.8.2-cp314-cp314-manylinux_2_24_aarch64.whl", hash = "sha256:e31a7d37675056d93dfc244605089dee67f5bba30f37c88436623c8c5ad9ba9d", size = 3535048, upload-time = "2025-09-16T15:34:12.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/07/b7a16cc0da91a4b902d47880ad24016abfe7880c63f7cdafda45d89a2f91/obstore-0.8.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:656313dd8170dde0f0cd471433283337a63912e8e790a121f7cc7639c83e3816", size = 3699035, upload-time = "2025-09-16T15:34:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/3269a3a58347e0b019742d888612c4b765293c9c75efa44e144b1e884c0d/obstore-0.8.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329038c9645d6d1741e77fe1a53e28a14b1a5c1461cfe4086082ad39ebabf981", size = 3687307, upload-time = "2025-09-16T15:34:14.501Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f9/4fd4819ad6a49d2f462a45be453561f4caebded0dc40112deeffc34b89b1/obstore-0.8.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1e4df99b369790c97c752d126b286dc86484ea49bff5782843a265221406566f", size = 3776076, upload-time = "2025-09-16T15:34:16.207Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/7c4f958fa0b9fc4778fb3d232e38b37db8c6b260f641022fbba48b049d7e/obstore-0.8.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9e1c65c65e20cc990414a8a9af88209b1bbc0dd9521b5f6b0293c60e19439bb7", size = 3947445, upload-time = "2025-09-16T15:34:17.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/37/14bae1f5bf4369027abc5315cdba2428ad4c16e2fd3bd5d35b7ee584aa0c/obstore-0.8.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:6ea04118980a9c22fc8581225ff4507b6a161baf8949d728d96e68326ebaab59", size = 3624857, upload-time = "2025-09-16T15:34:35.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c4/8cba91629aa20479ba86a57c2c2b3bc0a54fc6a31a4594014213603efae6/obstore-0.8.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5f33a7570b6001b54252260fbec18c3f6d21e25d3ec57e9b6c5e7330e8290eb2", size = 3355999, upload-time = "2025-09-16T15:34:36.954Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/10/3e40557d6d9c38c5a0f7bac1508209b9dbb8c4da918ddfa9326ba9a1de3f/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:11fa78dfb749edcf5a041cd6db20eae95b3e8b09dfdd9b38d14939da40e7c115", size = 3457322, upload-time = "2025-09-16T15:34:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/dcf7988350c286683698cbdd8c15498aec43cbca72eaabad06fd77f0f34a/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:872bc0921ff88305884546ba05e258ccd95672a03d77db123f0d0563fd3c000b", size = 3689452, upload-time = "2025-09-16T15:34:39.638Z" },
+    { url = "https://files.pythonhosted.org/packages/97/02/643eb2ede58933e47bdbc92786058c83d9aa569826d5bf6e83362d24a27a/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:72556a2fbf018edd921286283e5c7eec9f69a21c6d12516d8a44108eceaa526a", size = 3961171, upload-time = "2025-09-16T15:34:41.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5d/c0b515df6089d0f54109de8031a6f6ed31271361948bee90ab8271d22f79/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75fa1abf21499dfcfb0328941a175f89a9aa58245bf00e3318fe928e4b10d297", size = 3935988, upload-time = "2025-09-16T15:34:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/97/114d7bc172bb846472181d6fa3e950172ee1b1ccd11291777303c499dbdd/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f54f72f30cd608c4399679781c884bf8a0e816c1977a2fac993bf5e1fb30609f", size = 3771781, upload-time = "2025-09-16T15:34:44.405Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/43/4aa6de6dc406ef5e109b21a5614c34999575de638254deb456703fae24aa/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:b044ebf1bf7b8f7b0ca309375c1cd9e140be79e072ae8c70bbd5d9b2ad1f7678", size = 3536689, upload-time = "2025-09-16T15:34:45.649Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a5/870ce541aa1a9ee1d9c3e99c2187049bf5a4d278ee9678cc449aae0a4e68/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:b1326cd2288b64d6fe8857cc22d3a8003b802585fc0741eff2640a8dc35e8449", size = 3700560, upload-time = "2025-09-16T15:34:47.252Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/93/76a5fc3833aaa833b4152950d9cdfd328493a48316c24e32ddefe9b8870f/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:ba6863230648a9b0e11502d2745d881cf74262720238bc0093c3eabd22a3b24c", size = 3683450, upload-time = "2025-09-16T15:34:49.589Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/4c389362c187630c42f61ef9214e67fc336e44b8aafc47cf49ba9ab8007d/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:887615da9eeefeb2df849d87c380e04877487aa29dbeb367efc3f17f667470d3", size = 3766628, upload-time = "2025-09-16T15:34:51.937Z" },
+    { url = "https://files.pythonhosted.org/packages/03/12/08547e63edf2239ec6660af434602208ab6f394955ef660a6edda13a0bee/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:4eec1fb32ffa4fb9fe9ad584611ff031927a5c22732b56075ee7204f0e35ebdf", size = 3944069, upload-time = "2025-09-16T15:34:54.108Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.46.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1152,6 +1435,127 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/af/ac/f725c4efbda8657d02be684607e5a2e5ce362e4790fdbcbdfb7c15018647/openai-2.46.0.tar.gz", hash = "sha256:0421e0735ac41451cad894af4cddf0435bfbf8cbc538ac0e15b3c062f2ddc06a", size = 1114628, upload-time = "2026-07-17T02:48:06.05Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/7b/206238ebcb50b235942b1c66dba4974776f2057402a8d91c399be587d66a/openai-2.46.0-py3-none-any.whl", hash = "sha256:672381db55efb3a1e2610f29304c130cccdd0b319bace4d492b2443cb64c1e7c", size = 1637556, upload-time = "2026-07-17T02:48:03.695Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aiohttp-client"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/33/3ff7230b035e8b696db6be54f5c52dfa409829d634d91431c076ad789820/opentelemetry_instrumentation_aiohttp_client-0.65b0.tar.gz", hash = "sha256:85906a2806ee5641756b5c33274e9aa75c3cc2441e3b830aa5804cf0e1fa9dd1", size = 19042, upload-time = "2026-07-16T15:25:51.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/f9/5c8459224f175829601cabbcffaeab0f9041903c086e4a0368f9971093a5/opentelemetry_instrumentation_aiohttp_client-0.65b0-py3-none-any.whl", hash = "sha256:3a060efa53fa44d02ba7372a7ed2b42cdfa6be6df81b089845067ad840e25729", size = 13677, upload-time = "2026-07-16T15:24:53.361Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
 ]
 
 [[package]]
@@ -1192,10 +1596,14 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "asyncssh" },
+    { name = "daytona-sdk" },
     { name = "docker" },
     { name = "e2b-code-interpreter" },
     { name = "modal" },
     { name = "sandlock" },
+]
+daytona = [
+    { name = "daytona-sdk" },
 ]
 docker = [
     { name = "docker" },
@@ -1217,10 +1625,11 @@ ssh = [
 requires-dist = [
     { name = "asyncssh", marker = "extra == 'ssh'", specifier = ">=2.14.0" },
     { name = "click", specifier = ">=8.4.2" },
+    { name = "daytona-sdk", marker = "extra == 'daytona'", specifier = ">=0.1.0" },
     { name = "docker", marker = "extra == 'docker'", specifier = ">=7.0.0" },
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = ">=1.0.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=0.64.0" },
-    { name = "praisonai-sandbox", extras = ["docker", "e2b", "sandlock", "ssh", "modal"], marker = "extra == 'all'" },
+    { name = "praisonai-sandbox", extras = ["docker", "e2b", "sandlock", "ssh", "modal", "daytona"], marker = "extra == 'all'" },
     { name = "praisonaiagents", directory = "../praisonai-agents" },
     { name = "rich", specifier = ">=13.7" },
     { name = "sandlock", marker = "extra == 'sandlock'", specifier = ">=0.1.0" },
@@ -1230,7 +1639,7 @@ provides-extras = ["docker", "e2b", "sandlock", "ssh", "modal", "daytona", "all"
 
 [[package]]
 name = "praisonaiagents"
-version = "1.6.153"
+version = "1.6.154"
 source = { directory = "../praisonai-agents" }
 dependencies = [
     { name = "aiohttp" },
@@ -1604,6 +2013,58 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-engineio"
+version = "4.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simple-websocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a0/f75491f942184d9960b15e763270f765fe9f239745ca5f9e16289011aed4/python_engineio-4.13.3.tar.gz", hash = "sha256:572b7783e341fed21edbc7cea297ccd378dad79265fdde96aa4664420a7c06c9", size = 79734, upload-time = "2026-06-20T22:53:52.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/96/82f6328e410515fab21d5602ba35b9377a47b5a141a0c1f9efa00ce21eb4/python_engineio-4.13.3-py3-none-any.whl", hash = "sha256:1f60ecaf1358190f0e26c48c578a60428dc02a8f1295bc3dbf53d1b31116821f", size = 59993, upload-time = "2026-06-20T22:53:50.775Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "python-socketio"
+version = "5.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bidict" },
+    { name = "python-engineio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/2d/ffce71017c106b75099fea569df6518c63fee5d6202ce0cfe7b01e6f22c3/python_socketio-5.16.3.tar.gz", hash = "sha256:89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e", size = 128095, upload-time = "2026-06-15T22:07:04.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl", hash = "sha256:e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041", size = 82087, upload-time = "2026-06-15T22:07:02.498Z" },
+]
+
+[package.optional-dependencies]
+asyncio-client = [
+    { name = "aiohttp" },
+]
+client = [
+    { name = "requests" },
+    { name = "websocket-client" },
+]
+
+[[package]]
 name = "pywin32"
 version = "312"
 source = { registry = "https://pypi.org/simple" }
@@ -1743,6 +2204,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "simple-websocket"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
 ]
 
 [[package]]
@@ -2029,6 +2502,113 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/11/15/dc61746d8c0852f6d711ad09c774b63cf7c8211aa49e30871ac3d342b7e2/wcmatch-10.2.1.tar.gz", hash = "sha256:ecac70a5c70e62ba854b78318d3a1408e8651f8f1c96e5837743b71aa6a4fb92", size = 132497, upload-time = "2026-07-02T17:21:48.484Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/ba/20b48eedeab5316bf9a502bb9eb7e3b1588bd61d0f565822fefa8f06e10b/wcmatch-10.2.1-py3-none-any.whl", hash = "sha256:2d775395b93f233af66690f62cb9d52b084ec159a31cc4084f4069d72f437acd", size = 39763, upload-time = "2026-07-02T17:21:47.134Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/8b/59781d0fe7b0adfbea37f600857de4be68921e454aeecf1a11bda35cdccc/wrapt-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:055e6fcfaa28e58c6a8c247d48b92be9d56f818b7068aa4f22b15b3343a09931", size = 80556, upload-time = "2026-06-20T23:47:28.473Z" },
+    { url = "https://files.pythonhosted.org/packages/94/dc/66c61aca927230c9cf97a3cb005c803971a1076ff9f7d61085d035c20085/wrapt-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8374eb6b1a58809211e84ff835a182bb17ab2807a5bfef23204c8cff38178a00", size = 81648, upload-time = "2026-06-20T23:47:30.504Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1b/545eee1c18f3af4cf140bb5822b6ef81ebe569df0a63ac109973103a30a5/wrapt-2.2.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:656593bb3f5529f03d27af4136c4d7b11990e470bcbc6fefa5ef218695bece55", size = 152956, upload-time = "2026-06-20T23:47:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a7/6f42a3d03e44dc612a5dcff324e7366075a7857f0be2d49a8cb8a68279b8/wrapt-2.2.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfb00cb7bb22099e2f64b7340fb96113639aa7260c0972af3797ace2297b936c", size = 154771, upload-time = "2026-06-20T23:47:33.352Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/55/4d76175aaa97523c38f1d28f79d18ab41a1b116814158a818bc0eba00571/wrapt-2.2.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7f10ee0bd53673bfd52b67cbce83336fe6cad90d2377b03baf66491d2bbfb91", size = 149460, upload-time = "2026-06-20T23:47:34.712Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9b/12e23264d8f4735e8483262f95c5a6b03c3665fd2a84bdf99a45b6a2f4ec/wrapt-2.2.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4402f57c5f0d0579599858ffbdd9bf4e3f0972f51096f2bd6cc7dab6b76ee49e", size = 153648, upload-time = "2026-06-20T23:47:36.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a3/bcd5ec37289dcd85ecd4d15395a6a6063d60bc45ff94a9d77814e1e54d64/wrapt-2.2.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3a4eb7964ff4643d333c84f880bcf554652b2a1050aebc54ae696327f61acfaf", size = 148502, upload-time = "2026-06-20T23:47:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/be/716d708f607fa70f8a6eb47dff8ee945d5278dfc89ffeeff33039d052e63/wrapt-2.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e542b7c5af91e2123a8aabf19894319d5ec4268d2a9ffd2f239386133fc47746", size = 152238, upload-time = "2026-06-20T23:47:39.118Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c0/1a48e7e54501274f5d906f18372221b13183b0afbb5b8bb4c7ca0392c0b4/wrapt-2.2.2-cp310-cp310-win32.whl", hash = "sha256:6e7e45b43d3c774d244fe7264378f5a3f0f383bc55a54a9866434e524540110f", size = 77278, upload-time = "2026-06-20T23:47:40.476Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/82/9cd69a1af288fbdedf01a10e3c8a0b6890b08c7f3f96d36a213699dbcd94/wrapt-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:955f1d6e72a352e478de8d8b503abe301c5e139a141b62eb0923bd694995025f", size = 80131, upload-time = "2026-06-20T23:47:41.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/73/8db7e27daef37ae70a53ea62bef7fe80cc51a8b5e9e9181a8be6eb9a999c/wrapt-2.2.2-cp310-cp310-win_arm64.whl", hash = "sha256:b89d8d73c82db2bb7e6090b3afd7973f980d24e905cc34394eab60b884b3bf67", size = 79615, upload-time = "2026-06-20T23:47:43.109Z" },
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]

--- a/src/praisonai/praisonai/cli/features/sandbox_cli.py
+++ b/src/praisonai/praisonai/cli/features/sandbox_cli.py
@@ -15,6 +15,16 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
+def _ensure_backends():
+    """Bootstrap praisonai-sandbox before registry imports (fail loud if missing)."""
+    try:
+        from praisonai._bootstrap import ensure_praisonai_sandbox
+
+        ensure_praisonai_sandbox()
+    except ImportError:
+        pass
+
+
 class SandboxHandler:
     """Handler for sandbox CLI commands."""
     
@@ -38,6 +48,8 @@ class SandboxHandler:
         if not code and not file:
             print("Error: Provide code via --code or --file")
             return
+        
+        _ensure_backends()
         
         if file:
             if not os.path.exists(file):
@@ -111,6 +123,7 @@ class SandboxHandler:
             sandbox_type: Type of sandbox (subprocess, docker)
             image: Docker image to use
         """
+        _ensure_backends()
         try:
             from praisonaiagents.sandbox import ResourceLimits
             
@@ -176,21 +189,18 @@ class SandboxHandler:
         asyncio.run(run_shell())
     
     def status(self) -> None:
-        """Check sandbox availability."""
-        print("Sandbox Status:")
+        """Check sandbox backend availability."""
+        print("Sandbox backends:")
         print()
-        
-        print("Subprocess sandbox: Available")
-        
         try:
-            from praisonai_sandbox import DockerSandbox
-            sandbox = DockerSandbox()
-            if sandbox.is_available:
-                print("Docker sandbox: Available")
-            else:
-                print("Docker sandbox: Not available (Docker not running)")
-        except ImportError:
-            print("Docker sandbox: Not available (dependencies not installed)")
+            from praisonaiagents.sandbox import SandboxManager, SandboxConfig
+
+            manager = SandboxManager(SandboxConfig.subprocess())
+            for name, info in sorted(manager.get_available_types().items()):
+                flag = "Available" if info.get("available") else "Unavailable"
+                print(f"  {name}: {flag}")
+        except ImportError as exc:
+            print(f"  Error: {exc}")
 
 
 def handle_sandbox_command(args) -> None:

--- a/src/praisonai/praisonai/cli/features/sandbox_cli.py
+++ b/src/praisonai/praisonai/cli/features/sandbox_cli.py
@@ -255,7 +255,7 @@ def add_sandbox_parser(subparsers) -> None:
     )
     run_parser.add_argument(
         "--type", "-t",
-        choices=["subprocess", "docker"],
+        choices=["subprocess", "docker", "daytona"],
         default="subprocess",
         help="Sandbox type (default: subprocess)",
     )
@@ -277,7 +277,7 @@ def add_sandbox_parser(subparsers) -> None:
     )
     shell_parser.add_argument(
         "--type", "-t",
-        choices=["subprocess", "docker"],
+        choices=["subprocess", "docker", "daytona"],
         default="subprocess",
         help="Sandbox type (default: subprocess)",
     )

--- a/src/praisonai/tests/PRAISONAI_SANDBOX_MANIFEST.md
+++ b/src/praisonai/tests/PRAISONAI_SANDBOX_MANIFEST.md
@@ -1,6 +1,6 @@
 # praisonai-sandbox Boundary Manifest (C13)
 
-> **Status:** C13 extraction. PyPI package `praisonai-sandbox` (0.0.1+). Wrapper shims preserve `praisonai.sandbox.*` imports.
+> **Status:** implemented. PyPI package `praisonai-sandbox` (0.0.1+). Wrapper shims preserve `praisonai.sandbox.*` imports.
 
 ## Eight-package stack
 
@@ -26,8 +26,9 @@ praisonaiagents → praisonai-code + praisonai-bot + praisonai-train + praisonai
 | `praisonai_sandbox/sandlock.py` | Landlock/seccomp |
 | `praisonai_sandbox/ssh.py` | Remote SSH |
 | `praisonai_sandbox/modal.py` | Modal serverless |
-| `praisonai_sandbox/daytona.py` | Stub backend |
+| `praisonai_sandbox/daytona.py` | Daytona cloud (`daytona-sdk`) |
 | `praisonai_sandbox/_registry.py` | `SandboxRegistry` + entry-point group `praisonai.sandbox` |
+| `praisonai_sandbox/_plugin_registry.py` | Lazy `PluginRegistry` bridge to `praisonai_code` |
 | `praisonai_sandbox/_compat.py` | Path safety helper |
 | `praisonai_sandbox/_shell.py` | argv builder |
 | `praisonai_sandbox/_code_bridge.py` | Lazy `PluginRegistry` from `praisonai_code` |
@@ -56,14 +57,14 @@ Console script: `praisonai-sandbox = praisonai_sandbox.__main__:main`
 
 | Path | Notes |
 |------|-------|
-| `praisonai_code/cli/commands/sandbox.py` | Container mgmt Typer (`status/explain/list/recreate`) |
+| `praisonai_code/cli/commands/sandbox.py` | Typer: `run`/`shell`/`backends` (code-exec) + `status`/`explain`/`list`/`recreate` (containers) |
 | `praisonai_code/cli/features/sandbox_executor.py` | `--sandbox` flag executor |
 
 ## Stays in `praisonai` wrapper
 
 | Path | Notes |
 |------|-------|
-| `praisonai/cli/features/sandbox_cli.py` | Legacy code-exec handler (`run/shell/status`) |
+| `praisonai/cli/features/sandbox_cli.py` | `SandboxHandler` for code-exec (delegated from Typer `run`/`shell`/`backends`) |
 | `praisonai/SANDLOCK_README.md` | Sandlock user guide |
 
 ## Install matrix
@@ -74,7 +75,7 @@ Console script: `praisonai-sandbox = praisonai_sandbox.__main__:main`
 | `pip install praisonai-sandbox` | ✅ | host docker | `[sandlock]` | `[e2b]` | entry points |
 | `pip install "praisonai[sandbox]"` | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-Backend extras on `praisonai-sandbox`: `[docker]`, `[e2b]`, `[sandlock]`, `[ssh]`, `[modal]`, `[all]`.
+Backend extras on `praisonai-sandbox`: `[docker]`, `[e2b]`, `[sandlock]`, `[ssh]`, `[modal]`, `[daytona]`, `[all]`.
 
 ## Publish order
 

--- a/src/praisonai/tests/unit/test_c13_sandbox_backward_compat.py
+++ b/src/praisonai/tests/unit/test_c13_sandbox_backward_compat.py
@@ -56,6 +56,18 @@ class TestSandboxModuleIdentity:
 
         assert OldCls is NewCls
 
+    @pytest.mark.parametrize(
+        "name",
+        ["SubprocessSandbox", "E2BSandbox", "ModalSandbox", "DaytonaSandbox"],
+    )
+    def test_lazy_class_exports(self, name: str):
+        from praisonai_sandbox import __getattr__ as lazy_get
+
+        cls = lazy_get(name)
+        from praisonai.sandbox import __getattr__ as shim_get
+
+        assert shim_get(name) is cls
+
     def test_no_nested_shadow_package(self):
         nested = WRAPPER_PKG / "praisonai" / "praisonai_sandbox"
         assert not nested.exists()
@@ -75,3 +87,37 @@ class TestSandboxBridge:
         assert "praisonai_sandbox.docker" not in sys.modules
         assert "praisonai_sandbox.modal" not in sys.modules
         assert "praisonai_sandbox.e2b" not in sys.modules
+
+    def test_resolve_subprocess_class(self):
+        from praisonaiagents.sandbox._sandbox_bridge import resolve_sandbox_class
+        from praisonai_sandbox import SubprocessSandbox
+
+        assert resolve_sandbox_class("subprocess") is SubprocessSandbox
+
+    def test_get_sandbox_registry(self):
+        from praisonaiagents.sandbox._sandbox_bridge import get_sandbox_registry
+
+        registry = get_sandbox_registry().default()
+        assert "subprocess" in registry.list_names()
+
+    def test_sandbox_install_hint(self):
+        from praisonaiagents.sandbox._sandbox_bridge import sandbox_install_hint
+
+        assert "docker" in sandbox_install_hint("docker").lower()
+
+
+class TestSandboxCliRouting:
+    def test_sandbox_typer_command_resolves(self):
+        import click
+        from praisonai_code.cli.app import app  # noqa: F401
+        from typer.main import get_command as typer_get_command
+
+        root = typer_get_command(app)
+        ctx = click.Context(root)
+        assert root.get_command(ctx, "sandbox") is not None
+
+    def test_sandbox_run_and_backends_commands(self):
+        from praisonai_code.cli.commands import sandbox as sandbox_mod
+
+        assert hasattr(sandbox_mod, "sandbox_run")
+        assert hasattr(sandbox_mod, "sandbox_backends")


### PR DESCRIPTION
## Summary

- Unifies the sandbox CLI: `praisonai sandbox run`, `shell`, and `backends` now work via Typer (delegating to wrapper `SandboxHandler`); legacy argparse path routes to Typer; container commands (`status`/`explain`/`list`/`recreate`) unchanged.
- Implements real `DaytonaSandbox` using `daytona-sdk` (mirrors compute provider pattern); adds `[daytona]` extra and rewrites unit tests.
- Expands live integration tests (subprocess, Docker, manager bridge, shim); `backends` status uses `SandboxManager.get_available_types()`.
- Extends C13 backward-compat tests (lazy exports, bridge resolution, CLI routing) and updates manifest to **implemented**; adds C12 import gate to MCP CI shard.
- Regenerates `praisonai-sandbox/uv.lock` and `praisonai-agents/uv.lock` (drops stale sandbox extras).

## Deferred items closed

| Gap | Resolution |
|-----|------------|
| Typer `sandbox run` collision | `run`/`shell`/`backends` Typer commands + legacy → Typer delegation |
| Daytona stub | Full `daytona-sdk` backend |
| E2B mock skips | Already realigned on main (104 unit tests pass) |
| Live Docker coverage | `test_docker_live_execute` + manager docker live |
| Thin backward-compat | +9 tests (bridge, CLI, lazy exports) |
| Stale agents lock | Regenerated |

## Test plan

- [x] `bash scripts/check_c13_sandbox_imports.sh`
- [x] `pytest src/praisonai-sandbox/tests -m "not network"` — **104 passed**
- [x] `pytest src/praisonai/tests/unit/test_c13_sandbox_backward_compat.py` — **22 passed**
- [x] `pytest src/praisonai-agents/tests/unit/sandbox/` — **39 passed**
- [x] `pytest src/praisonai-sandbox/tests/test_live_sandbox.py -m network` — **5 passed** (Docker + subprocess); E2B/Daytona skipped (no keys in env)
- [x] `praisonai sandbox run --code "print(42)"` — prints `42`
- [x] `praisonai sandbox backends` — lists registry availability
- [ ] CI green

## Notes

- `src/praisonai/uv.lock` not regenerated — pre-existing `litellm`/`click`/`google-adk` resolver conflict unrelated to C13.
- E2B/Daytona live tests require `E2B_API_KEY` / `DAYTONA_API_KEY` in the environment.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `praisonai sandbox run`, `praisonai sandbox shell`, and `praisonai sandbox backends` for code execution and backend discovery.
  * Added a real Daytona cloud sandbox backend (via optional dependency extra).
* **Improvements**
  * Updated sandbox CLI help/status to list backend availability (available/unavailable) and improved help/error output.
  * Improved sandbox backend support by enabling `daytona` as a selectable execution type.
* **Bug Fixes**
  * Improved CI validation for MCP unit test shards by running import checks before tests.
* **Tests**
  * Reworked Daytona tests into behavioral coverage and expanded live integration tests for Docker and Daytona.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->