### PR TITLE
fix: use UTF-8 encoding in examples suite runner on Windows

### DIFF
--- a/src/praisonai/praisonai/suite_runner/runner.py
+++ b/src/praisonai/praisonai/suite_runner/runner.py
@@ -70,7 +70,10 @@ class ScriptRunner:
         
         # Apply overrides
         env.update(self.env_overrides)
-        
+
+        # Ensure child Python processes emit UTF-8 on Windows (avoid cp1252 decode errors)
+        env.setdefault("PYTHONIOENCODING", "utf-8")
+
         return env
     
     def check_required_env(self, require_env: List[str]) -> Optional[str]:
@@ -167,6 +170,8 @@ class ScriptRunner:
                     env=env,
                     cwd=cwd,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     bufsize=1,
                 )
                 
@@ -219,6 +224,8 @@ class ScriptRunner:
                     cmd,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=timeout,
                     env=env,
                     cwd=cwd,

--- a/src/praisonai/tests/unit/suite_runner/test_suite_runner.py
+++ b/src/praisonai/tests/unit/suite_runner/test_suite_runner.py
@@ -297,7 +297,7 @@ class TestSuiteReporter:
             
             assert md_path.exists()
             assert md_path.name == "report.md"
-            content = md_path.read_text()
+            content = md_path.read_text(encoding="utf-8")
             assert "Examples Execution Report" in content
     
     def test_generate_csv(self):


### PR DESCRIPTION

**Impact:**
- `praisonai examples run-all` unreliable on Windows
- Example reports incomplete or missing
- False failures / inability to distinguish real example bugs from runner crashes

---

## Root cause

| Component | Issue |
|-----------|--------|
| `ScriptRunner.run()` → `subprocess.run()` | No `encoding=` → cp1252 on Windows |
| `ScriptRunner.run()` → `subprocess.Popen()` | Same for streaming path |
| Child Python processes | No `PYTHONIOENCODING` set |
| `test_generate_markdown` | Read UTF-8 report with default cp1252 on Windows |

Linux/macOS often tolerate this; Windows does not.

---

## Fix

### 1. `src/praisonai/praisonai/suite_runner/runner.py`

- Add `encoding="utf-8"` and `errors="replace"` to both `subprocess.Popen` and `subprocess.run`
- Set `PYTHONIOENCODING=utf-8` in `_build_env()` for child processes

### 2. `src/praisonai/tests/unit/suite_runner/test_suite_runner.py`

- Read markdown reports with `read_text(encoding="utf-8")` so Windows tests pass

---

## Files changed

| File | Change |
|------|--------|
| `src/praisonai/praisonai/suite_runner/runner.py` | UTF-8 subprocess capture + child env |
| `src/praisonai/tests/unit/suite_runner/test_suite_runner.py` | UTF-8 report read in test |

---

## Verification

```bash
# Unit tests
pytest src/praisonai/tests/unit/suite_runner/test_suite_runner.py -q
# Result: 23 passed

# Smoke — consolidated_params group (21 examples)
python -c "from praisonai.cli.commands.examples import app; app(['run','--path','examples','--group','consolidated_params','--no-stream','--quiet'], standalone_mode=False)"
# Result: no UnicodeDecodeError; examples run to completion (some timeout due to test API key — expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess output handling on Windows by consistently decoding command output as UTF-8.
  * Prevented execution failures caused by unexpected or unsupported characters in streamed and captured output.
  * Added graceful replacement for invalid byte sequences to keep command results available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->