### PR TITLE
fix: unblock auto-merge when smoke/windows cancel but core CI passes

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -72,6 +72,29 @@ assert('bestRunsByName prefers success over cancelled', (() => {
   ]);
   return best.length === 1 && best[0].conclusion === 'success';
 })());
+assert('bestRunsByName prefers pending over completed cancelled', (() => {
+  const best = mg.bestRunsByName([
+    { name: 'smoke', status: 'completed', conclusion: 'cancelled' },
+    { name: 'smoke', status: 'in_progress', conclusion: null },
+  ]);
+  return best.length === 1 && best[0].status === 'in_progress';
+})());
+assert('bestRunsByName keeps pending regardless of order', (() => {
+  const best = mg.bestRunsByName([
+    { name: 'smoke', status: 'in_progress', conclusion: null },
+    { name: 'smoke', status: 'completed', conclusion: 'success' },
+  ]);
+  return best.length === 1 && best[0].status === 'in_progress';
+})());
+assert('allChecksGreenOnSha style: pending re-run blocks despite core green', (() => {
+  const runs = mg.bestRunsByName([
+    { name: 'test-core', status: 'completed', conclusion: 'success' },
+    { name: 'smoke', status: 'completed', conclusion: 'cancelled' },
+    { name: 'smoke', status: 'queued', conclusion: null },
+  ]);
+  const smoke = runs.find((r) => r.name === 'smoke');
+  return smoke.status !== 'completed';
+})());
 
 // Stale-FINAL recovery guards (PR #2560 push loop)
 const nowMs = Date.now();

--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -40,6 +40,39 @@ assert('claude final reply detected', mg.isClaudeFinalReplyComment(withClaudeRep
 
 assert('cancelled detect-and-trigger does not block', mg.OPTIONAL_CANCELLED_CHECKS.has('detect-and-trigger'));
 
+const coreGreenRuns = [
+  { name: 'test-core', status: 'completed', conclusion: 'success' },
+  { name: 'test-core (cli)', status: 'completed', conclusion: 'success' },
+  { name: 'smoke', status: 'completed', conclusion: 'cancelled' },
+  { name: 'test-windows', status: 'completed', conclusion: 'cancelled' },
+];
+assert('core green allows cancelled smoke', mg.isAcceptableCheckConclusion(
+  { name: 'smoke', status: 'completed', conclusion: 'cancelled' },
+  coreGreenRuns
+));
+assert('core green allows cancelled test-windows', mg.isAcceptableCheckConclusion(
+  { name: 'test-windows', status: 'completed', conclusion: 'cancelled' },
+  coreGreenRuns
+));
+assert('cancelled smoke blocks when core missing', !mg.isAcceptableCheckConclusion(
+  { name: 'smoke', status: 'completed', conclusion: 'cancelled' },
+  [{ name: 'smoke', status: 'completed', conclusion: 'cancelled' }]
+));
+assert('cancelled smoke blocks when core failed', !mg.isAcceptableCheckConclusion(
+  { name: 'smoke', status: 'completed', conclusion: 'cancelled' },
+  [
+    { name: 'test-core', status: 'completed', conclusion: 'failure' },
+    { name: 'smoke', status: 'completed', conclusion: 'cancelled' },
+  ]
+));
+assert('bestRunsByName prefers success over cancelled', (() => {
+  const best = mg.bestRunsByName([
+    { name: 'smoke', conclusion: 'cancelled' },
+    { name: 'smoke', conclusion: 'success' },
+  ]);
+  return best.length === 1 && best[0].conclusion === 'success';
+})());
+
 // Stale-FINAL recovery guards (PR #2560 push loop)
 const nowMs = Date.now();
 const iso = (ms) => new Date(ms).toISOString();

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -350,11 +350,26 @@ function checkConclusionRank(conclusion) {
   return 0;
 }
 
+function isPendingRun(run) {
+  return !!(run && run.status && run.status !== 'completed');
+}
+
 function bestRunsByName(runs) {
   const byName = new Map();
   for (const run of runs || []) {
+    if (!run) continue;
     const existing = byName.get(run.name);
-    if (!existing || checkConclusionRank(run.conclusion) > checkConclusionRank(existing.conclusion)) {
+    if (!existing) {
+      byName.set(run.name, run);
+      continue;
+    }
+    const runPending = isPendingRun(run);
+    const existingPending = isPendingRun(existing);
+    if (existingPending) continue;
+    if (
+      runPending ||
+      checkConclusionRank(run.conclusion) > checkConclusionRank(existing.conclusion)
+    ) {
       byName.set(run.name, run);
     }
   }
@@ -911,6 +926,7 @@ module.exports = {
   OPTIONAL_CANCELLED_WHEN_CORE_GREEN,
   isCoreTestRun,
   coreTestsGreenOnRuns,
+  isPendingRun,
   bestRunsByName,
   isAcceptableCheckConclusion,
   listChecksOnSha,

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -44,6 +44,8 @@ const BLOCK_LABELS = new Set([
 const MERGE_READY_LABEL = 'pipeline/merge-ready';
 /** Superseded concurrency runs; must not block merge when real tests passed. */
 const OPTIONAL_CANCELLED_CHECKS = new Set(['detect-and-trigger']);
+/** Cancelled smoke/windows after timeout are non-blocking when core shards passed on HEAD. */
+const OPTIONAL_CANCELLED_WHEN_CORE_GREEN = new Set(['smoke', 'test-windows']);
 const BOT_REVIEWER_PATTERNS = [
   'coderabbit',
   'qodo',
@@ -325,8 +327,55 @@ function listFailedChecksOnSha(runs) {
   });
 }
 
+function isCoreTestRun(run) {
+  const name = run?.name || '';
+  return name === 'test-core' || name.startsWith('test-core ') || name === 'test-core-collect';
+}
+
+function coreTestsGreenOnRuns(runs) {
+  const coreRuns = (runs || []).filter(isCoreTestRun);
+  if (coreRuns.length === 0) return false;
+  return coreRuns.every(
+    (run) =>
+      run.status === 'completed' &&
+      ['success', 'neutral', 'skipped'].includes(run.conclusion)
+  );
+}
+
+function checkConclusionRank(conclusion) {
+  if (conclusion === 'success') return 4;
+  if (conclusion === 'neutral') return 3;
+  if (conclusion === 'skipped') return 2;
+  if (conclusion === 'cancelled') return 1;
+  return 0;
+}
+
+function bestRunsByName(runs) {
+  const byName = new Map();
+  for (const run of runs || []) {
+    const existing = byName.get(run.name);
+    if (!existing || checkConclusionRank(run.conclusion) > checkConclusionRank(existing.conclusion)) {
+      byName.set(run.name, run);
+    }
+  }
+  return [...byName.values()];
+}
+
+function isAcceptableCheckConclusion(run, runs) {
+  if (['success', 'neutral', 'skipped'].includes(run.conclusion)) return true;
+  if (run.conclusion === 'cancelled' && OPTIONAL_CANCELLED_CHECKS.has(run.name)) return true;
+  if (
+    run.conclusion === 'cancelled' &&
+    OPTIONAL_CANCELLED_WHEN_CORE_GREEN.has(run.name) &&
+    coreTestsGreenOnRuns(runs)
+  ) {
+    return true;
+  }
+  return false;
+}
+
 async function allChecksGreenOnSha(github, owner, repo, sha, core) {
-  const runs = await listChecksOnSha(github, owner, repo, sha);
+  const runs = bestRunsByName(await listChecksOnSha(github, owner, repo, sha));
   if (runs.length === 0) {
     core?.info?.(`No check runs on ${sha.slice(0, 7)} — allowing (e.g. docs-only PR)`);
     return true;
@@ -336,12 +385,16 @@ async function allChecksGreenOnSha(github, owner, repo, sha, core) {
       core?.info?.(`Check pending: ${run.name} (${run.status})`);
       return false;
     }
-    const ok =
-      ['success', 'neutral', 'skipped'].includes(run.conclusion) ||
-      (run.conclusion === 'cancelled' && OPTIONAL_CANCELLED_CHECKS.has(run.name));
-    if (!ok) {
+    if (!isAcceptableCheckConclusion(run, runs)) {
       core?.info?.(`Check failed: ${run.name} (${run.conclusion})`);
       return false;
+    }
+    if (
+      run.conclusion === 'cancelled' &&
+      OPTIONAL_CANCELLED_WHEN_CORE_GREEN.has(run.name) &&
+      coreTestsGreenOnRuns(runs)
+    ) {
+      core?.info?.(`Ignoring cancelled ${run.name} — test-core green on HEAD`);
     }
   }
   return true;
@@ -855,6 +908,11 @@ module.exports = {
   finalClaudeCompletedOnSha,
   getMergeState,
   OPTIONAL_CANCELLED_CHECKS,
+  OPTIONAL_CANCELLED_WHEN_CORE_GREEN,
+  isCoreTestRun,
+  coreTestsGreenOnRuns,
+  bestRunsByName,
+  isAcceptableCheckConclusion,
   listChecksOnSha,
   listFailedChecksOnSha,
   allChecksGreenOnSha,

--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -42,7 +42,7 @@ jobs:
   # ============================================
   smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 12
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   test-windows:
     runs-on: windows-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_MODEL_NAME: gpt-4o-mini


### PR DESCRIPTION
## Summary
- Merge gate: treat `cancelled` `smoke` / `test-windows` as non-blocking when all `test-core*` shards succeeded on HEAD; dedupe check runs by best conclusion per name
- CI: raise `smoke` job timeout 8→12 min and `test-windows` 5→10 min to reduce timeout cancellations

## Context
Auto-merge was stuck on PRs like #3248 where FINAL Claude approved and `test-core` passed, but cancelled `smoke`/`test-windows` (job timeouts) made `allChecksGreenOnSha` fail → `pipeline/blocked:ci` → merge gate never ran.

## Test plan
- [x] `node .github/scripts/merge-gate-selftest.js`
- [ ] Merge and confirm stuck PRs (e.g. #3248) reach `pipeline/merge-ready` after pipeline sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved merge checks to choose the best outcome when multiple check runs share the same name.
  - Cancelled smoke and Windows checks no longer block merging when core test checks are green.
  - Cancelled checks still block merging when core checks are missing or not successful.
- **CI Improvements**
  - Increased smoke test timeout from 8 to 12 minutes.
  - Increased Windows test timeout from 5 to 10 minutes.
- **Tests**
  - Expanded merge-check self-test coverage for conclusion handling and run selection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->