### PR TITLE
fix: calculator division by zero handling

### DIFF
--- a/src/praisonai/tests/fixtures/ai_code_editor_fixture/src/mathlib/calculator.py
+++ b/src/praisonai/tests/fixtures/ai_code_editor_fixture/src/mathlib/calculator.py
@@ -15,7 +15,9 @@ class Calculator:
     def multiply(self, a, b):
         """Multiply two numbers."""
         return a * b
-    
+        
     def divide(self, a, b):
-        """Divide two numbers. INTENTIONAL BUG: No zero check."""
-        return a / b  # This should raise ValueError for division by zero
+        """Divide two numbers."""
+        if b == 0:
+            raise ValueError("Cannot divide by zero")
+        return a / b


### PR DESCRIPTION
## fix:  calculator division by zero handling

### Description

This PR fixes an issue in the calculator fixture where dividing a number by zero raised Python's default `ZeroDivisionError` instead of the expected `ValueError`.

The test suite expects `Calculator.divide()` to provide a clear and consistent error when division by zero is attempted:

```python
ValueError: Cannot divide by zero
```

### Changes Made

- Added an explicit zero check in `Calculator.divide()`
- Raise `ValueError("Cannot divide by zero")` when the divisor is `0`
- Preserved the existing behavior for valid division operations

### Testing

Ran:

```bash
pytest src/praisonai/tests/fixtures/ai_code_editor_fixture/tests/test_calculator.py
```

Result:

```text
5 passed
```

This confirms that the calculator fixture now handles division by zero according to the expected behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calculator division behavior by providing a clear error when attempting to divide by zero.
  * Normal division continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->