### PR TITLE
fix: E2E examples failures (Windows timeout, missing modules, broken examples)

### DIFF
--- a/examples/doctor/ci_integration.py
+++ b/examples/doctor/ci_integration.py
@@ -19,7 +19,9 @@ def run_doctor_ci():
         [sys.executable, "-m", "praisonai", "doctor", "ci"],
         capture_output=True,
         text=True,
-        timeout=120
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
     )
     
     # Parse JSON output

--- a/examples/knowledge/compression_demo.py
+++ b/examples/knowledge/compression_demo.py
@@ -149,21 +149,28 @@ def main():
             
             print(f"\nOriginal document length: {len(content)} characters")
             
+            chunks = [{"text": content, "metadata": {"source": doc_path}}]
+            target_tokens = 2000
+
             # Compress with different ratios
             for ratio in [0.3, 0.5, 0.7]:
-                compressor = ContextCompressor(
-                    max_tokens=2000,
-                    target_ratio=ratio,
+                compressor = ContextCompressor(verbose=False)
+                result = compressor.compress(
+                    chunks,
+                    query="security verification code",
+                    target_tokens=target_tokens,
+                    compression_ratio=ratio,
                 )
-                result = compressor.compress([content], query="security verification code")
                 
                 print(f"\nCompression ratio {ratio}:")
                 print(f"  Original tokens: {result.original_tokens}")
                 print(f"  Compressed tokens: {result.compressed_tokens}")
-                print(f"  Actual ratio: {result.compressed_tokens / max(result.original_tokens, 1):.2f}")
+                print(f"  Actual ratio: {result.compression_ratio:.2f}")
                 
                 # Check if secret code is preserved
-                compressed_text = " ".join(result.chunks) if result.chunks else ""
+                compressed_text = " ".join(
+                    c.get("text", "") for c in result.chunks
+                ) if result.chunks else ""
                 if SECRET_CODE in compressed_text:
                     print(f"  ✅ Secret code preserved in compressed output")
                 else:

--- a/examples/routing/routellm_workflow.py
+++ b/examples/routing/routellm_workflow.py
@@ -12,7 +12,7 @@ Prerequisites:
      --port 6060
 """
 
-from praisonaiagents import Agent, Workflow
+from praisonaiagents import Agent, AgentFlow, Workflow
 
 ROUTELLM_URL = "http://localhost:6060/v1"
 

--- a/examples/workflow_output_modes.py
+++ b/examples/workflow_output_modes.py
@@ -13,7 +13,7 @@ Available presets:
 - json: JSONL output for piping
 """
 
-from praisonaiagents import Agent, Workflow
+from praisonaiagents import Agent, AgentFlow, Workflow
 
 
 def main():

--- a/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
@@ -20,9 +20,13 @@ from ._lazy_display import _get_console, _get_live, _get_display_functions
 
 logger = logging.getLogger(__name__)
 
-
-
 from typing import List, Optional, Any, Dict, Union, Generator, TYPE_CHECKING
+
+# Shared HTTP launch state (Agent.launch() multi-endpoint registration)
+_server_lock = threading.Lock()
+_server_started: Dict[int, bool] = {}
+_registered_agents: Dict[int, Dict[str, str]] = {}
+_shared_apps: Dict[int, Any] = {}
 
 if TYPE_CHECKING:
     pass

--- a/src/praisonai-bot/praisonai_bot/cli/features/bots_cli.py
+++ b/src/praisonai-bot/praisonai_bot/cli/features/bots_cli.py
@@ -978,7 +978,11 @@ class BotHandler:
         if capabilities.browser:
             try:
                 from praisonai_tools import BrowserBaseTool
-                tools.append(BrowserBaseTool())
+                browser_tool = BrowserBaseTool()
+                # Agent/LLM tool schema expects callables with __name__ (#E2E browser bot).
+                if not hasattr(browser_tool, "__name__"):
+                    browser_tool.__name__ = getattr(browser_tool, "name", "browserbase")
+                tools.append(browser_tool)
                 logger.info("Browser tool enabled")
             except ImportError:
                 logger.warning("Browser tool not available. Install praisonai-tools.")

--- a/src/praisonai-code/praisonai_code/cli/features/action_orchestrator.py
+++ b/src/praisonai-code/praisonai_code/cli/features/action_orchestrator.py
@@ -456,6 +456,31 @@ class ActionOrchestrator:
                     "returncode": -1
                 }
                 
+            # Honor an optional per-step working directory (relative to the
+            # workspace). Reject anything that escapes the workspace so a
+            # command can't be run outside the sandbox.
+            run_cwd = workspace
+            requested_cwd = step.params.get("cwd")
+            if requested_cwd:
+                candidate = (workspace / requested_cwd).resolve()
+                try:
+                    candidate.relative_to(workspace)
+                except ValueError:
+                    return {
+                        "command": step.target,
+                        "stdout": "",
+                        "stderr": f"cwd escapes workspace: {requested_cwd}",
+                        "returncode": -1,
+                    }
+                if not candidate.is_dir():
+                    return {
+                        "command": step.target,
+                        "stdout": "",
+                        "stderr": f"cwd not found: {requested_cwd}",
+                        "returncode": -1,
+                    }
+                run_cwd = candidate
+
             # Use shell=False with shlex.split for safer execution
             args = shlex.split(step.target)
             result = subprocess.run(
@@ -463,7 +488,7 @@ class ActionOrchestrator:
                 shell=False,  # Use shell=False for security
                 capture_output=True,
                 text=True,
-                cwd=str(workspace),
+                cwd=str(run_cwd),
                 timeout=30
             )
             return {

--- a/src/praisonai-code/praisonai_code/cli/features/agent_tools.py
+++ b/src/praisonai-code/praisonai_code/cli/features/agent_tools.py
@@ -1,0 +1,603 @@
+"""
+Agent-Centric Tools for PraisonAI Interactive Mode.
+
+These tools route file operations and code intelligence through LSP/ACP,
+making the Agent the central orchestrator for all actions.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Callable, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .interactive_runtime import InteractiveRuntime
+    from .code_intelligence import CodeIntelligenceRouter
+    from .action_orchestrator import ActionOrchestrator
+
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize_filepath(filepath: str, workspace: Optional[str] = None) -> str:
+    """Validate and sanitize a filepath against injection attacks.
+    
+    Raises ValueError if the path is unsafe.
+    """
+    # Reject null bytes (common injection technique)
+    if '\x00' in filepath:
+        raise ValueError("Null bytes are not allowed in file paths")
+    
+    # Reject obvious shell meta-characters in file names
+    if any(ch in filepath for ch in ('|', ';', '`', '$', '&', '\n', '\r')):
+        raise ValueError(f"Unsafe characters in filepath: {filepath!r}")
+    
+    # Reject absolute paths — files must be relative to workspace
+    if os.path.isabs(filepath):
+        raise ValueError(f"Absolute paths are not allowed: {filepath!r}")
+    
+    # Normalize and reject path traversal
+    normalized = os.path.normpath(filepath)
+    if '..' in normalized.split(os.sep):
+        raise ValueError(f"Path traversal detected in: {filepath!r}")
+    
+    # If we have a workspace, ensure the resolved path stays within it
+    if workspace:
+        resolved = Path(os.path.realpath(os.path.join(workspace, normalized)))
+        ws_resolved = Path(os.path.realpath(workspace))
+        try:
+            resolved.relative_to(ws_resolved)
+        except ValueError:
+            raise ValueError(
+                f"Path {filepath!r} resolves outside workspace {workspace!r}"
+            )
+    
+    return normalized
+
+
+def _sanitize_command(command: str) -> str:
+    """Basic command sanitization — reject common injection vectors.
+    
+    The command still goes through ACP approval flow, but this prevents
+    the most egregious prompt-injection-to-shell-injection chains.
+    
+    Raises ValueError if dangerous patterns are detected.
+    """
+    if '\x00' in command:
+        raise ValueError("Null bytes are not allowed in commands")
+    
+    # Reject command chaining operators that indicate injection
+    DANGEROUS_PATTERNS = [
+        '$(', '`',      # Command substitution
+        '&&', '||',     # Command chaining
+        '>>', '>',      # Output redirection
+        '|', ';', '&',  # Pipe and separators
+        '\n', '\r'      # Line breaks
+    ]
+    for pattern in DANGEROUS_PATTERNS:
+        if pattern in command:
+            raise ValueError(
+                f"Potentially unsafe command pattern detected: {pattern!r} "
+                f"in command: {command!r}. Use separate commands instead."
+            )
+    
+    return command
+
+
+def create_agent_centric_tools(
+    runtime: "InteractiveRuntime",
+    router: "CodeIntelligenceRouter" = None,
+    orchestrator: "ActionOrchestrator" = None
+) -> List[Callable]:
+    """
+    Create tools that route through LSP/ACP for agent-centric architecture.
+    
+    Args:
+        runtime: The InteractiveRuntime instance
+        router: Optional CodeIntelligenceRouter (created if not provided)
+        orchestrator: Optional ActionOrchestrator (created if not provided)
+        
+    Returns:
+        List of tool functions for the Agent
+    """
+    from .code_intelligence import CodeIntelligenceRouter
+    from .action_orchestrator import ActionOrchestrator
+    
+    if router is None:
+        router = CodeIntelligenceRouter(runtime)
+    if orchestrator is None:
+        orchestrator = ActionOrchestrator(runtime)
+    
+    # Helper to run async functions synchronously using the shared bridge
+    from praisonai._async_bridge import run_sync
+    
+    # =========================================================================
+    # ACP-Powered File Tools
+    # =========================================================================
+    
+    def acp_create_file(filepath: str, content: str) -> str:
+        """
+        Create a file through ACP with plan/approve/apply/verify flow.
+        
+        This tool routes file creation through the ActionOrchestrator,
+        ensuring proper tracking, approval, and verification.
+        
+        Args:
+            filepath: Path to the file to create (relative to workspace)
+            content: Content to write to the file
+            
+        Returns:
+            JSON string with result including plan status and verification
+        """
+        async def _create():
+            # Validate filepath
+            try:
+                safe_path = _sanitize_filepath(
+                    filepath, 
+                    workspace=getattr(runtime.config, 'workspace', None)
+                )
+            except ValueError as e:
+                return json.dumps({"success": False, "error": str(e)})
+            
+            # Build a detailed prompt for the orchestrator
+            prompt = f"create file {safe_path}"
+            
+            # Create plan
+            result = await orchestrator.create_plan(prompt)
+            if not result.success:
+                return json.dumps({
+                    "success": False,
+                    "error": result.error,
+                    "read_only": result.read_only_blocked
+                })
+            
+            plan = result.plan
+            
+            # Update the plan step with actual content
+            if plan.steps:
+                plan.steps[0].params["content"] = content
+            
+            # Approve based on runtime config
+            auto_approve = runtime.config.approval_mode == "auto"
+            approved = await orchestrator.approve_plan(plan, auto=auto_approve)
+            
+            if not approved and runtime.config.approval_mode == "manual":
+                return json.dumps({
+                    "success": False,
+                    "error": "Manual approval required",
+                    "plan": plan.to_dict(),
+                    "requires_approval": True
+                })
+            
+            # Apply the plan
+            result = await orchestrator.apply_plan(plan, force=auto_approve)
+            if not result.success:
+                return json.dumps({
+                    "success": False,
+                    "error": result.error,
+                    "plan": plan.to_dict()
+                })
+            
+            # Verify
+            result = await orchestrator.verify_plan(plan)
+            
+            return json.dumps({
+                "success": result.success,
+                "file_created": filepath,
+                "plan_id": plan.id,
+                "status": plan.status.value,
+                "verified": result.success
+            })
+        
+        return run_sync(_create())
+    
+    def acp_edit_file(filepath: str, new_content: str) -> str:
+        """
+        Edit a file through ACP with plan/approve/apply/verify flow.
+        
+        Args:
+            filepath: Path to the file to edit (relative to workspace)
+            new_content: New content for the file
+            
+        Returns:
+            JSON string with result including plan status
+        """
+        async def _edit():
+            try:
+                safe_path = _sanitize_filepath(
+                    filepath,
+                    workspace=getattr(runtime.config, 'workspace', None)
+                )
+            except ValueError as e:
+                return json.dumps({"success": False, "error": str(e)})
+            
+            prompt = f"edit file {safe_path}"
+            
+            result = await orchestrator.create_plan(prompt)
+            if not result.success:
+                return json.dumps({
+                    "success": False,
+                    "error": result.error,
+                    "read_only": result.read_only_blocked
+                })
+            
+            plan = result.plan
+            
+            # Update step with new content
+            if plan.steps:
+                plan.steps[0].params["new_content"] = new_content
+            
+            auto_approve = runtime.config.approval_mode == "auto"
+            approved = await orchestrator.approve_plan(plan, auto=auto_approve)
+            
+            if not approved and runtime.config.approval_mode == "manual":
+                return json.dumps({
+                    "success": False,
+                    "error": "Manual approval required",
+                    "requires_approval": True
+                })
+            
+            result = await orchestrator.apply_plan(plan, force=auto_approve)
+            
+            return json.dumps({
+                "success": result.success,
+                "file_edited": filepath,
+                "plan_id": plan.id,
+                "error": result.error
+            })
+        
+        return run_sync(_edit())
+    
+    def acp_delete_file(filepath: str) -> str:
+        """
+        Delete a file through ACP with plan/approve/apply/verify flow.
+        
+        Args:
+            filepath: Path to the file to delete
+            
+        Returns:
+            JSON string with result
+        """
+        async def _delete():
+            try:
+                safe_path = _sanitize_filepath(
+                    filepath,
+                    workspace=getattr(runtime.config, 'workspace', None)
+                )
+            except ValueError as e:
+                return json.dumps({"success": False, "error": str(e)})
+            
+            prompt = f"delete file {safe_path}"
+            
+            result = await orchestrator.create_plan(prompt)
+            if not result.success:
+                return json.dumps({
+                    "success": False,
+                    "error": result.error
+                })
+            
+            plan = result.plan
+            
+            # Delete requires explicit approval even in auto mode
+            auto_approve = runtime.config.approval_mode == "auto"
+            approved = await orchestrator.approve_plan(plan, auto=auto_approve)
+            
+            if not approved:
+                return json.dumps({
+                    "success": False,
+                    "error": "Delete requires approval",
+                    "requires_approval": True
+                })
+            
+            result = await orchestrator.apply_plan(plan)
+            result = await orchestrator.verify_plan(plan)
+            
+            return json.dumps({
+                "success": result.success,
+                "file_deleted": filepath,
+                "verified": result.success
+            })
+        
+        return run_sync(_delete())
+    
+    def acp_execute_command(command: str, cwd: str = None) -> str:
+        """
+        Execute a shell command through ACP with tracking.
+        
+        Args:
+            command: The command to execute
+            cwd: Working directory (optional)
+            
+        Returns:
+            JSON string with command output
+        """
+        async def _execute():
+            try:
+                safe_cmd = _sanitize_command(command)
+            except ValueError as e:
+                return json.dumps({"success": False, "error": str(e)})
+            
+            prompt = f"run command: {safe_cmd}"
+            
+            result = await orchestrator.create_plan(prompt)
+            if not result.success:
+                return json.dumps({
+                    "success": False,
+                    "error": result.error
+                })
+            
+            plan = result.plan
+            
+            # Commands require approval
+            auto_approve = runtime.config.approval_mode == "auto"
+            approved = await orchestrator.approve_plan(plan, auto=auto_approve)
+            
+            if not approved:
+                return json.dumps({
+                    "success": False,
+                    "error": "Command requires approval",
+                    "requires_approval": True
+                })
+            
+            result = await orchestrator.apply_plan(plan)
+            
+            # Extract command result
+            if plan.steps and plan.steps[0].result:
+                cmd_result = plan.steps[0].result
+                return json.dumps({
+                    "success": result.success,
+                    "command": command,
+                    "stdout": cmd_result.get("stdout", ""),
+                    "stderr": cmd_result.get("stderr", ""),
+                    "returncode": cmd_result.get("returncode", -1)
+                })
+            
+            return json.dumps({
+                "success": result.success,
+                "error": result.error
+            })
+        
+        return run_sync(_execute())
+    
+    # =========================================================================
+    # LSP-Powered Code Intelligence Tools
+    # =========================================================================
+    
+    def lsp_list_symbols(file_path: str) -> str:
+        """
+        List all symbols (functions, classes, methods) in a file using LSP.
+        
+        Falls back to regex-based extraction if LSP is unavailable.
+        
+        Args:
+            file_path: Path to the file to analyze
+            
+        Returns:
+            JSON string with list of symbols and their locations
+        """
+        async def _list():
+            # Add 10s timeout to prevent LSP from blocking autonomy
+            try:
+                result = await asyncio.wait_for(
+                    router.handle_query(
+                        f"list all functions and classes in {file_path}",
+                        file_path=file_path
+                    ),
+                    timeout=10.0
+                )
+                return json.dumps(result.to_dict())
+            except asyncio.TimeoutError:
+                return json.dumps({"error": "LSP list_symbols timed out (10s)", "success": False})
+        
+        return run_sync(_list())
+    
+    def lsp_find_definition(symbol: str, file_path: str = None) -> str:
+        """
+        Find where a symbol is defined using LSP.
+        
+        Args:
+            symbol: The symbol name to find
+            file_path: Optional file path for context
+            
+        Returns:
+            JSON string with definition location(s)
+        """
+        async def _find():
+            query = f"where is {symbol} defined"
+            if file_path:
+                query += f" in {file_path}"
+            
+            # Add 10s timeout to prevent LSP from blocking autonomy
+            try:
+                result = await asyncio.wait_for(
+                    router.handle_query(query, file_path=file_path),
+                    timeout=10.0
+                )
+                return json.dumps(result.to_dict())
+            except asyncio.TimeoutError:
+                return json.dumps({"error": "LSP find_definition timed out (10s)", "success": False})
+        
+        return run_sync(_find())
+    
+    def lsp_find_references(symbol: str, file_path: str = None) -> str:
+        """
+        Find all references to a symbol using LSP.
+        
+        Args:
+            symbol: The symbol name to find references for
+            file_path: Optional file path for context
+            
+        Returns:
+            JSON string with reference locations
+        """
+        async def _find():
+            query = f"find all references to {symbol}"
+            if file_path:
+                query += f" in {file_path}"
+            
+            # Add 10s timeout to prevent LSP from blocking autonomy
+            try:
+                result = await asyncio.wait_for(
+                    router.handle_query(query, file_path=file_path),
+                    timeout=10.0
+                )
+                return json.dumps(result.to_dict())
+            except asyncio.TimeoutError:
+                return json.dumps({"error": "LSP find_references timed out (10s)", "success": False})
+        
+        return run_sync(_find())
+    
+    def lsp_get_diagnostics(file_path: str = None) -> str:
+        """
+        Get diagnostics (errors, warnings) for a file using LSP.
+        
+        Args:
+            file_path: Path to the file (optional, gets all if not specified)
+            
+        Returns:
+            JSON string with diagnostic information
+        """
+        async def _get():
+            query = "show all errors and warnings"
+            if file_path:
+                query += f" in {file_path}"
+            
+            # Add 10s timeout to prevent LSP from blocking autonomy
+            try:
+                result = await asyncio.wait_for(
+                    router.handle_query(query, file_path=file_path),
+                    timeout=10.0
+                )
+                return json.dumps(result.to_dict())
+            except asyncio.TimeoutError:
+                return json.dumps({"error": "LSP diagnostics timed out (10s)", "success": False})
+        
+        return run_sync(_get())
+    
+    # =========================================================================
+    # Basic File Tools (for read-only operations)
+    # =========================================================================
+    
+    def read_file(filepath: str) -> str:
+        """
+        Read content from a file.
+        
+        This is a read-only operation that doesn't require ACP.
+        
+        Args:
+            filepath: Path to the file to read
+            
+        Returns:
+            File content or error message
+        """
+        from pathlib import Path
+        
+        try:
+            path = Path(filepath)
+            if not path.is_absolute():
+                path = Path(runtime.config.workspace) / filepath
+            
+            # SECURITY: Ensure resolved path stays within workspace
+            resolved = path.resolve()
+            ws_resolved = Path(runtime.config.workspace).resolve()
+            try:
+                resolved.relative_to(ws_resolved)
+            except ValueError:
+                return json.dumps({"error": f"Path escapes workspace: {filepath}"})
+            
+            if not resolved.exists():
+                return json.dumps({"error": f"File not found: {filepath}"})
+            
+            content = resolved.read_text()
+            
+            # Track in trace if enabled
+            if runtime._trace:
+                runtime._trace.add_entry(
+                    category="file",
+                    action="read",
+                    params={"file": str(path)},
+                    result={"size": len(content)}
+                )
+            
+            return content
+            
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+    
+    def list_files(directory: str = ".", pattern: str = "*") -> str:
+        """
+        List files in a directory.
+        
+        Args:
+            directory: Directory to list (relative to workspace)
+            pattern: Glob pattern to filter files
+            
+        Returns:
+            JSON string with list of files
+        """
+        from pathlib import Path
+        
+        try:
+            path = Path(directory)
+            if not path.is_absolute():
+                path = Path(runtime.config.workspace) / directory
+            
+            # SECURITY: Ensure resolved path stays within workspace
+            resolved = path.resolve()
+            ws_resolved = Path(runtime.config.workspace).resolve()
+            try:
+                resolved.relative_to(ws_resolved)
+            except ValueError:
+                return json.dumps({"error": f"Directory escapes workspace: {directory}"})
+            
+            if not resolved.exists():
+                return json.dumps({"error": f"Directory not found: {directory}"})
+            
+            files = []
+            for f in path.glob(pattern):
+                files.append({
+                    "name": f.name,
+                    "path": str(f.relative_to(runtime.config.workspace)),
+                    "is_dir": f.is_dir(),
+                    "size": f.stat().st_size if f.is_file() else None
+                })
+            
+            return json.dumps({"files": files, "count": len(files)})
+            
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+    
+    # Return all tools
+    return [
+        # ACP-powered file tools
+        acp_create_file,
+        acp_edit_file,
+        acp_delete_file,
+        acp_execute_command,
+        # LSP-powered code intelligence
+        lsp_list_symbols,
+        lsp_find_definition,
+        lsp_find_references,
+        lsp_get_diagnostics,
+        # Basic read-only tools
+        read_file,
+        list_files,
+    ]
+
+
+def get_tool_descriptions() -> Dict[str, str]:
+    """Get descriptions of all agent-centric tools."""
+    return {
+        "acp_create_file": "Create a file through ACP with plan/approve/apply/verify",
+        "acp_edit_file": "Edit a file through ACP with tracking",
+        "acp_delete_file": "Delete a file through ACP (requires approval)",
+        "acp_execute_command": "Execute a shell command through ACP",
+        "lsp_list_symbols": "List symbols in a file using LSP",
+        "lsp_find_definition": "Find where a symbol is defined",
+        "lsp_find_references": "Find all references to a symbol",
+        "lsp_get_diagnostics": "Get errors and warnings for a file",
+        "read_file": "Read content from a file (read-only)",
+        "list_files": "List files in a directory",
+    }

--- a/src/praisonai-code/praisonai_code/cli/features/agent_tools.py
+++ b/src/praisonai-code/praisonai_code/cli/features/agent_tools.py
@@ -21,6 +21,26 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+def _run_sync(coro):
+    """Run a coroutine to completion from sync code without a wrapper dependency.
+
+    ``praisonai-code`` is a Tier-2 package and must not import the ``praisonai``
+    wrapper at the hot path (C7 gate / ARCHITECTURE §2). When no event loop is
+    running we use ``asyncio.run``; when one is already running (e.g. called from
+    within async agent execution) we offload to a worker thread so we never try
+    to nest ``asyncio.run`` on a live loop.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
 def _sanitize_filepath(filepath: str, workspace: Optional[str] = None) -> str:
     """Validate and sanitize a filepath against injection attacks.
     
@@ -110,9 +130,9 @@ def create_agent_centric_tools(
     if orchestrator is None:
         orchestrator = ActionOrchestrator(runtime)
     
-    # Helper to run async functions synchronously using the shared bridge
-    from praisonai._async_bridge import run_sync
-    
+    # Async→sync bridge (module-local; no wrapper dependency — see C7 gate).
+    run_sync = _run_sync
+
     # =========================================================================
     # ACP-Powered File Tools
     # =========================================================================
@@ -329,6 +349,12 @@ def create_agent_centric_tools(
                 })
             
             plan = result.plan
+            
+            # Forward the requested working directory into the command step so
+            # the orchestrator runs it there (relative to the workspace) instead
+            # of always at the workspace root.
+            if cwd and plan.steps:
+                plan.steps[0].params["cwd"] = cwd
             
             # Commands require approval
             auto_approve = runtime.config.approval_mode == "auto"

--- a/src/praisonai/praisonai/suite_runner/runner.py
+++ b/src/praisonai/praisonai/suite_runner/runner.py
@@ -179,7 +179,14 @@ class ScriptRunner:
         status = "passed"
         error_type = None
         error_message = None
-        
+
+        # On POSIX, put the child in its own process group so that killing it on
+        # timeout (os.killpg in _kill_process_tree) only reaps the child and its
+        # descendants — never the suite runner itself or sibling scripts.
+        popen_kwargs = {}
+        if os.name != "nt":
+            popen_kwargs["start_new_session"] = True
+
         try:
             if self.stream_output and on_output:
                 # Stream output in real-time
@@ -193,6 +200,7 @@ class ScriptRunner:
                     encoding="utf-8",
                     errors="replace",
                     bufsize=1,
+                    **popen_kwargs,
                 )
                 
                 import selectors
@@ -250,6 +258,7 @@ class ScriptRunner:
                     errors="replace",
                     env=env,
                     cwd=cwd,
+                    **popen_kwargs,
                 )
                 try:
                     stdout, stderr = process.communicate(timeout=timeout)

--- a/src/praisonai/praisonai/suite_runner/runner.py
+++ b/src/praisonai/praisonai/suite_runner/runner.py
@@ -75,6 +75,26 @@ class ScriptRunner:
         env.setdefault("PYTHONIOENCODING", "utf-8")
 
         return env
+
+    def _kill_process_tree(self, pid: int) -> None:
+        """Kill a process and its children (needed for uvicorn --reload on Windows)."""
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                capture_output=True,
+                check=False,
+            )
+            return
+
+        import signal
+
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
     
     def check_required_env(self, require_env: List[str]) -> Optional[str]:
         """
@@ -185,9 +205,9 @@ class ScriptRunner:
                 while process.poll() is None:
                     remaining = deadline - time.time()
                     if remaining <= 0:
-                        process.terminate()
+                        self._kill_process_tree(process.pid)
                         try:
-                            process.wait(timeout=2)
+                            process.wait(timeout=5)
                         except subprocess.TimeoutExpired:
                             process.kill()
                         status = "timeout"
@@ -219,20 +239,36 @@ class ScriptRunner:
                 exit_code = process.returncode or 0
                 
             else:
-                # Capture output without streaming
-                result = subprocess.run(
+                # Capture output without streaming (Popen + communicate so we
+                # can kill child processes on timeout — uvicorn --reload hangs on Windows).
+                process = subprocess.Popen(
                     cmd,
-                    capture_output=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
                     text=True,
                     encoding="utf-8",
                     errors="replace",
-                    timeout=timeout,
                     env=env,
                     cwd=cwd,
                 )
-                exit_code = result.returncode
-                stdout_data = [result.stdout] if result.stdout else []
-                stderr_data = [result.stderr] if result.stderr else []
+                try:
+                    stdout, stderr = process.communicate(timeout=timeout)
+                    exit_code = process.returncode or 0
+                    stdout_data = [stdout] if stdout else []
+                    stderr_data = [stderr] if stderr else []
+                except subprocess.TimeoutExpired as exc:
+                    self._kill_process_tree(process.pid)
+                    try:
+                        stdout, stderr = process.communicate(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        stdout, stderr = process.communicate()
+                    stdout_data = [stdout or exc.stdout or ""]
+                    stderr_data = [stderr or exc.stderr or ""]
+                    status = "timeout"
+                    error_type = "TimeoutError"
+                    error_message = f"Exceeded {timeout}s timeout"
+                    exit_code = -1
                 
         except subprocess.TimeoutExpired:
             status = "timeout"


### PR DESCRIPTION
## Summary
- Fix Windows suite-runner hangs on uvicorn/server examples by killing full subprocess trees on timeout
- Restore missing \_server_lock\ globals for \Agent.launch()\ (NameError in serve examples)
- Add missing \praisonai_code.cli.features.agent_tools\ module (ModuleNotFoundError in agent_tools examples)
- Fix \compression_demo.py\ to use current \ContextCompressor\ API
- Fix \workflow_output_modes.py\ and \outellm_workflow.py\ missing \AgentFlow\ import
- Fix \doctor/ci_integration.py\ UTF-8 decode on Windows
- Fix BrowserBaseTool \__name__\ for agent tool schema in bots CLI

## Context
From PraisonAI platform E2E examples audit (811 examples). Many failures are env/optional-deps/timeouts; this PR targets confirmed code/example bugs.

## Test plan
- [x] \compression_demo.py\ runs without TypeError
- [x] \workflow_output_modes.py\ runs without NameError
- [x] \rom praisonai_code.cli.features.agent_tools import create_agent_centric_tools\ succeeds
- [ ] Full \python\ examples batch still running in background (~234/542)
- [ ] \pytest tests/unit/suite_runner/test_suite_runner.py\

## Notes
Does not fix optional dependency failures (postgres, langfuse, clickhouse, etc.) or 90s server timeouts — those need separate triage after full E2E report.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive agent tools for safely reading, creating, editing, and deleting files, running commands, and performing code intelligence queries.
  - Improved support for registering multiple agent HTTP endpoints.
- **Bug Fixes**
  - Script execution now terminates full process trees more reliably on timeouts.
  - Browser tooling now reports consistent naming metadata.
  - CI output parsing now decodes subprocess output more robustly.
  - Command execution steps can now run from a validated working directory inside the workspace.
- **Documentation**
  - Updated example scripts and outputs to align with current interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->