### PR TITLE
fix: triage bug reports before "how to" question label

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,13 +49,13 @@ jobs:
             // --- Label triage ---
             const labels = [];
 
-            // Kind labels
+            // Kind labels (bug before "how to" — bug reports often include "## How to fix")
             if (content.includes('feature request') || content.includes('[feature')) {
               labels.push('enhancement');
-            } else if (title.includes('[question]') || content.includes('how do i') || content.includes('how to')) {
-              labels.push('question');
             } else if (content.includes('bug') || content.includes('error') || content.includes('crash') || content.includes('traceback')) {
               labels.push('bug');
+            } else if (title.includes('[question]') || content.includes('how do i') || (content.includes('how to') && !content.includes('how to fix'))) {
+              labels.push('question');
             } else if (content.includes('question')) {
               labels.push('question');
             }
@@ -108,7 +108,10 @@ jobs:
             // --- Auto-trigger Claude for owner issues and actionable external bug/enhancement reports ---
             const titleLower = (issue.title || '').toLowerCase();
             const hasActionableTitle = /^(\[[^\]]+\]|bug:|fix[:(]|feat:|ux:|enhancement:)/i.test(titleLower);
-            const autoClaude = isOwner || (hasActionableTitle && (labels.includes('bug') || labels.includes('enhancement')) && !labels.includes('question'));
+            const autoClaude = isOwner || (hasActionableTitle && (
+              labels.includes('bug') ||
+              (labels.includes('enhancement') && !labels.includes('question'))
+            ));
             if (autoClaude) {
               await github.rest.issues.addLabels({
                 issue_number: issue.number,

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,7 +52,7 @@ jobs:
             // Kind labels (bug before "how to" — bug reports often include "## How to fix")
             if (content.includes('feature request') || content.includes('[feature')) {
               labels.push('enhancement');
-            } else if (content.includes('bug') || content.includes('error') || content.includes('crash') || content.includes('traceback')) {
+            } else if (!title.includes('[question]') && (content.includes('bug') || content.includes('error') || content.includes('crash') || content.includes('traceback'))) {
               labels.push('bug');
             } else if (title.includes('[question]') || content.includes('how do i') || (content.includes('how to') && !content.includes('how to fix'))) {
               labels.push('question');


### PR DESCRIPTION
## Summary
- Run **bug/error/crash** kind detection **before** the `how to` / `how do i` question heuristics
- Exclude **`how to fix`** from question detection (common in structured bug reports)
- **`bug` label wins** for `autoClaude` even if a stale `question` label is also present

## Context
Dhivya Terminal-Bench issues #3280–#3282 were labelled `question` because the body includes `## How to fix`, which blocked Claude auto-triage. Manually re-triggered those four issues; this prevents recurrence.

## Test plan
- [x] Logic review against #3280 body (`[BUG]` title + `## How to fix`)
- [ ] Merge and confirm new external `[BUG]` issues get `bug` + `claude` automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated issue classification by prioritizing bug-related terms more reliably.
  * Refined question detection to avoid mislabeling “how to fix” style requests as general questions.
  * Updated auto-trigger logic so bug and enhancement issue handling follow the intended label-exclusion rules consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->