### PR TITLE
feat(train/data): task-aware script purity + translation-share metric

### DIFF
--- a/src/praisonai-train/praisonai_train/data/__init__.py
+++ b/src/praisonai-train/praisonai_train/data/__init__.py
@@ -7,7 +7,11 @@ Protocol-driven and extendable: recipes and QC checks self-register (see
 from praisonai_train.data import checks as _checks  # noqa: F401  registers checks
 from praisonai_train.data import recipes as _recipes  # noqa: F401  registers recipes
 from praisonai_train.data.generate import generate_dataset
+from praisonai_train.data.intent import translation_intent
 from praisonai_train.data.qc import filter_rows, score
 from praisonai_train.data.registry import checks, recipes
 
-__all__ = ["generate_dataset", "score", "filter_rows", "recipes", "checks"]
+__all__ = [
+    "generate_dataset", "score", "filter_rows", "recipes", "checks",
+    "translation_intent",
+]

--- a/src/praisonai-train/praisonai_train/data/checks.py
+++ b/src/praisonai-train/praisonai_train/data/checks.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 
 from praisonai_train.data._util import jaccard, norm
+from praisonai_train.data.intent import translation_intent
 from praisonai_train.data.registry import checks
 
 _BOILER = re.compile(
@@ -18,6 +19,28 @@ _BOILER = re.compile(
     re.I,
 )
 _ALPHA = re.compile(r"[^\W\d_]", re.UNICODE)
+
+
+def _script_ratio(output, cfg):
+    """Fraction of alphabetic chars inside the target script block (None if no
+    alphabetic chars — nothing to judge)."""
+    lo, hi = cfg.get("script_range", (0x0B80, 0x0BFF))
+    alpha = _ALPHA.findall(output or "")
+    if not alpha:
+        return None
+    return sum(1 for c in alpha if lo <= ord(c) <= hi) / len(alpha)
+
+
+def _target_is_english(instruction, cfg):
+    """True when this row is a resolved translation-INTO-English task, so its
+    output is legitimately English and must be exempted from the target-script
+    purity thresholds. Metadata (``task_type``) wins; text is the fallback. Only a
+    resolved English target exempts — en->ta / ambiguous / native stay strict.
+    Disabled by ``task_aware_purity: false``.
+    """
+    if not cfg.get("task_aware_purity", True):
+        return False
+    return translation_intent(instruction, cfg.get("task_type"))["expected_script"] == "english"
 
 
 @checks.register
@@ -40,30 +63,61 @@ class BoilerplateRefusal:
 
 @checks.register
 class LowScriptPurity:
+    """Drop rows whose output falls below the target-script purity floor.
+
+    TASK-AWARE: a translation-into-English row's correct output *is* English, so
+    exempt it here instead of deleting a legitimate row (see ``_target_is_english``).
+    """
+
     name = "low_script_purity"
     kind = "drop"
 
     def triggered(self, instruction, input, output, cfg):
-        lo, hi = cfg.get("script_range", (0x0B80, 0x0BFF))
-        alpha = _ALPHA.findall(output or "")
-        if not alpha:
+        if _target_is_english(instruction, cfg):
             return False
-        ratio = sum(1 for c in alpha if lo <= ord(c) <= hi) / len(alpha)
+        ratio = _script_ratio(output, cfg)
+        if ratio is None:
+            return False
         return ratio < cfg.get("script_drop", 0.50)
 
 
 @checks.register
 class ScriptReview:
+    """Flag borderline-purity rows for review — also skipped for English targets."""
+
     name = "script_review"
     kind = "flag"
 
     def triggered(self, instruction, input, output, cfg):
-        lo, hi = cfg.get("script_range", (0x0B80, 0x0BFF))
-        alpha = _ALPHA.findall(output or "")
-        if not alpha:
+        if _target_is_english(instruction, cfg):
             return False
-        ratio = sum(1 for c in alpha if lo <= ord(c) <= hi) / len(alpha)
+        ratio = _script_ratio(output, cfg)
+        if ratio is None:
+            return False
         return cfg.get("script_drop", 0.50) <= ratio < cfg.get("script_flag", 0.70)
+
+
+@checks.register
+class WrongTargetScript:
+    """Flag a *failed* translation: the task asked for English output but the
+    output is still mostly in the source script. Net-new signal that only the
+    task-aware path can surface — a naive purity filter would have kept this
+    silently (Tamil output passes a Tamil-purity check). Toggle with
+    ``verify_translation_target: false``.
+    """
+
+    name = "wrong_target_script"
+    kind = "flag"
+
+    def triggered(self, instruction, input, output, cfg):
+        if not cfg.get("verify_translation_target", True):
+            return False
+        if not _target_is_english(instruction, cfg):
+            return False
+        ratio = _script_ratio(output, cfg)
+        if ratio is None:
+            return False
+        return ratio >= cfg.get("script_drop", 0.50)
 
 
 @checks.register

--- a/src/praisonai-train/praisonai_train/data/intent.py
+++ b/src/praisonai-train/praisonai_train/data/intent.py
@@ -52,12 +52,14 @@ def translation_intent(instruction: str, task_type: str | None = None) -> dict:
     default rather than exempt the row).
     """
     # 1) Ground-truth metadata path (authoritative for generator-made rows).
-    if task_type:
-        if task_type == TA_EN_TASK:
-            return {"is_translation": True, "direction": "ta_en", "expected_script": "english"}
-        if task_type == EN_TA_TASK:
-            return {"is_translation": True, "direction": "en_ta", "expected_script": "tamil"}
-        return {"is_translation": False, "direction": None, "expected_script": None}
+    # Only the two labels the recipe stamps are authoritative; an *unrecognised*
+    # non-empty label (e.g. an external row tagged ``"translation"``) is NOT
+    # evidence the row is native, so we fall through to text detection rather than
+    # declaring it non-translation and losing a legitimate English output.
+    if task_type == TA_EN_TASK:
+        return {"is_translation": True, "direction": "ta_en", "expected_script": "english"}
+    if task_type == EN_TA_TASK:
+        return {"is_translation": True, "direction": "en_ta", "expected_script": "tamil"}
 
     # 2) Text-detection fallback (external rows without metadata).
     text = instruction or ""

--- a/src/praisonai-train/praisonai_train/data/intent.py
+++ b/src/praisonai-train/praisonai_train/data/intent.py
@@ -1,0 +1,73 @@
+"""Translation-intent detection — the single source of truth for task-awareness.
+
+Two QC features depend on knowing whether a row is a *translation* task and which
+script its output should be written in:
+
+* task-aware script purity (``checks.LowScriptPurity`` / ``ScriptReview`` /
+  ``WrongTargetScript``) — a Tamil->English row's correct output is English, so it
+  must be exempted from the Tamil-purity drop instead of being deleted as
+  "low_script_purity"; and
+* the corpus-level ``translation`` metric in ``qc.score`` — the fraction of rows
+  that are translation tasks, by direction.
+
+Both import ``translation_intent`` from here so they can never disagree (DRY).
+The generator's ground-truth ``task_type`` label is authoritative when present;
+for externally-sourced rows without metadata we fall back to keyword/directional
+cues on the instruction text. An unresolved direction yields *no* exemption (safe
+default) so garbage can never slip past the strict purity thresholds.
+"""
+from __future__ import annotations
+
+import re
+
+# Ground-truth task labels the Tamil recipe stamps (see ``recipes.Tamil``). Kept
+# here so the recipe axis label and the detector share one literal (no drift).
+EN_TA_TASK = "ஆங்கிலத்திலிருந்து தமிழுக்கு மொழிபெயர்ப்பு"  # en->ta (output: Tamil)
+TA_EN_TASK = "தமிழிலிருந்து ஆங்கிலத்துக்கு மொழிபெயர்ப்பு"  # ta->en (output: English)
+
+# Translation lemma: Tamil root 'மொழிபெயர்' covers every inflection; 'translat'
+# covers translate/translation/translated.
+_XLATE_RE = re.compile(r"மொழிபெயர்|translat", re.IGNORECASE)
+# Directional cues keyed to the language the OUTPUT should be written in.
+_TO_EN_RE = re.compile(  # -> English output (ta->en)
+    r"ஆங்கிலத்துக்கு|ஆங்கிலத்திற்கு|ஆங்கிலத்தில்|to\s+english|into\s+english|in\s+english",
+    re.IGNORECASE,
+)
+_TO_TA_RE = re.compile(  # -> Tamil output (en->ta)
+    r"தமிழுக்கு|தமிழிற்கு|தமிழில்|to\s+tamil|into\s+tamil|in\s+tamil",
+    re.IGNORECASE,
+)
+
+
+def translation_intent(instruction: str, task_type: str | None = None) -> dict:
+    """Classify a row's translation intent and the script its output should use.
+
+    Prefers the generator's ground-truth ``task_type`` label; falls back to
+    keyword/directional detection on the instruction text for external rows.
+
+    Returns ``{is_translation, direction, expected_script}`` where ``direction``
+    is ``'en_ta' | 'ta_en' | 'unknown' | None`` and ``expected_script`` is
+    ``'tamil' | 'english' | None`` (``None`` when the row is not translation or
+    the direction is unresolved — callers must then apply the strict Tamil-purity
+    default rather than exempt the row).
+    """
+    # 1) Ground-truth metadata path (authoritative for generator-made rows).
+    if task_type:
+        if task_type == TA_EN_TASK:
+            return {"is_translation": True, "direction": "ta_en", "expected_script": "english"}
+        if task_type == EN_TA_TASK:
+            return {"is_translation": True, "direction": "en_ta", "expected_script": "tamil"}
+        return {"is_translation": False, "direction": None, "expected_script": None}
+
+    # 2) Text-detection fallback (external rows without metadata).
+    text = instruction or ""
+    if not _XLATE_RE.search(text):
+        return {"is_translation": False, "direction": None, "expected_script": None}
+    to_en, to_ta = bool(_TO_EN_RE.search(text)), bool(_TO_TA_RE.search(text))
+    if to_en and not to_ta:
+        return {"is_translation": True, "direction": "ta_en", "expected_script": "english"}
+    if to_ta and not to_en:
+        return {"is_translation": True, "direction": "en_ta", "expected_script": "tamil"}
+    # Direction ambiguous ('both ways', neither/both named): it IS translation,
+    # but default SAFE — no script exemption — so garbage can't slip through.
+    return {"is_translation": True, "direction": "unknown", "expected_script": None}

--- a/src/praisonai-train/praisonai_train/data/qc.py
+++ b/src/praisonai-train/praisonai_train/data/qc.py
@@ -15,6 +15,7 @@ from typing import Any, Iterable
 
 from praisonai_train.data import checks as _checks_mod  # noqa: F401  (registers checks)
 from praisonai_train.data._util import fields, jaccard, ngrams, norm
+from praisonai_train.data.intent import translation_intent
 from praisonai_train.data.registry import checks
 
 
@@ -38,16 +39,20 @@ def score(rows: Iterable[dict], cfg: dict | None = None) -> dict[str, Any]:
             drops["exact_dup"] += 1
             continue
         seen.add(key)
+        # Per-row context: expose the generator's ground-truth ``task_type`` (when
+        # the row carries one) so task-aware checks can prefer metadata over text
+        # detection. Existing checks ignore the extra key.
+        rcfg = {**cfg, "task_type": r.get("task_type")} if isinstance(r, dict) else cfg
         dropped = False
         for c in drop_checks:
-            if c.triggered(ins, inp, out, cfg):
+            if c.triggered(ins, inp, out, rcfg):
                 drops[c.name] += 1
                 dropped = True
                 break
         if dropped:
             continue
         for c in flag_checks:
-            if c.triggered(ins, inp, out, cfg):
+            if c.triggered(ins, inp, out, rcfg):
                 flags[c.name] += 1
         kept.append(r)
 
@@ -71,6 +76,22 @@ def score(rows: Iterable[dict], cfg: dict | None = None) -> dict[str, Any]:
     prefixes = Counter(" ".join(norm(fields(r)[0]).split()[:5]) for r in kept)
     top_prefix = prefixes.most_common(1)[0][1] / max(len(kept), 1) if kept else 0.0
 
+    # Translation composition of the clean corpus. Computed with the SAME detector
+    # the task-aware purity checks use (praisonai_train.data.intent), so the share,
+    # the by-direction counts, and the exempted count always reconcile with the
+    # per-row exemptions. Denominator is the kept (post-dedup) content rows.
+    intents = [translation_intent(fields(r)[0], r.get("task_type") if isinstance(r, dict) else None)
+               for r in kept]
+    by_dir = Counter(i["direction"] or "unknown" for i in intents if i["is_translation"])
+    trans_n = sum(1 for i in intents if i["is_translation"])
+    exempted = sum(1 for i in intents if i["expected_script"] == "english")
+    translation = {
+        "share": round(trans_n / max(len(kept), 1), 3),
+        "by_direction": {"en_ta": by_dir["en_ta"], "ta_en": by_dir["ta_en"],
+                         "unknown": by_dir["unknown"]},
+        "exempted": exempted,
+    }
+
     warnings = []
     if distinct2 < 0.5:
         warnings.append(f"low instruction diversity (distinct-2={distinct2:.2f} < 0.5)")
@@ -89,6 +110,7 @@ def score(rows: Iterable[dict], cfg: dict | None = None) -> dict[str, Any]:
             "distinct_2": round(distinct2, 3),
             "length_cv": round(cv, 2),
             "top_prefix_share": round(top_prefix, 3),
+            "translation": translation,
         },
         "warnings": warnings,
     }

--- a/src/praisonai-train/praisonai_train/data/qc.py
+++ b/src/praisonai-train/praisonai_train/data/qc.py
@@ -14,6 +14,7 @@ from collections import Counter
 from typing import Any, Iterable
 
 from praisonai_train.data import checks as _checks_mod  # noqa: F401  (registers checks)
+from praisonai_train.data.checks import _script_ratio
 from praisonai_train.data._util import fields, jaccard, ngrams, norm
 from praisonai_train.data.intent import translation_intent
 from praisonai_train.data.registry import checks
@@ -84,7 +85,21 @@ def score(rows: Iterable[dict], cfg: dict | None = None) -> dict[str, Any]:
                for r in kept]
     by_dir = Counter(i["direction"] or "unknown" for i in intents if i["is_translation"])
     trans_n = sum(1 for i in intents if i["is_translation"])
-    exempted = sum(1 for i in intents if i["expected_script"] == "english")
+    # ``exempted`` = rows the English-target exemption *actually* rescued from the
+    # LowScriptPurity drop, so it reconciles with the check's behaviour: it counts
+    # an English-target row ONLY when task-awareness is on AND the output would
+    # otherwise have failed the purity floor (a failed translation whose Tamil
+    # output passes strict purity is caught by ``wrong_target_script``, not here).
+    task_aware = cfg.get("task_aware_purity", True)
+    drop_floor = cfg.get("script_drop", 0.50)
+    exempted = 0
+    if task_aware:
+        for r, i in zip(kept, intents):
+            if i["expected_script"] != "english":
+                continue
+            ratio = _script_ratio(fields(r)[2], cfg)
+            if ratio is not None and ratio < drop_floor:
+                exempted += 1
     translation = {
         "share": round(trans_n / max(len(kept), 1), 3),
         "by_direction": {"en_ta": by_dir["en_ta"], "ta_en": by_dir["ta_en"],

--- a/src/praisonai-train/praisonai_train/data/recipes.py
+++ b/src/praisonai-train/praisonai_train/data/recipes.py
@@ -6,6 +6,7 @@ another class, or define one inline in YAML via ``CustomRecipe``.
 """
 from __future__ import annotations
 
+from praisonai_train.data.intent import EN_TA_TASK
 from praisonai_train.data.registry import recipes
 
 
@@ -54,7 +55,7 @@ class Tamil(_AxisRecipe):
     )
     axes = {
         "task": ["ஒரு பொதுவான கேள்வி-பதில்", "ஒரு விளக்கம்", "ஒரு சுருக்கம்",
-                 "ஆங்கிலத்திலிருந்து தமிழுக்கு மொழிபெயர்ப்பு", "படைப்பாக்க எழுத்து",
+                 EN_TA_TASK, "படைப்பாக்க எழுத்து",
                  "நடைமுறை அறிவுரை", "பகுத்தறிவு/கணிதப் problem", "குறியீட்டு கேள்வி",
                  "கருத்து பகுப்பாய்வு", "படிப்படியான வழிகாட்டி"],
         "topic": ["தமிழ் இலக்கியம்", "வரலாறு", "அறிவியல்", "உடல்நலம்", "விவசாயம்",

--- a/src/praisonai-train/tests/unit/data/test_task_aware_qc.py
+++ b/src/praisonai-train/tests/unit/data/test_task_aware_qc.py
@@ -49,6 +49,19 @@ def test_intent_language_topic_without_translate_intent():
     assert i["is_translation"] is False
 
 
+def test_intent_unknown_metadata_falls_back_to_text():
+    # An external row with an UNRECOGNISED task_type must still honour a clear
+    # "translate into English" instruction via the text fallback — an unknown
+    # label is not evidence the row is native.
+    i = translation_intent("Translate this sentence into English.", task_type="translation")
+    assert i["is_translation"] is True and i["expected_script"] == "english"
+
+
+def test_intent_unknown_metadata_non_translation_text_stays_native():
+    i = translation_intent("Write a short story.", task_type="some_external_label")
+    assert i["is_translation"] is False and i["expected_script"] is None
+
+
 # ---- feature #1: task-aware purity via registered RowChecks ----------------
 
 def test_ta_en_english_output_recovered_via_metadata():
@@ -128,6 +141,26 @@ def test_translation_share_reconciles_with_exempted():
              "task_type": TA_EN_TASK} for n in range(3)]
     t = score(rows, {"near_dup": False})["metrics"]["translation"]
     assert t["by_direction"]["ta_en"] == t["exempted"] == 3
+
+
+def test_exempted_excludes_passing_purity_rows():
+    # A failed ta->en translation whose output is still pure Tamil passes strict
+    # purity on its own, so it was never *exempted* — it must NOT inflate the
+    # exempted count (it is surfaced via wrong_target_script instead).
+    rows = [{"instruction": "ஆங்கிலத்துக்கு மொழிபெயர்க்கவும்.", "input": "",
+             "output": TAMIL_OUT, "task_type": TA_EN_TASK}]
+    res = score(rows, {"near_dup": False})
+    assert res["metrics"]["translation"]["exempted"] == 0
+    assert res["flags"].get("wrong_target_script") == 1
+
+
+def test_exempted_zero_when_task_aware_disabled():
+    # With task-awareness off the row is dropped, not exempted; the metric must
+    # agree with the check behaviour it claims to measure.
+    rows = [{"instruction": "மொழிபெயர்க்க", "input": "", "output": ENGLISH_OUT,
+             "task_type": TA_EN_TASK}]
+    res = score(rows, {"near_dup": False, "task_aware_purity": False})
+    assert res["metrics"]["translation"]["exempted"] == 0
 
 
 def test_empty_corpus_guard():

--- a/src/praisonai-train/tests/unit/data/test_task_aware_qc.py
+++ b/src/praisonai-train/tests/unit/data/test_task_aware_qc.py
@@ -1,0 +1,135 @@
+"""Task-aware script purity + translation-share metric in the praisonai-train
+data SDK, plus the shared translation-intent detector.
+
+Mirrors the modeltrain reference (tests/test_task_aware_qc.py) but exercises the
+SDK idiom: the purity behaviour lives in registered ``RowCheck`` classes and the
+translation composition is a corpus metric returned by ``score``.
+"""
+from praisonai_train.data import score, translation_intent
+from praisonai_train.data.intent import EN_TA_TASK, TA_EN_TASK
+
+TAMIL_OUT = "இது ஒரு முழுமையான தமிழ் பதில். இது நன்றாக முடிகிறது."  # >20 chars, pure Tamil
+ENGLISH_OUT = "This is a complete English translation of the given Tamil sentence."
+
+
+# ---- shared detector (single source of truth) ------------------------------
+
+def test_intent_metadata_ta_en():
+    i = translation_intent("anything", task_type=TA_EN_TASK)
+    assert i == {"is_translation": True, "direction": "ta_en", "expected_script": "english"}
+
+
+def test_intent_metadata_en_ta():
+    i = translation_intent("anything", task_type=EN_TA_TASK)
+    assert i == {"is_translation": True, "direction": "en_ta", "expected_script": "tamil"}
+
+
+def test_intent_metadata_native_is_not_translation():
+    i = translation_intent("ஆங்கிலம் பற்றிய கேள்வி", task_type="ஒரு பொதுவான கேள்வி-பதில்")
+    assert i["is_translation"] is False and i["expected_script"] is None
+
+
+def test_intent_text_fallback_ta_en():
+    i = translation_intent("இந்த வாக்கியத்தை ஆங்கிலத்துக்கு மொழிபெயர்க்கவும்.")
+    assert i["direction"] == "ta_en" and i["expected_script"] == "english"
+
+
+def test_intent_text_fallback_en_ta():
+    i = translation_intent("Translate this sentence into Tamil.")
+    assert i["direction"] == "en_ta" and i["expected_script"] == "tamil"
+
+
+def test_intent_ambiguous_direction_is_safe():
+    i = translation_intent("Translate between Tamil and English both ways.")
+    assert i["is_translation"] is True and i["expected_script"] is None
+
+
+def test_intent_language_topic_without_translate_intent():
+    i = translation_intent("ஆங்கிலம் கற்றுக்கொள்வது எப்படி என்று விளக்குங்கள்.")
+    assert i["is_translation"] is False
+
+
+# ---- feature #1: task-aware purity via registered RowChecks ----------------
+
+def test_ta_en_english_output_recovered_via_metadata():
+    rows = [{"instruction": "மொழிபெயர்க்க", "input": "", "output": ENGLISH_OUT,
+             "task_type": TA_EN_TASK}]
+    res = score(rows, {"near_dup": False})
+    assert res["kept_n"] == 1                        # NOT dropped as low_script_purity
+    assert "low_script_purity" not in res["drops"]
+    assert res["metrics"]["translation"]["exempted"] == 1
+
+
+def test_ta_en_english_output_recovered_via_text_fallback():
+    rows = [{"instruction": "இந்த வாக்கியத்தை ஆங்கிலத்தில் மொழிபெயர்க்கவும்.",
+             "input": "", "output": ENGLISH_OUT}]
+    res = score(rows, {"near_dup": False})
+    assert res["kept_n"] == 1 and res["metrics"]["translation"]["exempted"] == 1
+
+
+def test_native_low_purity_still_dropped():
+    rows = [{"instruction": "தமிழில் ஒரு கதை எழுதுங்கள்.", "input": "",
+             "output": ENGLISH_OUT}]   # native task, English body -> bad
+    res = score(rows, {"near_dup": False})
+    assert res["kept_n"] == 0 and res["drops"].get("low_script_purity") == 1
+    assert res["metrics"]["translation"]["exempted"] == 0
+
+
+def test_wrong_target_script_flag_for_failed_ta_en():
+    # ta->en asked, but output is still Tamil = failed translation: kept + flagged.
+    rows = [{"instruction": "ஆங்கிலத்துக்கு மொழிபெயர்க்கவும்.", "input": "",
+             "output": TAMIL_OUT, "task_type": TA_EN_TASK}]
+    res = score(rows, {"near_dup": False})
+    assert res["kept_n"] == 1
+    assert res["flags"].get("wrong_target_script") == 1
+
+
+def test_wrong_target_disabled():
+    rows = [{"instruction": "ஆங்கிலத்துக்கு மொழிபெயர்க்கவும்.", "input": "",
+             "output": TAMIL_OUT, "task_type": TA_EN_TASK}]
+    res = score(rows, {"near_dup": False, "verify_translation_target": False})
+    assert "wrong_target_script" not in res["flags"]
+
+
+def test_task_aware_purity_can_be_disabled():
+    # Turning off task-awareness restores the strict behaviour: the English
+    # output of a ta->en row is then dropped as low purity.
+    rows = [{"instruction": "மொழிபெயர்க்க", "input": "", "output": ENGLISH_OUT,
+             "task_type": TA_EN_TASK}]
+    res = score(rows, {"near_dup": False, "task_aware_purity": False})
+    assert res["kept_n"] == 0 and res["drops"].get("low_script_purity") == 1
+
+
+def test_ambiguous_translation_stays_strict():
+    rows = [{"instruction": "Translate this both ways between Tamil and English.",
+             "input": "", "output": ENGLISH_OUT}]
+    res = score(rows, {"near_dup": False})
+    assert res["kept_n"] == 0 and res["drops"].get("low_script_purity") == 1
+
+
+# ---- feature #2: translation-share corpus metric ---------------------------
+
+def test_translation_share_and_by_direction():
+    rows = [
+        {"instruction": "a", "input": "", "output": ENGLISH_OUT, "task_type": TA_EN_TASK},
+        {"instruction": "b", "input": "", "output": TAMIL_OUT, "task_type": EN_TA_TASK},
+        {"instruction": "c", "input": "", "output": TAMIL_OUT, "task_type": "ஒரு விளக்கம்"},
+        {"instruction": "d", "input": "", "output": TAMIL_OUT, "task_type": "ஒரு விளக்கம்"},
+    ]
+    res = score(rows, {"near_dup": False})
+    t = res["metrics"]["translation"]
+    assert t["share"] == 0.5                          # 2 of 4 kept rows
+    assert t["by_direction"] == {"en_ta": 1, "ta_en": 1, "unknown": 0}
+    assert t["exempted"] == 1                         # only the English-target row
+
+
+def test_translation_share_reconciles_with_exempted():
+    rows = [{"instruction": f"i{n}", "input": "", "output": ENGLISH_OUT,
+             "task_type": TA_EN_TASK} for n in range(3)]
+    t = score(rows, {"near_dup": False})["metrics"]["translation"]
+    assert t["by_direction"]["ta_en"] == t["exempted"] == 3
+
+
+def test_empty_corpus_guard():
+    res = score([], {"near_dup": False})
+    assert res["metrics"]["translation"]["share"] == 0.0 and res["kept_n"] == 0


### PR DESCRIPTION
## What

Two dataset-QC features for the **praisonai-train** data SDK, added in the SDK's protocol-driven idiom (registered `RowCheck`s + a corpus metric), sharing **one** translation-intent detector so they can never disagree (DRY).

### 1. Task-aware script purity (enhances the existing purity checks)
A script-purity filter must **not** drop an output that is legitimately in another script because the *instruction asked to translate into that language*. A Tamil→English translation row correctly has an English output; a naive Tamil-purity filter wrongly deletes it as `low_script_purity`.

- `LowScriptPurity` (drop) and `ScriptReview` (flag) now **exempt** a row whose translation target is resolved English — instead of silently deleting a good row.
- New `WrongTargetScript` (flag) catches the inverse failure: the task asked for English but the output is still mostly Tamil (a failed translation). This is **net-new signal** — a naive Tamil-purity check keeps such rows silently, because Tamil output trivially passes a Tamil-purity test.
- Only a **resolved English target** exempts. `en→ta` / ambiguous-direction / native rows keep the strict target-script thresholds.
- Toggles via config: `task_aware_purity: false` restores strict behaviour; `verify_translation_target: false` disables the new flag.

### 2. Translation-share corpus metric
`metrics.translation` reports:
- `share` — fraction of kept rows that are translation tasks,
- `by_direction` — `{en_ta, ta_en, unknown}` counts,
- `exempted` — per-row count of English-target rows exempted from the purity drop.

Computed with the **same** detector as feature #1, so the numbers reconcile with the per-row exemptions. It surfaces automatically in `praisonai-train validate` (printed under `metrics:`).

## Why
The false-positive above was silently discarding legitimate translation rows and silently keeping failed ones. Making purity *task-aware* recovers the good rows and flags the bad ones, and the share metric makes the corpus's translation composition auditable.

## DRY / single source of truth
Both features import `translation_intent()` from the new `praisonai_train/data/intent.py`. Ground-truth `task_type` metadata is authoritative; instruction-text detection is the fallback for external rows; an ambiguous direction yields **no** exemption (safe default). The Tamil recipe's `en→ta` task label now references the same shared constant, so the recipe label and the detector can't drift.

## Scope
A prior multi-agent validation reviewed six candidate features; **four were rejected as already covered** by the SDK's existing checks (exact/near-dedup, boilerplate/refusal, too-short, and the base script-purity + diversity metrics). Only these two — task-aware purity and the translation-share metric — added new value, so only they are included here.

## Files changed
- `data/intent.py` — **new**, shared `translation_intent()` detector + task-label constants.
- `data/checks.py` — `LowScriptPurity`/`ScriptReview` made task-aware; new `WrongTargetScript` flag.
- `data/qc.py` — plumbs per-row `task_type` into checks; adds the `translation` corpus metric.
- `data/recipes.py` — Tamil recipe references the shared `EN_TA_TASK` constant (DRY).
- `data/__init__.py` — exports `translation_intent`.
- `tests/unit/data/test_task_aware_qc.py` — **new**, 17 tests mirroring the reference.

## Tests
`python -m pytest tests/unit/data/` → **25 passed** (17 new + 8 existing, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added translation-intent detection for Tamil–English and English–Tamil tasks, including safe handling for ambiguous cases.
  * Introduced task-aware QC for script purity: English-target translations can be exempted and wrong-target outputs can be flagged.
  * Added corpus-level translation metrics (share, by-direction counts, exempted rows).
* **Bug Fixes**
  * Reduced incorrect low-script-purity drops for valid translation outputs when task-aware purity is enabled.
* **Tests**
  * Added unit tests covering intent detection, QC behavior, metrics reconciliation, and empty-corpus guarding.
* **Documentation/Export**
  * Re-exported the translation-intent detector for easier SDK access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->