### PR TITLE
feat(praisonai-train): optional progress_callback for synthetic-data generation

### DIFF
--- a/src/praisonai-train/praisonai_train/cli/commands/data.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/data.py
@@ -26,6 +26,41 @@ def _load_cfg(config: Optional[str], **overrides) -> dict:
     return cfg
 
 
+class _Progress:
+    """Default progress reporter for the ``generate`` command.
+
+    Uses a ``tqdm`` bar when tqdm is importable (it's already an optional dep of
+    the training path — never added as a hard requirement here), otherwise falls
+    back to printing ``done/total`` every ``every`` requests. Pass ``self.update``
+    as ``generate_dataset(..., progress_callback=...)``.
+    """
+
+    def __init__(self, total: Optional[int], every: int = 500) -> None:
+        self.total = total
+        self.every = max(1, every)
+        self._bar = None
+        self._last = 0
+        try:
+            from tqdm import tqdm  # optional; guarded so it's never a hard dep
+            self._bar = tqdm(total=total, unit="req", desc="generating")
+        except Exception:
+            self._bar = None
+
+    def update(self, done: int, total: int, kept: int) -> None:
+        if self._bar is not None:
+            self._bar.update(done - self._last)
+            self._last = done
+            self._bar.set_postfix(kept=kept)
+            return
+        # Plain fallback: throttle so large runs don't flood stdout.
+        if done and (done % self.every == 0 or done == total):
+            typer.echo(f"  ...{done}/{total} requests ({kept} kept)")
+
+    def close(self) -> None:
+        if self._bar is not None:
+            self._bar.close()
+
+
 @app.command("generate")
 def generate_data(
     config: Optional[str] = typer.Option(None, "--config", "-c", help="YAML config"),
@@ -60,28 +95,32 @@ def generate_data(
     # Consume the first row *before* truncating the destination, so a run that
     # fails on credentials/recipe/first-request never destroys an existing file
     # (and a self-referential dedup_from is read before it would be emptied).
-    gen = generate_dataset(cfg)
+    progress = _Progress(cfg.get("num_examples"))
+    gen = generate_dataset(cfg, progress_callback=progress.update)
     try:
-        first = next(gen)
-    except StopIteration:
-        first = None
+        try:
+            first = next(gen)
+        except StopIteration:
+            first = None
 
-    kept = 0
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
-    with open(out_path, "w", buffering=1) as fh:
-        for row in ([first] if first is not None else []):
-            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
-            fh.flush()
-            kept += 1
-        for row in gen:
-            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
-            fh.flush()
-            kept += 1
-            if snap_every and kept % snap_every == 0:
-                Path(snap_dir).mkdir(parents=True, exist_ok=True)
-                snap = Path(snap_dir) / f"{Path(out_path).stem}_{kept}.jsonl"
-                snap.write_text(Path(out_path).read_text())
-                typer.echo(f"  snapshot: {snap} ({kept} rows)")
+        kept = 0
+        Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w", buffering=1) as fh:
+            for row in ([first] if first is not None else []):
+                fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+                fh.flush()
+                kept += 1
+            for row in gen:
+                fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+                fh.flush()
+                kept += 1
+                if snap_every and kept % snap_every == 0:
+                    Path(snap_dir).mkdir(parents=True, exist_ok=True)
+                    snap = Path(snap_dir) / f"{Path(out_path).stem}_{kept}.jsonl"
+                    snap.write_text(Path(out_path).read_text())
+                    typer.echo(f"  snapshot: {snap} ({kept} rows)")
+    finally:
+        progress.close()
     typer.echo(f"generated {kept} unique examples -> {out_path}")
     if kept == 0:
         typer.echo("error: no rows generated — check endpoint/api_key/deployment "

--- a/src/praisonai-train/praisonai_train/data/generate.py
+++ b/src/praisonai-train/praisonai_train/data/generate.py
@@ -89,10 +89,12 @@ def generate_dataset(
     ``progress_callback`` is an optional ``fn(done, total, kept)`` invoked as work
     completes so a CLI/monitor/notebook can show completion + remaining. ``done``
     counts teacher requests finished (monotonic, up to ``total`` = number of prompt
-    specs); ``kept`` counts unique rows emitted so far. It fires once up-front with
-    ``(0, total, 0)`` and again after each completed request. Default ``None`` keeps
-    the original behaviour (no callback). Keep it cheap — it runs on the hot path;
-    throttle any printing inside the callback.
+    specs); ``kept`` counts unique rows emitted so far — it is reported *after* the
+    row is yielded, so ``kept`` never runs ahead of the rows the consumer has
+    received. It fires once up-front with ``(0, total, 0)`` and again after each
+    completed request. Default ``None`` keeps the original behaviour (no callback).
+    Keep it cheap — it runs on the hot path; throttle any printing inside the
+    callback.
     """
     cfg = dict(config)
     cfg.setdefault("endpoint", os.environ.get("AZURE_OPENAI_ENDPOINT",
@@ -139,7 +141,7 @@ def generate_dataset(
                     emit = True
                     if on_row:
                         on_row(row)
-            if progress_callback:
-                progress_callback(done, total, kept)
             if emit:
                 yield row
+            if progress_callback:
+                progress_callback(done, total, kept)

--- a/src/praisonai-train/praisonai_train/data/generate.py
+++ b/src/praisonai-train/praisonai_train/data/generate.py
@@ -74,13 +74,25 @@ def _norm_row(row: dict) -> str:
     return _norm_text(row.get("instruction") or "")
 
 
-def generate_dataset(config: dict, on_row: Callable[[dict], None] | None = None) -> Iterator[dict]:
+def generate_dataset(
+    config: dict,
+    on_row: Callable[[dict], None] | None = None,
+    progress_callback: Callable[[int, int, int], None] | None = None,
+) -> Iterator[dict]:
     """Yield unique synthetic rows.
 
     Required config: deployment, num_examples (+ endpoint/api_key or env).
     Optional: recipe (name|dict, default 'tamil'), concurrency, start_offset,
     dedup_from (rows or JSONL paths), stop_file, azure (bool), api_version,
     max_completion_tokens.
+
+    ``progress_callback`` is an optional ``fn(done, total, kept)`` invoked as work
+    completes so a CLI/monitor/notebook can show completion + remaining. ``done``
+    counts teacher requests finished (monotonic, up to ``total`` = number of prompt
+    specs); ``kept`` counts unique rows emitted so far. It fires once up-front with
+    ``(0, total, 0)`` and again after each completed request. Default ``None`` keeps
+    the original behaviour (no callback). Keep it cheap — it runs on the hot path;
+    throttle any printing inside the callback.
     """
     cfg = dict(config)
     cfg.setdefault("endpoint", os.environ.get("AZURE_OPENAI_ENDPOINT",
@@ -103,6 +115,10 @@ def generate_dataset(config: dict, on_row: Callable[[dict], None] | None = None)
 
     stop_file = cfg.get("stop_file") or os.path.expanduser("~/.praisonai_train_stop")
     specs = recipe.prompts(cfg["num_examples"], start=cfg.get("start_offset", 0))
+    total = len(specs)
+    done = kept = 0
+    if progress_callback:
+        progress_callback(done, total, kept)
     with ThreadPoolExecutor(max_workers=cfg.get("concurrency", 32)) as pool:
         futures = {pool.submit(_call, cfg, s): s for s in specs}
         for fut in as_completed(futures):
@@ -113,12 +129,17 @@ def generate_dataset(config: dict, on_row: Callable[[dict], None] | None = None)
                 row = fut.result()
             except Exception:
                 row = None
-            if not row:
-                continue
-            key = _norm_row(row)
-            if not key or key in seen:
-                continue
-            seen.add(key)
-            if on_row:
-                on_row(row)
-            yield row
+            done += 1
+            emit = False
+            if row:
+                key = _norm_row(row)
+                if key and key not in seen:
+                    seen.add(key)
+                    kept += 1
+                    emit = True
+                    if on_row:
+                        on_row(row)
+            if progress_callback:
+                progress_callback(done, total, kept)
+            if emit:
+                yield row

--- a/src/praisonai-train/tests/unit/data/test_generate_progress.py
+++ b/src/praisonai-train/tests/unit/data/test_generate_progress.py
@@ -1,0 +1,56 @@
+"""Tests for the optional progress_callback on generate_dataset.
+
+Network is stubbed out (``_call`` is monkeypatched) so these run offline and
+deterministically — we only exercise the progress-reporting contract.
+"""
+from praisonai_train.data import generate as gen_mod
+from praisonai_train.data.generate import generate_dataset
+
+
+def _cfg(n):
+    return {"endpoint": "http://x", "api_key": "k", "deployment": "d", "num_examples": n,
+            "concurrency": 4, "stop_file": "/nonexistent/stop"}
+
+
+def _fake_call(cfg, spec):
+    # One unique row per prompt spec so dedup keeps them all.
+    return {"instruction": spec["user"], "input": "", "output": "ஒரு முழுமையான தமிழ் பதில் இங்கே."}
+
+
+def test_progress_callback_monotonic_to_total(monkeypatch):
+    monkeypatch.setattr(gen_mod, "_call", _fake_call)
+    n = 12
+    calls = []
+    rows = list(generate_dataset(_cfg(n), progress_callback=lambda d, t, k: calls.append((d, t, k))))
+
+    assert calls, "callback should fire at least once"
+    dones = [d for d, _, _ in calls]
+    kepts = [k for _, _, k in calls]
+    totals = {t for _, t, _ in calls}
+
+    assert totals == {n}                       # total is stable and equals the spec count
+    assert dones == sorted(dones)              # done is monotonic non-decreasing
+    assert kepts == sorted(kepts)              # kept is monotonic non-decreasing
+    assert dones[0] == 0                       # fires once up-front with done=0
+    assert dones[-1] == n                       # reaches total when the run completes
+    assert kepts[-1] == len(rows) == n          # final kept matches emitted rows
+    assert all(k <= d for d, _, k in calls)     # never more kept than done
+
+
+def test_progress_callback_optional_default_none(monkeypatch):
+    # Backward compatible: no callback => original behaviour, still yields rows.
+    monkeypatch.setattr(gen_mod, "_call", _fake_call)
+    rows = list(generate_dataset(_cfg(5)))
+    assert len(rows) == 5
+
+
+def test_progress_kept_tracks_dedup(monkeypatch):
+    # When the teacher returns duplicates, done keeps climbing but kept plateaus.
+    monkeypatch.setattr(gen_mod, "_call",
+                        lambda cfg, spec: {"instruction": "same", "input": "",
+                                           "output": "ஒரு முழுமையான தமிழ் பதில் இங்கே."})
+    calls = []
+    rows = list(generate_dataset(_cfg(8), progress_callback=lambda d, t, k: calls.append((d, t, k))))
+    assert len(rows) == 1                       # dedup collapses to one row
+    assert calls[-1][0] == 8                     # done still reaches total
+    assert calls[-1][2] == 1                     # kept stays at 1


### PR DESCRIPTION
## What

Adds an **optional** progress mechanism to the praisonai-train synthetic-data generator so consumers (CLI / monitor / notebook) can see how much of a run is done and remaining. Previously `generate_dataset()` yielded rows with no progress signal.

## API

`generate_dataset(config, on_row=None, progress_callback=None)`

```python
progress_callback: Callable[[int, int, int], None] | None = None
# called as: progress_callback(done, total, kept)
```

- `done` — teacher requests finished (monotonic, up to `total`)
- `total` — number of prompt specs (`= num_examples`)
- `kept` — unique rows emitted so far
- Fires once up-front with `(0, total, 0)`, then after every completed request.

**Backward compatible:** default `None` = current behaviour, no callback. The existing `on_row` callback is untouched.

## CLI default reporter

The `praisonai-train generate` command now wires a default `_Progress` reporter:
- a **tqdm** bar when tqdm is importable (guarded import — tqdm stays optional, **no new hard dependency**),
- otherwise throttled `done/total (kept)` prints every 500 requests.

This replaces the ad-hoc "print every 500" pattern with a clean, callback-based design.

## Tests

New `tests/unit/data/test_generate_progress.py` (network stubbed, offline/deterministic):
- callback fires with **monotonic `done` up to `total`**, `total` stable and equal to spec count, `kept <= done` throughout;
- `kept` tracks dedup (duplicates → `done` climbs, `kept` plateaus);
- no-callback path still yields rows unchanged.

```
87 passed in 0.40s   # full unit suite
11 passed in 0.15s   # tests/unit/data
```

## Files changed
- `src/praisonai-train/praisonai_train/data/generate.py`
- `src/praisonai-train/praisonai_train/cli/commands/data.py`
- `src/praisonai-train/tests/unit/data/test_generate_progress.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional progress reporting to dataset generation, reporting completed requests and deduplicated/kept rows.
  - Displays a progress bar when available, otherwise falls back to periodic done/total updates.

- **Bug Fixes**
  - Ensures progress reporting starts/stops reliably and preserves existing generation and deduplication behavior.
  - Maintains backward compatibility when progress reporting is not provided.

- **Tests**
  - Added unit tests validating progress callback behavior, including monotonicity, initial/final values, and deduplication effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->