### PR TITLE
feat(praisonai-train): speed-benchmark SDK feature + CLI

### DIFF
--- a/src/praisonai-train/praisonai_train/cli/app.py
+++ b/src/praisonai-train/praisonai_train/cli/app.py
@@ -12,5 +12,6 @@ from __future__ import annotations
 
 from praisonai_train.cli.commands.train import app
 from praisonai_train.cli.commands import data as _data  # noqa: F401  registers generate/validate
+from praisonai_train.cli.commands import benchmark as _benchmark  # noqa: F401  registers benchmark
 
 __all__ = ["app"]

--- a/src/praisonai-train/praisonai_train/cli/commands/benchmark.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/benchmark.py
@@ -1,0 +1,101 @@
+"""``praisonai-train benchmark`` — compare generation speed across deployments.
+
+YAML-driven (``--config bench.yaml``) to match ``generate`` / ``validate`` /
+``llm``, with the common knobs also exposed as flags. Prints a ranked table
+(fastest first) and, optionally, writes machine-readable JSON.
+
+    praisonai-train benchmark --config bench.yaml
+    praisonai-train benchmark -d gpt-4o -d gpt-4o-mini --n 24 --concurrency 8 -o bench.json
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+
+from praisonai_train.cli.commands.data import _load_cfg
+from praisonai_train.cli.commands.train import app
+
+_TABLE_HEADERS = ["deployment", "rows/min", "tok/s", "avg_lat", "p50", "p95", "out_tok", "ok"]
+
+
+def _row_cells(r) -> list:
+    return [r.deployment, f"{r.rows_per_min:.0f}", f"{r.compl_tok_per_s:.0f}",
+            f"{r.avg_latency_s:.1f}", f"{r.p50_s:.1f}", f"{r.p95_s:.1f}",
+            f"{r.avg_out_tok:.0f}", f"{r.ok}/{r.n}"]
+
+
+@app.command("benchmark")
+def benchmark(
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="YAML config"),
+    deployment: Optional[List[str]] = typer.Option(
+        None, "--deployment", "-d", help="Deployment/model to benchmark (repeatable)"),
+    n: Optional[int] = typer.Option(None, "--n", "-n", help="Requests per deployment (default 24)"),
+    concurrency: Optional[int] = typer.Option(
+        None, "--concurrency", help="In-flight requests per deployment (default 8)"),
+    api_version: Optional[str] = typer.Option(None, "--api-version", help="Azure OpenAI api-version"),
+    max_tokens: Optional[int] = typer.Option(None, "--max-tokens", help="max_completion_tokens per request"),
+    recipe: Optional[str] = typer.Option(None, "--recipe", "-r", help="Recipe for the default prompt"),
+    output: Optional[str] = typer.Option(None, "--output", "-o", help="Write results JSON here"),
+):
+    """Measure and rank generation speed across LLM deployments.
+
+    Sends N identical requests to each deployment at a fixed concurrency and
+    reports throughput (rows/min, completion-tokens/sec), latency (avg/p50/p95),
+    success count and average output tokens. Endpoint/api-key are read from the
+    config or the AZURE_OPENAI_* / OPENAI_* environment.
+
+    Example: praisonai-train benchmark --config bench.yaml
+             praisonai-train benchmark -d gpt-4o -d gpt-4o-mini --n 24 -o bench.json
+    """
+    from praisonai_train.data import benchmark_deployments
+    from praisonai_train.data.benchmark import (
+        DEFAULT_API_VERSION, DEFAULT_CONCURRENCY, DEFAULT_MAX_TOKENS, DEFAULT_N)
+
+    cfg = _load_cfg(config, api_version=api_version, max_tokens=max_tokens, recipe=recipe)
+    # CLI --deployment overrides config; config accepts "deployments" or "targets".
+    targets = deployment or cfg.get("deployments") or cfg.get("targets")
+    if not targets:
+        typer.echo("error: provide at least one deployment (--deployment or 'deployments' "
+                   "in config)", err=True)
+        raise typer.Exit(1)
+
+    n = n if n is not None else cfg.get("n", DEFAULT_N)
+    concurrency = concurrency if concurrency is not None else cfg.get("concurrency", DEFAULT_CONCURRENCY)
+    # Shared endpoint/api_key/azure for every target (env fallbacks apply downstream).
+    base = {k: cfg[k] for k in ("endpoint", "api_key", "azure") if k in cfg}
+
+    typer.echo(f"benchmark: n={n} concurrency={concurrency} per deployment "
+               f"({len(targets)} target{'s' if len(targets) != 1 else ''})\n")
+
+    def _live(r):  # print each result as it lands so long runs show progress
+        typer.echo(f"  measured {r.deployment}: {r.rows_per_min:.0f} rows/min, "
+                   f"{r.compl_tok_per_s:.0f} tok/s, ok={r.ok}/{r.n}")
+
+    results = benchmark_deployments(
+        targets, n=n, concurrency=concurrency, base=base or None,
+        recipe=cfg.get("recipe", "tamil"), prompt=cfg.get("prompt"),
+        max_tokens=cfg.get("max_tokens", DEFAULT_MAX_TOKENS),
+        api_version=cfg.get("api_version", DEFAULT_API_VERSION),
+        request_timeout=cfg.get("request_timeout", 180),
+        on_result=_live,
+    )
+
+    from praisonai_train.cli.output.console import get_output_controller
+    get_output_controller().print_table(
+        _TABLE_HEADERS, [_row_cells(r) for r in results],
+        title=f"speed benchmark (ranked by rows/min)",
+    )
+
+    out_path = output or cfg.get("output")
+    if out_path:
+        Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(out_path).write_text(json.dumps([r.as_dict() for r in results], indent=2))
+        typer.echo(f"\nwrote results -> {out_path}")
+
+    if not any(r.ok for r in results):
+        typer.echo("error: every request failed — check endpoint/api_key/deployment "
+                   "and provider availability", err=True)
+        raise typer.Exit(1)

--- a/src/praisonai-train/praisonai_train/cli/commands/benchmark.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/benchmark.py
@@ -38,6 +38,9 @@ def benchmark(
     api_version: Optional[str] = typer.Option(None, "--api-version", help="Azure OpenAI api-version"),
     max_tokens: Optional[int] = typer.Option(None, "--max-tokens", help="max_completion_tokens per request"),
     recipe: Optional[str] = typer.Option(None, "--recipe", "-r", help="Recipe for the default prompt"),
+    json_mode: Optional[bool] = typer.Option(
+        None, "--json-mode/--no-json-mode",
+        help="Send response_format json_object (disable for endpoints without JSON mode)"),
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Write results JSON here"),
 ):
     """Measure and rank generation speed across LLM deployments.
@@ -54,7 +57,8 @@ def benchmark(
     from praisonai_train.data.benchmark import (
         DEFAULT_API_VERSION, DEFAULT_CONCURRENCY, DEFAULT_MAX_TOKENS, DEFAULT_N)
 
-    cfg = _load_cfg(config, api_version=api_version, max_tokens=max_tokens, recipe=recipe)
+    cfg = _load_cfg(config, api_version=api_version, max_tokens=max_tokens, recipe=recipe,
+                    json_mode=json_mode)
     # CLI --deployment overrides config; config accepts "deployments" or "targets".
     targets = deployment or cfg.get("deployments") or cfg.get("targets")
     if not targets:
@@ -80,6 +84,7 @@ def benchmark(
         max_tokens=cfg.get("max_tokens", DEFAULT_MAX_TOKENS),
         api_version=cfg.get("api_version", DEFAULT_API_VERSION),
         request_timeout=cfg.get("request_timeout", 180),
+        json_mode=cfg.get("json_mode", True),
         on_result=_live,
     )
 

--- a/src/praisonai-train/praisonai_train/data/__init__.py
+++ b/src/praisonai-train/praisonai_train/data/__init__.py
@@ -6,12 +6,19 @@ Protocol-driven and extendable: recipes and QC checks self-register (see
 """
 from praisonai_train.data import checks as _checks  # noqa: F401  registers checks
 from praisonai_train.data import recipes as _recipes  # noqa: F401  registers recipes
+from praisonai_train.data.benchmark import BenchResult, benchmark_deployments
 from praisonai_train.data.generate import generate_dataset
 from praisonai_train.data.intent import translation_intent
 from praisonai_train.data.qc import filter_rows, score
 from praisonai_train.data.registry import checks, recipes
 
 __all__ = [
-    "generate_dataset", "score", "filter_rows", "recipes", "checks",
+    "BenchResult",
+    "benchmark_deployments",
+    "checks",
+    "filter_rows",
+    "generate_dataset",
+    "recipes",
+    "score",
     "translation_intent",
 ]

--- a/src/praisonai-train/praisonai_train/data/benchmark.py
+++ b/src/praisonai-train/praisonai_train/data/benchmark.py
@@ -1,0 +1,219 @@
+"""Generation-speed benchmark for OpenAI-compatible LLM deployments.
+
+Send ``n`` identical chat requests to each target at a fixed ``concurrency`` and
+report throughput (rows/min, completion-tokens/sec) and latency (avg / p50 / p95),
+plus success count and average output tokens — then rank the targets by throughput.
+
+Designed as a first-class, protocol-driven SDK component that mirrors the data
+generator:
+
+* it reuses the generator's own HTTP call path (:func:`build_chat_request` and
+  :func:`resolve_cfg` in ``praisonai_train.data.generate``) so a benchmark hits
+  endpoints exactly the way real generation does — no duplicated HTTP code, and
+  it works against Azure OpenAI *and* any OpenAI-compatible server for free;
+* the prompt defaults to a registered :class:`~praisonai_train.data.protocols.Recipe`
+  (the same recipes generation uses), so "identical requests" stay representative
+  of the workload you actually run; and
+* everything is plain data in / dataclasses out, so it is equally usable from the
+  SDK (:func:`benchmark_deployments`) and the ``praisonai-train benchmark`` CLI.
+
+Stdlib HTTP only. Network is confined to :func:`_timed_call` / :func:`_measure_target`
+so tests can stub it and assert the pure aggregation in :func:`aggregate`.
+"""
+from __future__ import annotations
+
+import json
+import statistics as _st
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from typing import Callable, Sequence
+
+from praisonai_train.data.generate import build_chat_request, resolve_cfg
+from praisonai_train.data.recipes import resolve as _resolve_recipe
+
+DEFAULT_N = 24
+DEFAULT_CONCURRENCY = 8
+DEFAULT_MAX_TOKENS = 2048
+DEFAULT_API_VERSION = "2024-10-21"
+DEFAULT_REQUEST_TIMEOUT = 180
+
+
+@dataclass
+class BenchResult:
+    """One deployment's measured speed. ``rows_per_min`` is the ranking key."""
+
+    deployment: str
+    n: int
+    ok: int
+    wall_s: float
+    rows_per_min: float
+    compl_tok_per_s: float
+    avg_latency_s: float
+    p50_s: float
+    p95_s: float
+    avg_out_tok: float
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def _percentile(sorted_vals: list[float], q: float) -> float:
+    """Nearest-rank percentile on an already-sorted list (matches the scratch
+    benchmark: index ``min(int(len*q), len-1)``)."""
+    if not sorted_vals:
+        return 0.0
+    idx = min(int(len(sorted_vals) * q), len(sorted_vals) - 1)
+    return sorted_vals[idx]
+
+
+def aggregate(deployment: str, n: int, latencies: Sequence[float], ctoks: int,
+              ok: int, wall_s: float) -> BenchResult:
+    """Turn raw measurements into a :class:`BenchResult` (pure, no I/O).
+
+    ``latencies`` is one wall-time-per-request (seconds), ``ctoks`` the summed
+    ``usage.completion_tokens`` over successful calls, ``ok`` the success count
+    and ``wall_s`` the elapsed wall-clock of the whole batch. Throughput is
+    per wall-clock second so it reflects real concurrency; latency percentiles
+    are over the per-request times.
+    """
+    lat = sorted(latencies)
+    wall = wall_s if wall_s > 0 else 1e-9
+    return BenchResult(
+        deployment=deployment,
+        n=n,
+        ok=ok,
+        wall_s=round(wall_s, 2),
+        rows_per_min=round(ok / wall * 60, 1),
+        compl_tok_per_s=round(ctoks / wall, 1),
+        avg_latency_s=round(_st.mean(lat), 2) if lat else 0.0,
+        p50_s=round(_percentile(lat, 0.50), 2),
+        p95_s=round(_percentile(lat, 0.95), 2),
+        avg_out_tok=round(ctoks / max(ok, 1), 1),
+    )
+
+
+def _timed_call(cfg: dict, messages: list[dict], timeout: int) -> tuple[float, int, bool]:
+    """One timed chat request via the shared call path.
+
+    Returns ``(latency_s, completion_tokens, ok)``. Never raises: a failed call
+    still contributes its latency but counts as ``ok=False`` with 0 tokens, so
+    error rates show up as a lower success count rather than crashing the run.
+    This is the single network seam — tests monkeypatch it.
+    """
+    req = build_chat_request(cfg, messages)
+    t0 = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.load(resp)
+        dt = time.perf_counter() - t0
+        ctok = int(data.get("usage", {}).get("completion_tokens", 0) or 0)
+        ok = bool(data.get("choices", [{}])[0].get("message", {}).get("content"))
+        return dt, ctok, ok
+    except Exception:
+        return time.perf_counter() - t0, 0, False
+
+
+def _measure_target(cfg: dict, messages: list[dict], n: int, concurrency: int,
+                    timeout: int) -> tuple[list[float], int, int, float]:
+    """Fire ``n`` identical requests at ``concurrency`` and collect raw numbers.
+
+    Returns ``(latencies, total_completion_tokens, ok_count, wall_s)``. Tests
+    monkeypatch this to inject deterministic timings without touching the wall
+    clock or the thread pool.
+    """
+    latencies: list[float] = []
+    ctoks = 0
+    ok = 0
+    wall0 = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+        futs = [pool.submit(_timed_call, cfg, messages, timeout) for _ in range(n)]
+        for fut in as_completed(futs):
+            dt, ct, is_ok = fut.result()
+            latencies.append(dt)
+            ctoks += ct
+            if is_ok:
+                ok += 1
+    return latencies, ctoks, ok, time.perf_counter() - wall0
+
+
+def _messages_for(prompt, recipe) -> list[dict]:
+    """Resolve the fixed system+user messages sent on every request.
+
+    ``prompt`` may be a ``{"system","user"}`` dict, a plain string (used as the
+    user turn), or ``None`` — in which case the first spec of the registered
+    ``recipe`` is reused, so the benchmark exercises the same prompt shape as a
+    real generation run.
+    """
+    if isinstance(prompt, dict):
+        spec = {"system": prompt.get("system", ""), "user": prompt["user"]}
+    elif isinstance(prompt, str):
+        spec = {"system": "", "user": prompt}
+    else:
+        spec = _resolve_recipe(recipe).prompts(1)[0]
+    return [{"role": "system", "content": spec["system"]},
+            {"role": "user", "content": spec["user"]}]
+
+
+def benchmark_deployments(
+    targets: Sequence,
+    n: int = DEFAULT_N,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    *,
+    base: dict | None = None,
+    prompt=None,
+    recipe: str = "tamil",
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    api_version: str = DEFAULT_API_VERSION,
+    request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
+    on_result: Callable[[BenchResult], None] | None = None,
+) -> list[BenchResult]:
+    """Benchmark generation speed across one or more deployments; ranked fastest first.
+
+    Args:
+        targets: deployment names (``str``) and/or per-target config dicts. A
+            dict may carry ``deployment`` plus any override (``endpoint``,
+            ``api_key``, ``azure``, ``api_version``, ``max_completion_tokens``)
+            for benchmarking across endpoints in one call.
+        n: identical requests per target.
+        concurrency: in-flight requests per target.
+        base: shared config merged under every target (e.g. ``endpoint``,
+            ``api_key``, ``azure``). Endpoint/key/azure fall back to the
+            ``AZURE_OPENAI_*`` / ``OPENAI_*`` environment, exactly like
+            :func:`~praisonai_train.data.generate.generate_dataset`.
+        prompt: fixed prompt for every request — a ``{"system","user"}`` dict, a
+            user string, or ``None`` to reuse the ``recipe``'s first prompt.
+        recipe: registered recipe name used when ``prompt`` is ``None``.
+        max_tokens: ``max_completion_tokens`` cap per request.
+        api_version: Azure OpenAI api-version (ignored for plain OpenAI).
+        request_timeout: per-request timeout in seconds.
+        on_result: optional callback invoked with each :class:`BenchResult` as
+            soon as that target finishes (for live CLI/notebook output).
+
+    Returns:
+        ``list[BenchResult]`` sorted by ``rows_per_min`` descending.
+    """
+    messages = _messages_for(prompt, recipe)
+    base = dict(base or {})
+    base.setdefault("api_version", api_version)
+    base.setdefault("max_completion_tokens", max_tokens)
+
+    results: list[BenchResult] = []
+    for target in targets:
+        merged = dict(base)
+        if isinstance(target, dict):
+            merged.update(target)
+        else:
+            merged["deployment"] = target
+        cfg = resolve_cfg(merged)
+        name = cfg["deployment"]
+        latencies, ctoks, ok, wall = _measure_target(
+            cfg, messages, n, concurrency, request_timeout)
+        res = aggregate(name, n, latencies, ctoks, ok, wall)
+        results.append(res)
+        if on_result:
+            on_result(res)
+
+    results.sort(key=lambda r: r.rows_per_min, reverse=True)
+    return results

--- a/src/praisonai-train/praisonai_train/data/benchmark.py
+++ b/src/praisonai-train/praisonai_train/data/benchmark.py
@@ -94,29 +94,34 @@ def aggregate(deployment: str, n: int, latencies: Sequence[float], ctoks: int,
     )
 
 
-def _timed_call(cfg: dict, messages: list[dict], timeout: int) -> tuple[float, int, bool]:
+def _timed_call(cfg: dict, messages: list[dict], timeout: int,
+                json_mode: bool = True) -> tuple[float, int, bool]:
     """One timed chat request via the shared call path.
 
     Returns ``(latency_s, completion_tokens, ok)``. Never raises: a failed call
     still contributes its latency but counts as ``ok=False`` with 0 tokens, so
     error rates show up as a lower success count rather than crashing the run.
-    This is the single network seam — tests monkeypatch it.
+    Tokens are only reported for successful (``ok=True``) responses so token
+    throughput and average-output-tokens stay consistent with the success count.
+    ``json_mode`` toggles the ``response_format`` hint; disable it for endpoints
+    that don't support JSON mode. This is the single network seam — tests
+    monkeypatch it.
     """
-    req = build_chat_request(cfg, messages)
+    req = build_chat_request(cfg, messages, json_mode=json_mode)
     t0 = time.perf_counter()
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             data = json.load(resp)
         dt = time.perf_counter() - t0
-        ctok = int(data.get("usage", {}).get("completion_tokens", 0) or 0)
         ok = bool(data.get("choices", [{}])[0].get("message", {}).get("content"))
+        ctok = int(data.get("usage", {}).get("completion_tokens", 0) or 0) if ok else 0
         return dt, ctok, ok
     except Exception:
         return time.perf_counter() - t0, 0, False
 
 
 def _measure_target(cfg: dict, messages: list[dict], n: int, concurrency: int,
-                    timeout: int) -> tuple[list[float], int, int, float]:
+                    timeout: int, json_mode: bool = True) -> tuple[list[float], int, int, float]:
     """Fire ``n`` identical requests at ``concurrency`` and collect raw numbers.
 
     Returns ``(latencies, total_completion_tokens, ok_count, wall_s)``. Tests
@@ -128,7 +133,7 @@ def _measure_target(cfg: dict, messages: list[dict], n: int, concurrency: int,
     ok = 0
     wall0 = time.perf_counter()
     with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
-        futs = [pool.submit(_timed_call, cfg, messages, timeout) for _ in range(n)]
+        futs = [pool.submit(_timed_call, cfg, messages, timeout, json_mode) for _ in range(n)]
         for fut in as_completed(futs):
             dt, ct, is_ok = fut.result()
             latencies.append(dt)
@@ -147,6 +152,8 @@ def _messages_for(prompt, recipe) -> list[dict]:
     real generation run.
     """
     if isinstance(prompt, dict):
+        if not prompt.get("user"):
+            raise ValueError("prompt dict must include a non-empty 'user' field")
         spec = {"system": prompt.get("system", ""), "user": prompt["user"]}
     elif isinstance(prompt, str):
         spec = {"system": "", "user": prompt}
@@ -167,6 +174,7 @@ def benchmark_deployments(
     max_tokens: int = DEFAULT_MAX_TOKENS,
     api_version: str = DEFAULT_API_VERSION,
     request_timeout: int = DEFAULT_REQUEST_TIMEOUT,
+    json_mode: bool = True,
     on_result: Callable[[BenchResult], None] | None = None,
 ) -> list[BenchResult]:
     """Benchmark generation speed across one or more deployments; ranked fastest first.
@@ -188,12 +196,22 @@ def benchmark_deployments(
         max_tokens: ``max_completion_tokens`` cap per request.
         api_version: Azure OpenAI api-version (ignored for plain OpenAI).
         request_timeout: per-request timeout in seconds.
+        json_mode: send the ``response_format={"type":"json_object"}`` hint.
+            Set ``False`` for OpenAI-compatible endpoints that don't support
+            JSON mode so the benchmark measures speed, not JSON-mode support.
         on_result: optional callback invoked with each :class:`BenchResult` as
             soon as that target finishes (for live CLI/notebook output).
 
     Returns:
         ``list[BenchResult]`` sorted by ``rows_per_min`` descending.
+
+    Raises:
+        ValueError: if ``n`` or ``concurrency`` is not a positive integer.
     """
+    if n < 1:
+        raise ValueError(f"n must be a positive integer, got {n}")
+    if concurrency < 1:
+        raise ValueError(f"concurrency must be a positive integer, got {concurrency}")
     messages = _messages_for(prompt, recipe)
     base = dict(base or {})
     base.setdefault("api_version", api_version)
@@ -209,7 +227,7 @@ def benchmark_deployments(
         cfg = resolve_cfg(merged)
         name = cfg["deployment"]
         latencies, ctoks, ok, wall = _measure_target(
-            cfg, messages, n, concurrency, request_timeout)
+            cfg, messages, n, concurrency, request_timeout, json_mode)
         res = aggregate(name, n, latencies, ctoks, ok, wall)
         results.append(res)
         if on_result:

--- a/src/praisonai-train/praisonai_train/data/generate.py
+++ b/src/praisonai-train/praisonai_train/data/generate.py
@@ -21,25 +21,58 @@ from praisonai_train.data._util import norm as _norm_text
 from praisonai_train.data.recipes import resolve
 
 
-def _call(cfg: dict, spec: dict) -> dict | None:
+def resolve_cfg(config: dict) -> dict:
+    """Fill endpoint/api_key/azure defaults from the environment and validate.
+
+    Shared by generation and benchmarking so every call path resolves
+    credentials and the Azure-vs-OpenAI flag the same way. Returns a *copy*;
+    the input dict is never mutated. Raises ``ValueError`` if the endpoint,
+    api_key or deployment cannot be determined.
+    """
+    cfg = dict(config)
+    cfg.setdefault("endpoint", os.environ.get("AZURE_OPENAI_ENDPOINT",
+                                              os.environ.get("OPENAI_BASE_URL", "")))
+    cfg.setdefault("api_key", os.environ.get("AZURE_OPENAI_KEY",
+                                             os.environ.get("OPENAI_API_KEY", "")))
+    if "azure" not in cfg:
+        cfg["azure"] = bool(os.environ.get("AZURE_OPENAI_ENDPOINT")) or "openai.azure.com" in cfg["endpoint"]
+    if not (cfg["endpoint"] and cfg["api_key"] and cfg.get("deployment")):
+        raise ValueError("endpoint, api_key and deployment are required")
+    return cfg
+
+
+def build_chat_request(cfg: dict, messages: list[dict],
+                       json_mode: bool = True) -> "urllib.request.Request":
+    """Build a urllib chat-completion ``Request`` for any OpenAI-compatible endpoint.
+
+    Encapsulates the only vendor-specific bits — the Azure deployment URL +
+    ``api-key`` header vs the plain OpenAI ``/chat/completions`` URL + bearer
+    token + ``model`` field — so generation and benchmarking share one call
+    path and both work against Azure OpenAI or any OpenAI-compatible server.
+    """
     if cfg.get("azure"):
         url = (f"{cfg['endpoint'].rstrip('/')}/openai/deployments/{cfg['deployment']}"
                f"/chat/completions?api-version={cfg.get('api_version', '2024-10-21')}")
     else:
         url = f"{cfg['endpoint'].rstrip('/')}/chat/completions"
     body = {
-        "messages": [{"role": "system", "content": spec["system"]},
-                     {"role": "user", "content": spec["user"]}],
+        "messages": messages,
         "max_completion_tokens": cfg.get("max_completion_tokens", 2048),
-        "response_format": {"type": "json_object"},
     }
+    if json_mode:
+        body["response_format"] = {"type": "json_object"}
     headers = {"Content-Type": "application/json"}
     if cfg.get("azure"):
         headers["api-key"] = cfg["api_key"]
     else:
         headers["Authorization"] = f"Bearer {cfg['api_key']}"
         body["model"] = cfg["deployment"]
-    req = urllib.request.Request(url, data=json.dumps(body).encode(), headers=headers)
+    return urllib.request.Request(url, data=json.dumps(body).encode(), headers=headers)
+
+
+def _call(cfg: dict, spec: dict) -> dict | None:
+    req = build_chat_request(cfg, [{"role": "system", "content": spec["system"]},
+                                   {"role": "user", "content": spec["user"]}])
     content = None
     timeout = cfg.get("request_timeout", 120)
     for attempt in range(2):
@@ -96,15 +129,7 @@ def generate_dataset(
     Keep it cheap — it runs on the hot path; throttle any printing inside the
     callback.
     """
-    cfg = dict(config)
-    cfg.setdefault("endpoint", os.environ.get("AZURE_OPENAI_ENDPOINT",
-                                              os.environ.get("OPENAI_BASE_URL", "")))
-    cfg.setdefault("api_key", os.environ.get("AZURE_OPENAI_KEY",
-                                             os.environ.get("OPENAI_API_KEY", "")))
-    if "azure" not in cfg:
-        cfg["azure"] = bool(os.environ.get("AZURE_OPENAI_ENDPOINT")) or "openai.azure.com" in cfg["endpoint"]
-    if not (cfg["endpoint"] and cfg["api_key"] and cfg.get("deployment")):
-        raise ValueError("endpoint, api_key and deployment are required")
+    cfg = resolve_cfg(config)
 
     recipe = resolve(cfg.get("recipe", "tamil"))
 

--- a/src/praisonai-train/praisonai_train/setup/benchmark.yaml
+++ b/src/praisonai-train/praisonai_train/setup/benchmark.yaml
@@ -1,0 +1,27 @@
+# praisonai-train benchmark --config benchmark.yaml
+# Compare generation speed across OpenAI-compatible deployments.
+# Sends N identical requests to each at a fixed concurrency and ranks them by
+# throughput (rows/min). Endpoint/api_key default to the AZURE_OPENAI_* / OPENAI_*
+# environment if omitted here.
+
+deployments:                       # deployment/model names to compare (ranked fastest first)
+  - gpt-4o
+  - gpt-4o-mini
+# Cross-endpoint form: each target may override endpoint/api_key/azure/api_version
+# deployments:
+#   - {deployment: gpt-4o, azure: true}
+#   - {deployment: llama-3.1-70b, endpoint: https://my-host/v1, azure: false}
+
+n: 24                              # identical requests per deployment
+concurrency: 8                     # in-flight requests per deployment
+azure: true                        # true for Azure OpenAI; false for OpenAI-compatible
+api_version: "2024-10-21"          # Azure OpenAI api-version (ignored when azure: false)
+max_tokens: 2048                   # max_completion_tokens cap per request
+request_timeout: 180               # per-request timeout (seconds)
+
+recipe: tamil                      # the fixed prompt reuses this recipe's first prompt...
+# prompt:                          # ...or set an explicit identical prompt for every request
+#   system: "You generate concise answers."
+#   user: "Write one short factual paragraph about photosynthesis."
+
+output: bench_results.json         # optional: write the ranked results as JSON

--- a/src/praisonai-train/praisonai_train/setup/benchmark.yaml
+++ b/src/praisonai-train/praisonai_train/setup/benchmark.yaml
@@ -18,6 +18,8 @@ azure: true                        # true for Azure OpenAI; false for OpenAI-com
 api_version: "2024-10-21"          # Azure OpenAI api-version (ignored when azure: false)
 max_tokens: 2048                   # max_completion_tokens cap per request
 request_timeout: 180               # per-request timeout (seconds)
+json_mode: true                    # send response_format json_object; set false for
+                                   # OpenAI-compatible endpoints that don't support JSON mode
 
 recipe: tamil                      # the fixed prompt reuses this recipe's first prompt...
 # prompt:                          # ...or set an explicit identical prompt for every request

--- a/src/praisonai-train/tests/unit/data/test_benchmark.py
+++ b/src/praisonai-train/tests/unit/data/test_benchmark.py
@@ -1,0 +1,162 @@
+"""Tests for the speed-benchmark SDK component.
+
+The network is fully stubbed: aggregation is tested as a pure function, the
+target-measurement seam (``_measure_target``) is monkeypatched to inject
+deterministic timings for ranking/success tests, and one test monkeypatches the
+low-level ``_timed_call`` to prove the real threaded path counts successes and
+failures correctly. Nothing here touches a socket.
+"""
+import math
+
+import pytest
+
+from praisonai_train.data import benchmark_deployments, BenchResult
+from praisonai_train.data import benchmark as bm
+
+
+def _cfg():
+    return {"endpoint": "http://x", "api_key": "k", "azure": False}
+
+
+# --------------------------------------------------------------------------- #
+# aggregate(): pure math on a known set of fake timings                         #
+# --------------------------------------------------------------------------- #
+
+def test_aggregate_throughput_and_percentiles():
+    # 10 requests, all ok, latencies 1..10s, 100 tokens each (1000 total),
+    # batch wall clock 20s.
+    latencies = [float(i) for i in range(1, 11)]
+    r = bm.aggregate("d", n=10, latencies=latencies, ctoks=1000, ok=10, wall_s=20.0)
+
+    assert r.rows_per_min == pytest.approx(10 / 20 * 60)   # 30 rows/min
+    assert r.compl_tok_per_s == pytest.approx(1000 / 20)   # 50 tok/s
+    assert r.avg_latency_s == pytest.approx(5.5)           # mean(1..10)
+    assert r.p50_s == pytest.approx(6.0)                   # index int(10*0.5)=5 -> 6.0
+    assert r.p95_s == pytest.approx(10.0)                  # index min(9,9) -> 10.0
+    assert r.avg_out_tok == pytest.approx(100.0)           # 1000 / 10
+    assert r.ok == 10 and r.n == 10
+
+
+def test_aggregate_counts_only_successful_tokens_for_avg():
+    # 4 requests, 2 ok; 400 tokens over 2 successes -> 200 avg out tokens.
+    r = bm.aggregate("d", n=4, latencies=[1.0, 2.0, 3.0, 4.0], ctoks=400, ok=2, wall_s=8.0)
+    assert r.avg_out_tok == pytest.approx(200.0)
+    assert r.rows_per_min == pytest.approx(2 / 8 * 60)     # only successes count
+    assert r.ok == 2
+
+
+def test_aggregate_all_failed_is_safe():
+    r = bm.aggregate("d", n=3, latencies=[1.0, 1.0, 1.0], ctoks=0, ok=0, wall_s=3.0)
+    assert r.ok == 0
+    assert r.rows_per_min == 0.0
+    assert r.compl_tok_per_s == 0.0
+    assert r.avg_out_tok == 0.0                            # max(ok,1) guard, no ZeroDivision
+
+
+def test_aggregate_zero_wall_does_not_divide_by_zero():
+    r = bm.aggregate("d", n=1, latencies=[0.0], ctoks=10, ok=1, wall_s=0.0)
+    assert math.isfinite(r.rows_per_min) and math.isfinite(r.compl_tok_per_s)
+
+
+# --------------------------------------------------------------------------- #
+# benchmark_deployments(): ranking + success handling with stubbed measurement  #
+# --------------------------------------------------------------------------- #
+
+def _fake_measure_factory(table):
+    """Return a _measure_target stub driven by a {deployment: (lat, ctoks, ok, wall)} table."""
+    def _fake(cfg, messages, n, concurrency, timeout):
+        return table[cfg["deployment"]]
+    return _fake
+
+
+def test_ranks_descending_by_throughput(monkeypatch):
+    # slow: 5 ok / 10s = 30 rows/min; fast: 10 ok / 10s = 60 rows/min.
+    table = {
+        "slow": ([1.0] * 5, 500, 5, 10.0),
+        "fast": ([1.0] * 10, 1000, 10, 10.0),
+        "mid":  ([1.0] * 8, 800, 8, 10.0),
+    }
+    monkeypatch.setattr(bm, "_measure_target", _fake_measure_factory(table))
+
+    results = benchmark_deployments(["slow", "fast", "mid"], n=10, concurrency=4,
+                                    base=_cfg())
+
+    assert [r.deployment for r in results] == ["fast", "mid", "slow"]
+    assert all(isinstance(r, BenchResult) for r in results)
+    # monotonically non-increasing throughput
+    tputs = [r.rows_per_min for r in results]
+    assert tputs == sorted(tputs, reverse=True)
+
+
+def test_success_count_reflects_failures(monkeypatch):
+    # 10 requests, only 3 succeeded (7 failed): ok=3, tokens only from the 3.
+    table = {"d": ([2.0] * 10, 300, 3, 20.0)}
+    monkeypatch.setattr(bm, "_measure_target", _fake_measure_factory(table))
+
+    (r,) = benchmark_deployments(["d"], n=10, concurrency=5, base=_cfg())
+
+    assert r.ok == 3 and r.n == 10
+    assert r.rows_per_min == pytest.approx(3 / 20 * 60)
+    assert r.avg_out_tok == pytest.approx(100.0)           # 300 / 3
+
+
+def test_on_result_callback_fires_per_target(monkeypatch):
+    table = {"a": ([1.0], 100, 1, 1.0), "b": ([1.0], 100, 1, 1.0)}
+    monkeypatch.setattr(bm, "_measure_target", _fake_measure_factory(table))
+    seen = []
+    benchmark_deployments(["a", "b"], n=1, concurrency=1, base=_cfg(),
+                          on_result=seen.append)
+    assert {r.deployment for r in seen} == {"a", "b"}
+
+
+# --------------------------------------------------------------------------- #
+# Real threaded path (only the HTTP seam stubbed): success/failure counting      #
+# --------------------------------------------------------------------------- #
+
+def test_real_thread_pool_counts_success_and_failure(monkeypatch):
+    # Every odd call "fails" (ok=False, 0 tokens); even calls succeed with 50 tok.
+    state = {"i": 0}
+
+    def _fake_timed(cfg, messages, timeout):
+        i = state["i"]
+        state["i"] += 1
+        if i % 2 == 0:
+            return 0.01, 50, True
+        return 0.01, 0, False
+
+    monkeypatch.setattr(bm, "_timed_call", _fake_timed)
+
+    (r,) = benchmark_deployments(["d"], n=10, concurrency=4, base=_cfg())
+
+    assert r.n == 10
+    assert r.ok == 5                                       # half succeeded
+    assert r.avg_out_tok == pytest.approx(50.0)            # 250 tokens / 5 ok
+
+
+def test_per_target_endpoint_override(monkeypatch):
+    # A dict target may override the endpoint; benchmark must resolve per-target.
+    captured = {}
+
+    def _fake(cfg, messages, n, concurrency, timeout):
+        captured[cfg["deployment"]] = cfg["endpoint"]
+        return ([1.0], 100, 1, 1.0)
+
+    monkeypatch.setattr(bm, "_measure_target", _fake)
+    benchmark_deployments(
+        [{"deployment": "x", "endpoint": "http://a", "api_key": "k", "azure": False},
+         {"deployment": "y", "endpoint": "http://b", "api_key": "k", "azure": False}],
+        n=1, concurrency=1)
+    assert captured == {"x": "http://a", "y": "http://b"}
+
+
+def test_default_prompt_uses_recipe():
+    msgs = bm._messages_for(None, "tamil")
+    assert msgs[0]["role"] == "system" and msgs[1]["role"] == "user"
+    assert msgs[0]["content"] and msgs[1]["content"]       # recipe filled both turns
+
+
+def test_explicit_prompt_forms():
+    d = bm._messages_for({"system": "s", "user": "u"}, "tamil")
+    assert d[0]["content"] == "s" and d[1]["content"] == "u"
+    s = bm._messages_for("just user", "tamil")
+    assert s[0]["content"] == "" and s[1]["content"] == "just user"

--- a/src/praisonai-train/tests/unit/data/test_benchmark.py
+++ b/src/praisonai-train/tests/unit/data/test_benchmark.py
@@ -6,6 +6,8 @@ deterministic timings for ranking/success tests, and one test monkeypatches the
 low-level ``_timed_call`` to prove the real threaded path counts successes and
 failures correctly. Nothing here touches a socket.
 """
+import io
+import json
 import math
 
 import pytest
@@ -64,7 +66,7 @@ def test_aggregate_zero_wall_does_not_divide_by_zero():
 
 def _fake_measure_factory(table):
     """Return a _measure_target stub driven by a {deployment: (lat, ctoks, ok, wall)} table."""
-    def _fake(cfg, messages, n, concurrency, timeout):
+    def _fake(cfg, messages, n, concurrency, timeout, json_mode=True):
         return table[cfg["deployment"]]
     return _fake
 
@@ -117,7 +119,7 @@ def test_real_thread_pool_counts_success_and_failure(monkeypatch):
     # Every odd call "fails" (ok=False, 0 tokens); even calls succeed with 50 tok.
     state = {"i": 0}
 
-    def _fake_timed(cfg, messages, timeout):
+    def _fake_timed(cfg, messages, timeout, json_mode=True):
         i = state["i"]
         state["i"] += 1
         if i % 2 == 0:
@@ -137,7 +139,7 @@ def test_per_target_endpoint_override(monkeypatch):
     # A dict target may override the endpoint; benchmark must resolve per-target.
     captured = {}
 
-    def _fake(cfg, messages, n, concurrency, timeout):
+    def _fake(cfg, messages, n, concurrency, timeout, json_mode=True):
         captured[cfg["deployment"]] = cfg["endpoint"]
         return ([1.0], 100, 1, 1.0)
 
@@ -160,3 +162,54 @@ def test_explicit_prompt_forms():
     assert d[0]["content"] == "s" and d[1]["content"] == "u"
     s = bm._messages_for("just user", "tamil")
     assert s[0]["content"] == "" and s[1]["content"] == "just user"
+
+
+# --------------------------------------------------------------------------- #
+# Input validation + provider-compat edge cases (reviewer feedback)             #
+# --------------------------------------------------------------------------- #
+
+def test_malformed_prompt_dict_raises_valueerror():
+    # A dict without 'user' must be a clear config error, not a KeyError mid-run.
+    with pytest.raises(ValueError):
+        bm._messages_for({"system": "You are helpful"}, "tamil")
+    with pytest.raises(ValueError):
+        bm._messages_for({"user": ""}, "tamil")
+
+
+def test_invalid_counts_raise_valueerror():
+    with pytest.raises(ValueError):
+        benchmark_deployments(["d"], n=0, concurrency=8, base=_cfg())
+    with pytest.raises(ValueError):
+        benchmark_deployments(["d"], n=8, concurrency=0, base=_cfg())
+
+
+def test_failed_response_does_not_add_tokens(monkeypatch):
+    # A completion that reports tokens but has empty content is ok=False AND
+    # contributes 0 tokens, so token throughput stays consistent with success.
+    payload = {"usage": {"completion_tokens": 99},
+               "choices": [{"message": {"content": ""}}]}
+
+    def _fake_urlopen(req, timeout=None):
+        return io.BytesIO(json.dumps(payload).encode())
+
+    monkeypatch.setattr(bm.urllib.request, "urlopen", _fake_urlopen)
+    dt, ctok, ok = bm._timed_call({**_cfg(), "deployment": "d"}, [], 5)
+    assert ok is False and ctok == 0
+
+
+def test_json_mode_flag_reaches_request_builder(monkeypatch):
+    # The json_mode flag must be threaded through to build_chat_request so an
+    # endpoint without JSON mode can be benchmarked (--no-json-mode).
+    captured = {}
+
+    def _fake_build(cfg, messages, json_mode=True):
+        captured["json_mode"] = json_mode
+        return object()
+
+    def _fake_urlopen(req, timeout=None):
+        raise OSError("no network in test")
+
+    monkeypatch.setattr(bm, "build_chat_request", _fake_build)
+    monkeypatch.setattr(bm.urllib.request, "urlopen", _fake_urlopen)
+    bm._timed_call({**_cfg(), "deployment": "d"}, [], 5, json_mode=False)
+    assert captured["json_mode"] is False


### PR DESCRIPTION
## What

Adds a **first-class, protocol-driven speed-benchmark capability** to the `praisonai-train` data SDK, in the same idiom as `generate` / `validate`.

For each deployment it sends **N identical requests at a fixed concurrency** and reports:
- **throughput** — rows/min and completion-tokens/sec
- **latency** — avg / p50 / p95
- **success count** and **average output tokens**

…then prints a **ranked comparison table** (fastest first) and optional **machine-readable JSON**. This ports the working scratch benchmark (`scripts/benchmark_models.py`) into a proper, reusable SDK component.

## DRY / how the backend is reused

The generator's HTTP call path is extracted into two shared helpers in `data/generate.py`:
- `build_chat_request(cfg, messages, json_mode=True)` — the only vendor-specific bit (Azure deployment URL + `api-key` header vs plain OpenAI `/chat/completions` + bearer token + `model`). Benchmark calls through it, so it works against **Azure OpenAI and any OpenAI-compatible server** for free.
- `resolve_cfg(config)` — endpoint/api-key/azure resolution from `AZURE_OPENAI_*` / `OPENAI_*`, shared with `generate_dataset`.

No HTTP code is duplicated. `generate_dataset` was refactored to use these helpers with **identical behavior** (all pre-existing tests still pass). The default benchmark prompt reuses a registered `Recipe`, so runs reflect the real workload.

## Public SDK API

```python
from praisonai_train.data import benchmark_deployments, BenchResult

results: list[BenchResult] = benchmark_deployments(
    targets,                 # list[str | dict]: names or per-target cfg overrides
    n=24, concurrency=8, *,
    base=None,               # shared endpoint/api_key/azure (env fallbacks apply)
    prompt=None,             # {"system","user"} | str | None (reuse recipe)
    recipe="tamil",
    max_tokens=2048, api_version="2024-10-21", request_timeout=180,
    on_result=None,          # callback per finished target
)  # -> list[BenchResult] ranked by rows_per_min desc
```

## CLI

```
praisonai-train benchmark --config bench.yaml
praisonai-train benchmark -d gpt-4o -d gpt-4o-mini --n 24 --concurrency 8 -o bench.json
```

Sample `setup/benchmark.yaml` included. Sensible defaults so a non-developer can run `--config bench.yaml`.

## Tests

Network fully stubbed (monkeypatched call layer). Covers aggregation math (rows/min, tok/s, percentiles, avg out-tokens), descending ranking by throughput, success/failure counting through the real thread pool, per-target endpoint override, and prompt resolution. **98 passed** (11 new benchmark tests + 87 pre-existing, incl. the untouched generate suite).

## Files
- `data/benchmark.py` (new), `cli/commands/benchmark.py` (new), `setup/benchmark.yaml` (new), `tests/unit/data/test_benchmark.py` (new)
- `data/generate.py`, `data/__init__.py`, `cli/app.py` (changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `benchmark` CLI command to compare LLM deployments by speed, latency, throughput, and success rate.
  * Supports YAML config plus overrides for deployments, request count, concurrency, recipe/prompt, max tokens, API version, and an optional JSON-mode output format.
  * Added a ready-to-run `benchmark.yaml` example for common comparisons.
* **Bug Fixes**
  * Improved OpenAI/Azure request setup and validation for consistent endpoint and authentication handling.
  * Benchmark execution now safely handles failure cases and produces ranked output.
* **Tests**
  * Added unit tests covering benchmarking aggregation, ranking, per-target callbacks, prompt handling, and JSON-mode propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->