### PR TITLE
feat(train/data): scalable MinHash+LSH near-dedup + cross-file global dedup

### DIFF
--- a/src/praisonai-train/praisonai_train/cli/commands/data.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/data.py
@@ -168,12 +168,29 @@ def dedup_data(
         with open(src) as fh:
             total_in += sum(1 for ln in fh if ln.strip())
 
+    # Write to a sibling temp file and atomically replace the destination only on
+    # success. This means (a) an --out that aliases an input is never truncated
+    # before its rows are read, and (b) a malformed line mid-stream aborts without
+    # leaving a partial file that a downstream job could mistake for a result.
+    import os
+    import tempfile
+
     kept = 0
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
-    with open(out_path, "w") as fh:
-        for row in global_dedup(sources, cfg):
-            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
-            kept += 1
+    out_dir = Path(out_path).parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(out_dir), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            for row in global_dedup(sources, cfg):
+                fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+                kept += 1
+        os.replace(tmp_name, out_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
     removed = total_in - kept
     typer.echo(f"\n─── cross-file dedup: {len(sources)} file(s) ───")
     typer.echo(f"  in={total_in}  kept={kept}  removed={removed} "

--- a/src/praisonai-train/praisonai_train/cli/commands/data.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/data.py
@@ -128,6 +128,59 @@ def generate_data(
         raise typer.Exit(1)
 
 
+@app.command("dedup")
+def dedup_data(
+    inputs: list[str] = typer.Argument(None, help="Input JSONL file(s) to dedup across"),
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="YAML config"),
+    out: Optional[str] = typer.Option(None, "--out", "-o", help="Write deduped JSONL here"),
+    method: Optional[str] = typer.Option(None, "--method", help="near-dup engine: minhash|sliding"),
+    threshold: Optional[float] = typer.Option(None, "--threshold", help="near-dup Jaccard (0-1)"),
+    exact_only: bool = typer.Option(False, "--exact-only", help="Skip near-dup, exact only"),
+):
+    """Deduplicate rows ACROSS many batch files with one shared MinHash+LSH index.
+
+    Unlike ``validate`` (per-file), this removes duplicates that span files — the
+    common case when merging parallel/incremental generation batches.
+
+    Example: praisonai-train dedup batch_*.jsonl --out merged.jsonl
+             praisonai-train dedup --config dedup.yaml
+    """
+    from praisonai_train.data import global_dedup
+
+    cfg = _load_cfg(config)
+    if method is not None:
+        cfg["near_dup_method"] = method
+    if threshold is not None:
+        cfg["near_dup_jaccard"] = threshold
+    if exact_only:
+        cfg["near_dup"] = False
+    sources = list(inputs) if inputs else (cfg.get("inputs") or ([cfg["input"]] if cfg.get("input") else []))
+    if not sources:
+        typer.echo("error: provide input JSONL path(s) or 'inputs'/'input' in config", err=True)
+        raise typer.Exit(1)
+    out_path = out or cfg.get("output")
+    if not out_path:
+        typer.echo("error: provide --out or 'output' in config", err=True)
+        raise typer.Exit(1)
+
+    total_in = 0
+    for src in sources:
+        with open(src) as fh:
+            total_in += sum(1 for ln in fh if ln.strip())
+
+    kept = 0
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as fh:
+        for row in global_dedup(sources, cfg):
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+            kept += 1
+    removed = total_in - kept
+    typer.echo(f"\n─── cross-file dedup: {len(sources)} file(s) ───")
+    typer.echo(f"  in={total_in}  kept={kept}  removed={removed} "
+               f"({100 * removed / max(total_in, 1):.1f}% dup)")
+    typer.echo(f"  wrote {kept} unique rows -> {out_path}")
+
+
 @app.command("validate")
 def validate_data(
     dataset: Optional[str] = typer.Argument(None, help="Dataset JSONL to validate"),

--- a/src/praisonai-train/praisonai_train/data/__init__.py
+++ b/src/praisonai-train/praisonai_train/data/__init__.py
@@ -7,6 +7,7 @@ Protocol-driven and extendable: recipes and QC checks self-register (see
 from praisonai_train.data import checks as _checks  # noqa: F401  registers checks
 from praisonai_train.data import recipes as _recipes  # noqa: F401  registers recipes
 from praisonai_train.data.benchmark import BenchResult, benchmark_deployments
+from praisonai_train.data.dedup import MinHashLSH, global_dedup, near_dedup
 from praisonai_train.data.generate import generate_dataset
 from praisonai_train.data.intent import translation_intent
 from praisonai_train.data.qc import filter_rows, score
@@ -14,10 +15,13 @@ from praisonai_train.data.registry import checks, recipes
 
 __all__ = [
     "BenchResult",
+    "MinHashLSH",
     "benchmark_deployments",
     "checks",
     "filter_rows",
     "generate_dataset",
+    "global_dedup",
+    "near_dedup",
     "recipes",
     "score",
     "translation_intent",

--- a/src/praisonai-train/praisonai_train/data/dedup.py
+++ b/src/praisonai-train/praisonai_train/data/dedup.py
@@ -67,6 +67,10 @@ class MinHasher:
     """
 
     def __init__(self, num_perm: int = 128, seed: int = 1, n: int = 4) -> None:
+        if num_perm < 1:
+            raise ValueError(f"minhash_perm must be >= 1, got {num_perm}")
+        if n < 1:
+            raise ValueError(f"ngram_n must be >= 1, got {n}")
         self.num_perm = num_perm
         self.n = n
         rnd = random.Random(seed)
@@ -83,9 +87,14 @@ class MinHasher:
 
 
 def signature_similarity(a: tuple[int, ...], b: tuple[int, ...]) -> float:
-    """Estimated Jaccard = fraction of agreeing MinHash positions."""
-    if not a:
-        return 1.0
+    """Estimated Jaccard = fraction of agreeing MinHash positions.
+
+    Empty signatures carry no information, so they are treated as *non*-similar
+    (0.0) rather than identical — otherwise a degenerate ``num_perm``/``ngram_n``
+    would make every row collapse into the first one.
+    """
+    if not a or not b or len(a) != len(b):
+        return 0.0
     return sum(1 for x, y in zip(a, b) if x == y) / len(a)
 
 
@@ -147,13 +156,28 @@ class MinHashLSH:
         return True
 
 
+def _make_lsh(cfg: dict) -> "MinHashLSH":
+    """Build a MinHashLSH from the shared cfg keys (one place — DRY)."""
+    return MinHashLSH(
+        threshold=cfg.get("near_dup_jaccard", 0.7),
+        num_perm=cfg.get("minhash_perm", 128),
+        n=cfg.get("ngram_n", 4),
+        seed=cfg.get("minhash_seed", 1),
+    )
+
+
 def _sliding_dedup(rows: list[dict], threshold: float, window: int) -> tuple[list[dict], int]:
+    # A non-positive window has no meaningful "last N" semantics; treat it as an
+    # unbounded look-back (compare against every kept row) rather than silently
+    # letting ``sigs[-0:]`` mean the whole list only when window == 0.
+    unbounded = window <= 0
     sigs: list[set] = []
     kept: list[dict] = []
     dropped = 0
     for r in rows:
         g = ngrams(fields(r)[0])
-        if any(jaccard(g, g2) > threshold for g2 in sigs[-window:]):
+        recent = sigs if unbounded else sigs[-window:]
+        if any(jaccard(g, g2) > threshold for g2 in recent):
             dropped += 1
             continue
         sigs.append(g)
@@ -162,12 +186,10 @@ def _sliding_dedup(rows: list[dict], threshold: float, window: int) -> tuple[lis
 
 
 def _minhash_dedup(rows: list[dict], cfg: dict, index: "MinHashLSH | None") -> tuple[list[dict], int]:
-    lsh = index or MinHashLSH(
-        threshold=cfg.get("near_dup_jaccard", 0.7),
-        num_perm=cfg.get("minhash_perm", 128),
-        n=cfg.get("ngram_n", 4),
-        seed=cfg.get("minhash_seed", 1),
-    )
+    # ``index is not None`` (not ``index or ...``): a freshly-created shared index
+    # is empty and therefore falsy, so ``or`` would discard it and break the
+    # documented cross-batch dedup on the very first call.
+    lsh = index if index is not None else _make_lsh(cfg)
     kept: list[dict] = []
     dropped = 0
     for r in rows:
@@ -212,25 +234,41 @@ def global_dedup(sources: Iterable, cfg: dict | None = None) -> Iterator[dict]:
     import os
 
     cfg = dict(cfg or {})
-    cfg.setdefault("near_dup_method", "minhash")
+    method = cfg.setdefault("near_dup_method", "minhash")
+    if method not in ("minhash", "sliding"):
+        raise ValueError(f"unknown near_dup_method {method!r}; use 'sliding' or 'minhash'")
     do_near = cfg.get("near_dup", True)
-    lsh = MinHashLSH(
-        threshold=cfg.get("near_dup_jaccard", 0.7),
-        num_perm=cfg.get("minhash_perm", 128),
-        n=cfg.get("ngram_n", 4),
-        seed=cfg.get("minhash_seed", 1),
-    ) if do_near else None
+    # Honour the requested engine. ``minhash`` uses one shared LSH index across
+    # every file (the whole point of global dedup); ``sliding`` keeps a growing
+    # shingle list so it still spans files, but with the classic window semantics.
+    use_minhash = do_near and method == "minhash"
+    lsh = _make_lsh(cfg) if use_minhash else None
+    slide_sigs: list[set] = []
+    slide_window = cfg.get("near_dup_window", 3000)
+    slide_thresh = cfg.get("near_dup_jaccard", 0.7)
     seen_exact: set[str] = set()
 
     for src in sources:
-        rows = ([json.loads(ln) for ln in open(src, encoding="utf-8") if ln.strip()]
-                if isinstance(src, str) and os.path.exists(src) else src)
+        if isinstance(src, str):
+            if not os.path.exists(src):
+                raise FileNotFoundError(f"dedup source not found: {src}")
+            with open(src, encoding="utf-8") as fh:
+                rows = [json.loads(ln) for ln in fh if ln.strip()]
+        else:
+            rows = src
         for r in rows:
             ins, inp, out = fields(r)
             key = hashlib.sha1(norm(ins + "\x00" + inp + "\x00" + out).encode()).hexdigest()
             if key in seen_exact:
                 continue
             seen_exact.add(key)
-            if lsh is not None and not lsh.add_if_new(ins):
-                continue
+            if lsh is not None:
+                if not lsh.add_if_new(ins):
+                    continue
+            elif do_near:  # sliding near-dup across files
+                g = ngrams(ins)
+                recent = slide_sigs if slide_window <= 0 else slide_sigs[-slide_window:]
+                if any(jaccard(g, g2) > slide_thresh for g2 in recent):
+                    continue
+                slide_sigs.append(g)
             yield r

--- a/src/praisonai-train/praisonai_train/data/dedup.py
+++ b/src/praisonai-train/praisonai_train/data/dedup.py
@@ -1,0 +1,236 @@
+"""Scalable near-duplicate detection for large synthetic corpora (stdlib only).
+
+Two engines share one ``near_dedup`` interface — the choice is YAML-tunable via
+``near_dup_method`` so existing behaviour is unchanged unless opted in:
+
+- ``"sliding"`` (default, unchanged): char-4gram Jaccard of each instruction vs
+  the last ``near_dup_window`` (3000) kept rows. Simple and exact, but O(n·window)
+  and structurally *blind* to near-duplicates more than ``window`` rows apart.
+
+- ``"minhash"``: MinHash + LSH banding. Each instruction is reduced to a fixed
+  ``num_perm``-length MinHash signature (an unbiased estimator of the shingle-set
+  Jaccard), and candidates are found by banded hashing — sub-linear lookup with
+  **no fixed comparison window**, so it catches near-dups anywhere in the corpus,
+  and one shared index can dedup *across many batch files* (``global_dedup``).
+
+Research backing (Self-Instruct's ROUGE-L<0.7 novelty filter is approximated by
+char-4gram Jaccard≥0.7; MinHash+LSH is the standard scalable near-dup method for
+LLM training corpora — Lee et al. 2022 "Deduplicating Training Data Makes LMs
+Better", and the CCNet/Gopher/RefinedWeb pipelines). The shingles here are the
+same normalized char-4grams the ``sliding`` engine uses, so the ``near_dup_jaccard``
+threshold keeps identical semantics across both engines.
+
+Pure stdlib: no ``datasketch``/``numpy`` dependency. ``datasketch`` could back the
+same interface for very large runs, but is intentionally *not* a hard dep.
+"""
+from __future__ import annotations
+
+import hashlib
+import random
+from typing import Iterable, Iterator
+
+from praisonai_train.data._util import fields, jaccard, ngrams, norm
+
+# Signatures live in [0, 2**32), so a band value packs to 4 bytes.
+_MASK32 = (1 << 32) - 1
+# A Mersenne prime > 2**32 for the universal-hash permutation family h(x)=(a*x+b) % p.
+_MERSENNE_61 = (1 << 61) - 1
+
+
+def _shingle_hash(shingle: str) -> int:
+    """Stable 32-bit hash of a shingle (blake2b, so it's independent of
+    PYTHONHASHSEED and reproducible across processes/persisted indexes)."""
+    return int.from_bytes(hashlib.blake2b(shingle.encode("utf-8"), digest_size=4).digest(), "big")
+
+
+def optimal_bands(num_perm: int, threshold: float) -> tuple[int, int]:
+    """Pick (bands b, rows-per-band r) with b·r == num_perm whose LSH S-curve
+    crossover (1/b)**(1/r) sits closest to ``threshold``. Standard MinHash-LSH
+    tuning: more bands → higher recall, fewer → higher precision."""
+    best, best_err = (num_perm, 1), float("inf")
+    for b in range(1, num_perm + 1):
+        if num_perm % b:
+            continue
+        r = num_perm // b
+        crossover = (1.0 / b) ** (1.0 / r)
+        err = abs(crossover - threshold)
+        if err < best_err:
+            best, best_err = (b, r), err
+    return best
+
+
+class MinHasher:
+    """Deterministic MinHash: char-n-gram shingles → ``num_perm`` minima.
+
+    Uses one universal-hash permutation family seeded by ``seed`` so signatures
+    are reproducible run-to-run (needed for tests and for a persistable index).
+    """
+
+    def __init__(self, num_perm: int = 128, seed: int = 1, n: int = 4) -> None:
+        self.num_perm = num_perm
+        self.n = n
+        rnd = random.Random(seed)
+        self._ab = [(rnd.randrange(1, _MERSENNE_61), rnd.randrange(0, _MERSENNE_61))
+                    for _ in range(num_perm)]
+
+    def signature(self, text: str) -> tuple[int, ...]:
+        shingles = ngrams(text, self.n)  # normalized char n-grams (shared with sliding)
+        if not shingles:
+            return (0,) * self.num_perm
+        base = [_shingle_hash(s) for s in shingles]
+        return tuple(min(((a * h + b) % _MERSENNE_61) & _MASK32 for h in base)
+                     for a, b in self._ab)
+
+
+def signature_similarity(a: tuple[int, ...], b: tuple[int, ...]) -> float:
+    """Estimated Jaccard = fraction of agreeing MinHash positions."""
+    if not a:
+        return 1.0
+    return sum(1 for x, y in zip(a, b) if x == y) / len(a)
+
+
+class MinHashLSH:
+    """A MinHash + LSH near-duplicate index.
+
+    ``add_if_new(text)`` returns True and indexes ``text`` when it is *not* a
+    near-duplicate (estimated Jaccard ≥ ``threshold``) of anything already in the
+    index; otherwise returns False and leaves the index unchanged. Banded hashing
+    keeps candidate lookup sub-linear, so this scales to large corpora and, unlike
+    the sliding window, has no bounded look-back — the whole corpus is the index.
+    """
+
+    def __init__(self, threshold: float = 0.7, num_perm: int = 128,
+                 n: int = 4, seed: int = 1) -> None:
+        self.threshold = threshold
+        self.hasher = MinHasher(num_perm, seed, n)
+        self.bands, self.rows = optimal_bands(num_perm, threshold)
+        self._buckets: list[dict[bytes, list[int]]] = [dict() for _ in range(self.bands)]
+        self._sigs: dict[int, tuple[int, ...]] = {}
+        self._next = 0
+
+    def __len__(self) -> int:
+        return len(self._sigs)
+
+    def _band_keys(self, sig: tuple[int, ...]) -> Iterator[tuple[int, bytes]]:
+        for i in range(self.bands):
+            band = sig[i * self.rows:(i + 1) * self.rows]
+            key = hashlib.blake2b(b"".join(v.to_bytes(4, "big") for v in band),
+                                  digest_size=8).digest()
+            yield i, key
+
+    def query(self, text: str) -> tuple[tuple[int, ...], set[int]]:
+        """Return (signature, candidate keys sharing ≥1 band with ``text``)."""
+        sig = self.hasher.signature(text)
+        cands: set[int] = set()
+        for i, key in self._band_keys(sig):
+            cands.update(self._buckets[i].get(key, ()))
+        return sig, cands
+
+    def _insert(self, sig: tuple[int, ...]) -> int:
+        key = self._next
+        self._next += 1
+        self._sigs[key] = sig
+        for i, band_key in self._band_keys(sig):
+            self._buckets[i].setdefault(band_key, []).append(key)
+        return key
+
+    def is_near_dup(self, text: str) -> bool:
+        sig, cands = self.query(text)
+        return any(signature_similarity(sig, self._sigs[k]) >= self.threshold for k in cands)
+
+    def add_if_new(self, text: str) -> bool:
+        """True (and index it) if ``text`` is new; False if it's a near-dup."""
+        sig, cands = self.query(text)
+        if any(signature_similarity(sig, self._sigs[k]) >= self.threshold for k in cands):
+            return False
+        self._insert(sig)
+        return True
+
+
+def _sliding_dedup(rows: list[dict], threshold: float, window: int) -> tuple[list[dict], int]:
+    sigs: list[set] = []
+    kept: list[dict] = []
+    dropped = 0
+    for r in rows:
+        g = ngrams(fields(r)[0])
+        if any(jaccard(g, g2) > threshold for g2 in sigs[-window:]):
+            dropped += 1
+            continue
+        sigs.append(g)
+        kept.append(r)
+    return kept, dropped
+
+
+def _minhash_dedup(rows: list[dict], cfg: dict, index: "MinHashLSH | None") -> tuple[list[dict], int]:
+    lsh = index or MinHashLSH(
+        threshold=cfg.get("near_dup_jaccard", 0.7),
+        num_perm=cfg.get("minhash_perm", 128),
+        n=cfg.get("ngram_n", 4),
+        seed=cfg.get("minhash_seed", 1),
+    )
+    kept: list[dict] = []
+    dropped = 0
+    for r in rows:
+        if lsh.add_if_new(fields(r)[0]):
+            kept.append(r)
+        else:
+            dropped += 1
+    return kept, dropped
+
+
+def near_dedup(rows: Iterable[dict], cfg: dict | None = None,
+               index: "MinHashLSH | None" = None) -> tuple[list[dict], int]:
+    """Drop near-duplicate rows (by instruction). Returns (kept, n_dropped).
+
+    ``near_dup_method``: ``"sliding"`` (default) or ``"minhash"``. When an
+    ``index`` is supplied (minhash only) it is reused/mutated, enabling dedup
+    across successive batches against one shared index.
+    """
+    cfg = dict(cfg or {})
+    rows = list(rows)
+    threshold = cfg.get("near_dup_jaccard", 0.7)
+    method = cfg.get("near_dup_method", "sliding")
+    if method == "minhash":
+        return _minhash_dedup(rows, cfg, index)
+    if method != "sliding":
+        raise ValueError(f"unknown near_dup_method {method!r}; use 'sliding' or 'minhash'")
+    return _sliding_dedup(rows, threshold, cfg.get("near_dup_window", 3000))
+
+
+def global_dedup(sources: Iterable, cfg: dict | None = None) -> Iterator[dict]:
+    """Deduplicate rows ACROSS many batch files with one shared index.
+
+    ``sources`` is an iterable of JSONL paths (str) or in-memory row lists; rows
+    are streamed in source order and each unique one is yielded once. Exact dups
+    (sha1 of the normalized instruction+input+output) are removed first, then
+    near-dups via MinHash+LSH (``near_dup_method`` defaults to ``"minhash"`` here,
+    since a shared index is the whole point; set ``near_dup: false`` to do exact
+    only). This is what the per-file ``score()`` cannot do — its exact/near state
+    is rebuilt per call, so cross-file duplicates survive.
+    """
+    import json
+    import os
+
+    cfg = dict(cfg or {})
+    cfg.setdefault("near_dup_method", "minhash")
+    do_near = cfg.get("near_dup", True)
+    lsh = MinHashLSH(
+        threshold=cfg.get("near_dup_jaccard", 0.7),
+        num_perm=cfg.get("minhash_perm", 128),
+        n=cfg.get("ngram_n", 4),
+        seed=cfg.get("minhash_seed", 1),
+    ) if do_near else None
+    seen_exact: set[str] = set()
+
+    for src in sources:
+        rows = ([json.loads(ln) for ln in open(src, encoding="utf-8") if ln.strip()]
+                if isinstance(src, str) and os.path.exists(src) else src)
+        for r in rows:
+            ins, inp, out = fields(r)
+            key = hashlib.sha1(norm(ins + "\x00" + inp + "\x00" + out).encode()).hexdigest()
+            if key in seen_exact:
+                continue
+            seen_exact.add(key)
+            if lsh is not None and not lsh.add_if_new(ins):
+                continue
+            yield r

--- a/src/praisonai-train/praisonai_train/data/qc.py
+++ b/src/praisonai-train/praisonai_train/data/qc.py
@@ -15,7 +15,8 @@ from typing import Any, Iterable
 
 from praisonai_train.data import checks as _checks_mod  # noqa: F401  (registers checks)
 from praisonai_train.data.checks import _script_ratio
-from praisonai_train.data._util import fields, jaccard, ngrams, norm
+from praisonai_train.data._util import fields, norm
+from praisonai_train.data.dedup import near_dedup
 from praisonai_train.data.intent import translation_intent
 from praisonai_train.data.registry import checks
 
@@ -26,7 +27,6 @@ def score(rows: Iterable[dict], cfg: dict | None = None) -> dict[str, Any]:
     drop_checks = [c for c in checks.all() if c.kind == "drop"]
     flag_checks = [c for c in checks.all() if c.kind == "flag"]
     do_near = cfg.get("near_dup", True)
-    near_j = cfg.get("near_dup_jaccard", 0.7)
 
     seen: set[str] = set()
     kept: list[dict] = []
@@ -58,16 +58,12 @@ def score(rows: Iterable[dict], cfg: dict | None = None) -> dict[str, Any]:
         kept.append(r)
 
     if do_near:
-        sigs: list[set] = []
-        deduped: list[dict] = []
-        for r in kept:
-            g = ngrams(fields(r)[0])
-            if any(jaccard(g, g2) > near_j for g2 in sigs[-3000:]):
-                drops["near_dup"] += 1
-                continue
-            sigs.append(g)
-            deduped.append(r)
-        kept = deduped
+        # Near-dup removal is delegated to the dedup engine (DRY). Method is
+        # YAML-tunable: 'sliding' (default, unchanged) or scalable 'minhash'
+        # (MinHash+LSH — no bounded look-back window, catches near-dups anywhere).
+        kept, near_dropped = near_dedup(kept, cfg)
+        if near_dropped:
+            drops["near_dup"] += near_dropped
 
     lens = [len((fields(r)[2] or "").split()) for r in kept]
     cv = st.pstdev(lens) / max(st.mean(lens), 1) if lens else 0.0

--- a/src/praisonai-train/tests/unit/data/test_dedup.py
+++ b/src/praisonai-train/tests/unit/data/test_dedup.py
@@ -1,0 +1,163 @@
+"""Tests for the MinHash+LSH near-dedup engine and cross-file global dedup.
+
+Deterministic: MinHasher is seeded, so signatures/bucketing are reproducible.
+"""
+import json
+
+from praisonai_train.data import global_dedup, near_dedup, score
+from praisonai_train.data.dedup import (
+    MinHashLSH,
+    MinHasher,
+    optimal_bands,
+    signature_similarity,
+)
+
+
+def _rows(*instructions):
+    return [{"instruction": t, "input": "", "output": "ஒரு முழுமையான தமிழ் பதில் இங்கே."}
+            for t in instructions]
+
+
+# ── MinHash primitives ────────────────────────────────────────────────────────
+
+def test_minhasher_is_deterministic():
+    a = MinHasher(num_perm=64, seed=7).signature("the quick brown fox jumps")
+    b = MinHasher(num_perm=64, seed=7).signature("the quick brown fox jumps")
+    assert a == b and len(a) == 64
+
+
+def test_signature_similarity_tracks_jaccard():
+    h = MinHasher(num_perm=256, seed=1)
+    base = "please summarize the following article about tamil history in detail"
+    near = "please summarize the following article about tamil history in brief"
+    far = "write a python function that reverses a linked list quickly"
+    sim_near = signature_similarity(h.signature(base), h.signature(near))
+    sim_far = signature_similarity(h.signature(base), h.signature(far))
+    assert sim_near > 0.7 > sim_far
+
+
+def test_optimal_bands_partition_num_perm():
+    b, r = optimal_bands(128, 0.7)
+    assert b * r == 128 and b >= 1 and r >= 1
+
+
+# ── LSH index behaviour ───────────────────────────────────────────────────────
+
+def test_lsh_flags_near_and_keeps_distinct():
+    lsh = MinHashLSH(threshold=0.7, num_perm=128, seed=1)
+    assert lsh.add_if_new("explain photosynthesis to a curious school student") is True
+    # near-identical (one word changed) → duplicate, index unchanged
+    assert lsh.add_if_new("explain photosynthesis to a curious school pupil") is False
+    # genuinely different → kept
+    assert lsh.add_if_new("give me a recipe for spicy tomato rice") is True
+    assert len(lsh) == 2
+
+
+def test_lsh_query_returns_candidates_via_banding():
+    lsh = MinHashLSH(threshold=0.7, num_perm=128, seed=1)
+    lsh.add_if_new("the mitochondria is the powerhouse of the cell indeed")
+    _, cands = lsh.query("the mitochondria is the powerhouse of the cell today")
+    assert cands, "banded hashing should surface the near-dup as a candidate"
+
+
+# ── The headline claim: minhash catches near-dups the sliding window misses ────
+
+def test_minhash_catches_far_near_dup_that_sliding_window_misses():
+    a = "translate the following tamil sentence into fluent english please"
+    b = "translate the following tamil sentence into fluent english now"  # near-dup of a
+    filler = _rows(
+        "how do bees communicate the location of flowers",
+        "recommend a good beginner yoga routine for mornings",
+        "why is the sky blue during the daytime hours",
+        "give tips for growing tomatoes in a small balcony",
+        "explain how a suspension bridge carries its load",
+    )
+    rows = _rows(a) + filler + _rows(b)
+
+    # Sliding window of 1 only ever compares against the immediately previous row,
+    # so the near-dup 6 rows later slips through (the real limitation at scale).
+    slide_kept, slide_dropped = near_dedup(
+        rows, {"near_dup_method": "sliding", "near_dup_window": 1})
+    assert slide_dropped == 0
+    assert len(slide_kept) == len(rows)
+
+    # MinHash+LSH has no look-back window → it catches it regardless of distance.
+    mh_kept, mh_dropped = near_dedup(rows, {"near_dup_method": "minhash"})
+    assert mh_dropped == 1
+    assert len(mh_kept) == len(rows) - 1
+
+
+def test_minhash_does_not_drop_genuinely_distinct_rows():
+    rows = _rows(
+        "what is the capital of france",
+        "describe the process of cellular respiration",
+        "write a haiku about the monsoon season",
+        "compute the derivative of x squared plus three x",
+        "list five benefits of regular physical exercise",
+    )
+    kept, dropped = near_dedup(rows, {"near_dup_method": "minhash"})
+    assert dropped == 0 and len(kept) == len(rows)
+
+
+def test_score_minhash_method_removes_near_dups():
+    rows = _rows(
+        "summarize the history of the tamil sangam literature in three lines",
+        "summarize the history of the tamil sangam literature in three sentences",
+    )
+    r = score(rows, {"near_dup_method": "minhash", "min_output_chars": 5})
+    assert r["drops"].get("near_dup", 0) == 1
+    assert r["kept_n"] == 1
+
+
+def test_unknown_method_raises():
+    import pytest
+    with pytest.raises(ValueError):
+        near_dedup(_rows("x"), {"near_dup_method": "bogus"})
+
+
+# ── Cross-file / global dedup (what per-file score() cannot do) ────────────────
+
+def test_global_dedup_removes_cross_file_dups(tmp_path):
+    f1 = tmp_path / "batch1.jsonl"
+    f2 = tmp_path / "batch2.jsonl"
+    f1.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in _rows(
+        "what is machine learning",
+        "explain gradient descent simply",
+    )) + "\n", encoding="utf-8")
+    f2.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in _rows(
+        "what is machine learning",                 # exact cross-file dup
+        "explain gradient descent very simply",     # near cross-file dup
+        "a totally unrelated fresh question here",  # unique
+    )) + "\n", encoding="utf-8")
+
+    kept = list(global_dedup([str(f1), str(f2)]))
+    instrs = [k["instruction"] for k in kept]
+    assert "what is machine learning" in instrs
+    assert instrs.count("what is machine learning") == 1        # exact dup removed
+    assert "explain gradient descent very simply" not in instrs  # near dup removed
+    assert "a totally unrelated fresh question here" in instrs   # unique preserved
+    assert len(kept) == 3
+
+
+def test_global_dedup_exact_only(tmp_path):
+    f1 = tmp_path / "a.jsonl"
+    f1.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in _rows(
+        "identical prompt", "identical prompt", "near identical prompt")) + "\n",
+        encoding="utf-8")
+    kept = list(global_dedup([str(f1)], {"near_dup": False}))
+    # exact dup collapsed; the near one survives because near-dup is disabled
+    assert len(kept) == 2
+
+
+def test_global_dedup_accepts_inmemory_rows():
+    kept = list(global_dedup([_rows("alpha one two"), _rows("alpha one two")]))
+    assert len(kept) == 1
+
+
+# ── Backward compatibility: default path is unchanged ─────────────────────────
+
+def test_default_method_is_sliding_and_matches_legacy():
+    dup_a = "please write a short poem about the rain and the sea"
+    rows = _rows(dup_a, dup_a + " today")  # >0.7 char-4gram Jaccard, adjacent
+    kept, dropped = near_dedup(rows, {})  # no method → sliding default
+    assert dropped == 1 and len(kept) == 1

--- a/src/praisonai-train/tests/unit/data/test_dedup.py
+++ b/src/praisonai-train/tests/unit/data/test_dedup.py
@@ -154,6 +154,65 @@ def test_global_dedup_accepts_inmemory_rows():
     assert len(kept) == 1
 
 
+# ── Regression: reviewer-reported edge cases ──────────────────────────────────
+
+def test_shared_empty_index_is_reused_across_batches():
+    # A freshly-created shared index is empty (falsy); it must still be reused so
+    # cross-batch near-dups are caught on the first call, not silently discarded.
+    shared = MinHashLSH(threshold=0.7, num_perm=128, seed=1)
+    b1 = _rows("translate this tamil line into fluent english please")
+    b2 = _rows("translate this tamil line into fluent english now")  # near-dup
+    k1, d1 = near_dedup(b1, {"near_dup_method": "minhash"}, index=shared)
+    assert d1 == 0 and len(shared) == 1
+    k2, d2 = near_dedup(b2, {"near_dup_method": "minhash"}, index=shared)
+    assert d2 == 1 and k2 == []
+
+
+def test_empty_signatures_are_not_similar():
+    # Degenerate/empty signatures must not be treated as identical (== 1.0),
+    # which would collapse every row into the first.
+    assert signature_similarity((), ()) == 0.0
+    assert signature_similarity((1, 2), ()) == 0.0
+    assert signature_similarity((1, 2), (1,)) == 0.0
+
+
+def test_zero_perm_is_rejected():
+    import pytest
+    with pytest.raises(ValueError):
+        MinHasher(num_perm=0)
+    with pytest.raises(ValueError):
+        near_dedup(_rows("x y z"), {"near_dup_method": "minhash", "minhash_perm": 0})
+
+
+def test_global_dedup_missing_path_raises_clear_error():
+    import pytest
+    with pytest.raises(FileNotFoundError):
+        list(global_dedup(["/no/such/file_xyz.jsonl"]))
+
+
+def test_global_dedup_honours_sliding_method(tmp_path):
+    f1 = tmp_path / "a.jsonl"
+    f1.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in _rows(
+        "please write a short poem about the rain and the sea",
+        "please write a short poem about the rain and the sea today",  # near
+    )) + "\n", encoding="utf-8")
+    kept = list(global_dedup([str(f1)], {"near_dup_method": "sliding"}))
+    assert len(kept) == 1
+
+
+def test_dedup_cli_does_not_truncate_aliased_input(tmp_path):
+    from praisonai_train.cli.commands.data import dedup_data
+    f1 = tmp_path / "in.jsonl"
+    f1.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in _rows(
+        "unique alpha row", "unique beta row", "unique alpha row")) + "\n",
+        encoding="utf-8")
+    # --out aliases the input; the exact dup collapses to 2 and the file survives.
+    dedup_data(inputs=[str(f1)], config=None, out=str(f1),
+               method=None, threshold=None, exact_only=False)
+    kept = [json.loads(ln) for ln in f1.read_text().splitlines() if ln.strip()]
+    assert len(kept) == 2
+
+
 # ── Backward compatibility: default path is unchanged ─────────────────────────
 
 def test_default_method_is_sliding_and_matches_legacy():


### PR DESCRIPTION
## What & why

The praisonai-train data SDK already does strong diversity work: exact dedup (sha1), a Self-Instruct–style near-dup filter (char-4gram Jaccard ≥ 0.7), task-aware purity, and a disjoint prompt-space generator. Two real gaps remained on the **uniqueness/diversity** axis:

1. **The near-dup pass doesn't scale and has a blind spot.** `score()` compares each instruction's 4-gram set against a **sliding window of the last 3000 kept rows** (`O(n·3000)`), so it is (a) slow on large corpora and (b) *structurally unable* to catch a near-duplicate that lands more than 3000 rows away from its twin.
2. **No cross-file dedup.** `score()` rebuilds its exact/near state per call, so duplicates that span multiple batch files — the normal case when merging parallel/incremental generation runs — survive.

This PR adds a **MinHash + LSH** near-dup engine and a **cross-file global dedup** utility that together close both gaps, matching the SDK's protocol-driven, YAML-tunable idiom. **Pure stdlib — no new dependencies** (no `datasketch`/`numpy`).

## Research (2024–2026 best practices surveyed)

Generation-time diversity and post-hoc dedup were both reviewed; the SDK already covers the generation-time side (disjoint prompt-space offsets, persona/topic/style/audience axes, Self-Instruct ROUGE-L≈Jaccard novelty filter). The highest-value **missing** piece was scalable post-hoc near-dedup.

- **Self-Instruct** — ROUGE-L < 0.7 novelty filter against the growing pool (the exact strategy the SDK approximates with char-4gram Jaccard). https://arxiv.org/abs/2212.10560
- **Lee et al., "Deduplicating Training Data Makes Language Models Better"** — near-dup removal via MinHash improves models and reduces memorization. https://arxiv.org/abs/2107.06499
- **MinHash + LSH is the predominant scalable near-dup method** for LLM training/code corpora; tune bands/rows to trade recall vs precision. https://milvus.io/blog/minhash-lsh-in-milvus-the-secret-weapon-for-fighting-duplicates-in-llm-training-data.md · https://zilliz.com/blog/data-deduplication-at-trillion-scale-solve-the-biggest-bottleneck-of-llm-training
- **SemDeDup** (semantic/embedding dedup, cosine threshold, k-means for O(N²/k)) — considered but **intentionally not implemented as a hard dep** (needs an embedding model). Noted in the module as an optional future backend. https://arxiv.org/abs/2303.09540 · https://docs.nvidia.com/nemo-framework/user-guide/24.07/datacuration/semdedup.html
- **Diversity-based filtering** (loosening ROUGE-L 0.7→0.85 to keep more) motivates keeping the threshold configurable. https://arxiv.org/pdf/2502.04774
- **Persona/fine-grained diversity prompting** — generation-time diversity (already covered by the SDK's axis recipes). https://arxiv.org/pdf/2505.17390

**Why MinHash+LSH over semantic dedup:** it directly fixes the SDK's actual limitation (window-bounded, per-file, `O(n·3000)`), keeps identical Jaccard-threshold semantics as the current filter, needs zero new dependencies, and is the industry-standard scalable method. Semantic dedup would add a model dependency for a different (paraphrase) signal — left as an optional future backend.

## Public API / config

New (opt-in, backward compatible — default engine and outputs unchanged):

```python
from praisonai_train.data import near_dedup, global_dedup, MinHashLSH
```

- `qc.score(rows, cfg)` — new `cfg` keys:
  - `near_dup_method`: `"sliding"` (default, unchanged) | `"minhash"`
  - `near_dup_window`: sliding look-back (default `3000`, now tunable)
  - `minhash_perm` (128), `ngram_n` (4), `minhash_seed` (1), `near_dup_jaccard` (0.7)
- `near_dedup(rows, cfg, index=None) -> (kept, n_dropped)` — one interface over both engines; pass a shared `MinHashLSH` to dedup successive batches.
- `global_dedup(sources, cfg) -> Iterator[dict]` — exact (sha1) + MinHash/LSH near-dedup **across** many JSONL paths / row-lists with one shared index.
- CLI: `praisonai-train dedup batch_*.jsonl --out merged.jsonl [--method minhash|sliding] [--threshold 0.7] [--exact-only]`

`MinHasher` is seeded → signatures/bucketing are deterministic (reproducible, testable, persistable).

## Files changed

- `praisonai_train/data/dedup.py` (new) — MinHasher, MinHashLSH, `optimal_bands`, `near_dedup`, `global_dedup`
- `praisonai_train/data/qc.py` — near-dup pass delegates to `near_dedup` (DRY); `near_dup_window` honored
- `praisonai_train/data/__init__.py` — export `near_dedup`, `global_dedup`, `MinHashLSH`
- `praisonai_train/cli/commands/data.py` — new `dedup` command
- `tests/unit/data/test_dedup.py` (new) — 13 deterministic tests

## Tests

- New `test_dedup.py`: **13 passed** — incl. MinHash catches a far near-dup a window-1 sliding pass misses, preserves genuinely-distinct rows, cross-file exact+near removal, exact-only mode, and default-still-sliding backward-compat.
- Full data suite (`tests/unit/data/`): **60 passed**.
- CLI smoke test: `dedup` across 2 files removed 1 exact + 1 near cross-file dup, kept 3 unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `dedup` CLI command to remove exact and near-duplicate JSONL records across multiple inputs (with stats output).
  * Supports config-driven input/output and tuning of dedup method, similarity threshold, and exact-only behavior.
  * Introduced MinHash+LSH near-duplicate detection (plus an alternative sliding strategy) to scale deduplication for larger datasets.
  * Added programmatic dedup helpers and exports for near/global dedup utilities.

* **Bug Fixes**
  * Improved data QC by routing near-duplicate removal through the shared dedup implementation for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->