### PR TITLE
fix(agents): stop claude-code OAuth refresh invalidating shared sessions

### DIFF
--- a/src/praisonai-agents/praisonaiagents/auth/subscription/claude_code.py
+++ b/src/praisonai-agents/praisonaiagents/auth/subscription/claude_code.py
@@ -6,20 +6,12 @@ import os
 import re
 import subprocess
 import sys
-import time
-import urllib.parse
-import urllib.request
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from .protocols import AuthError, SubscriptionAuthProtocol, SubscriptionCredentials
+from .protocols import AuthError, SubscriptionCredentials
 from .registry import register_subscription_provider
 
-_OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_TOKEN_ENDPOINTS = (
-    "https://platform.claude.com/v1/oauth/token",
-    "https://console.anthropic.com/v1/oauth/token",
-)
 _CLAUDE_CODE_VERSION_FALLBACK = "2.1.74"
 
 
@@ -97,43 +89,6 @@ def _read_file_credentials() -> Optional[Dict[str, Any]]:
     }
 
 
-def _is_expiring(expires_at_ms: Optional[int], skew_ms: int = 60_000) -> bool:
-    if not expires_at_ms:
-        return False
-    return int(time.time() * 1000) >= (expires_at_ms - skew_ms)
-
-
-def _refresh(refresh_token: str) -> Dict[str, Any]:
-    """Pure refresh — does not touch local files."""
-    if not refresh_token:
-        raise AuthError("no refresh_token; please re-run 'claude /login'")
-    body = urllib.parse.urlencode({
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-        "client_id": _OAUTH_CLIENT_ID,
-    }).encode()
-    last = None
-    for endpoint in _TOKEN_ENDPOINTS:
-        req = urllib.request.Request(
-            endpoint, data=body, method="POST",
-            headers={
-                "Content-Type": "application/x-www-form-urlencoded",
-                "User-Agent":   f"claude-cli/{_detect_claude_code_version()} (external, cli)",
-            },
-        )
-        try:
-            with urllib.request.urlopen(req, timeout=10) as resp:
-                payload = json.loads(resp.read().decode())
-            return {
-                "accessToken":  payload["access_token"],
-                "refreshToken": payload.get("refresh_token", refresh_token),
-                "expiresAt":    int(time.time() * 1000) + int(payload.get("expires_in", 3600)) * 1000,
-            }
-        except Exception as exc:
-            last = exc
-    raise AuthError(f"Anthropic refresh failed: {last}")
-
-
 class ClaudeCodeAuth:
     """Claude Code OAuth subscription auth."""
 
@@ -159,8 +114,9 @@ class ClaudeCodeAuth:
                 "No Claude Code credentials found. Install Claude Code and run "
                 "'claude /login', or set ANTHROPIC_TOKEN."
             )
-        if _is_expiring(creds["expiresAt"]) and creds.get("refreshToken"):
-            creds.update(_refresh(creds["refreshToken"]))
+        # Read-only: never refresh here. Anthropic rotates refresh tokens and
+        # PraisonAI does not write back to Keychain, which would invalidate
+        # Claude CLI and other tools sharing the same session.
         return SubscriptionCredentials(
             api_key=creds["accessToken"],
             base_url="https://api.anthropic.com",
@@ -171,17 +127,11 @@ class ClaudeCodeAuth:
         )
 
     def refresh(self) -> SubscriptionCredentials:
-        creds = _read_keychain_credentials() or _read_file_credentials()
-        if not creds or not creds.get("refreshToken"):
-            raise AuthError("cannot refresh: no refresh token available")
-        new = _refresh(creds["refreshToken"])
-        return SubscriptionCredentials(
-            api_key=new["accessToken"],
-            base_url="https://api.anthropic.com",
-            headers=self.headers_for("https://api.anthropic.com", ""),
-            auth_scheme="bearer",
-            expires_at_ms=new["expiresAt"],
-            source="claude-code-refreshed",
+        raise AuthError(
+            "PraisonAI does not refresh shared Claude Code OAuth sessions "
+            "(refresh-token rotation would invalidate Claude CLI and other "
+            "tools using the same Keychain entry). Run 'claude /login' or "
+            "let Claude CLI refresh credentials, then retry."
         )
 
     def headers_for(self, base_url: str, model: str) -> Dict[str, str]:
@@ -190,8 +140,7 @@ class ClaudeCodeAuth:
         return {
             "anthropic-beta": ",".join([
                 "interleaved-thinking-2025-05-14",
-                "fine-grained-tool-streaming-2025-05-14", 
-                "context-1m-2025-08-07",
+                "fine-grained-tool-streaming-2025-05-14",
                 "claude-code-20250219",
             ]),
             "user-agent":     f"claude-cli/{_detect_claude_code_version()} (external, cli)",

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -755,15 +755,17 @@ Respond with ONLY a valid JSON tool call in this format:
         
         # Check for permanent auth errors first (non-retryable)
         if any(indicator in error_str for indicator in [
-            "invalid api key", "api key not found", "invalid_api_key", 
-            "incorrect api key", "authentication_error"
+            "invalid api key", "api key not found", "invalid_api_key",
+            "incorrect api key", "authentication_error",
+            "oauth access token has been revoked", "token has been revoked",
+            "oauth session expired", "could not be refreshed",
         ]):
             return "auth_permanent"
         
         # Retryable authentication errors
         if any(indicator in error_str for indicator in [
             "unauthorized", "api key", "authentication failed",
-            "invalid_request_error", "openai_error"
+            "openai_error",
         ]):
             return "auth"
         
@@ -975,6 +977,10 @@ Respond with ONLY a valid JSON tool call in this format:
         for the same exception, which would double-count those mutations.
         """
         if not (self._auth_provider_id and attempt == 0):
+            return False
+        # Shared OAuth stores (Claude Code Keychain) must not be refreshed here:
+        # rotation invalidates tokens for other CLI consumers without persisting back.
+        if self._auth_provider_id == "claude-code":
             return False
         return self.classify_error_kind(e) == "auth"
 

--- a/src/praisonai-agents/tests/smoke/test_subscription_auth.py
+++ b/src/praisonai-agents/tests/smoke/test_subscription_auth.py
@@ -64,66 +64,42 @@ def test_claude_code_auth_flow():
             assert params.get("api_key") == "sk-ant-oat-test-oauth-token"
 
 
-def test_auth_refresh_on_401():
-    """Test that auth errors trigger credential refresh and retry."""
-    # First call: return 401, second call: success
+def test_claude_code_does_not_refresh_on_auth_error():
+    """claude-code must not rotate shared OAuth tokens on auth errors."""
     mock_response = Mock()
     mock_response.choices = [Mock()]
     mock_response.choices[0].message = Mock()
-    mock_response.choices[0].message.content = "Success after refresh"
-    
-    auth_error = Exception("AuthenticationError: Invalid API key")
-    
+    mock_response.choices[0].message.content = "Success after retry"
+
+    auth_error = Exception("Unauthorized")
+
     with patch('litellm.completion') as mock_completion:
-        # First call raises auth error, second succeeds
         mock_completion.side_effect = [auth_error, mock_response]
-        
-        # Mock credential resolution and refresh
+
         initial_creds = SubscriptionCredentials(
             api_key="sk-ant-oat-expired-token",
-            base_url="https://api.anthropic.com", 
-            headers={},
-            auth_scheme="bearer",
-            source="claude-code-test"
-        )
-        
-        refreshed_creds = SubscriptionCredentials(
-            api_key="sk-ant-oat-fresh-token",
             base_url="https://api.anthropic.com",
             headers={},
-            auth_scheme="bearer", 
-            source="claude-code-refreshed"
+            auth_scheme="bearer",
+            source="claude-code-keychain",
         )
-        
+
         with patch('praisonaiagents.auth.resolve_subscription_credentials') as mock_resolve:
             mock_resolve.return_value = initial_creds
-            
+
             with patch('praisonaiagents.auth.subscription.registry.get_subscription_provider') as mock_provider:
                 mock_auth_provider = Mock()
-                mock_auth_provider.refresh.return_value = refreshed_creds
                 mock_provider.return_value = mock_auth_provider
-                
-                # Mock error classification to detect auth error
-                from praisonaiagents.llm.llm import LLM
-                with patch.object(LLM, '_classify_error_and_should_retry') as mock_classify:
-                    # First call: auth error, can retry
-                    # Second call: shouldn't be called since retry succeeds
-                    mock_classify.return_value = ("auth", True, 0.0)
-                    
-                    agent = Agent(
-                        name="test-agent",
-                        instructions="Test agent",
-                        auth="claude-code"
-                    )
-                    
-                    # This should trigger refresh on first 401 and succeed on retry
-                    response = agent.start("Test refresh flow")
-                    
-                    # Verify refresh was called
-                    assert mock_auth_provider.refresh.called
-                    
-                    # Verify we got success response
-                    assert "Success after refresh" in response
+
+                agent = Agent(
+                    name="test-agent",
+                    instructions="Test agent",
+                    auth="claude-code",
+                )
+
+                agent.start("Test no refresh on auth error")
+
+                assert not mock_auth_provider.refresh.called
 
 
 def test_invalid_auth_provider():
@@ -160,7 +136,7 @@ def test_gemini_experimental_error():
 if __name__ == "__main__":
     # Manual test runner for development
     test_claude_code_auth_flow()
-    test_auth_refresh_on_401()
+    test_claude_code_does_not_refresh_on_auth_error()
     test_invalid_auth_provider()
     test_codex_experimental_error()
     test_gemini_experimental_error()

--- a/src/praisonai-agents/tests/unit/auth/test_claude_code_auth.py
+++ b/src/praisonai-agents/tests/unit/auth/test_claude_code_auth.py
@@ -61,6 +61,9 @@ def test_refresh_is_read_only():
 def test_resolve_credentials_does_not_refresh_when_expiring(monkeypatch):
     """Expiring tokens are returned as-is; no network refresh."""
     import time
+    # Isolate from ambient OAuth env vars so the Keychain path is exercised.
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
     monkeypatch.setattr(
         "praisonaiagents.auth.subscription.claude_code._read_keychain_credentials",
         lambda: {
@@ -110,6 +113,10 @@ def test_headers_for_includes_required_oauth_headers():
     headers = auth.headers_for("https://api.anthropic.com", "claude-3-haiku")
 
     assert "interleaved-thinking-2025-05-14" in headers["anthropic-beta"]
+    assert "fine-grained-tool-streaming-2025-05-14" in headers["anthropic-beta"]
     assert "claude-code-20250219" in headers["anthropic-beta"]
+    # The unsupported long-context beta caused subscription API failures and
+    # must stay removed for shared OAuth sessions.
+    assert "context-1m-2025-08-07" not in headers["anthropic-beta"]
     assert headers["user-agent"].startswith("claude-cli/")
     assert headers["x-app"] == "cli"

--- a/src/praisonai-agents/tests/unit/auth/test_claude_code_auth.py
+++ b/src/praisonai-agents/tests/unit/auth/test_claude_code_auth.py
@@ -11,7 +11,6 @@ from praisonaiagents.auth.subscription.claude_code import (
     ClaudeCodeAuth,
     _read_keychain_credentials,
     _read_file_credentials,
-    _is_expiring,
     AuthError
 )
 
@@ -52,22 +51,30 @@ def test_file_path_reads_credentials(monkeypatch):
         os.unlink(tmp_path)
 
 
-def test_is_expiring():
-    """Test token expiry detection."""
+def test_refresh_is_read_only():
+    """Refresh must not rotate shared Keychain OAuth tokens."""
+    auth = ClaudeCodeAuth()
+    with pytest.raises(AuthError, match="does not refresh shared Claude Code"):
+        auth.refresh()
+
+
+def test_resolve_credentials_does_not_refresh_when_expiring(monkeypatch):
+    """Expiring tokens are returned as-is; no network refresh."""
     import time
-    current_ms = int(time.time() * 1000)
-    
-    # Token expires in 30 seconds (should be considered expiring with default 60s skew)
-    soon_expired = current_ms + 30_000
-    assert _is_expiring(soon_expired) is True
-    
-    # Token expires in 2 minutes (should not be expiring)
-    not_expired = current_ms + 120_000
-    assert _is_expiring(not_expired) is False
-    
-    # No expiry time
-    assert _is_expiring(0) is False
-    assert _is_expiring(None) is False
+    monkeypatch.setattr(
+        "praisonaiagents.auth.subscription.claude_code._read_keychain_credentials",
+        lambda: {
+            "accessToken": "sk-ant-oat-test",
+            "refreshToken": "rt-test",
+            "expiresAt": int(time.time() * 1000) + 5_000,
+            "source": "claude-code-keychain",
+        },
+    )
+
+    auth = ClaudeCodeAuth()
+    creds = auth.resolve_credentials()
+    assert creds.api_key == "sk-ant-oat-test"
+    assert creds.source == "claude-code-keychain"
 
 
 def test_resolve_credentials_uses_env_first(monkeypatch):
@@ -101,7 +108,8 @@ def test_headers_for_includes_required_oauth_headers():
     """Test that OAuth-specific headers are included."""
     auth = ClaudeCodeAuth()
     headers = auth.headers_for("https://api.anthropic.com", "claude-3-haiku")
-    
-    assert headers["anthropic-beta"] == "oauth-2025-04-20,interleaved-thinking-2025-05-14"
-    assert headers["user-agent"] == "claude-cli/2.1.0 (external, cli)"
+
+    assert "interleaved-thinking-2025-05-14" in headers["anthropic-beta"]
+    assert "claude-code-20250219" in headers["anthropic-beta"]
+    assert headers["user-agent"].startswith("claude-cli/")
     assert headers["x-app"] == "cli"

--- a/src/praisonai-agents/tests/unit/test_error_classification.py
+++ b/src/praisonai-agents/tests/unit/test_error_classification.py
@@ -89,7 +89,7 @@ class TestClassifyErrorKind:
     
     def setup_method(self):
         """Set up test fixtures."""
-        self.llm = LLM(api_base="test", api_key="test")
+        self.llm = LLM(model="gpt-4o-mini", base_url="test", api_key="test")
     
     def test_auth_permanent_classification(self):
         """Test classification of permanent auth errors."""
@@ -110,14 +110,35 @@ class TestClassifyErrorKind:
         test_cases = [
             "Unauthorized",
             "Authentication failed",
-            "invalid_request_error",
-            "openai_error"
+            "openai_error",
         ]
         
         for error_msg in test_cases:
             error = Exception(error_msg)
             result = self.llm.classify_error_kind(error)
             assert result == "auth", f"Failed for: {error_msg}"
+
+    def test_invalid_request_error_not_auth(self):
+        """invalid_request_error must not trigger OAuth refresh."""
+        error = Exception(
+            'AnthropicException - {"type":"invalid_request_error",'
+            '"message":"The long context beta is not yet available"}'
+        )
+        assert self.llm.classify_error_kind(error) == "unknown"
+
+    def test_revoked_token_is_auth_permanent(self):
+        """Revoked OAuth tokens must not trigger refresh retries."""
+        error = Exception(
+            'AuthenticationError - {"type":"authentication_error",'
+            '"message":"OAuth access token has been revoked."}'
+        )
+        assert self.llm.classify_error_kind(error) == "auth_permanent"
+
+    def test_claude_code_skips_auth_refresh_retry(self):
+        """claude-code shared OAuth must never refresh on LLM auth errors."""
+        llm = LLM(model="gpt-4o-mini", base_url="test", api_key="test", auth="claude-code")
+        error = Exception("Unauthorized")
+        assert llm._should_attempt_auth_refresh(error, attempt=0) is False
     
     def test_rate_limit_classification(self):
         """Test classification of rate limit errors."""
@@ -256,7 +277,7 @@ class TestResolveFailoverDecision:
     
     def setup_method(self):
         """Set up test fixtures."""
-        self.llm = LLM(api_base="test", api_key="test")
+        self.llm = LLM(model="gpt-4o-mini", base_url="test", api_key="test")
     
     def test_non_retryable_errors_surface_immediately(self):
         """Test that non-retryable errors surface immediately."""


### PR DESCRIPTION
## Summary
- Makes `auth="claude-code"` **read-only**: PraisonAI reads Keychain or ~/.claude/.credentials.json but no longer calls Anthropic OAuth refresh (which rotated tokens without persisting back and broke Claude CLI and other tools sharing the same session).
- Disables LLM auth-refresh retries for `claude-code` and stops classifying `invalid_request_error` as retryable auth.
- Removes the `context-1m-2025-08-07` beta header that caused subscription API failures on many plans.

## Root cause
Anthropic OAuth refresh-token rotation invalidated the shared Keychain refresh token for all Claude consumers when PraisonAI refreshed in memory only.

## Test plan
- [x] pytest tests/unit/auth/test_claude_code_auth.py and related error-classification tests
- [x] Live: Agent with auth=claude-code returns a response with Keychain token unchanged
- [x] Claude CLI still works after PraisonAI agent call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Claude Code subscription authentication now works in read-only mode, so shared OAuth credentials are no longer auto-refreshed when auth errors occur.
  * Tightened authentication failure classification to better distinguish retryable vs non-retryable token/OAuth issues.
* **Tests**
  * Updated smoke and unit tests to validate the new no-refresh behavior and the revised error categorization expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->