### PR TITLE
feat(code): add codex-cli and grok-cli agent backends

### DIFF
--- a/src/praisonai-code/praisonai_code/cli_backends/__init__.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/__init__.py
@@ -91,6 +91,12 @@ def __getattr__(name: str):
     elif name == "ClaudeCodeBackend":
         from .claude import ClaudeCodeBackend
         return ClaudeCodeBackend
+    elif name == "CodexBackend":
+        from .codex import CodexBackend
+        return CodexBackend
+    elif name == "GrokBackend":
+        from .grok import GrokBackend
+        return GrokBackend
     elif name == "list_cli_backends":
         from .registry import list_cli_backends
         return list_cli_backends
@@ -103,5 +109,7 @@ __all__ = [
     "resolve_cli_backend_config",
     "_is_cli_backend_instance",
     "ClaudeCodeBackend",
+    "CodexBackend",
+    "GrokBackend",
     "list_cli_backends"
 ]

--- a/src/praisonai-code/praisonai_code/cli_backends/__init__.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/__init__.py
@@ -97,6 +97,9 @@ def __getattr__(name: str):
     elif name == "GrokBackend":
         from .grok import GrokBackend
         return GrokBackend
+    elif name == "GeminiBackend":
+        from .gemini import GeminiBackend
+        return GeminiBackend
     elif name == "list_cli_backends":
         from .registry import list_cli_backends
         return list_cli_backends
@@ -111,5 +114,6 @@ __all__ = [
     "ClaudeCodeBackend",
     "CodexBackend",
     "GrokBackend",
+    "GeminiBackend",
     "list_cli_backends"
 ]

--- a/src/praisonai-code/praisonai_code/cli_backends/codex.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/codex.py
@@ -1,0 +1,132 @@
+"""OpenAI Codex CLI backend."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import os
+import subprocess
+from typing import AsyncIterator, List, Optional
+
+try:
+    from praisonaiagents import (
+        CliBackendConfig,
+        CliBackendDelta,
+        CliBackendProtocol,
+        CliBackendResult,
+        CliSessionBinding,
+    )
+except ImportError:
+    from praisonaiagents.cli_backend.protocols import (
+        CliBackendConfig,
+        CliBackendDelta,
+        CliBackendProtocol,
+        CliBackendResult,
+        CliSessionBinding,
+    )
+
+DEFAULT_CONFIG = CliBackendConfig(
+    command="codex",
+    args=["exec", "--skip-git-repo-check"],
+    output="text",
+    input="arg",
+    clear_env=["OPENAI_API_KEY"],
+    timeout_ms=300_000,
+)
+
+
+class CodexBackend:
+    """Codex CLI backend — delegates agent turns to ``codex exec``."""
+
+    def __init__(self, config: Optional[CliBackendConfig] = None):
+        self.config = copy.deepcopy(config if config is not None else DEFAULT_CONFIG)
+
+    async def execute(
+        self,
+        prompt: str,
+        *,
+        session: Optional[CliSessionBinding] = None,
+        images: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+        **kwargs,
+    ) -> CliBackendResult:
+        cmd = self._build_command(
+            prompt,
+            session=session,
+            images=images,
+            system_prompt=system_prompt,
+            **kwargs,
+        )
+        try:
+            content = await self._execute_subprocess(cmd)
+            return CliBackendResult(
+                content=content.strip(),
+                session_id=session.session_id if session else None,
+                metadata={"command": cmd},
+            )
+        except subprocess.CalledProcessError as exc:
+            return CliBackendResult(
+                content="",
+                error=f"Codex CLI failed: {exc}",
+                metadata={"command": cmd, "return_code": getattr(exc, "returncode", -1)},
+            )
+
+    async def stream(self, prompt: str, **kwargs) -> AsyncIterator[CliBackendDelta]:
+        result = await self.execute(prompt, **kwargs)
+        if result.error:
+            yield CliBackendDelta(type="error", content=result.error)
+            return
+        yield CliBackendDelta(type="text", content=result.content)
+
+    def _build_command(
+        self,
+        prompt: str,
+        *,
+        session: Optional[CliSessionBinding] = None,
+        images: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+        **kwargs,
+    ) -> List[str]:
+        cmd = [self.config.command, *self.config.args, "-C", os.getcwd()]
+
+        if system_prompt:
+            cmd.extend(["-c", f'instructions="{system_prompt}"'])
+
+        if images:
+            for image_path in images:
+                cmd.extend(["--image", image_path])
+
+        if self.config.input == "arg":
+            cmd.append(prompt)
+
+        return cmd
+
+    async def _execute_subprocess(self, cmd: List[str]) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=self._get_env(),
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=self.config.timeout_ms / 1000,
+            )
+        except asyncio.TimeoutError as exc:
+            process.kill()
+            await process.wait()
+            raise TimeoutError(f"Codex CLI timed out after {self.config.timeout_ms}ms") from exc
+
+        if process.returncode != 0:
+            error_msg = stderr.decode() if stderr else f"Exit code {process.returncode}"
+            raise subprocess.CalledProcessError(process.returncode, cmd, stderr=error_msg)
+
+        return stdout.decode()
+
+    def _get_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        for var in self.config.clear_env:
+            env.pop(var, None)
+        env.update(self.config.env)
+        return env

--- a/src/praisonai-code/praisonai_code/cli_backends/codex.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/codex.py
@@ -87,7 +87,12 @@ class CodexBackend:
         system_prompt: Optional[str] = None,
         **kwargs,
     ) -> List[str]:
-        cmd = [self.config.command, *self.config.args, "-C", os.getcwd()]
+        cmd = [self.config.command, *self.config.args]
+
+        if session and session.session_id and getattr(session, "is_resume", False):
+            cmd.extend(["resume", session.session_id])
+
+        cmd.extend(["-C", os.getcwd()])
 
         if system_prompt:
             cmd.extend(["-c", f'instructions="{system_prompt}"'])

--- a/src/praisonai-code/praisonai_code/cli_backends/gemini.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/gemini.py
@@ -1,0 +1,129 @@
+"""Google Gemini CLI backend."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import os
+import subprocess
+from typing import AsyncIterator, List, Optional
+
+try:
+    from praisonaiagents import (
+        CliBackendConfig,
+        CliBackendDelta,
+        CliBackendProtocol,
+        CliBackendResult,
+        CliSessionBinding,
+    )
+except ImportError:
+    from praisonaiagents.cli_backend.protocols import (
+        CliBackendConfig,
+        CliBackendDelta,
+        CliBackendProtocol,
+        CliBackendResult,
+        CliSessionBinding,
+    )
+
+DEFAULT_CONFIG = CliBackendConfig(
+    command="gemini",
+    args=["--yolo", "--skip-trust", "--output-format", "text"],
+    output="text",
+    input="single",
+    timeout_ms=300_000,
+)
+
+
+class GeminiBackend:
+    """Gemini CLI backend — delegates agent turns to ``gemini -p``."""
+
+    def __init__(self, config: Optional[CliBackendConfig] = None):
+        self.config = copy.deepcopy(config if config is not None else DEFAULT_CONFIG)
+
+    async def execute(
+        self,
+        prompt: str,
+        *,
+        session: Optional[CliSessionBinding] = None,
+        images: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+        **kwargs,
+    ) -> CliBackendResult:
+        cmd = self._build_command(
+            prompt,
+            session=session,
+            images=images,
+            system_prompt=system_prompt,
+            **kwargs,
+        )
+        try:
+            content = await self._execute_subprocess(cmd)
+            return CliBackendResult(
+                content=content.strip(),
+                session_id=session.session_id if session else None,
+                metadata={"command": cmd},
+            )
+        except subprocess.CalledProcessError as exc:
+            return CliBackendResult(
+                content="",
+                error=f"Gemini CLI failed: {exc}",
+                metadata={"command": cmd, "return_code": getattr(exc, "returncode", -1)},
+            )
+
+    async def stream(self, prompt: str, **kwargs) -> AsyncIterator[CliBackendDelta]:
+        result = await self.execute(prompt, **kwargs)
+        if result.error:
+            yield CliBackendDelta(type="error", content=result.error)
+            return
+        yield CliBackendDelta(type="text", content=result.content)
+
+    def _build_command(
+        self,
+        prompt: str,
+        *,
+        session: Optional[CliSessionBinding] = None,
+        images: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+        **kwargs,
+    ) -> List[str]:
+        cmd = [self.config.command, *self.config.args]
+
+        if session and session.session_id:
+            cmd.extend(["--resume", session.session_id])
+
+        if system_prompt:
+            prompt = f"{system_prompt}\n\n{prompt}"
+
+        cmd.extend(["-p", prompt])
+        return cmd
+
+    async def _execute_subprocess(self, cmd: List[str]) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=os.getcwd(),
+            env=self._get_env(),
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=self.config.timeout_ms / 1000,
+            )
+        except asyncio.TimeoutError as exc:
+            process.kill()
+            await process.wait()
+            raise TimeoutError(f"Gemini CLI timed out after {self.config.timeout_ms}ms") from exc
+
+        if process.returncode != 0:
+            error_msg = stderr.decode() if stderr else f"Exit code {process.returncode}"
+            raise subprocess.CalledProcessError(process.returncode, cmd, stderr=error_msg)
+
+        return stdout.decode()
+
+    def _get_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        for var in self.config.clear_env:
+            env.pop(var, None)
+        env.update(self.config.env)
+        return env

--- a/src/praisonai-code/praisonai_code/cli_backends/gemini.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/gemini.py
@@ -88,7 +88,7 @@ class GeminiBackend:
     ) -> List[str]:
         cmd = [self.config.command, *self.config.args]
 
-        if session and session.session_id:
+        if session and session.session_id and getattr(session, "is_resume", False):
             cmd.extend(["--resume", session.session_id])
 
         if system_prompt:

--- a/src/praisonai-code/praisonai_code/cli_backends/grok.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/grok.py
@@ -88,7 +88,7 @@ class GrokBackend:
     ) -> List[str]:
         cmd = [self.config.command, *self.config.args, "--cwd", os.getcwd()]
 
-        if session and session.session_id:
+        if session and session.session_id and getattr(session, "is_resume", False):
             cmd.extend(["--resume", session.session_id])
 
         if system_prompt:

--- a/src/praisonai-code/praisonai_code/cli_backends/grok.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/grok.py
@@ -1,0 +1,132 @@
+"""xAI Grok CLI backend."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import os
+import subprocess
+from typing import AsyncIterator, List, Optional
+
+try:
+    from praisonaiagents import (
+        CliBackendConfig,
+        CliBackendDelta,
+        CliBackendProtocol,
+        CliBackendResult,
+        CliSessionBinding,
+    )
+except ImportError:
+    from praisonaiagents.cli_backend.protocols import (
+        CliBackendConfig,
+        CliBackendDelta,
+        CliBackendProtocol,
+        CliBackendResult,
+        CliSessionBinding,
+    )
+
+DEFAULT_CONFIG = CliBackendConfig(
+    command="grok",
+    args=["--always-approve", "--output-format", "plain"],
+    output="text",
+    input="single",
+    timeout_ms=300_000,
+)
+
+
+class GrokBackend:
+    """Grok CLI backend — delegates agent turns to ``grok --single``."""
+
+    def __init__(self, config: Optional[CliBackendConfig] = None):
+        self.config = copy.deepcopy(config if config is not None else DEFAULT_CONFIG)
+
+    async def execute(
+        self,
+        prompt: str,
+        *,
+        session: Optional[CliSessionBinding] = None,
+        images: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+        **kwargs,
+    ) -> CliBackendResult:
+        cmd = self._build_command(
+            prompt,
+            session=session,
+            images=images,
+            system_prompt=system_prompt,
+            **kwargs,
+        )
+        try:
+            content = await self._execute_subprocess(cmd)
+            return CliBackendResult(
+                content=content.strip(),
+                session_id=session.session_id if session else None,
+                metadata={"command": cmd},
+            )
+        except subprocess.CalledProcessError as exc:
+            return CliBackendResult(
+                content="",
+                error=f"Grok CLI failed: {exc}",
+                metadata={"command": cmd, "return_code": getattr(exc, "returncode", -1)},
+            )
+
+    async def stream(self, prompt: str, **kwargs) -> AsyncIterator[CliBackendDelta]:
+        result = await self.execute(prompt, **kwargs)
+        if result.error:
+            yield CliBackendDelta(type="error", content=result.error)
+            return
+        yield CliBackendDelta(type="text", content=result.content)
+
+    def _build_command(
+        self,
+        prompt: str,
+        *,
+        session: Optional[CliSessionBinding] = None,
+        images: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+        **kwargs,
+    ) -> List[str]:
+        cmd = [self.config.command, *self.config.args, "--cwd", os.getcwd()]
+
+        if session and session.session_id:
+            cmd.extend(["--resume", session.session_id])
+
+        if system_prompt:
+            cmd.extend(["--system-prompt-override", system_prompt])
+
+        if images:
+            for image_path in images:
+                cmd.extend(["--image", image_path])
+
+        cmd.extend(["-p", prompt])
+        return cmd
+
+    async def _execute_subprocess(self, cmd: List[str]) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=self._get_env(),
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=self.config.timeout_ms / 1000,
+            )
+        except asyncio.TimeoutError as exc:
+            process.kill()
+            await process.wait()
+            raise TimeoutError(f"Grok CLI timed out after {self.config.timeout_ms}ms") from exc
+
+        if process.returncode != 0:
+            error_msg = stderr.decode() if stderr else f"Exit code {process.returncode}"
+            raise subprocess.CalledProcessError(process.returncode, cmd, stderr=error_msg)
+
+        return stdout.decode()
+
+    def _get_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        for var in self.config.clear_env:
+            env.pop(var, None)
+        env.update(self.config.env)
+        return env

--- a/src/praisonai-code/praisonai_code/cli_backends/registry.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/registry.py
@@ -17,8 +17,18 @@ def _get_builtin_cli_backend_loaders() -> Dict[str, Callable[[], Any]]:
         from .claude import ClaudeCodeBackend
         return ClaudeCodeBackend
 
+    def codex_loader():
+        from .codex import CodexBackend
+        return CodexBackend
+
+    def grok_loader():
+        from .grok import GrokBackend
+        return GrokBackend
+
     return {
-        "claude-code": claude_loader
+        "claude-code": claude_loader,
+        "codex-cli": codex_loader,
+        "grok-cli": grok_loader,
     }
 
 # Global CLI backend registry instance

--- a/src/praisonai-code/praisonai_code/cli_backends/registry.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/registry.py
@@ -25,10 +25,15 @@ def _get_builtin_cli_backend_loaders() -> Dict[str, Callable[[], Any]]:
         from .grok import GrokBackend
         return GrokBackend
 
+    def gemini_loader():
+        from .gemini import GeminiBackend
+        return GeminiBackend
+
     return {
         "claude-code": claude_loader,
         "codex-cli": codex_loader,
         "grok-cli": grok_loader,
+        "gemini-cli": gemini_loader,
     }
 
 # Global CLI backend registry instance


### PR DESCRIPTION
## Summary

- Adds `codex-cli` backend delegating agent turns to `codex exec` (ChatGPT subscription login)
- Adds `grok-cli` backend delegating agent turns to `grok -p` headless single-turn mode
- Registers both in the CLI backend registry alongside existing `claude-code`

## Usage

```python
from praisonai import Agent

# Codex (ChatGPT subscription via codex login)
agent = Agent(name="assistant", cli_backend="codex-cli")
agent.start("Hello")

# Grok (Grok CLI OAuth / subscription)
agent = Agent(name="assistant", cli_backend="grok-cli")
agent.start("Hello")
```

## Test plan

- [x] grok -p single-turn headless → GROK_SINGLE_OK
- [x] resolve_cli_backend("grok-cli").execute(...) → GROK_DIRECT_OK
- [x] Agent(cli_backend="grok-cli").start(...) → GROK_BACKEND_OK
- [x] codex exec → CODEX_OK
- [x] Agent(cli_backend="codex-cli").start(...) → CODEX_BACKEND_OK
- [x] list_cli_backends() → claude-code, codex-cli, grok-cli


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Codex CLI as an AI backend (prompt handling, session support, images, system prompts, streaming, configurable environment, and execution timeouts).
  - Added support for Grok CLI as an AI backend with the same capabilities.
  - Added support for Gemini CLI as an AI backend with the same capabilities.
  - Extended automatic discovery and configuration via the built-in backend registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->