### PR TITLE
feat(bot): opt-in shell execution for inbound Slack channels

### DIFF
--- a/src/praisonai-bot/praisonai_bot/bots/_defaults.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_defaults.py
@@ -468,9 +468,34 @@ def _wire_shell_approval_backend(
     except ImportError:
         pass
 
+    # No usable approval backend could be wired. A prior apply_bot_smart_defaults()
+    # may have installed an AutoApproveBackend (config.auto_approve_tools). Leaving it
+    # in place would silently auto-approve shell despite the explicit opt-out, so fail
+    # closed: replace it with a deny-by-default backend that rejects shell commands.
+    from praisonaiagents.approval.backends import AutoApproveBackend
+
+    backend = getattr(agent, "_approval_backend", None)
+    if backend is None or isinstance(backend, AutoApproveBackend):
+        try:
+            from praisonaiagents.approval.backends import CallbackBackend
+            from praisonaiagents.approval.protocols import ApprovalDecision
+
+            def _deny_shell(tool_name, arguments, risk_level):
+                if tool_name in _SHELL_TOOL_NAMES:
+                    return ApprovalDecision(
+                        approved=False,
+                        reason="shell auto-approval disabled; no approval backend configured",
+                        approver="system",
+                    )
+                return ApprovalDecision(approved=True, reason="auto-approved", approver="system")
+
+            agent._approval_backend = CallbackBackend(_deny_shell)
+        except ImportError:  # pragma: no cover - core always present in-tree
+            agent._approval_backend = None
     logger.warning(
         "allow_shell with auto_approve_shell=false needs approval_channel, "
-        "approval_mode (gateway|http|webhook), or a custom approval backend on the agent"
+        "approval_mode (gateway|http|webhook), or a custom approval backend on the agent "
+        "— shell commands will be denied until one is configured"
     )
 
 

--- a/src/praisonai-bot/praisonai_bot/gateway/server.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/server.py
@@ -868,6 +868,13 @@ class WebSocketGateway:
         self._scheduled_outbox: Optional[Any] = None
         self._routing_rules: Dict[str, Dict[str, str]] = {}  # channel_name -> {context -> agent_id}
         self._routing_bindings: Dict[str, List[Any]] = {}  # channel_name -> [RouteBinding] (Issue #2225)
+        # channel_name -> (config, ch_cfg) for channels that opt into shell
+        # execution, so routed agents also receive the shell tool/approval setup.
+        self._channel_shell_cfg: Dict[str, Any] = {}
+        # (channel_name, agent_id) -> shell-enabled clone of a routed agent, so
+        # shell enablement never leaks onto the shared agent used by other,
+        # non-shell channels and is only computed once per routed agent.
+        self._shell_routed_agents: Dict[Any, "Agent"] = {}
         self._channel_tasks: Dict[str, asyncio.Task] = {}  # channel_name -> asyncio task
         
         # Pairing store for channel authorization
@@ -5056,6 +5063,10 @@ class WebSocketGateway:
                 bot = self._create_bot(channel_type, token, default_agent, config, ch_cfg)
                 if bot is None:
                     continue
+                # Record shell opt-in so routed agents (resolved per-message in
+                # _inject_routing_handler) also receive the shell tool/approval
+                # setup applied to the default channel clone in _create_bot.
+                self._register_channel_shell_cfg(channel_name, config, ch_cfg)
                 # Issue #2721: enable inbound speech-to-text so voice notes are
                 # transcribed and fed to the agent. On by default; the resolved
                 # policy (config.metadata["stt"]) drives the opt-out.
@@ -5317,6 +5328,61 @@ class WebSocketGateway:
         elif hasattr(bot, "_turn_lock_map"):
             bot._turn_lock_map = lock_map
 
+    def _register_channel_shell_cfg(
+        self, channel_name: str, config: Any, ch_cfg: Dict[str, Any]
+    ) -> None:
+        """Remember a channel's shell opt-in for per-message routed agents.
+
+        ``_create_bot`` applies ``enable_shell_tools`` to the default channel
+        clone, but ``_inject_routing_handler`` swaps in a routed agent per
+        message. Recording the channel's shell config here lets that handler
+        re-apply the same (idempotent) setup so routed agents are not silently
+        stripped of ``execute_command`` despite ``allow_shell: true``.
+        """
+        if ch_cfg and ch_cfg.get("allow_shell"):
+            self._channel_shell_cfg[channel_name] = (config, dict(ch_cfg))
+        else:
+            self._channel_shell_cfg.pop(channel_name, None)
+
+    def _apply_channel_shell(
+        self, channel_name: str, agent: "Agent"
+    ) -> "Agent":
+        """Return a shell-enabled variant of a routed agent for this channel.
+
+        No-op (returns the same instance) when the channel did not opt into
+        shell execution. When it did, the routed agent is cloned once per
+        ``(channel, agent)`` and shell-enabled, so the shared agent used by
+        other non-shell channels never gains ``execute_command`` and the setup
+        is computed once rather than on every inbound message.
+        """
+        entry = self._channel_shell_cfg.get(channel_name)
+        if not entry or agent is None:
+            return agent
+        config, ch_cfg = entry
+        cache_key = (channel_name, id(agent))
+        cached = self._shell_routed_agents.get(cache_key)
+        if cached is not None:
+            return cached
+        # Resolve the *platform* (slack/telegram/...) — not the per-message chat
+        # type — so SlackApproval wiring in enable_shell_tools keys correctly.
+        platform = str(ch_cfg.get("platform") or channel_name).lower()
+        try:
+            from praisonai_bot.bots._defaults import enable_shell_tools
+
+            clone = agent.clone_for_channel() if hasattr(agent, "clone_for_channel") else agent
+            enabled = enable_shell_tools(
+                clone, config, ch_cfg, channel_type=platform
+            )
+            self._shell_routed_agents[cache_key] = enabled
+            return enabled
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "Failed to apply shell config to routed agent on channel %r: %s",
+                channel_name,
+                exc,
+            )
+            return agent
+
     def _create_bot(
         self,
         channel_type: str,
@@ -5505,6 +5571,10 @@ class WebSocketGateway:
                 channel_name, routing_ctx, facts=facts
             )
             if agent:
+                # Routed agents come straight from self._agents and lack the
+                # shell setup applied to the default channel clone; re-apply it
+                # here so ``allow_shell: true`` also covers routed turns.
+                agent = gateway._apply_channel_shell(channel_name, agent)
                 bot.set_agent(agent)
                 # Per-route toolset scope (Issue #2298): the adapter's own
                 # on_message calls ``_session.chat()`` without a tool_policy
@@ -5598,7 +5668,12 @@ class WebSocketGateway:
                 channel_name, routing_ctx, facts=facts
             )
             if not agent:
-                agent = bot._agent  # fallback to default
+                agent = bot._agent  # fallback to default (already shell-enabled)
+            else:
+                # Routed agents come from self._agents without the shell setup
+                # applied to the default channel clone; re-apply so allow_shell
+                # also covers routed turns.
+                agent = gateway._apply_channel_shell(channel_name, agent)
             # Per-route toolset scope for this inbound message (Issue #2298).
             tool_policy = gateway._resolve_tool_policy_for_message(
                 channel_name, facts=facts
@@ -5950,6 +6025,11 @@ class WebSocketGateway:
             del self._routing_rules[channel_name]
         if channel_name in self._routing_bindings:
             del self._routing_bindings[channel_name]
+        # Drop stale shell config + cached routed clones so the reloaded channel
+        # rebuilds them from the new config (and a removed allow_shell is honoured).
+        self._channel_shell_cfg.pop(channel_name, None)
+        for key in [k for k in self._shell_routed_agents if k[0] == channel_name]:
+            self._shell_routed_agents.pop(key, None)
         
         # Start the channel again with new config
         if channel_name in channels_cfg:
@@ -6059,6 +6139,9 @@ class WebSocketGateway:
             bot = self._create_bot(channel_type, token, default_agent, config, ch_cfg)
             if bot is None:
                 return
+            # Record shell opt-in so routed agents also get shell setup (parity
+            # with start_channels; see _inject_routing_handler).
+            self._register_channel_shell_cfg(channel_name, config, ch_cfg)
             # Issue #2721: enable inbound STT on the hot-reloaded channel too.
             self._enable_stt(bot, config)
             # Issue #2454: stamp the shared admission gate so a channel restarted
@@ -6161,6 +6244,8 @@ class WebSocketGateway:
                 guardrails_cfg = (new_cfg.get("guardrails") or {}).get("registry")
                 if agents_cfg:
                     self._agents.clear()
+                    # Recreating agents invalidates id()-keyed shell clones.
+                    self._shell_routed_agents.clear()
                     self._create_agents_from_config(
                         agents_cfg,
                         default_model=default_model,
@@ -6212,6 +6297,8 @@ class WebSocketGateway:
             guardrails_cfg = (new_cfg.get("guardrails") or {}).get("registry")
             if agents_cfg:
                 self._agents.clear()
+                # Recreating agents invalidates id()-keyed shell clones.
+                self._shell_routed_agents.clear()
                 self._create_agents_from_config(
                     agents_cfg,
                     default_model=default_model,
@@ -6232,6 +6319,8 @@ class WebSocketGateway:
                 guardrails_cfg = (new_cfg.get("guardrails") or {}).get("registry")
                 if agents_cfg:
                     self._agents.clear()
+                    # Recreating agents invalidates id()-keyed shell clones.
+                    self._shell_routed_agents.clear()
                     self._create_agents_from_config(
                         agents_cfg,
                         default_model=default_model,

--- a/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
+++ b/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
@@ -256,3 +256,74 @@ def test_enable_shell_whatsapp_falls_back_to_gateway(mock_execute_command):
 
     gw_cls.assert_called_once()
     assert agent._approval_backend is gw_cls.return_value
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_manual_approval_replaces_stale_auto_backend(mock_execute_command, monkeypatch):
+    """auto_approve_shell=false must not leave a prior AutoApproveBackend that
+    silently auto-approves shell (Greptile security P1)."""
+    from praisonaiagents.approval.backends import AutoApproveBackend
+    from praisonaiagents.approval.protocols import ApprovalRequest
+
+    monkeypatch.delenv("SLACK_APPROVAL_CHANNEL", raising=False)
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.name = "assistant"
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+    # Simulate apply_bot_smart_defaults() having installed auto-approve.
+    agent._approval_backend = AutoApproveBackend()
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch(
+            "praisonai_bot.gateway.gateway_approval.GatewayApprovalBackend",
+            side_effect=ImportError,
+        ):
+            enable_shell_tools(
+                agent,
+                config=BotConfig(),
+                ch_cfg={"allow_shell": True, "auto_approve_shell": False},
+                channel_type="slack",  # no approval_channel -> no SlackApproval
+            )
+
+    backend = agent._approval_backend
+    assert not isinstance(backend, AutoApproveBackend)
+    # Shell commands are denied fail-closed.
+    decision = backend.request_approval_sync(
+        ApprovalRequest(tool_name="execute_command", arguments={}, risk_level="high")
+    )
+    assert decision.approved is False
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_manual_approval_without_backend_denies_shell(mock_execute_command, monkeypatch):
+    """auto_approve_shell=false with no pre-existing backend also fails closed."""
+    from praisonaiagents.approval.backends import AutoApproveBackend
+    from praisonaiagents.approval.protocols import ApprovalRequest
+
+    monkeypatch.delenv("SLACK_APPROVAL_CHANNEL", raising=False)
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.name = "assistant"
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+    agent._approval_backend = None
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch(
+            "praisonai_bot.gateway.gateway_approval.GatewayApprovalBackend",
+            side_effect=ImportError,
+        ):
+            enable_shell_tools(
+                agent,
+                config=BotConfig(),
+                ch_cfg={"allow_shell": True, "auto_approve_shell": False},
+                channel_type="slack",
+            )
+
+    backend = agent._approval_backend
+    assert not isinstance(backend, AutoApproveBackend)
+    decision = backend.request_approval_sync(
+        ApprovalRequest(tool_name="execute_command", arguments={}, risk_level="high")
+    )
+    assert decision.approved is False


### PR DESCRIPTION
## Summary

- Adds channel-level `allow_shell` opt-in for gateway bots (Slack, Telegram, etc.)
- Injects `execute_command`, clears shell entries from `_perm_deny`, and sets approval backend
- Defaults to `auto_approve_shell: true`; optional SlackApproval when disabled

## Usage

```yaml
channels:
  slack:
    token: "${SLACK_BOT_TOKEN}"
    app_token: "${SLACK_APP_TOKEN}"
    allow_shell: true
    auto_approve_shell: true
```

Commands run on the **bot server host**, not the Slack user machine.

## Test plan

- [x] pytest src/praisonai-bot/tests/unit/bots/test_enable_shell.py (3 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-channel opt-in support for shell tools.
  * Shell commands can use automatic approval or configurable manual approval through supported channels and gateways.
  * Routed agents now consistently inherit channel shell-tool settings.

* **Bug Fixes**
  * Shell access now fails closed when approval services are unavailable, preventing unauthorized command execution.
  * Channel restarts and configuration reloads correctly refresh shell-tool settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->