### PR TITLE
feat(bot): allow_shell with multi-channel approval wiring

### DIFF
--- a/examples/yaml/gateway.yaml
+++ b/examples/yaml/gateway.yaml
@@ -19,6 +19,9 @@ agents:
 channels:
   telegram:
     token: "${TELEGRAM_BOT_TOKEN}"
+    # allow_shell: true
+    # auto_approve_shell: false
+    # approval_channel: "123456789"   # Telegram chat ID for shell approvals
     routing:
       dm: "personal"
       group: "support"
@@ -26,6 +29,9 @@ channels:
 
   discord:
     token: "${DISCORD_BOT_TOKEN}"
+    # allow_shell: true
+    # auto_approve_shell: false
+    # approval_channel: "9876543210"  # Discord channel ID (or use home_channel)
     routing:
       dm: "personal"
       channel: "support"

--- a/examples/yaml/gateway.yaml
+++ b/examples/yaml/gateway.yaml
@@ -34,6 +34,8 @@ channels:
   slack:
     token: "${SLACK_BOT_TOKEN}"
     app_token: "${SLACK_APP_TOKEN}"
+    allow_shell: true
+    auto_approve_shell: true
     routing:
       dm: "personal"
       channel: "support"

--- a/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
@@ -320,6 +320,12 @@ class ChannelConfigSchema(BaseModel):
     # adapters transcribe it and feed the transcript to the agent. On by
     # default; set ``stt.enabled: false`` to opt out.
     stt: Optional[SttConfigSchema] = None
+
+    # Shell execution opt-in for inbound channel bots (Slack/Telegram/etc.)
+    allow_shell: bool = False
+    auto_approve_shell: bool = True
+    approval_channel: Optional[str] = None
+    approval_users: Optional[Union[str, List[str]]] = None
     
     # Platform-specific fields
     phone_number_id: Optional[str] = None  # WhatsApp

--- a/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
@@ -428,6 +428,26 @@ class ChannelConfigSchema(BaseModel):
                 f"Invalid group_policy '{v}'. Must be one of: {', '.join(sorted(allowed))}"
             )
         return v
+
+    @field_validator("approval_mode")
+    @classmethod
+    def validate_approval_mode(cls, v: Optional[str]) -> Optional[str]:
+        """Fail-closed on an unknown shell-approval backend selector.
+
+        A typo (``chanel``/``webook``) must be rejected at load time rather
+        than silently falling through to the gateway-queue fallback, which
+        would leave shell approvals stuck where the operator never looks.
+        """
+        if v is None:
+            return v
+        allowed = {"channel", "gateway", "http", "webhook"}
+        normalized = v.strip().lower()
+        if normalized not in allowed:
+            raise ValueError(
+                f"Invalid approval_mode '{v}'. Must be one of: "
+                f"{', '.join(sorted(allowed))}"
+            )
+        return normalized
     
     @model_validator(mode="after")
     def validate_security(self):

--- a/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
@@ -326,6 +326,11 @@ class ChannelConfigSchema(BaseModel):
     auto_approve_shell: bool = True
     approval_channel: Optional[str] = None
     approval_users: Optional[Union[str, List[str]]] = None
+    # channel (default) | gateway | http | webhook
+    approval_mode: Optional[str] = None
+    approval_webhook_url: Optional[str] = None
+    approval_http_host: Optional[str] = None
+    approval_http_port: Optional[int] = None
     
     # Platform-specific fields
     phone_number_id: Optional[str] = None  # WhatsApp

--- a/src/praisonai-bot/praisonai_bot/bots/_defaults.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_defaults.py
@@ -327,6 +327,146 @@ def _get_fallback_tools_with_workspace(workspace=None) -> list:
 
 _SHELL_TOOL_NAMES = frozenset({"execute_command", "shell_command", "acp_execute_command"})
 
+_APPROVER_ENV = {
+    "slack": "SLACK_APPROVERS",
+    "telegram": "TELEGRAM_APPROVERS",
+    "discord": "DISCORD_APPROVERS",
+}
+
+
+def _parse_shell_approvers(ch_cfg: Dict[str, Any], channel_type: str) -> List[str]:
+    env_key = _APPROVER_ENV.get(channel_type, "")
+    approvers_raw = ch_cfg.get("approval_users") or (os.environ.get(env_key, "") if env_key else "")
+    if isinstance(approvers_raw, str):
+        return [u.strip() for u in approvers_raw.split(",") if u.strip()]
+    if isinstance(approvers_raw, list):
+        return [str(u).strip() for u in approvers_raw if str(u).strip()]
+    return []
+
+
+def _channel_token(config: Optional[Any], ch_cfg: Dict[str, Any]) -> Optional[str]:
+    token = ch_cfg.get("token") or (getattr(config, "token", None) if config else None)
+    return str(token) if token else None
+
+
+def _wire_shell_approval_backend(
+    agent: Any,
+    *,
+    channel_type: str,
+    config: Optional[Any],
+    ch_cfg: Dict[str, Any],
+    allowed_approvers: List[str],
+) -> None:
+    """Attach a platform or gateway approval backend when auto-approve is off."""
+    approval_mode = str(ch_cfg.get("approval_mode") or "channel").strip().lower()
+    token = _channel_token(config, ch_cfg)
+    approvers = allowed_approvers or None
+
+    if approval_mode == "gateway":
+        try:
+            from praisonai_bot.gateway.gateway_approval import GatewayApprovalBackend
+
+            agent._approval_backend = GatewayApprovalBackend()
+            return
+        except ImportError:
+            logger.warning("GatewayApprovalBackend unavailable for allow_shell")
+
+    if approval_mode == "http":
+        try:
+            from praisonai_bot.bots import HTTPApproval
+
+            agent._approval_backend = HTTPApproval(
+                host=str(ch_cfg.get("approval_http_host") or "127.0.0.1"),
+                port=int(ch_cfg.get("approval_http_port") or 8899),
+            )
+            return
+        except ImportError:
+            logger.warning("HTTPApproval unavailable for allow_shell")
+
+    webhook_url = ch_cfg.get("approval_webhook_url") or os.environ.get("APPROVAL_WEBHOOK_URL")
+    if approval_mode == "webhook" or webhook_url:
+        try:
+            from praisonai_bot.bots import WebhookApproval
+
+            agent._approval_backend = WebhookApproval(webhook_url=str(webhook_url))
+            return
+        except (ImportError, ValueError) as exc:
+            logger.warning("WebhookApproval unavailable for allow_shell: %s", exc)
+
+    if channel_type == "slack":
+        approval_channel = (
+            ch_cfg.get("approval_channel")
+            or (getattr(config, "owner_user_id", None) if config else None)
+            or os.environ.get("SLACK_APPROVAL_CHANNEL")
+        )
+        if approval_channel:
+            try:
+                from praisonai_bot.bots import SlackApproval
+
+                agent._approval_backend = SlackApproval(
+                    token=token,
+                    channel=str(approval_channel),
+                    allowed_approvers=approvers,
+                )
+                return
+            except ImportError:
+                logger.warning("SlackApproval unavailable for allow_shell")
+
+    elif channel_type == "telegram":
+        chat_id = (
+            ch_cfg.get("approval_channel")
+            or (getattr(config, "owner_user_id", None) if config else None)
+            or os.environ.get("TELEGRAM_CHAT_ID")
+        )
+        if chat_id:
+            try:
+                from praisonai_bot.bots import TelegramApproval
+
+                agent._approval_backend = TelegramApproval(
+                    token=token,
+                    chat_id=str(chat_id),
+                    allowed_approvers=approvers,
+                )
+                return
+            except ImportError:
+                logger.warning("TelegramApproval unavailable for allow_shell")
+
+    elif channel_type == "discord":
+        channel_id = (
+            ch_cfg.get("approval_channel")
+            or ch_cfg.get("home_channel")
+            or os.environ.get("DISCORD_APPROVAL_CHANNEL")
+        )
+        if channel_id:
+            try:
+                from praisonai_bot.bots import DiscordApproval
+
+                agent._approval_backend = DiscordApproval(
+                    token=token,
+                    channel_id=str(channel_id),
+                    allowed_approvers=approvers,
+                )
+                return
+            except ImportError:
+                logger.warning("DiscordApproval unavailable for allow_shell")
+
+    try:
+        from praisonai_bot.gateway.gateway_approval import GatewayApprovalBackend
+
+        agent._approval_backend = GatewayApprovalBackend()
+        logger.info(
+            "Shell approval falling back to gateway queue for channel %r",
+            channel_type or "?",
+        )
+        return
+    except ImportError:
+        pass
+
+    logger.warning(
+        "allow_shell with auto_approve_shell=false needs approval_channel, "
+        "approval_mode (gateway|http|webhook), or a custom approval backend on the agent"
+    )
+
 
 def enable_shell_tools(
     agent: Any,
@@ -381,34 +521,13 @@ def enable_shell_tools(
             logger.warning("AutoApproveBackend unavailable for allow_shell")
         return agent
 
-    approval_channel = (
-        ch_cfg.get("approval_channel")
-        or (getattr(config, "owner_user_id", None) if config else None)
-        or os.environ.get("SLACK_APPROVAL_CHANNEL")
+    _wire_shell_approval_backend(
+        agent,
+        channel_type=channel_type,
+        config=config,
+        ch_cfg=ch_cfg,
+        allowed_approvers=_parse_shell_approvers(ch_cfg, channel_type),
     )
-    approvers_raw = ch_cfg.get("approval_users") or os.environ.get("SLACK_APPROVERS", "")
-    if isinstance(approvers_raw, str):
-        allowed_approvers = [u.strip() for u in approvers_raw.split(",") if u.strip()]
-    elif isinstance(approvers_raw, list):
-        allowed_approvers = [str(u).strip() for u in approvers_raw if str(u).strip()]
-    else:
-        allowed_approvers = []
-
-    if channel_type == "slack" and approval_channel:
-        try:
-            from praisonai_bot.bots import SlackApproval
-
-            agent._approval_backend = SlackApproval(
-                channel=str(approval_channel),
-                allowed_approvers=allowed_approvers or None,
-            )
-        except ImportError:
-            logger.warning("SlackApproval unavailable — shell commands may block without approval backend")
-    elif not auto_approve:
-        logger.warning(
-            "allow_shell with auto_approve_shell=false requires approval_channel "
-            "(Slack) or a custom approval backend on the agent"
-        )
 
     logger.info(
         "Shell tools enabled for agent %r on channel %r (auto_approve_shell=%s)",

--- a/src/praisonai-bot/praisonai_bot/bots/_defaults.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_defaults.py
@@ -7,7 +7,8 @@ consistent behavior across all entry points.
 """
 
 import logging
-from typing import Any, Optional, List
+import os
+from typing import Any, Optional, List, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -322,3 +323,97 @@ def _get_fallback_tools_with_workspace(workspace=None) -> list:
             pass
         
     return fallback_tools
+
+
+_SHELL_TOOL_NAMES = frozenset({"execute_command", "shell_command", "acp_execute_command"})
+
+
+def enable_shell_tools(
+    agent: Any,
+    config: Optional[Any] = None,
+    ch_cfg: Optional[Dict[str, Any]] = None,
+    *,
+    channel_type: str = "",
+) -> Any:
+    """Opt-in shell execution for inbound channel bots (Slack, Telegram, etc.)."""
+    if agent is None:
+        return agent
+
+    ch_cfg = ch_cfg or {}
+    if not ch_cfg.get("allow_shell"):
+        return agent
+
+    tools = list(getattr(agent, "tools", None) or [])
+    existing = {
+        getattr(t, "name", None) or getattr(t, "__name__", "")
+        for t in tools
+    }
+    if "execute_command" not in existing:
+        try:
+            from praisonaiagents.tools import execute_command
+
+            tools.append(execute_command)
+            agent.tools = tools
+        except ImportError:
+            logger.warning("execute_command unavailable — install praisonaiagents with shell tools")
+
+    instructions = getattr(agent, "instructions", "") or ""
+    if "execute_command" not in instructions.lower():
+        agent.instructions = (
+            instructions
+            + "\n\nYou can run shell commands on the bot server using the execute_command tool."
+        ).strip()
+
+    deny = set(getattr(agent, "_perm_deny", None) or frozenset())
+    deny -= _SHELL_TOOL_NAMES
+    agent._perm_deny = frozenset(deny)
+
+    auto_approve = ch_cfg.get("auto_approve_shell", True)
+    if isinstance(auto_approve, str):
+        auto_approve = auto_approve.strip().lower() in ("1", "true", "yes", "on")
+
+    if auto_approve:
+        try:
+            from praisonaiagents.approval.backends import AutoApproveBackend
+
+            agent._approval_backend = AutoApproveBackend()
+        except ImportError:
+            logger.warning("AutoApproveBackend unavailable for allow_shell")
+        return agent
+
+    approval_channel = (
+        ch_cfg.get("approval_channel")
+        or (getattr(config, "owner_user_id", None) if config else None)
+        or os.environ.get("SLACK_APPROVAL_CHANNEL")
+    )
+    approvers_raw = ch_cfg.get("approval_users") or os.environ.get("SLACK_APPROVERS", "")
+    if isinstance(approvers_raw, str):
+        allowed_approvers = [u.strip() for u in approvers_raw.split(",") if u.strip()]
+    elif isinstance(approvers_raw, list):
+        allowed_approvers = [str(u).strip() for u in approvers_raw if str(u).strip()]
+    else:
+        allowed_approvers = []
+
+    if channel_type == "slack" and approval_channel:
+        try:
+            from praisonai_bot.bots import SlackApproval
+
+            agent._approval_backend = SlackApproval(
+                channel=str(approval_channel),
+                allowed_approvers=allowed_approvers or None,
+            )
+        except ImportError:
+            logger.warning("SlackApproval unavailable — shell commands may block without approval backend")
+    elif not auto_approve:
+        logger.warning(
+            "allow_shell with auto_approve_shell=false requires approval_channel "
+            "(Slack) or a custom approval backend on the agent"
+        )
+
+    logger.info(
+        "Shell tools enabled for agent %r on channel %r (auto_approve_shell=%s)",
+        getattr(agent, "name", "?"),
+        channel_type or "?",
+        auto_approve,
+    )
+    return agent

--- a/src/praisonai-bot/praisonai_bot/bots/_defaults.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_defaults.py
@@ -385,13 +385,19 @@ def _wire_shell_approval_backend(
 
     webhook_url = ch_cfg.get("approval_webhook_url") or os.environ.get("APPROVAL_WEBHOOK_URL")
     if approval_mode == "webhook" or webhook_url:
-        try:
-            from praisonai_bot.bots import WebhookApproval
+        if not webhook_url:
+            logger.warning(
+                "approval_mode=webhook requires approval_webhook_url or "
+                "APPROVAL_WEBHOOK_URL — falling back to gateway approval queue"
+            )
+        else:
+            try:
+                from praisonai_bot.bots import WebhookApproval
 
-            agent._approval_backend = WebhookApproval(webhook_url=str(webhook_url))
-            return
-        except (ImportError, ValueError) as exc:
-            logger.warning("WebhookApproval unavailable for allow_shell: %s", exc)
+                agent._approval_backend = WebhookApproval(webhook_url=str(webhook_url))
+                return
+            except (ImportError, ValueError) as exc:
+                logger.warning("WebhookApproval unavailable for allow_shell: %s", exc)
 
     if channel_type == "slack":
         approval_channel = (

--- a/src/praisonai-bot/praisonai_bot/gateway/server.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/server.py
@@ -5331,8 +5331,15 @@ class WebSocketGateway:
         agent = agent.clone_for_channel()
         
         # Apply smart defaults to agent (same logic as Bot() wrapper)
-        from praisonai_bot.bots._defaults import apply_bot_smart_defaults
+        from praisonai_bot.bots._defaults import apply_bot_smart_defaults, enable_shell_tools
         agent = apply_bot_smart_defaults(agent, config)
+        if ch_cfg.get("allow_shell"):
+            agent = enable_shell_tools(
+                agent,
+                config,
+                ch_cfg,
+                channel_type=channel_type,
+            )
 
         # Check if agent ended up with zero tools after defaults and warn
         current_tools = getattr(agent, 'tools', None) or []

--- a/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
+++ b/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
@@ -54,7 +54,7 @@ def test_enable_shell_slack_approval_when_not_auto(mock_execute_command):
             slack_cls.return_value = object()
             enable_shell_tools(
                 agent,
-                config=BotConfig(owner_user_id="UOWNER"),
+                config=BotConfig(owner_user_id="UOWNER", token="xoxb-test"),
                 ch_cfg={
                     "allow_shell": True,
                     "auto_approve_shell": False,
@@ -64,5 +64,139 @@ def test_enable_shell_slack_approval_when_not_auto(mock_execute_command):
                 channel_type="slack",
             )
 
-    slack_cls.assert_called_once()
+    slack_cls.assert_called_once_with(
+        token="xoxb-test",
+        channel="UOWNER",
+        allowed_approvers=["UOWNER"],
+    )
     assert agent._approval_backend is slack_cls.return_value
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_telegram_approval(mock_execute_command):
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch("praisonai_bot.bots.TelegramApproval") as tg_cls:
+            tg_cls.return_value = object()
+            enable_shell_tools(
+                agent,
+                config=BotConfig(token="tg-token"),
+                ch_cfg={
+                    "allow_shell": True,
+                    "auto_approve_shell": False,
+                    "approval_channel": "123456789",
+                    "token": "tg-token",
+                },
+                channel_type="telegram",
+            )
+
+    tg_cls.assert_called_once_with(
+        token="tg-token",
+        chat_id="123456789",
+        allowed_approvers=None,
+    )
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_discord_approval(mock_execute_command):
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch("praisonai_bot.bots.DiscordApproval") as dc_cls:
+            dc_cls.return_value = object()
+            enable_shell_tools(
+                agent,
+                config=BotConfig(token="dc-token"),
+                ch_cfg={
+                    "allow_shell": True,
+                    "auto_approve_shell": False,
+                    "home_channel": "9876543210",
+                    "token": "dc-token",
+                },
+                channel_type="discord",
+            )
+
+    dc_cls.assert_called_once_with(
+        token="dc-token",
+        channel_id="9876543210",
+        allowed_approvers=None,
+    )
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_gateway_approval_mode(mock_execute_command):
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch("praisonai_bot.gateway.gateway_approval.GatewayApprovalBackend") as gw_cls:
+            gw_cls.return_value = object()
+            enable_shell_tools(
+                agent,
+                config=BotConfig(),
+                ch_cfg={
+                    "allow_shell": True,
+                    "auto_approve_shell": False,
+                    "approval_mode": "gateway",
+                },
+                channel_type="whatsapp",
+            )
+
+    gw_cls.assert_called_once()
+    assert agent._approval_backend is gw_cls.return_value
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_http_approval_mode(mock_execute_command):
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch("praisonai_bot.bots.HTTPApproval") as http_cls:
+            http_cls.return_value = object()
+            enable_shell_tools(
+                agent,
+                config=BotConfig(),
+                ch_cfg={
+                    "allow_shell": True,
+                    "auto_approve_shell": False,
+                    "approval_mode": "http",
+                    "approval_http_host": "0.0.0.0",
+                    "approval_http_port": 9000,
+                },
+                channel_type="email",
+            )
+
+    http_cls.assert_called_once_with(host="0.0.0.0", port=9000)
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_whatsapp_falls_back_to_gateway(mock_execute_command):
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch("praisonai_bot.gateway.gateway_approval.GatewayApprovalBackend") as gw_cls:
+            gw_cls.return_value = object()
+            enable_shell_tools(
+                agent,
+                config=BotConfig(),
+                ch_cfg={"allow_shell": True, "auto_approve_shell": False},
+                channel_type="whatsapp",
+            )
+
+    gw_cls.assert_called_once()
+    assert agent._approval_backend is gw_cls.return_value

--- a/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
+++ b/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
@@ -1,0 +1,68 @@
+"""Tests for allow_shell channel opt-in."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from praisonai_bot.bots._defaults import enable_shell_tools
+from praisonaiagents.bots.config import BotConfig
+
+
+def test_enable_shell_noop_when_disabled():
+    agent = MagicMock()
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    enable_shell_tools(agent, ch_cfg={"allow_shell": False})
+
+    assert agent.tools == []
+    assert "execute_command" in agent._perm_deny
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_adds_tool_and_clears_deny(mock_execute_command):
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.name = "assistant"
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command", "delete_file"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        enable_shell_tools(
+            agent,
+            config=BotConfig(),
+            ch_cfg={"allow_shell": True, "auto_approve_shell": True},
+            channel_type="slack",
+        )
+
+    assert mock_execute_command in agent.tools
+    assert "execute_command" not in agent._perm_deny
+    assert "delete_file" in agent._perm_deny
+    assert agent._approval_backend is not None
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_slack_approval_when_not_auto(mock_execute_command):
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.name = "assistant"
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch("praisonai_bot.bots.SlackApproval") as slack_cls:
+            slack_cls.return_value = object()
+            enable_shell_tools(
+                agent,
+                config=BotConfig(owner_user_id="UOWNER"),
+                ch_cfg={
+                    "allow_shell": True,
+                    "auto_approve_shell": False,
+                    "approval_channel": "UOWNER",
+                    "approval_users": "UOWNER",
+                },
+                channel_type="slack",
+            )
+
+    slack_cls.assert_called_once()
+    assert agent._approval_backend is slack_cls.return_value

--- a/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
+++ b/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
@@ -182,6 +182,62 @@ def test_enable_shell_http_approval_mode(mock_execute_command):
 
 
 @patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_webhook_mode_without_url_falls_back(mock_execute_command):
+    """approval_mode=webhook with no URL must not build WebhookApproval("None")."""
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch("praisonai_bot.bots.WebhookApproval") as wh_cls:
+            with patch(
+                "praisonai_bot.gateway.gateway_approval.GatewayApprovalBackend"
+            ) as gw_cls:
+                gw_cls.return_value = object()
+                enable_shell_tools(
+                    agent,
+                    config=BotConfig(),
+                    ch_cfg={
+                        "allow_shell": True,
+                        "auto_approve_shell": False,
+                        "approval_mode": "webhook",
+                    },
+                    channel_type="whatsapp",
+                )
+
+    wh_cls.assert_not_called()
+    gw_cls.assert_called_once()
+    assert agent._approval_backend is gw_cls.return_value
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_webhook_mode_with_url(mock_execute_command):
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        with patch("praisonai_bot.bots.WebhookApproval") as wh_cls:
+            wh_cls.return_value = object()
+            enable_shell_tools(
+                agent,
+                config=BotConfig(),
+                ch_cfg={
+                    "allow_shell": True,
+                    "auto_approve_shell": False,
+                    "approval_mode": "webhook",
+                    "approval_webhook_url": "https://hooks.example.com/approve",
+                },
+                channel_type="whatsapp",
+            )
+
+    wh_cls.assert_called_once_with(webhook_url="https://hooks.example.com/approve")
+    assert agent._approval_backend is wh_cls.return_value
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
 def test_enable_shell_whatsapp_falls_back_to_gateway(mock_execute_command):
     mock_execute_command.name = "execute_command"
     agent = MagicMock()


### PR DESCRIPTION
## Summary
- Adds opt-in allow_shell gateway channel config to enable execute_command on inbound bots (Slack, Telegram, Discord, etc.)
- Wires human-in-the-loop approval backends per platform: Slack, Telegram, Discord, plus approval_mode options for gateway queue, HTTP dashboard, and webhook
- Falls back to GatewayApprovalBackend for channels without native approval wiring (e.g. WhatsApp)

## Usage
```yaml
channels:
  slack:
    allow_shell: true
    auto_approve_shell: false
    approval_channel: "UOWNER"
    approval_users: "UOWNER"

  telegram:
    allow_shell: true
    auto_approve_shell: false
    approval_channel: "123456789"

  discord:
    allow_shell: true
    auto_approve_shell: false
    approval_channel: "9876543210"

  whatsapp:
    allow_shell: true
    auto_approve_shell: false
    approval_mode: gateway
```

## Test plan
- [x] pytest src/praisonai-bot/tests/unit/bots/test_enable_shell.py -q (8 passed)
- [ ] Gateway smoke: start gateway with allow_shell on Slack and confirm shell commands execute on server host
- [ ] Telegram/Discord: set auto_approve_shell false and confirm approval prompt appears in configured channel

Supersedes #3335 (same allow_shell base plus extended approval wiring).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in shell command execution for inbound channel bots, enabled per-channel.
  * Added automatic shell approval controls, including routing via supported channels, HTTP, or webhooks (with backend selection validation).
  * Extended gateway smart defaults to apply shell settings based on channel configuration.
  * Updated Telegram/Discord configuration examples to reflect the new shell-approval and routing options.
* **Tests**
  * Expanded unit tests for disabled shell access, auto-approval behavior, and channel-specific approval workflows (including WhatsApp webhook fallback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->