### PR TITLE
Gateway readiness CLI: shell fixes, preflight helpers, doctor checks, gateway test

### DIFF
--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -782,6 +782,7 @@ jobs:
           tests/unit/test_decorator_simple.py
           tests/unit/test_db_adapter_tracing_init.py
           ../praisonai-bot/tests/unit/test_bot_wiring.py
+          ../praisonai-bot/tests/unit/bots/test_enable_shell.py
           ../praisonai-bot/tests/unit/test_bot_history.py
           ../praisonai-bot/tests/unit/test_bot_fixes.py
           tests/unit/test_auto_lazy_loading.py

--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -783,6 +783,8 @@ jobs:
           tests/unit/test_db_adapter_tracing_init.py
           ../praisonai-bot/tests/unit/test_bot_wiring.py
           ../praisonai-bot/tests/unit/bots/test_enable_shell.py
+          ../praisonai-bot/tests/unit/gateway/test_preflight.py
+          ../praisonai-bot/tests/unit/gateway/test_gateway_doctor.py
           ../praisonai-bot/tests/unit/test_bot_history.py
           ../praisonai-bot/tests/unit/test_bot_fixes.py
           tests/unit/test_auto_lazy_loading.py

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -625,11 +625,26 @@ Your Goal: {self.goal}"""
                     formatted_tools.extend(openai_tools)
                 elif openai_tools is not None:
                     formatted_tools.append(openai_tools)
-            # Handle callable functions
-            elif callable(tool):
-                tool_def = self._generate_tool_definition(tool.__name__)
+            # Handle BaseTool-style instances (ClarifyTool, etc.)
+            elif getattr(tool, "name", None) and hasattr(tool, "run"):
+                tool_def = self._generate_tool_definition(tool.name)
                 if tool_def:
                     formatted_tools.append(tool_def)
+                else:
+                    logging.warning(
+                        "Could not generate definition for tool: %s", tool.name
+                    )
+            # Handle callable functions
+            elif callable(tool):
+                fname = getattr(tool, "name", None) or getattr(tool, "__name__", None)
+                if not fname:
+                    logging.warning("Tool %r not recognized (no name)", tool)
+                    continue
+                tool_def = self._generate_tool_definition(fname)
+                if tool_def:
+                    formatted_tools.append(tool_def)
+                else:
+                    logging.warning(f"Could not generate definition for tool: {fname}")
             else:
                 logging.warning(f"Tool {tool} not recognized")
         

--- a/src/praisonai-agents/praisonaiagents/approval/registry.py
+++ b/src/praisonai-agents/praisonaiagents/approval/registry.py
@@ -199,8 +199,6 @@ class ApprovalRegistry:
         # for critical tools (e.g. execute_command after AutoApproveBackend).
         if self._approval_cache_key(tool_name, arguments or {}) in self._approved_context.get(set()):
             return True
-        if self.get_risk_level(tool_name) == "critical":
-            return False
         return False
 
     def _is_session_scoped(

--- a/src/praisonai-agents/praisonaiagents/approval/registry.py
+++ b/src/praisonai-agents/praisonaiagents/approval/registry.py
@@ -195,9 +195,13 @@ class ApprovalRegistry:
         self._approved_context.set(approved)
 
     def is_already_approved(self, tool_name: str, arguments: Optional[Dict] = None) -> bool:
+        # Honour an explicit mark_approved() from the agent approval path even
+        # for critical tools (e.g. execute_command after AutoApproveBackend).
+        if self._approval_cache_key(tool_name, arguments or {}) in self._approved_context.get(set()):
+            return True
         if self.get_risk_level(tool_name) == "critical":
             return False
-        return self._approval_cache_key(tool_name, arguments or {}) in self._approved_context.get(set())
+        return False
 
     def _is_session_scoped(
         self, agent_name: Optional[str], tool_name: str, arguments: Optional[Dict]

--- a/src/praisonai-agents/tests/unit/test_approval_protocol.py
+++ b/src/praisonai-agents/tests/unit/test_approval_protocol.py
@@ -210,6 +210,14 @@ class TestApprovalRegistry:
         reg.mark_approved("write_file")
         assert reg.is_already_approved("write_file")
 
+    def test_critical_tool_honours_mark_approved(self):
+        from praisonaiagents.approval.registry import ApprovalRegistry
+        reg = ApprovalRegistry()
+        reg.add_requirement("execute_command", "critical")
+        assert not reg.is_already_approved("execute_command")
+        reg.mark_approved("execute_command")
+        assert reg.is_already_approved("execute_command")
+
     def test_already_approved_skips_backend(self):
         """Once approved, no backend call needed."""
         from praisonaiagents.approval.registry import ApprovalRegistry

--- a/src/praisonai-bot/praisonai_bot/bots/_defaults.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_defaults.py
@@ -349,6 +349,27 @@ def _channel_token(config: Optional[Any], ch_cfg: Dict[str, Any]) -> Optional[st
     return str(token) if token else None
 
 
+def _sync_approval_registry(agent: Any) -> None:
+    """Mirror ``agent._approval_backend`` onto the approval registry.
+
+    Tool functions decorated with ``@require_approval`` consult the registry
+    (often with ``agent_name=None``), so the agent backend alone is not enough
+    for bot/gateway shell paths.
+    """
+    backend = getattr(agent, "_approval_backend", None)
+    if backend is None:
+        return
+    try:
+        from praisonaiagents.approval import get_approval_registry
+
+        reg = get_approval_registry()
+        agent_name = getattr(agent, "name", None)
+        if agent_name:
+            reg.set_backend(backend, agent_name=agent_name)
+    except ImportError:
+        logger.warning("Approval registry unavailable — shell approval may prompt in CLI")
+
+
 def _wire_shell_approval_backend(
     agent: Any,
     *,
@@ -550,15 +571,16 @@ def enable_shell_tools(
             agent._approval_backend = AutoApproveBackend()
         except ImportError:
             logger.warning("AutoApproveBackend unavailable for allow_shell")
-        return agent
+    else:
+        _wire_shell_approval_backend(
+            agent,
+            channel_type=channel_type,
+            config=config,
+            ch_cfg=ch_cfg,
+            allowed_approvers=_parse_shell_approvers(ch_cfg, channel_type),
+        )
 
-    _wire_shell_approval_backend(
-        agent,
-        channel_type=channel_type,
-        config=config,
-        ch_cfg=ch_cfg,
-        allowed_approvers=_parse_shell_approvers(ch_cfg, channel_type),
-    )
+    _sync_approval_registry(agent)
 
     logger.info(
         "Shell tools enabled for agent %r on channel %r (auto_approve_shell=%s)",

--- a/src/praisonai-bot/praisonai_bot/bots/slack.py
+++ b/src/praisonai-bot/praisonai_bot/bots/slack.py
@@ -637,7 +637,19 @@ class SlackBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                 user_allowed = await UnknownUserHandler.handle(bot_message, self._bot_context)
                 if not user_allowed:
                     return
-            
+
+            # Gateway routing (shell opt-in, per-route agents) runs via on_message
+            # handlers — mirror the regular message path so @mentions are not stuck
+            # on a stale default agent missing execute_command.
+            for handler in self._message_handlers:
+                try:
+                    if asyncio.iscoroutinefunction(handler):
+                        await handler(bot_message)
+                    else:
+                        handler(bot_message)
+                except Exception as e:
+                    logger.error(f"Message handler error: {e}")
+
             text = event.get("text", "")
             if self._bot_user:
                 text = text.replace(f"<@{self._bot_user.user_id}>", "").strip()

--- a/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
@@ -401,26 +401,15 @@ def _check_gateway_secret_strength(config_path: str):
     return str(WeakGatewaySecretError(field="gateway.auth_token"))
 
 
-def _resolve_env_token(value):
-    """Resolve a credential input to its value for probing.
-
-    Handles ``${VAR}`` placeholders and the additive secret-reference form
-    ``{source: file|env|exec, id: ...}`` (Issue #3102). Resolved values are
-    registered for log redaction. Plain strings pass through unchanged.
-    """
-    import os
-
-    if isinstance(value, dict) and "source" in value and "id" in value:
-        try:
-            from praisonaiagents.secrets import resolve_secret
-
-            result = resolve_secret(value)
-            return result.value or ""
-        except Exception:  # pragma: no cover — defensive
-            return ""
-    if isinstance(value, str) and value.startswith("${") and value.endswith("}"):
-        return os.environ.get(value[2:-1], "")
-    return value
+from praisonai_bot.gateway.preflight import (  # noqa: E402 — re-exported for tests/CLI
+    apply_probe_ca_bundle as _apply_probe_ca_bundle,
+    check_gateway_running as _check_gateway_running,
+    probe_channels as _probe_channels,
+    probe_results_to_dict as _probe_results_to_dict,
+    resolve_env_token as _resolve_env_token,
+    run_shell_readiness_check as _run_shell_readiness_check,
+    run_turn_test as _run_gateway_turn_test,
+)
 
 
 def _secret_availability(value) -> str:
@@ -476,43 +465,6 @@ def _is_ssl_error(result) -> bool:
     )
 
 
-def _apply_probe_ca_bundle() -> None:
-    """Point the probe HTTP client at a custom CA bundle if configured.
-
-    Honors ``PRAISONAI_SSL_CA_BUNDLE`` (preferred), ``REQUESTS_CA_BUNDLE`` and
-    ``SSL_CERT_FILE`` so enterprise users behind an SSL-inspecting proxy can
-    supply their corporate CA and have the preflight probe trust it — mirroring
-    what the runtime adapter's SSL stack already honors (#2845). Setting
-    ``SSL_CERT_FILE`` is what Python's default ``ssl`` context (used by
-    ``aiohttp``) reads at load time.
-    """
-    import os
-
-    preferred = os.environ.get("PRAISONAI_SSL_CA_BUNDLE")
-    ca_bundle = (
-        preferred
-        or os.environ.get("REQUESTS_CA_BUNDLE")
-        or os.environ.get("SSL_CERT_FILE")
-    )
-    if not ca_bundle:
-        return
-
-    if not os.path.exists(ca_bundle):
-        print(
-            f"Warning: CA bundle path '{ca_bundle}' does not exist — "
-            "SSL_CERT_FILE / REQUESTS_CA_BUNDLE not updated for probe."
-        )
-        return
-
-    if preferred and preferred == ca_bundle:
-        # Explicit PraisonAI override wins over any pre-existing values.
-        os.environ["SSL_CERT_FILE"] = ca_bundle
-        os.environ["REQUESTS_CA_BUNDLE"] = ca_bundle
-    else:
-        os.environ.setdefault("SSL_CERT_FILE", ca_bundle)
-        os.environ.setdefault("REQUESTS_CA_BUNDLE", ca_bundle)
-
-
 def _load_channels(config: str) -> dict:
     """Load the ``channels`` mapping from a gateway.yaml file (or exit)."""
     import os
@@ -526,129 +478,6 @@ def _load_channels(config: str) -> dict:
         cfg = yaml.safe_load(f) or {}
 
     return cfg.get("channels", {})
-
-
-async def _probe_channels(channels: dict, timeout: float = 15.0) -> dict:
-    """Build a lightweight Bot per channel and probe its credentials.
-
-    Probing builds the adapter lazily and calls the platform identity API
-    (Telegram getMe, Slack auth.test, …) without starting message
-    processing. No agent is required. Returns ``{name: ProbeResult}``.
-
-    Each probe is bounded by ``timeout`` (seconds) so one stuck adapter
-    cannot hang the whole pre-flight; a timeout is reported as a failure.
-
-    Loads ``~/.praisonai/.env`` first so ``${VAR}`` tokens stored there
-    (e.g. by ``praisonai onboard``) resolve — mirroring what
-    ``GatewayHandler.start()`` does at runtime, so every credential check
-    (doctor / channels --probe / start --preflight) uses the same
-    token-resolution behavior (#2426).
-    """
-    import asyncio as _asyncio
-
-    # Load env-file BEFORE resolving ${VAR} tokens so all probe paths
-    # (doctor, channels --probe, start --preflight) match runtime behavior.
-    try:
-        from ..features.gateway import _load_praisonai_env_file
-        _load_praisonai_env_file()
-    except Exception:  # pragma: no cover — defensive
-        pass
-
-    # Honor a custom CA bundle so the probe's HTTP client trusts a corporate
-    # proxy/MITM certificate the same way the runtime adapter does (#2845).
-    _apply_probe_ca_bundle()
-
-    from praisonai_bot.bots import Bot
-    from praisonaiagents.bots import ProbeResult
-
-    async def _probe_one(name: str, ch_cfg: dict):
-        platform = ch_cfg.get("platform", name)
-        token = _resolve_env_token(ch_cfg.get("token", ""))
-        extras = {
-            k: _resolve_env_token(v)
-            for k, v in ch_cfg.items()
-            if k not in ("platform", "token")
-        }
-        try:
-            bot = Bot(platform, token=token, **extras)
-            return name, await _asyncio.wait_for(bot.probe(), timeout=timeout)
-        except _asyncio.TimeoutError:
-            return name, ProbeResult(
-                ok=False,
-                platform=platform,
-                error=f"probe timed out after {timeout:g}s",
-            )
-        except Exception as e:  # pragma: no cover — defensive
-            return name, ProbeResult(ok=False, platform=platform, error=str(e))
-
-    results = await _asyncio.gather(
-        *(_probe_one(name, ch_cfg or {}) for name, ch_cfg in channels.items())
-    )
-    return dict(results)
-
-
-async def _run_gateway_turn_test(
-    config_path: str,
-    channel_name: str,
-    prompt: str,
-) -> tuple:
-    """Simulate one inbound channel turn offline (no gateway process required).
-
-    Mirrors gateway routing + ``allow_shell`` setup, then runs
-    ``BotSessionManager.chat()`` — the same path Slack/Telegram use.
-    Returns ``(ok, message)``.
-    """
-    import yaml
-    from praisonaiagents import Agent
-    from praisonaiagents.bots.config import BotConfig
-    from praisonai_bot.bots._defaults import apply_bot_smart_defaults, enable_shell_tools
-    from praisonai_bot.bots._session import BotSessionManager
-
-    with open(config_path) as f:
-        cfg = yaml.safe_load(f) or {}
-
-    channels = cfg.get("channels") or {}
-    if channel_name not in channels:
-        return False, f"Channel '{channel_name}' not found in config"
-
-    ch_cfg = dict(channels[channel_name] or {})
-    ch_cfg.setdefault("platform", channel_name)
-
-    agents_cfg = cfg.get("agents") or {}
-    routing = ch_cfg.get("routing") or cfg.get("routing") or {}
-    agent_id = routing.get("default")
-    if not agent_id:
-        agent_id = next(iter(agents_cfg), None)
-    if not agent_id or agent_id not in agents_cfg:
-        return False, f"No agent configured for channel '{channel_name}'"
-
-    acfg = agents_cfg[agent_id] or {}
-    agent = Agent(
-        name=acfg.get("name", agent_id),
-        instructions=acfg.get("instructions", ""),
-        llm=acfg.get("model") or acfg.get("llm", "gpt-4o-mini"),
-    )
-    bot_config = BotConfig()
-    agent = apply_bot_smart_defaults(agent, bot_config)
-    platform = str(ch_cfg.get("platform") or channel_name).lower()
-    if ch_cfg.get("allow_shell"):
-        agent = enable_shell_tools(agent, bot_config, ch_cfg, channel_type=platform)
-
-    mgr = BotSessionManager(platform=platform)
-    try:
-        result = await mgr.chat(
-            agent,
-            "gateway-doctor-test",
-            prompt,
-            chat_id="gateway-doctor-test",
-        )
-    except Exception as exc:
-        return False, str(exc)
-
-    text = str(result or "").strip()
-    if not text:
-        return False, "Agent returned an empty response"
-    return True, text[:500]
 
 
 def _compute_secret_availability(channels: dict) -> dict:
@@ -682,14 +511,6 @@ def _print_secret_availability(report: dict) -> None:
             mark = "✓" if status == "available" else "✗"
             print(f"{name:<12} {f:<13} {mark}  {status}")
     print()
-
-
-def _probe_results_to_dict(results: dict) -> dict:
-    """JSON-serializable per-channel probe payload."""
-    return {
-        name: r.to_dict() if hasattr(r, "to_dict") else vars(r)
-        for name, r in results.items()
-    }
 
 
 def _render_probe_results(results: dict, json_output: bool = False) -> bool:
@@ -744,9 +565,9 @@ def gateway_doctor(
     (Telegram getMe, Slack auth.test, Discord identify, WhatsApp token check)
     without starting message processing. Exits non-zero if any channel fails.
 
-    Optional ``--turn`` simulates one inbound message through the same agent
-    path a channel uses (including ``allow_shell`` setup) without starting the
-    gateway or waiting for Slack/Telegram traffic.
+    Optional ``--turn`` runs an offline inbound agent turn via
+    ``BotSessionManager.chat`` (including ``allow_shell`` setup). It does
+    **not** exercise Slack Bolt/socket handlers or @mention routing.
 
     Examples:
         praisonai gateway doctor
@@ -754,23 +575,16 @@ def gateway_doctor(
         praisonai gateway doctor --config gateway.yaml --channel slack --turn "Say OK"
     """
     import asyncio
+    import json
 
-    # Inspect the gateway's OWN auth_token for known-weak/placeholder values
-    # (Issue #3259) — channel probes never cover this. Fail closed on an
-    # external bind, warn on loopback (consistent with runtime posture).
     gateway_secret_error = _check_gateway_secret_strength(config)
-
     channels = _load_channels(config)
-    if not channels:
-        if json_output:
-            # Always emit a single parseable JSON document, even on the
-            # weak/missing gateway-secret failure path, so automation can
-            # distinguish an auth failure from an empty/interrupted run.
-            import json
 
-            payload: dict = {"probes": {}}
-            if gateway_secret_error:
-                payload["gateway_auth_token"] = "weak"
+    if not channels:
+        payload: dict = {"probes": {}}
+        if gateway_secret_error:
+            payload["gateway_auth_token"] = "weak"
+        if json_output:
             print(json.dumps(payload, indent=2))
         else:
             print("No channels configured.")
@@ -780,49 +594,182 @@ def gateway_doctor(
             raise typer.Exit(1)
         raise typer.Exit(0)
 
-    # Credential source availability, computed WITHOUT printing any value
-    # (Issue #3102): operators can validate file/env secret wiring even when
-    # the network probe cannot run.
     availability = _compute_secret_availability(channels)
-
     results = asyncio.run(_probe_channels(channels))
     all_ok = all(getattr(r, "ok", False) for r in results.values())
+    turn_gate_ok = all_ok
+    if channel and channel in results:
+        turn_gate_ok = getattr(results[channel], "ok", False)
 
-    if json_output:
-        # Emit a SINGLE JSON document so consumers using json.load(s) can parse
-        # the whole output (previously the availability and probe blocks were
-        # printed as two separate top-level documents — invalid JSON).
-        import json
+    payload: dict = {"probes": _probe_results_to_dict(results)}
+    if availability:
+        payload["secrets"] = availability
+    if gateway_secret_error:
+        payload["gateway_auth_token"] = "weak"
 
-        payload = {"probes": _probe_results_to_dict(results)}
-        if availability:
-            payload["secrets"] = availability
-        if gateway_secret_error:
-            payload["gateway_auth_token"] = "weak"
-        print(json.dumps(payload, indent=2))
-    else:
+    if not json_output:
         _print_secret_availability(availability)
         _render_probe_results(results, json_output=False)
         if gateway_secret_error:
             print(gateway_secret_error)
 
-    if not all_ok or gateway_secret_error:
+    if gateway_secret_error:
+        if json_output:
+            print(json.dumps(payload, indent=2))
+        raise typer.Exit(1)
+
+    probe_blocks_turn = not all_ok and not (turn and channel and turn_gate_ok)
+    if probe_blocks_turn and not turn:
+        if json_output:
+            print(json.dumps(payload, indent=2))
         raise typer.Exit(1)
 
     if turn:
         target = channel or (next(iter(channels.keys())) if channels else None)
         if not target:
+            if json_output:
+                print(json.dumps(payload, indent=2))
             print("Error: --turn requires at least one configured channel")
             raise typer.Exit(1)
+        if not turn_gate_ok:
+            if json_output:
+                print(json.dumps(payload, indent=2))
+            print(f"Error: channel '{target}' probe failed — cannot run --turn")
+            raise typer.Exit(1)
         ok, message = asyncio.run(_run_gateway_turn_test(config, target, turn))
+        payload["turn"] = {"channel": target, "ok": ok, "response": message}
         if json_output:
-            import json
-            print(json.dumps({"turn": {"channel": target, "ok": ok, "response": message}}, indent=2))
+            print(json.dumps(payload, indent=2))
         else:
             print(f"\nTurn test ({target}): {'OK' if ok else 'FAIL'}")
             print(message if ok else f"Error: {message}")
-        if not ok:
+        if not ok or not all_ok:
             raise typer.Exit(1)
+        return
+
+    if json_output:
+        print(json.dumps(payload, indent=2))
+    if not all_ok:
+        raise typer.Exit(1)
+
+
+@app.command("test")
+def gateway_test(
+    config: str = typer.Option("gateway.yaml", "--config", "-c", help="Path to gateway.yaml"),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON"),
+    channel: Optional[str] = typer.Option(
+        None,
+        "--channel",
+        help="Channel name for --turn (default: first configured channel)",
+    ),
+    turn: Optional[str] = typer.Option(
+        None,
+        "--turn",
+        help="Run one live inbound agent turn offline (requires LLM API key)",
+    ),
+    check_running: bool = typer.Option(
+        False,
+        "--check-running",
+        help="Verify the gateway REST /info endpoint is reachable",
+    ),
+):
+    """One-shot gateway readiness check (probes + shell wiring + optional turn).
+
+    Recommended onboarding path before ``gateway start``. Combines credential
+    probes, offline shell wiring validation, and an optional offline agent turn.
+
+    ``--turn`` uses ``BotSessionManager.chat`` only — it does not prove live
+    Slack @mention delivery. After starting, confirm ``@mention received`` in
+    gateway logs.
+
+    Examples:
+        praisonai gateway test --config bot.yaml
+        praisonai gateway test --config bot.yaml --channel slack --turn "Say OK"
+        praisonai gateway test --config bot.yaml --check-running
+    """
+    import asyncio
+    import json
+
+    gateway_secret_error = _check_gateway_secret_strength(config)
+    channels = _load_channels(config)
+    payload: dict = {}
+
+    if gateway_secret_error:
+        payload["gateway_auth_token"] = "weak"
+
+    if not channels:
+        payload.setdefault("probes", {})
+        if json_output:
+            print(json.dumps(payload, indent=2))
+        else:
+            print("No channels configured.")
+            if gateway_secret_error:
+                print(gateway_secret_error)
+        raise typer.Exit(1 if gateway_secret_error else 0)
+
+    availability = _compute_secret_availability(channels)
+    results = asyncio.run(_probe_channels(channels))
+    all_ok = all(getattr(r, "ok", False) for r in results.values())
+    turn_gate_ok = all_ok
+    if channel and channel in results:
+        turn_gate_ok = getattr(results[channel], "ok", False)
+
+    payload["probes"] = _probe_results_to_dict(results)
+    if availability:
+        payload["secrets"] = availability
+
+    shell_result = _run_shell_readiness_check(config)
+    payload["shell"] = {
+        "ok": shell_result.ok,
+        "message": shell_result.message,
+        "issues": shell_result.issues,
+    }
+
+    if not json_output:
+        _print_secret_availability(availability)
+        _render_probe_results(results, json_output=False)
+        shell_mark = "✓" if shell_result.ok else "✗"
+        print(f"shell wiring  {shell_mark}  {shell_result.message}")
+        if shell_result.issues:
+            for issue in shell_result.issues:
+                print(f"  - {issue}")
+        if gateway_secret_error:
+            print(gateway_secret_error)
+
+    failed = bool(gateway_secret_error) or not all_ok or not shell_result.ok
+
+    if check_running:
+        running_ok, running_msg = _check_gateway_running(config)
+        payload["running"] = {"ok": running_ok, "message": running_msg}
+        if not json_output:
+            mark = "✓" if running_ok else "✗"
+            print(f"gateway up    {mark}  {running_msg}")
+        failed = failed or not running_ok
+
+    if turn:
+        target = channel or (next(iter(channels.keys())) if channels else None)
+        if not target:
+            if json_output:
+                print(json.dumps(payload, indent=2))
+            print("Error: --turn requires at least one configured channel")
+            raise typer.Exit(1)
+        if not turn_gate_ok:
+            if json_output:
+                print(json.dumps(payload, indent=2))
+            print(f"Error: channel '{target}' probe failed — cannot run --turn")
+            raise typer.Exit(1)
+        ok, message = asyncio.run(_run_gateway_turn_test(config, target, turn))
+        payload["turn"] = {"channel": target, "ok": ok, "response": message}
+        if not json_output:
+            print(f"\nTurn test ({target}): {'OK' if ok else 'FAIL'}")
+            print(message if ok else f"Error: {message}")
+        failed = failed or not ok
+
+    if json_output:
+        print(json.dumps(payload, indent=2))
+
+    if failed:
+        raise typer.Exit(1)
 
 
 @app.command("channels")
@@ -1417,6 +1364,7 @@ Manage the gateway server: praisonai gateway <command>
   [green]stop[/green]        Stop a running gateway instance
   [green]status[/green]      Check gateway and daemon status
   [green]doctor[/green]      Validate channel credentials (pre-flight check)
+  [green]test[/green]        One-shot readiness (probes + shell + optional turn)
   [green]channels[/green]    List channels from gateway.yaml (use --probe to check creds)
   [green]send[/green]        Send a test message to a channel
   [green]hooks[/green]       Manage inbound trigger hooks (add | list | remove)

--- a/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
@@ -627,14 +627,20 @@ def gateway_doctor(
     if turn:
         target = channel or (next(iter(channels.keys())) if channels else None)
         if not target:
+            err = "--turn requires at least one configured channel"
+            payload["turn"] = {"channel": None, "ok": False, "response": err}
             if json_output:
                 print(json.dumps(payload, indent=2))
-            print("Error: --turn requires at least one configured channel")
+            else:
+                print(f"Error: {err}")
             raise typer.Exit(1)
         if not turn_gate_ok:
+            err = f"channel '{target}' probe failed — cannot run --turn"
+            payload["turn"] = {"channel": target, "ok": False, "response": err}
             if json_output:
                 print(json.dumps(payload, indent=2))
-            print(f"Error: channel '{target}' probe failed — cannot run --turn")
+            else:
+                print(f"Error: {err}")
             raise typer.Exit(1)
         ok, message = asyncio.run(_run_gateway_turn_test(config, target, turn))
         payload["turn"] = {"channel": target, "ok": ok, "response": message}
@@ -749,14 +755,20 @@ def gateway_test(
     if turn:
         target = channel or (next(iter(channels.keys())) if channels else None)
         if not target:
+            err = "--turn requires at least one configured channel"
+            payload["turn"] = {"channel": None, "ok": False, "response": err}
             if json_output:
                 print(json.dumps(payload, indent=2))
-            print("Error: --turn requires at least one configured channel")
+            else:
+                print(f"Error: {err}")
             raise typer.Exit(1)
         if not turn_gate_ok:
+            err = f"channel '{target}' probe failed — cannot run --turn"
+            payload["turn"] = {"channel": target, "ok": False, "response": err}
             if json_output:
                 print(json.dumps(payload, indent=2))
-            print(f"Error: channel '{target}' probe failed — cannot run --turn")
+            else:
+                print(f"Error: {err}")
             raise typer.Exit(1)
         ok, message = asyncio.run(_run_gateway_turn_test(config, target, turn))
         payload["turn"] = {"channel": target, "ok": ok, "response": message}

--- a/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
@@ -587,6 +587,70 @@ async def _probe_channels(channels: dict, timeout: float = 15.0) -> dict:
     return dict(results)
 
 
+async def _run_gateway_turn_test(
+    config_path: str,
+    channel_name: str,
+    prompt: str,
+) -> tuple:
+    """Simulate one inbound channel turn offline (no gateway process required).
+
+    Mirrors gateway routing + ``allow_shell`` setup, then runs
+    ``BotSessionManager.chat()`` — the same path Slack/Telegram use.
+    Returns ``(ok, message)``.
+    """
+    import yaml
+    from praisonaiagents import Agent
+    from praisonaiagents.bots.config import BotConfig
+    from praisonai_bot.bots._defaults import apply_bot_smart_defaults, enable_shell_tools
+    from praisonai_bot.bots._session import BotSessionManager
+
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f) or {}
+
+    channels = cfg.get("channels") or {}
+    if channel_name not in channels:
+        return False, f"Channel '{channel_name}' not found in config"
+
+    ch_cfg = dict(channels[channel_name] or {})
+    ch_cfg.setdefault("platform", channel_name)
+
+    agents_cfg = cfg.get("agents") or {}
+    routing = ch_cfg.get("routing") or cfg.get("routing") or {}
+    agent_id = routing.get("default")
+    if not agent_id:
+        agent_id = next(iter(agents_cfg), None)
+    if not agent_id or agent_id not in agents_cfg:
+        return False, f"No agent configured for channel '{channel_name}'"
+
+    acfg = agents_cfg[agent_id] or {}
+    agent = Agent(
+        name=acfg.get("name", agent_id),
+        instructions=acfg.get("instructions", ""),
+        llm=acfg.get("model") or acfg.get("llm", "gpt-4o-mini"),
+    )
+    bot_config = BotConfig()
+    agent = apply_bot_smart_defaults(agent, bot_config)
+    platform = str(ch_cfg.get("platform") or channel_name).lower()
+    if ch_cfg.get("allow_shell"):
+        agent = enable_shell_tools(agent, bot_config, ch_cfg, channel_type=platform)
+
+    mgr = BotSessionManager(platform=platform)
+    try:
+        result = await mgr.chat(
+            agent,
+            "gateway-doctor-test",
+            prompt,
+            chat_id="gateway-doctor-test",
+        )
+    except Exception as exc:
+        return False, str(exc)
+
+    text = str(result or "").strip()
+    if not text:
+        return False, "Agent returned an empty response"
+    return True, text[:500]
+
+
 def _compute_secret_availability(channels: dict) -> dict:
     """Per-channel credential availability without revealing values (#3102).
 
@@ -663,6 +727,16 @@ def _render_probe_results(results: dict, json_output: bool = False) -> bool:
 def gateway_doctor(
     config: str = typer.Option("gateway.yaml", "--config", "-c", help="Path to gateway.yaml"),
     json_output: bool = typer.Option(False, "--json", help="Output JSON"),
+    channel: Optional[str] = typer.Option(
+        None,
+        "--channel",
+        help="Channel name for --turn (default: first configured channel)",
+    ),
+    turn: Optional[str] = typer.Option(
+        None,
+        "--turn",
+        help="Run one live inbound agent turn offline (requires LLM API key)",
+    ),
 ):
     """Validate every configured channel's credentials (pre-flight check).
 
@@ -670,9 +744,14 @@ def gateway_doctor(
     (Telegram getMe, Slack auth.test, Discord identify, WhatsApp token check)
     without starting message processing. Exits non-zero if any channel fails.
 
+    Optional ``--turn`` simulates one inbound message through the same agent
+    path a channel uses (including ``allow_shell`` setup) without starting the
+    gateway or waiting for Slack/Telegram traffic.
+
     Examples:
         praisonai gateway doctor
         praisonai gateway doctor --config my-gateway.yaml --json
+        praisonai gateway doctor --config gateway.yaml --channel slack --turn "Say OK"
     """
     import asyncio
 
@@ -729,6 +808,21 @@ def gateway_doctor(
 
     if not all_ok or gateway_secret_error:
         raise typer.Exit(1)
+
+    if turn:
+        target = channel or (next(iter(channels.keys())) if channels else None)
+        if not target:
+            print("Error: --turn requires at least one configured channel")
+            raise typer.Exit(1)
+        ok, message = asyncio.run(_run_gateway_turn_test(config, target, turn))
+        if json_output:
+            import json
+            print(json.dumps({"turn": {"channel": target, "ok": ok, "response": message}}, indent=2))
+        else:
+            print(f"\nTurn test ({target}): {'OK' if ok else 'FAIL'}")
+            print(message if ok else f"Error: {message}")
+        if not ok:
+            raise typer.Exit(1)
 
 
 @app.command("channels")

--- a/src/praisonai-bot/praisonai_bot/gateway/preflight.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/preflight.py
@@ -1,0 +1,305 @@
+"""Gateway preflight helpers — probes, shell wiring, and offline turn tests.
+
+Shared by ``praisonai gateway doctor``, ``praisonai gateway test``, and
+``praisonai doctor bots`` so probe/turn logic lives in one place (not the CLI
+module).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class ShellReadinessResult:
+    """Outcome of offline shell wiring validation."""
+
+    ok: bool
+    message: str
+    issues: List[str] = field(default_factory=list)
+
+
+def load_channels_mapping(config_path: str) -> dict:
+    """Load the ``channels`` mapping from a gateway/bot YAML file."""
+    import yaml
+
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f) or {}
+    return cfg.get("channels") or {}
+
+
+def resolve_gateway_endpoint(config_path: str) -> Tuple[str, int]:
+    """Resolve ``(host, port)`` from config and ``GATEWAY_PORT`` env."""
+    import yaml
+
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f) or {}
+    gateway_cfg = cfg.get("gateway") or {}
+    host = str(gateway_cfg.get("host") or "127.0.0.1")
+    raw_port = gateway_cfg.get("port")
+    if raw_port is None:
+        raw_port = os.environ.get("GATEWAY_PORT", "8765")
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError):
+        port = 8765
+    return host, port
+
+
+def probe_results_to_dict(results: dict) -> dict:
+    """JSON-serializable per-channel probe payload."""
+    return {
+        name: r.to_dict() if hasattr(r, "to_dict") else vars(r)
+        for name, r in results.items()
+    }
+
+
+def resolve_env_token(value):
+    """Resolve a credential input to its value for probing."""
+    if isinstance(value, dict) and "source" in value and "id" in value:
+        try:
+            from praisonaiagents.secrets import resolve_secret
+
+            result = resolve_secret(value)
+            return result.value or ""
+        except Exception:  # pragma: no cover — defensive
+            return ""
+    if isinstance(value, str) and value.startswith("${") and value.endswith("}"):
+        return os.environ.get(value[2:-1], "")
+    return value
+
+
+def apply_probe_ca_bundle() -> None:
+    """Point the probe HTTP client at a custom CA bundle if configured."""
+    preferred = os.environ.get("PRAISONAI_SSL_CA_BUNDLE")
+    ca_bundle = (
+        preferred
+        or os.environ.get("REQUESTS_CA_BUNDLE")
+        or os.environ.get("SSL_CERT_FILE")
+    )
+    if not ca_bundle:
+        return
+
+    if not os.path.exists(ca_bundle):
+        print(
+            f"Warning: CA bundle path '{ca_bundle}' does not exist — "
+            "SSL_CERT_FILE / REQUESTS_CA_BUNDLE not updated for probe."
+        )
+        return
+
+    if preferred and preferred == ca_bundle:
+        os.environ["SSL_CERT_FILE"] = ca_bundle
+        os.environ["REQUESTS_CA_BUNDLE"] = ca_bundle
+    else:
+        os.environ.setdefault("SSL_CERT_FILE", ca_bundle)
+        os.environ.setdefault("REQUESTS_CA_BUNDLE", ca_bundle)
+
+
+async def probe_channels(channels: dict, timeout: float = 15.0) -> dict:
+    """Probe each channel's credentials without starting message processing."""
+    try:
+        from praisonai_bot.cli.features.gateway import _load_praisonai_env_file
+
+        _load_praisonai_env_file()
+    except Exception:  # pragma: no cover — defensive
+        pass
+
+    apply_probe_ca_bundle()
+
+    from praisonai_bot.bots import Bot
+    from praisonaiagents.bots import ProbeResult
+
+    async def _probe_one(name: str, ch_cfg: dict):
+        platform = ch_cfg.get("platform", name)
+        token = resolve_env_token(ch_cfg.get("token", ""))
+        extras = {
+            k: resolve_env_token(v)
+            for k, v in ch_cfg.items()
+            if k not in ("platform", "token")
+        }
+        try:
+            bot = Bot(platform, token=token, **extras)
+            return name, await asyncio.wait_for(bot.probe(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return name, ProbeResult(
+                ok=False,
+                platform=platform,
+                error=f"probe timed out after {timeout:g}s",
+            )
+        except Exception as e:  # pragma: no cover — defensive
+            return name, ProbeResult(ok=False, platform=platform, error=str(e))
+
+    results = await asyncio.gather(
+        *(_probe_one(name, ch_cfg or {}) for name, ch_cfg in channels.items())
+    )
+    return dict(results)
+
+
+async def probe_channels_from_config(
+    config_path: str,
+    channel_filter: Optional[str] = None,
+    timeout: float = 15.0,
+) -> dict:
+    """Load config and probe channels, optionally filtering to one channel."""
+    channels = load_channels_mapping(config_path)
+    if channel_filter:
+        if channel_filter not in channels:
+            raise ValueError(f"Channel '{channel_filter}' not found in config")
+        channels = {channel_filter: channels[channel_filter]}
+    return await probe_channels(channels, timeout=timeout)
+
+
+def run_shell_readiness_check(config_path: str) -> ShellReadinessResult:
+    """Offline validation of ``allow_shell`` wiring (no LLM, no network)."""
+    import yaml
+    from praisonaiagents import Agent
+    from praisonaiagents.approval import get_approval_registry
+    from praisonaiagents.bots.config import BotConfig
+    from praisonai_bot.bots._defaults import apply_bot_smart_defaults, enable_shell_tools
+
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f) or {}
+
+    channels = cfg.get("channels") or {}
+    agents_cfg = cfg.get("agents") or {}
+    shell_channels = [
+        name for name, ch in channels.items() if (ch or {}).get("allow_shell")
+    ]
+
+    if not shell_channels:
+        return ShellReadinessResult(
+            ok=True,
+            message="No channels with allow_shell: true",
+        )
+
+    issues: List[str] = []
+    bot_config = BotConfig()
+
+    for channel_name in shell_channels:
+        ch_cfg = dict(channels[channel_name] or {})
+        ch_cfg.setdefault("platform", channel_name)
+        platform = str(ch_cfg.get("platform") or channel_name).lower()
+
+        routing = ch_cfg.get("routing") or cfg.get("routing") or {}
+        agent_id = routing.get("default") or next(iter(agents_cfg), None)
+        if not agent_id or agent_id not in agents_cfg:
+            issues.append(f"{channel_name}: no agent configured for shell routing")
+            continue
+
+        acfg = agents_cfg[agent_id] or {}
+        agent = Agent(
+            name=acfg.get("name", agent_id),
+            instructions=acfg.get("instructions", ""),
+        )
+        agent = apply_bot_smart_defaults(agent, bot_config)
+        agent = enable_shell_tools(agent, bot_config, ch_cfg, channel_type=platform)
+
+        tool_names = {
+            getattr(t, "name", None) or getattr(t, "__name__", "")
+            for t in (getattr(agent, "tools", None) or [])
+        }
+        if "execute_command" not in tool_names:
+            issues.append(f"{channel_name}: execute_command not in agent tools")
+
+        if getattr(agent, "_approval_backend", None) is None:
+            issues.append(f"{channel_name}: no approval backend on agent")
+
+        reg = get_approval_registry()
+        agent_name = getattr(agent, "name", None)
+        if agent_name and reg.get_backend(agent_name=agent_name) is None:
+            issues.append(f"{channel_name}: approval registry not synced for agent")
+
+    if issues:
+        return ShellReadinessResult(
+            ok=False,
+            message=f"Shell wiring issues on {len(issues)} check(s)",
+            issues=issues,
+        )
+    return ShellReadinessResult(
+        ok=True,
+        message=f"Shell wiring OK for {len(shell_channels)} channel(s)",
+    )
+
+
+async def run_turn_test(
+    config_path: str,
+    channel_name: str,
+    prompt: str,
+) -> Tuple[bool, str]:
+    """Simulate one inbound agent turn offline via ``BotSessionManager.chat``.
+
+    Does **not** exercise Slack Bolt/socket handlers or @mention routing — only
+    the BotSessionManager path after manual shell setup.
+    """
+    import yaml
+    from praisonaiagents import Agent
+    from praisonaiagents.bots.config import BotConfig
+    from praisonai_bot.bots._defaults import apply_bot_smart_defaults, enable_shell_tools
+    from praisonai_bot.bots._session import BotSessionManager
+
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f) or {}
+
+    channels = cfg.get("channels") or {}
+    if channel_name not in channels:
+        return False, f"Channel '{channel_name}' not found in config"
+
+    ch_cfg = dict(channels[channel_name] or {})
+    ch_cfg.setdefault("platform", channel_name)
+
+    agents_cfg = cfg.get("agents") or {}
+    routing = ch_cfg.get("routing") or cfg.get("routing") or {}
+    agent_id = routing.get("default")
+    if not agent_id:
+        agent_id = next(iter(agents_cfg), None)
+    if not agent_id or agent_id not in agents_cfg:
+        return False, f"No agent configured for channel '{channel_name}'"
+
+    acfg = agents_cfg[agent_id] or {}
+    agent = Agent(
+        name=acfg.get("name", agent_id),
+        instructions=acfg.get("instructions", ""),
+        llm=acfg.get("model") or acfg.get("llm", "gpt-4o-mini"),
+    )
+    bot_config = BotConfig()
+    agent = apply_bot_smart_defaults(agent, bot_config)
+    platform = str(ch_cfg.get("platform") or channel_name).lower()
+    if ch_cfg.get("allow_shell"):
+        agent = enable_shell_tools(agent, bot_config, ch_cfg, channel_type=platform)
+
+    mgr = BotSessionManager(platform=platform)
+    try:
+        result = await mgr.chat(
+            agent,
+            "gateway-doctor-test",
+            prompt,
+            chat_id="gateway-doctor-test",
+        )
+    except Exception as exc:
+        return False, str(exc)
+
+    text = str(result or "").strip()
+    if not text:
+        return False, "Agent returned an empty response"
+    return True, text[:500]
+
+
+def check_gateway_running(config_path: str, timeout: float = 5.0) -> Tuple[bool, str]:
+    """Probe the gateway REST ``/info`` endpoint (advisory)."""
+    import urllib.error
+    import urllib.request
+
+    host, port = resolve_gateway_endpoint(config_path)
+    url = f"http://{host}:{port}/info"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            if resp.status == 200:
+                return True, f"Gateway reachable at {url}"
+            return False, f"Gateway returned HTTP {resp.status} at {url}"
+    except urllib.error.URLError as exc:
+        return False, f"Gateway not reachable at {url}: {exc.reason}"
+    except Exception as exc:  # pragma: no cover — defensive
+        return False, str(exc)

--- a/src/praisonai-bot/praisonai_bot/gateway/server.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/server.py
@@ -5367,9 +5367,13 @@ class WebSocketGateway:
         # type — so SlackApproval wiring in enable_shell_tools keys correctly.
         platform = str(ch_cfg.get("platform") or channel_name).lower()
         try:
-            from praisonai_bot.bots._defaults import enable_shell_tools
+            from praisonai_bot.bots._defaults import (
+                apply_bot_smart_defaults,
+                enable_shell_tools,
+            )
 
             clone = agent.clone_for_channel() if hasattr(agent, "clone_for_channel") else agent
+            clone = apply_bot_smart_defaults(clone, config)
             enabled = enable_shell_tools(
                 clone, config, ch_cfg, channel_type=platform
             )

--- a/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
+++ b/src/praisonai-bot/tests/unit/bots/test_enable_shell.py
@@ -296,6 +296,54 @@ def test_manual_approval_replaces_stale_auto_backend(mock_execute_command, monke
 
 
 @patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_syncs_approval_registry(mock_execute_command):
+    mock_execute_command.name = "execute_command"
+    agent = MagicMock()
+    agent.name = "assistant"
+    agent.tools = []
+    agent._perm_deny = frozenset({"execute_command"})
+
+    with patch("praisonaiagents.tools.execute_command", mock_execute_command):
+        enable_shell_tools(
+            agent,
+            config=BotConfig(),
+            ch_cfg={"allow_shell": True, "auto_approve_shell": True},
+            channel_type="slack",
+        )
+
+    from praisonaiagents.approval import get_approval_registry
+    from praisonaiagents.approval.backends import AutoApproveBackend
+
+    reg = get_approval_registry()
+    assert isinstance(reg.get_backend("assistant"), AutoApproveBackend)
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
+def test_enable_shell_critical_tool_honours_agent_approval(mock_execute_command):
+    """Agent-level approval must flow through to @require_approval(critical)."""
+    from praisonaiagents import Agent
+    from praisonaiagents.approval import get_approval_registry, mark_approved
+    from praisonaiagents.tools import execute_command
+
+    mock_execute_command.name = "execute_command"
+    agent = Agent(name="assistant", tools=[])
+    enable_shell_tools(
+        agent,
+        config=BotConfig(),
+        ch_cfg={"allow_shell": True, "auto_approve_shell": True},
+        channel_type="slack",
+    )
+
+    decision = agent._resolve_approval_decision(
+        "execute_command", {"command": "uname -a"}, is_async=False
+    )
+    assert decision.approved is True
+    mark_approved("execute_command")
+    assert get_approval_registry().is_already_approved("execute_command")
+    assert execute_command in (agent.tools or [])
+
+
+@patch("praisonaiagents.tools.execute_command", create=True)
 def test_manual_approval_without_backend_denies_shell(mock_execute_command, monkeypatch):
     """auto_approve_shell=false with no pre-existing backend also fails closed."""
     from praisonaiagents.approval.backends import AutoApproveBackend

--- a/src/praisonai-bot/tests/unit/gateway/test_gateway_doctor.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_gateway_doctor.py
@@ -373,3 +373,101 @@ def test_start_no_preflight_skips_probe(monkeypatch, tmp_path):
     result = runner.invoke(app, ["start", "--config", str(cfg), "--no-preflight"])
     assert result.exit_code == 0
     assert started.get("called") is True
+
+
+def test_doctor_json_single_document_with_turn(monkeypatch, tmp_path):
+    """--json with --turn must emit one parseable document (#gateway-readiness)."""
+    typer_testing = pytest.importorskip("typer.testing")
+    import json
+
+    async def all_ok_probe(self):
+        return ProbeResult(ok=True, platform=self._platform, bot_username="bot")
+
+    monkeypatch.setattr(Bot, "probe", all_ok_probe)
+    monkeypatch.setattr(
+        "praisonai_bot.cli.commands.gateway._check_gateway_secret_strength",
+        lambda _cfg: None,
+    )
+
+    async def fake_turn(config_path, channel_name, prompt):
+        return True, "turn-ok"
+
+    monkeypatch.setattr(
+        "praisonai_bot.cli.commands.gateway._run_gateway_turn_test",
+        fake_turn,
+    )
+
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text("channels:\n  slack:\n    platform: slack\n    token: s\n")
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    runner = typer_testing.CliRunner()
+    result = runner.invoke(
+        app,
+        ["doctor", "--config", str(cfg), "--json", "--channel", "slack", "--turn", "hi"],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout.strip())
+    assert "probes" in payload
+    assert payload["turn"]["ok"] is True
+    assert payload["turn"]["response"] == "turn-ok"
+
+
+def test_doctor_turn_runs_when_other_channel_fails(monkeypatch, tmp_path):
+    """--channel slack --turn runs when slack ok even if telegram fails."""
+    typer_testing = pytest.importorskip("typer.testing")
+
+    async def mixed_probe(self):
+        if self._platform == "slack":
+            return ProbeResult(ok=True, platform="slack", bot_username="slackbot")
+        return ProbeResult(ok=False, platform=self._platform, error="bad")
+
+    monkeypatch.setattr(Bot, "probe", mixed_probe)
+
+    async def fake_turn(config_path, channel_name, prompt):
+        return True, "slack-turn"
+
+    monkeypatch.setattr(
+        "praisonai_bot.cli.commands.gateway._run_gateway_turn_test",
+        fake_turn,
+    )
+
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text(
+        "channels:\n"
+        "  telegram:\n    platform: telegram\n    token: t\n"
+        "  slack:\n    platform: slack\n    token: s\n"
+    )
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    runner = typer_testing.CliRunner()
+    result = runner.invoke(
+        app,
+        ["doctor", "--config", str(cfg), "--channel", "slack", "--turn", "hi"],
+    )
+    assert result.exit_code == 1  # telegram still failed overall
+    assert "Turn test (slack): OK" in result.stdout
+    assert "slack-turn" in result.stdout
+
+
+def test_gateway_test_command(monkeypatch, tmp_path):
+    typer_testing = pytest.importorskip("typer.testing")
+
+    async def all_ok_probe(self):
+        return ProbeResult(ok=True, platform=self._platform, bot_username="bot")
+
+    monkeypatch.setattr(Bot, "probe", all_ok_probe)
+
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text("channels:\n  slack:\n    platform: slack\n    token: s\n")
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    runner = typer_testing.CliRunner()
+    result = runner.invoke(app, ["test", "--config", str(cfg)])
+    assert result.exit_code == 0
+    assert "shell wiring" in result.stdout
+    assert "slack" in result.stdout
+

--- a/src/praisonai-bot/tests/unit/gateway/test_preflight.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_preflight.py
@@ -1,0 +1,101 @@
+"""Tests for praisonai_bot.gateway.preflight helpers."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from praisonaiagents.bots import ProbeResult
+
+
+def test_run_shell_readiness_no_shell_channels(tmp_path):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text(
+        "channels:\n"
+        "  slack:\n    platform: slack\n    token: x\n"
+        "agents:\n  assistant:\n    instructions: hi\n"
+    )
+    from praisonai_bot.gateway.preflight import run_shell_readiness_check
+
+    result = run_shell_readiness_check(str(cfg))
+    assert result.ok is True
+    assert "No channels with allow_shell" in result.message
+
+
+def test_run_shell_readiness_wires_execute_command(tmp_path):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text(
+        "channels:\n"
+        "  slack:\n"
+        "    platform: slack\n"
+        "    token: x\n"
+        "    allow_shell: true\n"
+        "    auto_approve_shell: true\n"
+        "agents:\n"
+        "  assistant:\n"
+        "    name: assistant\n"
+        "    instructions: hi\n"
+        "routing:\n  default: assistant\n"
+    )
+    from praisonai_bot.gateway.preflight import run_shell_readiness_check
+
+    result = run_shell_readiness_check(str(cfg))
+    assert result.ok is True
+    assert result.issues == []
+
+
+def test_probe_channels_from_config_filters_channel(tmp_path, monkeypatch):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text(
+        "channels:\n"
+        "  telegram:\n    platform: telegram\n    token: t\n"
+        "  slack:\n    platform: slack\n    token: s\n"
+    )
+
+    async def fake_probe(channels, timeout=15.0):
+        return {name: ProbeResult(ok=True, platform=name, bot_username="bot") for name in channels}
+
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight.probe_channels",
+        fake_probe,
+    )
+    from praisonai_bot.gateway.preflight import probe_channels_from_config
+
+    results = asyncio.run(probe_channels_from_config(str(cfg), channel_filter="slack"))
+    assert set(results) == {"slack"}
+
+
+def test_check_gateway_running_unreachable(tmp_path):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("gateway:\n  host: 127.0.0.1\n  port: 59999\n")
+    from praisonai_bot.gateway.preflight import check_gateway_running
+
+    ok, msg = check_gateway_running(str(cfg), timeout=1.0)
+    assert ok is False
+    assert "59999" in msg
+
+
+def test_run_turn_test_mocked(tmp_path, monkeypatch):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text(
+        "channels:\n"
+        "  slack:\n"
+        "    platform: slack\n"
+        "    token: x\n"
+        "agents:\n"
+        "  assistant:\n"
+        "    name: assistant\n"
+        "    instructions: hi\n"
+        "routing:\n  default: assistant\n"
+    )
+
+    mock_chat = AsyncMock(return_value="OK from test")
+    monkeypatch.setattr(
+        "praisonai_bot.bots._session.BotSessionManager.chat",
+        mock_chat,
+    )
+    from praisonai_bot.gateway.preflight import run_turn_test
+
+    ok, message = asyncio.run(run_turn_test(str(cfg), "slack", "Say OK"))
+    assert ok is True
+    assert message == "OK from test"

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/gateway_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/gateway_checks.py
@@ -411,3 +411,192 @@ def check_gateway_env_substitution(config: DoctorConfig) -> CheckResult:
             remediation="Check config file access",
             duration_ms=(time.time() - start) * 1000,
         )
+
+
+def _find_gateway_config_path(config: DoctorConfig) -> Optional[str]:
+    """Resolve gateway/bot config path, honouring ``--file`` first."""
+    config_paths: List[str] = []
+    if getattr(config, "config_file", None):
+        config_paths.append(config.config_file)
+
+    from praisonai_code.cli._paths import resolve_bot_config_path
+
+    config_paths.extend([
+        resolve_bot_config_path("gateway.yaml"),
+        resolve_bot_config_path("bot.yaml"),
+        "gateway.yaml",
+        "bot.yaml",
+    ])
+
+    for path in config_paths:
+        if path and os.path.exists(path):
+            return path
+    return None
+
+
+@register_check(
+    id="gateway_shell_readiness",
+    title="Gateway Shell Readiness",
+    description="Validate allow_shell wiring offline (no LLM)",
+    category=CheckCategory.BOTS,
+    severity=CheckSeverity.HIGH,
+)
+def check_gateway_shell_readiness(config: DoctorConfig) -> CheckResult:
+    """Offline shell wiring check for channels with ``allow_shell: true``."""
+    start = time.time()
+    skipped = skip_if_no_wrapper(
+        "gateway_shell_readiness", "Gateway Shell Readiness", start=start
+    )
+    if skipped:
+        return skipped
+    skipped = skip_if_no_bot_package(
+        "gateway_shell_readiness", "Gateway Shell Readiness", start=start
+    )
+    if skipped:
+        return skipped
+
+    config_path = _find_gateway_config_path(config)
+    if not config_path:
+        return CheckResult(
+            id="gateway_shell_readiness",
+            title="Gateway Shell Readiness",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.WARN,
+            message="No gateway/bot config found",
+            remediation="Run 'praisonai onboard' or pass --file /path/to/bot.yaml",
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    try:
+        from praisonai_code._bot_bridge import import_bot_module
+
+        preflight = import_bot_module("praisonai_bot.gateway.preflight")
+        result = preflight.run_shell_readiness_check(config_path)
+    except Exception as exc:
+        return CheckResult(
+            id="gateway_shell_readiness",
+            title="Gateway Shell Readiness",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.ERROR,
+            message=f"Shell readiness check failed: {str(exc)[:100]}",
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    if result.ok:
+        return CheckResult(
+            id="gateway_shell_readiness",
+            title="Gateway Shell Readiness",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.PASS,
+            message=result.message,
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    return CheckResult(
+        id="gateway_shell_readiness",
+        title="Gateway Shell Readiness",
+        category=CheckCategory.BOTS,
+        status=CheckStatus.FAIL,
+        message=result.message,
+        details="\n".join(result.issues) if result.issues else None,
+        remediation="Fix allow_shell / auto_approve_shell settings in bot.yaml",
+        duration_ms=(time.time() - start) * 1000,
+    )
+
+
+@register_check(
+    id="gateway_channel_probe",
+    title="Gateway Channel Probe",
+    description="Live credential probe for configured channels",
+    category=CheckCategory.BOTS,
+    severity=CheckSeverity.HIGH,
+    requires_deep=True,
+)
+def check_gateway_channel_probe(config: DoctorConfig) -> CheckResult:
+    """Live platform credential probe (``auth.test``, ``getMe``, etc.)."""
+    import asyncio
+
+    start = time.time()
+    skipped = skip_if_no_wrapper(
+        "gateway_channel_probe", "Gateway Channel Probe", start=start
+    )
+    if skipped:
+        return skipped
+    skipped = skip_if_no_bot_package(
+        "gateway_channel_probe", "Gateway Channel Probe", start=start
+    )
+    if skipped:
+        return skipped
+
+    config_path = _find_gateway_config_path(config)
+    if not config_path:
+        return CheckResult(
+            id="gateway_channel_probe",
+            title="Gateway Channel Probe",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.SKIP,
+            message="No gateway/bot config found",
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    try:
+        from praisonai_code._bot_bridge import import_bot_module
+
+        preflight = import_bot_module("praisonai_bot.gateway.preflight")
+        channels = preflight.load_channels_mapping(config_path)
+        if not channels:
+            return CheckResult(
+                id="gateway_channel_probe",
+                title="Gateway Channel Probe",
+                category=CheckCategory.BOTS,
+                status=CheckStatus.SKIP,
+                message="No channels configured",
+                duration_ms=(time.time() - start) * 1000,
+            )
+        results = asyncio.run(preflight.probe_channels(channels))
+    except Exception as exc:
+        return CheckResult(
+            id="gateway_channel_probe",
+            title="Gateway Channel Probe",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.ERROR,
+            message=f"Probe failed: {str(exc)[:100]}",
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    lines = []
+    failed = []
+    for name, probe in results.items():
+        if getattr(probe, "ok", False):
+            identity = getattr(probe, "bot_username", None) or ""
+            detail = f"@{identity}" if identity else getattr(probe, "platform", name)
+            lines.append(f"{name}: OK ({detail})")
+        else:
+            err = getattr(probe, "error", None) or "unknown error"
+            lines.append(f"{name}: FAIL ({err})")
+            failed.append(name)
+
+    if failed:
+        return CheckResult(
+            id="gateway_channel_probe",
+            title="Gateway Channel Probe",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.FAIL,
+            message=f"{len(failed)} channel probe(s) failed",
+            details="\n".join(lines),
+            remediation=(
+                "Fix channel tokens or run: "
+                f"praisonai gateway test --config {config_path}"
+            ),
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    return CheckResult(
+        id="gateway_channel_probe",
+        title="Gateway Channel Probe",
+        category=CheckCategory.BOTS,
+        status=CheckStatus.PASS,
+        message=f"All {len(results)} channel probe(s) passed",
+        details="\n".join(lines),
+        duration_ms=(time.time() - start) * 1000,
+    )

--- a/src/praisonai-code/tests/unit/doctor/test_gateway_readiness_checks.py
+++ b/src/praisonai-code/tests/unit/doctor/test_gateway_readiness_checks.py
@@ -1,0 +1,62 @@
+"""Doctor checks for gateway shell readiness and channel probes."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from praisonai_code.cli.features.doctor.models import DoctorConfig
+from praisonai_code.cli.features.doctor.checks import gateway_checks
+
+
+def test_shell_readiness_pass(tmp_path, monkeypatch):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("channels:\n  slack:\n    allow_shell: true\n")
+
+    mock_result = MagicMock(ok=True, message="Shell wiring OK", issues=[])
+
+    def fake_import(name):
+        mod = MagicMock()
+        mod.run_shell_readiness_check.return_value = mock_result
+        return mod
+
+    monkeypatch.setattr(gateway_checks, "skip_if_no_wrapper", lambda *a, **k: None)
+    monkeypatch.setattr(gateway_checks, "skip_if_no_bot_package", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "praisonai_code._bot_bridge.import_bot_module",
+        fake_import,
+    )
+
+    result = gateway_checks.check_gateway_shell_readiness(
+        DoctorConfig(config_file=str(cfg))
+    )
+    assert result.status.value == "pass"
+
+
+def test_channel_probe_deep_mock(tmp_path, monkeypatch):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text(
+        "channels:\n  telegram:\n    platform: telegram\n    token: t\n"
+    )
+
+    from praisonaiagents.bots import ProbeResult
+
+    async def fake_probe(channels, timeout=15.0):
+        return {"telegram": ProbeResult(ok=True, platform="telegram", bot_username="bot")}
+
+    mod = MagicMock()
+    mod.load_channels_mapping.return_value = {"telegram": {"platform": "telegram", "token": "t"}}
+    mod.probe_channels = fake_probe
+
+    monkeypatch.setattr(gateway_checks, "skip_if_no_wrapper", lambda *a, **k: None)
+    monkeypatch.setattr(gateway_checks, "skip_if_no_bot_package", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "praisonai_code._bot_bridge.import_bot_module",
+        lambda name: mod,
+    )
+
+    result = gateway_checks.check_gateway_channel_probe(
+        DoctorConfig(config_file=str(cfg))
+    )
+    assert result.status.value == "pass"
+    assert "telegram" in (result.details or "")


### PR DESCRIPTION
## Summary

- Fixes gateway shell approval path: critical tools honour mark_approved(), registry sync after enable_shell_tools, Slack @mention routing through message handlers, and routed-agent shell re-apply.
- Extracts shared preflight logic to praisonai_bot.gateway.preflight (probes, shell wiring, offline turn test, running check).
- Adds praisonai gateway test — one-shot readiness orchestrator (probes + shell wiring + optional --turn + --check-running).
- Adds praisonai doctor bots checks: gateway_shell_readiness (offline) and gateway_channel_probe (--deep only).
- Fixes gateway doctor --json to emit a single document including the turn block; allows --channel slack --turn when Slack probe passes even if another channel fails.

## Test plan

- [x] pytest src/praisonai-bot/tests/unit/bots/test_enable_shell.py — 14 passed
- [x] pytest src/praisonai-bot/tests/unit/gateway/test_preflight.py — 5 passed
- [x] pytest src/praisonai-bot/tests/unit/gateway/test_gateway_doctor.py — 20 passed
- [x] pytest src/praisonai-code/tests/unit/doctor/test_gateway_readiness_checks.py — 2 passed
- [x] pytest src/praisonai-bot/tests/unit/gateway/ — 456 passed
- [ ] Manual: praisonai gateway test --config /path/to/bot.yaml --channel slack --turn "run uname -a with execute_command"
- [ ] Manual: confirm live Slack @mention shows @mention received in gateway logs

## Docs

Companion docs PR: https://github.com/MervinPraison/PraisonAIDocs/pull/2334

## Notes

--turn validates BotSessionManager offline path only — it does not prove live Slack socket/@mention delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `gateway test` for one-shot readiness checks (auth strength, channel credential probing, shell wiring, optional running reachability and offline turn testing).
  - Enhanced `gateway doctor` with `--channel` and `--turn`, richer JSON/human output, and gateway availability checks.
  - Added new gateway “doctor” readiness checks for channel probing and shell readiness.

- **Bug Fixes**
  - Tool formatting now better supports tool objects that expose a `name` and `run`.
  - Critical approval decisions now correctly honor previously marked approvals.
  - Slack mentions now run the same registered message handlers as standard messages.
  - Shell approval synchronization and routed-agent shell setup are now more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->