### PR TITLE
feat(gateway): tiered diagnostics for runtime, inbound, and duplicates

### DIFF
--- a/src/praisonai-bot/praisonai_bot/bots/slack.py
+++ b/src/praisonai-bot/praisonai_bot/bots/slack.py
@@ -655,7 +655,11 @@ class SlackBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                 except Exception as e:
                     logger.error(f"Message handler error: {e}")
 
-            text = (decision.get("content") or event.get("text", "")).strip()
+            # fire_message_received always returns the (possibly hook-rewritten)
+            # inbound content, seeded from the converted message. Use it
+            # verbatim so a hook that intentionally redacts to empty is honoured
+            # instead of silently restoring the raw Slack event text.
+            text = (decision.get("content") or "").strip()
             if self._bot_user:
                 text = text.replace(f"<@{self._bot_user.user_id}>", "").strip()
 

--- a/src/praisonai-bot/praisonai_bot/bots/slack.py
+++ b/src/praisonai-bot/praisonai_bot/bots/slack.py
@@ -626,6 +626,11 @@ class SlackBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
             bot_message = self._convert_event_to_message(event)
             bot_message._channel_type = "slack"
 
+            decision = self.fire_message_received(bot_message)
+            if decision.get("drop"):
+                logger.debug("@mention dropped by MESSAGE_RECEIVED hook")
+                return
+
             if not self.config.is_channel_allowed(
                 bot_message.channel.channel_id if bot_message.channel else ""
             ):
@@ -650,10 +655,10 @@ class SlackBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                 except Exception as e:
                     logger.error(f"Message handler error: {e}")
 
-            text = event.get("text", "")
+            text = (decision.get("content") or event.get("text", "")).strip()
             if self._bot_user:
                 text = text.replace(f"<@{self._bot_user.user_id}>", "").strip()
-            
+
             if self._agent:
                 try:
                     user_id = event.get("user", "unknown")

--- a/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
@@ -284,13 +284,18 @@ def gateway_restart(
 def gateway_status(
     host: str = typer.Option("127.0.0.1", "--host", help="Gateway host"),
     port: Optional[int] = typer.Option(None, "--port", help="Gateway port"),
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="Gateway config path"),
     daemon_only: bool = typer.Option(False, "--daemon-only", help="Show only daemon status"),
+    deep: bool = typer.Option(False, "--deep", help="Extended diagnostics (health + log tail)"),
+    probe: bool = typer.Option(False, "--probe", help="Live credential probe per channel"),
 ):
     """Check gateway status and daemon service status.
 
     Examples:
         praisonai gateway status
         praisonai gateway status --port 9000
+        praisonai gateway status --deep --config bot.yaml
+        praisonai gateway status --probe --config bot.yaml
         praisonai gateway status --daemon-only
     """
     import os
@@ -334,7 +339,26 @@ def gateway_status(
     if not daemon_only:
         try:
             handler = GatewayHandler()
-            handler.status(host=host, port=port)
+            handler.status(host=host, port=port, deep=deep)
+            if deep and config and os.path.exists(config):
+                from praisonai_bot.daemon.launchd import get_logs
+
+                output.print_info("Recent log tail:")
+                print(get_logs(lines=20))
+                channels = _load_channels(config)
+                for name, ch in channels.items():
+                    platform = (ch or {}).get("platform", name)
+                    dlq_path = _resolve_platform_dlq_path(str(platform))
+                    output.print_info(
+                        f"DLQ ({name}): praisonai bot dlq list --path {dlq_path}"
+                    )
+            if probe and config and os.path.exists(config):
+                import asyncio
+
+                channels = _load_channels(config)
+                results = asyncio.run(_probe_channels(channels))
+                output.print_info("Live channel probe:")
+                _render_probe_results(results, json_output=False)
         except Exception as e:
             output.print_error(f"Error checking gateway server status: {str(e)}")
 
@@ -403,10 +427,14 @@ def _check_gateway_secret_strength(config_path: str):
 
 from praisonai_bot.gateway.preflight import (  # noqa: E402 — re-exported for tests/CLI
     apply_probe_ca_bundle as _apply_probe_ca_bundle,
+    check_duplicates as _check_duplicates,
     check_gateway_running as _check_gateway_running,
+    check_inbound as _check_inbound,
+    check_runtime as _check_runtime,
     probe_channels as _probe_channels,
     probe_results_to_dict as _probe_results_to_dict,
     resolve_env_token as _resolve_env_token,
+    resolve_platform_dlq_path as _resolve_platform_dlq_path,
     run_shell_readiness_check as _run_shell_readiness_check,
     run_turn_test as _run_gateway_turn_test,
 )
@@ -678,20 +706,41 @@ def gateway_test(
         "--check-running",
         help="Verify the gateway REST /info endpoint is reachable",
     ),
+    check_runtime: bool = typer.Option(
+        False,
+        "--check-runtime",
+        help="Probe /info, /health, /ready, and /live (superset of --check-running)",
+    ),
+    check_inbound: bool = typer.Option(
+        False,
+        "--check-inbound",
+        help="Verify recent inbound delivery via gateway logs",
+    ),
+    check_duplicates: bool = typer.Option(
+        False,
+        "--check-duplicates",
+        help="Scan for competing gateway services and shared tokens",
+    ),
+    since: str = typer.Option(
+        "10m",
+        "--since",
+        help="Time window for --check-inbound (e.g. 5m, 2h)",
+    ),
 ):
     """One-shot gateway readiness check (probes + shell wiring + optional turn).
 
     Recommended onboarding path before ``gateway start``. Combines credential
-    probes, offline shell wiring validation, and an optional offline agent turn.
+    probes, offline shell wiring validation, and optional offline agent turn.
 
     ``--turn`` uses ``BotSessionManager.chat`` only — it does not prove live
     Slack @mention delivery. After starting, confirm ``@mention received`` in
-    gateway logs.
+    gateway logs or use ``--check-inbound``.
 
     Examples:
         praisonai gateway test --config bot.yaml
         praisonai gateway test --config bot.yaml --channel slack --turn "Say OK"
-        praisonai gateway test --config bot.yaml --check-running
+        praisonai gateway test --config bot.yaml --check-runtime --check-duplicates
+        praisonai gateway test --config bot.yaml --check-inbound --since 5m
     """
     import asyncio
     import json
@@ -744,13 +793,60 @@ def gateway_test(
 
     failed = bool(gateway_secret_error) or not all_ok or not shell_result.ok
 
-    if check_running:
-        running_ok, running_msg = _check_gateway_running(config)
-        payload["running"] = {"ok": running_ok, "message": running_msg}
+    runtime_requested = check_runtime or check_running
+    if runtime_requested:
+        if check_runtime:
+            runtime_result = _check_runtime(config)
+            payload["runtime"] = runtime_result.to_dict()
+            runtime_ok = runtime_result.ok
+            if not json_output:
+                for name, key in (
+                    ("info", "info"),
+                    ("health", "health"),
+                    ("ready", "ready"),
+                    ("live", "live"),
+                ):
+                    probe = getattr(runtime_result, key)
+                    mark = "✓" if probe.ok else "✗"
+                    print(f"gateway {name:<6} {mark}  HTTP {probe.status_code or '—'}")
+        else:
+            running_ok, running_msg = _check_gateway_running(config)
+            payload["running"] = {"ok": running_ok, "message": running_msg}
+            runtime_ok = running_ok
+            if not json_output:
+                mark = "✓" if running_ok else "✗"
+                print(f"gateway up    {mark}  {running_msg}")
+        failed = failed or not runtime_ok
+
+    if check_duplicates:
+        dup_result = _check_duplicates(config)
+        payload["duplicates"] = dup_result.to_dict()
         if not json_output:
-            mark = "✓" if running_ok else "✗"
-            print(f"gateway up    {mark}  {running_msg}")
-        failed = failed or not running_ok
+            mark = "✓" if dup_result.ok else "✗"
+            print(f"duplicates  {mark}  {len(dup_result.warnings)} warning(s)")
+            for warning in dup_result.warnings:
+                print(f"  - {warning}")
+        failed = failed or not dup_result.ok
+
+    if check_inbound:
+        inbound_result = _check_inbound(
+            config,
+            since=since,
+            probe_results=results,
+        )
+        payload["inbound"] = inbound_result.to_dict()
+        if not json_output:
+            mark = "✓" if inbound_result.ok else "✗"
+            print(
+                f"inbound     {mark}  "
+                f"{inbound_result.mentions_in_window} mention(s) in window "
+                f"(proves {inbound_result.proves})"
+            )
+            if inbound_result.last_mention_at:
+                print(f"  last: {inbound_result.last_mention_at}")
+            if inbound_result.hint:
+                print(f"  hint: {inbound_result.hint}")
+        failed = failed or not inbound_result.ok
 
     if turn:
         target = channel or (next(iter(channels.keys())) if channels else None)
@@ -1297,6 +1393,71 @@ hooks_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(hooks_app, name="hooks")
+
+
+sessions_app = typer.Typer(
+    help="Inspect stored gateway conversation sessions",
+    no_args_is_help=True,
+)
+app.add_typer(sessions_app, name="sessions")
+
+
+@sessions_app.command("list")
+def gateway_sessions_list(
+    platform: Optional[str] = typer.Option(None, "--platform", help="Filter by platform (e.g. slack)"),
+    active: Optional[int] = typer.Option(None, "--active", help="Only sessions updated within N seconds"),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON"),
+):
+    """List stored bot session files under ~/.praisonai/sessions/."""
+    import json
+
+    from praisonai_bot.gateway.preflight import list_gateway_sessions
+
+    rows = list_gateway_sessions(platform=platform, active_seconds=active)
+    if json_output:
+        print(json.dumps(rows, indent=2))
+    else:
+        if not rows:
+            print("No sessions found.")
+        for row in rows:
+            print(
+                f"{row['session_id']:<40} "
+                f"msgs={row['message_count']:<4} "
+                f"user={row.get('user_id') or '—'}"
+            )
+        print(
+            "\nSessions reflect stored history; use "
+            "`praisonai gateway test --check-inbound` for live delivery."
+        )
+
+
+@sessions_app.command("show")
+def gateway_sessions_show(
+    session_ref: str = typer.Argument(..., help="Session id, user id, or partial filename match"),
+    tail: int = typer.Option(20, "--tail", help="Number of recent messages to show"),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON"),
+):
+    """Show a stored session's recent messages."""
+    import json
+
+    from praisonai_bot.gateway.preflight import show_gateway_session
+
+    try:
+        data = show_gateway_session(session_ref, tail=tail)
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(1) from exc
+
+    if json_output:
+        print(json.dumps(data, indent=2))
+    else:
+        print(f"Session: {data.get('session_id')}  user={data.get('user_id')}")
+        print(f"Agent: {data.get('agent_name')}  messages={data.get('message_count')}")
+        for msg in data.get("messages") or []:
+            role = msg.get("role", "?")
+            content = (msg.get("content") or "")[:200]
+            print(f"  [{role}] {content}")
+        print(f"\n{data.get('footer')}")
 
 
 def _run_hooks_action(**kwargs) -> None:

--- a/src/praisonai-bot/praisonai_bot/cli/features/gateway.py
+++ b/src/praisonai-bot/praisonai_bot/cli/features/gateway.py
@@ -604,12 +604,13 @@ class GatewayHandler:
         print("Usage: praisonai gateway hooks {add|list|remove} ...")
         return 1
 
-    def status(self, host: str = "127.0.0.1", port: int = 8765) -> None:
+    def status(self, host: str = "127.0.0.1", port: int = 8765, deep: bool = False) -> None:
         """Check gateway status.
         
         Args:
             host: Gateway host
             port: Gateway port
+            deep: Print per-channel health rows from /health
         """
         import urllib.request
         import json
@@ -650,6 +651,8 @@ class GatewayHandler:
         url = f"http://{host}:{port}/health"
         
         try:
+            import time as _time
+
             with urllib.request.urlopen(url, timeout=5) as response:
                 data = json.loads(response.read().decode())
                 print(f"Gateway Status: {data.get('status', 'unknown')}")
@@ -657,10 +660,69 @@ class GatewayHandler:
                 print(f"  Agents: {data.get('agents', 0)}")
                 print(f"  Sessions: {data.get('sessions', 0)}")
                 print(f"  Clients: {data.get('clients', 0)}")
+                if data.get("last_inbound_at"):
+                    age = _time.time() - float(data["last_inbound_at"])
+                    print(
+                        f"  Last inbound: "
+                        f"{_time.strftime('%H:%M:%S', _time.localtime(data['last_inbound_at']))} "
+                        f"({age:.0f}s ago)"
+                    )
+                channels = data.get("channels") or {}
+                if channels and deep:
+                    print("  Channels:")
+                    for name, ch in channels.items():
+                        running = ch.get("running", False)
+                        state = (ch.get("supervision") or {}).get("state", "—")
+                        reason = ch.get("reason", "—")
+                        probe_ok = (ch.get("probe") or {}).get("ok")
+                        last = ch.get("last_activity")
+                        last_s = f"{_time.time() - last:.0f}s ago" if last else "—"
+                        mark = "✓" if running else "✗"
+                        probe_s = f" probe_ok={probe_ok}" if probe_ok is not None else ""
+                        print(
+                            f"    {mark} {name}: running={running} state={state} "
+                            f"reason={reason} last_activity={last_s}{probe_s}"
+                        )
+                if deep:
+                    self._print_version_skew(host, port)
                 self._print_reload_status(data)
         except Exception as e:
             print(f"Gateway not reachable at {url}")
             print(f"Error: {e}")
+
+    @staticmethod
+    def _print_version_skew(host: str, port: int) -> None:
+        """Warn when the running gateway version differs from the installed CLI."""
+        import json
+        import urllib.request
+
+        try:
+            from importlib.metadata import version as pkg_version
+        except ImportError:
+            from importlib_metadata import version as pkg_version  # type: ignore
+
+        try:
+            cli_version = pkg_version("praisonai-bot")
+        except Exception:
+            return
+
+        url = f"http://{host}:{port}/info"
+        try:
+            req = urllib.request.Request(url)
+            token = __import__("os").environ.get("GATEWAY_AUTH_TOKEN", "").strip()
+            if token and host not in ("127.0.0.1", "localhost", "::1"):
+                req.add_header("Authorization", f"Bearer {token}")
+            with urllib.request.urlopen(req, timeout=3) as response:
+                data = json.loads(response.read().decode())
+        except Exception:
+            return
+
+        runtime_version = data.get("version")
+        if runtime_version and runtime_version != cli_version:
+            print(
+                f"  Version skew: running gateway reports {runtime_version}, "
+                f"installed praisonai-bot is {cli_version}"
+            )
 
     @staticmethod
     def _print_reload_status(data: dict) -> None:

--- a/src/praisonai-bot/praisonai_bot/cli/features/gateway.py
+++ b/src/praisonai-bot/praisonai_bot/cli/features/gateway.py
@@ -710,7 +710,10 @@ class GatewayHandler:
         try:
             req = urllib.request.Request(url)
             token = __import__("os").environ.get("GATEWAY_AUTH_TOKEN", "").strip()
-            if token and host not in ("127.0.0.1", "localhost", "::1"):
+            # Only attach the bearer token where it cannot leak to a network
+            # observer: over loopback (never on the wire). A remote plaintext
+            # HTTP probe deliberately omits it rather than expose the credential.
+            if token and host in ("127.0.0.1", "localhost", "::1"):
                 req.add_header("Authorization", f"Bearer {token}")
             with urllib.request.urlopen(req, timeout=3) as response:
                 data = json.loads(response.read().decode())

--- a/src/praisonai-bot/praisonai_bot/gateway/preflight.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/preflight.py
@@ -122,7 +122,12 @@ async def probe_channels(channels: dict, timeout: float = 15.0) -> dict:
         }
         try:
             bot = Bot(platform, token=token, **extras)
-            return name, await asyncio.wait_for(bot.probe(), timeout=timeout)
+            result = await asyncio.wait_for(bot.probe(), timeout=timeout)
+            if str(platform).lower() == "slack" and not resolve_env_token(ch_cfg.get("app_token", "")):
+                warnings = list((result.details or {}).get("warnings") or [])
+                warnings.append("SLACK_APP_TOKEN missing — Socket Mode will not start")
+                result.details = {**(result.details or {}), "warnings": warnings}
+            return name, result
         except asyncio.TimeoutError:
             return name, ProbeResult(
                 ok=False,
@@ -303,3 +308,699 @@ def check_gateway_running(config_path: str, timeout: float = 5.0) -> Tuple[bool,
         return False, f"Gateway not reachable at {url}: {exc.reason}"
     except Exception as exc:  # pragma: no cover — defensive
         return False, str(exc)
+
+
+# ── Runtime / inbound / duplicate diagnostics (gateway test) ─────────────
+
+
+@dataclass
+class RuntimeProbeResult:
+    """Outcome of a single HTTP runtime probe."""
+
+    ok: bool
+    status_code: Optional[int] = None
+    body: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class RuntimeCheckResult:
+    """Combined runtime reachability check."""
+
+    ok: bool
+    host: str
+    port: int
+    info: RuntimeProbeResult
+    health: RuntimeProbeResult
+    ready: RuntimeProbeResult
+    live: RuntimeProbeResult
+
+    def to_dict(self) -> Dict[str, Any]:
+        def _probe_dict(p: RuntimeProbeResult, path: str) -> Dict[str, Any]:
+            return {
+                "ok": p.ok,
+                "path": path,
+                "status_code": p.status_code,
+                "error": p.error,
+                "body": p.body,
+            }
+
+        return {
+            "ok": self.ok,
+            "host": self.host,
+            "port": self.port,
+            "info": _probe_dict(self.info, "/info"),
+            "health": _probe_dict(self.health, "/health"),
+            "ready": _probe_dict(self.ready, "/ready"),
+            "live": _probe_dict(self.live, "/live"),
+        }
+
+
+@dataclass
+class InboundCheckResult:
+    """Outcome of live inbound delivery verification."""
+
+    ok: bool
+    proves: str = "inbound_delivery"
+    since_seconds: float = 0.0
+    mentions_in_window: int = 0
+    last_mention_at: Optional[str] = None
+    last_mention_text: Optional[str] = None
+    no_inbound_in_window: bool = False
+    metrics_inbound_total: Optional[float] = None
+    metrics_inbound_delta: Optional[float] = None
+    hint: Optional[str] = None
+    log_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "proves": self.proves,
+            "since_seconds": self.since_seconds,
+            "mentions_in_window": self.mentions_in_window,
+            "last_mention_at": self.last_mention_at,
+            "last_mention_text": self.last_mention_text,
+            "no_inbound_in_window": self.no_inbound_in_window,
+            "metrics_inbound_total": self.metrics_inbound_total,
+            "metrics_inbound_delta": self.metrics_inbound_delta,
+            "hint": self.hint,
+            "log_path": self.log_path,
+        }
+
+
+@dataclass
+class DuplicateService:
+    """A detected gateway or bot service."""
+
+    label: str
+    installed: bool = False
+    running: bool = False
+    pid: Optional[int] = None
+    plist_path: Optional[str] = None
+    token_fingerprints: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DuplicateCheckResult:
+    """Outcome of duplicate gateway / token conflict scan."""
+
+    ok: bool
+    services: List[DuplicateService] = field(default_factory=list)
+    shared_tokens: List[str] = field(default_factory=list)
+    hermes_platforms: Dict[str, Any] = field(default_factory=dict)
+    pid_lock: Optional[Dict[str, Any]] = None
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "services": [
+                {
+                    "label": s.label,
+                    "installed": s.installed,
+                    "running": s.running,
+                    "pid": s.pid,
+                    "plist_path": s.plist_path,
+                    "token_fingerprints": s.token_fingerprints,
+                }
+                for s in self.services
+            ],
+            "shared_tokens": self.shared_tokens,
+            "hermes_platforms": self.hermes_platforms,
+            "pid_lock": self.pid_lock,
+            "warnings": self.warnings,
+        }
+
+
+def default_log_path() -> str:
+    """Return the default gateway stderr log path."""
+    return os.path.expanduser("~/.praisonai/logs/bot-stderr.log")
+
+
+def parse_since_window(since: str) -> float:
+    """Parse a human duration like ``10m`` or ``2h`` into seconds."""
+    raw = (since or "10m").strip().lower()
+    if raw.isdigit():
+        return float(raw)
+    multipliers = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    if len(raw) >= 2 and raw[-1] in multipliers:
+        try:
+            return float(raw[:-1]) * multipliers[raw[-1]]
+        except ValueError:
+            pass
+    return 600.0
+
+
+def _gateway_auth_headers(host: str) -> Dict[str, str]:
+    """Build auth headers for gateway endpoints that require a token."""
+    token = os.environ.get("GATEWAY_AUTH_TOKEN", "").strip()
+    if not token:
+        return {}
+    if host in ("127.0.0.1", "localhost", "::1"):
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _http_get_json(
+    host: str,
+    port: int,
+    path: str,
+    timeout: float = 5.0,
+    auth: bool = False,
+) -> RuntimeProbeResult:
+    """Fetch a JSON endpoint from the gateway."""
+    import json
+    import urllib.error
+    import urllib.request
+
+    url = f"http://{host}:{port}{path}"
+    headers = _gateway_auth_headers(host) if auth else {}
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = json.loads(resp.read().decode())
+            ok = 200 <= resp.status < 300
+            if path == "/ready" and isinstance(body, dict):
+                ok = ok and bool(body.get("ready", False))
+            if path == "/live" and isinstance(body, dict):
+                ok = ok and bool(body.get("alive", False))
+            return RuntimeProbeResult(ok=ok, status_code=resp.status, body=body)
+    except urllib.error.HTTPError as exc:
+        body = None
+        try:
+            body = json.loads(exc.read().decode())
+        except Exception:
+            pass
+        ok = False
+        if path in ("/ready", "/live") and exc.code == 503:
+            ok = False
+        return RuntimeProbeResult(
+            ok=ok,
+            status_code=exc.code,
+            body=body,
+            error=str(exc.reason),
+        )
+    except Exception as exc:
+        return RuntimeProbeResult(ok=False, error=str(exc))
+
+
+def check_runtime(
+    config_path: str,
+    timeout: float = 5.0,
+) -> RuntimeCheckResult:
+    """Probe gateway runtime endpoints: ``/info``, ``/health``, ``/ready``, ``/live``."""
+    host, port = resolve_gateway_endpoint(config_path)
+    info = _http_get_json(host, port, "/info", timeout=timeout, auth=True)
+    health = _http_get_json(host, port, "/health", timeout=timeout)
+    ready = _http_get_json(host, port, "/ready", timeout=timeout)
+    live = _http_get_json(host, port, "/live", timeout=timeout)
+    ok = info.ok and health.ok and ready.ok and live.ok
+    return RuntimeCheckResult(
+        ok=ok,
+        host=host,
+        port=port,
+        info=info,
+        health=health,
+        ready=ready,
+        live=live,
+    )
+
+
+def _parse_log_timestamp(line: str) -> Optional[float]:
+    """Best-effort parse of a log line timestamp."""
+    import datetime
+    import re
+
+    match = re.match(
+        r"^(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:,\d+)?)",
+        line,
+    )
+    if not match:
+        return None
+    raw = match.group(1).replace(",", ".")
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.datetime.strptime(raw[:26], fmt).timestamp()
+        except ValueError:
+            continue
+    return None
+
+
+def parse_inbound_log(
+    log_path: str,
+    since_seconds: float,
+    marker: str = "@mention received:",
+) -> Tuple[int, Optional[str], Optional[str]]:
+    """Scan a log file for inbound mention markers within a time window."""
+    import time
+
+    if not os.path.exists(log_path):
+        return 0, None, None
+
+    cutoff = time.time() - since_seconds
+    count = 0
+    last_at: Optional[str] = None
+    last_text: Optional[str] = None
+
+    try:
+        with open(log_path, encoding="utf-8", errors="replace") as handle:
+            lines = handle.readlines()
+    except OSError:
+        return 0, None, None
+
+    for line in lines:
+        if marker not in line:
+            continue
+        ts = _parse_log_timestamp(line)
+        if ts is not None and ts < cutoff:
+            continue
+        count += 1
+        if ts is not None:
+            import datetime
+
+            last_at = datetime.datetime.fromtimestamp(ts).isoformat()
+        idx = line.find(marker)
+        last_text = line[idx + len(marker) :].strip() if idx >= 0 else line.strip()
+
+    return count, last_at, last_text
+
+
+def _scrape_metrics_counter(
+    host: str,
+    port: int,
+    counter: str,
+    timeout: float = 5.0,
+) -> Optional[float]:
+    """Scrape a Prometheus counter value from ``GET /metrics``."""
+    import re
+    import urllib.error
+    import urllib.request
+
+    url = f"http://{host}:{port}/metrics"
+    headers = _gateway_auth_headers(host)
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            text = resp.read().decode()
+    except Exception:
+        return None
+
+    total = 0.0
+    found = False
+    pattern = re.compile(rf"^{re.escape(counter)}(?:\{{[^}}]*\}})?\s+([0-9.eE+-]+)")
+    for line in text.splitlines():
+        if line.startswith("#"):
+            continue
+        match = pattern.match(line.strip())
+        if match:
+            found = True
+            total += float(match.group(1))
+    return total if found else None
+
+
+def _metrics_baseline_path() -> str:
+    return os.path.expanduser("~/.praisonai/state/inbound_metrics_baseline.json")
+
+
+def _load_metrics_baseline(host: str, port: int) -> Optional[Dict[str, Any]]:
+    import json
+
+    path = _metrics_baseline_path()
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        if data.get("host") == host and int(data.get("port", -1)) == int(port):
+            return data
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        pass
+    return None
+
+
+def _save_metrics_baseline(host: str, port: int, counter: Optional[float]) -> None:
+    import json
+    import time
+
+    if counter is None:
+        return
+    path = _metrics_baseline_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    payload = {"host": host, "port": int(port), "counter": counter, "ts": time.time()}
+    try:
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+    except OSError:
+        pass
+
+
+def _metrics_inbound_delta(
+    host: str,
+    port: int,
+    since_seconds: float,
+    timeout: float = 5.0,
+) -> Tuple[Optional[float], Optional[float]]:
+    """Return ``(current_total, delta_since_baseline)`` for inbound metrics."""
+    import time
+
+    current = _scrape_metrics_counter(host, port, "messages_inbound_total", timeout=timeout)
+    baseline = _load_metrics_baseline(host, port)
+    delta: Optional[float] = None
+    if (
+        baseline is not None
+        and current is not None
+        and baseline.get("counter") is not None
+    ):
+        age = time.time() - float(baseline.get("ts") or 0)
+        if age <= since_seconds:
+            delta = max(0.0, current - float(baseline["counter"]))
+    _save_metrics_baseline(host, port, current)
+    return current, delta
+
+
+def _expected_bot_hint(probe_results: dict) -> Optional[str]:
+    """Build expected bot identity hint from probe results."""
+    for _name, probe in probe_results.items():
+        if not getattr(probe, "ok", False):
+            continue
+        username = getattr(probe, "bot_username", None) or ""
+        details = getattr(probe, "details", None) or {}
+        user_id = details.get("user_id") if isinstance(details, dict) else None
+        if username and user_id:
+            return f"Expected bot: @{username} ({user_id})"
+        if username:
+            return f"Expected bot: @{username}"
+    return None
+
+
+def check_inbound(
+    config_path: str,
+    since: str = "10m",
+    log_path: Optional[str] = None,
+    timeout: float = 5.0,
+    probe_results: Optional[dict] = None,
+) -> InboundCheckResult:
+    """Verify recent inbound delivery via logs and optional metrics."""
+    since_seconds = parse_since_window(since)
+    path = log_path or default_log_path()
+    count, last_at, last_text = parse_inbound_log(path, since_seconds)
+
+    host, port = resolve_gateway_endpoint(config_path)
+    metrics_total, metrics_delta = _metrics_inbound_delta(
+        host, port, since_seconds, timeout=timeout
+    )
+
+    hint = _expected_bot_hint(probe_results or {})
+    no_inbound = count == 0 and not (metrics_delta and metrics_delta > 0)
+    ok = count > 0 or bool(metrics_delta and metrics_delta > 0)
+
+    if no_inbound and hint:
+        hint = (
+            f"{hint}. Message may have hit a different Slack app. "
+            "Use --check-duplicates to scan for competing gateways."
+        )
+    elif no_inbound:
+        hint = (
+            "No @mention received in the log window. "
+            "Send a Slack message to your bot, then re-run with --check-inbound."
+        )
+
+    return InboundCheckResult(
+        ok=ok,
+        since_seconds=since_seconds,
+        mentions_in_window=count,
+        last_mention_at=last_at,
+        last_mention_text=last_text,
+        no_inbound_in_window=no_inbound,
+        metrics_inbound_total=metrics_total,
+        metrics_inbound_delta=metrics_delta,
+        hint=hint,
+        log_path=path,
+    )
+
+
+def _token_fingerprint(value: str) -> Optional[str]:
+    """Return a short fingerprint for a token value."""
+    if not value or not str(value).strip():
+        return None
+    import hashlib
+
+    return hashlib.sha256(str(value).encode()).hexdigest()[:12]
+
+
+def _read_env_file_tokens(path: str) -> Dict[str, str]:
+    """Read ``KEY=value`` tokens from an env file."""
+    tokens: Dict[str, str] = {}
+    if not os.path.exists(path):
+        return tokens
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, val = line.partition("=")
+                key = key.strip()
+                val = val.strip().strip('"').strip("'")
+                if key.endswith("_TOKEN") and val:
+                    tokens[key] = _token_fingerprint(val) or ""
+    except OSError:
+        pass
+    return tokens
+
+
+def _scan_launch_agent(label: str) -> DuplicateService:
+    """Inspect a macOS LaunchAgent plist by label."""
+    import plistlib
+    import subprocess
+
+    plist_path = os.path.expanduser(f"~/Library/LaunchAgents/{label}.plist")
+    service = DuplicateService(label=label, plist_path=plist_path)
+    service.installed = os.path.exists(plist_path)
+
+    if service.installed:
+        try:
+            with open(plist_path, "rb") as handle:
+                data = plistlib.load(handle)
+            env = data.get("EnvironmentVariables") or {}
+            for key, val in env.items():
+                if key.endswith("_TOKEN") and val:
+                    fp = _token_fingerprint(str(val))
+                    if fp:
+                        service.token_fingerprints[key] = fp
+        except Exception:
+            pass
+
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+        )
+        service.running = result.returncode == 0
+        if service.running and result.stdout:
+            parts = result.stdout.strip().split("\t")
+            if len(parts) >= 1 and parts[0].isdigit():
+                service.pid = int(parts[0])
+    except Exception:
+        pass
+
+    return service
+
+
+def _read_hermes_platform_state() -> Dict[str, Any]:
+    """Read Hermes runtime platform state if present."""
+    import json
+
+    path = os.path.expanduser("~/.hermes/gateway_state.json")
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        platforms = data.get("platforms") or {}
+        return platforms if isinstance(platforms, dict) else {}
+    except Exception:
+        return {}
+
+
+def check_duplicates(
+    config_path: str,
+) -> DuplicateCheckResult:
+    """Scan for competing gateway services and shared Slack tokens."""
+    warnings: List[str] = []
+    services: List[DuplicateService] = []
+
+    for label in ("ai.praison.bot", "ai.hermes.gateway"):
+        services.append(_scan_launch_agent(label))
+
+    praison_env = _read_env_file_tokens(os.path.expanduser("~/.praisonai/.env"))
+    hermes_env = _read_env_file_tokens(os.path.expanduser("~/.hermes/.env"))
+
+    fingerprint_map: Dict[str, List[str]] = {}
+    for source, mapping in (("praisonai", praison_env), ("hermes", hermes_env)):
+        for key, fp in mapping.items():
+            fingerprint_map.setdefault(fp, []).append(f"{source}:{key}")
+
+    for service in services:
+        for key, fp in service.token_fingerprints.items():
+            fingerprint_map.setdefault(fp, []).append(f"{service.label}:{key}")
+
+    shared = [
+        fp for fp, owners in fingerprint_map.items() if len(set(owners)) > 1
+    ]
+
+    hermes_platforms = _read_hermes_platform_state()
+    if hermes_platforms.get("slack", {}).get("state") == "connected":
+        warnings.append(
+            "Hermes Slack is connected — events may split if SLACK_APP_TOKEN is shared."
+        )
+    if hermes_platforms.get("telegram", {}).get("state") == "connected":
+        warnings.append(
+            "Hermes Telegram is connected — stopping ai.hermes.gateway affects Telegram."
+        )
+
+    pid_lock: Optional[Dict[str, Any]] = None
+    try:
+        host, port = resolve_gateway_endpoint(config_path)
+        from praisonai_bot.gateway.port_utils import GatewayPIDLock
+
+        pid_lock = GatewayPIDLock(host=host, port=port).get_lock_info()
+        if pid_lock and pid_lock.get("is_running"):
+            daemon = _scan_launch_agent("ai.praison.bot")
+            if daemon.pid and pid_lock.get("pid") and daemon.pid != pid_lock["pid"]:
+                warnings.append(
+                    f"LaunchAgent PID ({daemon.pid}) differs from gateway lock PID "
+                    f"({pid_lock['pid']})."
+                )
+    except Exception:
+        pass
+
+    log_path = default_log_path()
+    if os.path.exists(log_path):
+        try:
+            with open(log_path, encoding="utf-8", errors="replace") as handle:
+                tail = handle.read()[-8000:]
+            if "Conflict: terminated by other getUpdates request" in tail:
+                warnings.append(
+                    "Telegram getUpdates Conflict detected — another bot may be polling."
+                )
+        except OSError:
+            pass
+
+    ok = not shared and not any(
+        s.label == "ai.hermes.gateway"
+        and s.running
+        and hermes_platforms.get("slack", {}).get("state") == "connected"
+        for s in services
+    )
+    if shared:
+        warnings.append(
+            "Shared token fingerprint detected across services — inbound events may split."
+        )
+
+    return DuplicateCheckResult(
+        ok=ok,
+        services=services,
+        shared_tokens=shared,
+        hermes_platforms=hermes_platforms,
+        pid_lock=pid_lock,
+        warnings=warnings,
+    )
+
+
+def resolve_platform_dlq_path(platform: str) -> str:
+    """Resolve the durable inbound DLQ path for a platform."""
+    from praisonai_bot.bots._session import resolve_durable_store_dir
+
+    store_dir = resolve_durable_store_dir(platform)
+    return str(store_dir / "inbound_dlq.sqlite")
+
+
+def _sessions_dir() -> str:
+    from praisonaiagents.paths import get_sessions_dir
+
+    return str(get_sessions_dir())
+
+
+def list_gateway_sessions(
+    platform: Optional[str] = None,
+    active_seconds: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """List stored gateway bot session files."""
+    import json
+    import time
+
+    sessions: List[Dict[str, Any]] = []
+    base = _sessions_dir()
+    if not os.path.isdir(base):
+        return sessions
+
+    prefix = f"bot_{platform}_" if platform else "bot_"
+    for fname in sorted(os.listdir(base)):
+        if not fname.endswith(".json") or not fname.startswith(prefix):
+            continue
+        path = os.path.join(base, fname)
+        try:
+            with open(path, encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            continue
+        updated = data.get("updated_at") or data.get("created_at")
+        if active_seconds and updated:
+            try:
+                if time.time() - float(updated) > active_seconds:
+                    continue
+            except (TypeError, ValueError):
+                pass
+        sessions.append(
+            {
+                "session_id": data.get("session_id") or fname[:-5],
+                "platform": platform or fname.split("_")[1] if fname.count("_") >= 2 else "",
+                "user_id": data.get("user_id"),
+                "message_count": len(data.get("messages") or []),
+                "updated_at": updated,
+                "path": path,
+            }
+        )
+    return sessions
+
+
+def show_gateway_session(
+    session_ref: str,
+    tail: int = 20,
+) -> Dict[str, Any]:
+    """Show a stored session by id or user id suffix."""
+    import json
+
+    base = _sessions_dir()
+    candidates = []
+    if os.path.isfile(session_ref):
+        candidates = [session_ref]
+    elif os.path.isfile(os.path.join(base, f"{session_ref}.json")):
+        candidates = [os.path.join(base, f"{session_ref}.json")]
+    else:
+        for fname in os.listdir(base) if os.path.isdir(base) else []:
+            if session_ref in fname:
+                candidates.append(os.path.join(base, fname))
+
+    if not candidates:
+        raise FileNotFoundError(f"Session not found: {session_ref}")
+
+    path = sorted(candidates)[0]
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    messages = data.get("messages") or []
+    return {
+        "session_id": data.get("session_id"),
+        "user_id": data.get("user_id"),
+        "agent_name": data.get("agent_name"),
+        "message_count": len(messages),
+        "messages": messages[-tail:],
+        "path": path,
+        "footer": (
+            "Sessions reflect stored history; use `praisonai gateway test "
+            "--check-inbound` for live delivery."
+        ),
+    }

--- a/src/praisonai-bot/praisonai_bot/gateway/preflight.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/preflight.py
@@ -451,14 +451,20 @@ def parse_since_window(since: str) -> float:
     return 600.0
 
 
-def _gateway_auth_headers(host: str) -> Dict[str, str]:
-    """Build auth headers for gateway endpoints that require a token."""
+def _gateway_auth_headers(host: str, scheme: str = "http") -> Dict[str, str]:
+    """Build auth headers for gateway endpoints that require a token.
+
+    The bearer token is only attached when it cannot be exposed to a network
+    observer: over loopback, or over HTTPS. Sending it over plaintext HTTP to a
+    remote host would leak the credential, so it is deliberately withheld there.
+    """
     token = os.environ.get("GATEWAY_AUTH_TOKEN", "").strip()
     if not token:
         return {}
-    if host in ("127.0.0.1", "localhost", "::1"):
-        return {}
-    return {"Authorization": f"Bearer {token}"}
+    is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    if is_loopback or scheme == "https":
+        return {"Authorization": f"Bearer {token}"}
+    return {}
 
 
 def _http_get_json(
@@ -474,7 +480,7 @@ def _http_get_json(
     import urllib.request
 
     url = f"http://{host}:{port}{path}"
-    headers = _gateway_auth_headers(host) if auth else {}
+    headers = _gateway_auth_headers(host, scheme="http") if auth else {}
     req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -659,23 +665,27 @@ def _metrics_inbound_delta(
     port: int,
     since_seconds: float,
     timeout: float = 5.0,
-) -> Tuple[Optional[float], Optional[float]]:
-    """Return ``(current_total, delta_since_baseline)`` for inbound metrics."""
+) -> Tuple[Optional[float], Optional[float], bool]:
+    """Return ``(current_total, delta_since_baseline, had_baseline)``.
+
+    ``had_baseline`` is ``False`` on the first check for a host/port (or after
+    the state file is cleared), signalling that ``delta`` could not be computed
+    yet because there was nothing to compare against — not that inbound traffic
+    is absent. Callers use this to avoid a false "no inbound" verdict on the
+    first run when the gateway already has a non-zero counter.
+    """
     import time
 
     current = _scrape_metrics_counter(host, port, "messages_inbound_total", timeout=timeout)
     baseline = _load_metrics_baseline(host, port)
+    had_baseline = baseline is not None and baseline.get("counter") is not None
     delta: Optional[float] = None
-    if (
-        baseline is not None
-        and current is not None
-        and baseline.get("counter") is not None
-    ):
+    if had_baseline and current is not None:
         age = time.time() - float(baseline.get("ts") or 0)
         if age <= since_seconds:
             delta = max(0.0, current - float(baseline["counter"]))
     _save_metrics_baseline(host, port, current)
-    return current, delta
+    return current, delta, had_baseline
 
 
 def _expected_bot_hint(probe_results: dict) -> Optional[str]:
@@ -706,13 +716,21 @@ def check_inbound(
     count, last_at, last_text = parse_inbound_log(path, since_seconds)
 
     host, port = resolve_gateway_endpoint(config_path)
-    metrics_total, metrics_delta = _metrics_inbound_delta(
+    metrics_total, metrics_delta, had_baseline = _metrics_inbound_delta(
         host, port, since_seconds, timeout=timeout
     )
 
+    has_delta = bool(metrics_delta and metrics_delta > 0)
+    # First run for this host/port: we just seeded the baseline, so a windowed
+    # delta cannot exist yet. Treat a pre-existing non-zero counter as evidence
+    # rather than reporting a false "no inbound" for already-active traffic.
+    baseline_just_seeded = (
+        not had_baseline and metrics_total is not None and metrics_total > 0
+    )
+
     hint = _expected_bot_hint(probe_results or {})
-    no_inbound = count == 0 and not (metrics_delta and metrics_delta > 0)
-    ok = count > 0 or bool(metrics_delta and metrics_delta > 0)
+    no_inbound = count == 0 and not has_delta and not baseline_just_seeded
+    ok = count > 0 or has_delta or baseline_just_seeded
 
     if no_inbound and hint:
         hint = (
@@ -723,6 +741,11 @@ def check_inbound(
         hint = (
             "No @mention received in the log window. "
             "Send a Slack message to your bot, then re-run with --check-inbound."
+        )
+    elif baseline_just_seeded and not has_delta and count == 0:
+        hint = (
+            "Inbound metrics baseline established from existing traffic; "
+            "re-run with --check-inbound to confirm delivery within the window."
         )
 
     return InboundCheckResult(

--- a/src/praisonai-bot/praisonai_bot/gateway/server.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/server.py
@@ -2109,6 +2109,14 @@ class WebSocketGateway:
         """
         self._last_inbound_ts = time.time()
 
+    def _record_channel_inbound(self, channel_name: str) -> None:
+        """Record inbound channel activity for metrics and idle tracking."""
+        self.notify_inbound()
+        self.record_metric(
+            "messages_inbound_total",
+            labels={"channel": channel_name},
+        )
+
     def _probe_idle_facts(self) -> Tuple[int, float, bool]:
         """Read live liveness facts from gateway sessions for the idle policy.
 
@@ -4045,28 +4053,70 @@ class WebSocketGateway:
 
     def health(self) -> Dict[str, Any]:
         """Get gateway health status including per-channel bot status and supervision state."""
+        from praisonaiagents.bots.protocols import HealthReason, HealthResult, evaluate_channel_health
+
         uptime = time.time() - self._started_at if self._started_at else 0
         channel_status = {}
         supervision_status = self._channel_supervisor.get_all_status()
+        stale_after = (
+            getattr(self._health_config, "stale_after", 120.0)
+            if self._health_config is not None
+            else 120.0
+        )
+        startup_grace = (
+            getattr(self._health_config, "startup_grace", 60.0)
+            if self._health_config is not None
+            else 60.0
+        )
         
         for name, bot in self._channel_bots.items():
             running = getattr(bot, "is_running", False)
             platform = getattr(bot, "platform", "unknown")
-            
+            last_activity = getattr(bot, "_last_inbound_activity", None)
+            if last_activity is None:
+                last_activity = getattr(bot, "_started_at", None)
+            active_runs = 0
+            counter = getattr(bot, "_active_run_count", None)
+            if callable(counter):
+                try:
+                    active_runs = int(counter() or 0)
+                except Exception:
+                    active_runs = 0
+
+            health_result = HealthResult(
+                ok=running,
+                platform=platform,
+                is_running=running,
+                last_activity=last_activity,
+                active_runs=int(active_runs or 0),
+            )
+            reason = evaluate_channel_health(
+                health_result,
+                startup_grace_seconds=startup_grace,
+                stale_after_seconds=stale_after,
+            )
+            cached_probe = getattr(bot, "_last_probe_result", None)
+            probe_ok = getattr(cached_probe, "ok", None) if cached_probe is not None else None
+
             # Get supervision state
             sup_status = supervision_status.get(name)
+            entry: Dict[str, Any] = {
+                "platform": platform,
+                "running": running,
+                "last_activity": last_activity,
+                "ok": reason == HealthReason.HEALTHY,
+                "reason": reason.value,
+            }
+            if probe_ok is not None:
+                entry["probe"] = {"ok": probe_ok}
             if sup_status:
-                entry = {
-                    "platform": platform,
-                    "running": running,
-                    "supervision": {
-                        "state": sup_status.state.value,
-                        "last_error": sup_status.last_error,
-                        "last_error_time": sup_status.last_error_time,
-                        "next_retry_at": sup_status.next_retry_at,
-                        "total_recoveries": sup_status.total_recoveries,
-                        "manual_pause": sup_status.manual_pause,
-                    }
+                entry["supervision"] = {
+                    "state": sup_status.state.value,
+                    "last_error": sup_status.last_error,
+                    "last_error_time": sup_status.last_error_time,
+                    "next_retry_at": sup_status.next_retry_at,
+                    "total_recoveries": sup_status.total_recoveries,
+                    "manual_pause": sup_status.manual_pause,
                 }
                 # Issue #3348: a channel whose credential was rejected at
                 # runtime (revoked/rotated/expired token) is surfaced as the
@@ -4077,12 +4127,7 @@ class WebSocketGateway:
                 if sup_status.state == ChannelState.CREDENTIAL_UNAVAILABLE:
                     entry["status"] = "degraded"
                     entry["reason"] = "credential unavailable"
-                channel_status[name] = entry
-            else:
-                channel_status[name] = {
-                    "platform": platform,
-                    "running": running,
-                }
+            channel_status[name] = entry
 
         # Issue #3159: surface channels that were configured but skipped at
         # startup because their credential was unavailable. Without this a
@@ -4105,6 +4150,7 @@ class WebSocketGateway:
             "sessions": len(self._sessions),
             "clients": len(self._clients),
             "channels": channel_status,
+            "last_inbound_at": self._last_inbound_ts,
         }
 
         # Issue #3021: surface opt-in lifecycle state so an operator can see
@@ -5499,6 +5545,7 @@ class WebSocketGateway:
             # its own event loop which conflicts with our gateway loop.
             # Use the lower-level API instead.
             if self._is_telegram_bot(bot):
+                self._inject_routing_handler(name, bot)
                 await self._start_telegram_bot_polling(name, bot)
             elif type(bot).__name__ in ("WhatsAppBot", "LinearBot"):
                 # WhatsApp/Linear run their own aiohttp webhook servers
@@ -5556,6 +5603,7 @@ class WebSocketGateway:
         async def _routed_message_handler(message):
             if not message.sender:
                 return
+            gateway._record_channel_inbound(channel_name)
             # Determine routing context from channel type
             ch_type = message.channel.channel_type if message.channel else ""
             is_dm = ch_type in ("dm", "private")

--- a/src/praisonai-bot/tests/unit/cli/test_gateway_install.py
+++ b/src/praisonai-bot/tests/unit/cli/test_gateway_install.py
@@ -115,7 +115,7 @@ def test_gateway_status_with_daemon(mock_handler_class, mock_status):
     result = runner.invoke(app, ["status"])
     
     mock_status.assert_called_once()
-    mock_handler.status.assert_called_once_with(host="127.0.0.1", port=8765)
+    mock_handler.status.assert_called_once_with(host="127.0.0.1", port=8765, deep=False)
     assert result.exit_code == 0
 
 

--- a/src/praisonai-bot/tests/unit/gateway/test_gateway_doctor.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_gateway_doctor.py
@@ -471,3 +471,105 @@ def test_gateway_test_command(monkeypatch, tmp_path):
     assert "shell wiring" in result.stdout
     assert "slack" in result.stdout
 
+
+def test_gateway_test_check_runtime_json(monkeypatch, tmp_path):
+    typer_testing = pytest.importorskip("typer.testing")
+
+    async def all_ok_probe(self):
+        return ProbeResult(ok=True, platform=self._platform, bot_username="bot")
+
+    monkeypatch.setattr(Bot, "probe", all_ok_probe)
+    monkeypatch.setattr(
+        "praisonai_bot.cli.commands.gateway._check_gateway_secret_strength",
+        lambda _cfg: None,
+    )
+    monkeypatch.setattr(
+        "praisonai_bot.cli.commands.gateway._check_runtime",
+        lambda _cfg: type(
+            "R",
+            (),
+            {
+                "ok": True,
+                "to_dict": lambda self: {"ok": True, "health": {"ok": True}},
+            },
+        )(),
+    )
+
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text("channels:\n  slack:\n    platform: slack\n    token: s\n")
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    runner = typer_testing.CliRunner()
+    result = runner.invoke(
+        app, ["test", "--config", str(cfg), "--check-runtime", "--json"]
+    )
+    assert result.exit_code == 0
+    import json
+
+    payload = json.loads(result.stdout)
+    assert payload["runtime"]["ok"] is True
+
+
+def test_gateway_test_check_inbound_fails(monkeypatch, tmp_path):
+    typer_testing = pytest.importorskip("typer.testing")
+
+    async def all_ok_probe(self):
+        return ProbeResult(ok=True, platform=self._platform, bot_username="bot")
+
+    monkeypatch.setattr(Bot, "probe", all_ok_probe)
+    monkeypatch.setattr(
+        "praisonai_bot.cli.commands.gateway._check_gateway_secret_strength",
+        lambda _cfg: None,
+    )
+    monkeypatch.setattr(
+        "praisonai_bot.cli.commands.gateway._check_inbound",
+        lambda *a, **k: type(
+            "I",
+            (),
+            {
+                "ok": False,
+                "proves": "inbound_delivery",
+                "mentions_in_window": 0,
+                "hint": "No inbound",
+                "to_dict": lambda self: {
+                    "ok": False,
+                    "proves": "inbound_delivery",
+                    "mentions_in_window": 0,
+                },
+            },
+        )(),
+    )
+
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text("channels:\n  slack:\n    platform: slack\n    token: s\n")
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    runner = typer_testing.CliRunner()
+    result = runner.invoke(
+        app, ["test", "--config", str(cfg), "--check-inbound", "--since", "5m"]
+    )
+    assert result.exit_code == 1
+    assert "inbound" in result.stdout
+
+
+def test_gateway_sessions_list_cli(tmp_path, monkeypatch):
+    typer_testing = pytest.importorskip("typer.testing")
+    import json
+
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight.list_gateway_sessions",
+        lambda **kwargs: [
+            {"session_id": "bot_slack_U1", "message_count": 2, "user_id": "U1"}
+        ],
+    )
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    runner = typer_testing.CliRunner()
+    result = runner.invoke(app, ["sessions", "list", "--platform", "slack"])
+    assert result.exit_code == 0
+    assert "bot_slack_U1" in result.stdout
+    assert "--check-inbound" in result.stdout
+

--- a/src/praisonai-bot/tests/unit/gateway/test_gateway_readiness.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_gateway_readiness.py
@@ -104,6 +104,34 @@ def test_draining_reset_clears_ready_after_restart():
     assert failing == []
 
 
+def test_health_includes_channel_reason_and_last_inbound():
+    """Per-channel /health rows expose reason, ok, and gateway last_inbound_at."""
+    import time
+
+    gw = _make_gateway()
+    gw._is_running = True
+    gw._started_at = time.time()
+    gw._last_inbound_ts = time.time()
+
+    class _FakeBot:
+        platform = "slack"
+        is_running = True
+        _started_at = time.time()
+        _last_inbound_activity = time.time()
+
+        def _active_run_count(self):
+            return 0
+
+    gw._channel_bots["slack"] = _FakeBot()
+    health = gw.health()
+
+    assert "last_inbound_at" in health
+    ch = health["channels"]["slack"]
+    assert "reason" in ch
+    assert "ok" in ch
+    assert "last_activity" in ch
+
+
 if __name__ == "__main__":
     test_readiness_startup_pending_before_start()
     test_readiness_ready_when_running()

--- a/src/praisonai-bot/tests/unit/gateway/test_preflight.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_preflight.py
@@ -99,3 +99,220 @@ def test_run_turn_test_mocked(tmp_path, monkeypatch):
     ok, message = asyncio.run(run_turn_test(str(cfg), "slack", "Say OK"))
     assert ok is True
     assert message == "OK from test"
+
+
+def test_parse_since_window():
+    from praisonai_bot.gateway.preflight import parse_since_window
+
+    assert parse_since_window("10m") == 600.0
+    assert parse_since_window("2h") == 7200.0
+    assert parse_since_window("30") == 30.0
+
+
+def test_parse_inbound_log(tmp_path):
+    from praisonai_bot.gateway.preflight import parse_inbound_log
+    import time
+
+    log = tmp_path / "bot-stderr.log"
+    now = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    log.write_text(f"{now} - slack - INFO - @mention received: run uname -a\n")
+
+    count, last_at, last_text = parse_inbound_log(str(log), since_seconds=3600)
+    assert count == 1
+    assert last_text == "run uname -a"
+    assert last_at is not None
+
+
+def test_check_duplicates_no_conflict(tmp_path, monkeypatch):
+    from praisonai_bot.gateway.preflight import check_duplicates
+
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("gateway:\n  host: 127.0.0.1\n  port: 8765\n")
+
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._scan_launch_agent",
+        lambda label: __import__(
+            "praisonai_bot.gateway.preflight", fromlist=["DuplicateService"]
+        ).DuplicateService(label=label, installed=False, running=False),
+    )
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._read_env_file_tokens",
+        lambda _path: {},
+    )
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._read_hermes_platform_state",
+        lambda: {},
+    )
+
+    result = check_duplicates(str(cfg))
+    assert result.ok is True
+    assert result.shared_tokens == []
+
+
+def test_check_inbound_from_log(tmp_path, monkeypatch):
+    from praisonai_bot.gateway.preflight import check_inbound
+    import time
+
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("gateway:\n  host: 127.0.0.1\n  port: 59999\n")
+    log = tmp_path / "bot-stderr.log"
+    now = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    log.write_text(f"{now} - slack - INFO - @mention received: hello\n")
+
+    result = check_inbound(str(cfg), since="1h", log_path=str(log), probe_results={})
+    assert result.ok is True
+    assert result.proves == "inbound_delivery"
+    assert result.mentions_in_window == 1
+
+
+def test_check_runtime_unreachable(tmp_path):
+    from praisonai_bot.gateway.preflight import check_runtime
+
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("gateway:\n  host: 127.0.0.1\n  port: 59998\n")
+    result = check_runtime(str(cfg), timeout=1.0)
+    assert result.ok is False
+    assert result.info.ok is False
+
+
+def test_list_and_show_gateway_sessions(tmp_path, monkeypatch):
+    import json
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    data = {
+        "session_id": "bot_slack_U123",
+        "user_id": "U123",
+        "agent_name": "assistant",
+        "messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}],
+        "updated_at": 1_700_000_000,
+    }
+    (sessions_dir / "bot_slack_U123.json").write_text(json.dumps(data))
+
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._sessions_dir",
+        lambda: str(sessions_dir),
+    )
+    from praisonai_bot.gateway.preflight import list_gateway_sessions, show_gateway_session
+
+    rows = list_gateway_sessions(platform="slack")
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == "bot_slack_U123"
+
+    shown = show_gateway_session("U123", tail=5)
+    assert shown["message_count"] == 2
+    assert "footer" in shown
+    assert "--check-inbound" in shown["footer"]
+
+
+def test_resolve_platform_dlq_path():
+    from praisonai_bot.gateway.preflight import resolve_platform_dlq_path
+
+    path = resolve_platform_dlq_path("slack")
+    assert path.endswith("inbound_dlq.sqlite")
+    assert "slack" in path
+
+
+def test_parse_inbound_log_missing_file(tmp_path):
+    from praisonai_bot.gateway.preflight import parse_inbound_log
+
+    count, last_at, last_text = parse_inbound_log(str(tmp_path / "missing.log"), 600)
+    assert count == 0
+    assert last_at is None
+    assert last_text is None
+
+
+def test_metrics_inbound_delta(tmp_path, monkeypatch):
+    import json
+    import time
+
+    from praisonai_bot.gateway.preflight import (
+        _metrics_baseline_path,
+        _metrics_inbound_delta,
+        check_inbound,
+    )
+
+    baseline = _metrics_baseline_path()
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._metrics_baseline_path",
+        lambda: str(tmp_path / "baseline.json"),
+    )
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._scrape_metrics_counter",
+        lambda *a, **k: 5.0,
+    )
+
+    host, port = "127.0.0.1", 8765
+    (tmp_path / "baseline.json").write_text(
+        json.dumps({"host": host, "port": port, "counter": 2.0, "ts": time.time()})
+    )
+    current, delta = _metrics_inbound_delta(host, port, since_seconds=600)
+    assert current == 5.0
+    assert delta == 3.0
+
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("gateway:\n  host: 127.0.0.1\n  port: 8765\n")
+    log = tmp_path / "bot-stderr.log"
+    log.write_text("")
+    # Reset baseline so check_inbound sees a fresh delta on the next scrape.
+    (tmp_path / "baseline.json").write_text(
+        json.dumps({"host": host, "port": port, "counter": 1.0, "ts": time.time()})
+    )
+    result = check_inbound(str(cfg), since="1h", log_path=str(log))
+    assert result.metrics_inbound_delta == 4.0
+    assert result.ok is True
+
+
+def test_check_runtime_success(monkeypatch, tmp_path):
+    from praisonai_bot.gateway.preflight import RuntimeProbeResult, check_runtime
+
+    def fake_get(host, port, path, timeout=5.0, auth=False):
+        if path == "/info":
+            body = {"name": "PraisonAI Gateway", "version": "1.0.0"}
+        elif path == "/ready":
+            body = {"ready": True}
+        elif path == "/live":
+            body = {"alive": True}
+        else:
+            body = {"status": "healthy", "channels": {}}
+        return RuntimeProbeResult(ok=True, status_code=200, body=body)
+
+    monkeypatch.setattr("praisonai_bot.gateway.preflight._http_get_json", fake_get)
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("gateway:\n  host: 127.0.0.1\n  port: 8765\n")
+
+    result = check_runtime(str(cfg))
+    assert result.ok is True
+    assert result.health.ok is True
+
+
+def test_check_duplicates_shared_token(tmp_path, monkeypatch):
+    from praisonai_bot.gateway.preflight import DuplicateService, check_duplicates
+
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("gateway:\n  host: 127.0.0.1\n  port: 8765\n")
+
+    shared_fp = "abc123shared"
+
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._scan_launch_agent",
+        lambda label: DuplicateService(label=label, installed=True, running=False),
+    )
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._read_env_file_tokens",
+        lambda path: {"SLACK_APP_TOKEN": shared_fp}
+        if "praisonai" in path
+        else {"SLACK_APP_TOKEN": shared_fp},
+    )
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._read_hermes_platform_state",
+        lambda: {},
+    )
+    monkeypatch.setattr(
+        "praisonai_bot.gateway.preflight._token_fingerprint",
+        lambda _v: shared_fp,
+    )
+
+    result = check_duplicates(str(cfg))
+    assert result.shared_tokens == [shared_fp]
+    assert result.ok is False

--- a/src/praisonai-bot/tests/unit/gateway/test_preflight.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_preflight.py
@@ -246,9 +246,10 @@ def test_metrics_inbound_delta(tmp_path, monkeypatch):
     (tmp_path / "baseline.json").write_text(
         json.dumps({"host": host, "port": port, "counter": 2.0, "ts": time.time()})
     )
-    current, delta = _metrics_inbound_delta(host, port, since_seconds=600)
+    current, delta, had_baseline = _metrics_inbound_delta(host, port, since_seconds=600)
     assert current == 5.0
     assert delta == 3.0
+    assert had_baseline is True
 
     cfg = tmp_path / "bot.yaml"
     cfg.write_text("gateway:\n  host: 127.0.0.1\n  port: 8765\n")

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/gateway_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/gateway_checks.py
@@ -600,3 +600,158 @@ def check_gateway_channel_probe(config: DoctorConfig) -> CheckResult:
         details="\n".join(lines),
         duration_ms=(time.time() - start) * 1000,
     )
+
+
+@register_check(
+    id="gateway_duplicate_services",
+    title="Gateway Duplicate Services",
+    description="Scan for competing gateway services and shared Slack tokens",
+    category=CheckCategory.BOTS,
+    severity=CheckSeverity.HIGH,
+    requires_deep=True,
+)
+def check_gateway_duplicate_services(config: DoctorConfig) -> CheckResult:
+    """Detect duplicate LaunchAgents and shared token fingerprints."""
+    start = time.time()
+    skipped = skip_if_no_wrapper(
+        "gateway_duplicate_services", "Gateway Duplicate Services", start=start
+    )
+    if skipped:
+        return skipped
+    skipped = skip_if_no_bot_package(
+        "gateway_duplicate_services", "Gateway Duplicate Services", start=start
+    )
+    if skipped:
+        return skipped
+
+    config_path = _find_gateway_config_path(config)
+    if not config_path:
+        return CheckResult(
+            id="gateway_duplicate_services",
+            title="Gateway Duplicate Services",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.SKIP,
+            message="No gateway/bot config found",
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    try:
+        from praisonai_code._bot_bridge import import_bot_module
+
+        preflight = import_bot_module("praisonai_bot.gateway.preflight")
+        result = preflight.check_duplicates(config_path)
+    except Exception as exc:
+        return CheckResult(
+            id="gateway_duplicate_services",
+            title="Gateway Duplicate Services",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.ERROR,
+            message=f"Duplicate scan failed: {str(exc)[:100]}",
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    lines = list(result.warnings)
+    for service in result.services:
+        if service.running:
+            lines.append(f"{service.label}: running (pid={service.pid})")
+
+    if not result.ok:
+        return CheckResult(
+            id="gateway_duplicate_services",
+            title="Gateway Duplicate Services",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.WARN,
+            message="Possible competing gateway or shared token detected",
+            details="\n".join(lines) if lines else None,
+            remediation=(
+                "Compare SLACK_APP_TOKEN across services; stop duplicate gateways "
+                "before messaging Slack."
+            ),
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    return CheckResult(
+        id="gateway_duplicate_services",
+        title="Gateway Duplicate Services",
+        category=CheckCategory.BOTS,
+        status=CheckStatus.PASS,
+        message="No duplicate gateway conflicts detected",
+        details="\n".join(lines) if lines else None,
+        duration_ms=(time.time() - start) * 1000,
+    )
+
+
+@register_check(
+    id="gateway_no_inbound_recent",
+    title="Gateway Recent Inbound",
+    description="Check for recent inbound delivery in gateway logs",
+    category=CheckCategory.BOTS,
+    severity=CheckSeverity.MEDIUM,
+    requires_deep=True,
+)
+def check_gateway_no_inbound_recent(config: DoctorConfig) -> CheckResult:
+    """Warn when no inbound mentions appear in recent gateway logs."""
+    start = time.time()
+    skipped = skip_if_no_wrapper(
+        "gateway_no_inbound_recent", "Gateway Recent Inbound", start=start
+    )
+    if skipped:
+        return skipped
+    skipped = skip_if_no_bot_package(
+        "gateway_no_inbound_recent", "Gateway Recent Inbound", start=start
+    )
+    if skipped:
+        return skipped
+
+    config_path = _find_gateway_config_path(config)
+    if not config_path:
+        return CheckResult(
+            id="gateway_no_inbound_recent",
+            title="Gateway Recent Inbound",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.SKIP,
+            message="No gateway/bot config found",
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    try:
+        from praisonai_code._bot_bridge import import_bot_module
+
+        preflight = import_bot_module("praisonai_bot.gateway.preflight")
+        inbound = preflight.check_inbound(config_path, since="10m")
+    except Exception as exc:
+        return CheckResult(
+            id="gateway_no_inbound_recent",
+            title="Gateway Recent Inbound",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.ERROR,
+            message=f"Inbound check failed: {str(exc)[:100]}",
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    if inbound.ok:
+        detail = f"{inbound.mentions_in_window} mention(s) in last 10m"
+        if inbound.last_mention_at:
+            detail += f"; last at {inbound.last_mention_at}"
+        return CheckResult(
+            id="gateway_no_inbound_recent",
+            title="Gateway Recent Inbound",
+            category=CheckCategory.BOTS,
+            status=CheckStatus.PASS,
+            message=detail,
+            duration_ms=(time.time() - start) * 1000,
+        )
+
+    return CheckResult(
+        id="gateway_no_inbound_recent",
+        title="Gateway Recent Inbound",
+        category=CheckCategory.BOTS,
+        status=CheckStatus.WARN,
+        message="No inbound delivery in recent logs",
+        details=inbound.hint,
+        remediation=(
+            "Send a Slack @mention to your bot, then run: "
+            f"praisonai gateway test --config {config_path} --check-inbound --since 5m"
+        ),
+        duration_ms=(time.time() - start) * 1000,
+    )

--- a/src/praisonai-code/tests/unit/doctor/test_gateway_readiness_checks.py
+++ b/src/praisonai-code/tests/unit/doctor/test_gateway_readiness_checks.py
@@ -60,3 +60,95 @@ def test_channel_probe_deep_mock(tmp_path, monkeypatch):
     )
     assert result.status.value == "pass"
     assert "telegram" in (result.details or "")
+
+
+def test_duplicate_services_check(tmp_path, monkeypatch):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("channels:\n  slack:\n    platform: slack\n")
+
+    dup = MagicMock(
+        ok=True,
+        warnings=[],
+        services=[],
+    )
+    mod = MagicMock()
+    mod.check_duplicates.return_value = dup
+
+    monkeypatch.setattr(gateway_checks, "skip_if_no_wrapper", lambda *a, **k: None)
+    monkeypatch.setattr(gateway_checks, "skip_if_no_bot_package", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "praisonai_code._bot_bridge.import_bot_module",
+        lambda name: mod,
+    )
+
+    result = gateway_checks.check_gateway_duplicate_services(
+        DoctorConfig(config_file=str(cfg))
+    )
+    assert result.status.value == "pass"
+
+
+def test_no_inbound_recent_warns(tmp_path, monkeypatch):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("channels:\n  slack:\n    platform: slack\n")
+
+    inbound = MagicMock(
+        ok=False,
+        mentions_in_window=0,
+        hint="No @mention received",
+    )
+    mod = MagicMock()
+    mod.check_inbound.return_value = inbound
+
+    monkeypatch.setattr(gateway_checks, "skip_if_no_wrapper", lambda *a, **k: None)
+    monkeypatch.setattr(gateway_checks, "skip_if_no_bot_package", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "praisonai_code._bot_bridge.import_bot_module",
+        lambda name: mod,
+    )
+
+    result = gateway_checks.check_gateway_no_inbound_recent(
+        DoctorConfig(config_file=str(cfg))
+    )
+    assert result.status.value == "warn"
+
+
+def test_no_inbound_recent_pass(tmp_path, monkeypatch):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("channels:\n  slack:\n    platform: slack\n")
+
+    inbound = MagicMock(ok=True, mentions_in_window=2, last_mention_at="2026-07-24T08:00:00")
+    mod = MagicMock()
+    mod.check_inbound.return_value = inbound
+
+    monkeypatch.setattr(gateway_checks, "skip_if_no_wrapper", lambda *a, **k: None)
+    monkeypatch.setattr(gateway_checks, "skip_if_no_bot_package", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "praisonai_code._bot_bridge.import_bot_module",
+        lambda name: mod,
+    )
+
+    result = gateway_checks.check_gateway_no_inbound_recent(
+        DoctorConfig(config_file=str(cfg))
+    )
+    assert result.status.value == "pass"
+
+
+def test_duplicate_services_warn(tmp_path, monkeypatch):
+    cfg = tmp_path / "bot.yaml"
+    cfg.write_text("channels:\n  slack:\n    platform: slack\n")
+
+    dup = MagicMock(ok=False, warnings=["Shared token"], services=[])
+    mod = MagicMock()
+    mod.check_duplicates.return_value = dup
+
+    monkeypatch.setattr(gateway_checks, "skip_if_no_wrapper", lambda *a, **k: None)
+    monkeypatch.setattr(gateway_checks, "skip_if_no_bot_package", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "praisonai_code._bot_bridge.import_bot_module",
+        lambda name: mod,
+    )
+
+    result = gateway_checks.check_gateway_duplicate_services(
+        DoctorConfig(config_file=str(cfg))
+    )
+    assert result.status.value == "warn"


### PR DESCRIPTION
## Summary
- Add `gateway test --check-runtime`, `--check-inbound`, and `--check-duplicates` with Python preflight helpers for scripts/CI
- Enrich `/health` (per-channel `ok`/`reason`/`last_activity`, `last_inbound_at`) and wire `messages_inbound_total` on inbound dispatch
- Add `gateway sessions list|show`, `gateway status --deep|--probe`, and doctor deep checks (`gateway_duplicate_services`, `gateway_no_inbound_recent`)
- Fix Slack @mention liveness (`fire_message_received`) so supervisor health reflects @mentions

## Test plan
- [x] `pytest src/praisonai-bot/tests/unit/gateway/test_preflight.py`
- [x] `pytest src/praisonai-bot/tests/unit/gateway/test_gateway_doctor.py`
- [x] `pytest src/praisonai-bot/tests/unit/gateway/test_gateway_readiness.py`
- [x] `pytest src/praisonai-code/tests/unit/doctor/test_gateway_readiness_checks.py`
- [x] Full gateway shard: 471 passed
- [x] Live: `gateway test --config bot.yaml --check-runtime --check-duplicates` detects shared Hermes/Praison tokens

## Docs
Companion PR: MervinPraison/PraisonAIDocs (gateway-readiness.mdx five-tier guide)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced `gateway status` diagnostics with optional deep mode (last inbound timing, per-channel activity/reason) and loopback-only version skew reporting, plus live per-channel probing.
  * Expanded `gateway test` with runtime, inbound-recency, and duplicate-service checks (including configurable time windows).
  * Added `gateway sessions` list/show commands with filtering and JSON output.
  * Added gateway “doctor” checks for duplicate services and missing recent inbound mentions.
* **Bug Fixes**
  * Improved Slack `@mention` handling to run the message-received hook, honor drop responses, and derive downstream mention text safely.
  * Health reporting now includes `last_inbound_at` plus per-channel last-activity/reason updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->