### PR TITLE
feat(train): non-developer robustness — clean errors, preflight, export command, Ollama/GGUF/HF failure handling

### DIFF
--- a/src/praisonai-train/praisonai_train/cli/commands/train.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/train.py
@@ -333,7 +333,7 @@ def train_export(
         )
         raise typer.Exit(1)
 
-    if not Path(model_dir).exists():
+    if not Path(model_dir).is_dir():
         output.print_error(
             f"Model directory not found: {model_dir}",
             remediation="Pass --model-dir pointing at your trained model (e.g. lora_model).",
@@ -345,6 +345,12 @@ def train_export(
     if config:
         import yaml
         cfg = yaml.safe_load(Path(config).read_text()) or {}
+        if not isinstance(cfg, dict):
+            output.print_error(
+                f"Config file must be a YAML mapping: {config}",
+                remediation="Use `key: value` pairs at the top level.",
+            )
+            raise typer.Exit(1)
     cfg["final_model_dir"] = model_dir
     cfg.setdefault("model_parameters", "latest")
     if quant:
@@ -393,6 +399,8 @@ def train_export(
         )
         raise typer.Exit(1)
 
+    import subprocess
+
     try:
         trainer = TrainModel.for_export(cfg)
         model, tokenizer = trainer.load_model()
@@ -404,7 +412,7 @@ def train_export(
             trainer.push_model_gguf()
         else:
             trainer.create_and_push_ollama_model()
-    except (ValueError, RuntimeError) as exc:
+    except (ValueError, RuntimeError, subprocess.CalledProcessError) as exc:
         output.print_error(str(exc))
         raise typer.Exit(1)
 

--- a/src/praisonai-train/praisonai_train/cli/commands/train.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/train.py
@@ -297,6 +297,120 @@ def train_agents(
         raise typer.Exit(0)
 
 
+@app.command("export")
+def train_export(
+    target: str = typer.Argument(..., help="Export target: ollama | gguf | hf"),
+    model_dir: str = typer.Option(
+        ..., "--model-dir", "-d", help="Directory of the already-trained model"),
+    config: Optional[str] = typer.Option(
+        None, "--config", "-c", help="Optional config.yaml (for extra export knobs)"),
+    ollama: Optional[str] = typer.Option(
+        None, "--ollama", help="Ollama model name, e.g. myuser/mymodel"),
+    hf: Optional[str] = typer.Option(
+        None, "--hf", help="Hugging Face repo id, e.g. myuser/mymodel"),
+    quant: Optional[str] = typer.Option(
+        None, "--quant", help="Quantization method for gguf/ollama, e.g. q4_k_m"),
+    base_model: Optional[str] = typer.Option(
+        None, "--base-model", help="Base model id (for chat-template selection)"),
+):
+    """
+    Export / publish an ALREADY-trained model without re-running training.
+
+    Examples:
+        praisonai-train export hf     --model-dir lora_model --hf   me/my-model
+        praisonai-train export gguf   --model-dir lora_model --hf   me/my-model --quant q4_k_m
+        praisonai-train export ollama --model-dir lora_model --ollama me/my-model --quant q4_k_m
+    """
+    from ..output.console import get_output_controller
+
+    output = get_output_controller()
+
+    target = target.lower()
+    if target not in ("ollama", "gguf", "hf"):
+        output.print_error(
+            f"Unknown export target: {target}",
+            remediation="Use one of: ollama, gguf, hf",
+        )
+        raise typer.Exit(1)
+
+    if not Path(model_dir).exists():
+        output.print_error(
+            f"Model directory not found: {model_dir}",
+            remediation="Pass --model-dir pointing at your trained model (e.g. lora_model).",
+        )
+        raise typer.Exit(1)
+
+    # Build an export-only config, merging an optional YAML file with CLI flags.
+    cfg: dict = {}
+    if config:
+        import yaml
+        cfg = yaml.safe_load(Path(config).read_text()) or {}
+    cfg["final_model_dir"] = model_dir
+    cfg.setdefault("model_parameters", "latest")
+    if quant:
+        cfg["quantization_method"] = quant
+    if hf:
+        cfg["hf_model_name"] = hf
+    if ollama:
+        cfg["ollama_model"] = ollama
+
+    # Recover the model name (drives chat-template selection) from --base-model or
+    # the trained model's config.json (_name_or_path), falling back to the dir name.
+    model_name = base_model or cfg.get("model_name")
+    if not model_name:
+        cfg_json = Path(model_dir) / "config.json"
+        if cfg_json.exists():
+            try:
+                model_name = json.loads(cfg_json.read_text()).get("_name_or_path")
+            except (json.JSONDecodeError, OSError):
+                model_name = None
+    cfg["model_name"] = model_name or model_dir
+
+    # Validate the destination is present for the chosen target.
+    if target in ("hf", "gguf") and not cfg.get("hf_model_name"):
+        output.print_error(
+            "A Hugging Face repo id is required for this target",
+            remediation="Pass --hf <your-username>/<name>.",
+        )
+        raise typer.Exit(1)
+    if target == "ollama" and not cfg.get("ollama_model"):
+        output.print_error(
+            "An Ollama model name is required for this target",
+            remediation="Pass --ollama <your-username>/<name>.",
+        )
+        raise typer.Exit(1)
+    # For an Ollama modelfile the FROM line uses hf_model_name; default it to the
+    # local model dir so `ollama create` reads the trained model on disk.
+    if target == "ollama":
+        cfg.setdefault("hf_model_name", model_dir)
+
+    try:
+        from praisonai_train.train.llm.trainer import TrainModel
+    except ImportError as exc:
+        output.print_error(
+            f"LLM export dependencies not installed: {exc}",
+            remediation='pip install "praisonai-train[llm]"',
+        )
+        raise typer.Exit(1)
+
+    try:
+        trainer = TrainModel.for_export(cfg)
+        model, tokenizer = trainer.load_model()
+        trainer.model = model
+        trainer.hf_tokenizer = tokenizer
+        if target == "hf":
+            trainer.save_model_merged()
+        elif target == "gguf":
+            trainer.push_model_gguf()
+        else:
+            trainer.create_and_push_ollama_model()
+    except (ValueError, RuntimeError) as exc:
+        output.print_error(str(exc))
+        raise typer.Exit(1)
+
+    output.print_success(f"Exported model to {target}.")
+
+
 @app.command("list")
 def train_list(
     limit: int = typer.Option(20, "--limit", "-n", help="Max sessions to show"),

--- a/src/praisonai-train/praisonai_train/train/_ollama.py
+++ b/src/praisonai-train/praisonai_train/train/_ollama.py
@@ -16,7 +16,35 @@ import urllib.request
 from typing import Optional
 
 
-def _ollama_ready(host: str = "127.0.0.1", port: int = 11434, timeout: float = 0.2) -> bool:
+def _ollama_endpoint() -> tuple:
+    """Resolve the (host, port) Ollama listens on, honouring OLLAMA_HOST.
+
+    The `ollama serve/create/push` subprocesses all inherit OLLAMA_HOST, so the
+    readiness probe must target the same endpoint instead of a hardcoded
+    127.0.0.1:11434 — otherwise a healthy configured/remote daemon is ignored.
+    Accepts forms like `host`, `host:port`, and `http://host:port`.
+    """
+    raw = os.environ.get("OLLAMA_HOST", "").strip()
+    if not raw:
+        return "127.0.0.1", 11434
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    raw = raw.rstrip("/")
+    if raw.startswith("["):  # IPv6 literal e.g. [::1]:11434
+        host, _, rest = raw[1:].partition("]")
+        port = rest.lstrip(":") or "11434"
+    elif ":" in raw:
+        host, _, port = raw.rpartition(":")
+    else:
+        host, port = raw, "11434"
+    try:
+        port_num = int(port)
+    except ValueError:
+        port_num = 11434
+    return host or "127.0.0.1", port_num
+
+
+def _ollama_ready(host: Optional[str] = None, port: Optional[int] = None, timeout: float = 0.2) -> bool:
     """Check if Ollama daemon is accepting connections AND serving its HTTP API.
 
     A bare socket connect can succeed before the HTTP server is actually ready
@@ -24,13 +52,17 @@ def _ollama_ready(host: str = "127.0.0.1", port: int = 11434, timeout: float = 0
     ``GET /api/version`` before declaring the daemon usable.
 
     Args:
-        host: Ollama host (default 127.0.0.1)
-        port: Ollama port (default 11434)
+        host: Ollama host (defaults to the OLLAMA_HOST-resolved host)
+        port: Ollama port (defaults to the OLLAMA_HOST-resolved port)
         timeout: Connection timeout in seconds
 
     Returns:
         True if Ollama's API responds, False otherwise
     """
+    if host is None or port is None:
+        resolved_host, resolved_port = _ollama_endpoint()
+        host = host or resolved_host
+        port = port if port is not None else resolved_port
     # Fast socket pre-check: if the port isn't even open, skip the HTTP attempt.
     try:
         with socket.create_connection((host, port), timeout):
@@ -68,28 +100,31 @@ def ensure_ollama_running(max_wait_seconds: float = 15.0) -> Optional[subprocess
     # Capture serve stderr to a temp file so a startup failure (e.g. port in use,
     # bad OLLAMA_HOST) can be surfaced in the timeout message instead of vanishing.
     serve_err = tempfile.TemporaryFile(mode="w+")
-    proc = subprocess.Popen(
-        ["ollama", "serve"],
-        stdout=subprocess.DEVNULL,
-        stderr=serve_err,
-        start_new_session=True,  # Detach from parent
-    )
+    try:
+        proc = subprocess.Popen(
+            ["ollama", "serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=serve_err,
+            start_new_session=True,  # Detach from parent
+        )
 
-    # Poll until ready or timeout
-    wait_interval = 0.25
-    max_polls = max(1, int(max_wait_seconds / wait_interval))
+        # Poll until ready or timeout
+        wait_interval = 0.25
+        max_polls = max(1, int(max_wait_seconds / wait_interval))
 
-    for _ in range(max_polls):
-        if _ollama_ready():
-            return proc
-        time.sleep(wait_interval)
+        for _ in range(max_polls):
+            if _ollama_ready():
+                return proc
+            time.sleep(wait_interval)
 
-    # If we get here, daemon didn't become ready in time — include serve's stderr.
-    proc.terminate()
-    err_text = ""
-    with contextlib.suppress(OSError, ValueError):
-        serve_err.seek(0)
-        err_text = serve_err.read().strip()
+        # If we get here, daemon didn't become ready in time — include serve's stderr.
+        proc.terminate()
+        err_text = ""
+        with contextlib.suppress(OSError, ValueError):
+            serve_err.seek(0)
+            err_text = serve_err.read().strip()
+    finally:
+        serve_err.close()
     detail = f"\nollama serve output:\n{err_text}" if err_text else ""
     raise RuntimeError(
         f"ollama serve did not become ready in {max_wait_seconds} seconds.{detail}"
@@ -191,8 +226,7 @@ def create_and_push_ollama_model(
             ``ollama create --quantize`` so the model isn't stored as huge f16.
 
     Raises:
-        RuntimeError: If ollama operations fail (with actionable guidance)
-        subprocess.CalledProcessError: If the create command fails
+        RuntimeError: If ollama create/push operations fail (with actionable guidance)
     """
     # Write Modelfile
     with open("Modelfile", "w") as f:
@@ -211,7 +245,14 @@ def create_and_push_ollama_model(
     create_cmd = ["ollama", "create", tag, "-f", "Modelfile"]
     if quantization:
         create_cmd += ["--quantize", quantization]
-    subprocess.run(create_cmd, check=True)
+    # Capture output so a create failure (the most common Ollama error) surfaces
+    # as an actionable RuntimeError instead of a raw CalledProcessError traceback.
+    create = subprocess.run(create_cmd, capture_output=True, text=True)
+    if create.returncode != 0:
+        raise RuntimeError(
+            f"`ollama create {tag}` failed:\n"
+            f"{(create.stderr or create.stdout or '').strip()}"
+        )
 
     # Push with captured output so a 401/403 becomes an actionable message rather
     # than a raw non-zero exit.

--- a/src/praisonai-train/praisonai_train/train/_ollama.py
+++ b/src/praisonai-train/praisonai_train/train/_ollama.py
@@ -5,93 +5,221 @@ fixing the blocking subprocess.run(["ollama", "serve"]) issue present
 in multiple files.
 """
 import contextlib
+import os
 import shutil
 import socket
 import subprocess
+import tempfile
 import time
+import urllib.error
+import urllib.request
 from typing import Optional
 
 
 def _ollama_ready(host: str = "127.0.0.1", port: int = 11434, timeout: float = 0.2) -> bool:
-    """Check if Ollama daemon is ready to accept connections.
-    
+    """Check if Ollama daemon is accepting connections AND serving its HTTP API.
+
+    A bare socket connect can succeed before the HTTP server is actually ready
+    (or when something unrelated holds the port), so we confirm with a real
+    ``GET /api/version`` before declaring the daemon usable.
+
     Args:
         host: Ollama host (default 127.0.0.1)
         port: Ollama port (default 11434)
         timeout: Connection timeout in seconds
-        
+
     Returns:
-        True if Ollama is ready, False otherwise
+        True if Ollama's API responds, False otherwise
     """
-    with contextlib.suppress(OSError):
+    # Fast socket pre-check: if the port isn't even open, skip the HTTP attempt.
+    try:
         with socket.create_connection((host, port), timeout):
-            return True
-    return False
+            pass
+    except OSError:
+        return False
+    url = f"http://{host}:{port}/api/version"
+    try:
+        with urllib.request.urlopen(url, timeout=max(timeout, 1.0)) as resp:
+            return 200 <= getattr(resp, "status", 200) < 300
+    except (urllib.error.URLError, OSError):
+        return False
 
 
-def ensure_ollama_running(max_wait_seconds: float = 5.0) -> Optional[subprocess.Popen]:
+def ensure_ollama_running(max_wait_seconds: float = 15.0) -> Optional[subprocess.Popen]:
     """Ensure Ollama daemon is running, start it if necessary.
-    
+
     Args:
         max_wait_seconds: Maximum time to wait for daemon to become ready
-        
+
     Returns:
         Process object if we started the daemon, None if it was already running
-        
+
     Raises:
         RuntimeError: If ollama CLI not found or daemon doesn't become ready
     """
     # Check if already running
     if _ollama_ready():
         return None
-    
+
     # Check if ollama CLI is available
     if shutil.which("ollama") is None:
         raise RuntimeError("`ollama` CLI not found; install from https://ollama.com")
-    
-    # Start daemon in detached mode
+
+    # Capture serve stderr to a temp file so a startup failure (e.g. port in use,
+    # bad OLLAMA_HOST) can be surfaced in the timeout message instead of vanishing.
+    serve_err = tempfile.TemporaryFile(mode="w+")
     proc = subprocess.Popen(
         ["ollama", "serve"],
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stderr=serve_err,
         start_new_session=True,  # Detach from parent
     )
-    
+
     # Poll until ready or timeout
-    wait_interval = 0.1
-    max_polls = int(max_wait_seconds / wait_interval)
-    
+    wait_interval = 0.25
+    max_polls = max(1, int(max_wait_seconds / wait_interval))
+
     for _ in range(max_polls):
         if _ollama_ready():
             return proc
         time.sleep(wait_interval)
-    
-    # If we get here, daemon didn't become ready in time
+
+    # If we get here, daemon didn't become ready in time — include serve's stderr.
     proc.terminate()
-    raise RuntimeError(f"ollama serve did not become ready in {max_wait_seconds} seconds")
+    err_text = ""
+    with contextlib.suppress(OSError, ValueError):
+        serve_err.seek(0)
+        err_text = serve_err.read().strip()
+    detail = f"\nollama serve output:\n{err_text}" if err_text else ""
+    raise RuntimeError(
+        f"ollama serve did not become ready in {max_wait_seconds} seconds.{detail}"
+    )
 
 
-def create_and_push_ollama_model(ollama_model: str, model_parameters: str, modelfile_content: str) -> None:
+def _ollama_models_dir() -> str:
+    """Directory Ollama stores models in (OLLAMA_MODELS or ~/.ollama/models)."""
+    return os.environ.get(
+        "OLLAMA_MODELS", os.path.join(os.path.expanduser("~"), ".ollama", "models")
+    )
+
+
+def _dir_size_bytes(path: str) -> int:
+    """Best-effort total size of a file or directory tree, in bytes (0 if absent)."""
+    if os.path.isfile(path):
+        with contextlib.suppress(OSError):
+            return os.path.getsize(path)
+        return 0
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            with contextlib.suppress(OSError):
+                total += os.path.getsize(os.path.join(root, name))
+    return total
+
+
+def _source_model_path(modelfile_content: str) -> Optional[str]:
+    """Extract the local FROM path from a Modelfile, if it points to a real path."""
+    for line in modelfile_content.splitlines():
+        stripped = line.strip()
+        if stripped.upper().startswith("FROM "):
+            candidate = stripped[5:].strip().strip('"')
+            if os.path.exists(candidate):
+                return candidate
+            return None
+    return None
+
+
+def _check_ollama_disk(modelfile_content: str) -> None:
+    """Fail fast if the Ollama models volume lacks room for the created model.
+
+    Requires ~1.5x the source model size, with a 15GB floor when the size is
+    unknown (e.g. FROM references a Hub id rather than a local path).
+    """
+    models_dir = _ollama_models_dir()
+    # disk_usage needs an existing path; walk up to the nearest existing parent.
+    probe = models_dir
+    while probe and not os.path.exists(probe):
+        parent = os.path.dirname(probe)
+        if parent == probe:
+            break
+        probe = parent
+    if not probe or not os.path.exists(probe):
+        return  # Can't determine the volume; skip rather than block.
+    try:
+        free = shutil.disk_usage(probe).free
+    except OSError:
+        return
+    floor = 15 * 2 ** 30
+    src = _source_model_path(modelfile_content)
+    src_size = _dir_size_bytes(src) if src else 0
+    required = max(floor, int(src_size * 1.5))
+    if free < required:
+        raise RuntimeError(
+            f"Not enough disk for the Ollama model: {free / 2 ** 30:.1f} GB free on "
+            f"'{models_dir}', need ~{required / 2 ** 30:.1f} GB. Point Ollama at a "
+            f"bigger disk, e.g. `export OLLAMA_MODELS=/big/disk/ollama-models`."
+        )
+
+
+def _ollama_key_hint() -> str:
+    """Message telling the user how to register their Ollama signing key to push."""
+    pub_path = os.path.join(os.path.expanduser("~"), ".ollama", "id_ed25519.pub")
+    key_line = ""
+    with contextlib.suppress(OSError):
+        with open(pub_path) as f:
+            key_line = f"\nYour public key ({pub_path}):\n{f.read().strip()}"
+    return (
+        "Ollama rejected the push (unauthorized). Register your public key at "
+        "https://ollama.com/settings/keys and make sure the model is namespaced as "
+        "`<username>/<name>`." + key_line
+    )
+
+
+def create_and_push_ollama_model(
+    ollama_model: str,
+    model_parameters: str,
+    modelfile_content: str,
+    quantization: Optional[str] = None,
+) -> None:
     """Create and push an Ollama model with proper daemon management.
-    
+
     Args:
         ollama_model: Name of the Ollama model
         model_parameters: Model parameters/tag
         modelfile_content: Content for the Modelfile
-        
+        quantization: Optional quantization (e.g. "q4_k_m") passed to
+            ``ollama create --quantize`` so the model isn't stored as huge f16.
+
     Raises:
-        RuntimeError: If ollama operations fail
-        subprocess.CalledProcessError: If create/push commands fail
+        RuntimeError: If ollama operations fail (with actionable guidance)
+        subprocess.CalledProcessError: If the create command fails
     """
     # Write Modelfile
     with open("Modelfile", "w") as f:
         f.write(modelfile_content)
-    
+
+    # Disk pre-check BEFORE we start the daemon / create, so we fail with clear
+    # guidance instead of a cryptic "no space left on device" mid-create.
+    _check_ollama_disk(modelfile_content)
+
     # Ensure daemon is running
     ensure_ollama_running()
-    
+
     # Create and push model
     tag = f"{ollama_model}:{model_parameters}"
-    
-    subprocess.run(["ollama", "create", tag, "-f", "Modelfile"], check=True)
-    subprocess.run(["ollama", "push", tag], check=True)
+
+    create_cmd = ["ollama", "create", tag, "-f", "Modelfile"]
+    if quantization:
+        create_cmd += ["--quantize", quantization]
+    subprocess.run(create_cmd, check=True)
+
+    # Push with captured output so a 401/403 becomes an actionable message rather
+    # than a raw non-zero exit.
+    result = subprocess.run(["ollama", "push", tag], capture_output=True, text=True)
+    if result.returncode != 0:
+        combined = f"{result.stderr or ''}\n{result.stdout or ''}".lower()
+        if any(t in combined for t in ("unauthorized", "401", "403", "forbidden", "invalid key")):
+            raise RuntimeError(_ollama_key_hint())
+        raise RuntimeError(
+            f"`ollama push {tag}` failed:\n{(result.stderr or result.stdout or '').strip()}"
+        )

--- a/src/praisonai-train/praisonai_train/train/llm/trainer.py
+++ b/src/praisonai-train/praisonai_train/train/llm/trainer.py
@@ -12,6 +12,7 @@ import sys
 import yaml
 import shutil
 import difflib
+import contextlib
 import subprocess
 from functools import partial
 
@@ -172,6 +173,15 @@ class TrainModel:
         obj.config = dict(config or {})
         if "model" in obj.config and "model_name" not in obj.config:
             obj.config["model_name"] = obj.config["model"]
+        # Validate quantization up front here too — for_export skips the full
+        # training validate_config, so an invalid --quant would otherwise only
+        # fail deep inside Unsloth / `ollama create`.
+        q = obj.config.get("quantization_method")
+        if q is not None and str(q).lower() not in VALID_QUANTIZATION_METHODS:
+            raise ValueError(
+                f"quantization_method '{q}' is not valid. Choose one of: "
+                f"{', '.join(sorted(VALID_QUANTIZATION_METHODS))}."
+            )
         obj.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         obj.model = None
         obj.hf_tokenizer = None
@@ -248,23 +258,27 @@ class TrainModel:
         # traceback after minutes of downloads. ---
 
         # GPU: fine-tuning cannot run on CPU. Catch it before Unsloth tries.
-        if not torch.cuda.is_available():
+        # Only enforced when training is enabled — publish/export-only runs
+        # (train: false) are valid on CPU.
+        if self._flag(self.config.get("train"), default=True) and not torch.cuda.is_available():
             raise ValueError(
                 "No CUDA GPU detected. Fine-tuning needs a GPU. On a rented box "
                 "check the driver; on CPU it cannot run."
             )
 
         # Hugging Face token: required to publish. Checked up front so a long run
-        # doesn't finish only to fail at the upload step.
+        # doesn't finish only to fail at the upload step. A cached login via
+        # `huggingface-cli login` is also accepted (downstream Hub calls use it),
+        # so only fail when NEITHER an env token NOR a cached token is present.
         publishing = (
             self._flag(self.config.get("huggingface_save"))
             or self._flag(self.config.get("huggingface_save_gguf"))
             or self._flag(self.config.get("push_to_hub"))
         )
-        if publishing and not os.getenv("HF_TOKEN"):
+        if publishing and not self._has_hf_credentials():
             raise ValueError(
-                "Publishing to Hugging Face is enabled but HF_TOKEN is not set. Run "
-                "`huggingface-cli login` or `export HF_TOKEN=hf_...`. To train "
+                "Publishing to Hugging Face is enabled but no credentials were found. "
+                "Run `huggingface-cli login` or `export HF_TOKEN=hf_...`. To train "
                 "without publishing, set huggingface_save: false."
             )
 
@@ -277,7 +291,7 @@ class TrainModel:
         if free_gb is not None and free_gb < 10:
             raise ValueError(
                 f"Low disk: only {free_gb:.1f} GB free on the training disk "
-                f"(need ~10 GB minimum). Free up free space or set output_dir to a "
+                f"(need ~10 GB minimum). Free up space or set output_dir to a "
                 f"larger disk."
             )
 
@@ -312,6 +326,19 @@ class TrainModel:
         if isinstance(value, bool):
             return value
         return str(value).strip().lower() in ("true", "1", "yes", "on")
+
+    @staticmethod
+    def _has_hf_credentials():
+        """True if a Hugging Face token is available via env OR a cached
+        `huggingface-cli login`. The Hub client accepts a cached token when
+        ``token=None``, so preflight must not reject a valid cached login."""
+        if os.getenv("HF_TOKEN") or os.getenv("HUGGING_FACE_HUB_TOKEN"):
+            return True
+        with contextlib.suppress(Exception):
+            from huggingface_hub import get_token
+            if get_token():
+                return True
+        return False
 
     def _supports_assistant_mask(self):
         """True iff assistant-only loss will actually produce a usable mask for this
@@ -1221,7 +1248,7 @@ def main():
         try:
             trainer_obj = TrainModel(config_path=args.config)
             trainer_obj.run()
-        except (ValueError, RuntimeError) as exc:
+        except (ValueError, RuntimeError, subprocess.CalledProcessError) as exc:
             print(f"\nERROR: {exc}\n", file=sys.stderr)
             sys.exit(1)
         except KeyboardInterrupt:

--- a/src/praisonai-train/praisonai_train/train/llm/trainer.py
+++ b/src/praisonai-train/praisonai_train/train/llm/trainer.py
@@ -11,8 +11,17 @@ import os
 import sys
 import yaml
 import shutil
+import difflib
 import subprocess
 from functools import partial
+
+# GGUF / Ollama quantization methods supported by Unsloth's exporter. Validated up
+# front so a typo (e.g. "q4km") fails fast with a clear message instead of after a
+# long training run when the export step finally rejects it.
+VALID_QUANTIZATION_METHODS = frozenset({
+    "q4_k_m", "q5_k_m", "q8_0", "q4_0", "q4_1", "q5_0", "q5_1",
+    "q3_k_m", "q6_k", "f16", "bf16", "q2_k",
+})
 
 
 def _lazy_import_training_deps():
@@ -149,6 +158,26 @@ class TrainModel:
         self.hf_tokenizer = None   # The underlying HF tokenizer
         self.chat_tokenizer = None # Chat wrapper for formatting
 
+    @classmethod
+    def for_export(cls, config):
+        """Build a trainer for EXPORT ONLY (push an already-trained model) from a
+        config dict, skipping the training-only validation (no dataset required).
+
+        Used by the standalone `export` command so a non-developer can publish a
+        model that was trained earlier without re-running training. The caller loads
+        the model via load_model() and assigns self.model / self.hf_tokenizer.
+        """
+        obj = cls.__new__(cls)
+        _lazy_import_training_deps()
+        obj.config = dict(config or {})
+        if "model" in obj.config and "model_name" not in obj.config:
+            obj.config["model_name"] = obj.config["model"]
+        obj.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        obj.model = None
+        obj.hf_tokenizer = None
+        obj.chat_tokenizer = None
+        return obj
+
     def load_config(self, path):
         with open(path, "r") as file:
             self.config = yaml.safe_load(file) or {}
@@ -213,9 +242,65 @@ class TrainModel:
                 )
         if self._flag(self.config.get("ollama_save")) and not self.config.get("ollama_model"):
             raise ValueError("ollama_model is required when ollama_save is enabled.")
-        for key in self.config:
-            if key not in self.KNOWN_KEYS:
-                print(f"WARNING: ignoring unknown config key '{key}' (typo, or not supported).")
+
+        # --- Preflight: fail FAST with friendly messages BEFORE any model/GPU load,
+        # so a non-developer gets a clear, actionable error in seconds instead of a
+        # traceback after minutes of downloads. ---
+
+        # GPU: fine-tuning cannot run on CPU. Catch it before Unsloth tries.
+        if not torch.cuda.is_available():
+            raise ValueError(
+                "No CUDA GPU detected. Fine-tuning needs a GPU. On a rented box "
+                "check the driver; on CPU it cannot run."
+            )
+
+        # Hugging Face token: required to publish. Checked up front so a long run
+        # doesn't finish only to fail at the upload step.
+        publishing = (
+            self._flag(self.config.get("huggingface_save"))
+            or self._flag(self.config.get("huggingface_save_gguf"))
+            or self._flag(self.config.get("push_to_hub"))
+        )
+        if publishing and not os.getenv("HF_TOKEN"):
+            raise ValueError(
+                "Publishing to Hugging Face is enabled but HF_TOKEN is not set. Run "
+                "`huggingface-cli login` or `export HF_TOKEN=hf_...`. To train "
+                "without publishing, set huggingface_save: false."
+            )
+
+        # Disk: model downloads + checkpoints + merged export need headroom. A 10GB
+        # floor catches the common "no space left on device" mid-run failure early.
+        try:
+            free_gb = shutil.disk_usage(self.config.get("output_dir") or ".").free / 2 ** 30
+        except OSError:
+            free_gb = None
+        if free_gb is not None and free_gb < 10:
+            raise ValueError(
+                f"Low disk: only {free_gb:.1f} GB free on the training disk "
+                f"(need ~10 GB minimum). Free up free space or set output_dir to a "
+                f"larger disk."
+            )
+
+        # Quantization method: only relevant when a GGUF/Ollama export is requested.
+        if self._flag(self.config.get("huggingface_save_gguf")) or self._flag(
+            self.config.get("ollama_save")
+        ):
+            q = self.config.get("quantization_method")
+            if q is not None and str(q).lower() not in VALID_QUANTIZATION_METHODS:
+                raise ValueError(
+                    f"quantization_method '{q}' is not valid. Choose one of: "
+                    f"{', '.join(sorted(VALID_QUANTIZATION_METHODS))}."
+                )
+
+        # --- Unknown keys: collect ALL, suggest the closest known key, print once. ---
+        unknown = [k for k in self.config if k not in self.KNOWN_KEYS]
+        if unknown:
+            lines = ["WARNING: unrecognized config key(s) — these will be ignored:"]
+            for key in unknown:
+                match = difflib.get_close_matches(str(key), self.KNOWN_KEYS, n=1)
+                suggestion = f"  (did you mean '{match[0]}'?)" if match else ""
+                lines.append(f"  - {key}{suggestion}")
+            print("\n".join(lines))
 
     @staticmethod
     def _flag(value, default=False):
@@ -263,6 +348,12 @@ class TrainModel:
         print("DEBUG: Python Path:", sys.executable)
 
     def check_gpu(self):
+        # Guard the CUDA query: get_device_properties(0) raises a raw error on a
+        # CPU-only box. validate_config already fails fast for training, but this
+        # keeps other entry points (e.g. export) from crashing here.
+        if not torch.cuda.is_available():
+            print("DEBUG: No CUDA GPU available.")
+            return
         gpu_stats = torch.cuda.get_device_properties(0)
         print(f"DEBUG: GPU = {gpu_stats.name}. Max memory = {round(gpu_stats.total_memory/(1024**3),3)} GB.")
 
@@ -403,6 +494,12 @@ class TrainModel:
                 )
             dataset = dataset.select(range(min(num_samples, len(dataset))))
             print(f"DEBUG: Using {len(dataset)} samples (num_samples={num_samples}).")
+            # num_samples takes a head slice, which runs BEFORE the shuffle below —
+            # so without shuffle you always train on the first N rows (often sorted
+            # by source/topic and unrepresentative). Say so once, clearly.
+            if not self._flag(dataset_info.get("shuffle"), default=False):
+                print("NOTE: num_samples takes the FIRST N rows before shuffle; "
+                      "add shuffle: true to sample randomly.")
         print("DEBUG: Dataset columns:", dataset.column_names)
         if "conversations" in dataset.column_names:
             print("DEBUG: Standardizing dataset (ShareGPT style)...")
@@ -431,6 +528,14 @@ class TrainModel:
         datasets = []
         for dataset_info in self.config["dataset"]:
             print("DEBUG: Processing dataset info:", dataset_info)
+            # A validation/test split loaded here is CONCATENATED into training, not
+            # held out — an easy way to contaminate eval without noticing. Warn, and
+            # point at the real held-out mechanism (val_split_ratio).
+            split_type = str(dataset_info.get("split_type", "train")).strip().lower()
+            if split_type in {"validation", "valid", "test", "eval"}:
+                print(f"WARNING: dataset split_type '{split_type}' is ADDED to the "
+                      f"TRAINING data (not held out). Use val_split_ratio for a "
+                      f"held-out eval set.")
             datasets.append(self.process_dataset(dataset_info))
         combined = concatenate_datasets(datasets)
         print("DEBUG: Combined dataset has", len(combined), "examples.")
@@ -484,6 +589,12 @@ class TrainModel:
         if self.config.get("num_train_epochs") and not self.config.get("max_steps"):
             sft_params["num_train_epochs"] = self.config["num_train_epochs"]
         else:
+            if not self.config.get("num_train_epochs") and not self.config.get("max_steps"):
+                # Neither was set — the run silently defaults to 2800 steps, which is
+                # rarely what a first-time user wants. Tell them how to control it.
+                print("NOTE: neither num_train_epochs nor max_steps set; defaulting to "
+                      "max_steps: 2800. Set num_train_epochs: 1-3 (or max_steps) to "
+                      "control training length.")
             sft_params["max_steps"] = self.config.get("max_steps", 2800)
         # When both epochs and max_steps are set, max_steps silently wins — say so.
         if self.config.get("num_train_epochs") and self.config.get("max_steps"):
@@ -761,23 +872,58 @@ class TrainModel:
         model, tokenizer = FastLanguageModel.from_pretrained(**load_kwargs)
         return model, tokenizer
 
+    @staticmethod
+    def _raise_hf_push_error(exc, repo):
+        """Translate a Hugging Face Hub HTTP error into an actionable message."""
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status == 401:
+            raise RuntimeError(
+                "Hugging Face rejected the token (401). It is invalid or expired — "
+                "run `huggingface-cli login` or `export HF_TOKEN=hf_...` with a valid "
+                "write token."
+            ) from exc
+        if status == 403:
+            raise RuntimeError(
+                f"No write access to '{repo}' (403). The repo must be under your own "
+                f"username and the token must have write scope. Set hf_model_name to "
+                f"'<your-username>/<name>'."
+            ) from exc
+        raise RuntimeError(f"Hugging Face upload to '{repo}' failed: {exc}") from exc
+
+    def _clean_local_repo_dir(self):
+        """Remove a stale LOCAL output dir before an export — but only when
+        hf_model_name is a plain local directory name, never a namespaced Hub repo
+        id like 'user/model' (which must not be interpreted as a path to delete)."""
+        name = self.config["hf_model_name"]
+        if "/" not in name.strip("/") and os.path.isdir(name):
+            shutil.rmtree(name)
+
     def save_model_merged(self):
-        if os.path.exists(self.config["hf_model_name"]):
-            shutil.rmtree(self.config["hf_model_name"])
-        self.model.push_to_hub_merged(
-            self.config["hf_model_name"],
-            self.hf_tokenizer,
-            save_method="merged_16bit",
-            token=os.getenv("HF_TOKEN")
-        )
+        from huggingface_hub.utils import HfHubHTTPError
+        repo = self.config["hf_model_name"]
+        self._clean_local_repo_dir()
+        try:
+            self.model.push_to_hub_merged(
+                repo,
+                self.hf_tokenizer,
+                save_method="merged_16bit",
+                token=os.getenv("HF_TOKEN")
+            )
+        except HfHubHTTPError as exc:
+            self._raise_hf_push_error(exc, repo)
 
     def push_model_gguf(self):
-        self.model.push_to_hub_gguf(
-            self.config["hf_model_name"],
-            self.hf_tokenizer,
-            quantization_method=self.config.get("quantization_method", "q4_k_m"),
-            token=os.getenv("HF_TOKEN")
-        )
+        from huggingface_hub.utils import HfHubHTTPError
+        repo = self.config["hf_model_name"]
+        try:
+            self.model.push_to_hub_gguf(
+                repo,
+                self.hf_tokenizer,
+                quantization_method=self.config.get("quantization_method", "q4_k_m"),
+                token=os.getenv("HF_TOKEN")
+            )
+        except HfHubHTTPError as exc:
+            self._raise_hf_push_error(exc, repo)
 
     def save_model_gguf(self):
         self.model.save_pretrained_gguf(
@@ -908,7 +1054,9 @@ class TrainModel:
     {{- if and $last (ne .Role "assistant") }}
     {{ end }}
     {{- end }}""",
-                "stop_tokens": ["", "", "", ""]
+                # DeepSeek's end-of-sequence marker. Previously this was four empty
+                # strings, which emitted broken `PARAMETER stop` lines (no value).
+                "stop_tokens": ["<｜end▁of▁sentence｜>"]
             },
             "llava": {
                 "template": """{{- if .Suffix }}<|fim_prefix|>{{ .Prompt }}<|fim_suffix|>{{ .Suffix }}<|fim_middle|>
@@ -980,6 +1128,13 @@ class TrainModel:
                 chosen = settings
                 break
         if chosen is None:
+            # No known family matched the model name — the generic Llama-style
+            # template below may format prompts or stop tokens incorrectly for this
+            # model. Warn so a garbled Ollama model isn't a silent surprise.
+            print(f"WARNING: no known chat template matched model '{model_name}'; "
+                  f"using a generic template — stop tokens may be wrong. Verify the "
+                  f"Ollama output, or set model_name to a recognized family "
+                  f"(llama/qwen/gemma/mistral/phi/deepseek).")
             # Fallback default
             chosen = {
                 "template": """{{ if .System }}<|start_header_id|>system<|end_header_id|>
@@ -988,8 +1143,13 @@ class TrainModel:
     {{ .Response }}<|eot_id|>""",
                 "stop_tokens": ["<|start_header_id|>", "<|end_header_id|>", "<|eot_id|>"]
             }
-        # Build the stop parameter lines.
-        stop_params = "\n".join([f"PARAMETER stop {token}" for token in chosen["stop_tokens"]])
+        # Build the stop parameter lines. Skip empty/whitespace tokens so we never
+        # emit a broken `PARAMETER stop` line with no value.
+        stop_params = "\n".join(
+            f"PARAMETER stop {token}"
+            for token in chosen["stop_tokens"]
+            if str(token).strip()
+        )
         # Optionally include a SYSTEM line and num_ctx if defined in the mapping.
         system_line = ""
         if "system" in chosen:
@@ -1006,10 +1166,13 @@ class TrainModel:
     def create_and_push_ollama_model(self):
         from .._ollama import create_and_push_ollama_model
         modelfile_content = self.prepare_modelfile_content()
+        # Pass the configured quantization so `ollama create` quantizes on the way in
+        # (an unquantized f16 model can be many GB larger). None -> no --quantize.
         create_and_push_ollama_model(
-            self.config['ollama_model'], 
-            self.config['model_parameters'], 
-            modelfile_content
+            self.config['ollama_model'],
+            self.config.get('model_parameters', 'latest'),
+            modelfile_content,
+            quantization=self.config.get('quantization_method'),
         )
 
     def run(self):
@@ -1051,8 +1214,19 @@ def main():
     args = parser.parse_args()
 
     if args.command == "train":
-        trainer_obj = TrainModel(config_path=args.config)
-        trainer_obj.run()
+        # Wrap construction + run so config/preflight/runtime errors reach a
+        # non-developer as a single clean line, not a scary traceback. ValueError /
+        # RuntimeError are the "expected, actionable" failures we raise deliberately;
+        # anything else (a real bug) re-raises with its full traceback.
+        try:
+            trainer_obj = TrainModel(config_path=args.config)
+            trainer_obj.run()
+        except (ValueError, RuntimeError) as exc:
+            print(f"\nERROR: {exc}\n", file=sys.stderr)
+            sys.exit(1)
+        except KeyboardInterrupt:
+            print("\nInterrupted.", file=sys.stderr)
+            sys.exit(130)
 
 if __name__ == "__main__":
     main()

--- a/src/praisonai-train/tests/unit/train/test_robustness.py
+++ b/src/praisonai-train/tests/unit/train/test_robustness.py
@@ -1,0 +1,264 @@
+"""Robustness tests for the LLM trainer — clean errors, preflight validation, and
+export robustness. All heavy deps (torch CUDA, HF push, ollama subprocess) are
+stubbed so these run with no GPU and no network.
+"""
+import sys
+import types
+
+import pytest
+
+import praisonai_train.train.llm.trainer as trainer_mod
+import praisonai_train.train._ollama as ollama_mod
+
+
+# --------------------------------------------------------------------------- #
+# Helpers / fakes
+# --------------------------------------------------------------------------- #
+class _FakeCuda:
+    def __init__(self, available):
+        self._available = available
+
+    def is_available(self):
+        return self._available
+
+
+class _FakeTorch:
+    def __init__(self, available):
+        self.cuda = _FakeCuda(available)
+
+
+class _FreeDisk:
+    def __init__(self, free_gb):
+        self.free = int(free_gb * 2 ** 30)
+
+
+def _make_trainer(config, monkeypatch, gpu=True, free_gb=500):
+    """Build a bare TrainModel with a controllable GPU/disk environment."""
+    monkeypatch.setattr(trainer_mod, "torch", _FakeTorch(gpu), raising=False)
+    monkeypatch.setattr(trainer_mod.shutil, "disk_usage", lambda *_a, **_k: _FreeDisk(free_gb))
+    obj = trainer_mod.TrainModel.__new__(trainer_mod.TrainModel)
+    obj.config = config
+    return obj
+
+
+def _valid_config(**extra):
+    cfg = {
+        "model_name": "unsloth/gemma-2-2b-it-bnb-4bit",
+        "max_seq_length": 2048,
+        "dataset": [{"name": "yahma/alpaca-cleaned"}],
+    }
+    cfg.update(extra)
+    return cfg
+
+
+# --------------------------------------------------------------------------- #
+# 1. main() clean-error wrapper
+# --------------------------------------------------------------------------- #
+def test_main_wrapper_prints_clean_error_no_traceback(monkeypatch, capsys):
+    class _Boom:
+        def __init__(self, config_path=None):
+            pass
+
+        def run(self):
+            raise ValueError("something friendly went wrong")
+
+    monkeypatch.setattr(trainer_mod, "TrainModel", _Boom)
+    monkeypatch.setattr(sys, "argv", ["praisonai-train", "train", "--config", "x.yaml"])
+
+    with pytest.raises(SystemExit) as exc:
+        trainer_mod.main()
+    assert exc.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "ERROR: something friendly went wrong" in captured.err
+    assert "Traceback" not in captured.err
+    assert "ValueError" not in captured.err
+
+
+def test_main_wrapper_keyboardinterrupt_clean(monkeypatch, capsys):
+    class _Interrupt:
+        def __init__(self, config_path=None):
+            pass
+
+        def run(self):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(trainer_mod, "TrainModel", _Interrupt)
+    monkeypatch.setattr(sys, "argv", ["praisonai-train", "train"])
+
+    with pytest.raises(SystemExit) as exc:
+        trainer_mod.main()
+    assert exc.value.code == 130
+    assert "Interrupted." in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# 2. Preflight validations
+# --------------------------------------------------------------------------- #
+def test_no_gpu_raises_friendly(monkeypatch):
+    obj = _make_trainer(_valid_config(), monkeypatch, gpu=False)
+    with pytest.raises(ValueError, match="No CUDA GPU detected"):
+        obj.validate_config()
+
+
+def test_missing_hf_token_raises_friendly(monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    obj = _make_trainer(
+        _valid_config(huggingface_save=True, hf_model_name="me/model"),
+        monkeypatch,
+    )
+    with pytest.raises(ValueError, match="HF_TOKEN is not set"):
+        obj.validate_config()
+
+
+def test_bad_quantization_raises_friendly(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "hf_fake")
+    obj = _make_trainer(
+        _valid_config(
+            huggingface_save_gguf=True, hf_model_name="me/model",
+            quantization_method="q4km",
+        ),
+        monkeypatch,
+    )
+    with pytest.raises(ValueError, match="quantization_method 'q4km' is not valid"):
+        obj.validate_config()
+
+
+def test_valid_quantization_passes(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "hf_fake")
+    obj = _make_trainer(
+        _valid_config(
+            huggingface_save_gguf=True, hf_model_name="me/model",
+            quantization_method="q4_k_m",
+        ),
+        monkeypatch,
+    )
+    obj.validate_config()  # must not raise
+
+
+def test_low_disk_raises_friendly(monkeypatch):
+    obj = _make_trainer(_valid_config(), monkeypatch, free_gb=3)
+    with pytest.raises(ValueError, match="free space or set output_dir"):
+        obj.validate_config()
+
+
+def test_check_gpu_no_crash_on_cpu(monkeypatch, capsys):
+    monkeypatch.setattr(trainer_mod, "torch", _FakeTorch(False), raising=False)
+    obj = trainer_mod.TrainModel.__new__(trainer_mod.TrainModel)
+    obj.check_gpu()  # must not raise on CPU-only
+    assert "No CUDA GPU" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# 3. Unknown-key warning with suggestion
+# --------------------------------------------------------------------------- #
+def test_unknown_key_suggestion(monkeypatch, capsys):
+    obj = _make_trainer(_valid_config(learnign_rate=1e-4), monkeypatch)
+    obj.validate_config()  # warns, does not raise
+    out = capsys.readouterr().out
+    assert "learnign_rate" in out
+    assert "did you mean 'learning_rate'" in out
+
+
+# --------------------------------------------------------------------------- #
+# 5. Ollama export robustness
+# --------------------------------------------------------------------------- #
+def test_ollama_push_401_translates(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ollama_mod, "_check_ollama_disk", lambda *_a, **_k: None)
+    monkeypatch.setattr(ollama_mod, "ensure_ollama_running", lambda *_a, **_k: None)
+
+    def _fake_run(cmd, *a, **k):
+        if "create" in cmd:
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        return types.SimpleNamespace(
+            returncode=1, stdout="", stderr="Error: 401 unauthorized: invalid key")
+
+    monkeypatch.setattr(ollama_mod.subprocess, "run", _fake_run)
+
+    with pytest.raises(RuntimeError, match="settings/keys"):
+        ollama_mod.create_and_push_ollama_model("me/model", "latest", "FROM ./model\n")
+
+
+def test_ollama_push_passes_quantize_flag(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ollama_mod, "_check_ollama_disk", lambda *_a, **_k: None)
+    monkeypatch.setattr(ollama_mod, "ensure_ollama_running", lambda *_a, **_k: None)
+    seen = {}
+
+    def _fake_run(cmd, *a, **k):
+        if "create" in cmd:
+            seen["create"] = cmd
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(ollama_mod.subprocess, "run", _fake_run)
+    ollama_mod.create_and_push_ollama_model(
+        "me/model", "latest", "FROM ./model\n", quantization="q4_k_m")
+    assert "--quantize" in seen["create"]
+    assert "q4_k_m" in seen["create"]
+
+
+def test_ollama_disk_precheck_triggers(monkeypatch, tmp_path):
+    monkeypatch.setenv("OLLAMA_MODELS", str(tmp_path))
+    monkeypatch.setattr(ollama_mod.shutil, "disk_usage", lambda *_a, **_k: _FreeDisk(1))
+    with pytest.raises(RuntimeError, match="OLLAMA_MODELS"):
+        ollama_mod._check_ollama_disk("FROM some-hub-id\n")
+
+
+# --------------------------------------------------------------------------- #
+# 8. Standalone export command dispatch
+# --------------------------------------------------------------------------- #
+def test_export_command_dispatches_hf(monkeypatch, tmp_path):
+    import praisonai_train.cli.commands.train as cli
+
+    called = {}
+
+    class _FakeTrainer:
+        @classmethod
+        def for_export(cls, cfg):
+            obj = cls()
+            obj.config = cfg
+            obj.model = None
+            obj.hf_tokenizer = None
+            return obj
+
+        def load_model(self):
+            return ("MODEL", "TOK")
+
+        def save_model_merged(self):
+            called["target"] = "hf"
+
+        def push_model_gguf(self):
+            called["target"] = "gguf"
+
+        def create_and_push_ollama_model(self):
+            called["target"] = "ollama"
+
+    monkeypatch.setattr(trainer_mod, "TrainModel", _FakeTrainer)
+
+    cli.train_export(
+        target="hf",
+        model_dir=str(tmp_path),
+        config=None,
+        ollama=None,
+        hf="me/model",
+        quant=None,
+        base_model="unsloth/gemma-2-2b",
+    )
+    assert called["target"] == "hf"
+
+
+def test_export_command_bad_target_exits(monkeypatch, tmp_path):
+    import typer
+    import praisonai_train.cli.commands.train as cli
+
+    with pytest.raises(typer.Exit):
+        cli.train_export(
+            target="bogus",
+            model_dir=str(tmp_path),
+            config=None,
+            ollama=None,
+            hf=None,
+            quant=None,
+            base_model=None,
+        )

--- a/src/praisonai-train/tests/unit/train/test_robustness.py
+++ b/src/praisonai-train/tests/unit/train/test_robustness.py
@@ -103,11 +103,16 @@ def test_no_gpu_raises_friendly(monkeypatch):
 
 def test_missing_hf_token_raises_friendly(monkeypatch):
     monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    # No cached login either.
+    monkeypatch.setattr(
+        trainer_mod.TrainModel, "_has_hf_credentials", staticmethod(lambda: False)
+    )
     obj = _make_trainer(
         _valid_config(huggingface_save=True, hf_model_name="me/model"),
         monkeypatch,
     )
-    with pytest.raises(ValueError, match="HF_TOKEN is not set"):
+    with pytest.raises(ValueError, match="no credentials were found"):
         obj.validate_config()
 
 
@@ -138,8 +143,33 @@ def test_valid_quantization_passes(monkeypatch):
 
 def test_low_disk_raises_friendly(monkeypatch):
     obj = _make_trainer(_valid_config(), monkeypatch, free_gb=3)
-    with pytest.raises(ValueError, match="free space or set output_dir"):
+    with pytest.raises(ValueError, match="Free up space or set output_dir"):
         obj.validate_config()
+
+
+def test_cached_hf_login_accepted(monkeypatch):
+    """A cached `huggingface-cli login` (no env token) must NOT be rejected."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    monkeypatch.setattr(
+        trainer_mod.TrainModel, "_has_hf_credentials", staticmethod(lambda: True)
+    )
+    obj = _make_trainer(
+        _valid_config(huggingface_save=True, hf_model_name="me/model"),
+        monkeypatch,
+    )
+    obj.validate_config()  # must not raise despite HF_TOKEN unset
+
+
+def test_train_false_skips_gpu_check(monkeypatch):
+    """Publish/export-only (train: false) must validate on a CPU-only box."""
+    monkeypatch.setenv("HF_TOKEN", "hf_fake")
+    obj = _make_trainer(
+        _valid_config(train=False, huggingface_save=True, hf_model_name="me/model"),
+        monkeypatch,
+        gpu=False,
+    )
+    obj.validate_config()  # must not raise the no-GPU error
 
 
 def test_check_gpu_no_crash_on_cpu(monkeypatch, capsys):
@@ -196,6 +226,32 @@ def test_ollama_push_passes_quantize_flag(monkeypatch, tmp_path):
         "me/model", "latest", "FROM ./model\n", quantization="q4_k_m")
     assert "--quantize" in seen["create"]
     assert "q4_k_m" in seen["create"]
+
+
+def test_ollama_create_failure_translates(monkeypatch, tmp_path):
+    """A failing `ollama create` becomes a clean RuntimeError, not a traceback."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ollama_mod, "_check_ollama_disk", lambda *_a, **_k: None)
+    monkeypatch.setattr(ollama_mod, "ensure_ollama_running", lambda *_a, **_k: None)
+
+    def _fake_run(cmd, *a, **k):
+        if "create" in cmd:
+            return types.SimpleNamespace(
+                returncode=1, stdout="", stderr="Error: invalid Modelfile")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(ollama_mod.subprocess, "run", _fake_run)
+    with pytest.raises(RuntimeError, match="ollama create"):
+        ollama_mod.create_and_push_ollama_model("me/model", "latest", "FROM ./model\n")
+
+
+def test_ollama_endpoint_honours_host_env(monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "http://remote-box:12345")
+    assert ollama_mod._ollama_endpoint() == ("remote-box", 12345)
+    monkeypatch.setenv("OLLAMA_HOST", "1.2.3.4")
+    assert ollama_mod._ollama_endpoint() == ("1.2.3.4", 11434)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    assert ollama_mod._ollama_endpoint() == ("127.0.0.1", 11434)
 
 
 def test_ollama_disk_precheck_triggers(monkeypatch, tmp_path):


### PR DESCRIPTION
## What & why

Makes `praisonai-train` usable by a **non-developer**: clean, actionable errors instead of tracebacks, preflight validation that fails in seconds (not after minutes of downloads), and export robustness for the exact Ollama/GGUF/HF failures we hit in practice. Every change is small, guarded, and preserves the happy-path behavior.

## Changes

### Clean errors (BLOCKER)
- `main()` wraps construction + `run()`: `ValueError`/`RuntimeError` print as a single `ERROR: <msg>` line and `exit(1)` — **no traceback**. `KeyboardInterrupt` → clean `Interrupted.` (exit 130). Real bugs still re-raise with a full trace.

### Preflight validation — fails FAST before any model/GPU load (BLOCKER)
- **No GPU**: `torch.cuda.is_available()` false → friendly "needs a GPU" message. `check_gpu()` no longer crashes raw on a CPU-only box.
- **Missing HF token**: publishing enabled but `HF_TOKEN` unset → tells the user to `huggingface-cli login` / `export HF_TOKEN` or set `huggingface_save: false`.
- **Low disk**: `<10 GB` free on the training disk → reports the free amount and suggests `output_dir`.
- **Bad `quantization_method`**: validated against the supported set with the valid values listed.

### Clearer warnings (MAJOR)
- Unknown config keys are collected and matched with `difflib` ("did you mean `learning_rate`?") in one block instead of per-key bare prints.
- Silent-behavior NOTES: `num_samples` takes the first N rows *before* shuffle; a `validation`/`test` `split_type` is **added to training** (use `val_split_ratio`); and the `max_steps: 2800` default fires when neither length is set.

### Export robustness (P0/P1)
- **Ollama** (`_ollama.py`): optional `--quantize` (so models aren't stored as huge f16); disk pre-check on the `OLLAMA_MODELS` volume with guidance to `export OLLAMA_MODELS=/big/disk`; **push 401/403** translated into "register `~/.ollama/id_ed25519.pub` at ollama.com/settings/keys and namespace the model". `ensure_ollama_running` waits 15s, probes `GET /api/version`, and includes `ollama serve` stderr in the timeout message.
- **Hugging Face** (`trainer.py`): `push_to_hub_merged`/`_gguf` translate `HfHubHTTPError` 401 → "token invalid/expired" and 403 → "no write access to '<repo>'". The pre-export `rmtree` is guarded so a namespaced repo id (`user/model`) is never treated as a local path to delete.
- **Templates**: warn when no known chat family matches (generic template, stop tokens may be wrong); fixed DeepSeek's broken empty stop tokens; never emit an empty `PARAMETER stop` line.

### New standalone `export` command (P1)
- `praisonai-train export <ollama|gguf|hf> --model-dir <dir> [--config] [--ollama user/name] [--hf user/name] [--quant q4_k_m] [--base-model id]` publishes an **already-trained** model without re-running training. Recovers the model name (for template selection) from `<model-dir>/config.json` `_name_or_path` or `--base-model`.

## Tests
- New `tests/unit/train/test_robustness.py` — 14 tests, all torch/HF/subprocess calls stubbed (no GPU, no network): main()-wrapper clean error, no-GPU / missing-token / bad-quant / low-disk preflight, unknown-key suggestion, Ollama push-401 translation, disk pre-check, `--quantize` passthrough, and export-command dispatch.
- Full suite: **165 passed** (151 existing + 14 new), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI `export` command to convert trained models to **HF**, **GGUF**, or **Ollama**, with support for export config, optional identifiers, and quantization/base-model options.
* **Bug Fixes**
  * Strengthened export preflight validation (GPU/disk/token/quantization), improved unknown-key reporting, and enhanced Ollama readiness and subprocess error handling.
  * Improved generated Modelfile stop-token handling and clearer interruption/error output.
* **Tests**
  * Added robustness tests covering validation failures, export dispatch, Ollama behaviors, and friendly error/exit-code handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->