### PR TITLE
fix: read bundled default_app.py using UTF-8

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/commands/ui.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/ui.py
@@ -82,7 +82,9 @@ def _launch_aiui_app(
                     'Install with:\n  pip install "praisonai[ui]"\033[0m'
                 )
                 sys.exit(1)
-            default_app.write_text(bundled.read_text())
+            default_app.write_text(
+            bundled.read_text(encoding="utf-8"), encoding="utf-8"
+             )
             print(f"   ✓ Created default {ui_name} config: {default_app}")
         
         resolved = default_app

--- a/src/praisonai-code/tests/unit/test_ui_command.py
+++ b/src/praisonai-code/tests/unit/test_ui_command.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from praisonai_code.cli.commands.ui import _launch_aiui_app
+
+
+def test_launch_aiui_copies_default_app_using_utf8(tmp_path, monkeypatch):
+    """Regression test for Windows UnicodeDecodeError when copying
+    bundled default_app.py.
+    """
+
+    # Create a fake bundled UI app containing UTF-8 characters.
+    bundled = tmp_path / "default_app.py"
+    expected = '"""Hello — café 😀 中文"""\n'
+    bundled.write_text(expected, encoding="utf-8")
+
+    # Redirect ~/.praisonai to our temporary directory.
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    # Pretend the bundled file exists.
+    with patch(
+        "praisonai_code.cli.commands.ui._resolve_bundled_default_app",
+        return_value=bundled,
+    ), patch(
+        "importlib.util.find_spec",
+        return_value=object(),
+    ), patch(
+        "subprocess.run"
+    ):
+        _launch_aiui_app(
+            app_dir="ui",
+            default_app_name="ui_chat",
+            port=8081,
+            host="127.0.0.1",
+            app_file=None,
+            reload=False,
+            ui_name="Chat",
+        )
+
+    created = tmp_path / ".praisonai" / "ui" / "app.py"
+
+    assert created.exists()
+    assert created.read_text(encoding="utf-8") == expected


### PR DESCRIPTION
## Summary

This PR fixes a Windows-specific `UnicodeDecodeError` that occurred when launching the bundled UI with:

```bash
praisonai ui
```

The bundled `default_app.py` contains UTF-8 characters (such as em dashes), but it was being read using the platform's default text encoding. On Windows, this defaults to CP1252, which caused the command to fail with a `UnicodeDecodeError`.

This change explicitly reads and writes the bundled `default_app.py` using UTF-8, ensuring consistent behavior across platforms.

## Changes

- Explicitly read the bundled `default_app.py` using `encoding="utf-8"`.
- Explicitly write the generated user `app.py` using `encoding="utf-8"`.
- Added a regression test to verify that UTF-8 encoded bundled UI assets are copied correctly.

## Testing

### Automated Tests

Added a new unit test:

- `test_launch_aiui_copies_default_app_using_utf8`

Verified with:

```bash
pytest src/praisonai-code/tests/unit/test_ui_command.py -v
```

Result:

```text
1 passed
```

Also verified by running the targeted test suite:

```bash
pytest -k test_ui_command
```

Result:

```text
1 passed, 329 deselected
```

### Manual Testing

Verified on Windows by running:

```bash
praisonai ui
```

The UI now launches successfully, and the default `app.py` is created without raising a `UnicodeDecodeError`.

## Why this change?

This is a small, targeted fix that improves cross-platform compatibility by ensuring UTF-8 is used consistently when copying bundled UI assets. The accompanying regression test helps prevent this issue from recurring in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI app setup to correctly preserve UTF-8 characters when copying the bundled default app.
  * Prevents character corruption in generated UI files across supported environments.

* **Tests**
  * Added coverage verifying that UTF-8 content is copied accurately during UI initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->