### PR TITLE
fix: stop project config discovery at home directory

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/configuration/resolver.py
+++ b/src/praisonai-code/praisonai_code/cli/configuration/resolver.py
@@ -531,9 +531,12 @@ class ConfigResolver:
     def _load_project_config(self) -> Optional[Dict[str, Any]]:
         """Load project configuration with walk-up discovery.
 
-        Walk-up stops at (and does not walk past) the user's home directory.
-        Home itself is still searched for project configs (e.g.
-        ``~/praison.yaml``). The legacy ``.praison/config.toml`` is
+        Walk-up stops before reaching the user's home directory, so home is
+        never treated as a project directory (its configs, e.g.
+        ``~/praison.yaml``, are not discovered here). This prevents a
+        profile-level file from being mislabelled as a ``project:`` source —
+        important on platforms where temporary project directories live under
+        the user's profile. The legacy ``.praison/config.toml`` is
         intentionally NOT a project config name — it is a global user config
         loaded exclusively by ``_load_global_config()`` with a ``global:``
         label. Keeping it out of ``PROJECT_CONFIG_NAMES`` prevents the walk-up

--- a/src/praisonai-code/praisonai_code/cli/configuration/resolver.py
+++ b/src/praisonai-code/praisonai_code/cli/configuration/resolver.py
@@ -555,13 +555,17 @@ class ConfigResolver:
         
         # Collect paths from current directory upward
         while current != current.parent:
-            search_paths.append(current)
-            if git_root and current == git_root:
-                break  # Stop at git root if found
+            # Never treat the user's home directory as a project directory.
             if home is not None and current == home:
-                break  # Do not walk past home into shared parents
+                break
+
+            search_paths.append(current)
+
+            if git_root and current == git_root:
+                break
+
             current = current.parent
-        
+                
         # Search for config files
         for search_dir in search_paths:
             for config_name in self.PROJECT_CONFIG_NAMES:
@@ -572,7 +576,6 @@ class ConfigResolver:
                         data["_source"] = str(config_path)
                         self._validate(data, str(config_path))
                         return data
-        
         return None
     
     def _managed_source_spec(self) -> Dict[str, Any]:

--- a/src/praisonai-code/tests/unit/test_config_interpolation_provenance.py
+++ b/src/praisonai-code/tests/unit/test_config_interpolation_provenance.py
@@ -85,10 +85,17 @@ def test_resolve_with_provenance_env_overrides_project(tmp_path, monkeypatch):
     assert prov["agent.model"]["layer"] == "environment"
 
 
-def test_resolve_with_provenance_defaults_present(tmp_path):
+def test_resolve_with_provenance_defaults_present(tmp_path, monkeypatch):
+    
+    monkeypatch.setattr(
+        ConfigResolver,
+        "_load_global_config",
+        lambda self: None,
+    )
+
     resolver = ConfigResolver(cwd=tmp_path)
     prov = resolver.resolve_with_provenance()
-    # With no config files, values come from built-in defaults.
+
     assert prov["telemetry"]["layer"] == "defaults"
 
 

--- a/src/praisonai-code/tests/unit/test_config_interpolation_provenance.py
+++ b/src/praisonai-code/tests/unit/test_config_interpolation_provenance.py
@@ -99,6 +99,31 @@ def test_resolve_with_provenance_defaults_present(tmp_path, monkeypatch):
     assert prov["telemetry"]["layer"] == "defaults"
 
 
+def test_project_config_ignores_home_directory(tmp_path, monkeypatch):
+    # A config at the user's home directory must not be discovered as a
+    # project config (regression for the home-directory walk-up boundary).
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "praison.yaml").write_text("agent:\n  model: home-model\n")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    resolver = ConfigResolver(cwd=home)
+    assert resolver._load_project_config() is None
+
+
+def test_project_config_ignores_home_when_cwd_below_home(tmp_path, monkeypatch):
+    # Walking up from a sub-directory must stop before home, so a home-level
+    # config is never picked up while still allowing project-level configs.
+    home = tmp_path / "home"
+    project = home / "project"
+    project.mkdir(parents=True)
+    (home / "praison.yaml").write_text("agent:\n  model: home-model\n")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    resolver = ConfigResolver(cwd=project)
+    assert resolver._load_project_config() is None
+
+
 def test_interpolate_env_missing_no_default_preserves_directive(monkeypatch):
     # {env:VAR} with no default and unset var stays visible (like ${VAR}).
     monkeypatch.delenv("UNSET_KEY", raising=False)


### PR DESCRIPTION

## Summary

This change prevents the project configuration walk-up from treating the user's home directory as a project directory. Previously, if a user had a configuration file in their home directory (for example, `~/.praisonai/config.yaml`), the resolver could incorrectly discover it during project configuration lookup and label it as a project configuration. This could lead to incorrect configuration resolution and provenance, particularly on Windows where temporary project directories are commonly created under the user's profile.

## Changes

* Stop the project configuration walk-up before reaching the user's home directory.
* Continue stopping at the Git repository root when one exists.
* Update the provenance tests to ensure the resolver correctly falls back to the default configuration when no project configuration is present.

## Testing

```bash
pytest tests/unit/test_config_interpolation_provenance.py -vv
```

**Result:** All 15 tests passed.

This change is limited to project configuration discovery and its associated tests. It does not modify the managed configuration functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project configuration discovery no longer searches the user’s home directory for `praison.yaml`.
  * Configuration resolution now preserves built-in default values and correctly records provenance when no configuration files are present.
* **Tests**
  * Added regression coverage to ensure home-directory config files are ignored, including when the current working directory is at or beneath the home directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->