### PR TITLE
fix: serialize workspace paths consistently across platforms

### DIFF
--- a/src/praisonai/praisonai/acp/session.py
+++ b/src/praisonai/praisonai/acp/session.py
@@ -80,7 +80,7 @@ class ACPSession:
         """Serialize session to dictionary."""
         return {
             "session_id": self.session_id,
-            "workspace": str(self.workspace),
+            "workspace": self.workspace.as_posix(),
             "created_at": self.created_at,
             "last_activity": self.last_activity,
             "agent_id": self.agent_id,


### PR DESCRIPTION
## Summary

Normalize serialized workspace paths by using POSIX-style separators during session serialization.

Previously, `Path` objects were serialized using their platform-native string representation. On Windows this produced paths like:

```
\tmp\test
```

while tests and serialized session data expected the platform-independent form:

```
/tmp/test
```

This caused cross-platform inconsistencies and test failures.

## Changes

- Serialize workspace paths using:

```python
self.workspace.as_posix()
```

instead of the default string representation.

## Why

Using `Path.as_posix()` provides a consistent serialized representation across all operating systems while preserving the actual filesystem path internally.

This makes session serialization deterministic and avoids platform-specific test failures.

## Testing

### Before

```
pytest src/praisonai/tests/unit/acp/test_session.py::TestACPSession::test_to_dict -vv
```

Failed with:

```
AssertionError:
'\\tmp\\test' != '/tmp/test'
```

### After

```
pytest src/praisonai/tests/unit/acp/test_session.py -vv
```

Result:

```
12 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workspace path serialization to use a consistent, portable path format while preserving the existing session data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->