### PR TITLE
ci(release): single commit per release, authored by praisonai-triage-agent[bot]

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -147,14 +147,28 @@ jobs:
       # PyPI API token auth: username __token__, password = pypi-… token (see pypi.org/help/#invalid-auth)
       UV_PUBLISH_USERNAME: __token__
       UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_TOKEN || secrets.PYPI_API_TOKEN }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      # GH_TOKEN is NOT set here: it is a GitHub App installation token minted in
+      # "Generate GitHub App token" and exported via $GITHUB_ENV, so releases are
+      # authored by praisonai-triage-agent[bot] rather than MervinPraison.
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout main
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+          # Do not bake the token into .git/config: an http.extraheader would
+          # outrank the remote URL set in "Configure git" and pin this first
+          # (1h) token, defeating the refresh before the wrapper release.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -165,10 +179,19 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
 
       - name: Configure git
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
         run: |
-          git config user.name "MervinPraison"
-          git config user.email "454862+MervinPraison@users.noreply.github.com"
-          gh auth setup-git
+          set -euo pipefail
+          git config user.name "praisonai-triage-agent[bot]"
+          git config user.email "272766704+praisonai-triage-agent[bot]@users.noreply.github.com"
+          # persist-credentials:false left the remote unauthenticated; push auth
+          # comes from the app token embedded here (masked in logs, and the
+          # token dies with the runner).
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git"
+          echo "GH_TOKEN=${APP_TOKEN}" >> "$GITHUB_ENV"
+          GH_TOKEN="${APP_TOKEN}" gh auth setup-git
 
       - name: Release summary
         run: |
@@ -610,19 +633,6 @@ jobs:
             sleep "$INTERVAL"
           done
 
-      - name: Commit agents version bump
-        if: >-
-          inputs.dry_run != true &&
-          inputs.skip_agents != true &&
-          steps.pypi_exists.outputs.skip_agents != 'true'
-        run: |
-          set -euo pipefail
-          git add src/praisonai-agents/pyproject.toml src/praisonai-agents/uv.lock
-          git diff --cached --quiet && { echo "No agents files to commit"; exit 0; }
-          git commit -m "Bump praisonaiagents to ${{ steps.versions.outputs.agents_version }}"
-          git pull --rebase origin main
-          git push origin main
-
       - name: Publish praisonai-code
         if: >-
           inputs.dry_run != true &&
@@ -679,19 +689,6 @@ jobs:
             echo "⏳ Waiting for ${PACKAGE}==${VERSION} ($(( MAX_WAIT - ELAPSED ))s remaining...)"
             sleep "$INTERVAL"
           done
-
-      - name: Commit praisonai-code version bump
-        if: >-
-          inputs.dry_run != true &&
-          inputs.skip_code != true &&
-          steps.pypi_exists.outputs.skip_code != 'true'
-        run: |
-          set -euo pipefail
-          git add src/praisonai-code/pyproject.toml src/praisonai-code/uv.lock src/praisonai-code/praisonai_code/__init__.py
-          git diff --cached --quiet && { echo "No code files to commit"; exit 0; }
-          git commit -m "Bump praisonai-code to ${{ steps.versions.outputs.code_version }}"
-          git pull --rebase origin main
-          git push origin main
 
       - name: Publish praisonai-bot
         if: >-
@@ -750,19 +747,6 @@ jobs:
             sleep "$INTERVAL"
           done
 
-      - name: Commit praisonai-bot version bump
-        if: >-
-          inputs.dry_run != true &&
-          inputs.skip_bot != true &&
-          steps.pypi_exists.outputs.skip_bot != 'true'
-        run: |
-          set -euo pipefail
-          git add src/praisonai-bot/pyproject.toml src/praisonai-bot/uv.lock src/praisonai-bot/praisonai_bot/_version.py
-          git diff --cached --quiet && { echo "No bot files to commit"; exit 0; }
-          git commit -m "Bump praisonai-bot to ${{ steps.versions.outputs.bot_version }}"
-          git pull --rebase origin main
-          git push origin main
-
       - name: Publish praisonai-train
         if: >-
           inputs.dry_run != true &&
@@ -819,19 +803,6 @@ jobs:
             echo "⏳ Waiting for ${PACKAGE}==${VERSION} ($(( MAX_WAIT - ELAPSED ))s remaining...)"
             sleep "$INTERVAL"
           done
-
-      - name: Commit praisonai-train version bump
-        if: >-
-          inputs.dry_run != true &&
-          inputs.skip_train != true &&
-          steps.pypi_exists.outputs.skip_train != 'true'
-        run: |
-          set -euo pipefail
-          git add src/praisonai-train/pyproject.toml src/praisonai-train/uv.lock src/praisonai-train/praisonai_train/_version.py
-          git diff --cached --quiet && { echo "No train files to commit"; exit 0; }
-          git commit -m "Bump praisonai-train to ${{ steps.versions.outputs.train_version }}"
-          git pull --rebase origin main
-          git push origin main
 
       - name: Publish praisonai-browser
         if: >-
@@ -890,19 +861,6 @@ jobs:
             sleep "$INTERVAL"
           done
 
-      - name: Commit praisonai-browser version bump
-        if: >-
-          inputs.dry_run != true &&
-          inputs.skip_browser != true &&
-          steps.pypi_exists.outputs.skip_browser != 'true'
-        run: |
-          set -euo pipefail
-          git add src/praisonai-browser/pyproject.toml src/praisonai-browser/uv.lock src/praisonai-browser/praisonai_browser/_version.py
-          git diff --cached --quiet && { echo "No browser files to commit"; exit 0; }
-          git commit -m "Bump praisonai-browser to ${{ steps.versions.outputs.browser_version }}"
-          git pull --rebase origin main
-          git push origin main
-
       - name: Publish praisonai-mcp
         if: >-
           inputs.dry_run != true &&
@@ -959,19 +917,6 @@ jobs:
             echo "⏳ Waiting for ${PACKAGE}==${VERSION} ($(( MAX_WAIT - ELAPSED ))s remaining...)"
             sleep "$INTERVAL"
           done
-
-      - name: Commit praisonai-mcp version bump
-        if: >-
-          inputs.dry_run != true &&
-          inputs.skip_mcp != true &&
-          steps.pypi_exists.outputs.skip_mcp != 'true'
-        run: |
-          set -euo pipefail
-          git add src/praisonai-mcp/pyproject.toml src/praisonai-mcp/uv.lock src/praisonai-mcp/praisonai_mcp/_version.py
-          git diff --cached --quiet && { echo "No mcp files to commit"; exit 0; }
-          git commit -m "Bump praisonai-mcp to ${{ steps.versions.outputs.mcp_version }}"
-          git pull --rebase origin main
-          git push origin main
 
       - name: Publish praisonai-sandbox
         if: >-
@@ -1030,19 +975,6 @@ jobs:
             sleep "$INTERVAL"
           done
 
-      - name: Commit praisonai-sandbox version bump
-        if: >-
-          inputs.dry_run != true &&
-          inputs.skip_sandbox != true &&
-          steps.pypi_exists.outputs.skip_sandbox != 'true'
-        run: |
-          set -euo pipefail
-          git add src/praisonai-sandbox/pyproject.toml src/praisonai-sandbox/uv.lock src/praisonai-sandbox/praisonai_sandbox/_version.py
-          git diff --cached --quiet && { echo "No sandbox files to commit"; exit 0; }
-          git commit -m "Bump praisonai-sandbox to ${{ steps.versions.outputs.sandbox_version }}"
-          git pull --rebase origin main
-          git push origin main
-
       - name: Publish praisonai-deploy
         if: >-
           inputs.dry_run != true &&
@@ -1100,18 +1032,31 @@ jobs:
             sleep "$INTERVAL"
           done
 
-      - name: Commit praisonai-deploy version bump
-        if: >-
-          inputs.dry_run != true &&
-          inputs.skip_deploy != true &&
-          steps.pypi_exists.outputs.skip_deploy != 'true'
+      # All per-package version bumps are still uncommitted at this point: the
+      # wrapper release below stages every one of them (bump_and_release.py's
+      # release_files list) into a SINGLE "Release v…" commit.
+
+      # App tokens expire after 1h and this job can exceed that (9 packages ×
+      # up to a 600s PyPI wait). Re-mint so the final commit/tag/push/release
+      # never runs on an expired token.
+      - name: Refresh GitHub App token
+        id: app-token-final
+        if: ${{ !cancelled() && inputs.dry_run != true }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Use refreshed GitHub App token
+        if: ${{ !cancelled() && inputs.dry_run != true }}
+        env:
+          APP_TOKEN: ${{ steps.app-token-final.outputs.token }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          git add src/praisonai-deploy/pyproject.toml src/praisonai-deploy/uv.lock src/praisonai-deploy/praisonai_deploy/_version.py
-          git diff --cached --quiet && { echo "No deploy files to commit"; exit 0; }
-          git commit -m "Bump praisonai-deploy to ${{ steps.versions.outputs.deploy_version }}"
-          git pull --rebase origin main
-          git push origin main
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git"
+          echo "GH_TOKEN=${APP_TOKEN}" >> "$GITHUB_ENV"
 
       - name: Bump and release wrapper
         if: >-
@@ -1129,7 +1074,7 @@ jobs:
             --mcp-pin "${{ steps.versions.outputs.mcp_version }}" \
             --sandbox-pin "${{ steps.versions.outputs.sandbox_version }}" \
             --deploy-pin "${{ steps.versions.outputs.deploy_version }}" \
-            --wait --max-wait 600 --no-add-all
+            --wait --max-wait 600 --no-add-all --force
 
       - name: Publish praisonai wrapper to PyPI
         if: >-
@@ -1215,3 +1160,20 @@ jobs:
           if [ "${{ inputs.skip_wrapper }}" != "true" ]; then
             echo "✅ praisonai==${WRAPPER}"
           fi
+
+      # Safety net. On a clean run the wrapper's "Release v…" commit already
+      # carries every bump and this is a no-op. It only fires when the single
+      # commit could not happen: a package publish failed midway (those versions
+      # are already live on PyPI, so the bumps must not be lost), skip_wrapper
+      # was set, or the wrapper itself failed.
+      - name: Persist any uncommitted version bumps
+        if: ${{ !cancelled() && inputs.dry_run != true }}
+        run: |
+          set -euo pipefail
+          # -u = tracked modifications only; uv build output under dist/ is
+          # untracked and stays out of the commit.
+          git add -u
+          git diff --cached --quiet && { echo "Nothing left to commit"; exit 0; }
+          git commit -m "chore(release): persist version bumps [skip ci]"
+          git pull --rebase origin main
+          git push origin main

--- a/src/praisonai-deploy/infra/compose/agents-stack/.env.example
+++ b/src/praisonai-deploy/infra/compose/agents-stack/.env.example
@@ -4,9 +4,10 @@
 AGENTS_FILE=./agents.yaml
 API_PORT=8005
 
-# Postgres host binding: keep 127.0.0.1 to avoid exposing the DB on all interfaces.
-POSTGRES_BIND=127.0.0.1
 POSTGRES_PORT=5432
+# Host interface Postgres is published on. Defaults to loopback; only set to
+# 0.0.0.0 when the host network is trusted.
+POSTGRES_BIND=127.0.0.1
 POSTGRES_USER=praisonai
 POSTGRES_DB=praisonai
 # REQUIRED — generate a strong unique value, e.g. `openssl rand -hex 24`.

--- a/src/praisonai-deploy/infra/compose/agents-stack/docker-compose.yml
+++ b/src/praisonai-deploy/infra/compose/agents-stack/docker-compose.yml
@@ -19,7 +19,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-    # Bind to loopback by default so Postgres is not exposed on all host interfaces.
+    # Bound to loopback by default so the DB is not published on every host
+    # interface. Override POSTGRES_BIND=0.0.0.0 only for trusted networks.
     ports:
       - "${POSTGRES_BIND:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
 


### PR DESCRIPTION
## Problem

A full `pypi-release.yml` run lands **9 separate commits and 9 pushes** on `main` — one per package (`praisonaiagents`, `praisonai-code`, `-bot`, `-train`, `-browser`, `-mcp`, `-sandbox`, `-deploy`, then the wrapper) — and every one is authored as **MervinPraison**.

## 1. One commit instead of nine

Deleted the 8 `Commit <pkg> version bump` steps. They were redundant: the wrapper step already calls `bump_and_release.py --no-add-all`, and that script's `release_files` list is a **superset of every file those steps staged**. All bumps now land in the script's single `Release v<x.y.z>` commit → one commit, one tag, one push.

This required adding `--force` to the invocation: with the per-package commits gone the tree is dirty when the script runs, and its pre-flight guard `sys.exit(1)`s under `--no-add-all`. `--no-add-all` still restricts staging to the explicit file list, so `--force` only suppresses the dirty-tree abort.

A trailing **`Persist any uncommitted version bumps`** step (`if: !cancelled()`) covers what the single commit can't:

- a package publish failing midway — those versions are already live on PyPI, so the bumps must not be lost
- `skip_wrapper: true`
- the wrapper itself failing

It's a no-op on a clean run, and uses `git add -u` so untracked `uv build` output stays out.

## 2. Commits authored by `praisonai-triage-agent[bot]`

Mints an installation token from `secrets.CLAUDE_APP_ID` / `CLAUDE_APP_PRIVATE_KEY` — the app already behind that bot in `claude.yml`, `claude-merge-gate.yml` and `pipeline-status-sync.yml`. Git identity becomes `praisonai-triage-agent[bot] <272766704+praisonai-triage-agent[bot]@users.noreply.github.com>`, and `GH_TOKEN` is exported via `$GITHUB_ENV` — so the commit, the tag push and `gh release create` are all the bot's. `secrets.GH_TOKEN` is no longer referenced.

Two details this depends on:

- **Token expiry.** App tokens last 1h and this job can exceed that (9 packages × up to a 600s PyPI wait each), so the token is **re-minted immediately before the wrapper release**.
- **`persist-credentials: false`** on checkout — otherwise its `http.extraheader` outranks the remote URL and pins the first, expiring token, defeating the refresh.

## Verification

**The identity string is copied from real commits, not guessed.** Existing bot commits in this repo carry exactly `praisonai-triage-agent[bot]` / `272766704+praisonai-triage-agent[bot]@users.noreply.github.com` — e.g. `15f58fb7`, `07767fea`.

**No repo-settings change is required.** Verified against the live repo:

| Check | Result |
|---|---|
| Classic branch protection on `main` | None (`404 Branch not protected`) |
| Rulesets targeting `main` | `preventdelete` + `restrictdeletion` — rules are `deletion` and `non_fast_forward` only |
| Any `pull_request` rule on `main` | **No** — direct pushes to `main` are permitted |
| App has `contents: write` | Yes — it already pushes non-merge commits reachable from `main` |
| App has `workflows: write` | Yes — commits `52c729d4`, `98701ee2`, `78cdb340` are single-parent commits by the bot that modify `.github/workflows/`, which GitHub rejects without that permission |

The one active constraint on `main` is `non_fast_forward`, which this flow respects: the release does `git pull --rebase origin main && git push origin main` (fast-forward), and the `git push --tags -f` targets tags, which a branch-target ruleset doesn't cover.

Other checks:

- YAML parses; `actionlint` reports only the same pre-existing `SC2129` style warning already present on `main` (confirmed by re-running against a stash) — no new findings.
- `src/praisonai/scripts/bump_and_release.py` is **unchanged** — it shells out to bare `git`/`gh` and inherits both the repo config and `GH_TOKEN`.

Suggested checks on the first real release after merge:

1. `git log --oneline -5 origin/main` shows **one** new `Release v…` commit, not nine.
2. `git log -1 --format='%an <%ae>' origin/main` → the bot.
3. The commit appears under [`?author=praisonai-triage-agent[bot]`](https://github.com/MervinPraison/PraisonAI/commits?author=praisonai-triage-agent%5Bbot%5D).
4. `gh release view v<new>` — author is the bot.
5. Failure path: `-f skip_wrapper=true` should produce the single `chore(release): persist version bumps` commit instead.

## Out of scope

`release.yml`, `update-api-md.yml`, `update-docs-parity.yml` and `update-parity-tracker.yml` also commit as MervinPraison, but they're doc automation rather than releases — deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved automated package releases with safer authentication and consolidated version updates.
  * Added a final safeguard to commit and publish any remaining release changes.

* **Documentation**
  * Clarified database port configuration guidance.
  * Documented loopback binding as the default and advised using broader network access only on trusted networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->