### PR TITLE
ci(release): scope the release app token to this repository

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -158,6 +158,10 @@ jobs:
           app-id: ${{ secrets.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # Scope to this repo only. Without it the token is minted for every
+          # repository the owner has; this job never leaves PraisonAI (checkout,
+          # push to origin, and gh release create all target it).
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout main
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -1047,6 +1051,7 @@ jobs:
           app-id: ${{ secrets.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Use refreshed GitHub App token
         if: ${{ !cancelled() && inputs.dry_run != true }}


### PR DESCRIPTION
## Gap

Follow-up to #3572. Both `actions/create-github-app-token` steps in `pypi-release.yml` omitted `repositories:`, so the dry-run log reported:

```
repositories not set, creating token for all repositories for given owner "MervinPraison"
```

The installation token therefore carried write access to **every repository under the account** for the duration of the release, while the job only ever touches `PraisonAI`. Least-privilege gap rather than a bug — nothing was broken, the blast radius was just wider than the work.

## Fix

Add `repositories: ${{ github.event.repository.name }}` to both mint steps (the initial one and the mid-job refresh).

## Why this is safe

Verified the release job is single-repo before narrowing:

- No cross-repo call anywhere in `pypi-release.yml` — no `gh repo`/`gh api` against another repo, no secondary clone.
- `bump_and_release.py`'s only `gh` invocation is `gh release create` against this repo; every git operation targets `origin`.

## Verification

- YAML parses; `actionlint` reports only the same pre-existing `SC2129` style warning already on `main` — no new findings.
- A `dry_run=true` release will be run after merge to confirm the token still mints with the scoped value (the mint step is the only thing this change can affect, and dry run exercises it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation security by restricting generated access tokens to the current repository.
  * No changes to release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->