### PR TITLE
ci(release): name the packages in the safety-net commit message

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1179,6 +1179,17 @@ jobs:
           # untracked and stays out of the commit.
           git add -u
           git diff --cached --quiet && { echo "Nothing left to commit"; exit 0; }
-          git commit -m "chore(release): persist version bumps [skip ci]"
+          # Name the packages actually staged, so a single-package release
+          # (every other skip_* set) reads "bump praisonai-mcp" rather than a
+          # generic message. Falls back when nothing under src/ is staged.
+          PKGS="$(git diff --cached --name-only \
+            | sed -n 's#^src/\([^/]*\)/.*#\1#p' | sort -u | tr '\n' ' ' | sed 's/ *$//')"
+          if [ -n "$PKGS" ]; then
+            MSG="chore(release): bump ${PKGS} [skip ci]"
+          else
+            MSG="chore(release): persist version bumps [skip ci]"
+          fi
+          echo "Commit message: ${MSG}"
+          git commit -m "$MSG"
           git pull --rebase origin main
           git push origin main


### PR DESCRIPTION
## Context

Follow-up to #3572, which collapsed the release to a single commit and removed the per-package `Bump praisonai-mcp to 0.0.12` commits.

For a **full** release that's fine — the wrapper's `Release v<x.y.z>` commit describes the whole batch. But a **single-package** release (every other `skip_*` set, including `skip_wrapper`) never reaches the wrapper step, so its bump lands via the safety-net step and was labelled with the generic `chore(release): persist version bumps [skip ci]`.

That's a small regression #3572 introduced for exactly the single-package case.

## Change

Derive the package list from the staged paths:

```bash
PKGS="$(git diff --cached --name-only \
  | sed -n 's#^src/\([^/]*\)/.*#\1#p' | sort -u | tr '\n' ' ' | sed 's/ *$//')"
```

So a single-package release now commits as:

```
chore(release): bump praisonai-mcp [skip ci]
```

Falls back to the previous generic message when nothing under `src/` is staged (e.g. only wrapper-level files like `docker/Dockerfile`).

## Verification

Extraction logic tested against a scratch git repo:

| Case | Result |
|---|---|
| Single package, 3 files staged (`pyproject.toml`, `_version.py`, `uv.lock`) | `praisonai-mcp` |
| Two packages | `praisonai-code praisonai-mcp` |
| Nothing under `src/` | empty → generic message |

`actionlint` reports only the same pre-existing `SC2129` warning already on `main` — no new findings. No behaviour change on a full release, where this step remains a no-op (`Nothing left to commit`), as observed in release v4.6.159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release commit messages to include the names of staged packages when available.
  * Retained a generic fallback message when no package paths are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->