### PR TITLE
fix(claude-code): live progress from stream-json + on_event callback

### DIFF
--- a/src/praisonai/praisonai/integrations/claude_code.py
+++ b/src/praisonai/praisonai/integrations/claude_code.py
@@ -27,6 +27,7 @@ Usage:
     tool = claude.as_tool()
 """
 
+import inspect
 import json
 import os
 from typing import AsyncIterator, Dict, Any, Optional, List
@@ -185,7 +186,11 @@ class ClaudeCodeIntegration(BaseCLIIntegration):
         Returns:
             str: The CLI output (parsed from JSON if output_format is "json")
         """
-        if self.use_sdk:
+        # Live progress requires the stream-json subprocess path; the SDK path
+        # yields no partial events. When a progress sink is supplied, route
+        # through the subprocess so callers are never silently dropped.
+        wants_progress = ("on_event" in options) or ("on_progress" in options)
+        if self.use_sdk and not wants_progress:
             return await self._execute_sdk(prompt, **options)
         
         return await self._execute_subprocess(prompt, **options)
@@ -226,17 +231,20 @@ class ClaudeCodeIntegration(BaseCLIIntegration):
     async def _execute_streaming(self, prompt: str, on_event, **options) -> str:
         """Stream the run, forward each event to ``on_event``, return final text.
 
-        ``on_event`` may raise nothing meaningful -- a broken progress sink must
-        not fail the underlying work -- so its exceptions are swallowed. The
-        final text is taken from the terminal ``result`` event when present,
-        otherwise accumulated from ``text_delta`` chunks.
+        ``on_event`` may be sync or ``async``; awaitable results are awaited so
+        coroutine callbacks actually run. A broken progress sink must not fail
+        the underlying work, so its exceptions are swallowed. The final text is
+        taken from the terminal ``result`` event when present, otherwise
+        accumulated from ``text_delta`` chunks.
         """
         options.pop("output_format", None)  # streaming forces stream-json
         final_result = None
         text_parts: List[str] = []
         async for event in self.stream(prompt, **options):
             try:
-                on_event(event)
+                callback_result = on_event(event)
+                if inspect.isawaitable(callback_result):
+                    await callback_result
             except Exception:
                 pass
             if not isinstance(event, dict):

--- a/src/praisonai/praisonai/integrations/claude_code.py
+++ b/src/praisonai/praisonai/integrations/claude_code.py
@@ -135,7 +135,13 @@ class ClaudeCodeIntegration(BaseCLIIntegration):
         # Add output format (local parameter takes precedence)
         fmt = output_format or self.output_format
         cmd.extend(["--output-format", fmt])
-        
+
+        # stream-json in print mode REQUIRES --verbose, and --include-partial-
+        # messages is what emits the token/tool-use deltas that make live
+        # progress visible. Without these, `claude -p --output-format
+        # stream-json` errors out, so stream() could never work.
+        stream_json = fmt == "stream-json"
+
         # Add continue flag if needed
         if continue_session:
             cmd.append("--continue")
@@ -156,13 +162,16 @@ class ClaudeCodeIntegration(BaseCLIIntegration):
         if self.disallowed_tools:
             cmd.extend(["--disallowedTools", ",".join(self.disallowed_tools)])
         
-        # Add verbose if needed
-        if options.get('verbose'):
+        # Add verbose if needed (forced for stream-json, which the CLI rejects
+        # without it).
+        if options.get('verbose') or stream_json:
             cmd.append("--verbose")
-        
+        if stream_json:
+            cmd.append("--include-partial-messages")
+
         # Add prompt last
         cmd.append(prompt)
-        
+
         return cmd
     
     async def execute(self, prompt: str, **options) -> str:
@@ -182,14 +191,25 @@ class ClaudeCodeIntegration(BaseCLIIntegration):
         return await self._execute_subprocess(prompt, **options)
     
     async def _execute_subprocess(self, prompt: str, **options) -> str:
-        """Execute using subprocess."""
+        """Execute using subprocess.
+
+        If an ``on_event`` (or ``on_progress``) callable is passed, the run is
+        streamed via ``stream()`` and every parsed event is handed to it while
+        it is still in flight, so a caller/UI can show live progress ("reading
+        X", "running tool Y") instead of blocking on a single final result. The
+        method still returns the final result text in every case.
+        """
+        on_event = options.pop("on_event", None) or options.pop("on_progress", None)
+        if on_event is not None:
+            return await self._execute_streaming(prompt, on_event, **options)
+
         output_format = options.pop("output_format", self.output_format)
         continue_session = options.pop("continue_session", False)
-        
+
         cmd = self._build_command(prompt, output_format=output_format, continue_session=continue_session, **options)
-        
+
         output = await self.execute_async(cmd)
-        
+
         # Parse JSON output if applicable
         if output_format == "json":
             try:
@@ -200,8 +220,36 @@ class ClaudeCodeIntegration(BaseCLIIntegration):
                 return str(data)
             except json.JSONDecodeError:
                 return output
-        
+
         return output
+
+    async def _execute_streaming(self, prompt: str, on_event, **options) -> str:
+        """Stream the run, forward each event to ``on_event``, return final text.
+
+        ``on_event`` may raise nothing meaningful -- a broken progress sink must
+        not fail the underlying work -- so its exceptions are swallowed. The
+        final text is taken from the terminal ``result`` event when present,
+        otherwise accumulated from ``text_delta`` chunks.
+        """
+        options.pop("output_format", None)  # streaming forces stream-json
+        final_result = None
+        text_parts: List[str] = []
+        async for event in self.stream(prompt, **options):
+            try:
+                on_event(event)
+            except Exception:
+                pass
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") == "result":
+                final_result = event.get("result")
+            elif event.get("type") == "stream_event":
+                delta = (event.get("event") or {}).get("delta") or {}
+                if delta.get("type") == "text_delta":
+                    text_parts.append(delta.get("text", ""))
+        if final_result is not None:
+            return final_result
+        return "".join(text_parts)
     
     async def _execute_sdk(self, prompt: str, **options) -> str:
         """Execute using the Claude Code SDK."""

--- a/src/praisonai/tests/unit/integrations/test_claude_code.py
+++ b/src/praisonai/tests/unit/integrations/test_claude_code.py
@@ -91,11 +91,35 @@ class TestClaudeCodeIntegration:
     def test_build_command_with_allowed_tools(self):
         """Test building command with allowed tools."""
         from praisonai.integrations.claude_code import ClaudeCodeIntegration
-        
+
         integration = ClaudeCodeIntegration(allowed_tools=["Read", "Write"])
         cmd = integration._build_command("Hello")
-        
+
         assert "--allowedTools" in cmd
+
+    def test_stream_json_forces_verbose_and_partial_messages(self):
+        """`claude -p --output-format stream-json` errors without --verbose, and
+        needs --include-partial-messages to emit progress deltas. Both must be
+        added automatically so stream() actually works."""
+        from praisonai.integrations.claude_code import ClaudeCodeIntegration
+
+        integration = ClaudeCodeIntegration()
+        cmd = integration._build_command("Hello", output_format="stream-json")
+
+        assert "--output-format" in cmd
+        assert cmd[cmd.index("--output-format") + 1] == "stream-json"
+        assert "--verbose" in cmd
+        assert "--include-partial-messages" in cmd
+
+    def test_json_format_does_not_add_streaming_flags(self):
+        """The default json path must stay a single blocking envelope."""
+        from praisonai.integrations.claude_code import ClaudeCodeIntegration
+
+        integration = ClaudeCodeIntegration()
+        cmd = integration._build_command("Hello")  # json default
+
+        assert "--include-partial-messages" not in cmd
+        assert "--verbose" not in cmd
 
 
 class TestClaudeCodeIntegrationAsync:
@@ -136,19 +160,66 @@ class TestClaudeCodeIntegrationAsync:
     async def test_stream_yields_events(self):
         """Test that stream yields parsed events."""
         from praisonai.integrations.claude_code import ClaudeCodeIntegration
-        
+
         integration = ClaudeCodeIntegration()
-        
+
         async def mock_stream(*args, **kwargs):
             yield '{"type": "assistant", "content": "Hello"}'
             yield '{"type": "result", "content": "Done"}'
-        
+
         with patch.object(integration, 'stream_async', side_effect=mock_stream):
             events = []
             async for event in integration.stream("Say hello"):
                 events.append(event)
-            
+
             assert len(events) >= 0  # May be empty if stream_async not called correctly
+
+    @pytest.mark.asyncio
+    async def test_execute_forwards_progress_events_and_returns_final(self):
+        """With on_event, execute streams every event to the callback while the
+        run is in flight and still returns the final result text."""
+        from praisonai.integrations.claude_code import ClaudeCodeIntegration
+
+        integration = ClaudeCodeIntegration()
+
+        async def mock_stream_async(cmd, *args, **kwargs):
+            # stream-json JSONL: init, a tool-use delta, then the result.
+            yield json.dumps({"type": "system", "subtype": "init",
+                              "session_id": "s1", "model": "claude-opus-5"})
+            yield json.dumps({"type": "stream_event", "event": {
+                "type": "content_block_start",
+                "content_block": {"type": "tool_use", "name": "Read"}}})
+            yield json.dumps({"type": "result", "subtype": "success",
+                              "result": "All done.", "total_cost_usd": 0.01})
+
+        seen = []
+        with patch.object(integration, 'stream_async', side_effect=mock_stream_async):
+            result = await integration.execute("Do the thing",
+                                               on_event=lambda e: seen.append(e))
+
+        assert result == "All done."
+        types = [e.get("type") for e in seen]
+        assert "system" in types and "result" in types
+        # The tool-use event carries progress the UI can show.
+        assert any(e.get("type") == "stream_event" for e in seen)
+
+    @pytest.mark.asyncio
+    async def test_progress_sink_errors_do_not_break_the_run(self):
+        """A broken on_event callback must not fail the underlying work."""
+        from praisonai.integrations.claude_code import ClaudeCodeIntegration
+
+        integration = ClaudeCodeIntegration()
+
+        async def mock_stream_async(cmd, *args, **kwargs):
+            yield json.dumps({"type": "result", "result": "ok"})
+
+        def boom(_event):
+            raise RuntimeError("sink is down")
+
+        with patch.object(integration, 'stream_async', side_effect=mock_stream_async):
+            result = await integration.execute("x", on_event=boom)
+
+        assert result == "ok"
 
 
 class TestClaudeCodeSDKIntegration:

--- a/src/praisonai/tests/unit/integrations/test_claude_code.py
+++ b/src/praisonai/tests/unit/integrations/test_claude_code.py
@@ -172,7 +172,10 @@ class TestClaudeCodeIntegrationAsync:
             async for event in integration.stream("Say hello"):
                 events.append(event)
 
-            assert len(events) >= 0  # May be empty if stream_async not called correctly
+            assert events == [
+                {"type": "assistant", "content": "Hello"},
+                {"type": "result", "content": "Done"},
+            ]
 
     @pytest.mark.asyncio
     async def test_execute_forwards_progress_events_and_returns_final(self):
@@ -220,6 +223,29 @@ class TestClaudeCodeIntegrationAsync:
             result = await integration.execute("x", on_event=boom)
 
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_async_progress_callback_is_awaited(self):
+        """An async on_event callback must actually run (its coroutine awaited),
+        not be created and discarded."""
+        from praisonai.integrations.claude_code import ClaudeCodeIntegration
+
+        integration = ClaudeCodeIntegration()
+
+        async def mock_stream_async(cmd, *args, **kwargs):
+            yield json.dumps({"type": "system", "subtype": "init"})
+            yield json.dumps({"type": "result", "result": "done"})
+
+        seen = []
+
+        async def async_sink(event):
+            seen.append(event)
+
+        with patch.object(integration, 'stream_async', side_effect=mock_stream_async):
+            result = await integration.execute("x", on_event=async_sink)
+
+        assert result == "done"
+        assert [e.get("type") for e in seen] == ["system", "result"]
 
 
 class TestClaudeCodeSDKIntegration:


### PR DESCRIPTION
## Problem

When Claude Code runs behind PraisonAI it is a black box: callers only get a final result, no live progress (which tool is running, tokens streaming, etc.).

Two concrete defects in `ClaudeCodeIntegration`:

1. **`stream()` could never work.** It built `claude -p --output-format stream-json` but `--verbose` was only added when the caller passed `verbose=True`, and `--include-partial-messages` was never added. The CLI **rejects** `stream-json` in print mode without `--verbose`, and without `--include-partial-messages` it emits no token/tool-use deltas — so there was nothing to show progress with.
2. **No progress hook on `execute()`.** The only entry point most callers use returns a single blocking string.

## Fix

- `_build_command` now forces `--verbose` **and** `--include-partial-messages` whenever the output format is `stream-json`. The default `json` path is unchanged (stays a single blocking envelope).
- `execute()` gains an optional `on_event` (alias `on_progress`) callback. When supplied, the run is streamed and every parsed event (`system/init`, tool-use start, `text_delta`, final `result`) is forwarded live, while the final result text is still returned. A failing progress sink never breaks the underlying work.

This is the reusable primitive downstream apps need to render "currently doing X" status while a long `claude -p` run is in flight.

## Tests

Added to `tests/unit/integrations/test_claude_code.py`:
- `stream-json` forces `--verbose` + `--include-partial-messages`; `json` adds neither.
- `execute(on_event=...)` forwards every event and returns the final result.
- a throwing progress sink does not fail the run.

`tests/unit/integrations/test_claude_code.py` (18) and `tests/unit/test_claude_code_integration.py` (5) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time streaming updates for Claude CLI operations.
  * Progress events can now be received as they occur through synchronous or asynchronous callbacks, with final results preserved.
  * Streaming output can reconstruct text when a terminal result is unavailable.
  * Streaming responses now include complete progress details for more reliable updates.

* **Bug Fixes**
  * Streaming continues safely when progress callbacks encounter errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->