### PR TITLE
Resolve hostnames in the trafilatura example's SSRF check

### DIFF
--- a/examples/python/tools/trafilatura/custom_trafilatura_tools.py
+++ b/examples/python/tools/trafilatura/custom_trafilatura_tools.py
@@ -77,13 +77,35 @@ class TrafilaturaTools:
             except ValueError:
                 # Not an IP address, continue with domain validation
                 pass
-            
+
             # Block common internal domains
             if any(hostname.endswith(domain) for domain in ['.local', '.internal', '.localdomain']):
                 return False
-            
+
             # Block metadata service endpoints
-            return hostname not in ['169.254.169.254', 'metadata.google.internal']
+            if hostname in ['169.254.169.254', 'metadata.google.internal']:
+                return False
+
+            # Resolve the hostname and reject if any address is internal. The
+            # checks above only inspect IP *literals*, so a plain domain (or an
+            # encoded form like a decimal IP or "<internal-ip>.nip.io") still
+            # passes even though it resolves to an internal address. Resolving
+            # here closes that SSRF bypass, mirroring the resolve-and-check
+            # approach already used in praisonaiagents/tools/file_tools.py.
+            import socket
+            default_port = 443 if parsed.scheme == 'https' else 80
+            try:
+                addrinfos = socket.getaddrinfo(hostname, parsed.port or default_port)
+            except socket.gaierror:
+                # Hostname does not resolve; treat it as unsafe.
+                return False
+            for addrinfo in addrinfos:
+                resolved = ipaddress.ip_address(addrinfo[4][0])
+                if (resolved.is_private or resolved.is_reserved
+                        or resolved.is_loopback or resolved.is_link_local):
+                    return False
+
+            return True
             
         except Exception:
             return False

--- a/examples/python/tools/trafilatura/custom_trafilatura_tools.py
+++ b/examples/python/tools/trafilatura/custom_trafilatura_tools.py
@@ -279,7 +279,17 @@ class TrafilaturaTools:
             "newspaper": None,
             "spider": None
         }
-        
+
+        # Validate the URL once before any fetcher runs so the newspaper and
+        # requests paths below are protected against SSRF, just like the
+        # trafilatura path (which validates inside extract_content).
+        if not self._validate_url(url):
+            error = {"error": f"Invalid or unsafe URL: {url}"}
+            comparison["trafilatura"] = error
+            comparison["newspaper"] = error
+            comparison["spider"] = error
+            return comparison
+
         # Get Trafilatura extraction
         try:
             comparison["trafilatura"] = self.extract_content(url)


### PR DESCRIPTION
The `_validate_url` helper in the trafilatura example is documented as preventing SSRF, but it only inspects IP **literals**. A hostname that resolves to an internal address still passes, so the guard is bypassable:

```python
tool._validate_url("http://169.254.169.254.nip.io/latest/meta-data/")  # True  (resolves to the cloud metadata IP)
tool._validate_url("http://127.0.0.1.nip.io/")                          # True  (resolves to loopback)
tool._validate_url("http://2130706433/")                                # True  (decimal-encoded 127.0.0.1)
```

`ipaddress.ip_address(hostname)` raises `ValueError` for anything that is not a bare IP literal, so plain domains, encoded IPs and `<internal-ip>.nip.io` style names skip the private/loopback/reserved/link-local check entirely and are then fetched by `trafilatura.fetch_url`.

The fix resolves the hostname with `socket.getaddrinfo` and rejects the URL if any resolved address is private, loopback, reserved or link-local. This is the same resolve-and-check approach already used in `praisonaiagents/tools/file_tools.py`. After the change the three cases above return `False` while ordinary public URLs like `http://example.com/` still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened URL validation to block requests targeting metadata services.
  * Prevented hostname-based access to private, reserved, loopback, and link-local addresses.
  * Safely rejects requests when hostname resolution fails.
  * Ensured URL safety checks run before extraction comparisons begin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->