### PR TITLE
fix: remove unused AutonomySignal deprecation helper and AST lazy-load state (#3874)

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/autonomy.py
+++ b/src/praisonai-agents/praisonaiagents/agent/autonomy.py
@@ -262,17 +262,6 @@ class AutonomySignal(str, Enum):
         )
         super().__init_subclass__(**kwargs)
 
-def _warn_autonomy_signal():
-    """Emit deprecation warning when AutonomySignal is accessed."""
-    from ..utils.deprecation import warn_deprecated_param
-    warn_deprecated_param(
-        "AutonomySignal",
-        since="1.0.0",
-        removal="2.0.0",
-        alternative="use EscalationSignal from praisonaiagents.escalation.types instead",
-        stacklevel=4
-    )
-
 class AutonomyTrigger:
     """Detects signals from prompts for autonomy decisions.
     

--- a/src/praisonai-agents/praisonaiagents/agent/context_agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/context_agent.py
@@ -22,7 +22,6 @@ from typing import Optional, Any, Dict, Union, List, TYPE_CHECKING
 # Lazy imports for performance - these are only loaded when needed
 _subprocess = None
 _glob = None
-_ast = None
 _asyncio = None
 
 def _get_subprocess():
@@ -40,14 +39,6 @@ def _get_glob():
         import glob
         _glob = glob
     return _glob
-
-def _get_ast():
-    """Lazy import ast to avoid import-time overhead."""
-    global _ast
-    if _ast is None:
-        import ast
-        _ast = ast
-    return _ast
 
 def _get_asyncio():
     """Lazy import asyncio to avoid import-time overhead."""


### PR DESCRIPTION
## Removes two unreferenced helpers from `agent/`

Dead-code cleanup for `praisonaiagents/agent/` — no behaviour changes.

**1. `_warn_autonomy_signal` (`autonomy.py`)** — A deprecation-warning helper that nothing calls. A repo-wide grep finds only its own definition; there's no module `__getattr__` or string reference that could invoke it. The `AutonomySignal` deprecation it nominally handles is already emitted by `AutonomySignal.__init_subclass__` (`autonomy.py:253-263`), so removing the helper doesn't change the warning users see.

**2. `_ast` global + `_get_ast()` (`context_agent.py`)** — An orphaned lazy-import loader. `_get_ast()` is never called, `_ast` is referenced only inside it, and `ast.` is never used anywhere in the file. The sibling lazy loaders (`subprocess`, `glob`, `asyncio`) are all genuinely used and stay untouched.

**Why it fixes the issue:** Both helpers read as live code — one advertises a deprecation path, the other a performance-motivated lazy import — so future readers waste time tracing them to find they do nothing. Removing them clears the false signal. Same spirit as the accepted #3787 / #3851 cleanups.

**Verification:** Repo-wide grep across `praisonaiagents/` and `tests/` confirmed zero callers for both helpers and no `ast` usage in `context_agent.py`. The `AutonomySignal` → `EscalationSignal` warning path via `__init_subclass__` is unaffected. Existing unit tests for autonomy and context agents pass.

**Notable details:** Deletion only — no refactoring, no renamed symbols, no public API impact.

Closes #3874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an obsolete deprecation warning related to autonomy signals.
  * Removed unused internal context-processing logic without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->