### PR TITLE
refactor: centralize JSON fence cleanup

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -3161,20 +3161,10 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 return None
 
     def clean_json_output(self, output: str) -> str:
-        """Clean and extract JSON from response text.
-        
-        NOTE: This method is duplicated in agents.Agents.clean_json_output.
-        Keep both implementations in sync when modifying either.
-        """
-        cleaned = output.strip()
-        # Remove markdown code blocks if present
-        if cleaned.startswith("```json"):
-            cleaned = cleaned[len("```json"):].strip()
-        if cleaned.startswith("```"):
-            cleaned = cleaned[len("```"):].strip()
-        if cleaned.endswith("```"):
-            cleaned = cleaned[:-3].strip()
-        return cleaned  
+        """Clean JSON output while preserving the legacy agent method."""
+        from ..main import clean_triple_backticks
+
+        return clean_triple_backticks(output)
 
     async def achat(self, prompt: str, temperature: float = 1.0, tools: Optional[List[Any]] = None, output_json: Optional[Any] = None, output_pydantic: Optional[Any] = None, reasoning_steps: bool = False, stream: Optional[bool] = None, task_name: Optional[str] = None, task_description: Optional[str] = None, task_id: Optional[str] = None, config: Optional[Dict[str, Any]] = None, force_retrieval: bool = False, skip_retrieval: bool = False, attachments: Optional[List[str]] = None, tool_choice: Optional[str] = None, seed: Optional[int] = None, cancel_token: Optional[Any] = None):
         """Async version of chat method with self-reflection support.

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -1112,16 +1112,10 @@ class AgentTeam(SpawnAnnounceProtocol):
         return None
 
     def clean_json_output(self, output: str) -> str:
-        # NOTE: This method is duplicated in chat_mixin.ChatMixin.clean_json_output.
-        # Keep both implementations in sync when modifying either.
-        cleaned = output.strip()
-        if cleaned.startswith("```json"):
-            cleaned = cleaned[len("```json"):].strip()
-        if cleaned.startswith("```"):
-            cleaned = cleaned[len("```"):].strip()
-        if cleaned.endswith("```"):
-            cleaned = cleaned[:-3].strip()
-        return cleaned
+        """Clean JSON output while preserving the legacy team method."""
+        from ..main import clean_triple_backticks
+
+        return clean_triple_backticks(output)
 
     @property
     def context_manager(self):

--- a/src/praisonai-agents/tests/unit/test_json_fence_cleanup.py
+++ b/src/praisonai-agents/tests/unit/test_json_fence_cleanup.py
@@ -1,0 +1,35 @@
+"""Regression tests for the shared JSON fence cleanup helper."""
+
+import pytest
+
+from praisonaiagents.agent.chat_mixin import ChatMixin
+from praisonaiagents.agents.agents import PraisonAIAgents
+from praisonaiagents.main import clean_triple_backticks
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ('  {"ok": true}  ', '{"ok": true}'),
+        ('```json\n{"ok": true}\n```', '{"ok": true}'),
+        ('```\n[1, 2]\n```', '[1, 2]'),
+        ('```JSON\n{"ok": true}\n```', 'JSON\n{"ok": true}'),
+    ],
+)
+def test_json_cleanup_surfaces_share_behavior(value, expected):
+    assert clean_triple_backticks(value) == expected
+    assert PraisonAIAgents.clean_json_output(None, value) == expected
+    assert ChatMixin.clean_json_output(None, value) == expected
+
+
+def test_legacy_methods_delegate_to_canonical_helper(monkeypatch):
+    sentinel = object()
+
+    def fake_cleaner(value):
+        assert value == "response"
+        return sentinel
+
+    monkeypatch.setattr("praisonaiagents.main.clean_triple_backticks", fake_cleaner)
+
+    assert PraisonAIAgents.clean_json_output(None, "response") is sentinel
+    assert ChatMixin.clean_json_output(None, "response") is sentinel


### PR DESCRIPTION
## Summary

- delegate both legacy clean_json_output entry points to the canonical clean_triple_backticks helper
- preserve the existing public methods and output behavior
- add regression coverage for all three call paths and delegation

## Validation

- 14 focused unit tests passed
- git diff --check

Closes #3765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of formatted JSON and markdown responses.
  * Ensured consistent handling of fenced content across agent response paths.
  * Preserved expected behavior for whitespace, JSON fences, generic fences, and case-sensitive markers.

* **Tests**
  * Added regression coverage to verify consistent fence cleanup and delegation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->