### PR TITLE
fix: close wrapper runtime regressions

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/commands/run.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/run.py
@@ -1497,6 +1497,7 @@ def run_main(
                 approval=approval,
                 approve_all_tools=approve_all_tools,
                 approval_timeout=approval_timeout,
+                output_mode=output_mode,
             )
         else:
             # Profiling for direct prompt
@@ -2107,6 +2108,7 @@ def _run_from_file_profiled(
     approval: Optional[str] = None,
     approve_all_tools: bool = False,
     approval_timeout: Optional[str] = None,
+    output_mode: Optional[str] = None,
 ):
     """Run agents from a YAML file with profiling enabled."""
     from praisonai_code.cli.features.cli_profiler import (
@@ -2174,7 +2176,7 @@ def _run_from_file_profiled(
     # the same ``args`` the legacy YAML path reads, so a profiled YAML run is
     # permission-gated identically to the non-profiled path instead of silently
     # dropping the deny policy.
-    if session_id or auto_save_name or approval or approve_all_tools:
+    if session_id or auto_save_name or approval or approve_all_tools or output_mode:
         class Args:
             pass
         
@@ -2182,6 +2184,7 @@ def _run_from_file_profiled(
         args.auto_save = auto_save_name
         args.resume_session = session_id
         args.cli_project_sessions = bool(session_id or auto_save_name)
+        args.output = output_mode
         if approval:
             args.approval = approval
         if approve_all_tools:

--- a/src/praisonai-code/praisonai_code/cli/commands/run.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/run.py
@@ -1688,7 +1688,13 @@ def _run_from_file(
         # approval / approve_all_tools / approval_timeout and session ids from
         # ``args``, so threading them here gives YAML the same permission gating
         # and continuity as `run "<prompt>"` — no new engine wiring needed.
-        if session_id or auto_save_name or effective_approval or approve_all_tools:
+        if (
+            session_id
+            or auto_save_name
+            or effective_approval
+            or approve_all_tools
+            or output_mode
+        ):
             class Args:
                 pass
             
@@ -1696,6 +1702,7 @@ def _run_from_file(
             args.auto_save = auto_save_name
             args.resume_session = session_id
             args.cli_project_sessions = bool(session_id or auto_save_name)
+            args.output = output_mode
             if effective_approval:
                 args.approval = effective_approval
             if approve_all_tools:

--- a/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
+++ b/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
@@ -1987,9 +1987,9 @@ class PraisonAI:
             if stream_metrics:
                 cli_config['stream_metrics'] = True
 
-        output_mode = getattr(
-            self.args, 'output', getattr(self.args, 'output_format', None)
-        )
+        output_mode = getattr(self.args, 'output', None)
+        if output_mode is None:
+            output_mode = getattr(self.args, 'output_format', None)
         if output_mode is not None:
             cli_config['output'] = output_mode
 

--- a/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
+++ b/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
@@ -364,7 +364,12 @@ class PraisonAI:
         # session flags (e.g. ``--allow`` with ``--no-save`` sets approval but not
         # cli_project_sessions), so preserve them unconditionally when present.
         if preserved_args:
-            for attr in ('approval', 'approve_all_tools', 'approval_timeout'):
+            for attr in (
+                'approval',
+                'approve_all_tools',
+                'approval_timeout',
+                'output',
+            ):
                 if hasattr(preserved_args, attr):
                     setattr(args, attr, getattr(preserved_args, attr))
         

--- a/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
+++ b/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
@@ -1982,6 +1982,12 @@ class PraisonAI:
             if stream_metrics:
                 cli_config['stream_metrics'] = True
 
+        output_mode = getattr(
+            self.args, 'output', getattr(self.args, 'output_format', None)
+        )
+        if output_mode is not None:
+            cli_config['output'] = output_mode
+
         # Extract handoff configuration for YAML CLI parity
         handoff = getattr(self.args, 'handoff', None)
         if handoff:

--- a/src/praisonai-code/tests/unit/test_run_yaml_permissions.py
+++ b/src/praisonai-code/tests/unit/test_run_yaml_permissions.py
@@ -8,6 +8,9 @@ YAML engine's ``args`` so YAML agents are permission-gated exactly like
 single-agent `run "<prompt>"`, instead of silently bypassing the approval gate.
 """
 
+import sys
+from types import ModuleType
+
 import pytest
 
 from praisonai_code.cli.commands import run as run_cmd
@@ -119,6 +122,7 @@ class _PreservedArgs:
         self.approval = None
         self.approve_all_tools = None
         self.approval_timeout = None
+        self.output = None
         self.cli_project_sessions = False
         for k, v in kw.items():
             setattr(self, k, v)
@@ -185,3 +189,35 @@ def test_main_preserves_approval_without_session_flag(monkeypatch):
     preserved = _PreservedArgs(approval="console", cli_project_sessions=False)
     args = _run_main_preserving(monkeypatch, preserved)
     assert args.approval == "console"
+
+
+def test_main_preserves_output_across_parse_args_boundary(monkeypatch):
+    preserved = _PreservedArgs(output="stream-json")
+    args = _run_main_preserving(monkeypatch, preserved)
+    assert args.output == "stream-json"
+
+
+def test_profiled_yaml_path_forwards_output_mode(monkeypatch):
+    class _Profiler:
+        def __init__(self, config):
+            pass
+
+        def __getattr__(self, name):
+            return lambda *args, **kwargs: None
+
+    profiler_module = ModuleType("praisonai_code.cli.features.cli_profiler")
+    profiler_module.CLIProfileConfig = lambda **kwargs: kwargs
+    profiler_module.CLIProfiler = _Profiler
+    monkeypatch.setitem(
+        sys.modules, "praisonai_code.cli.features.cli_profiler", profiler_module
+    )
+
+    run_cmd._run_from_file_profiled(
+        "workflow.yaml",
+        no_save=True,
+        output_mode="stream-json",
+    )
+
+    args = _FakePraisonAI.last_instance.args
+    assert args is not None
+    assert args.output == "stream-json"

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -1135,6 +1135,30 @@ class AgentsGenerator:
             or workflow_type in {'job', 'hybrid'}
         )
 
+    def _validate_adapter_cli_capabilities(self, adapter) -> None:
+        """Reject CLI modes an adapter would otherwise silently ignore."""
+        cli_config = getattr(self, "cli_config", None) or {}
+        adapter_name = getattr(adapter, "name", type(adapter).__name__)
+
+        if (
+            cli_config.get("resume_session") or cli_config.get("auto_save")
+        ) and not getattr(adapter, "SUPPORTS_SESSION_CONTINUITY", False):
+            raise ValueError(
+                "--resume / --session / --continue / --fork are not supported "
+                f"by framework {adapter_name!r}. Use --framework praisonai or "
+                "an adapter that declares SUPPORTS_SESSION_CONTINUITY = True."
+            )
+
+        output_mode = cli_config.get("output") or cli_config.get("output_format")
+        if output_mode == "stream-json" and not getattr(
+            adapter, "SUPPORTS_STREAM_BRIDGE", False
+        ):
+            raise ValueError(
+                "--output stream-json is not supported by framework "
+                f"{adapter_name!r}. Use --framework praisonai or an adapter "
+                "that declares SUPPORTS_STREAM_BRIDGE = True."
+            )
+
     def generate_crew_and_kickoff(self):
         """
         Generates a crew of agents and initiates tasks based on the provided configuration.
@@ -1164,6 +1188,7 @@ class AgentsGenerator:
 
         # Use shared preparation logic
         prep = self._prepare_for_run(config)
+        self._validate_adapter_cli_capabilities(prep['adapter'])
         
         self.logger.info(f"Using framework: {prep['adapter'].name}")
         # Own the observability lifecycle here so init and finalize are always
@@ -1211,6 +1236,7 @@ class AgentsGenerator:
 
         # Use shared preparation logic (off the event loop to avoid blocking imports)
         prep = await self._aprepare_for_run(config)
+        self._validate_adapter_cli_capabilities(prep['adapter'])
         
         self.logger.info(f"Using framework: {prep['adapter'].name}")
         # Own the observability lifecycle here so init and finalize are always

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -1140,9 +1140,9 @@ class AgentsGenerator:
         cli_config = getattr(self, "cli_config", None) or {}
         adapter_name = getattr(adapter, "name", type(adapter).__name__)
 
-        if (
-            cli_config.get("resume_session") or cli_config.get("auto_save")
-        ) and not getattr(adapter, "SUPPORTS_SESSION_CONTINUITY", False):
+        if cli_config.get("resume_session") and not getattr(
+            adapter, "SUPPORTS_SESSION_CONTINUITY", False
+        ):
             raise ValueError(
                 "--resume / --session / --continue / --fork are not supported "
                 f"by framework {adapter_name!r}. Use --framework praisonai or "
@@ -1169,7 +1169,7 @@ class AgentsGenerator:
         """
         cli_config = getattr(self, "cli_config", None) or {}
 
-        if cli_config.get("resume_session") or cli_config.get("auto_save"):
+        if cli_config.get("resume_session"):
             raise ValueError(
                 "--resume / --session / --continue / --fork are not supported "
                 "for workflow YAMLs. Session continuity is only available on "

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -1159,6 +1159,31 @@ class AgentsGenerator:
                 "that declares SUPPORTS_STREAM_BRIDGE = True."
             )
 
+    def _validate_workflow_cli_capabilities(self) -> None:
+        """Reject CLI modes the native workflow path would silently ignore.
+
+        Workflow YAMLs run through the native ``YAMLWorkflowParser`` rather than
+        ``PraisonAIAdapter.run``/``arun``, so session continuity and the
+        ``stream-json`` bridge are not wired up. Fail fast instead of accepting
+        the flags and ignoring them.
+        """
+        cli_config = getattr(self, "cli_config", None) or {}
+
+        if cli_config.get("resume_session") or cli_config.get("auto_save"):
+            raise ValueError(
+                "--resume / --session / --continue / --fork are not supported "
+                "for workflow YAMLs. Session continuity is only available on "
+                "the sequential/hierarchical praisonai path."
+            )
+
+        output_mode = cli_config.get("output") or cli_config.get("output_format")
+        if output_mode == "stream-json":
+            raise ValueError(
+                "--output stream-json is not supported for workflow YAMLs. "
+                "Use the sequential/hierarchical praisonai path for the "
+                "stream-json bridge."
+            )
+
     def generate_crew_and_kickoff(self):
         """
         Generates a crew of agents and initiates tasks based on the provided configuration.
@@ -1183,6 +1208,7 @@ class AgentsGenerator:
             # sequential/hierarchical path uses so AgentOps init/finalize fires
             # for workflow YAMLs too. Workflow YAMLs are native-only, so tag
             # them 'praisonai'.
+            self._validate_workflow_cli_capabilities()
             with observability_session("praisonai"):
                 return self._run_yaml_workflow(config)
 
@@ -1231,6 +1257,7 @@ class AgentsGenerator:
             # the sequential/hierarchical path uses so AgentOps init/finalize
             # fires for workflow YAMLs too. Workflow YAMLs are native-only, so
             # tag them 'praisonai'.
+            self._validate_workflow_cli_capabilities()
             with observability_session("praisonai"):
                 return await self._arun_yaml_workflow(config)
 

--- a/src/praisonai/praisonai/db/adapter.py
+++ b/src/praisonai/praisonai/db/adapter.py
@@ -302,25 +302,26 @@ class PraisonAIDB:
         from ..persistence.conversation._ops import resume_or_create_session
         
         store = self._conversation_store
-        existing = self._resolve_sync(store.get_session(session_id))
-        messages = self._resolve_sync(
-            resume_or_create_session(
-                store,
-                existing,
-                session_id,
-                build_session=lambda: ConversationSession(
-                    session_id=session_id,
-                    user_id=user_id or "default",
-                    agent_id=agent_name,
-                    name=f"Session {session_id}",
-                    metadata=metadata or {},
-                ),
-                # An async-mode store returns a coroutine from create_session;
-                # resolve it here so a new session is actually persisted instead
-                # of being silently dropped as an un-awaited coroutine.
-                create_session=lambda s: self._resolve_sync(store.create_session(s)),
-                get_messages=lambda: self._resolve_sync(store.get_messages(session_id)),
-            )
+        existing = self._call_store(
+            store, "get_session", "async_get_session", session_id
+        )
+        messages = resume_or_create_session(
+            store,
+            existing,
+            session_id,
+            build_session=lambda: ConversationSession(
+                session_id=session_id,
+                user_id=user_id or "default",
+                agent_id=agent_name,
+                name=f"Session {session_id}",
+                metadata=metadata or {},
+            ),
+            create_session=lambda s: self._call_store(
+                store, "create_session", "async_create_session", s
+            ),
+            get_messages=lambda: self._call_store(
+                store, "get_messages", "async_get_messages", session_id
+            ),
         )
         
         if messages is None:
@@ -361,7 +362,13 @@ class PraisonAIDB:
             metadata=metadata or {},
             created_at=time.time()
         )
-        self._conversation_store.add_message(session_id, msg)
+        self._call_store(
+            self._conversation_store,
+            "add_message",
+            "async_add_message",
+            session_id,
+            msg,
+        )
     
     def on_agent_message(
         self,
@@ -385,7 +392,13 @@ class PraisonAIDB:
             metadata=metadata or {},
             created_at=time.time()
         )
-        self._conversation_store.add_message(session_id, msg)
+        self._call_store(
+            self._conversation_store,
+            "add_message",
+            "async_add_message",
+            session_id,
+            msg,
+        )
     
     @staticmethod
     def _serialize_tool_call(tool_name: str, args: Any, result: Any) -> str:
@@ -428,7 +441,13 @@ class PraisonAIDB:
             metadata={"tool_name": tool_name, **(metadata or {})},
             created_at=time.time()
         )
-        self._conversation_store.add_message(session_id, msg)
+        self._call_store(
+            self._conversation_store,
+            "add_message",
+            "async_add_message",
+            session_id,
+            msg,
+        )
     
     def on_agent_end(
         self,
@@ -441,10 +460,20 @@ class PraisonAIDB:
             return
         
         # Update session metadata
-        session = self._conversation_store.get_session(session_id)
+        session = self._call_store(
+            self._conversation_store,
+            "get_session",
+            "async_get_session",
+            session_id,
+        )
         if session:
             session.metadata = {**(session.metadata or {}), "ended_at": time.time()}
-            self._conversation_store.update_session(session)
+            self._call_store(
+                self._conversation_store,
+                "update_session",
+                "async_update_session",
+                session,
+            )
     
     def on_run_start(
         self,
@@ -458,7 +487,7 @@ class PraisonAIDB:
         # Store run start in state if available (even without conversation store)
         if self._state_store:
             run_key = f"run:{session_id}:{run_id}"
-            self._state_store.set(run_key, {
+            self._call_store(self._state_store, "set", "async_set", run_key, {
                 "run_id": run_id,
                 "session_id": session_id,
                 "started_at": time.time(),
@@ -480,7 +509,9 @@ class PraisonAIDB:
         self._init_stores()
         if self._state_store:
             run_key = f"run:{session_id}:{run_id}"
-            run_data = self._state_store.get(run_key) or {}
+            run_data = self._call_store(
+                self._state_store, "get", "async_get", run_key
+            ) or {}
             run_data.update({
                 "ended_at": time.time(),
                 "output_content": output_content,
@@ -488,7 +519,9 @@ class PraisonAIDB:
                 "metrics": metrics or {},
                 "metadata": {**run_data.get("metadata", {}), **(metadata or {})}
             })
-            self._state_store.set(run_key, run_data)
+            self._call_store(
+                self._state_store, "set", "async_set", run_key, run_data
+            )
     
     def get_runs(
         self,
@@ -581,7 +614,12 @@ class PraisonAIDB:
             name=data.get("name", f"Imported Session {session_id}"),
             metadata=data.get("metadata", {})
         )
-        self._conversation_store.create_session(session)
+        self._call_store(
+            self._conversation_store,
+            "create_session",
+            "async_create_session",
+            session,
+        )
         
         # Import messages with new IDs to avoid conflicts
         for msg_data in data.get("messages", []):
@@ -593,7 +631,13 @@ class PraisonAIDB:
                 metadata=msg_data.get("metadata", {}),
                 created_at=msg_data.get("created_at", time.time())
             )
-            self._conversation_store.add_message(session_id, msg)
+            self._call_store(
+                self._conversation_store,
+                "add_message",
+                "async_add_message",
+                session_id,
+                msg,
+            )
         
         return session_id
     
@@ -612,7 +656,7 @@ class PraisonAIDB:
         self._init_stores()
         if self._state_store:
             trace_key = f"trace:{trace_id}"
-            self._state_store.set(trace_key, {
+            self._call_store(self._state_store, "set", "async_set", trace_key, {
                 "trace_id": trace_id,
                 "session_id": session_id,
                 "run_id": run_id,
@@ -634,13 +678,17 @@ class PraisonAIDB:
         self._init_stores()
         if self._state_store:
             trace_key = f"trace:{trace_id}"
-            trace_data = self._state_store.get(trace_key) or {}
+            trace_data = self._call_store(
+                self._state_store, "get", "async_get", trace_key
+            ) or {}
             trace_data.update({
                 "ended_at": time.time(),
                 "status": status,
                 "metadata": {**trace_data.get("metadata", {}), **(metadata or {})}
             })
-            self._state_store.set(trace_key, trace_data)
+            self._call_store(
+                self._state_store, "set", "async_set", trace_key, trace_data
+            )
     
     def on_span_start(
         self,
@@ -654,7 +702,7 @@ class PraisonAIDB:
         self._init_stores()
         if self._state_store:
             span_key = f"span:{span_id}"
-            self._state_store.set(span_key, {
+            self._call_store(self._state_store, "set", "async_set", span_key, {
                 "span_id": span_id,
                 "trace_id": trace_id,
                 "name": name,
@@ -675,13 +723,17 @@ class PraisonAIDB:
         self._init_stores()
         if self._state_store:
             span_key = f"span:{span_id}"
-            span_data = self._state_store.get(span_key) or {}
+            span_data = self._call_store(
+                self._state_store, "get", "async_get", span_key
+            ) or {}
             span_data.update({
                 "ended_at": time.time(),
                 "status": status,
                 "attributes": {**span_data.get("attributes", {}), **(attributes or {})}
             })
-            self._state_store.set(span_key, span_data)
+            self._call_store(
+                self._state_store, "set", "async_set", span_key, span_data
+            )
     
     def get_traces(
         self,
@@ -725,32 +777,33 @@ class PraisonAIDB:
     # ========================================================================
 
     @staticmethod
-    def _resolve_sync(value):
-        """Resolve a possibly-awaitable store result on the sync code path.
+    def _store_callable(store, sync_name, async_name):
+        """Select a real async method when declared, else the sync surface.
 
-        A store opened in ``mode="async"`` returns coroutines from its
-        ``get_session`` / ``get_messages`` methods. On the sync hooks that would
-        otherwise be handed straight into ``resume_or_create_session`` and later
-        crash with ``TypeError: 'coroutine' object is not iterable``. Here we run
-        the coroutine to completion when no event loop is active; if we are
-        already inside a running loop we cannot block, so we close the coroutine
-        and raise a clear, actionable error instead of a cryptic ``TypeError``.
+        ``Mock`` and some dynamic proxies fabricate arbitrary attributes from
+        ``getattr``. Static inspection prevents a fabricated ``async_*`` method
+        from shadowing the store's actual sync protocol method.
         """
-        if not inspect.isawaitable(value):
-            return value
         try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(value)
-        # Inside a running loop: cannot block. Close the coroutine to avoid a
-        # "coroutine was never awaited" warning and surface a clear message.
-        if inspect.iscoroutine(value):
-            value.close()
-        raise RuntimeError(
-            "PraisonAIDB sync hook called against an async-mode store from a "
-            "running event loop. Use the async surface (e.g. aon_agent_start) "
-            "or initialise the store with mode='sync'."
-        )
+            inspect.getattr_static(store, async_name)
+        except AttributeError:
+            async_fn = None
+        else:
+            async_fn = getattr(store, async_name, None)
+        return async_fn or getattr(store, sync_name, None)
+
+    @staticmethod
+    def _call_store(store, sync_name, async_name, *args, **kwargs):
+        """Call a store from a sync hook without creating per-call event loops."""
+        fn = PraisonAIDB._store_callable(store, sync_name, async_name)
+        if fn is None:
+            return None
+        result = fn(*args, **kwargs)
+        if inspect.isawaitable(result):
+            from .._async_bridge import run_sync_or_offload
+
+            return run_sync_or_offload(result)
+        return result
 
     @staticmethod
     async def _dispatch_async(store, sync_name, async_name, *args, **kwargs):
@@ -761,7 +814,7 @@ class PraisonAIDB:
         is awaited directly, otherwise it is off-loaded to a thread so the event
         loop is never blocked. Returns ``None`` when neither method exists.
         """
-        fn = getattr(store, async_name, None) or getattr(store, sync_name, None)
+        fn = PraisonAIDB._store_callable(store, sync_name, async_name)
         if fn is None:
             return None
         if inspect.iscoroutinefunction(fn):

--- a/src/praisonai/praisonai/framework_adapters/base.py
+++ b/src/praisonai/praisonai/framework_adapters/base.py
@@ -65,6 +65,12 @@ def warn_unsupported_fields(adapter_name: str, spec_extras: Dict[str, Any]) -> N
 class BaseFrameworkAdapter(_CoreBaseFrameworkAdapter):
     """Wrapper base adapter with PraisonAIModel LLM resolution for CrewAI etc."""
 
+    # CLI runtime capabilities are opt-in. Adapters that do not implement
+    # these contracts must fail before dispatch instead of silently ignoring
+    # session or structured-stream flags.
+    SUPPORTS_SESSION_CONTINUITY = False
+    SUPPORTS_STREAM_BRIDGE = False
+
     def _resolve_llm(self, spec: Any, llm_config: Optional[List[Dict]]):
         """Build a provider model object from spec and shared llm_config."""
         from ..inc import PraisonAIModel

--- a/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
@@ -38,6 +38,8 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
     # instead of hardcoding ``framework == "praisonai"``.
     SUPPORTS_WORKFLOW = True
     SUPPORTS_RUNTIME_FEATURES = True
+    SUPPORTS_SESSION_CONTINUITY = True
+    SUPPORTS_STREAM_BRIDGE = True
 
     @property
     def name(self) -> str:

--- a/src/praisonai/praisonai/profiler.py
+++ b/src/praisonai/praisonai/profiler.py
@@ -1050,11 +1050,13 @@ def _profiled_import(name, globals=None, locals=None, fromlist=(), level=0):
     finally:
         duration_ms = (time.time() - start) * 1000
         if duration_ms > 1:
-            records = [ImportRecord(module=name, duration_ms=duration_ms) for _ in profilers]
+            records = [
+                ImportRecord(module=name, duration_ms=duration_ms) for _ in profilers
+            ]
             with _IMPORT_HOOK_LOCK:
                 for profiler, record in zip(profilers, records):
                     profiler._imports.append(record)
-            for _ in profilers:
+            if profilers:
                 Profiler.record_import(name, duration_ms)
 
 class ImportProfiler:

--- a/src/praisonai/praisonai/profiler.py
+++ b/src/praisonai/praisonai/profiler.py
@@ -560,6 +560,15 @@ class _ProfilerImpl:
             with self._lock:
                 self._cprofile_stats.append((name, stats))
 
+    def record_cprofile(self, name: str, stats_text: str) -> None:
+        """Store rendered cProfile output for decorator-based profiling."""
+        with self._lock:
+            self._cprofile_stats.append({
+                "name": name,
+                "stats": stats_text,
+                "timestamp": time.time(),
+            })
+
     @contextmanager
     def memory(self, name: str):
         """Profile memory usage for a block when tracemalloc is available."""
@@ -910,6 +919,11 @@ class ProfilerCompat:
         return get_profiler().cprofile(name)
 
     @staticmethod
+    def record_cprofile(name: str, stats_text: str) -> None:
+        """Store detailed cProfile output on the active profiler."""
+        get_profiler().record_cprofile(name, stats_text)
+
+    @staticmethod
     def memory(name: str):
         """Context manager for memory profiling."""
         return get_profiler().memory(name)
@@ -1016,6 +1030,33 @@ def profile_async(func: Optional[Callable] = None, *, category: str = "async"):
 # Import Profiling
 # ============================================================================
 
+_IMPORT_HOOK_LOCK = threading.Lock()
+_IMPORT_HOOK_CONTEXTS: List["ImportProfiler"] = []
+_IMPORT_HOOK_ORIGINAL = None
+
+
+def _profiled_import(name, globals=None, locals=None, fromlist=(), level=0):
+    """Single process-wide dispatcher shared by active import profilers."""
+    with _IMPORT_HOOK_LOCK:
+        original = _IMPORT_HOOK_ORIGINAL
+        profilers = tuple(_IMPORT_HOOK_CONTEXTS)
+
+    if original is None:  # Defensive: the dispatcher is never installed alone.
+        raise RuntimeError("Import profiler dispatcher has no original import hook")
+
+    start = time.time()
+    try:
+        return original(name, globals, locals, fromlist, level)
+    finally:
+        duration_ms = (time.time() - start) * 1000
+        if duration_ms > 1:
+            records = [ImportRecord(module=name, duration_ms=duration_ms) for _ in profilers]
+            with _IMPORT_HOOK_LOCK:
+                for profiler, record in zip(profilers, records):
+                    profiler._imports.append(record)
+            for _ in profilers:
+                Profiler.record_import(name, duration_ms)
+
 class ImportProfiler:
     """
     Context manager to profile imports.
@@ -1028,30 +1069,35 @@ class ImportProfiler:
     """
     
     def __init__(self):
-        self._original_import = None
         self._imports: List[ImportRecord] = []
+        self._active = False
     
     def __enter__(self):
         import builtins
-        self._original_import = builtins.__import__
-        
-        def profiled_import(name, globals=None, locals=None, fromlist=(), level=0):
-            start = time.time()
-            try:
-                return self._original_import(name, globals, locals, fromlist, level)
-            finally:
-                duration_ms = (time.time() - start) * 1000
-                if duration_ms > 1:  # Only record imports > 1ms
-                    record = ImportRecord(module=name, duration_ms=duration_ms)
-                    self._imports.append(record)
-                    Profiler.record_import(name, duration_ms)
-        
-        builtins.__import__ = profiled_import
+        global _IMPORT_HOOK_ORIGINAL
+
+        with _IMPORT_HOOK_LOCK:
+            if self._active:
+                return self
+            if not _IMPORT_HOOK_CONTEXTS:
+                _IMPORT_HOOK_ORIGINAL = builtins.__import__
+                builtins.__import__ = _profiled_import
+            _IMPORT_HOOK_CONTEXTS.append(self)
+            self._active = True
         return self
     
     def __exit__(self, exc_type, exc_val, exc_tb):
         import builtins
-        builtins.__import__ = self._original_import
+        global _IMPORT_HOOK_ORIGINAL
+
+        with _IMPORT_HOOK_LOCK:
+            if self in _IMPORT_HOOK_CONTEXTS:
+                _IMPORT_HOOK_CONTEXTS.remove(self)
+            self._active = False
+            if not _IMPORT_HOOK_CONTEXTS:
+                if builtins.__import__ is _profiled_import and _IMPORT_HOOK_ORIGINAL is not None:
+                    builtins.__import__ = _IMPORT_HOOK_ORIGINAL
+                _IMPORT_HOOK_ORIGINAL = None
         return False
     
     def get_imports(self, min_duration_ms: float = 0) -> List[ImportRecord]:
@@ -1157,11 +1203,7 @@ def profile_detailed(func: Optional[Callable] = None):
                 s = io.StringIO()
                 ps = pstats.Stats(pr, stream=s).sort_stats('cumulative')
                 ps.print_stats(20)
-                Profiler._cprofile_stats.append({
-                    'name': fn.__name__,
-                    'stats': s.getvalue(),
-                    'timestamp': time.time()
-                })
+                Profiler.record_cprofile(fn.__name__, s.getvalue())
         
         return wrapper
     

--- a/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
+++ b/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
@@ -146,7 +146,6 @@ def test_import_profiler_survives_overlapping_out_of_order_scopes():
     "cli_config, capability, message",
     [
         ({"resume_session": "session"}, "SUPPORTS_SESSION_CONTINUITY", "--resume"),
-        ({"auto_save": "session"}, "SUPPORTS_SESSION_CONTINUITY", "--session"),
         ({"output": "stream-json"}, "SUPPORTS_STREAM_BRIDGE", "stream-json"),
     ],
 )
@@ -171,7 +170,6 @@ def test_adapter_capability_gate_rejects_unsupported_cli_modes(
     "cli_config, message",
     [
         ({"resume_session": "session"}, "--resume"),
-        ({"auto_save": "session"}, "workflow YAMLs"),
         ({"output": "stream-json"}, "stream-json"),
     ],
 )
@@ -189,7 +187,7 @@ def test_workflow_path_allows_supported_cli_modes():
     from praisonai.agents_generator import AgentsGenerator
 
     generator = object.__new__(AgentsGenerator)
-    generator.cli_config = {"output": "json"}
+    generator.cli_config = {"output": "json", "auto_save": "implicit-session"}
 
     generator._validate_workflow_cli_capabilities()
 

--- a/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
+++ b/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
@@ -1,0 +1,175 @@
+"""Regression coverage for wrapper issues reported in #3867."""
+
+import builtins
+
+import pytest
+
+
+class _AsyncConversationStore:
+    def __init__(self):
+        self.sessions = {}
+        self.messages = {}
+
+    async def get_session(self, session_id):
+        return self.sessions.get(session_id)
+
+    async def create_session(self, session):
+        self.sessions[session.session_id] = session
+
+    async def get_messages(self, session_id):
+        return list(self.messages.get(session_id, []))
+
+    async def add_message(self, session_id, message):
+        self.messages.setdefault(session_id, []).append(message)
+
+    async def update_session(self, session):
+        self.sessions[session.session_id] = session
+
+
+class _AsyncStateStore:
+    def __init__(self):
+        self.values = {}
+
+    async def get(self, key):
+        return self.values.get(key)
+
+    async def set(self, key, value):
+        self.values[key] = value
+
+
+def _db_with_async_stores():
+    from praisonai.db.adapter import PraisonAIDB
+
+    db = PraisonAIDB()
+    db._initialized = True
+    db._conversation_store = _AsyncConversationStore()
+    db._state_store = _AsyncStateStore()
+    db._init_stores = lambda: None
+    return db
+
+
+def test_sync_conversation_hooks_complete_async_store_calls():
+    db = _db_with_async_stores()
+
+    assert db.on_agent_start("agent", "session") == []
+    db.on_user_message("session", "hello")
+    db.on_agent_message("session", "hi")
+    db.on_tool_call("session", "lookup", {"q": "x"}, "result")
+    db.on_agent_end("session")
+
+    assert [m.role for m in db._conversation_store.messages["session"]] == [
+        "user",
+        "assistant",
+        "tool",
+    ]
+    assert "ended_at" in db._conversation_store.sessions["session"].metadata
+
+    imported = db.import_session(
+        {
+            "session_id": "imported",
+            "messages": [{"role": "user", "content": "restored"}],
+        }
+    )
+    assert imported == "imported"
+    assert db._conversation_store.messages["imported"][0].content == "restored"
+
+
+def test_sync_run_and_trace_hooks_complete_async_store_calls():
+    db = _db_with_async_stores()
+
+    db.on_run_start("session", "run")
+    db.on_run_end("session", "run", status="failed")
+    db.on_trace_start("trace", session_id="session")
+    db.on_trace_end("trace", status="error")
+    db.on_span_start("span", "trace", "work")
+    db.on_span_end("span", status="error")
+
+    values = db._state_store.values
+    assert values["run:session:run"]["status"] == "failed"
+    assert values["trace:trace"]["status"] == "error"
+    assert values["span:span"]["status"] == "error"
+
+
+def test_profile_detailed_records_without_losing_return_value():
+    from praisonai.profiler import Profiler, get_profiler, profile_detailed
+
+    Profiler.clear()
+    Profiler.enable()
+
+    @profile_detailed
+    def increment(value):
+        return value + 1
+
+    try:
+        assert increment(41) == 42
+        records = list(get_profiler()._cprofile_stats)
+        assert records[-1]["name"] == "increment"
+        assert "function calls" in records[-1]["stats"]
+    finally:
+        Profiler.disable()
+        Profiler.clear()
+
+
+def test_import_profiler_survives_overlapping_out_of_order_scopes():
+    from praisonai.profiler import ImportProfiler
+
+    original = builtins.__import__
+    first = ImportProfiler()
+    second = ImportProfiler()
+    first_entered = second_entered = False
+
+    try:
+        first.__enter__()
+        first_entered = True
+        shared_hook = builtins.__import__
+        second.__enter__()
+        second_entered = True
+
+        assert builtins.__import__ is shared_hook
+        first.__exit__(None, None, None)
+        first_entered = False
+        assert builtins.__import__ is shared_hook
+        second.__exit__(None, None, None)
+        second_entered = False
+        assert builtins.__import__ is original
+    finally:
+        if first_entered:
+            first.__exit__(None, None, None)
+        if second_entered:
+            second.__exit__(None, None, None)
+        builtins.__import__ = original
+
+
+@pytest.mark.parametrize(
+    "cli_config, capability, message",
+    [
+        ({"resume_session": "session"}, "SUPPORTS_SESSION_CONTINUITY", "--resume"),
+        ({"auto_save": "session"}, "SUPPORTS_SESSION_CONTINUITY", "--session"),
+        ({"output": "stream-json"}, "SUPPORTS_STREAM_BRIDGE", "stream-json"),
+    ],
+)
+def test_adapter_capability_gate_rejects_unsupported_cli_modes(
+    cli_config, capability, message
+):
+    from praisonai.agents_generator import AgentsGenerator
+
+    adapter = type(
+        "ExternalAdapter",
+        (),
+        {"name": "external", capability: False},
+    )()
+    generator = object.__new__(AgentsGenerator)
+    generator.cli_config = cli_config
+
+    with pytest.raises(ValueError, match=message):
+        generator._validate_adapter_cli_capabilities(adapter)
+
+
+def test_native_adapter_declares_cli_runtime_capabilities():
+    from praisonai.framework_adapters.base import BaseFrameworkAdapter
+    from praisonai.framework_adapters.praisonai_adapter import PraisonAIAdapter
+
+    assert BaseFrameworkAdapter.SUPPORTS_SESSION_CONTINUITY is False
+    assert BaseFrameworkAdapter.SUPPORTS_STREAM_BRIDGE is False
+    assert PraisonAIAdapter.SUPPORTS_SESSION_CONTINUITY is True
+    assert PraisonAIAdapter.SUPPORTS_STREAM_BRIDGE is True

--- a/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
+++ b/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
@@ -351,12 +351,13 @@ def test_import_profiler_defensive_and_idempotent_paths(monkeypatch):
         profiler.__exit__(None, None, None)
 
 
-def test_yaml_cli_config_extracts_output_mode():
+def test_yaml_cli_config_falls_back_to_legacy_output_format():
     from praisonai_code.cli.legacy.praison_ai import PraisonAI
 
     cli = object.__new__(PraisonAI)
     cli.args = SimpleNamespace(
-        output="stream-json",
+        output=None,
+        output_format="stream-json",
         tool_retry_attempts=1,
     )
 

--- a/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
+++ b/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
@@ -243,3 +243,109 @@ def test_native_adapter_declares_cli_runtime_capabilities():
     assert BaseFrameworkAdapter.SUPPORTS_STREAM_BRIDGE is False
     assert PraisonAIAdapter.SUPPORTS_SESSION_CONTINUITY is True
     assert PraisonAIAdapter.SUPPORTS_STREAM_BRIDGE is True
+
+
+def test_sync_entrypoints_run_capability_gates_before_execution():
+    from praisonai.agents_generator import AgentsGenerator
+
+    generator = object.__new__(AgentsGenerator)
+    generator._load_config = lambda: {"process": "workflow"}
+    generator._is_workflow_yaml = lambda config: config["process"] == "workflow"
+
+    def reject_workflow():
+        raise ValueError("workflow gate")
+
+    generator._validate_workflow_cli_capabilities = reject_workflow
+    with pytest.raises(ValueError, match="workflow gate"):
+        generator.generate_crew_and_kickoff()
+
+    adapter = object()
+    generator._load_config = lambda: {"process": "sequential"}
+    generator._prepare_for_run = lambda config: {"adapter": adapter}
+
+    def reject_adapter(candidate):
+        assert candidate is adapter
+        raise ValueError("adapter gate")
+
+    generator._validate_adapter_cli_capabilities = reject_adapter
+    with pytest.raises(ValueError, match="adapter gate"):
+        generator.generate_crew_and_kickoff()
+
+
+async def test_async_entrypoints_run_capability_gates_before_execution():
+    from praisonai.agents_generator import AgentsGenerator
+
+    generator = object.__new__(AgentsGenerator)
+    config = {"process": "workflow"}
+
+    async def load_config():
+        return config
+
+    generator._aload_config = load_config
+    generator._is_workflow_yaml = lambda candidate: candidate["process"] == "workflow"
+
+    def reject_workflow():
+        raise ValueError("workflow gate")
+
+    generator._validate_workflow_cli_capabilities = reject_workflow
+    with pytest.raises(ValueError, match="workflow gate"):
+        await generator.agenerate_crew_and_kickoff()
+
+    config["process"] = "sequential"
+    adapter = object()
+
+    async def prepare_for_run(candidate):
+        assert candidate is config
+        return {"adapter": adapter}
+
+    generator._aprepare_for_run = prepare_for_run
+
+    def reject_adapter(candidate):
+        assert candidate is adapter
+        raise ValueError("adapter gate")
+
+    generator._validate_adapter_cli_capabilities = reject_adapter
+    with pytest.raises(ValueError, match="adapter gate"):
+        await generator.agenerate_crew_and_kickoff()
+
+
+async def test_store_dispatch_helpers_cover_sync_async_and_missing_methods():
+    from praisonai.db.adapter import PraisonAIDB
+
+    class MixedStore:
+        def sync_value(self):
+            return "sync"
+
+        async def async_value(self):
+            return "async"
+
+    store = MixedStore()
+
+    assert (
+        PraisonAIDB._store_callable(store, "sync_value", "async_value")
+        == store.async_value
+    )
+    assert PraisonAIDB._call_store(store, "sync_value", "missing") == "sync"
+    assert PraisonAIDB._call_store(store, "missing", "also_missing") is None
+    assert (
+        await PraisonAIDB._dispatch_async(store, "sync_value", "async_value")
+        == "async"
+    )
+
+
+def test_import_profiler_defensive_and_idempotent_paths(monkeypatch):
+    from praisonai import profiler as profiler_module
+    from praisonai.profiler import ImportProfiler
+
+    monkeypatch.setattr(profiler_module, "_IMPORT_HOOK_ORIGINAL", None)
+    with pytest.raises(RuntimeError, match="no original import hook"):
+        profiler_module._profiled_import("json")
+
+    profiler = ImportProfiler()
+    try:
+        assert profiler.__enter__() is profiler
+        installed_hook = builtins.__import__
+        assert profiler.__enter__() is profiler
+        assert builtins.__import__ is installed_hook
+    finally:
+        profiler.__exit__(None, None, None)

--- a/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
+++ b/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
@@ -228,6 +228,8 @@ def test_import_profiler_records_default_once_across_overlapping_scopes():
         assert len(first_json) == 1
         assert len(second_json) == 1
     finally:
+        second.__exit__(None, None, None)
+        first.__exit__(None, None, None)
         builtins.__import__ = original
         Profiler.disable()
         Profiler.clear()

--- a/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
+++ b/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
@@ -1,6 +1,8 @@
 """Regression coverage for wrapper issues reported in #3867."""
 
 import builtins
+import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -349,3 +351,52 @@ def test_import_profiler_defensive_and_idempotent_paths(monkeypatch):
         assert builtins.__import__ is installed_hook
     finally:
         profiler.__exit__(None, None, None)
+
+
+def test_yaml_cli_config_extracts_output_mode():
+    from praisonai_code.cli.legacy.praison_ai import PraisonAI
+
+    cli = object.__new__(PraisonAI)
+    cli.args = SimpleNamespace(
+        output="stream-json",
+        tool_retry_attempts=1,
+    )
+
+    config = cli._extract_cli_config_for_yaml()
+
+    assert config["output"] == "stream-json"
+
+
+def test_typer_yaml_path_forwards_output_mode(monkeypatch):
+    import importlib
+
+    monkeypatch.setitem(sys.modules, "toml", SimpleNamespace())
+    main_module = importlib.import_module("praisonai_code.cli.main")
+    run_module = importlib.import_module("praisonai_code.cli.commands.run")
+    captured = {}
+
+    class FakePraisonAI:
+        def __init__(self, **kwargs):
+            self.config_list = [{}]
+
+        def run(self):
+            captured["output"] = self.args.output
+            return "ok"
+
+    output = SimpleNamespace(
+        emit_result=lambda **kwargs: None,
+        is_json_mode=True,
+        print_error=lambda message: None,
+        print_success=lambda message: None,
+    )
+    monkeypatch.setattr(main_module, "PraisonAI", FakePraisonAI)
+    monkeypatch.setattr(run_module, "get_output_controller", lambda: output)
+    monkeypatch.setattr(run_module, "_record_session_usage", lambda *args: None)
+
+    run_module._run_from_file(
+        "workflow.yaml",
+        output_mode="stream-json",
+        no_save=True,
+    )
+
+    assert captured["output"] == "stream-json"

--- a/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
+++ b/src/praisonai/tests/unit/test_wrapper_regressions_3867.py
@@ -165,6 +165,74 @@ def test_adapter_capability_gate_rejects_unsupported_cli_modes(
         generator._validate_adapter_cli_capabilities(adapter)
 
 
+@pytest.mark.parametrize(
+    "cli_config, message",
+    [
+        ({"resume_session": "session"}, "--resume"),
+        ({"auto_save": "session"}, "workflow YAMLs"),
+        ({"output": "stream-json"}, "stream-json"),
+    ],
+)
+def test_workflow_path_rejects_unsupported_cli_modes(cli_config, message):
+    from praisonai.agents_generator import AgentsGenerator
+
+    generator = object.__new__(AgentsGenerator)
+    generator.cli_config = cli_config
+
+    with pytest.raises(ValueError, match=message):
+        generator._validate_workflow_cli_capabilities()
+
+
+def test_workflow_path_allows_supported_cli_modes():
+    from praisonai.agents_generator import AgentsGenerator
+
+    generator = object.__new__(AgentsGenerator)
+    generator.cli_config = {"output": "json"}
+
+    generator._validate_workflow_cli_capabilities()
+
+
+def test_import_profiler_records_default_once_across_overlapping_scopes():
+    import time
+
+    from praisonai import profiler as profiler_module
+    from praisonai.profiler import ImportProfiler, Profiler, get_profiler
+
+    Profiler.clear()
+    Profiler.enable()
+
+    original = builtins.__import__
+    first = ImportProfiler()
+    second = ImportProfiler()
+    try:
+        first.__enter__()
+        second.__enter__()
+
+        def _slow_original(name, *args, **kwargs):
+            time.sleep(0.005)
+            return original(name, *args, **kwargs)
+
+        profiler_module._IMPORT_HOOK_ORIGINAL = _slow_original
+        builtins.__import__("json")
+
+        first.__exit__(None, None, None)
+        second.__exit__(None, None, None)
+
+        default_json = [
+            record for record in get_profiler()._imports if record.module == "json"
+        ]
+        first_json = [r for r in first._imports if r.module == "json"]
+        second_json = [r for r in second._imports if r.module == "json"]
+
+        assert len(default_json) == 1
+        assert len(first_json) == 1
+        assert len(second_json) == 1
+    finally:
+        builtins.__import__ = original
+        Profiler.disable()
+        Profiler.clear()
+
+
 def test_native_adapter_declares_cli_runtime_capabilities():
     from praisonai.framework_adapters.base import BaseFrameworkAdapter
     from praisonai.framework_adapters.praisonai_adapter import PraisonAIAdapter


### PR DESCRIPTION
## Summary

- complete async conversation and state-store calls from synchronous PraisonAIDB hooks through the shared async bridge
- reject session continuity and stream-json modes before dispatch when an adapter does not declare support
- route detailed profiler records through the active profiler and make overlapping import-profiler scopes safe

## Validation

- 98 regression tests passed
- 3 optional integration tests skipped
- git diff --check

Closes #3867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session continuity and structured streaming support for the native adapter.
  * Added profiling APIs for recording detailed performance statistics.
  * Improved compatibility with asynchronous data stores during synchronous operations.
  * YAML workflow runs now honor configured output modes, including structured streaming.

* **Bug Fixes**
  * Unsupported session and streaming options are rejected before execution.
  * Overlapping import-profiling sessions now work reliably.
  * Profiling preserves operation results while recording statistics.

* **Tests**
  * Added regression coverage for validation, profiling, output modes, and asynchronous store compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->