### PR TITLE
fix: render safe bot failure replies

### DIFF
--- a/src/praisonai-agents/praisonaiagents/gateway/adapters/recipe_adapter.py
+++ b/src/praisonai-agents/praisonaiagents/gateway/adapters/recipe_adapter.py
@@ -53,4 +53,6 @@ class RecipeBotAdapter:
             
         except Exception as e:
             logger.error(f"Recipe execution failed: {e}")
-            return f"Error executing recipe: {e}"
+            from ...bots.failure import render_failure_reply
+
+            return render_failure_reply(e).text

--- a/src/praisonai-agents/tests/unit/gateway/test_recipe_failure_reply.py
+++ b/src/praisonai-agents/tests/unit/gateway/test_recipe_failure_reply.py
@@ -1,0 +1,17 @@
+"""Recipe gateway failures use the core failure reply contract."""
+
+from praisonaiagents.gateway.adapters.recipe_adapter import RecipeBotAdapter
+
+
+def test_recipe_adapter_does_not_return_raw_exception(monkeypatch):
+    adapter = RecipeBotAdapter("demo")
+
+    def fail():
+        raise RuntimeError("private-recipe-detail")
+
+    monkeypatch.setattr(adapter, "_get_runtime", fail)
+
+    reply = adapter.chat("hello")
+
+    assert reply == "I couldn't complete that due to an unexpected error. Please resend."
+    assert "private-recipe-detail" not in reply

--- a/src/praisonai-bot/praisonai_bot/bots/_failure.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_failure.py
@@ -4,10 +4,22 @@ from __future__ import annotations
 
 from typing import Any
 
+_GENERIC_FAILURE_TEXT = (
+    "I couldn't complete that due to an unexpected error. Please resend."
+)
+
 
 def failure_reply_text(outcome: Any) -> str:
-    """Render a failed turn without exposing raw exception text."""
-    from praisonaiagents.bots.failure import render_failure_reply
+    """Render a failed turn without exposing raw exception text.
+
+    Falls back to a safe generic reply if the core renderer is unavailable
+    (e.g. an older ``praisonaiagents`` release), so the error path never itself
+    raises and leaves the user without a reply.
+    """
+    try:
+        from praisonaiagents.bots.failure import render_failure_reply
+    except ImportError:
+        return _GENERIC_FAILURE_TEXT
 
     return render_failure_reply(outcome).text
 

--- a/src/praisonai-bot/praisonai_bot/bots/_failure.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_failure.py
@@ -1,0 +1,15 @@
+"""Canonical user-facing failure replies for bot transports."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def failure_reply_text(outcome: Any) -> str:
+    """Render a failed turn without exposing raw exception text."""
+    from praisonaiagents.bots.failure import render_failure_reply
+
+    return render_failure_reply(outcome).text
+
+
+__all__ = ["failure_reply_text"]

--- a/src/praisonai-bot/praisonai_bot/bots/discord.py
+++ b/src/praisonai-bot/praisonai_bot/bots/discord.py
@@ -43,6 +43,7 @@ from ._commands import (
     get_last_user_message,
     build_command_access_policy,
 )
+from ._failure import failure_reply_text
 from ._session import BotSessionManager
 from ._debounce import InboundDebouncer
 from ._ack import AckReactor
@@ -447,13 +448,13 @@ class DiscordBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                                 await _send_agent_response()
                             except Exception as e:
                                 logger.error(f"Agent error: {e}")
-                                await message.reply(f"Error: {str(e)}")
+                                await message.reply(failure_reply_text(e))
                     else:
                         try:
                             await _send_agent_response()
                         except Exception as e:
                             logger.error(f"Agent error: {e}")
-                            await message.reply(f"Error: {str(e)}")
+                            await message.reply(failure_reply_text(e))
         
         await self._client.start(self._token)
     

--- a/src/praisonai-bot/praisonai_bot/bots/discord.py
+++ b/src/praisonai-bot/praisonai_bot/bots/discord.py
@@ -363,7 +363,7 @@ class DiscordBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                         await message.reply(response)
                     except Exception as e:  # noqa: BLE001 - surface a friendly message
                         logger.warning("retry failed: %s", e)
-                        await message.reply(f"❌ Retry failed: {e}")
+                        await message.reply(failure_reply_text(e))
                     return
                 elif command == "reasoning":
                     user_id = str(message.author.id)

--- a/src/praisonai-bot/praisonai_bot/bots/slack.py
+++ b/src/praisonai-bot/praisonai_bot/bots/slack.py
@@ -52,6 +52,7 @@ def _is_missing_metadata_scope(err: BaseException) -> bool:
     )
 
 from .media import split_media_from_output, is_audio_file
+from ._failure import failure_reply_text
 from ._commands import (
     format_status, 
     format_help, 
@@ -622,9 +623,7 @@ class SlackBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                         await self._ack.done(ack_ctx, react_fn=_slack_react, unreact_fn=_slack_unreact)
                 except Exception as e:
                     logger.error(f"Agent error: {e}")
-                    error_msg = str(e)
-                    if error_msg:
-                        await say(text=f"Error: {error_msg}", thread_ts=event.get("ts"))
+                    await say(text=failure_reply_text(e), thread_ts=event.get("ts"))
         
         @self._app.event("app_mention")
         async def handle_mention(event, say):
@@ -703,9 +702,7 @@ class SlackBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                     )
                 except Exception as e:
                     logger.error(f"Agent error: {e}")
-                    error_msg = str(e)
-                    if error_msg:
-                        await say(text=f"Error: {error_msg}", thread_ts=event.get("ts"))
+                    await say(text=failure_reply_text(e), thread_ts=event.get("ts"))
         
         for command, handler in self._command_handlers.items():
             @self._app.command(f"/{command}")

--- a/src/praisonai-bot/praisonai_bot/bots/slack.py
+++ b/src/praisonai-bot/praisonai_bot/bots/slack.py
@@ -519,7 +519,7 @@ class SlackBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                     await say(text=response, thread_ts=event.get("ts"))
                 except Exception as e:  # noqa: BLE001 - surface a friendly message
                     logger.warning("retry failed: %s", e)
-                    await say(text=f"❌ Retry failed: {e}", thread_ts=event.get("ts"))
+                    await say(text=failure_reply_text(e), thread_ts=event.get("ts"))
                 return
             elif text == "/reasoning":
                 user_id = event.get("user", "unknown")

--- a/src/praisonai-bot/praisonai_bot/bots/telegram.py
+++ b/src/praisonai-bot/praisonai_bot/bots/telegram.py
@@ -68,7 +68,7 @@ from ._streaming import StreamingConfig, StreamingMode, DraftStreamer
 from ._rate_limit import RateLimiter
 from ._resilience import deliver_with_retry, BackoffPolicy, TELEGRAM_BACKOFF
 from ._dlq import OutboundDLQ
-from ..gateway.unicode_utils import safe_error_message, safe_log_message, extract_root_cause_from_error
+from ..gateway.unicode_utils import safe_log_message
 from ..gateway.pairing import PairingStore
 
 logger = logging.getLogger(__name__)
@@ -985,10 +985,7 @@ class TelegramBot(ChatCommandMixin, MessageHookMixin):
                             command,
                             safe_log_message(e),
                         )
-                        user_error = extract_root_cause_from_error(str(e))
-                        await update.message.reply_text(
-                            f"❌ /{command} failed: {safe_error_message(user_error)}"
-                        )
+                        await update.message.reply_text(failure_reply_text(e))
         
         async def handle_status(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if not update.message:

--- a/src/praisonai-bot/praisonai_bot/bots/telegram.py
+++ b/src/praisonai-bot/praisonai_bot/bots/telegram.py
@@ -32,6 +32,7 @@ from praisonaiagents.bots import (
 )
 
 from .media import split_media_from_output, is_audio_file
+from ._failure import failure_reply_text
 from ._commands import (
     format_status, 
     format_help, 
@@ -892,8 +893,7 @@ class TelegramBot(ChatCommandMixin, MessageHookMixin):
                         await self._ack.done(ack_ctx, react_fn=_tg_react, unreact_fn=_tg_unreact)
                 except Exception as e:
                     logger.error(f"Agent error: {safe_log_message(e)}")
-                    user_error = extract_root_cause_from_error(str(e))
-                    await update.message.reply_text(f"Error: {safe_error_message(user_error)}")
+                    await update.message.reply_text(failure_reply_text(e))
                 finally:
                     # Inbound media is cached to temp files for this turn only;
                     # remove them so media-heavy bots don't fill the temp volume.

--- a/src/praisonai-bot/praisonai_bot/bots/telegram.py
+++ b/src/praisonai-bot/praisonai_bot/bots/telegram.py
@@ -1223,7 +1223,7 @@ class TelegramBot(ChatCommandMixin, MessageHookMixin):
                 await update.message.reply_text(response)
             except Exception as e:  # noqa: BLE001 - surface a friendly message
                 logger.warning("retry failed: %s", e)
-                await update.message.reply_text(f"❌ Retry failed: {e}")
+                await update.message.reply_text(failure_reply_text(e))
 
         async def handle_reasoning(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if not update.message:

--- a/src/praisonai-bot/praisonai_bot/bots/whatsapp.py
+++ b/src/praisonai-bot/praisonai_bot/bots/whatsapp.py
@@ -48,6 +48,7 @@ from praisonaiagents.bots import (
 )
 
 from ._commands import format_status, format_help, handle_stop_command
+from ._failure import failure_reply_text
 from ._session import BotSessionManager
 from ._rate_limit import RateLimiter
 from ._ack import AckReactor
@@ -590,7 +591,7 @@ class WhatsAppBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                                 self.fire_message_sent(chat_jid, send_result["content"])
                     except Exception as e:
                         logger.error(f"Agent chat error: {e}")
-                        await self._web_send(chat_jid, "Sorry, I encountered an error.")
+                        await self._web_send(chat_jid, failure_reply_text(e))
 
             except Exception as e:
                 logger.error(f"Web mode message processing error: {e}")
@@ -935,7 +936,7 @@ class WhatsAppBot(OutboundResilienceMixin, ChatCommandMixin, MessageHookMixin):
                             await self._ack.done(ack_ctx, react_fn=_wa_react, unreact_fn=_wa_unreact)
             except Exception as e:
                 logger.error(f"Agent chat error: {e}")
-                await self.send_message(sender_id, "Sorry, I encountered an error processing your message.")
+                await self.send_message(sender_id, failure_reply_text(e))
             finally:
                 # Inbound media is cached to temp files for this turn only;
                 # remove them so media-heavy bots don't fill the temp volume.

--- a/src/praisonai-bot/tests/unit/bots/test_failure_reply_wiring.py
+++ b/src/praisonai-bot/tests/unit/bots/test_failure_reply_wiring.py
@@ -1,0 +1,34 @@
+"""Regression tests for canonical bot failure rendering."""
+
+from pathlib import Path
+
+from praisonaiagents.errors import PraisonAIConfigError
+
+from praisonai_bot.bots._failure import failure_reply_text
+
+
+def test_failure_reply_uses_core_taxonomy_and_hides_raw_exception():
+    error = PraisonAIConfigError(
+        "secret-token-should-not-leak",
+        config_key="OPENAI_API_KEY",
+        remediation_hint="Run `praisonai onboard`, then resend.",
+    )
+
+    reply = failure_reply_text(error)
+
+    assert reply == "I couldn't complete that. Run `praisonai onboard`, then resend."
+    assert "secret-token" not in reply
+
+
+def test_terminal_agent_paths_use_the_canonical_renderer():
+    bots_dir = Path(__file__).parents[3] / "praisonai_bot" / "bots"
+    expected_calls = {
+        "telegram.py": 1,
+        "discord.py": 2,
+        "slack.py": 2,
+        "whatsapp.py": 2,
+    }
+
+    for filename, minimum in expected_calls.items():
+        source = (bots_dir / filename).read_text(encoding="utf-8")
+        assert source.count("failure_reply_text(e)") >= minimum

--- a/src/praisonai-bot/tests/unit/bots/test_failure_reply_wiring.py
+++ b/src/praisonai-bot/tests/unit/bots/test_failure_reply_wiring.py
@@ -23,7 +23,7 @@ def test_failure_reply_uses_core_taxonomy_and_hides_raw_exception():
 def test_terminal_agent_paths_use_the_canonical_renderer():
     bots_dir = Path(__file__).parents[3] / "praisonai_bot" / "bots"
     expected_calls = {
-        "telegram.py": 2,
+        "telegram.py": 3,
         "discord.py": 3,
         "slack.py": 3,
         "whatsapp.py": 2,

--- a/src/praisonai-bot/tests/unit/bots/test_failure_reply_wiring.py
+++ b/src/praisonai-bot/tests/unit/bots/test_failure_reply_wiring.py
@@ -23,12 +23,37 @@ def test_failure_reply_uses_core_taxonomy_and_hides_raw_exception():
 def test_terminal_agent_paths_use_the_canonical_renderer():
     bots_dir = Path(__file__).parents[3] / "praisonai_bot" / "bots"
     expected_calls = {
-        "telegram.py": 1,
-        "discord.py": 2,
-        "slack.py": 2,
+        "telegram.py": 2,
+        "discord.py": 3,
+        "slack.py": 3,
         "whatsapp.py": 2,
     }
 
     for filename, minimum in expected_calls.items():
         source = (bots_dir / filename).read_text(encoding="utf-8")
         assert source.count("failure_reply_text(e)") >= minimum
+
+
+def test_retry_paths_do_not_interpolate_raw_exception():
+    bots_dir = Path(__file__).parents[3] / "praisonai_bot" / "bots"
+    for filename in ("telegram.py", "discord.py", "slack.py"):
+        source = (bots_dir / filename).read_text(encoding="utf-8")
+        assert "Retry failed: {e}" not in source
+
+
+def test_failure_reply_falls_back_when_core_renderer_missing(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "praisonaiagents.bots.failure":
+            raise ImportError("simulated older core without bots.failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    reply = failure_reply_text(RuntimeError("secret-token-should-not-leak"))
+
+    assert "secret-token" not in reply
+    assert reply


### PR DESCRIPTION
## Summary

- add a lazy bot-side bridge to the canonical core failure renderer
- use structured, actionable replies for terminal agent failures in Telegram, Discord, Slack, and both WhatsApp transports
- stop the recipe gateway adapter from returning raw exception text

## Validation

- 16 focused core and bot tests passed
- bot and recipe modules compile successfully
- git diff --check

Closes #3868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized failure messages across recipe executions and Telegram, Discord, Slack, and WhatsApp integrations.
  * Prevented raw exception details and sensitive information from appearing in user-facing error responses.
  * Added remediation guidance for configuration-related failures where available.
  * Ensured consistent fallback messaging when detailed failure rendering is unavailable.

* **Tests**
  * Added coverage confirming sanitized failure responses, fallback behavior, and consistent handling across supported integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->