### PR TITLE
feat: make gateway doctor extensible

### DIFF
--- a/src/praisonai-agents/praisonaiagents/runtime/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/__init__.py
@@ -77,6 +77,14 @@ __all__ = [
     "collect_findings",
     "apply_fixes",
     "plan_fixes",
+    # Extensible runtime health checks
+    "HealthCheckProtocol",
+    "HealthCheckResult",
+    "HealthRepairResult",
+    "HealthCheckRegistry",
+    "get_health_check_registry",
+    "register_health_check",
+    "run_health_checks",
     # Capability types
     "RuntimeCapability",
     "RuntimeCapabilityMatrix",
@@ -164,6 +172,17 @@ _LAZY_GROUPS = {
         'collect_findings': ('praisonaiagents.runtime.doctor_registry', 'collect_findings'),
         'apply_fixes': ('praisonaiagents.runtime.doctor_registry', 'apply_fixes'),
         'plan_fixes': ('praisonaiagents.runtime.doctor_registry', 'plan_fixes'),
+    },
+    'health_check': {
+        'HealthCheckProtocol': ('praisonaiagents.runtime.health_check', 'HealthCheckProtocol'),
+        'HealthCheckResult': ('praisonaiagents.runtime.health_check', 'HealthCheckResult'),
+        'HealthRepairResult': ('praisonaiagents.runtime.health_check', 'HealthRepairResult'),
+    },
+    'health_registry': {
+        'HealthCheckRegistry': ('praisonaiagents.runtime.health_registry', 'HealthCheckRegistry'),
+        'get_health_check_registry': ('praisonaiagents.runtime.health_registry', 'get_health_check_registry'),
+        'register_health_check': ('praisonaiagents.runtime.health_registry', 'register_health_check'),
+        'run_health_checks': ('praisonaiagents.runtime.health_registry', 'run_health_checks'),
     },
     'journal': {
         'RunJournal': ('praisonaiagents.runtime.journal', 'RunJournal'),

--- a/src/praisonai-agents/praisonaiagents/runtime/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/__init__.py
@@ -85,6 +85,7 @@ __all__ = [
     "get_health_check_registry",
     "register_health_check",
     "run_health_checks",
+    "arun_health_checks",
     # Capability types
     "RuntimeCapability",
     "RuntimeCapabilityMatrix",
@@ -183,6 +184,7 @@ _LAZY_GROUPS = {
         'get_health_check_registry': ('praisonaiagents.runtime.health_registry', 'get_health_check_registry'),
         'register_health_check': ('praisonaiagents.runtime.health_registry', 'register_health_check'),
         'run_health_checks': ('praisonaiagents.runtime.health_registry', 'run_health_checks'),
+        'arun_health_checks': ('praisonaiagents.runtime.health_registry', 'arun_health_checks'),
     },
     'journal': {
         'RunJournal': ('praisonaiagents.runtime.journal', 'RunJournal'),

--- a/src/praisonai-agents/praisonaiagents/runtime/health_check.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/health_check.py
@@ -71,8 +71,12 @@ class HealthCheckProtocol(Protocol):
     """
 
     @property
-    def id(self) -> str:
-        """Stable namespaced identifier for this check."""
+    def check_id(self) -> str:
+        """Stable namespaced identifier for this check.
+
+        The registry also accepts ``id`` as a compatibility alias for checks
+        written against the first version of this contract.
+        """
         ...
 
     def detect(self, context: Mapping[str, Any]) -> List[Finding]:

--- a/src/praisonai-agents/praisonaiagents/runtime/health_check.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/health_check.py
@@ -1,0 +1,86 @@
+"""Extensible health-check contracts shared by runtime surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Protocol, runtime_checkable
+
+from .doctor_protocol import Finding
+
+
+@dataclass(frozen=True)
+class HealthRepairResult:
+    """Result returned by an optional health-check repair."""
+
+    changed: bool
+    message: str = ""
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HealthCheckResult:
+    """One check's detect → repair → re-validate outcome."""
+
+    check_id: str
+    findings: List[Finding]
+    residual_findings: List[Finding]
+    repair: Optional[HealthRepairResult] = None
+    error: Optional[str] = None
+
+    @property
+    def repaired(self) -> bool:
+        return bool(self.repair and self.repair.changed and not self.residual_findings)
+
+    def to_dict(self) -> Dict[str, Any]:
+        def _finding(value: Finding) -> Dict[str, Any]:
+            return {
+                "rule_id": value.rule_id,
+                "severity": value.severity,
+                "message": value.message,
+                "fix_description": value.fix_description,
+                "context": value.context,
+            }
+
+        return {
+            "id": self.check_id,
+            "findings": [_finding(item) for item in self.findings],
+            "repair": (
+                {
+                    "changed": self.repair.changed,
+                    "message": self.repair.message,
+                    "details": dict(self.repair.details),
+                }
+                if self.repair
+                else None
+            ),
+            "residual_findings": [
+                _finding(item) for item in self.residual_findings
+            ],
+            "repaired": self.repaired,
+            "error": self.error,
+        }
+
+
+@runtime_checkable
+class HealthCheckProtocol(Protocol):
+    """Minimum protocol implemented by runtime health checks.
+
+    A check may additionally expose ``repair(context, findings)``.  Keeping
+    repair outside the required protocol lets diagnostic-only integrations
+    participate without pretending that every problem is safe to automate.
+    """
+
+    @property
+    def id(self) -> str:
+        """Stable namespaced identifier for this check."""
+        ...
+
+    def detect(self, context: Mapping[str, Any]) -> List[Finding]:
+        """Return current health findings without mutating external state."""
+        ...
+
+__all__ = [
+    "HealthCheckProtocol",
+    "HealthCheckResult",
+    "HealthRepairResult",
+]

--- a/src/praisonai-agents/praisonaiagents/runtime/health_registry.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/health_registry.py
@@ -1,0 +1,151 @@
+"""Registry and entry-point discovery for runtime health checks."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, List, Mapping, Optional
+
+from .doctor_protocol import Finding
+from .health_check import (
+    HealthCheckProtocol,
+    HealthCheckResult,
+    HealthRepairResult,
+)
+
+
+class HealthCheckRegistry:
+    """Run registered checks with failure isolation and re-validation."""
+
+    ENTRY_POINT_GROUP = "praisonai.health_checks"
+
+    def __init__(self) -> None:
+        self._checks: Dict[str, HealthCheckProtocol] = {}
+        self._plugins_loaded = False
+
+    def register_check(self, check: HealthCheckProtocol) -> None:
+        check_id = getattr(check, "id", None) or getattr(check, "check_id", None)
+        if not callable(getattr(check, "detect", None)):
+            raise TypeError("Check must provide detect(context)")
+        if not isinstance(check_id, str) or "/" not in check_id:
+            raise ValueError("Health check IDs must be namespaced (for example channel/name)")
+        if check_id in self._checks:
+            warnings.warn(
+                f"Duplicate health check ID {check_id!r} - replacing existing check"
+            )
+        self._checks[check_id] = check
+
+    def get_checks(self) -> List[HealthCheckProtocol]:
+        if not self._plugins_loaded:
+            self._load_entry_points()
+            self._plugins_loaded = True
+        return list(self._checks.values())
+
+    def get_check_ids(self) -> List[str]:
+        """Return stable IDs after lazy plugin discovery."""
+        self.get_checks()
+        return list(self._checks)
+
+    def run(
+        self,
+        context: Mapping[str, Any],
+        *,
+        fix: bool = False,
+    ) -> List[HealthCheckResult]:
+        results: List[HealthCheckResult] = []
+        self.get_checks()
+        for check_id, check in self._checks.items():
+            try:
+                findings = list(check.detect(context))
+            except Exception as exc:
+                results.append(HealthCheckResult(
+                    check_id=check_id,
+                    findings=[],
+                    residual_findings=[Finding(
+                        rule_id=check_id,
+                        severity="error",
+                        message=f"Health check failed: {exc}",
+                        context={"error": str(exc)},
+                    )],
+                    error=str(exc),
+                ))
+                continue
+
+            repair: Optional[HealthRepairResult] = None
+            residual = findings
+            repair_fn = getattr(check, "repair", None)
+            if fix and findings and callable(repair_fn):
+                try:
+                    repair = repair_fn(context, findings)
+                    residual = list(check.detect(context))
+                except Exception as exc:
+                    residual = list(findings) + [Finding(
+                        rule_id=check_id,
+                        severity="error",
+                        message=f"Health check repair failed: {exc}",
+                        context={"error": str(exc)},
+                    )]
+                    results.append(HealthCheckResult(
+                        check_id=check_id,
+                        findings=findings,
+                        residual_findings=residual,
+                        repair=repair,
+                        error=str(exc),
+                    ))
+                    continue
+
+            results.append(HealthCheckResult(
+                check_id=check_id,
+                findings=findings,
+                residual_findings=residual,
+                repair=repair,
+            ))
+        return results
+
+    def _load_entry_points(self) -> None:
+        try:
+            from importlib.metadata import entry_points
+
+            discovered = entry_points()
+            if hasattr(discovered, "select"):
+                entries = discovered.select(group=self.ENTRY_POINT_GROUP)
+            else:  # pragma: no cover - Python <3.10 compatibility
+                entries = discovered.get(self.ENTRY_POINT_GROUP, [])
+        except Exception as exc:  # pragma: no cover - platform metadata failure
+            warnings.warn(f"Failed to discover health checks: {exc}")
+            return
+
+        for entry in entries:
+            try:
+                provider = entry.load()
+                check = provider() if callable(provider) else provider
+                self.register_check(check)
+            except Exception as exc:
+                warnings.warn(f"Failed to load health check {entry.name!r}: {exc}")
+
+
+_default_registry: Optional[HealthCheckRegistry] = None
+
+
+def get_health_check_registry() -> HealthCheckRegistry:
+    global _default_registry
+    if _default_registry is None:
+        _default_registry = HealthCheckRegistry()
+    return _default_registry
+
+
+def register_health_check(check: HealthCheckProtocol) -> None:
+    get_health_check_registry().register_check(check)
+
+
+def run_health_checks(
+    context: Mapping[str, Any], *, fix: bool = False
+) -> List[HealthCheckResult]:
+    return get_health_check_registry().run(context, fix=fix)
+
+
+__all__ = [
+    "HealthCheckRegistry",
+    "get_health_check_registry",
+    "register_health_check",
+    "run_health_checks",
+]

--- a/src/praisonai-agents/praisonaiagents/runtime/health_registry.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/health_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import warnings
 from typing import Any, Dict, List, Mapping, Optional
 
@@ -18,21 +20,40 @@ class HealthCheckRegistry:
 
     ENTRY_POINT_GROUP = "praisonai.health_checks"
 
-    def __init__(self) -> None:
+    def __init__(self, *, discover_plugins: bool = True) -> None:
         self._checks: Dict[str, HealthCheckProtocol] = {}
-        self._plugins_loaded = False
+        self._protected: set[str] = set()
+        self._plugins_loaded = not discover_plugins
 
-    def register_check(self, check: HealthCheckProtocol) -> None:
-        check_id = getattr(check, "id", None) or getattr(check, "check_id", None)
+    @staticmethod
+    def _check_id(check: HealthCheckProtocol) -> Optional[str]:
+        """Return the canonical ID, accepting ``id`` for compatibility."""
+        return getattr(check, "check_id", None) or getattr(check, "id", None)
+
+    def register_check(
+        self, check: HealthCheckProtocol, *, protected: bool = False
+    ) -> None:
+        check_id = self._check_id(check)
         if not callable(getattr(check, "detect", None)):
             raise TypeError("Check must provide detect(context)")
         if not isinstance(check_id, str) or "/" not in check_id:
             raise ValueError("Health check IDs must be namespaced (for example channel/name)")
-        if check_id in self._checks:
+        if check_id in self._protected and not protected:
+            # A mandatory built-in owns this ID; a plugin must not shadow the
+            # required validation/repair. Silently keep the protected check.
             warnings.warn(
-                f"Duplicate health check ID {check_id!r} - replacing existing check"
+                f"Ignoring health check {check_id!r}: reserved for a built-in check",
+                stacklevel=2,
+            )
+            return
+        if check_id in self._checks and not protected:
+            warnings.warn(
+                f"Duplicate health check ID {check_id!r} - replacing existing check",
+                stacklevel=2,
             )
         self._checks[check_id] = check
+        if protected:
+            self._protected.add(check_id)
 
     def get_checks(self) -> List[HealthCheckProtocol]:
         if not self._plugins_loaded:
@@ -45,6 +66,10 @@ class HealthCheckRegistry:
         self.get_checks()
         return list(self._checks)
 
+    def protected_ids(self) -> List[str]:
+        """Return IDs reserved for built-ins that plugins cannot shadow."""
+        return list(self._protected)
+
     def run(
         self,
         context: Mapping[str, Any],
@@ -52,8 +77,8 @@ class HealthCheckRegistry:
         fix: bool = False,
     ) -> List[HealthCheckResult]:
         results: List[HealthCheckResult] = []
-        self.get_checks()
-        for check_id, check in self._checks.items():
+        for check in self.get_checks():
+            check_id = self._check_id(check) or ""
             try:
                 findings = list(check.detect(context))
             except Exception as exc:
@@ -71,11 +96,17 @@ class HealthCheckRegistry:
                 continue
 
             repair: Optional[HealthRepairResult] = None
-            residual = findings
+            residual = list(findings)
             repair_fn = getattr(check, "repair", None)
             if fix and findings and callable(repair_fn):
                 try:
                     repair = repair_fn(context, findings)
+                    if repair is not None and not isinstance(
+                        repair, HealthRepairResult
+                    ):
+                        raise TypeError(
+                            "Check repair must return HealthRepairResult or None"
+                        )
                     residual = list(check.detect(context))
                 except Exception as exc:
                     residual = list(findings) + [Finding(
@@ -88,7 +119,92 @@ class HealthCheckRegistry:
                         check_id=check_id,
                         findings=findings,
                         residual_findings=residual,
-                        repair=repair,
+                        repair=(
+                            repair if isinstance(repair, HealthRepairResult) else None
+                        ),
+                        error=str(exc),
+                    ))
+                    continue
+
+            results.append(HealthCheckResult(
+                check_id=check_id,
+                findings=findings,
+                residual_findings=residual,
+                repair=repair,
+            ))
+        return results
+
+    async def arun(
+        self,
+        context: Mapping[str, Any],
+        *,
+        fix: bool = False,
+    ) -> List[HealthCheckResult]:
+        """Run checks without blocking an async caller's event loop.
+
+        Checks may provide ``adetect`` and ``arepair`` coroutine methods.
+        Synchronous implementations are isolated with ``asyncio.to_thread``.
+        """
+
+        async def _call(check, async_name: str, sync_name: str, *args):
+            async_fn = getattr(check, async_name, None)
+            if callable(async_fn):
+                value = async_fn(*args)
+                return await value if inspect.isawaitable(value) else value
+            return await asyncio.to_thread(getattr(check, sync_name), *args)
+
+        results: List[HealthCheckResult] = []
+        for check in self.get_checks():
+            check_id = self._check_id(check) or ""
+            try:
+                findings = list(await _call(check, "adetect", "detect", context))
+            except Exception as exc:
+                results.append(HealthCheckResult(
+                    check_id=check_id,
+                    findings=[],
+                    residual_findings=[Finding(
+                        rule_id=check_id,
+                        severity="error",
+                        message=f"Health check failed: {exc}",
+                        context={"error": str(exc)},
+                    )],
+                    error=str(exc),
+                ))
+                continue
+
+            repair: Optional[HealthRepairResult] = None
+            residual = list(findings)
+            repair_fn = getattr(check, "arepair", None) or getattr(
+                check, "repair", None
+            )
+            if fix and findings and callable(repair_fn):
+                try:
+                    repair = await _call(
+                        check, "arepair", "repair", context, findings
+                    )
+                    if repair is not None and not isinstance(
+                        repair, HealthRepairResult
+                    ):
+                        raise TypeError(
+                            "Check repair must return HealthRepairResult or None"
+                        )
+                    residual = list(
+                        await _call(check, "adetect", "detect", context)
+                    )
+                except Exception as exc:
+                    residual = list(findings) + [Finding(
+                        rule_id=check_id,
+                        severity="error",
+                        message=f"Health check repair failed: {exc}",
+                        context={"error": str(exc)},
+                    )]
+                    results.append(HealthCheckResult(
+                        check_id=check_id,
+                        findings=findings,
+                        residual_findings=residual,
+                        repair=(
+                            repair if isinstance(repair, HealthRepairResult) else None
+                        ),
                         error=str(exc),
                     ))
                     continue
@@ -111,7 +227,9 @@ class HealthCheckRegistry:
             else:  # pragma: no cover - Python <3.10 compatibility
                 entries = discovered.get(self.ENTRY_POINT_GROUP, [])
         except Exception as exc:  # pragma: no cover - platform metadata failure
-            warnings.warn(f"Failed to discover health checks: {exc}")
+            warnings.warn(
+                f"Failed to discover health checks: {exc}", stacklevel=2
+            )
             return
 
         for entry in entries:
@@ -120,7 +238,10 @@ class HealthCheckRegistry:
                 check = provider() if callable(provider) else provider
                 self.register_check(check)
             except Exception as exc:
-                warnings.warn(f"Failed to load health check {entry.name!r}: {exc}")
+                warnings.warn(
+                    f"Failed to load health check {entry.name!r}: {exc}",
+                    stacklevel=2,
+                )
 
 
 _default_registry: Optional[HealthCheckRegistry] = None
@@ -143,9 +264,16 @@ def run_health_checks(
     return get_health_check_registry().run(context, fix=fix)
 
 
+async def arun_health_checks(
+    context: Mapping[str, Any], *, fix: bool = False
+) -> List[HealthCheckResult]:
+    return await get_health_check_registry().arun(context, fix=fix)
+
+
 __all__ = [
     "HealthCheckRegistry",
     "get_health_check_registry",
     "register_health_check",
     "run_health_checks",
+    "arun_health_checks",
 ]

--- a/src/praisonai-agents/tests/unit/runtime/test_health_registry.py
+++ b/src/praisonai-agents/tests/unit/runtime/test_health_registry.py
@@ -1,0 +1,93 @@
+"""Tests for extensible runtime health checks."""
+
+from praisonaiagents.runtime.doctor_protocol import Finding
+from praisonaiagents.runtime.health_check import HealthRepairResult
+from praisonaiagents.runtime.health_registry import HealthCheckRegistry
+
+
+class _RepairableCheck:
+    check_id = "test/repairable"
+
+    def __init__(self):
+        self.healthy = False
+
+    def detect(self, context):
+        if self.healthy:
+            return []
+        return [Finding(
+            rule_id=self.check_id,
+            severity="error",
+            message="not healthy",
+            fix_description="repair it",
+        )]
+
+    def repair(self, context, findings):
+        self.healthy = True
+        return HealthRepairResult(changed=True, message="repaired")
+
+
+def test_registry_repairs_and_revalidates():
+    registry = HealthCheckRegistry()
+    registry._plugins_loaded = True
+    registry.register_check(_RepairableCheck())
+
+    result = registry.run({}, fix=True)[0]
+
+    assert result.repaired is True
+    assert result.findings
+    assert result.residual_findings == []
+    assert result.to_dict()["repair"]["message"] == "repaired"
+
+
+def test_registry_isolates_broken_checks():
+    class Broken(_RepairableCheck):
+        check_id = "test/broken"
+
+        def detect(self, context):
+            raise RuntimeError("boom")
+
+    registry = HealthCheckRegistry()
+    registry._plugins_loaded = True
+    registry.register_check(Broken())
+
+    result = registry.run({})[0]
+
+    assert result.error == "boom"
+    assert result.residual_findings[0].severity == "error"
+
+
+def test_registry_accepts_diagnostic_only_checks():
+    class DiagnosticOnly:
+        check_id = "test/diagnostic-only"
+
+        def detect(self, context):
+            return [Finding(
+                rule_id=self.check_id,
+                severity="warning",
+                message="manual action required",
+                fix_description="follow the integration guide",
+            )]
+
+    registry = HealthCheckRegistry()
+    registry._plugins_loaded = True
+    registry.register_check(DiagnosticOnly())
+
+    result = registry.run({}, fix=True)[0]
+
+    assert result.repair is None
+    assert result.residual_findings == result.findings
+
+
+def test_registry_accepts_canonical_id_attribute():
+    class CanonicalCheck:
+        id = "plugin/canonical"
+
+        def detect(self, context):
+            return []
+
+    registry = HealthCheckRegistry()
+    registry._plugins_loaded = True
+    registry.register_check(CanonicalCheck())
+
+    assert registry.get_check_ids() == ["plugin/canonical"]
+    assert registry.run({})[0].check_id == "plugin/canonical"

--- a/src/praisonai-agents/tests/unit/runtime/test_health_registry.py
+++ b/src/praisonai-agents/tests/unit/runtime/test_health_registry.py
@@ -1,7 +1,15 @@
 """Tests for extensible runtime health checks."""
 
+import os
+import threading
+
+import pytest
+
 from praisonaiagents.runtime.doctor_protocol import Finding
-from praisonaiagents.runtime.health_check import HealthRepairResult
+from praisonaiagents.runtime.health_check import (
+    HealthCheckProtocol,
+    HealthRepairResult,
+)
 from praisonaiagents.runtime.health_registry import HealthCheckRegistry
 
 
@@ -27,8 +35,7 @@ class _RepairableCheck:
 
 
 def test_registry_repairs_and_revalidates():
-    registry = HealthCheckRegistry()
-    registry._plugins_loaded = True
+    registry = HealthCheckRegistry(discover_plugins=False)
     registry.register_check(_RepairableCheck())
 
     result = registry.run({}, fix=True)[0]
@@ -46,8 +53,7 @@ def test_registry_isolates_broken_checks():
         def detect(self, context):
             raise RuntimeError("boom")
 
-    registry = HealthCheckRegistry()
-    registry._plugins_loaded = True
+    registry = HealthCheckRegistry(discover_plugins=False)
     registry.register_check(Broken())
 
     result = registry.run({})[0]
@@ -68,8 +74,7 @@ def test_registry_accepts_diagnostic_only_checks():
                 fix_description="follow the integration guide",
             )]
 
-    registry = HealthCheckRegistry()
-    registry._plugins_loaded = True
+    registry = HealthCheckRegistry(discover_plugins=False)
     registry.register_check(DiagnosticOnly())
 
     result = registry.run({}, fix=True)[0]
@@ -78,16 +83,273 @@ def test_registry_accepts_diagnostic_only_checks():
     assert result.residual_findings == result.findings
 
 
-def test_registry_accepts_canonical_id_attribute():
-    class CanonicalCheck:
+def test_registry_accepts_legacy_id_alias():
+    class LegacyCheck:
         id = "plugin/canonical"
 
         def detect(self, context):
             return []
 
-    registry = HealthCheckRegistry()
-    registry._plugins_loaded = True
-    registry.register_check(CanonicalCheck())
+    registry = HealthCheckRegistry(discover_plugins=False)
+    registry.register_check(LegacyCheck())
 
     assert registry.get_check_ids() == ["plugin/canonical"]
     assert registry.run({})[0].check_id == "plugin/canonical"
+
+
+def test_protocol_uses_canonical_check_id_attribute():
+    class CanonicalCheck:
+        check_id = "plugin/canonical"
+
+        def detect(self, context):
+            return []
+
+    assert isinstance(CanonicalCheck(), HealthCheckProtocol)
+
+
+def test_registry_rejects_invalid_checks():
+    class NoDetect:
+        check_id = "test/no-detect"
+
+    class UnnamespacedId:
+        check_id = "unnamespaced"
+
+        def detect(self, context):
+            return []
+
+    registry = HealthCheckRegistry(discover_plugins=False)
+
+    with pytest.raises(TypeError):
+        registry.register_check(NoDetect())
+    with pytest.raises(ValueError):
+        registry.register_check(UnnamespacedId())
+
+
+def test_protected_check_cannot_be_shadowed():
+    class Core:
+        check_id = "core/gateway/auth-token"
+
+        def detect(self, context):
+            return [Finding(
+                rule_id=self.check_id,
+                severity="error",
+                message="core saw a problem",
+            )]
+
+    class Impostor:
+        check_id = "core/gateway/auth-token"
+
+        def detect(self, context):
+            return []
+
+    registry = HealthCheckRegistry(discover_plugins=False)
+    registry.register_check(Core(), protected=True)
+    with pytest.warns(UserWarning):
+        registry.register_check(Impostor())
+
+    result = registry.run({})[0]
+
+    assert result.residual_findings[0].message == "core saw a problem"
+
+
+def test_protected_check_replaceable_by_protected_owner():
+    class First:
+        check_id = "core/gateway/auth-token"
+
+        def detect(self, context):
+            return [Finding(
+                rule_id=self.check_id,
+                severity="error",
+                message="first",
+            )]
+
+    class Second:
+        check_id = "core/gateway/auth-token"
+
+        def detect(self, context):
+            return [Finding(
+                rule_id=self.check_id,
+                severity="error",
+                message="second",
+            )]
+
+    registry = HealthCheckRegistry(discover_plugins=False)
+    registry.register_check(First(), protected=True)
+    registry.register_check(Second(), protected=True)
+
+    assert registry.get_check_ids() == ["core/gateway/auth-token"]
+    assert registry.run({})[0].residual_findings[0].message == "second"
+
+
+def test_malformed_repair_result_is_isolated():
+    class BadRepair:
+        check_id = "test/bad-repair"
+
+        def detect(self, context):
+            return [Finding(
+                rule_id=self.check_id,
+                severity="error",
+                message="needs repair",
+            )]
+
+        def repair(self, context, findings):
+            return "not-a-repair-result"
+
+    registry = HealthCheckRegistry(discover_plugins=False)
+    registry.register_check(BadRepair())
+
+    result = registry.run({}, fix=True)[0]
+
+    assert result.error is not None
+    assert result.repair is None
+    assert any(
+        "repair failed" in finding.message for finding in result.residual_findings
+    )
+    assert result.to_dict()["repair"] is None
+
+
+def test_registry_isolates_raising_repair():
+    class BadRepair(_RepairableCheck):
+        check_id = "test/raising-repair"
+
+        def repair(self, context, findings):
+            raise RuntimeError("repair boom")
+
+    registry = HealthCheckRegistry(discover_plugins=False)
+    registry.register_check(BadRepair())
+
+    result = registry.run({}, fix=True)[0]
+
+    assert result.error == "repair boom"
+    assert result.repaired is False
+    assert any(
+        "repair failed" in finding.message for finding in result.residual_findings
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_registry_prefers_async_check_methods():
+    class AsyncRepairable:
+        check_id = "test/async"
+
+        def __init__(self):
+            self.healthy = False
+
+        def detect(self, context):
+            raise AssertionError("sync detect must not run")
+
+        async def adetect(self, context):
+            if self.healthy:
+                return []
+            return [Finding(
+                rule_id=self.check_id,
+                severity="error",
+                message="not healthy",
+            )]
+
+        async def arepair(self, context, findings):
+            self.healthy = True
+            return HealthRepairResult(changed=True, message="repaired async")
+
+    registry = HealthCheckRegistry(discover_plugins=False)
+    registry.register_check(AsyncRepairable())
+
+    result = (await registry.arun({}, fix=True))[0]
+
+    assert result.repaired is True
+    assert result.repair.message == "repaired async"
+
+
+@pytest.mark.asyncio
+async def test_async_registry_offloads_sync_checks():
+    caller_thread = threading.get_ident()
+
+    class SyncCheck:
+        check_id = "test/sync-offload"
+
+        def __init__(self):
+            self.detect_thread = None
+
+        def detect(self, context):
+            self.detect_thread = threading.get_ident()
+            return []
+
+    check = SyncCheck()
+    registry = HealthCheckRegistry(discover_plugins=False)
+    registry.register_check(check)
+
+    await registry.arun({})
+
+    assert check.detect_thread is not None
+    assert check.detect_thread != caller_thread
+
+
+def _agent_health_fixture():
+    class HealthyCheck:
+        check_id = "agentic/runtime-health"
+
+        def __init__(self):
+            self.detect_calls = 0
+
+        def detect(self, context):
+            self.detect_calls += 1
+            return []
+
+    check = HealthyCheck()
+    registry = HealthCheckRegistry(discover_plugins=False)
+    registry.register_check(check)
+
+    def inspect_runtime_health() -> str:
+        """Inspect runtime health and return the exact registered check IDs."""
+        return ", ".join(result.check_id for result in registry.run({}))
+
+    return check, inspect_runtime_health
+
+
+def test_health_check_agent_smoke(monkeypatch):
+    from praisonaiagents import Agent
+
+    check, inspect_runtime_health = _agent_health_fixture()
+    agent = Agent(
+        name="health-smoke",
+        instructions="Inspect runtime health before answering.",
+        tools=[inspect_runtime_health],
+    )
+    monkeypatch.setattr(
+        agent,
+        "chat",
+        lambda prompt, **kwargs: inspect_runtime_health(),
+    )
+
+    result = agent.start("Inspect runtime health and report the check ID.")
+    print(result)
+
+    assert result == "agentic/runtime-health"
+    assert check.detect_calls == 1
+
+
+@pytest.mark.network
+@pytest.mark.skipif(
+    os.environ.get("RUN_REAL_KEY_TESTS") != "1"
+    or not os.environ.get("OPENAI_API_KEY"),
+    reason="Set RUN_REAL_KEY_TESTS=1 and OPENAI_API_KEY for the real agentic test",
+)
+def test_health_check_real_agentic():
+    from praisonaiagents import Agent
+
+    check, inspect_runtime_health = _agent_health_fixture()
+    agent = Agent(
+        name="health-agentic",
+        model="gpt-4o-mini",
+        instructions=(
+            "Always call inspect_runtime_health before answering and include "
+            "the exact check ID returned by the tool."
+        ),
+        tools=[inspect_runtime_health],
+    )
+
+    result = agent.start("Inspect runtime health and report the exact check ID.")
+    print(result)
+
+    assert result
+    assert check.detect_calls > 0

--- a/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
@@ -4,6 +4,7 @@ Gateway command group for PraisonAI CLI.
 Provides commands for managing the WebSocket gateway with multi-bot support.
 """
 
+import sys
 from typing import Optional
 
 import typer
@@ -610,9 +611,12 @@ def _check_gateway_secret_strength(config_path: str):
 
     # Present-but-weak token: warn on loopback, fail closed externally.
     if is_local:
+        # Advisory only — must go to stderr so callers rendering a
+        # machine-readable JSON document to stdout stay parseable.
         print(
             f"⚠  gateway.auth_token is a known-weak/placeholder value "
-            f"(loopback bind {bind_host}). Rotate before exposing externally."
+            f"(loopback bind {bind_host}). Rotate before exposing externally.",
+            file=sys.stderr,
         )
         return None
 
@@ -808,7 +812,10 @@ class _GatewaySecretHealthCheck:
     def detect(self, context):
         from praisonaiagents.runtime.doctor_protocol import Finding
 
-        message = _check_gateway_secret_strength(str(context["config_path"]))
+        config_path = context.get("config_path")
+        if not config_path:
+            return []
+        message = _check_gateway_secret_strength(str(config_path))
         if not message:
             return []
         return [Finding(
@@ -821,9 +828,14 @@ class _GatewaySecretHealthCheck:
     def repair(self, context, findings):
         from praisonaiagents.runtime.health_check import HealthRepairResult
 
+        config_path = context.get("config_path")
+        if not config_path:
+            return HealthRepairResult(
+                changed=False, message="gateway config path not provided; no action taken"
+            )
         action = _repair_gateway_secret(
             dry_run=bool(context.get("dry_run")),
-            config_path=str(context["config_path"]),
+            config_path=str(config_path),
         )
         if action == "would-repair":
             return HealthRepairResult(
@@ -844,7 +856,10 @@ class _GatewayConfigVersionHealthCheck:
     def detect(self, context):
         from praisonaiagents.runtime.doctor_protocol import Finding
 
-        migration = _check_config_version(str(context["config_path"]))
+        config_path = context.get("config_path")
+        if not config_path:
+            return []
+        migration = _check_config_version(str(config_path))
         if migration is None:
             return []
         if isinstance(migration, str):
@@ -874,9 +889,20 @@ class _GatewayConfigVersionHealthCheck:
     def repair(self, context, findings):
         from praisonaiagents.runtime.health_check import HealthRepairResult
 
+        config_path = context.get("config_path")
+        if not config_path:
+            return HealthRepairResult(
+                changed=False, message="gateway config path not provided; no action taken"
+            )
         details = findings[0].context or {}
         if details.get("unsupported"):
-            return HealthRepairResult(changed=False)
+            return HealthRepairResult(
+                changed=False,
+                message=(
+                    "config: written by a newer build; left untouched to avoid "
+                    "a downgrade"
+                ),
+            )
         reasons = list(details.get("reasons", []))
         from_version = details.get("from_version", "unstamped")
         to_version = details.get("to_version", "current")
@@ -888,7 +914,7 @@ class _GatewayConfigVersionHealthCheck:
             )
             return HealthRepairResult(changed=False, message="\n".join(lines))
 
-        applied = _repair_config_version(str(context["config_path"]))
+        applied = _repair_config_version(str(config_path))
         lines = [f"config: {reason}" for reason in applied]
         lines.append(f"config: config_version {from_version} -> {to_version}")
         return HealthRepairResult(changed=True, message="\n".join(lines))
@@ -899,10 +925,12 @@ def _run_gateway_health_checks(config_path: str, *, fix: bool, dry_run: bool):
     from praisonaiagents.runtime.health_registry import get_health_check_registry
 
     registry = get_health_check_registry()
-    existing = set(registry.get_check_ids())
+    # Register the mandatory gateway checks as protected BEFORE plugin
+    # discovery so an installed extension cannot shadow the required
+    # auth-token/config-version validation and repair.
     for check in (_GatewaySecretHealthCheck(), _GatewayConfigVersionHealthCheck()):
-        if check.check_id not in existing:
-            registry.register_check(check)
+        if check.check_id not in registry.protected_ids():
+            registry.register_check(check, protected=True)
     return registry.run(
         {"config_path": config_path, "dry_run": dry_run},
         fix=fix,
@@ -1203,9 +1231,10 @@ def gateway_doctor(
     config_health = _health_result(health_results, "core/gateway/config-version")
 
     gateway_secret_error = None
+    auth_check_error = auth_health.error if auth_health else None
     fix_report = None
     if auth_health:
-        if auth_health.residual_findings:
+        if auth_health.residual_findings and not auth_check_error:
             gateway_secret_error = auth_health.residual_findings[0].message
         if auth_health.repair:
             if auth_health.repaired:
@@ -1273,6 +1302,8 @@ def gateway_doctor(
         payload["health"] = _health_payload(health_results)
         if gateway_secret_error:
             payload["gateway_auth_token"] = "weak"
+        if auth_check_error:
+            payload["gateway_auth_token_check_error"] = auth_check_error
         if config_migration:
             payload["config_version"] = "out-of-date"
         if config_version_error:
@@ -1307,6 +1338,8 @@ def gateway_doctor(
         payload["secrets"] = availability
     if gateway_secret_error:
         payload["gateway_auth_token"] = "weak"
+    if auth_check_error:
+        payload["gateway_auth_token_check_error"] = auth_check_error
     if config_migration:
         payload["config_version"] = "out-of-date"
     if config_version_error:

--- a/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/gateway.py
@@ -800,6 +800,128 @@ def _repair_gateway_secret(dry_run: bool = False, config_path: str = ""):
     return "repaired"
 
 
+class _GatewaySecretHealthCheck:
+    """Adapter that exposes the gateway auth-token check to the registry."""
+
+    check_id = "core/gateway/auth-token"
+
+    def detect(self, context):
+        from praisonaiagents.runtime.doctor_protocol import Finding
+
+        message = _check_gateway_secret_strength(str(context["config_path"]))
+        if not message:
+            return []
+        return [Finding(
+            rule_id=self.check_id,
+            severity="error",
+            message=message,
+            fix_description="Mint and persist a strong gateway auth token",
+        )]
+
+    def repair(self, context, findings):
+        from praisonaiagents.runtime.health_check import HealthRepairResult
+
+        action = _repair_gateway_secret(
+            dry_run=bool(context.get("dry_run")),
+            config_path=str(context["config_path"]),
+        )
+        if action == "would-repair":
+            return HealthRepairResult(
+                changed=False,
+                message=(
+                    "gateway_auth_token: weak -> would mint a strong token "
+                    "(--dry-run)"
+                ),
+            )
+        return HealthRepairResult(changed=True, message="gateway auth token repaired")
+
+
+class _GatewayConfigVersionHealthCheck:
+    """Adapter that exposes config migration through the health registry."""
+
+    check_id = "core/gateway/config-version"
+
+    def detect(self, context):
+        from praisonaiagents.runtime.doctor_protocol import Finding
+
+        migration = _check_config_version(str(context["config_path"]))
+        if migration is None:
+            return []
+        if isinstance(migration, str):
+            return [Finding(
+                rule_id=self.check_id,
+                severity="error",
+                message=migration,
+                fix_description=None,
+                context={"unsupported": True},
+            )]
+        reasons, from_version, to_version = migration
+        return [Finding(
+            rule_id=self.check_id,
+            severity="warning",
+            message=(
+                "gateway config is out of date "
+                f"(config_version {from_version} -> {to_version})"
+            ),
+            fix_description="Apply safe migrations and stamp config_version",
+            context={
+                "reasons": list(reasons),
+                "from_version": from_version,
+                "to_version": to_version,
+            },
+        )]
+
+    def repair(self, context, findings):
+        from praisonaiagents.runtime.health_check import HealthRepairResult
+
+        details = findings[0].context or {}
+        if details.get("unsupported"):
+            return HealthRepairResult(changed=False)
+        reasons = list(details.get("reasons", []))
+        from_version = details.get("from_version", "unstamped")
+        to_version = details.get("to_version", "current")
+        if context.get("dry_run"):
+            lines = [f"config: would {reason}" for reason in reasons]
+            lines.append(
+                "config: would stamp config_version "
+                f"{from_version} -> {to_version} (--dry-run)"
+            )
+            return HealthRepairResult(changed=False, message="\n".join(lines))
+
+        applied = _repair_config_version(str(context["config_path"]))
+        lines = [f"config: {reason}" for reason in applied]
+        lines.append(f"config: config_version {from_version} -> {to_version}")
+        return HealthRepairResult(changed=True, message="\n".join(lines))
+
+
+def _run_gateway_health_checks(config_path: str, *, fix: bool, dry_run: bool):
+    """Run built-in and third-party checks through one shared lifecycle."""
+    from praisonaiagents.runtime.health_registry import get_health_check_registry
+
+    registry = get_health_check_registry()
+    existing = set(registry.get_check_ids())
+    for check in (_GatewaySecretHealthCheck(), _GatewayConfigVersionHealthCheck()):
+        if check.check_id not in existing:
+            registry.register_check(check)
+    return registry.run(
+        {"config_path": config_path, "dry_run": dry_run},
+        fix=fix,
+    )
+
+
+def _health_result(results, check_id):
+    return next((result for result in results if result.check_id == check_id), None)
+
+
+def _health_payload(results):
+    return {
+        "checksRun": len(results),
+        "repaired": sum(result.repaired for result in results),
+        "validated": sum(not result.residual_findings for result in results),
+        "results": [result.to_dict() for result in results],
+    }
+
+
 from praisonai_bot.gateway.preflight import (  # noqa: E402 — re-exported for tests/CLI
     apply_probe_ca_bundle as _apply_probe_ca_bundle,
     check_duplicates as _check_duplicates,
@@ -1076,58 +1198,79 @@ def gateway_doctor(
 
     config = _resolve_doctor_config(config)
 
-    gateway_secret_error = _check_gateway_secret_strength(config)
+    health_results = _run_gateway_health_checks(config, fix=fix, dry_run=dry_run)
+    auth_health = _health_result(health_results, "core/gateway/auth-token")
+    config_health = _health_result(health_results, "core/gateway/config-version")
 
+    gateway_secret_error = None
     fix_report = None
-    if fix and gateway_secret_error:
-        action = _repair_gateway_secret(dry_run=dry_run, config_path=config)
-        if action == "would-repair":
-            fix_report = "gateway_auth_token: weak → would mint a strong token (--dry-run)"
-        elif action == "repaired":
-            gateway_secret_error = _check_gateway_secret_strength(config)
-            if gateway_secret_error is None:
+    if auth_health:
+        if auth_health.residual_findings:
+            gateway_secret_error = auth_health.residual_findings[0].message
+        if auth_health.repair:
+            if auth_health.repaired:
                 fix_report = (
                     "gateway_auth_token: weak → generated a strong token… done\n"
                     "re-validated: gateway_auth_token now strong"
                 )
-            else:
+            elif auth_health.repair.changed:
                 fix_report = "gateway_auth_token: repair attempted but still weak"
-        if fix_report and not json_output:
-            print(fix_report)
+            else:
+                fix_report = auth_health.repair.message
 
-    # Config version stamp + declarative migration (#3841). Detect an
-    # out-of-date config (missing/stale ``config_version`` or a rule that fires)
-    # and, with ``--fix``, migrate it forward once and stamp the new version.
-    config_migration = _check_config_version(config)
+    config_migration = None
+    config_version_error = None
     config_fix_report = None
-    # A ``str`` means the config is newer than this build / malformed: warn and
-    # refuse to migrate (never downgrade a newer config with an older binary).
-    config_version_error = config_migration if isinstance(config_migration, str) else None
-    if config_version_error:
-        config_migration = None
-        if not json_output:
-            print(f"config: {config_version_error}")
-    if config_migration:
-        reasons, from_version, to_version = config_migration
-        if fix and not dry_run:
-            applied = _repair_config_version(config)
-            lines = [f"config: {r}" for r in applied]
-            lines.append(f"config: config_version {from_version} -> {to_version}")
-            config_fix_report = "\n".join(lines)
-            config_migration = None
-        elif fix and dry_run:
-            lines = [f"config: would {r}" for r in reasons]
-            lines.append(
-                f"config: would stamp config_version {from_version} -> {to_version} (--dry-run)"
+    if config_health and config_health.findings:
+        finding = config_health.findings[0]
+        details = finding.context or {}
+        if details.get("unsupported"):
+            config_version_error = finding.message
+        elif config_health.residual_findings:
+            config_migration = (
+                list(details.get("reasons", [])),
+                details.get("from_version", "unstamped"),
+                details.get("to_version", "current"),
             )
-            config_fix_report = "\n".join(lines)
-        if config_fix_report and not json_output:
+        if config_health.repair and config_health.repair.message:
+            config_fix_report = config_health.repair.message
+
+    extension_results = [
+        result for result in health_results
+        if not result.check_id.startswith("core/gateway/")
+    ]
+    health_failed = any(
+        finding.severity == "error"
+        for result in health_results
+        for finding in result.residual_findings
+    )
+
+    if not json_output:
+        if fix_report:
+            print(fix_report)
+        if config_version_error:
+            print(f"config: {config_version_error}")
+        if config_fix_report:
             print(config_fix_report)
+        summary = _health_payload(health_results)
+        print(
+            "health checks: "
+            f"{summary['checksRun']} run, {summary['repaired']} repaired, "
+            f"{summary['validated']} validated"
+        )
+        for result in extension_results:
+            for finding in result.residual_findings:
+                hint = f"; fix: {finding.fix_description}" if finding.fix_description else ""
+                print(
+                    f"{result.check_id}: {finding.severity}: "
+                    f"{finding.message}{hint}"
+                )
 
     channels = _load_channels(config)
 
     if not channels:
         payload: dict = {"probes": {}}
+        payload["health"] = _health_payload(health_results)
         if gateway_secret_error:
             payload["gateway_auth_token"] = "weak"
         if config_migration:
@@ -1145,7 +1288,7 @@ def gateway_doctor(
             print("No channels configured.")
             if gateway_secret_error:
                 print(gateway_secret_error)
-        if gateway_secret_error:
+        if health_failed:
             raise typer.Exit(1)
         raise typer.Exit(0)
 
@@ -1156,7 +1299,10 @@ def gateway_doctor(
     if channel and channel in results:
         turn_gate_ok = getattr(results[channel], "ok", False)
 
-    payload: dict = {"probes": _probe_results_to_dict(results)}
+    payload: dict = {
+        "probes": _probe_results_to_dict(results),
+        "health": _health_payload(health_results),
+    }
     if availability:
         payload["secrets"] = availability
     if gateway_secret_error:
@@ -1183,7 +1329,7 @@ def gateway_doctor(
                 "run 'gateway doctor --fix'"
             )
 
-    if gateway_secret_error:
+    if health_failed:
         if json_output:
             print(json.dumps(payload, indent=2))
         raise typer.Exit(1)

--- a/src/praisonai-bot/tests/unit/gateway/test_bind_aware_auth.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_bind_aware_auth.py
@@ -259,7 +259,9 @@ class TestDoctorGatewaySecretStrength:
             'gateway:\n  bind_host: 127.0.0.1\n  auth_token: "change-me"\n',
         )
         assert err is None
-        assert "known-weak" in capsys.readouterr().out
+        captured = capsys.readouterr()
+        assert "known-weak" in captured.err
+        assert captured.out == ""
 
 
 class TestLoopbackAuthBypassDefault:

--- a/src/praisonai-bot/tests/unit/gateway/test_extensible_doctor.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_extensible_doctor.py
@@ -34,7 +34,12 @@ def test_gateway_doctor_runs_repairs_and_revalidates_registered_check(
             self.healthy = True
             return HealthRepairResult(changed=True, message="webhook registered")
 
-    monkeypatch.setattr(health_registry, "_default_registry", None)
+    monkeypatch.setattr(
+        health_registry,
+        "_default_registry",
+        health_registry.HealthCheckRegistry(discover_plugins=False),
+    )
+    monkeypatch.delenv("GATEWAY_AUTH_TOKEN", raising=False)
     health_registry.register_health_check(PluginCheck())
 
     cfg = tmp_path / "gateway.yaml"
@@ -60,3 +65,143 @@ def test_gateway_doctor_runs_repairs_and_revalidates_registered_check(
     )
     assert plugin["repaired"] is True
     assert plugin["residual_findings"] == []
+
+
+def test_gateway_doctor_json_stays_pure_when_auth_token_env_is_weak(
+    monkeypatch, tmp_path
+):
+    """`doctor --json` stdout must be a single JSON document even when the
+    ambient GATEWAY_AUTH_TOKEN is a known-weak placeholder (the advisory is
+    routed to stderr). Guards the CI JSONDecodeError regression."""
+    typer_testing = pytest.importorskip("typer.testing")
+    from praisonaiagents.gateway.config import GATEWAY_CONFIG_VERSION
+    import praisonaiagents.runtime.health_registry as health_registry
+
+    monkeypatch.setattr(
+        health_registry,
+        "_default_registry",
+        health_registry.HealthCheckRegistry(discover_plugins=False),
+    )
+    monkeypatch.setenv("GATEWAY_AUTH_TOKEN", "changeme")
+
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text(
+        f"config_version: {GATEWAY_CONFIG_VERSION}\nchannels: {{}}\n",
+        encoding="utf-8",
+    )
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    result = typer_testing.CliRunner().invoke(
+        app, ["doctor", "--config", str(cfg), "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["health"]["checksRun"] == 2
+    assert "known-weak" in result.stderr
+
+
+def test_gateway_doctor_dry_run_previews_plugin_repair(monkeypatch, tmp_path):
+    typer_testing = pytest.importorskip("typer.testing")
+    from praisonaiagents.gateway.config import GATEWAY_CONFIG_VERSION
+    from praisonaiagents.runtime.doctor_protocol import Finding
+    from praisonaiagents.runtime.health_check import HealthRepairResult
+    import praisonaiagents.runtime.health_registry as health_registry
+
+    class PreviewCheck:
+        check_id = "channel/example/preview"
+
+        def __init__(self):
+            self.changed = False
+
+        def detect(self, context):
+            if self.changed:
+                return []
+            return [Finding(
+                rule_id=self.check_id,
+                severity="warning",
+                message="preview needed",
+            )]
+
+        def repair(self, context, findings):
+            if context.get("dry_run"):
+                return HealthRepairResult(
+                    changed=False, message="plugin: would repair (--dry-run)"
+                )
+            self.changed = True
+            return HealthRepairResult(changed=True, message="plugin repaired")
+
+    check = PreviewCheck()
+    monkeypatch.setattr(
+        health_registry,
+        "_default_registry",
+        health_registry.HealthCheckRegistry(discover_plugins=False),
+    )
+    monkeypatch.setenv("GATEWAY_AUTH_TOKEN", "a" * 32)
+    health_registry.register_health_check(check)
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text(
+        f"config_version: {GATEWAY_CONFIG_VERSION}\nchannels: {{}}\n",
+        encoding="utf-8",
+    )
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    result = typer_testing.CliRunner().invoke(
+        app, ["doctor", "--config", str(cfg), "--fix", "--dry-run", "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    plugin = next(
+        item for item in payload["health"]["results"]
+        if item["id"] == check.check_id
+    )
+    assert payload["health"]["repaired"] == 0
+    assert plugin["repair"]["message"] == "plugin: would repair (--dry-run)"
+    assert check.changed is False
+
+
+def test_gateway_doctor_fails_for_diagnostic_only_error(monkeypatch, tmp_path):
+    typer_testing = pytest.importorskip("typer.testing")
+    from praisonaiagents.gateway.config import GATEWAY_CONFIG_VERSION
+    from praisonaiagents.runtime.doctor_protocol import Finding
+    import praisonaiagents.runtime.health_registry as health_registry
+
+    class DiagnosticOnly:
+        check_id = "channel/example/diagnostic"
+
+        def detect(self, context):
+            return [Finding(
+                rule_id=self.check_id,
+                severity="error",
+                message="manual remediation required",
+            )]
+
+    monkeypatch.setattr(
+        health_registry,
+        "_default_registry",
+        health_registry.HealthCheckRegistry(discover_plugins=False),
+    )
+    monkeypatch.setenv("GATEWAY_AUTH_TOKEN", "a" * 32)
+    health_registry.register_health_check(DiagnosticOnly())
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text(
+        f"config_version: {GATEWAY_CONFIG_VERSION}\nchannels: {{}}\n",
+        encoding="utf-8",
+    )
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    result = typer_testing.CliRunner().invoke(
+        app, ["doctor", "--config", str(cfg), "--json"]
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    diagnostic = next(
+        item for item in payload["health"]["results"]
+        if item["id"] == DiagnosticOnly.check_id
+    )
+    assert diagnostic["residual_findings"][0]["severity"] == "error"

--- a/src/praisonai-bot/tests/unit/gateway/test_extensible_doctor.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_extensible_doctor.py
@@ -1,0 +1,62 @@
+"""Integration coverage for plugin-contributed gateway health checks."""
+
+import json
+
+import pytest
+
+
+def test_gateway_doctor_runs_repairs_and_revalidates_registered_check(
+    monkeypatch, tmp_path
+):
+    typer_testing = pytest.importorskip("typer.testing")
+    from praisonaiagents.gateway.config import GATEWAY_CONFIG_VERSION
+    from praisonaiagents.runtime.doctor_protocol import Finding
+    from praisonaiagents.runtime.health_check import HealthRepairResult
+    import praisonaiagents.runtime.health_registry as health_registry
+
+    class PluginCheck:
+        check_id = "channel/example/webhook"
+
+        def __init__(self):
+            self.healthy = False
+
+        def detect(self, context):
+            if self.healthy:
+                return []
+            return [Finding(
+                rule_id=self.check_id,
+                severity="error",
+                message="webhook is unreachable",
+                fix_description="re-register the webhook",
+            )]
+
+        def repair(self, context, findings):
+            self.healthy = True
+            return HealthRepairResult(changed=True, message="webhook registered")
+
+    monkeypatch.setattr(health_registry, "_default_registry", None)
+    health_registry.register_health_check(PluginCheck())
+
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text(
+        f"config_version: {GATEWAY_CONFIG_VERSION}\nchannels: {{}}\n",
+        encoding="utf-8",
+    )
+
+    from praisonai_bot.cli.commands.gateway import app
+
+    result = typer_testing.CliRunner().invoke(
+        app, ["doctor", "--config", str(cfg), "--fix", "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["health"]["checksRun"] == 3
+    assert payload["health"]["repaired"] == 1
+    assert payload["health"]["validated"] == 3
+    plugin = next(
+        item for item in payload["health"]["results"]
+        if item["id"] == "channel/example/webhook"
+    )
+    assert plugin["repaired"] is True
+    assert plugin["residual_findings"] == []


### PR DESCRIPTION
## Summary

- add a core health-check protocol, repair result, registry, and praisonai.health_checks entry-point discovery
- isolate failing checks and re-run detection after safe repairs
- adapt the gateway auth-token and config-version checks to the shared lifecycle
- expose checksRun, repaired, validated, per-check findings, and residual findings in doctor output
- allow channel, tool, and plugin packages to contribute diagnostic-only or repairable checks

## Validation

- 45 runtime registry and gateway doctor tests passed
- runtime and gateway modules compile successfully
- git diff --check

Closes #3869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added extensible runtime health checks with structured diagnostics, repair results, and re-validation.
  - Enhanced `gateway doctor` to run built-in and extension health checks.
  - Added optional automatic repairs with `--fix` and JSON health reporting.
  - Gateway checks now report aggregate status and return failure when issues remain.

- **Bug Fixes**
  - Isolated individual health-check failures so one problem does not prevent other checks from running.
  - Redirected loopback weak-token warnings to stderr to keep JSON output clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->