### PR TITLE
fix: honor scheduler timezones

### DIFF
--- a/src/praisonai-agents/praisonaiagents/scheduler/config_store.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/config_store.py
@@ -46,6 +46,7 @@ class ConfigYamlScheduleStore:
         # release them. Cross-process leases live in the persisted job
         # (``lease_until`` / ``lease_owner``) which is the source of truth.
         self._held_leases: Dict[str, str] = {}
+        self._default_timezone: Optional[str] = None
         self._load()
         self._load_history()
 
@@ -186,7 +187,7 @@ class ConfigYamlScheduleStore:
                 # An unexpired lease held by another owner blocks the claim.
                 if lease_until > now and lease_owner != owner_id:
                     continue
-                if not _is_due(job, now):
+                if not _is_due(job, now, self._default_timezone):
                     continue
                 # Win the claim: pre-advance + lease atomically.
                 job.last_run_at = now
@@ -336,6 +337,12 @@ class ConfigYamlScheduleStore:
             import yaml
             with open(self._path, "r") as f:
                 data = yaml.safe_load(f) or {}
+            self._default_timezone = None
+            scheduler_config = data.get("scheduler", {})
+            if isinstance(scheduler_config, dict):
+                self._default_timezone = (
+                    scheduler_config.get("timezone") or scheduler_config.get("tz")
+                )
             schedules = data.get("schedules", {})
             if isinstance(schedules, dict):
                 for job_id, job_data in schedules.items():

--- a/src/praisonai-agents/praisonaiagents/scheduler/config_store.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/config_store.py
@@ -14,7 +14,7 @@ import time
 from typing import Dict, Iterator, List, Optional
 
 from .models import ScheduleJob, RunRecord
-from .due import is_due as _is_due
+from .due import is_due as _is_due, resolve_schedule_timezone
 
 logger = get_logger(__name__)
 
@@ -340,9 +340,12 @@ class ConfigYamlScheduleStore:
             self._default_timezone = None
             scheduler_config = data.get("scheduler", {})
             if isinstance(scheduler_config, dict):
-                self._default_timezone = (
+                configured_timezone = (
                     scheduler_config.get("timezone") or scheduler_config.get("tz")
                 )
+                if configured_timezone:
+                    resolve_schedule_timezone(configured_timezone)
+                    self._default_timezone = configured_timezone
             schedules = data.get("schedules", {})
             if isinstance(schedules, dict):
                 for job_id, job_data in schedules.items():
@@ -350,6 +353,8 @@ class ConfigYamlScheduleStore:
                         job_data.setdefault("id", job_id)
                         job = ScheduleJob.from_dict(job_data)
                         self._jobs[job.id] = job
+        except ValueError:
+            raise
         except Exception as e:
             logger.warning("Failed to load schedules from %s: %s", self._path, e)
 

--- a/src/praisonai-agents/praisonaiagents/scheduler/due.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/due.py
@@ -9,15 +9,34 @@ definition of "is this job due now?" rather than duplicating it.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
+import os
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from praisonaiagents._logging import get_logger
 
 logger = get_logger(__name__)
 
 
-def next_fire_time(cron_expr: str, base: float) -> float:
+def resolve_schedule_timezone(tz: str | None = None) -> ZoneInfo:
+    """Resolve an explicit or instance-default IANA timezone.
+
+    ``PRAISONAI_SCHEDULE_TIMEZONE`` supplies the process-wide default; UTC is
+    retained when neither the schedule nor the instance selects a timezone.
+    """
+    name = tz or os.environ.get("PRAISONAI_SCHEDULE_TIMEZONE") or "UTC"
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError, TypeError) as exc:
+        raise ValueError(f"Unknown IANA timezone: {name!r}") from exc
+
+
+def next_fire_time(
+    cron_expr: str,
+    base: float,
+    tz: str | None = None,
+) -> float:
     """Return the next cron fire time (epoch) strictly after ``base``.
 
     Pure helper owning the "compute next fire from a base" step so wrapper
@@ -27,10 +46,15 @@ def next_fire_time(cron_expr: str, base: float) -> float:
     """
     from croniter import croniter  # type: ignore[import-untyped]
 
-    return croniter(cron_expr, base).get_next(float)
+    base_datetime = datetime.fromtimestamp(base, resolve_schedule_timezone(tz))
+    return croniter(cron_expr, base_datetime).get_next(datetime).timestamp()
 
 
-def is_due(job: Any, now: float) -> bool:
+def is_due(
+    job: Any,
+    now: float,
+    default_timezone: str | None = None,
+) -> bool:
     """Return ``True`` if ``job`` is due to run at epoch ``now``.
 
     Supports the three schedule kinds: ``every`` (interval), ``at`` (one-shot
@@ -55,7 +79,11 @@ def is_due(job: Any, now: float) -> bool:
         try:
             target = datetime.fromisoformat(sched.at)
             if target.tzinfo is None:
-                target = target.replace(tzinfo=timezone.utc)
+                target = target.replace(
+                    tzinfo=resolve_schedule_timezone(
+                        sched.tz or default_timezone
+                    )
+                )
             # Evaluate against the caller-supplied ``now`` (not wall-clock) so
             # one-shot jobs are deterministic and consistent with every/cron.
             return now >= target.timestamp()
@@ -76,7 +104,11 @@ def is_due(job: Any, now: float) -> bool:
             return False
         base_time = job.last_run_at or job.created_at
         try:
-            next_run = next_fire_time(sched.cron_expr, base_time)
+            next_run = next_fire_time(
+                sched.cron_expr,
+                base_time,
+                sched.tz or default_timezone,
+            )
         except (ValueError, KeyError, TypeError) as e:
             # A malformed cron expression must not abort the whole tick loop
             # (which iterates all jobs) — treat this job as not-due instead.

--- a/src/praisonai-agents/praisonaiagents/scheduler/parser.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/parser.py
@@ -45,7 +45,7 @@ _UNIT_MULTIPLIER = {
 }
 
 
-def parse_schedule(expr: str) -> Schedule:
+def parse_schedule(expr: str, tz: str | None = None) -> Schedule:
     """Parse a schedule expression string into a ``Schedule`` object.
 
     Raises ``ValueError`` for unrecognised expressions.
@@ -54,25 +54,28 @@ def parse_schedule(expr: str) -> Schedule:
         raise ValueError("Schedule expression cannot be empty")
 
     expr = expr.strip()
+    if tz:
+        from .due import resolve_schedule_timezone
+        resolve_schedule_timezone(tz)
 
     # Keyword shortcuts
     lower = expr.lower()
     if lower in _KEYWORD_MAP:
-        return Schedule(kind="every", every_seconds=_KEYWORD_MAP[lower])
+        return Schedule(kind="every", every_seconds=_KEYWORD_MAP[lower], tz=tz)
 
     # Cron prefix
     if lower.startswith("cron:"):
         cron_expr = expr[5:].strip()
         if not cron_expr:
             raise ValueError("Empty cron expression after 'cron:' prefix")
-        return Schedule(kind="cron", cron_expr=cron_expr)
+        return Schedule(kind="cron", cron_expr=cron_expr, tz=tz)
 
     # At prefix (ISO timestamp)
     if lower.startswith("at:"):
         at_str = expr[3:].strip()
         if not at_str:
             raise ValueError("Empty timestamp after 'at:' prefix")
-        return Schedule(kind="at", at=at_str)
+        return Schedule(kind="at", at=at_str, tz=tz)
 
     # Interval pattern: */30m, */6h, */10s
     m = _INTERVAL_RE.match(expr)
@@ -80,7 +83,7 @@ def parse_schedule(expr: str) -> Schedule:
         value = int(m.group(1))
         unit = m.group(2).lower()
         seconds = value * _UNIT_MULTIPLIER[unit]
-        return Schedule(kind="every", every_seconds=seconds)
+        return Schedule(kind="every", every_seconds=seconds, tz=tz)
 
     # Relative pattern: "in 20 minutes"
     m = _RELATIVE_RE.match(expr)
@@ -89,13 +92,13 @@ def parse_schedule(expr: str) -> Schedule:
         unit = m.group(2).lower()
         delta_seconds = value * _UNIT_MULTIPLIER[unit]
         target = datetime.now(timezone.utc) + timedelta(seconds=delta_seconds)
-        return Schedule(kind="at", at=target.isoformat())
+        return Schedule(kind="at", at=target.isoformat(), tz=tz)
 
     # Raw numeric seconds
     try:
         seconds = int(expr)
         if seconds > 0:
-            return Schedule(kind="every", every_seconds=seconds)
+            return Schedule(kind="every", every_seconds=seconds, tz=tz)
     except ValueError:
         pass
 

--- a/src/praisonai-agents/praisonaiagents/tools/schedule_tools.py
+++ b/src/praisonai-agents/praisonaiagents/tools/schedule_tools.py
@@ -106,6 +106,7 @@ def schedule_add(
     accept_suggestion: str = "",
     continuable: bool = True,
     principal: str = "",
+    tz: str = "",
 ) -> str:
     """Add a new scheduled job.
 
@@ -139,6 +140,9 @@ def schedule_add(
                     (``SessionContext.unified_user_id``) so a multi-user
                     gateway isolates each user's jobs. Empty ⇒ no identity ⇒
                     global (single-tenant) behaviour, unchanged for CLI.
+        tz: Optional IANA timezone for cron and naive one-shot timestamps
+            (for example ``America/New_York``). If omitted, the instance
+            default ``PRAISONAI_SCHEDULE_TIMEZONE`` is used, then UTC.
 
     Note:
         The ``pre_run`` shell gate is intentionally NOT exposed through this
@@ -155,7 +159,7 @@ def schedule_add(
         from ..scheduler.parser import parse_schedule
         from ..scheduler.models import ScheduleJob, DeliveryTarget
 
-        sched = parse_schedule(schedule)
+        sched = parse_schedule(schedule, tz=tz or None)
 
         delivery = None
         origin = None
@@ -223,7 +227,8 @@ def schedule_add(
         else:
             delivery_note = ""
         agent_note = f" agent={agent_id}" if agent_id else ""
-        confirmation = f"Schedule '{name}' added (id: {job.id}, {schedule}{agent_note}{delivery_note})."
+        timezone_note = f" tz={tz}" if tz else ""
+        confirmation = f"Schedule '{name}' added (id: {job.id}, {schedule}{timezone_note}{agent_note}{delivery_note})."
 
         # ── Suggestion acceptance integration ─────────────────────
         if accept_suggestion:

--- a/src/praisonai-agents/tests/unit/test_schedule_timezone.py
+++ b/src/praisonai-agents/tests/unit/test_schedule_timezone.py
@@ -1,5 +1,6 @@
 """Timezone and DST coverage for the core scheduler."""
 
+import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -24,10 +25,8 @@ def _job(schedule, *, created_at=0.0, last_run_at=None):
     )
 
 
-pytest.importorskip("croniter")
-
-
 def test_cron_keeps_local_hour_across_spring_dst_transition():
+    pytest.importorskip("croniter")
     next_run = next_fire_time(
         "0 8 * * *",
         _epoch(2026, 3, 7, 13),
@@ -38,6 +37,7 @@ def test_cron_keeps_local_hour_across_spring_dst_transition():
 
 
 def test_cron_keeps_local_hour_across_fall_dst_transition():
+    pytest.importorskip("croniter")
     next_run = next_fire_time(
         "0 8 * * *",
         _epoch(2026, 10, 31, 12),
@@ -137,3 +137,90 @@ def test_config_store_uses_instance_default_timezone(tmp_path):
     assert store.claim_due(_epoch(2026, 7, 1, 12, 59), "worker") == []
     claimed = store.claim_due(_epoch(2026, 7, 1, 13, 0), "worker")
     assert [item.id for item in claimed] == ["brief"]
+
+
+def test_config_store_rejects_invalid_instance_timezone(tmp_path):
+    import yaml
+
+    from praisonaiagents.scheduler.config_store import ConfigYamlScheduleStore
+
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        yaml.safe_dump({"scheduler": {"timezone": "Mars/Base"}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Mars/Base"):
+        ConfigYamlScheduleStore(str(config))
+
+
+def _schedule_agent_fixture(tmp_path):
+    from praisonaiagents.scheduler.store import FileScheduleStore
+    from praisonaiagents.tools.schedule_tools import schedule_add
+
+    return FileScheduleStore(store_dir=str(tmp_path)), schedule_add
+
+
+def test_schedule_tool_agent_smoke(monkeypatch, tmp_path):
+    from unittest.mock import patch
+
+    from praisonaiagents import Agent
+
+    store, schedule_add = _schedule_agent_fixture(tmp_path)
+    agent = Agent(
+        name="schedule-smoke",
+        instructions="Use the scheduling tool to create the requested job.",
+        tools=[schedule_add],
+    )
+    monkeypatch.setattr(
+        agent,
+        "chat",
+        lambda prompt, **kwargs: schedule_add(
+            name="agent-morning-brief",
+            schedule="cron:0 8 * * *",
+            tz="America/New_York",
+        ),
+    )
+
+    with patch(
+        "praisonaiagents.tools.schedule_tools._get_store", return_value=store
+    ):
+        result = agent.start("Schedule a morning brief for 8 AM New York time.")
+    print(result)
+
+    assert store.get_by_name("agent-morning-brief").schedule.tz == "America/New_York"
+
+
+@pytest.mark.network
+@pytest.mark.skipif(
+    os.environ.get("RUN_REAL_KEY_TESTS") != "1"
+    or not os.environ.get("OPENAI_API_KEY"),
+    reason="Set RUN_REAL_KEY_TESTS=1 and OPENAI_API_KEY for the real agentic test",
+)
+def test_schedule_tool_real_agentic(tmp_path):
+    from unittest.mock import patch
+
+    from praisonaiagents import Agent
+
+    store, schedule_add = _schedule_agent_fixture(tmp_path)
+    agent = Agent(
+        name="schedule-agentic",
+        model="gpt-4o-mini",
+        instructions=(
+            "Always use schedule_add for scheduling requests and preserve the "
+            "timezone exactly as requested."
+        ),
+        tools=[schedule_add],
+    )
+
+    with patch(
+        "praisonaiagents.tools.schedule_tools._get_store", return_value=store
+    ):
+        result = agent.start(
+            "Use schedule_add to create a job named agent-morning-brief at "
+            "cron:0 8 * * * with timezone America/New_York."
+        )
+    print(result)
+
+    assert result
+    assert store.get_by_name("agent-morning-brief").schedule.tz == "America/New_York"

--- a/src/praisonai-agents/tests/unit/test_schedule_timezone.py
+++ b/src/praisonai-agents/tests/unit/test_schedule_timezone.py
@@ -1,0 +1,139 @@
+"""Timezone and DST coverage for the core scheduler."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from praisonaiagents.scheduler.due import is_due, next_fire_time
+from praisonaiagents.scheduler.models import Schedule
+
+
+def _epoch(year, month, day, hour, minute=0):
+    return datetime(
+        year, month, day, hour, minute, tzinfo=timezone.utc
+    ).timestamp()
+
+
+def _job(schedule, *, created_at=0.0, last_run_at=None):
+    return SimpleNamespace(
+        id="timezone-test",
+        schedule=schedule,
+        created_at=created_at,
+        last_run_at=last_run_at,
+    )
+
+
+pytest.importorskip("croniter")
+
+
+def test_cron_keeps_local_hour_across_spring_dst_transition():
+    next_run = next_fire_time(
+        "0 8 * * *",
+        _epoch(2026, 3, 7, 13),
+        "America/New_York",
+    )
+
+    assert next_run == _epoch(2026, 3, 8, 12)
+
+
+def test_cron_keeps_local_hour_across_fall_dst_transition():
+    next_run = next_fire_time(
+        "0 8 * * *",
+        _epoch(2026, 10, 31, 12),
+        "America/New_York",
+    )
+
+    assert next_run == _epoch(2026, 11, 1, 13)
+
+
+def test_naive_one_shot_uses_schedule_timezone():
+    job = _job(Schedule(
+        kind="at",
+        at="2026-07-01T09:00:00",
+        tz="America/New_York",
+    ))
+
+    assert is_due(job, _epoch(2026, 7, 1, 12, 59)) is False
+    assert is_due(job, _epoch(2026, 7, 1, 13, 0)) is True
+
+
+def test_offset_one_shot_keeps_its_explicit_offset():
+    job = _job(Schedule(
+        kind="at",
+        at="2026-07-01T09:00:00+02:00",
+        tz="America/New_York",
+    ))
+
+    assert is_due(job, _epoch(2026, 7, 1, 7, 0)) is True
+
+
+def test_instance_timezone_environment_is_default(monkeypatch):
+    monkeypatch.setenv("PRAISONAI_SCHEDULE_TIMEZONE", "Asia/Singapore")
+    job = _job(Schedule(kind="at", at="2026-07-01T09:00:00"))
+
+    assert is_due(job, _epoch(2026, 7, 1, 0, 59)) is False
+    assert is_due(job, _epoch(2026, 7, 1, 1, 0)) is True
+
+
+def test_invalid_timezone_fails_closed(caplog):
+    job = _job(Schedule(kind="at", at="2026-07-01T09:00:00", tz="Mars/Base"))
+
+    assert is_due(job, _epoch(2026, 7, 1, 9, 0)) is False
+    assert "Invalid 'at' timestamp" in caplog.text
+
+
+def test_parser_sets_and_validates_timezone():
+    from praisonaiagents.scheduler.parser import parse_schedule
+
+    schedule = parse_schedule("cron:0 8 * * *", tz="America/New_York")
+    assert schedule.tz == "America/New_York"
+    with pytest.raises(ValueError, match="Unknown IANA timezone"):
+        parse_schedule("daily", tz="Mars/Base")
+
+
+def test_schedule_tool_persists_timezone(tmp_path):
+    from unittest.mock import patch
+
+    from praisonaiagents.scheduler.store import FileScheduleStore
+    from praisonaiagents.tools.schedule_tools import schedule_add
+
+    store = FileScheduleStore(store_dir=str(tmp_path))
+    with patch(
+        "praisonaiagents.tools.schedule_tools._get_store",
+        return_value=store,
+    ):
+        result = schedule_add(
+            name="morning-brief",
+            schedule="cron:0 8 * * *",
+            tz="America/New_York",
+        )
+
+    assert "tz=America/New_York" in result
+    assert store.get_by_name("morning-brief").schedule.tz == "America/New_York"
+
+
+def test_config_store_uses_instance_default_timezone(tmp_path):
+    import yaml
+
+    from praisonaiagents.scheduler.config_store import ConfigYamlScheduleStore
+    from praisonaiagents.scheduler.models import ScheduleJob
+
+    job = ScheduleJob(
+        id="brief",
+        name="brief",
+        schedule=Schedule(kind="at", at="2026-07-01T09:00:00"),
+    )
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        yaml.safe_dump({
+            "scheduler": {"timezone": "America/New_York"},
+            "schedules": {job.id: job.to_dict()},
+        }),
+        encoding="utf-8",
+    )
+    store = ConfigYamlScheduleStore(str(config))
+
+    assert store.claim_due(_epoch(2026, 7, 1, 12, 59), "worker") == []
+    claimed = store.claim_due(_epoch(2026, 7, 1, 13, 0), "worker")
+    assert [item.id for item in claimed] == ["brief"]

--- a/src/praisonai/praisonai/cli/commands/schedule.py
+++ b/src/praisonai/praisonai/cli/commands/schedule.py
@@ -41,6 +41,7 @@ def _run_schedule(args: list) -> int:
 def schedule_add_cmd(
     name: str = typer.Argument(..., help="Schedule name (e.g. 'morning-hello')"),
     schedule: str = typer.Option(..., "--schedule", "-s", help="When to run: 'hourly', 'daily', '*/30m', 'cron:0 9 * * *', 'at:2026-03-01T09:00', 'in 20 minutes'"),
+    tz: str = typer.Option("", "--tz", help="IANA timezone for cron or naive one-shot times (e.g. America/New_York)"),
     message: str = typer.Option("", "--message", "-m", help="Prompt / reminder text"),
     agent: str = typer.Option("", "--agent", "-a", help="Agent ID to execute this job (default: first registered agent)"),
     deliver: str = typer.Option("", "--deliver", "-d", help="Delivery token: 'origin', 'telegram', 'all', or 'platform:chat_id[:thread_id]'"),
@@ -60,6 +61,7 @@ def schedule_add_cmd(
 
     Examples:
         praisonai schedule add "morning-hello" -s "cron:0 9 * * *" -m "say hello"
+        praisonai schedule add "morning-brief" -s "cron:0 8 * * *" --tz America/New_York -m "summarise activity"
         praisonai schedule add "news" -s daily -m "news summary" --deliver telegram
         praisonai schedule add "report" -s hourly -m "status report" --deliver all
         praisonai schedule add "tg-reminder" -s daily -m "check email" --agent support --channel telegram --channel-id 12345
@@ -91,6 +93,7 @@ def schedule_add_cmd(
         result = _schedule_add(
             name=name,
             schedule=schedule,
+            tz=tz,
             message=message,
             agent_id=agent,
             **delivery_kwargs

--- a/src/praisonai/praisonai/scheduler/agent_scheduler.py
+++ b/src/praisonai/praisonai/scheduler/agent_scheduler.py
@@ -151,7 +151,8 @@ class AgentScheduler(_BaseAgentScheduler):
         self,
         schedule_expr: str,
         max_retries: int = 3,
-        run_immediately: bool = False
+        run_immediately: bool = False,
+        timezone: Optional[str] = None,
     ) -> bool:
         """
         Start scheduled agent execution.
@@ -173,7 +174,9 @@ class AgentScheduler(_BaseAgentScheduler):
             # once-only catch-up across downtime); plain intervals are unchanged.
             self._load_persisted_last_run()
             ticker = ScheduleTicker(
-                schedule_expr, last_run_at=getattr(self, "_last_run_at", None)
+                schedule_expr,
+                last_run_at=getattr(self, "_last_run_at", None),
+                timezone=timezone,
             )
             self.is_running = True
             self._stop_event.clear()
@@ -496,7 +499,12 @@ class AgentScheduler(_BaseAgentScheduler):
         max_retries = schedule_config.get('max_retries', 3)
         run_immediately = schedule_config.get('run_immediately', False)
         
-        return self.start(interval, max_retries, run_immediately)
+        return self.start(
+            interval,
+            max_retries,
+            run_immediately,
+            timezone=schedule_config.get('tz'),
+        )
 
 
     @classmethod

--- a/src/praisonai/praisonai/scheduler/async_agent_scheduler.py
+++ b/src/praisonai/praisonai/scheduler/async_agent_scheduler.py
@@ -180,7 +180,8 @@ class AsyncAgentScheduler(_BaseAgentScheduler):
         self,
         schedule_expr: str,
         max_retries: int = 3,
-        run_immediately: bool = False
+        run_immediately: bool = False,
+        timezone: Optional[str] = None,
     ) -> bool:
         """
         Start scheduled agent execution.
@@ -202,7 +203,9 @@ class AsyncAgentScheduler(_BaseAgentScheduler):
             # once-only catch-up across downtime); plain intervals are unchanged.
             self._load_persisted_last_run()
             ticker = ScheduleTicker(
-                schedule_expr, last_run_at=getattr(self, "_last_run_at", None)
+                schedule_expr,
+                last_run_at=getattr(self, "_last_run_at", None),
+                timezone=timezone,
             )
             self.is_running = True
             self._start_time = datetime.now()
@@ -590,7 +593,12 @@ class AsyncAgentScheduler(_BaseAgentScheduler):
         max_retries = schedule_config.get('max_retries', 3)
         run_immediately = schedule_config.get('run_immediately', False)
         
-        return await self.start(interval, max_retries, run_immediately)
+        return await self.start(
+            interval,
+            max_retries,
+            run_immediately,
+            timezone=schedule_config.get('tz'),
+        )
 
     @classmethod
     def from_recipe(

--- a/src/praisonai/praisonai/scheduler/shared.py
+++ b/src/praisonai/praisonai/scheduler/shared.py
@@ -50,9 +50,15 @@ class ScheduleTicker:
     mirroring core ``ScheduleJob.last_run_at``.
     """
 
-    def __init__(self, schedule_expr: str, last_run_at: Optional[float] = None):
+    def __init__(
+        self,
+        schedule_expr: str,
+        last_run_at: Optional[float] = None,
+        timezone: Optional[str] = None,
+    ):
         self.schedule_expr = schedule_expr.strip()
         self.last_run_at: Optional[float] = last_run_at
+        self.timezone = timezone
         # Anchor for a never-run cron job, mirroring core ``ScheduleJob``'s use
         # of ``created_at``: the schedule is measured from here so a slot that
         # falls between this anchor and "now" is treated as missed → caught up.
@@ -91,7 +97,7 @@ class ScheduleTicker:
         # (mirrors core ``is_due`` using ``last_run_at or created_at``).
         base = self.last_run_at if self.last_run_at is not None else self.created_at
         try:
-            next_run = next_fire_time(self._cron_expr(), base)
+            next_run = next_fire_time(self._cron_expr(), base, self.timezone)
         except ImportError:
             # ``croniter`` engine absent — degrade like the missing-import path.
             _warn_cron_unavailable()
@@ -113,14 +119,13 @@ class ScheduleTicker:
         if now is None:
             now = time.time()
         try:
-            from croniter import croniter  # type: ignore[import-untyped]
+            from praisonaiagents.scheduler.due import next_fire_time
+            next_run = next_fire_time(self._cron_expr(), now, self.timezone)
         except ImportError:
             # Degrade gracefully to the coarse interval rather than busy-loop,
             # but surface a one-time warning so the degrade isn't silent.
             _warn_cron_unavailable()
             return float(ScheduleParser._parse_cron_to_interval(self._cron_expr()))
-        try:
-            next_run = croniter(self._cron_expr(), now).get_next(float)
         except (ValueError, KeyError, TypeError):
             return float(ScheduleParser._parse_cron_to_interval(self._cron_expr()))
         return max(0.0, next_run - now)

--- a/src/praisonai/praisonai/scheduler/shared.py
+++ b/src/praisonai/praisonai/scheduler/shared.py
@@ -64,6 +64,10 @@ class ScheduleTicker:
         # falls between this anchor and "now" is treated as missed → caught up.
         self.created_at: float = time.time()
         self._is_cron = self.schedule_expr.lower().startswith("cron:")
+        if self._is_cron:
+            from praisonaiagents.scheduler.due import resolve_schedule_timezone
+
+            resolve_schedule_timezone(self.timezone)
         # For plain intervals we reuse the existing integer-interval parse so
         # behaviour is byte-for-byte identical to the fixed-interval loop.
         self._interval: Optional[int] = None

--- a/src/praisonai/praisonai/scheduler/yaml_loader.py
+++ b/src/praisonai/praisonai/scheduler/yaml_loader.py
@@ -91,10 +91,15 @@ def load_agent_yaml_with_schedule(yaml_path: str) -> Tuple[Dict[str, Any], Dict[
     
     # Set defaults for schedule if not provided. ``every`` is accepted as an
     # alias for ``interval`` so the terser scheduler-block form validates too.
+    cron_expr = schedule_section.get('cron')
     schedule_config = {
         'interval': schedule_section.get(
-            'interval', schedule_section.get('every', 'hourly')
+            'interval',
+            schedule_section.get(
+                'every', f"cron:{cron_expr}" if cron_expr else 'hourly'
+            ),
         ),
+        'tz': schedule_section.get('tz', schedule_section.get('timezone')),
         'max_retries': schedule_section.get('max_retries', 3),
         'run_immediately': schedule_section.get('run_immediately', False),
         'timeout': schedule_section.get('timeout'),  # Optional timeout in seconds

--- a/src/praisonai/praisonai/scheduler/yaml_loader.py
+++ b/src/praisonai/praisonai/scheduler/yaml_loader.py
@@ -200,12 +200,22 @@ def validate_schedule_config(schedule_config: Dict[str, Any]) -> None:
     valid_intervals = ['hourly', 'daily']
     
     if interval not in valid_intervals:
+        if interval.startswith('cron:'):
+            if not interval[len('cron:'):].strip():
+                raise ValueError("Cron expression must not be empty")
         # Check if it's a custom format (*/Nm, */Nh, */Ns, or plain number)
-        if not (interval.startswith('*/') or interval.isdigit()):
+        elif not (interval.startswith('*/') or interval.isdigit()):
             raise ValueError(
                 f"Invalid interval format: {interval}. "
-                f"Use 'hourly', 'daily', '*/30m', '*/6h', or seconds as number"
+                f"Use 'hourly', 'daily', 'cron:0 8 * * *', '*/30m', "
+                f"'*/6h', or seconds as number"
             )
+
+    tz = schedule_config.get('tz')
+    if tz:
+        from praisonaiagents.scheduler.due import resolve_schedule_timezone
+
+        resolve_schedule_timezone(tz)
     
     # Validate max_retries
     max_retries = schedule_config.get('max_retries', 3)

--- a/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
+++ b/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
@@ -10,6 +10,9 @@ def _epoch(year, month, day, hour, minute=0):
 
 
 def test_schedule_ticker_uses_timezone_across_dst():
+    import pytest
+
+    pytest.importorskip("croniter")
     from praisonai.scheduler.shared import ScheduleTicker
 
     ticker = ScheduleTicker(

--- a/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
+++ b/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
@@ -22,8 +22,20 @@ def test_schedule_ticker_uses_timezone_across_dst():
     assert ticker.is_due(_epoch(2026, 3, 8, 12, 0)) is True
 
 
+def test_schedule_ticker_rejects_invalid_timezone():
+    import pytest
+
+    from praisonai.scheduler.shared import ScheduleTicker
+
+    with pytest.raises(ValueError, match="Mars/Base"):
+        ScheduleTicker("cron:0 8 * * *", timezone="Mars/Base")
+
+
 def test_yaml_cron_and_timezone_are_preserved(tmp_path):
-    from praisonai.scheduler.yaml_loader import load_agent_yaml_with_schedule
+    from praisonai.scheduler.yaml_loader import (
+        load_agent_yaml_with_schedule,
+        validate_schedule_config,
+    )
 
     config = tmp_path / "agents.yaml"
     config.write_text(
@@ -38,9 +50,19 @@ def test_yaml_cron_and_timezone_are_preserved(tmp_path):
     )
 
     _, schedule = load_agent_yaml_with_schedule(str(config))
+    validate_schedule_config(schedule)
 
     assert schedule["interval"] == "cron:0 8 * * *"
     assert schedule["tz"] == "America/New_York"
+
+
+def test_yaml_validator_rejects_empty_cron():
+    import pytest
+
+    from praisonai.scheduler.yaml_loader import validate_schedule_config
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        validate_schedule_config({"interval": "cron:"})
 
 
 def test_schedule_add_cli_passes_timezone(monkeypatch):

--- a/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
+++ b/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
@@ -1,0 +1,72 @@
+"""Wrapper CLI/YAML timezone wiring."""
+
+from datetime import datetime, timezone
+
+
+def _epoch(year, month, day, hour, minute=0):
+    return datetime(
+        year, month, day, hour, minute, tzinfo=timezone.utc
+    ).timestamp()
+
+
+def test_schedule_ticker_uses_timezone_across_dst():
+    from praisonai.scheduler.shared import ScheduleTicker
+
+    ticker = ScheduleTicker(
+        "cron:0 8 * * *",
+        last_run_at=_epoch(2026, 3, 7, 13),
+        timezone="America/New_York",
+    )
+
+    assert ticker.is_due(_epoch(2026, 3, 8, 11, 59)) is False
+    assert ticker.is_due(_epoch(2026, 3, 8, 12, 0)) is True
+
+
+def test_yaml_cron_and_timezone_are_preserved(tmp_path):
+    from praisonai.scheduler.yaml_loader import load_agent_yaml_with_schedule
+
+    config = tmp_path / "agents.yaml"
+    config.write_text(
+        "agents:\n"
+        "  - name: reporter\n"
+        "    instructions: report\n"
+        "task: send report\n"
+        "schedule:\n"
+        "  cron: '0 8 * * *'\n"
+        "  tz: America/New_York\n",
+        encoding="utf-8",
+    )
+
+    _, schedule = load_agent_yaml_with_schedule(str(config))
+
+    assert schedule["interval"] == "cron:0 8 * * *"
+    assert schedule["tz"] == "America/New_York"
+
+
+def test_schedule_add_cli_passes_timezone(monkeypatch):
+    from typer.testing import CliRunner
+
+    import praisonaiagents.tools.schedule_tools as tools
+    from praisonai.cli.commands.schedule import app
+
+    captured = {}
+
+    def fake_add(**kwargs):
+        captured.update(kwargs)
+        return "Schedule added"
+
+    monkeypatch.setattr(tools, "schedule_add", fake_add)
+    result = CliRunner().invoke(
+        app,
+        [
+            "add",
+            "morning-brief",
+            "--schedule",
+            "cron:0 8 * * *",
+            "--tz",
+            "America/New_York",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["tz"] == "America/New_York"

--- a/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
+++ b/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
@@ -24,6 +24,9 @@ def test_schedule_ticker_uses_timezone_across_dst():
     assert ticker.is_due(_epoch(2026, 3, 8, 11, 59)) is False
     assert ticker.is_due(_epoch(2026, 3, 8, 12, 0)) is True
 
+    wait = ticker.seconds_until_next(_epoch(2026, 3, 8, 11, 0))
+    assert wait == 60 * 60
+
 
 def test_schedule_ticker_rejects_invalid_timezone():
     import pytest
@@ -66,6 +69,81 @@ def test_yaml_validator_rejects_empty_cron():
 
     with pytest.raises(ValueError, match="must not be empty"):
         validate_schedule_config({"interval": "cron:"})
+
+
+def test_yaml_validator_rejects_unknown_interval():
+    import pytest
+
+    from praisonai.scheduler.yaml_loader import validate_schedule_config
+
+    with pytest.raises(ValueError, match="Invalid interval format"):
+        validate_schedule_config({"interval": "sometimes"})
+
+
+def test_sync_yaml_scheduler_forwards_timezone():
+    from praisonai.scheduler.agent_scheduler import AgentScheduler
+
+    scheduler = object.__new__(AgentScheduler)
+    scheduler._yaml_schedule_config = {
+        "interval": "cron:0 8 * * *",
+        "max_retries": 5,
+        "run_immediately": True,
+        "tz": "America/New_York",
+    }
+    captured = {}
+
+    def fake_start(schedule_expr, max_retries, run_immediately, *, timezone=None):
+        captured.update(
+            schedule_expr=schedule_expr,
+            max_retries=max_retries,
+            run_immediately=run_immediately,
+            timezone=timezone,
+        )
+        return True
+
+    scheduler.start = fake_start
+
+    assert scheduler.start_from_yaml_config() is True
+    assert captured == {
+        "schedule_expr": "cron:0 8 * * *",
+        "max_retries": 5,
+        "run_immediately": True,
+        "timezone": "America/New_York",
+    }
+
+
+async def test_async_yaml_scheduler_forwards_timezone():
+    from praisonai.scheduler.async_agent_scheduler import AsyncAgentScheduler
+
+    scheduler = object.__new__(AsyncAgentScheduler)
+    scheduler._yaml_schedule_config = {
+        "interval": "cron:0 8 * * *",
+        "max_retries": 4,
+        "run_immediately": False,
+        "tz": "Asia/Singapore",
+    }
+    captured = {}
+
+    async def fake_start(
+        schedule_expr, max_retries, run_immediately, *, timezone=None
+    ):
+        captured.update(
+            schedule_expr=schedule_expr,
+            max_retries=max_retries,
+            run_immediately=run_immediately,
+            timezone=timezone,
+        )
+        return True
+
+    scheduler.start = fake_start
+
+    assert await scheduler.start_from_yaml_config() is True
+    assert captured == {
+        "schedule_expr": "cron:0 8 * * *",
+        "max_retries": 4,
+        "run_immediately": False,
+        "timezone": "Asia/Singapore",
+    }
 
 
 def test_schedule_add_cli_passes_timezone(monkeypatch):


### PR DESCRIPTION
## Summary

- evaluate cron and naive one-shot schedules in their configured IANA timezone
- preserve explicit timestamp offsets and UTC as the compatibility fallback
- support DST-aware cron calculation plus PRAISONAI_SCHEDULE_TIMEZONE and config.yaml scheduler.timezone defaults
- thread timezone selection through the Python parser, agent tool, CLI --tz option, and agents.yaml cron configuration
- share the same timezone-aware cron calculation with sync and async wrapper schedulers

## Validation

- 128 core scheduler tests passed
- 128 wrapper scheduler tests passed
- DST spring-forward and fall-back cases covered
- scheduler modules compile successfully
- git diff --check

Closes #3871

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timezone support for cron and one-time scheduled jobs.
  * Added the `--tz` option for schedule creation.
  * Added YAML support for cron expressions and schedule timezones.
  * Added environment- and configuration-based timezone defaults.
* **Bug Fixes**
  * Improved daylight-saving-time handling for recurring schedules.
  * Naive timestamps now use the configured schedule timezone.
  * Invalid timezone names and empty cron values now fail validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->