### PR TITLE
feat: prefetch memory at turn start

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/async_memory_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/async_memory_mixin.py
@@ -84,21 +84,36 @@ class AsyncMemoryMixin:
         if not hasattr(self, '_memory_instance') or self._memory_instance is None:
             logger.debug("No memory configured for async search")
             return []
+
+        # Shared adapters must receive the configured identity explicitly.
+        # FileMemory is already bound to a user-specific path and accepts these
+        # as harmless protocol kwargs.
+        scoped_kwargs = dict(kwargs)
+        config = getattr(self, "_memory_config", None)
+        user_id = getattr(config, "user_id", None)
+        session_id = getattr(config, "session_id", None)
+        if user_id:
+            scoped_kwargs.setdefault("user_id", user_id)
+        if session_id:
+            scoped_kwargs.setdefault("session_id", session_id)
+            metadata_filter = dict(scoped_kwargs.get("metadata_filter") or {})
+            metadata_filter.setdefault("session_id", session_id)
+            scoped_kwargs["metadata_filter"] = metadata_filter
             
         # Check if memory adapter supports async operations
         if isinstance(self._memory_instance, AsyncMemoryProtocol):
             try:
                 if memory_type == "long_term":
-                    return await self._memory_instance.asearch_long_term(query, limit, **kwargs)
+                    return await self._memory_instance.asearch_long_term(query, limit, **scoped_kwargs)
                 else:
-                    return await self._memory_instance.asearch_short_term(query, limit, **kwargs)
+                    return await self._memory_instance.asearch_short_term(query, limit, **scoped_kwargs)
             except Exception as e:
                 logger.error(f"Error in async memory search: {e}")
                 return []
         else:
             # Fallback: run sync memory operations in thread pool
             return await self._run_memory_in_thread(
-                "search", query, memory_type, limit=limit, **kwargs
+                "search", query, memory_type, limit=limit, **scoped_kwargs
             )
     
     async def _run_memory_in_thread(

--- a/src/praisonai-agents/praisonaiagents/agent/async_memory_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/async_memory_mixin.py
@@ -93,11 +93,11 @@ class AsyncMemoryMixin:
         user_id = getattr(config, "user_id", None)
         session_id = getattr(config, "session_id", None)
         if user_id:
-            scoped_kwargs.setdefault("user_id", user_id)
+            scoped_kwargs["user_id"] = user_id
         if session_id:
-            scoped_kwargs.setdefault("session_id", session_id)
+            scoped_kwargs["session_id"] = session_id
             metadata_filter = dict(scoped_kwargs.get("metadata_filter") or {})
-            metadata_filter.setdefault("session_id", session_id)
+            metadata_filter["session_id"] = session_id
             scoped_kwargs["metadata_filter"] = metadata_filter
             
         # Check if memory adapter supports async operations

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -63,6 +63,129 @@ class ChatMixin:
             return execute
         return execute_tool_fn
 
+    @staticmethod
+    def _memory_prefetch_query(prompt: Any) -> str:
+        """Return the user-authored text used for turn-start memory lookup."""
+        if isinstance(prompt, str):
+            return prompt.strip()
+        if isinstance(prompt, list):
+            parts = []
+            for item in prompt:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    text = item.get("text")
+                    if text:
+                        parts.append(str(text))
+            return "\n".join(parts).strip()
+        return str(prompt).strip() if prompt is not None else ""
+
+    @staticmethod
+    def _memory_prefetch_text(item: Any) -> str:
+        """Extract display text from the common memory-adapter result shapes."""
+        if isinstance(item, str):
+            return item.strip()
+        if isinstance(item, dict):
+            for key in ("memory", "text", "content", "value"):
+                value = item.get(key)
+                if value is not None:
+                    return str(value).strip()
+        for attr in ("memory", "text", "content", "value"):
+            value = getattr(item, attr, None)
+            if value is not None:
+                return str(value).strip()
+        return ""
+
+    def _format_memory_prefetch(self, results: Any, limit: int, token_budget: int) -> str:
+        """Format deduplicated memory hits inside a strict estimated-token budget."""
+        if not isinstance(results, (list, tuple)):
+            return ""
+
+        try:
+            from ..context.tokens import estimate_tokens_heuristic
+        except ImportError:  # pragma: no cover - core module is always present
+            estimate_tokens_heuristic = lambda text: max(1, len(text) // 4)
+
+        lines = []
+        seen = set()
+        for item in results:
+            text = self._memory_prefetch_text(item)
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            lines.append(f"- {text}")
+            if len(lines) >= limit:
+                break
+
+        if not lines or token_budget <= 0:
+            return ""
+
+        rendered = "\n".join(lines)
+        if estimate_tokens_heuristic(rendered) <= token_budget:
+            return rendered
+
+        # Token estimation is monotonic for prefixes, so binary search keeps
+        # the largest safe prefix and makes truncation explicit to the model.
+        suffix = "…"
+        low, high = 0, len(rendered)
+        while low < high:
+            mid = (low + high + 1) // 2
+            candidate = rendered[:mid].rstrip() + suffix
+            if estimate_tokens_heuristic(candidate) <= token_budget:
+                low = mid
+            else:
+                high = mid - 1
+        return (rendered[:low].rstrip() + suffix) if low else ""
+
+    def _prefetch_memory(self, prompt: Any) -> str:
+        """Best-effort synchronous turn-start retrieval (default-off)."""
+        config = getattr(self, "_memory_config", None)
+        memory = getattr(self, "_memory_instance", None)
+        if not config or not getattr(config, "prefetch", False) or memory is None:
+            return ""
+
+        query = self._memory_prefetch_query(prompt)
+        if not query:
+            return ""
+        limit = max(0, int(getattr(config, "prefetch_limit", 5)))
+        budget = max(0, int(getattr(config, "prefetch_token_budget", 512)))
+        if not limit or not budget:
+            return ""
+
+        try:
+            if hasattr(memory, "search_long_term"):
+                results = memory.search_long_term(query, limit=limit)
+            elif hasattr(memory, "search"):
+                results = memory.search(query, limit=limit)
+            else:
+                return ""
+            return self._format_memory_prefetch(results, limit, budget)
+        except Exception as exc:
+            logging.debug("Memory prefetch failed; continuing without recalled context: %s", exc)
+            return ""
+
+    async def _aprefetch_memory(self, prompt: Any) -> str:
+        """Best-effort asynchronous turn-start retrieval (default-off)."""
+        config = getattr(self, "_memory_config", None)
+        memory = getattr(self, "_memory_instance", None)
+        if not config or not getattr(config, "prefetch", False) or memory is None:
+            return ""
+
+        query = self._memory_prefetch_query(prompt)
+        if not query:
+            return ""
+        limit = max(0, int(getattr(config, "prefetch_limit", 5)))
+        budget = max(0, int(getattr(config, "prefetch_token_budget", 512)))
+        if not limit or not budget:
+            return ""
+
+        try:
+            results = await self.asearch_memory(
+                query, memory_type="long_term", limit=limit
+            )
+            return self._format_memory_prefetch(results, limit, budget)
+        except Exception as exc:
+            logging.debug("Async memory prefetch failed; continuing without recalled context: %s", exc)
+            return ""
+
     def _resolve_max_steps(self, default: int = 10) -> int:
         """Resolve the unified multi-step tool budget shared by both loops.
 
@@ -130,7 +253,7 @@ class ChatMixin:
         except Exception:
             return ""
 
-    def _build_system_prompt(self, tools=None):
+    def _build_system_prompt(self, tools=None, memory_prefetch_context: str = ""):
         """Build the system prompt with tool information.
         
         Args:
@@ -221,6 +344,9 @@ Your Goal: {self.goal}"""
             learn_context = self.get_learn_context()
             if learn_context:
                 system_prompt += f"\n\n## Learned Context (Patterns and insights from past interactions)\n{learn_context}"
+
+        if memory_prefetch_context:
+            system_prompt += f"\n\n## Recalled memories\n{memory_prefetch_context}"
         
         # Add skills prompt if skills are configured
         if self._skills or self._skills_dirs:
@@ -532,7 +658,7 @@ Your Goal: {self.goal}"""
             )
             return False
 
-    def _build_messages(self, prompt, temperature=1.0, output_json=None, output_pydantic=None, tools=None, use_native_format=False, restore_durable=True):
+    def _build_messages(self, prompt, temperature=1.0, output_json=None, output_pydantic=None, tools=None, use_native_format=False, restore_durable=True, memory_prefetch_context: str = ""):
         """Build messages list for chat completion.
         
         Args:
@@ -555,6 +681,7 @@ Your Goal: {self.goal}"""
                 prompt=prompt,
                 system_prompt=self._build_system_prompt(
                     tools=tools,
+                    memory_prefetch_context=memory_prefetch_context,
                 ),
                 chat_history=self.chat_history,
                 output_json=None if use_native_format else output_json,
@@ -564,6 +691,7 @@ Your Goal: {self.goal}"""
             # Build messages manually
             system_prompt = self._build_system_prompt(
                 tools=tools,
+                memory_prefetch_context=memory_prefetch_context,
             )
             if system_prompt:
                 messages.append({"role": "system", "content": system_prompt})
@@ -2778,6 +2906,10 @@ Your Goal: {self.goal}"""
         # Use agent's stream setting if not explicitly provided
         if stream is None:
             stream = self.stream
+
+        # Query long-term memory exactly once for this turn. The default-off
+        # guard returns before touching the backend.
+        memory_prefetch_context = self._prefetch_memory(prompt)
         
         # Unified retrieval handling with policy-based decision
         # Uses token-aware context building (DRY - same path as RAG pipeline)
@@ -2883,7 +3015,9 @@ Your Goal: {self.goal}"""
                 
                 try:
                     # --- Proactive Context Budget Management (sync custom LLM path) ---
-                    system_prompt_for_llm = self._build_system_prompt(tools)
+                    system_prompt_for_llm = self._build_system_prompt(
+                        tools, memory_prefetch_context=memory_prefetch_context
+                    )
                     
                     # Apply proactive context budget analysis before any other processing
                     try:
@@ -3025,7 +3159,8 @@ Your Goal: {self.goal}"""
             # Pass llm_prompt (which includes multimodal content if attachments present)
             messages, original_prompt = self._build_messages(
                 llm_prompt, temperature, output_json, output_pydantic,
-                use_native_format=use_native_format
+                use_native_format=use_native_format,
+                memory_prefetch_context=memory_prefetch_context,
             )
             
 
@@ -3451,6 +3586,10 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         start_time = time.time()
         reasoning_steps = reasoning_steps or self.reasoning_steps
         try:
+            # Async adapters are awaited (sync adapters are offloaded by
+            # AsyncMemoryMixin), so turn-start retrieval never blocks the loop.
+            memory_prefetch_context = await self._aprefetch_memory(prompt)
+
             # Default to self.tools if tools argument is None
             if tools is None:
                 tools = self.tools
@@ -3520,7 +3659,10 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     # C1 - per-call seed forwarding (async path)  
                     llm_kwargs = {
                         'prompt': prompt,
-                        'system_prompt': self._build_system_prompt(tools),
+                        'system_prompt': self._build_system_prompt(
+                            tools,
+                            memory_prefetch_context=memory_prefetch_context,
+                        ),
                         'chat_history': effective_history,
                         'temperature': temperature,
                         'tools': tools,
@@ -3609,6 +3751,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 output_json,
                 output_pydantic,
                 restore_durable=False,
+                memory_prefetch_context=memory_prefetch_context,
             )
             durable_context = self._get_durable_run_context()
             if durable_context is not None:
@@ -4263,6 +4406,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             # Temporarily disable verbose mode to prevent console output conflicts during streaming
             original_verbose = self.verbose
             self.verbose = False
+            memory_prefetch_context = self._prefetch_memory(prompt)
             
             # For custom LLM path, use the new get_response_stream generator
             if self._using_custom_llm:
@@ -4327,7 +4471,10 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         )
                     for chunk in self.llm_instance.get_response_stream(
                         prompt=actual_prompt,
-                        system_prompt=self._build_system_prompt(tool_param),
+                        system_prompt=self._build_system_prompt(
+                            tool_param,
+                            memory_prefetch_context=memory_prefetch_context,
+                        ),
                         chat_history=stream_history,
                         temperature=kwargs.get('temperature', 1.0),
                         tools=tool_param,
@@ -4388,7 +4535,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 
                 # Build messages using the helper method
                 messages, original_prompt = self._build_messages(actual_prompt, kwargs.get('temperature', 1.0), 
-                                                               kwargs.get('output_json'), kwargs.get('output_pydantic'))
+                                                               kwargs.get('output_json'), kwargs.get('output_pydantic'),
+                                                               memory_prefetch_context=memory_prefetch_context)
                 
                 # Store chat history length for potential rollback
                 chat_history_length = len(self.chat_history)

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -86,12 +86,18 @@ class ChatMixin:
         if isinstance(item, dict):
             for key in ("memory", "text", "content", "value"):
                 value = item.get(key)
-                if value is not None:
+                if isinstance(value, str):
                     return str(value).strip()
+            nested_item = item.get("item")
+            if nested_item is not None and nested_item is not item:
+                return ChatMixin._memory_prefetch_text(nested_item)
         for attr in ("memory", "text", "content", "value"):
             value = getattr(item, attr, None)
-            if value is not None:
+            if isinstance(value, str):
                 return str(value).strip()
+        nested_item = getattr(item, "item", None)
+        if nested_item is not None and nested_item is not item:
+            return ChatMixin._memory_prefetch_text(nested_item)
         return ""
 
     def _format_memory_prefetch(self, results: Any, limit: int, token_budget: int) -> str:
@@ -102,7 +108,8 @@ class ChatMixin:
         try:
             from ..context.tokens import estimate_tokens_heuristic
         except ImportError:  # pragma: no cover - core module is always present
-            estimate_tokens_heuristic = lambda text: max(1, len(text) // 4)
+            def estimate_tokens_heuristic(text: str) -> int:
+                return max(1, len(text) // 4)
 
         lines = []
         seen = set()
@@ -142,15 +149,14 @@ class ChatMixin:
         if not config or not getattr(config, "prefetch", False) or memory is None:
             return ""
 
-        query = self._memory_prefetch_query(prompt)
-        if not query:
-            return ""
-        limit = max(0, int(getattr(config, "prefetch_limit", 5)))
-        budget = max(0, int(getattr(config, "prefetch_token_budget", 512)))
-        if not limit or not budget:
-            return ""
-
         try:
+            query = self._memory_prefetch_query(prompt)
+            if not query:
+                return ""
+            limit = max(0, int(getattr(config, "prefetch_limit", 5)))
+            budget = max(0, int(getattr(config, "prefetch_token_budget", 512)))
+            if not limit or not budget:
+                return ""
             if hasattr(memory, "search_long_term"):
                 results = memory.search_long_term(query, limit=limit)
             elif hasattr(memory, "search"):
@@ -169,15 +175,14 @@ class ChatMixin:
         if not config or not getattr(config, "prefetch", False) or memory is None:
             return ""
 
-        query = self._memory_prefetch_query(prompt)
-        if not query:
-            return ""
-        limit = max(0, int(getattr(config, "prefetch_limit", 5)))
-        budget = max(0, int(getattr(config, "prefetch_token_budget", 512)))
-        if not limit or not budget:
-            return ""
-
         try:
+            query = self._memory_prefetch_query(prompt)
+            if not query:
+                return ""
+            limit = max(0, int(getattr(config, "prefetch_limit", 5)))
+            budget = max(0, int(getattr(config, "prefetch_token_budget", 512)))
+            if not limit or not budget:
+                return ""
             results = await self.asearch_memory(
                 query, memory_type="long_term", limit=limit
             )

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -157,6 +157,8 @@ class ChatMixin:
 
     def _prefetch_memory(self, prompt: Any) -> str:
         """Best-effort synchronous turn-start retrieval (default-off)."""
+        if not self.use_system_prompt:
+            return ""
         config = getattr(self, "_memory_config", None)
         memory = getattr(self, "_memory_instance", None)
         if not config or not getattr(config, "prefetch", False) or memory is None:
@@ -184,6 +186,8 @@ class ChatMixin:
 
     async def _aprefetch_memory(self, prompt: Any) -> str:
         """Best-effort asynchronous turn-start retrieval (default-off)."""
+        if not self.use_system_prompt:
+            return ""
         config = getattr(self, "_memory_config", None)
         memory = getattr(self, "_memory_instance", None)
         if not config or not getattr(config, "prefetch", False) or memory is None:

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -63,6 +63,19 @@ class ChatMixin:
             return execute
         return execute_tool_fn
 
+    def _memory_prefetch_scope(self) -> Dict[str, Any]:
+        """Return explicit identity filters for a shared memory backend."""
+        config = getattr(self, "_memory_config", None)
+        scope: Dict[str, Any] = {}
+        user_id = getattr(config, "user_id", None)
+        session_id = getattr(config, "session_id", None)
+        if user_id:
+            scope["user_id"] = user_id
+        if session_id:
+            scope["session_id"] = session_id
+            scope["metadata_filter"] = {"session_id": session_id}
+        return scope
+
     @staticmethod
     def _memory_prefetch_query(prompt: Any) -> str:
         """Return the user-authored text used for turn-start memory lookup."""
@@ -157,10 +170,11 @@ class ChatMixin:
             budget = max(0, int(getattr(config, "prefetch_token_budget", 512)))
             if not limit or not budget:
                 return ""
+            scope = self._memory_prefetch_scope()
             if hasattr(memory, "search_long_term"):
-                results = memory.search_long_term(query, limit=limit)
+                results = memory.search_long_term(query, limit=limit, **scope)
             elif hasattr(memory, "search"):
-                results = memory.search(query, limit=limit)
+                results = memory.search(query, limit=limit, **scope)
             else:
                 return ""
             return self._format_memory_prefetch(results, limit, budget)

--- a/src/praisonai-agents/praisonaiagents/config/feature_configs.py
+++ b/src/praisonai-agents/praisonaiagents/config/feature_configs.py
@@ -238,6 +238,12 @@ class MemoryConfig:
     # History injection (auto-inject session history into context)
     history: bool = False
     history_limit: int = 10
+
+    # Turn-start long-term memory retrieval. Disabled by default so existing
+    # agents incur no backend query or prompt changes.
+    prefetch: bool = False
+    prefetch_limit: int = 5
+    prefetch_token_budget: int = 512
     
     # Auto-save session name (consolidated from standalone auto_save param)
     # When set, automatically saves session to memory with this name
@@ -264,6 +270,9 @@ class MemoryConfig:
             "learn": learn_dict,
             "history": self.history,
             "history_limit": self.history_limit,
+            "prefetch": self.prefetch,
+            "prefetch_limit": self.prefetch_limit,
+            "prefetch_token_budget": self.prefetch_token_budget,
             "auto_save": self.auto_save,
         }
 

--- a/src/praisonai-agents/tests/integration/test_memory_prefetch_real.py
+++ b/src/praisonai-agents/tests/integration/test_memory_prefetch_real.py
@@ -1,0 +1,39 @@
+"""Opt-in real-provider smoke for memory prefetch.
+
+Run with RUN_REAL_KEY_TESTS=1 and a configured provider key.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_REAL_KEY_TESTS") != "1",
+    reason="requires an explicitly enabled real provider",
+)
+def test_real_agent_uses_prefetched_memory(tmp_path, monkeypatch):
+    from praisonaiagents import Agent, MemoryConfig
+
+    monkeypatch.setenv("PRAISONAI_MEMORY_DIR", str(tmp_path))
+    config = MemoryConfig(
+        backend="file",
+        user_id="prefetch-real-smoke",
+        prefetch=True,
+        prefetch_limit=3,
+    )
+    writer = Agent(name="writer", instructions="Store user facts.", memory=config)
+    writer.store_memory(
+        "The user's project codename is NEBULA-7.",
+        memory_type="long_term",
+    )
+
+    reader = Agent(
+        name="reader",
+        instructions="Answer only from recalled memories.",
+        memory=config,
+    )
+    result = reader.start("What is my project codename?")
+
+    print(result)
+    assert "NEBULA-7" in str(result)

--- a/src/praisonai-agents/tests/unit/memory/test_prefetch.py
+++ b/src/praisonai-agents/tests/unit/memory/test_prefetch.py
@@ -49,7 +49,12 @@ def test_prefetch_disabled_does_not_touch_backend():
 
 
 def test_prefetch_injects_deduplicated_system_context_before_user_message():
-    agent = _agent(MemoryConfig(prefetch=True, prefetch_limit=2))
+    agent = _agent(MemoryConfig(
+        prefetch=True,
+        prefetch_limit=2,
+        user_id="user-7",
+        session_id="session-9",
+    ))
     backend = MagicMock()
     backend.search_long_term.return_value = [
         {"memory": "Timezone: Asia/Kolkata"},
@@ -65,7 +70,11 @@ def test_prefetch_injects_deduplicated_system_context_before_user_message():
     )
 
     backend.search_long_term.assert_called_once_with(
-        "What timezone should I use?", limit=2
+        "What timezone should I use?",
+        limit=2,
+        user_id="user-7",
+        session_id="session-9",
+        metadata_filter={"session_id": "session-9"},
     )
     assert messages[0]["role"] == "system"
     assert "## Recalled memories" in messages[0]["content"]
@@ -144,7 +153,12 @@ def test_prefetch_invalid_numeric_config_is_non_fatal(field, value):
 
 @pytest.mark.asyncio
 async def test_async_prefetch_uses_async_memory_search():
-    agent = _agent(MemoryConfig(prefetch=True, prefetch_limit=1))
+    agent = _agent(MemoryConfig(
+        prefetch=True,
+        prefetch_limit=1,
+        user_id="user-7",
+        session_id="session-9",
+    ))
     agent.asearch_memory = AsyncMock(return_value=[{"text": "async memory"}])
 
     recalled = await agent._aprefetch_memory("async question")
@@ -152,6 +166,28 @@ async def test_async_prefetch_uses_async_memory_search():
     assert recalled == "- async memory"
     agent.asearch_memory.assert_awaited_once_with(
         "async question", memory_type="long_term", limit=1
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_memory_search_enforces_configured_identity_scope():
+    agent = _agent(MemoryConfig(
+        prefetch=True,
+        user_id="user-7",
+        session_id="session-9",
+    ))
+    backend = MagicMock()
+    backend.search_long_term.return_value = []
+    agent._memory_instance = backend
+
+    await agent.asearch_memory("question", memory_type="long_term", limit=2)
+
+    backend.search_long_term.assert_called_once_with(
+        "question",
+        2,
+        user_id="user-7",
+        session_id="session-9",
+        metadata_filter={"session_id": "session-9"},
     )
 
 

--- a/src/praisonai-agents/tests/unit/memory/test_prefetch.py
+++ b/src/praisonai-agents/tests/unit/memory/test_prefetch.py
@@ -1,0 +1,128 @@
+"""Tests for opt-in, turn-start long-term memory prefetch."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from praisonaiagents import Agent, MemoryConfig
+from praisonaiagents.context.tokens import estimate_tokens_heuristic
+
+
+def _agent(config: MemoryConfig) -> Agent:
+    if config.user_id is None:
+        config.user_id = "prefetch-test-user"
+    agent = Agent(
+        name="prefetch-test",
+        instructions="Answer from available context.",
+        llm="gpt-4o-mini",
+        memory=config,
+    )
+    # Message construction does not need a provider client; keep the unit test
+    # offline by selecting the existing custom-LLM fallback branch.
+    agent._using_custom_llm = True
+    return agent
+
+
+def test_memory_config_prefetch_defaults_and_round_trip():
+    config = MemoryConfig()
+    assert config.prefetch is False
+    assert config.prefetch_limit == 5
+    assert config.prefetch_token_budget == 512
+
+    loaded = MemoryConfig(**MemoryConfig(
+        prefetch=True,
+        prefetch_limit=3,
+        prefetch_token_budget=40,
+    ).to_dict())
+    assert loaded.prefetch is True
+    assert loaded.prefetch_limit == 3
+    assert loaded.prefetch_token_budget == 40
+
+
+def test_prefetch_disabled_does_not_touch_backend():
+    agent = _agent(MemoryConfig(prefetch=False))
+    backend = MagicMock()
+    agent._memory_instance = backend
+
+    assert agent._prefetch_memory("remember this") == ""
+    backend.search_long_term.assert_not_called()
+
+
+def test_prefetch_injects_deduplicated_system_context_before_user_message():
+    agent = _agent(MemoryConfig(prefetch=True, prefetch_limit=2))
+    backend = MagicMock()
+    backend.search_long_term.return_value = [
+        {"memory": "Timezone: Asia/Kolkata"},
+        {"text": "Preferred format: concise"},
+        {"memory": "Timezone: Asia/Kolkata"},
+    ]
+    agent._memory_instance = backend
+
+    recalled = agent._prefetch_memory("What timezone should I use?")
+    messages, _ = agent._build_messages(
+        "What timezone should I use?",
+        memory_prefetch_context=recalled,
+    )
+
+    backend.search_long_term.assert_called_once_with(
+        "What timezone should I use?", limit=2
+    )
+    assert messages[0]["role"] == "system"
+    assert "## Recalled memories" in messages[0]["content"]
+    assert messages[0]["content"].count("Timezone: Asia/Kolkata") == 1
+    assert "Preferred format: concise" in messages[0]["content"]
+    assert messages[-1] == {
+        "role": "user",
+        "content": "What timezone should I use?",
+    }
+
+
+def test_prefetch_limit_and_token_budget_are_enforced_with_ellipsis():
+    agent = _agent(MemoryConfig(
+        prefetch=True,
+        prefetch_limit=2,
+        prefetch_token_budget=8,
+    ))
+    backend = MagicMock()
+    backend.search_long_term.return_value = [
+        {"text": "A long remembered preference that exceeds the budget"},
+        {"text": "second memory"},
+        {"text": "must not be included"},
+    ]
+    agent._memory_instance = backend
+
+    recalled = agent._prefetch_memory("preference")
+
+    assert recalled.endswith("…")
+    assert "must not be included" not in recalled
+    assert estimate_tokens_heuristic(recalled) <= 8
+
+
+def test_prefetch_backend_failure_is_non_fatal():
+    agent = _agent(MemoryConfig(prefetch=True))
+    backend = MagicMock()
+    backend.search_long_term.side_effect = RuntimeError("backend unavailable")
+    agent._memory_instance = backend
+
+    assert agent._prefetch_memory("question") == ""
+
+
+@pytest.mark.asyncio
+async def test_async_prefetch_uses_async_memory_search():
+    agent = _agent(MemoryConfig(prefetch=True, prefetch_limit=1))
+    agent.asearch_memory = AsyncMock(return_value=[{"text": "async memory"}])
+
+    recalled = await agent._aprefetch_memory("async question")
+
+    assert recalled == "- async memory"
+    agent.asearch_memory.assert_awaited_once_with(
+        "async question", memory_type="long_term", limit=1
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_prefetch_failure_is_non_fatal():
+    agent = _agent(MemoryConfig(prefetch=True))
+    agent.asearch_memory = AsyncMock(side_effect=RuntimeError("offline"))
+
+    assert await agent._aprefetch_memory("async question") == ""

--- a/src/praisonai-agents/tests/unit/memory/test_prefetch.py
+++ b/src/praisonai-agents/tests/unit/memory/test_prefetch.py
@@ -77,6 +77,21 @@ def test_prefetch_injects_deduplicated_system_context_before_user_message():
     }
 
 
+def test_prefetch_extracts_default_file_memory_search_shape():
+    agent = _agent(MemoryConfig(prefetch=True))
+    backend = MagicMock()
+    backend.search_long_term.return_value = [
+        {
+            "type": "long_term",
+            "item": {"content": "Timezone: Asia/Singapore"},
+            "score": 0.9,
+        }
+    ]
+    agent._memory_instance = backend
+
+    assert agent._prefetch_memory("timezone") == "- Timezone: Asia/Singapore"
+
+
 def test_prefetch_limit_and_token_budget_are_enforced_with_ellipsis():
     agent = _agent(MemoryConfig(
         prefetch=True,
@@ -105,6 +120,26 @@ def test_prefetch_backend_failure_is_non_fatal():
     agent._memory_instance = backend
 
     assert agent._prefetch_memory("question") == ""
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("prefetch_limit", None),
+        ("prefetch_limit", "many"),
+        ("prefetch_token_budget", None),
+        ("prefetch_token_budget", "large"),
+    ],
+)
+def test_prefetch_invalid_numeric_config_is_non_fatal(field, value):
+    config = MemoryConfig(prefetch=True)
+    setattr(config, field, value)
+    agent = _agent(config)
+    backend = MagicMock()
+    agent._memory_instance = backend
+
+    assert agent._prefetch_memory("question") == ""
+    backend.search_long_term.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/src/praisonai-agents/tests/unit/memory/test_prefetch.py
+++ b/src/praisonai-agents/tests/unit/memory/test_prefetch.py
@@ -180,14 +180,21 @@ async def test_async_memory_search_enforces_configured_identity_scope():
     backend.search_long_term.return_value = []
     agent._memory_instance = backend
 
-    await agent.asearch_memory("question", memory_type="long_term", limit=2)
+    await agent.asearch_memory(
+        "question",
+        memory_type="long_term",
+        limit=2,
+        user_id="other-user",
+        session_id="other-session",
+        metadata_filter={"session_id": "other-session", "kind": "fact"},
+    )
 
     backend.search_long_term.assert_called_once_with(
         "question",
         2,
         user_id="user-7",
         session_id="session-9",
-        metadata_filter={"session_id": "session-9"},
+        metadata_filter={"session_id": "session-9", "kind": "fact"},
     )
 
 

--- a/src/praisonai-agents/tests/unit/memory/test_prefetch.py
+++ b/src/praisonai-agents/tests/unit/memory/test_prefetch.py
@@ -48,6 +48,16 @@ def test_prefetch_disabled_does_not_touch_backend():
     backend.search_long_term.assert_not_called()
 
 
+def test_prefetch_without_system_prompt_does_not_touch_backend():
+    agent = _agent(MemoryConfig(prefetch=True))
+    agent.use_system_prompt = False
+    backend = MagicMock()
+    agent._memory_instance = backend
+
+    assert agent._prefetch_memory("remember this") == ""
+    backend.search_long_term.assert_not_called()
+
+
 def test_prefetch_injects_deduplicated_system_context_before_user_message():
     agent = _agent(MemoryConfig(
         prefetch=True,
@@ -167,6 +177,16 @@ async def test_async_prefetch_uses_async_memory_search():
     agent.asearch_memory.assert_awaited_once_with(
         "async question", memory_type="long_term", limit=1
     )
+
+
+@pytest.mark.asyncio
+async def test_async_prefetch_without_system_prompt_does_not_touch_backend():
+    agent = _agent(MemoryConfig(prefetch=True))
+    agent.use_system_prompt = False
+    agent.asearch_memory = AsyncMock()
+
+    assert await agent._aprefetch_memory("async question") == ""
+    agent.asearch_memory.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add opt-in `MemoryConfig` controls for turn-start long-term memory prefetch
- inject bounded, deduplicated recalled memories into the system context before the first model call
- keep sync, async, and streaming paths failure-isolated with zero backend work when disabled
- add deterministic unit coverage and an opt-in real-provider smoke test

## Tests
- `python -m pytest tests/unit/memory/test_prefetch.py tests/unit/test_history_parameter.py -q` (25 passed)
- `python -m pytest tests/unit/config tests/unit/agent/test_achat_unified_dispatch.py tests/unit/test_memory_system_fixes.py -q` (245 passed)
- `python -m pytest tests/integration/test_memory_prefetch_real.py -q` (1 skipped; requires `RUN_REAL_KEY_TESTS=1`)

Closes #3762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in, default-off long-term memory prefetching at the start of conversation turns.
  * Recalled memories can appear in standard, asynchronous, custom-model, and streaming responses.
  * Supports memory queries from text and multimodal prompts.
  * Added controls for enabling prefetching, limiting recalled results, and setting a token budget.
  * Memory retrieval is scoped to the relevant identity and session, deduplicated, safely truncated, and won’t interrupt conversations if unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->