### PR TITLE
feat: resume durable tool runs

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -5,13 +5,14 @@ Contains all methods for chat completion, streaming, message building,
 and response processing. Extracted from agent.py for maintainability.
 """
 
+import asyncio
 import os
 import re
 import time
 import json
 import logging
 from praisonaiagents._logging import get_logger
-from ..errors import BudgetExceededError
+from ..errors import BudgetExceededError, ToolExecutionError
 
 # Shared lazy display helpers (cached, thread-safe; avoid circular imports)
 from ._lazy_display import _get_console, _get_live, _get_display_functions
@@ -45,12 +46,22 @@ class ChatMixin:
     def _durable_sync_tool_executor(self, execute_tool_fn):
         """Wrap tool execution only while an opt-in durable run is active."""
         context = self._get_durable_run_context()
-        return context.wrap_sync(execute_tool_fn) if context else execute_tool_fn
+        if context:
+            execute = context.wrap_sync(execute_tool_fn)
+            if execute is not None:
+                execute._accepts_durable_iteration = True
+            return execute
+        return execute_tool_fn
 
     def _durable_async_tool_executor(self, execute_tool_fn):
         """Async counterpart of :meth:`_durable_sync_tool_executor`."""
         context = self._get_durable_run_context()
-        return context.wrap_async(execute_tool_fn) if context else execute_tool_fn
+        if context:
+            execute = context.wrap_async(execute_tool_fn)
+            if execute is not None:
+                execute._accepts_durable_iteration = True
+            return execute
+        return execute_tool_fn
 
     def _resolve_max_steps(self, default: int = 10) -> int:
         """Resolve the unified multi-step tool budget shared by both loops.
@@ -59,21 +70,30 @@ class ChatMixin:
         OpenAI-native and LiteLLM tool-execution loops); otherwise falls back to
         ``max_iter`` and finally ``default`` for backward compatibility.
         """
+        resolved = default
         execution = getattr(self, "execution", None)
         if execution is not None:
             resolver = getattr(execution, "resolved_max_steps", None)
+            used_resolver = False
             if callable(resolver):
                 try:
-                    return int(resolver())
+                    resolved = int(resolver())
+                    used_resolver = True
                 except Exception:
                     pass
-            max_steps = getattr(execution, "max_steps", None)
-            if max_steps is not None:
-                return int(max_steps)
-            max_iter = getattr(execution, "max_iter", None)
-            if max_iter is not None:
-                return int(max_iter)
-        return default
+            if not used_resolver:
+                max_steps = getattr(execution, "max_steps", None)
+                if max_steps is not None:
+                    resolved = int(max_steps)
+                else:
+                    max_iter = getattr(execution, "max_iter", None)
+                    if max_iter is not None:
+                        resolved = int(max_iter)
+
+        durable_context = self._get_durable_run_context()
+        if durable_context is not None and durable_context.replaying:
+            resolved -= durable_context.completed_steps
+        return max(0, resolved)
 
     def _resolve_max_tool_calls(self, default: int = 10) -> int:
         """Resolve the per-turn tool-call guardrail (independent of ``max_steps``)."""
@@ -512,7 +532,7 @@ Your Goal: {self.goal}"""
             )
             return False
 
-    def _build_messages(self, prompt, temperature=1.0, output_json=None, output_pydantic=None, tools=None, use_native_format=False):
+    def _build_messages(self, prompt, temperature=1.0, output_json=None, output_pydantic=None, tools=None, use_native_format=False, restore_durable=True):
         """Build messages list for chat completion.
         
         Args:
@@ -596,7 +616,7 @@ Your Goal: {self.goal}"""
                     messages[-1]["content"] += json_instruction
         
         durable_context = self._get_durable_run_context()
-        if durable_context is not None:
+        if durable_context is not None and restore_durable:
             durable_context.restore_messages(messages)
 
         return messages, original_prompt
@@ -2655,6 +2675,11 @@ Your Goal: {self.goal}"""
                 durable_context.finalize(outcome)
                 self.execution.resume_run_id = None
             return result
+        except InterruptedError:
+            if durable_context is not None:
+                durable_context.finalize("cancelled")
+                self.execution.resume_run_id = None
+            raise
         finally:
             if durable_context is not None:
                 from .durable import end_durable_run
@@ -2911,6 +2936,7 @@ Your Goal: {self.goal}"""
                             self.execute_tool
                         ),
                         parallel_tool_calls=getattr(getattr(self, "execution", None), "parallel_tool_calls", False),
+                        max_iterations=self._resolve_max_steps(),
                         max_tool_calls_per_turn=self._resolve_max_tool_calls(),
                         reasoning_steps=reasoning_steps,
                         stream=stream
@@ -3298,9 +3324,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         durable_token = None
         try:
             if getattr(getattr(self, "execution", None), "durable", False):
-                from .durable import begin_durable_run
+                from .durable import abegin_durable_run
 
-                durable_context, durable_token = begin_durable_run(
+                durable_context, durable_token = await abegin_durable_run(
                     self, prompt if isinstance(prompt, str) else str(prompt)
                 )
             result = await self._achat_impl(
@@ -3318,15 +3344,20 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     if getattr(self, "last_stop_reason", None) == "cancelled"
                     else "succeeded"
                 )
-                durable_context.finalize(outcome)
+                await durable_context.afinalize(outcome)
                 self.execution.resume_run_id = None
             return result
+        except (InterruptedError, asyncio.CancelledError):
+            if durable_context is not None:
+                await durable_context.afinalize("cancelled")
+                self.execution.resume_run_id = None
+            raise
         finally:
             if durable_context is not None:
                 from .durable import end_durable_run
 
                 end_durable_run(durable_token)
-                durable_context.close()
+                await durable_context.aclose()
             _trace_emitter.agent_end(self.name)
 
     async def _achat_impl(self, prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice=None, seed=None, cancel_token=None):
@@ -3465,7 +3496,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
 
                 durable_context = self._get_durable_run_context()
                 if durable_context is not None:
-                    effective_history = durable_context.restore_messages(
+                    effective_history = await durable_context.arestore_messages(
                         list(effective_history)
                     )
 
@@ -3495,6 +3526,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             self.execute_tool_async
                         ),
                         'parallel_tool_calls': getattr(getattr(self, "execution", None), "parallel_tool_calls", False),
+                        'max_iterations': self._resolve_max_steps(),
                         'max_tool_calls_per_turn': self._resolve_max_tool_calls(),
                         'reasoning_steps': reasoning_steps,
                         'stream': stream
@@ -3553,7 +3585,16 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
 
             # For OpenAI client
             # Use the new _build_messages helper method
-            messages, original_prompt = self._build_messages(prompt, temperature, output_json, output_pydantic)
+            messages, original_prompt = self._build_messages(
+                prompt,
+                temperature,
+                output_json,
+                output_pydantic,
+                restore_durable=False,
+            )
+            durable_context = self._get_durable_run_context()
+            if durable_context is not None:
+                messages = await durable_context.arestore_messages(messages)
             
             # Store chat history length for potential rollback
             chat_history_length = len(self.chat_history)
@@ -4146,6 +4187,36 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         self._auto_save_session()
 
     def _start_stream(self, prompt: str, **kwargs) -> Generator[str, None, None]:
+        """Own the durable context for the complete streaming generator."""
+        durable_context = None
+        durable_token = None
+        try:
+            if getattr(getattr(self, "execution", None), "durable", False):
+                from .durable import begin_durable_run
+
+                durable_context, durable_token = begin_durable_run(self, prompt)
+            yield from self._start_stream_impl(prompt, **kwargs)
+            if durable_context is not None:
+                outcome = (
+                    "cancelled"
+                    if getattr(self, "last_stop_reason", None) == "cancelled"
+                    else "succeeded"
+                )
+                durable_context.finalize(outcome)
+                self.execution.resume_run_id = None
+        except (GeneratorExit, InterruptedError):
+            if durable_context is not None:
+                durable_context.finalize("cancelled")
+                self.execution.resume_run_id = None
+            raise
+        finally:
+            if durable_context is not None:
+                from .durable import end_durable_run
+
+                end_durable_run(durable_token)
+                durable_context.close()
+
+    def _start_stream_impl(self, prompt: str, **kwargs) -> Generator[str, None, None]:
         """Stream generator for real-time response chunks."""
         # Warn if an output guardrail is configured: token-level streaming
         # yields chunks before a full response exists to validate, so the
@@ -4221,10 +4292,16 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 try:
                     # Use the new streaming generator from LLM class
                     response_content = ""
+                    stream_history = self.chat_history
+                    durable_context = self._get_durable_run_context()
+                    if durable_context is not None:
+                        stream_history = durable_context.restore_messages(
+                            list(stream_history)
+                        )
                     for chunk in self.llm_instance.get_response_stream(
                         prompt=actual_prompt,
                         system_prompt=self._build_system_prompt(tool_param),
-                        chat_history=self.chat_history,
+                        chat_history=stream_history,
                         temperature=kwargs.get('temperature', 1.0),
                         tools=tool_param,
                         output_json=kwargs.get('output_json'),
@@ -4250,6 +4327,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     if response_content:
                         self._append_to_chat_history({"role": "assistant", "content": response_content})
                         
+                except ToolExecutionError:
+                    self._rollback_chat_history_to(chat_history_length)
+                    raise
                 except Exception as e:
                     # Rollback chat history on error
                     self._rollback_chat_history_to(chat_history_length)
@@ -4431,10 +4511,13 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                         logging.error(f"Failed to parse tool arguments as JSON: {json_error}")
                                         parsed_args = {}
                                     
-                                    tool_result = self.execute_tool(
-                                        tool_call['function']['name'], 
+                                    tool_result = self._durable_sync_tool_executor(
+                                        self.execute_tool
+                                    )(
+                                        tool_call['function']['name'],
                                         parsed_args,
-                                        tool_call_id=tool_call.get('id')
+                                        tool_call_id=tool_call.get('id'),
+                                        _durable_iteration_index=0,
                                     )
                                     # Add tool result to chat history (multimodal-aware)
                                     from .tool_execution import build_tool_result_message_pair
@@ -4458,6 +4541,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                         str(tool_result),
                                         tool_call_id=tool_call['id'],
                                     )
+                                except ToolExecutionError:
+                                    raise
                                 except Exception as tool_error:
                                     logging.error(f"Tool execution error in streaming: {tool_error}")
                                     # Add error result to chat history
@@ -4480,6 +4565,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         if response_text:
                             self._append_to_chat_history({"role": "assistant", "content": response_text})
                         
+                except ToolExecutionError:
+                    self._rollback_chat_history_to(chat_history_length)
+                    raise
                 except Exception as e:
                     # Rollback chat history on error
                     self._rollback_chat_history_to(chat_history_length)
@@ -4499,6 +4587,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             # Restore original verbose mode
             self.verbose = original_verbose
                     
+        except ToolExecutionError:
+            self.verbose = original_verbose
+            raise
         except Exception as e:
             # Restore verbose mode on any error
             self.verbose = original_verbose

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -2675,6 +2675,11 @@ Your Goal: {self.goal}"""
                 durable_context.finalize(outcome)
                 self.execution.resume_run_id = None
             return result
+        except ToolExecutionError:
+            if durable_context is not None:
+                durable_context.finalize("failed")
+                self.execution.resume_run_id = None
+            raise
         except InterruptedError:
             if durable_context is not None:
                 durable_context.finalize("cancelled")
@@ -3347,6 +3352,11 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 await durable_context.afinalize(outcome)
                 self.execution.resume_run_id = None
             return result
+        except ToolExecutionError:
+            if durable_context is not None:
+                await durable_context.afinalize("failed")
+                self.execution.resume_run_id = None
+            raise
         except (InterruptedError, asyncio.CancelledError):
             if durable_context is not None:
                 await durable_context.afinalize("cancelled")
@@ -4204,6 +4214,11 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 )
                 durable_context.finalize(outcome)
                 self.execution.resume_run_id = None
+        except ToolExecutionError:
+            if durable_context is not None:
+                durable_context.finalize("failed")
+                self.execution.resume_run_id = None
+            raise
         except (GeneratorExit, InterruptedError):
             if durable_context is not None:
                 durable_context.finalize("cancelled")

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -2666,7 +2666,7 @@ Your Goal: {self.goal}"""
                     self, prompt if isinstance(prompt, str) else str(prompt)
                 )
             result = self._chat_impl(prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice, seed=seed, cancel_token=_cancel)
-            if durable_context is not None and result is not None:
+            if durable_context is not None:
                 outcome = (
                     "cancelled"
                     if getattr(self, "last_stop_reason", None) == "cancelled"
@@ -2994,11 +2994,15 @@ Your Goal: {self.goal}"""
                         # Rollback chat history on guardrail failure
                         self._rollback_chat_history_to(chat_history_length)
                         return None
+                except ToolExecutionError:
+                    raise
                 except Exception as e:
                     # Rollback chat history if LLM call fails
                     self._rollback_chat_history_to(chat_history_length)
                     _get_display_functions()['display_error'](f"Error in LLM chat: {e}")
                     return None
+            except ToolExecutionError:
+                raise
             except Exception as e:
                 _get_display_functions()['display_error'](f"Error in LLM chat: {e}")
                 return None
@@ -3245,6 +3249,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     except Exception:
                         # Catch any exception from the inner try block and re-raise to outer handler
                         raise
+            except ToolExecutionError:
+                raise
             except Exception as e:
                 # Catch any exceptions that escape the while loop
                 _get_display_functions()['display_error'](f"Unexpected error in chat: {e}", console=self.console)
@@ -3343,7 +3349,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 attachments=attachments, _trace_emitter=_trace_emitter, tool_choice=tool_choice,
                 seed=seed, cancel_token=cancel_token
             )
-            if durable_context is not None and result is not None:
+            if durable_context is not None:
                 outcome = (
                     "cancelled"
                     if getattr(self, "last_stop_reason", None) == "cancelled"
@@ -3584,6 +3590,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         # Rollback chat history on guardrail failure
                         self._rollback_chat_history_to(chat_history_length)
                         return None
+                except ToolExecutionError:
+                    raise
                 except Exception as e:
                     # Rollback chat history if LLM call fails
                     self._rollback_chat_history_to(chat_history_length)
@@ -4043,12 +4051,16 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             # Rollback chat history on guardrail failure
                             self._rollback_chat_history_to(chat_history_length)
                             return None
+                except ToolExecutionError:
+                    raise
                 except Exception as e:
                     _get_display_functions()['display_error'](f"Error in chat completion: {e}")
                     if get_logger().getEffectiveLevel() == logging.DEBUG:
                         total_time = time.time() - start_time
                         logging.debug(f"Agent.achat failed in {total_time:.2f} seconds: {str(e)}")
                     return None
+        except ToolExecutionError:
+            raise
         except Exception as e:
             _get_display_functions()['display_error'](f"Error in achat: {e}")
             if get_logger().getEffectiveLevel() == logging.DEBUG:

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -2675,8 +2675,8 @@ Your Goal: {self.goal}"""
                 durable_context.finalize(outcome)
                 self.execution.resume_run_id = None
             return result
-        except ToolExecutionError:
-            if durable_context is not None:
+        except ToolExecutionError as exc:
+            if durable_context is not None and not exc.is_retryable:
                 durable_context.finalize("failed")
                 self.execution.resume_run_id = None
             raise
@@ -3352,8 +3352,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 await durable_context.afinalize(outcome)
                 self.execution.resume_run_id = None
             return result
-        except ToolExecutionError:
-            if durable_context is not None:
+        except ToolExecutionError as exc:
+            if durable_context is not None and not exc.is_retryable:
                 await durable_context.afinalize("failed")
                 self.execution.resume_run_id = None
             raise
@@ -4214,8 +4214,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 )
                 durable_context.finalize(outcome)
                 self.execution.resume_run_id = None
-        except ToolExecutionError:
-            if durable_context is not None:
+        except ToolExecutionError as exc:
+            if durable_context is not None and not exc.is_retryable:
                 durable_context.finalize("failed")
                 self.execution.resume_run_id = None
             raise
@@ -4526,13 +4526,23 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                         logging.error(f"Failed to parse tool arguments as JSON: {json_error}")
                                         parsed_args = {}
                                     
-                                    tool_result = self._durable_sync_tool_executor(
+                                    executor = self._durable_sync_tool_executor(
                                         self.execute_tool
-                                    )(
+                                    )
+                                    iteration_kwargs = (
+                                        {"_durable_iteration_index": 0}
+                                        if getattr(
+                                            executor,
+                                            "_accepts_durable_iteration",
+                                            False,
+                                        )
+                                        else {}
+                                    )
+                                    tool_result = executor(
                                         tool_call['function']['name'],
                                         parsed_args,
                                         tool_call_id=tool_call.get('id'),
-                                        _durable_iteration_index=0,
+                                        **iteration_kwargs,
                                     )
                                     # Add tool result to chat history (multimodal-aware)
                                     from .tool_execution import build_tool_result_message_pair

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -29,6 +29,29 @@ if TYPE_CHECKING:
 class ChatMixin:
     """Mixin providing chat methods for the Agent class."""
 
+    @property
+    def last_durable_run_id(self) -> Optional[str]:
+        """Identifier of the most recently started durable turn, if any."""
+        return getattr(self, "_last_durable_run_id", None)
+
+    def _get_durable_run_context(self):
+        execution = getattr(self, "execution", None)
+        if execution is None or not getattr(execution, "durable", False):
+            return None
+        from .durable import get_durable_run
+
+        return get_durable_run()
+
+    def _durable_sync_tool_executor(self, execute_tool_fn):
+        """Wrap tool execution only while an opt-in durable run is active."""
+        context = self._get_durable_run_context()
+        return context.wrap_sync(execute_tool_fn) if context else execute_tool_fn
+
+    def _durable_async_tool_executor(self, execute_tool_fn):
+        """Async counterpart of :meth:`_durable_sync_tool_executor`."""
+        context = self._get_durable_run_context()
+        return context.wrap_async(execute_tool_fn) if context else execute_tool_fn
+
     def _resolve_max_steps(self, default: int = 10) -> int:
         """Resolve the unified multi-step tool budget shared by both loops.
 
@@ -572,6 +595,10 @@ Your Goal: {self.goal}"""
                     json_instruction = f"\nPlease respond with valid JSON matching this schema: {json.dumps(schema_model)}"
                     messages[-1]["content"] += json_instruction
         
+        durable_context = self._get_durable_run_context()
+        if durable_context is not None:
+            durable_context.restore_messages(messages)
+
         return messages, original_prompt
 
     def _format_tools_for_completion(self, tools=None):
@@ -2072,7 +2099,9 @@ Your Goal: {self.goal}"""
                     max_tokens=getattr(self, 'max_tokens', None),
                     stream=True,  # Try streaming first
                     response_format=response_format,
-                    execute_tool_fn=getattr(self, 'execute_tool', None),
+                    execute_tool_fn=self._durable_sync_tool_executor(
+                        getattr(self, 'execute_tool', None)
+                    ),
                     console=self.console if (self.verbose or True) else None,  # Enable console for streaming
                     display_fn=self._display_generating if self.verbose else None,
                     stream_callback=stream_callback,
@@ -2111,7 +2140,9 @@ Your Goal: {self.goal}"""
                 max_tokens=getattr(self, 'max_tokens', None),
                 stream=stream,
                 response_format=response_format,
-                execute_tool_fn=getattr(self, 'execute_tool', None),
+                execute_tool_fn=self._durable_sync_tool_executor(
+                    getattr(self, 'execute_tool', None)
+                ),
                 console=self.console if (self.verbose or stream) else None,
                 display_fn=self._display_generating if self.verbose else None,
                 stream_callback=stream_callback,
@@ -2214,7 +2245,9 @@ Your Goal: {self.goal}"""
                 max_tokens=getattr(self, 'max_tokens', None),
                 stream=stream,
                 response_format=response_format,
-                execute_tool_fn=getattr(self, 'execute_tool_async', None),
+                execute_tool_fn=self._durable_async_tool_executor(
+                    getattr(self, 'execute_tool_async', None)
+                ),
                 console=self.console if (self.verbose or stream) else None,
                 display_fn=self._display_generating if self.verbose else None,
                 stream_callback=stream_callback,
@@ -2597,7 +2630,8 @@ Your Goal: {self.goal}"""
         from ..trace.context_events import get_context_emitter
         _trace_emitter = get_context_emitter()
         _trace_emitter.agent_start(self.name, {"role": self.role, "goal": self.goal})
-        
+        durable_context = None
+        durable_token = None
         try:
             # C2 - cooperative cancellation: abort early if a pre-set token is given
             _cancel = cancel_token if cancel_token is not None else getattr(self, "interrupt_controller", None)
@@ -2605,8 +2639,28 @@ Your Goal: {self.goal}"""
                 reason = getattr(_cancel, "reason", None) or "cancelled before LLM call"
                 raise InterruptedError(f"Agent chat cancelled: {reason}")
 
-            return self._chat_impl(prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice, seed=seed, cancel_token=_cancel)
+            if getattr(getattr(self, "execution", None), "durable", False):
+                from .durable import begin_durable_run
+
+                durable_context, durable_token = begin_durable_run(
+                    self, prompt if isinstance(prompt, str) else str(prompt)
+                )
+            result = self._chat_impl(prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice, seed=seed, cancel_token=_cancel)
+            if durable_context is not None and result is not None:
+                outcome = (
+                    "cancelled"
+                    if getattr(self, "last_stop_reason", None) == "cancelled"
+                    else "succeeded"
+                )
+                durable_context.finalize(outcome)
+                self.execution.resume_run_id = None
+            return result
         finally:
+            if durable_context is not None:
+                from .durable import end_durable_run
+
+                end_durable_run(durable_token)
+                durable_context.close()
             _trace_emitter.agent_end(self.name)
 
     def _chat_impl(self, prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice=None, seed=None, cancel_token=None):
@@ -2824,6 +2878,11 @@ Your Goal: {self.goal}"""
                         system_prompt=system_prompt_for_llm,
                         tools=tool_param,
                     )
+                    durable_context = self._get_durable_run_context()
+                    if durable_context is not None:
+                        processed_history = durable_context.restore_messages(
+                            list(processed_history)
+                        )
                     
                     # Pass everything to LLM class
                     # Use llm_prompt (which includes multimodal content if attachments present)
@@ -2848,7 +2907,9 @@ Your Goal: {self.goal}"""
                         task_name=task_name,
                         task_description=task_description,
                         task_id=task_id,
-                        execute_tool_fn=self.execute_tool,
+                        execute_tool_fn=self._durable_sync_tool_executor(
+                            self.execute_tool
+                        ),
                         parallel_tool_calls=getattr(getattr(self, "execution", None), "parallel_tool_calls", False),
                         max_tool_calls_per_turn=self._resolve_max_tool_calls(),
                         reasoning_steps=reasoning_steps,
@@ -3233,9 +3294,16 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         from ..trace.context_events import get_context_emitter
         _trace_emitter = get_context_emitter()
         _trace_emitter.agent_start(self.name, {"role": self.role, "goal": self.goal})
-        
+        durable_context = None
+        durable_token = None
         try:
-            return await self._achat_impl(
+            if getattr(getattr(self, "execution", None), "durable", False):
+                from .durable import begin_durable_run
+
+                durable_context, durable_token = begin_durable_run(
+                    self, prompt if isinstance(prompt, str) else str(prompt)
+                )
+            result = await self._achat_impl(
                 prompt=prompt, temperature=temperature, tools=tools,
                 output_json=output_json, output_pydantic=output_pydantic,
                 reasoning_steps=reasoning_steps, stream=stream,
@@ -3244,7 +3312,21 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 attachments=attachments, _trace_emitter=_trace_emitter, tool_choice=tool_choice,
                 seed=seed, cancel_token=cancel_token
             )
+            if durable_context is not None and result is not None:
+                outcome = (
+                    "cancelled"
+                    if getattr(self, "last_stop_reason", None) == "cancelled"
+                    else "succeeded"
+                )
+                durable_context.finalize(outcome)
+                self.execution.resume_run_id = None
+            return result
         finally:
+            if durable_context is not None:
+                from .durable import end_durable_run
+
+                end_durable_run(durable_token)
+                durable_context.close()
             _trace_emitter.agent_end(self.name)
 
     async def _achat_impl(self, prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice=None, seed=None, cancel_token=None):
@@ -3381,6 +3463,12 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     # Use the modified chat_history after compaction
                     pass
 
+                durable_context = self._get_durable_run_context()
+                if durable_context is not None:
+                    effective_history = durable_context.restore_messages(
+                        list(effective_history)
+                    )
+
                 try:
                     # C1 - per-call seed forwarding (async path)  
                     llm_kwargs = {
@@ -3403,7 +3491,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         'task_name': task_name,
                         'task_description': task_description,
                         'task_id': task_id,
-                        'execute_tool_fn': self.execute_tool_async,
+                        'execute_tool_fn': self._durable_async_tool_executor(
+                            self.execute_tool_async
+                        ),
                         'parallel_tool_calls': getattr(getattr(self, "execution", None), "parallel_tool_calls", False),
                         'max_tool_calls_per_turn': self._resolve_max_tool_calls(),
                         'reasoning_steps': reasoning_steps,
@@ -4147,7 +4237,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         task_name=kwargs.get('task_name'),
                         task_description=kwargs.get('task_description'),
                         task_id=kwargs.get('task_id'),
-                        execute_tool_fn=self.execute_tool,
+                        execute_tool_fn=self._durable_sync_tool_executor(
+                            self.execute_tool
+                        ),
                         parallel_tool_calls=getattr(getattr(self, "execution", None), "parallel_tool_calls", False),
                         max_tool_calls_per_turn=self._resolve_max_tool_calls()
                     ):

--- a/src/praisonai-agents/praisonaiagents/agent/durable.py
+++ b/src/praisonai-agents/praisonaiagents/agent/durable.py
@@ -50,7 +50,7 @@ def _accepts_idempotency_key(execute_tool_fn: Callable) -> bool:
     try:
         parameters = inspect.signature(execute_tool_fn).parameters.values()
     except (TypeError, ValueError):
-        return True
+        return False
     return any(
         parameter.name == "idempotency_key"
         or parameter.kind == inspect.Parameter.VAR_KEYWORD
@@ -297,9 +297,10 @@ class DurableRunContext:
                     call_kwargs["idempotency_key"] = idempotency_key
                 result = execute_tool_fn(function_name, arguments, **call_kwargs)
             except ToolExecutionError as exc:
-                self._record_terminal_failure(
-                    seq, call_id, exc, iteration_index
-                )
+                if not exc.is_retryable:
+                    self._record_terminal_failure(
+                        seq, call_id, exc, iteration_index
+                    )
                 raise
             except Exception as exc:
                 result = {"error": str(exc)}
@@ -331,13 +332,14 @@ class DurableRunContext:
                 if inspect.isawaitable(result):
                     result = await result
             except ToolExecutionError as exc:
-                await asyncio.to_thread(
-                    self._record_terminal_failure,
-                    seq,
-                    call_id,
-                    exc,
-                    iteration_index,
-                )
+                if not exc.is_retryable:
+                    await asyncio.to_thread(
+                        self._record_terminal_failure,
+                        seq,
+                        call_id,
+                        exc,
+                        iteration_index,
+                    )
                 raise
             except Exception as exc:
                 result = {"error": str(exc)}

--- a/src/praisonai-agents/praisonaiagents/agent/durable.py
+++ b/src/praisonai-agents/praisonaiagents/agent/durable.py
@@ -256,6 +256,27 @@ class DurableRunContext:
             }
         return safe_result
 
+    def _record_terminal_failure(
+        self,
+        seq: int,
+        tool_call_id: str,
+        error: ToolExecutionError,
+        iteration_index: Optional[int],
+    ) -> None:
+        """Persist a fatal tool outcome and make the run non-resumable."""
+        self._record_result(
+            seq,
+            tool_call_id,
+            {
+                "error": str(error),
+                "error_type": type(error).__name__,
+                "is_retryable": bool(error.is_retryable),
+                "terminal": True,
+            },
+            iteration_index,
+        )
+        self.finalize("failed")
+
     def wrap_sync(self, execute_tool_fn: Optional[Callable]) -> Optional[Callable]:
         if execute_tool_fn is None:
             return None
@@ -275,7 +296,10 @@ class DurableRunContext:
                 if _accepts_idempotency_key(execute_tool_fn):
                     call_kwargs["idempotency_key"] = idempotency_key
                 result = execute_tool_fn(function_name, arguments, **call_kwargs)
-            except ToolExecutionError:
+            except ToolExecutionError as exc:
+                self._record_terminal_failure(
+                    seq, call_id, exc, iteration_index
+                )
                 raise
             except Exception as exc:
                 result = {"error": str(exc)}
@@ -306,7 +330,14 @@ class DurableRunContext:
                 result = execute_tool_fn(function_name, arguments, **call_kwargs)
                 if inspect.isawaitable(result):
                     result = await result
-            except ToolExecutionError:
+            except ToolExecutionError as exc:
+                await asyncio.to_thread(
+                    self._record_terminal_failure,
+                    seq,
+                    call_id,
+                    exc,
+                    iteration_index,
+                )
                 raise
             except Exception as exc:
                 result = {"error": str(exc)}

--- a/src/praisonai-agents/praisonaiagents/agent/durable.py
+++ b/src/praisonai-agents/praisonaiagents/agent/durable.py
@@ -1,0 +1,296 @@
+"""Opt-in durable tool-loop context backed by :class:`RunJournal`."""
+
+from __future__ import annotations
+
+import contextvars
+import inspect
+import json
+import threading
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from uuid import uuid4
+
+from ..runtime.journal import (
+    JournalEvent,
+    KIND_ITERATION,
+    KIND_MODEL_DECISION,
+    KIND_TOOL_CALL,
+    KIND_TOOL_RESULT,
+    RunJournal,
+)
+
+
+_active_durable_run: contextvars.ContextVar[Optional["DurableRunContext"]] = (
+    contextvars.ContextVar("praisonai_active_durable_run", default=None)
+)
+
+
+def _json_safe(value: Any) -> Any:
+    try:
+        return json.loads(json.dumps(value))
+    except (TypeError, ValueError):
+        return json.loads(json.dumps(value, default=str))
+
+
+def _tool_result_content(result: Any) -> str:
+    if result is None:
+        return "Function returned an empty output"
+    try:
+        return json.dumps(result)
+    except (TypeError, ValueError):
+        return json.dumps({"result": str(result)})
+
+
+class DurableRunContext:
+    """Per-turn journal state; safe for parallel tool-call wrappers."""
+
+    def __init__(
+        self,
+        journal: RunJournal,
+        run_id: str,
+        *,
+        replaying: bool,
+    ) -> None:
+        self.journal = journal
+        self.run_id = run_id
+        self.replaying = replaying
+        self._lock = threading.RLock()
+        self._replay = journal.replay_index(run_id)
+        events = journal.events(run_id)
+        self._next_seq = max((event.seq for event in events), default=-1) + 1
+        self._restored = False
+        self._closed = False
+        self._results_by_tool_call_id: Dict[str, Any] = {}
+        for event in events:
+            if event.kind != KIND_TOOL_RESULT:
+                continue
+            tool_call_id = event.payload.get("tool_call_id")
+            if tool_call_id:
+                self._results_by_tool_call_id[str(tool_call_id)] = event.payload.get(
+                    "result"
+                )
+
+    @property
+    def completed_steps(self) -> int:
+        return sum(
+            1
+            for (seq, kind) in self._replay
+            if kind == KIND_TOOL_RESULT
+        )
+
+    def restore_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Append completed decision/result pairs once, before the next model call."""
+        if not self.replaying or self._restored:
+            return messages
+
+        existing_ids = set()
+        for message in messages:
+            for tool_call in message.get("tool_calls") or []:
+                if isinstance(tool_call, dict) and tool_call.get("id"):
+                    existing_ids.add(str(tool_call["id"]))
+
+        for seq in sorted({key[0] for key in self._replay}):
+            decision = self._replay.get((seq, KIND_MODEL_DECISION))
+            result = self._replay.get((seq, KIND_TOOL_RESULT))
+            if not decision or result is None:
+                continue
+            message = decision.get("message")
+            tool_call_id = result.get("tool_call_id")
+            if not isinstance(message, dict) or not tool_call_id:
+                continue
+            if str(tool_call_id) in existing_ids:
+                continue
+            messages.append(_json_safe(message))
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": str(tool_call_id),
+                    "content": _tool_result_content(result.get("result")),
+                }
+            )
+            existing_ids.add(str(tool_call_id))
+
+        self._restored = True
+        return messages
+
+    def _allocate_step(
+        self,
+        function_name: str,
+        arguments: Dict[str, Any],
+        tool_call_id: Optional[str],
+    ) -> Tuple[int, str]:
+        with self._lock:
+            seq = self._next_seq
+            self._next_seq += 1
+        call_id = str(tool_call_id or f"{self.run_id}-tool-{seq}")
+        idempotency_key = f"{self.run_id}:{seq}:{function_name}"
+        safe_arguments = _json_safe(arguments)
+        message = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": function_name,
+                        "arguments": json.dumps(safe_arguments),
+                    },
+                }
+            ],
+        }
+        self.journal.append(
+            JournalEvent(
+                self.run_id,
+                seq,
+                KIND_MODEL_DECISION,
+                {"message": message},
+            )
+        )
+        self.journal.append(
+            JournalEvent(
+                self.run_id,
+                seq,
+                KIND_TOOL_CALL,
+                {
+                    "name": function_name,
+                    "args": safe_arguments,
+                    "tool_call_id": call_id,
+                    "idempotency_key": idempotency_key,
+                },
+            )
+        )
+        return seq, call_id
+
+    def _record_result(self, seq: int, tool_call_id: str, result: Any) -> Any:
+        safe_result = _json_safe(result)
+        self.journal.append(
+            JournalEvent(
+                self.run_id,
+                seq,
+                KIND_TOOL_RESULT,
+                {"tool_call_id": tool_call_id, "result": safe_result},
+            )
+        )
+        self.journal.append(
+            JournalEvent(
+                self.run_id,
+                seq,
+                KIND_ITERATION,
+                {"index": seq},
+            )
+        )
+        with self._lock:
+            self._results_by_tool_call_id[tool_call_id] = safe_result
+            self._replay[(seq, KIND_TOOL_RESULT)] = {
+                "tool_call_id": tool_call_id,
+                "result": safe_result,
+            }
+        return safe_result
+
+    def wrap_sync(self, execute_tool_fn: Optional[Callable]) -> Optional[Callable]:
+        if execute_tool_fn is None:
+            return None
+
+        def execute(function_name, arguments, tool_call_id=None, **kwargs):
+            call_id = str(tool_call_id) if tool_call_id is not None else None
+            if call_id and call_id in self._results_by_tool_call_id:
+                return self._results_by_tool_call_id[call_id]
+            seq, call_id = self._allocate_step(
+                function_name, arguments, tool_call_id
+            )
+            try:
+                result = execute_tool_fn(
+                    function_name,
+                    arguments,
+                    tool_call_id=tool_call_id,
+                    **kwargs,
+                )
+            except Exception as exc:
+                result = {"error": str(exc)}
+            return self._record_result(seq, call_id, result)
+
+        return execute
+
+    def wrap_async(self, execute_tool_fn: Optional[Callable]) -> Optional[Callable]:
+        if execute_tool_fn is None:
+            return None
+
+        async def execute(function_name, arguments, tool_call_id=None, **kwargs):
+            call_id = str(tool_call_id) if tool_call_id is not None else None
+            if call_id and call_id in self._results_by_tool_call_id:
+                return self._results_by_tool_call_id[call_id]
+            seq, call_id = self._allocate_step(
+                function_name, arguments, tool_call_id
+            )
+            try:
+                result = execute_tool_fn(
+                    function_name,
+                    arguments,
+                    tool_call_id=tool_call_id,
+                    **kwargs,
+                )
+                if inspect.isawaitable(result):
+                    result = await result
+            except Exception as exc:
+                result = {"error": str(exc)}
+            return self._record_result(seq, call_id, result)
+
+        return execute
+
+    def finalize(self, outcome: str = "succeeded") -> None:
+        if not self._closed:
+            self.journal.close_run(self.run_id, outcome)
+            self._closed = True
+
+    def close(self) -> None:
+        self.journal.close()
+
+
+def begin_durable_run(agent: Any, prompt: str):
+    """Create and activate a context, or return ``(None, None)`` when disabled."""
+    execution = getattr(agent, "execution", None)
+    if execution is None or not getattr(execution, "durable", False):
+        return None, None
+
+    journal = RunJournal(getattr(execution, "journal_path", None))
+    resume_run_id = getattr(execution, "resume_run_id", None)
+    replaying = bool(resume_run_id)
+    run_id = str(resume_run_id or uuid4())
+
+    if replaying:
+        metadata = journal.run_meta(run_id)
+        if metadata is None:
+            journal.close()
+            raise ValueError(f"Cannot resume unknown durable run {run_id!r}")
+        if metadata.status != "running":
+            journal.close()
+            raise ValueError(
+                f"Cannot resume terminal durable run {run_id!r} "
+                f"(status={metadata.status!r})"
+            )
+        if metadata.task and metadata.task != prompt:
+            journal.close()
+            raise ValueError(
+                "Resume prompt does not match the prompt recorded for durable "
+                f"run {run_id!r}"
+            )
+
+    journal.open_run(
+        run_id,
+        agent=getattr(agent, "name", ""),
+        task=prompt,
+        metadata={"version": 1, "explicit_resume": replaying},
+    )
+    context = DurableRunContext(journal, run_id, replaying=replaying)
+    token = _active_durable_run.set(context)
+    agent._last_durable_run_id = run_id
+    return context, token
+
+
+def end_durable_run(token) -> None:
+    if token is not None:
+        _active_durable_run.reset(token)
+
+
+def get_durable_run() -> Optional[DurableRunContext]:
+    return _active_durable_run.get()

--- a/src/praisonai-agents/praisonaiagents/agent/durable.py
+++ b/src/praisonai-agents/praisonaiagents/agent/durable.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import inspect
 import json
@@ -9,6 +10,7 @@ import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from uuid import uuid4
 
+from ..errors import ToolExecutionError
 from ..runtime.journal import (
     JournalEvent,
     KIND_ITERATION,
@@ -21,6 +23,9 @@ from ..runtime.journal import (
 
 _active_durable_run: contextvars.ContextVar[Optional["DurableRunContext"]] = (
     contextvars.ContextVar("praisonai_active_durable_run", default=None)
+)
+_active_idempotency_key: contextvars.ContextVar[Optional[str]] = (
+    contextvars.ContextVar("praisonai_idempotency_key", default=None)
 )
 
 
@@ -38,6 +43,19 @@ def _tool_result_content(result: Any) -> str:
         return json.dumps(result)
     except (TypeError, ValueError):
         return json.dumps({"result": str(result)})
+
+
+def _accepts_idempotency_key(execute_tool_fn: Callable) -> bool:
+    """Return whether an executor accepts the optional durable key contract."""
+    try:
+        parameters = inspect.signature(execute_tool_fn).parameters.values()
+    except (TypeError, ValueError):
+        return True
+    return any(
+        parameter.name == "idempotency_key"
+        or parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
 
 
 class DurableRunContext:
@@ -60,22 +78,46 @@ class DurableRunContext:
         self._restored = False
         self._closed = False
         self._results_by_tool_call_id: Dict[str, Any] = {}
+        self._pending_by_call_id: Dict[str, Tuple[int, str, Dict[str, Any], str]] = {}
+        self._pending_by_fingerprint: Dict[str, Tuple[int, str, Dict[str, Any], str]] = {}
+        self._recorded_iterations = set()
         for event in events:
-            if event.kind != KIND_TOOL_RESULT:
-                continue
-            tool_call_id = event.payload.get("tool_call_id")
-            if tool_call_id:
-                self._results_by_tool_call_id[str(tool_call_id)] = event.payload.get(
-                    "result"
+            if event.kind == KIND_TOOL_RESULT:
+                tool_call_id = event.payload.get("tool_call_id")
+                if tool_call_id:
+                    self._results_by_tool_call_id[str(tool_call_id)] = event.payload.get(
+                        "result"
+                    )
+            elif event.kind == KIND_ITERATION:
+                self._recorded_iterations.add(
+                    int(event.payload.get("index", event.seq))
                 )
+
+        for event in events:
+            if event.kind != KIND_TOOL_CALL:
+                continue
+            call_id = str(event.payload.get("tool_call_id") or "")
+            if not call_id or call_id in self._results_by_tool_call_id:
+                continue
+            name = str(event.payload.get("name") or "")
+            args = event.payload.get("args") or {}
+            key = str(
+                event.payload.get("idempotency_key")
+                or f"{self.run_id}:{event.seq}:{name}"
+            )
+            pending = (event.seq, call_id, args, key)
+            self._pending_by_call_id[call_id] = pending
+            self._pending_by_fingerprint[self._fingerprint(name, args)] = pending
+
+        self._resume_completed_steps = len(self._recorded_iterations)
 
     @property
     def completed_steps(self) -> int:
-        return sum(
-            1
-            for (seq, kind) in self._replay
-            if kind == KIND_TOOL_RESULT
-        )
+        return len(self._recorded_iterations)
+
+    @staticmethod
+    def _fingerprint(function_name: str, arguments: Dict[str, Any]) -> str:
+        return f"{function_name}:{json.dumps(_json_safe(arguments), sort_keys=True)}"
 
     def restore_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Append completed decision/result pairs once, before the next model call."""
@@ -117,69 +159,96 @@ class DurableRunContext:
         function_name: str,
         arguments: Dict[str, Any],
         tool_call_id: Optional[str],
-    ) -> Tuple[int, str]:
+    ) -> Tuple[int, str, str]:
         with self._lock:
+            requested_call_id = str(tool_call_id) if tool_call_id is not None else None
+            pending = (
+                self._pending_by_call_id.pop(requested_call_id, None)
+                if requested_call_id
+                else None
+            )
+            fingerprint = self._fingerprint(function_name, arguments)
+            if pending is None and self.replaying:
+                pending = self._pending_by_fingerprint.pop(fingerprint, None)
+            if pending is not None:
+                seq, call_id, _args, idempotency_key = pending
+                self._pending_by_call_id.pop(call_id, None)
+                self._pending_by_fingerprint.pop(fingerprint, None)
+                return seq, call_id, idempotency_key
+
             seq = self._next_seq
             self._next_seq += 1
-        call_id = str(tool_call_id or f"{self.run_id}-tool-{seq}")
-        idempotency_key = f"{self.run_id}:{seq}:{function_name}"
-        safe_arguments = _json_safe(arguments)
-        message = {
-            "role": "assistant",
-            "content": "",
-            "tool_calls": [
-                {
-                    "id": call_id,
-                    "type": "function",
-                    "function": {
+            call_id = str(tool_call_id or f"{self.run_id}-tool-{seq}")
+            idempotency_key = f"{self.run_id}:{seq}:{function_name}"
+            safe_arguments = _json_safe(arguments)
+            message = {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": function_name,
+                            "arguments": json.dumps(safe_arguments),
+                        },
+                    }
+                ],
+            }
+            self.journal.append(
+                JournalEvent(
+                    self.run_id,
+                    seq,
+                    KIND_MODEL_DECISION,
+                    {"message": message},
+                )
+            )
+            self.journal.append(
+                JournalEvent(
+                    self.run_id,
+                    seq,
+                    KIND_TOOL_CALL,
+                    {
                         "name": function_name,
-                        "arguments": json.dumps(safe_arguments),
+                        "args": safe_arguments,
+                        "tool_call_id": call_id,
+                        "idempotency_key": idempotency_key,
                     },
-                }
-            ],
-        }
-        self.journal.append(
-            JournalEvent(
-                self.run_id,
-                seq,
-                KIND_MODEL_DECISION,
-                {"message": message},
+                )
             )
-        )
-        self.journal.append(
-            JournalEvent(
-                self.run_id,
-                seq,
-                KIND_TOOL_CALL,
-                {
-                    "name": function_name,
-                    "args": safe_arguments,
-                    "tool_call_id": call_id,
-                    "idempotency_key": idempotency_key,
-                },
-            )
-        )
-        return seq, call_id
+            return seq, call_id, idempotency_key
 
-    def _record_result(self, seq: int, tool_call_id: str, result: Any) -> Any:
+    def _record_result(
+        self,
+        seq: int,
+        tool_call_id: str,
+        result: Any,
+        iteration_index: Optional[int],
+    ) -> Any:
         safe_result = _json_safe(result)
-        self.journal.append(
-            JournalEvent(
-                self.run_id,
-                seq,
-                KIND_TOOL_RESULT,
-                {"tool_call_id": tool_call_id, "result": safe_result},
-            )
-        )
-        self.journal.append(
-            JournalEvent(
-                self.run_id,
-                seq,
-                KIND_ITERATION,
-                {"index": seq},
-            )
-        )
         with self._lock:
+            self.journal.append(
+                JournalEvent(
+                    self.run_id,
+                    seq,
+                    KIND_TOOL_RESULT,
+                    {"tool_call_id": tool_call_id, "result": safe_result},
+                )
+            )
+            if iteration_index is None:
+                global_iteration = max(self._recorded_iterations, default=-1) + 1
+            else:
+                global_iteration = self._resume_completed_steps + int(iteration_index)
+            if global_iteration not in self._recorded_iterations:
+                self.journal.append(
+                    JournalEvent(
+                        self.run_id,
+                        global_iteration,
+                        KIND_ITERATION,
+                        {"index": global_iteration},
+                    )
+                )
+                self._recorded_iterations.add(global_iteration)
             self._results_by_tool_call_id[tool_call_id] = safe_result
             self._replay[(seq, KIND_TOOL_RESULT)] = {
                 "tool_call_id": tool_call_id,
@@ -192,22 +261,27 @@ class DurableRunContext:
             return None
 
         def execute(function_name, arguments, tool_call_id=None, **kwargs):
+            iteration_index = kwargs.pop("_durable_iteration_index", None)
             call_id = str(tool_call_id) if tool_call_id is not None else None
             if call_id and call_id in self._results_by_tool_call_id:
                 return self._results_by_tool_call_id[call_id]
-            seq, call_id = self._allocate_step(
+            seq, call_id, idempotency_key = self._allocate_step(
                 function_name, arguments, tool_call_id
             )
+            token = _active_idempotency_key.set(idempotency_key)
             try:
-                result = execute_tool_fn(
-                    function_name,
-                    arguments,
-                    tool_call_id=tool_call_id,
-                    **kwargs,
-                )
+                call_kwargs = dict(kwargs)
+                call_kwargs["tool_call_id"] = tool_call_id
+                if _accepts_idempotency_key(execute_tool_fn):
+                    call_kwargs["idempotency_key"] = idempotency_key
+                result = execute_tool_fn(function_name, arguments, **call_kwargs)
+            except ToolExecutionError:
+                raise
             except Exception as exc:
                 result = {"error": str(exc)}
-            return self._record_result(seq, call_id, result)
+            finally:
+                _active_idempotency_key.reset(token)
+            return self._record_result(seq, call_id, result, iteration_index)
 
         return execute
 
@@ -216,24 +290,31 @@ class DurableRunContext:
             return None
 
         async def execute(function_name, arguments, tool_call_id=None, **kwargs):
+            iteration_index = kwargs.pop("_durable_iteration_index", None)
             call_id = str(tool_call_id) if tool_call_id is not None else None
             if call_id and call_id in self._results_by_tool_call_id:
                 return self._results_by_tool_call_id[call_id]
-            seq, call_id = self._allocate_step(
-                function_name, arguments, tool_call_id
+            seq, call_id, idempotency_key = await asyncio.to_thread(
+                self._allocate_step, function_name, arguments, tool_call_id
             )
+            token = _active_idempotency_key.set(idempotency_key)
             try:
-                result = execute_tool_fn(
-                    function_name,
-                    arguments,
-                    tool_call_id=tool_call_id,
-                    **kwargs,
-                )
+                call_kwargs = dict(kwargs)
+                call_kwargs["tool_call_id"] = tool_call_id
+                if _accepts_idempotency_key(execute_tool_fn):
+                    call_kwargs["idempotency_key"] = idempotency_key
+                result = execute_tool_fn(function_name, arguments, **call_kwargs)
                 if inspect.isawaitable(result):
                     result = await result
+            except ToolExecutionError:
+                raise
             except Exception as exc:
                 result = {"error": str(exc)}
-            return self._record_result(seq, call_id, result)
+            finally:
+                _active_idempotency_key.reset(token)
+            return await asyncio.to_thread(
+                self._record_result, seq, call_id, result, iteration_index
+            )
 
         return execute
 
@@ -245,12 +326,34 @@ class DurableRunContext:
     def close(self) -> None:
         self.journal.close()
 
+    async def arestore_messages(
+        self, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(self.restore_messages, messages)
+
+    async def afinalize(self, outcome: str = "succeeded") -> None:
+        await asyncio.to_thread(self.finalize, outcome)
+
+    async def aclose(self) -> None:
+        await asyncio.to_thread(self.close)
+
 
 def begin_durable_run(agent: Any, prompt: str):
     """Create and activate a context, or return ``(None, None)`` when disabled."""
     execution = getattr(agent, "execution", None)
     if execution is None or not getattr(execution, "durable", False):
         return None, None
+    if _active_durable_run.get() is not None:
+        return None, None
+
+    context = _open_durable_run(agent, prompt)
+    token = _active_durable_run.set(context)
+    return context, token
+
+
+def _open_durable_run(agent: Any, prompt: str) -> DurableRunContext:
+    """Open journal state without mutating the caller's ContextVar."""
+    execution = agent.execution
 
     journal = RunJournal(getattr(execution, "journal_path", None))
     resume_run_id = getattr(execution, "resume_run_id", None)
@@ -282,8 +385,19 @@ def begin_durable_run(agent: Any, prompt: str):
         metadata={"version": 1, "explicit_resume": replaying},
     )
     context = DurableRunContext(journal, run_id, replaying=replaying)
-    token = _active_durable_run.set(context)
     agent._last_durable_run_id = run_id
+    return context
+
+
+async def abegin_durable_run(agent: Any, prompt: str):
+    """Async durable-run creation with all SQLite I/O off the event loop."""
+    execution = getattr(agent, "execution", None)
+    if execution is None or not getattr(execution, "durable", False):
+        return None, None
+    if _active_durable_run.get() is not None:
+        return None, None
+    context = await asyncio.to_thread(_open_durable_run, agent, prompt)
+    token = _active_durable_run.set(context)
     return context, token
 
 
@@ -294,3 +408,8 @@ def end_durable_run(token) -> None:
 
 def get_durable_run() -> Optional[DurableRunContext]:
     return _active_durable_run.get()
+
+
+def get_durable_idempotency_key() -> Optional[str]:
+    """Return the stable key for the currently executing durable tool call."""
+    return _active_idempotency_key.get()

--- a/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
@@ -1620,6 +1620,26 @@ Write the complete compiled report:"""
                 # BaseTool instances (plugin system, e.g. BrowserBaseTool) are not
                 # directly callable — dispatch to their .run() method like the sync path.
                 call_target = func.run if isinstance(func, BaseTool) else func
+                try:
+                    from .durable import get_durable_idempotency_key
+
+                    durable_key = get_durable_idempotency_key()
+                except ImportError:
+                    durable_key = None
+                call_arguments = arguments
+                if durable_key:
+                    try:
+                        parameters = inspect.signature(call_target).parameters.values()
+                    except (TypeError, ValueError):
+                        parameters = ()
+                    if any(
+                        parameter.name == "idempotency_key"
+                        or parameter.kind == inspect.Parameter.VAR_KEYWORD
+                        for parameter in parameters
+                    ):
+                        call_arguments = dict(arguments)
+                        call_arguments["idempotency_key"] = durable_key
+
                 async def _invoke():
                     # Set the tool-progress channel BEFORE dispatch so the sink
                     # propagates into the executor thread via contextvars, mirroring
@@ -1627,13 +1647,13 @@ Write the complete compiled report:"""
                     if inspect.iscoroutinefunction(call_target):
                         logging.debug(f"Executing async function: {function_name}")
                         with tool_progress_channel(_progress_sink):
-                            return await call_target(**arguments)
+                            return await call_target(**call_arguments)
                     logging.debug(f"Executing sync function in executor: {function_name}")
                     loop = asyncio.get_running_loop()
                     from ..trace.context_events import copy_context_to_callable
                     with tool_progress_channel(_progress_sink):
                         return await loop.run_in_executor(
-                            None, copy_context_to_callable(lambda: call_target(**arguments))
+                            None, copy_context_to_callable(lambda: call_target(**call_arguments))
                         )
 
                 # Apply the per-agent tool timeout (ToolConfig.timeout) so the async

--- a/src/praisonai-agents/praisonaiagents/agent/tool_execution.py
+++ b/src/praisonai-agents/praisonaiagents/agent/tool_execution.py
@@ -447,6 +447,15 @@ class ToolExecutionMixin:
         
         # Set up injection context for tools with Injected parameters
         from ..tools.injected import AgentState
+        try:
+            from .durable import get_durable_idempotency_key
+
+            idempotency_key = get_durable_idempotency_key()
+        except ImportError:
+            idempotency_key = None
+        state_metadata = {'agent_name': self.name}
+        if idempotency_key:
+            state_metadata['idempotency_key'] = idempotency_key
         state = AgentState(
             agent_id=self.name,
             run_id=getattr(self, '_current_run_id', 'unknown'),
@@ -454,7 +463,7 @@ class ToolExecutionMixin:
             last_user_message=self.chat_history[-1].get('content') if self.chat_history else None,
             memory=getattr(self, '_memory_instance', None),
             learn_manager=getattr(getattr(self, '_memory_instance', None), 'learn', None),
-            metadata={'agent_name': self.name}
+            metadata=state_metadata,
         )
         
         # Route through user-supplied tool middleware (Agent(hooks=[...])) when
@@ -2426,11 +2435,36 @@ class ToolExecutionMixin:
             bind_target = func
             bind_arguments = arguments
             try:
+                try:
+                    from .durable import get_durable_idempotency_key
+
+                    durable_key = get_durable_idempotency_key()
+                except ImportError:
+                    durable_key = None
+
+                def _with_durable_key(target, values):
+                    if not durable_key:
+                        return values
+                    try:
+                        parameters = inspect.signature(target).parameters.values()
+                    except (TypeError, ValueError):
+                        return values
+                    if not any(
+                        parameter.name == "idempotency_key"
+                        or parameter.kind == inspect.Parameter.VAR_KEYWORD
+                        for parameter in parameters
+                    ):
+                        return values
+                    scoped = dict(values)
+                    scoped["idempotency_key"] = durable_key
+                    return scoped
+
                 # BaseTool instances (plugin system) - call run() method
                 from ..tools.base import BaseTool
                 if isinstance(func, BaseTool):
                     bind_target = func.run
-                    casted_arguments = self._cast_arguments(func.run, arguments)
+                    keyed_arguments = _with_durable_key(func.run, arguments)
+                    casted_arguments = self._cast_arguments(func.run, keyed_arguments)
                     bind_arguments = casted_arguments
                     return func.run(**casted_arguments)
                 
@@ -2438,7 +2472,8 @@ class ToolExecutionMixin:
                 if inspect.isclass(func) and hasattr(func, 'run') and not hasattr(func, '_run'):
                     instance = func()
                     bind_target = instance.run
-                    run_params = {k: v for k, v in arguments.items() 
+                    keyed_arguments = _with_durable_key(instance.run, arguments)
+                    run_params = {k: v for k, v in keyed_arguments.items()
                                   if k in inspect.signature(instance.run).parameters 
                                   and k != 'self'}
                     casted_params = self._cast_arguments(instance.run, run_params)
@@ -2449,7 +2484,8 @@ class ToolExecutionMixin:
                 elif inspect.isclass(func) and hasattr(func, '_run'):
                     instance = func()
                     bind_target = instance._run
-                    run_params = {k: v for k, v in arguments.items() 
+                    keyed_arguments = _with_durable_key(instance._run, arguments)
+                    run_params = {k: v for k, v in keyed_arguments.items()
                                   if k in inspect.signature(instance._run).parameters 
                                   and k != 'self'}
                     casted_params = self._cast_arguments(instance._run, run_params)
@@ -2459,7 +2495,8 @@ class ToolExecutionMixin:
                 # Otherwise treat as regular function
                 elif callable(func):
                     bind_target = func
-                    casted_arguments = self._cast_arguments(func, arguments)
+                    keyed_arguments = _with_durable_key(func, arguments)
+                    casted_arguments = self._cast_arguments(func, keyed_arguments)
                     bind_arguments = casted_arguments
                     return func(**casted_arguments)
             except Exception as e:

--- a/src/praisonai-agents/praisonaiagents/config/feature_configs.py
+++ b/src/praisonai-agents/praisonaiagents/config/feature_configs.py
@@ -842,6 +842,12 @@ class ExecutionConfig:
     # Default False preserves existing behavior for backward compatibility
     parallel_tool_calls: bool = False
 
+    # Durable tool-loop replay. Default-off keeps the execution hot path free
+    # of journal construction and SQLite writes.
+    durable: bool = False
+    journal_path: Optional[str] = None
+    resume_run_id: Optional[str] = None
+
     def __post_init__(self) -> None:
         """Post-initialization processing with deprecation warnings and validation."""
         # Validate the unified step budget early (before any early returns below).
@@ -943,6 +949,9 @@ class ExecutionConfig:
             "compaction_strategy": self.compaction_strategy.value if self.compaction_strategy and hasattr(self.compaction_strategy, 'value') else (str(self.compaction_strategy) if self.compaction_strategy else None),
             "max_budget": self.max_budget,
             "parallel_tool_calls": self.parallel_tool_calls,
+            "durable": self.durable,
+            "journal_path": self.journal_path,
+            "resume_run_id": self.resume_run_id,
         }
     
     @classmethod
@@ -983,6 +992,9 @@ class ExecutionConfig:
             compaction_strategy=compaction_strategy,
             max_budget=data.get("max_budget", None),
             parallel_tool_calls=data.get("parallel_tool_calls", False),
+            durable=data.get("durable", False),
+            journal_path=data.get("journal_path", None),
+            resume_run_id=data.get("resume_run_id", None),
         )
 
 

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -32,6 +32,29 @@ def _durable_iteration_kwargs(execute_tool_fn: Callable, index: int) -> Dict[str
     if getattr(execute_tool_fn, "_accepts_durable_iteration", False):
         return {"_durable_iteration_index": index}
     return {}
+
+
+async def _dispatch_async_tool(
+    execute_tool_fn: Callable,
+    function_name: str,
+    arguments: Dict[str, Any],
+    tool_call_id: Optional[str],
+    iteration_index: int,
+) -> Any:
+    """Run sync or async tool callbacks without blocking the event loop."""
+    call_kwargs = {
+        "tool_call_id": tool_call_id,
+        **_durable_iteration_kwargs(execute_tool_fn, iteration_index),
+    }
+    if inspect.iscoroutinefunction(execute_tool_fn):
+        result = execute_tool_fn(function_name, arguments, **call_kwargs)
+    else:
+        result = await asyncio.to_thread(
+            execute_tool_fn, function_name, arguments, **call_kwargs
+        )
+    if inspect.isawaitable(result):
+        return await result
+    return result
 # Display functions - lazy loaded to avoid importing rich at startup
 # These are only needed when output=verbose
 _display_module = None
@@ -2737,7 +2760,8 @@ Respond with ONLY a valid JSON tool call in this format:
                                     function_name=function_name,
                                     arguments=arguments,
                                     tool_call_id=tool_call_id,
-                                    is_ollama=is_ollama
+                                    is_ollama=is_ollama,
+                                    iteration_index=iteration_count,
                                 ))
                             
                             # Create appropriate executor based on parallel_tool_calls setting
@@ -2806,7 +2830,7 @@ Respond with ONLY a valid JSON tool call in this format:
                                 })
 
                             # Safety: break after max_iter iterations
-                            if iteration_count >= self.max_iter:
+                            if iteration_count + 1 >= max_iterations:
                                 self._last_stop_reason = "max_steps"
                                 final_response_text = self._finalise_on_limit(
                                     messages, response_text, temperature=temperature,
@@ -3665,7 +3689,7 @@ Respond with ONLY a valid JSON tool call in this format:
                             continue
                         
                         # Safety check: prevent infinite loops for any provider
-                        if iteration_count >= self.max_iter:
+                        if iteration_count + 1 >= max_iterations:
                             self._last_stop_reason = "max_steps"
                             final_response_text = self._finalise_on_limit(
                                 messages, response_text, temperature=temperature,
@@ -3702,7 +3726,7 @@ Respond with ONLY a valid JSON tool call in this format:
                         final_response_text = response_text.strip() if response_text else ""
                         break
                         
-                except LLMResponseError:
+                except (LLMResponseError, ToolExecutionError):
                     raise
                 except Exception as e:
                     logging.error(f"Error in LLM iteration {iteration_count}: {e}")
@@ -4270,7 +4294,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 function_name=function_name,
                                 arguments=arguments, 
                                 tool_call_id=tool_call_id,
-                                is_ollama=is_ollama
+                                is_ollama=is_ollama,
+                                iteration_index=iteration_count,
                             ))
                         
                         # Create appropriate executor based on parallel_tool_calls setting
@@ -4642,24 +4667,13 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         for tool_call in tool_calls:
                             function_name, arguments, tool_call_id = self._extract_tool_call_info(tool_call)
                             logging.debug(f"[RESPONSES_API_ASYNC] Executing tool {function_name}")
-                            if asyncio.iscoroutinefunction(execute_tool_fn):
-                                tool_result = await execute_tool_fn(
-                                    function_name,
-                                    arguments,
-                                    tool_call_id=tool_call_id,
-                                    **_durable_iteration_kwargs(
-                                        execute_tool_fn, iteration_count
-                                    ),
-                                )
-                            else:
-                                tool_result = execute_tool_fn(
-                                    function_name,
-                                    arguments,
-                                    tool_call_id=tool_call_id,
-                                    **_durable_iteration_kwargs(
-                                        execute_tool_fn, iteration_count
-                                    ),
-                                )
+                            tool_result = await _dispatch_async_tool(
+                                execute_tool_fn,
+                                function_name,
+                                arguments,
+                                tool_call_id,
+                                iteration_count,
+                            )
                             tool_call_count += 1  # Increment tool call counter for guardrails
                             accumulated_tool_results.append(tool_result)
 
@@ -4681,7 +4695,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 "content": content,
                             })
 
-                        if iteration_count >= self.max_iter:
+                        if iteration_count + 1 >= max_iterations:
                             self._last_stop_reason = "max_steps"
                             final_response_text = await self._finalise_on_limit_async(
                                 messages, response_text, temperature=temperature,
@@ -4905,13 +4919,12 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         if is_ollama and tools:
                             arguments = self._validate_and_filter_ollama_arguments(function_name, arguments, tools)
 
-                        tool_result = await execute_tool_fn(
+                        tool_result = await _dispatch_async_tool(
+                            execute_tool_fn,
                             function_name,
                             arguments,
-                            tool_call_id=tool_call_id,
-                            **_durable_iteration_kwargs(
-                                execute_tool_fn, iteration_count
-                            ),
+                            tool_call_id,
+                            iteration_count,
                         )
                         tool_call_count += 1  # Increment tool call counter for guardrails
                         tool_results.append(tool_result)  # Store the result
@@ -5109,7 +5122,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         continue
                     
                     # Safety check: prevent infinite loops for any provider
-                    if iteration_count >= self.max_iter:
+                    if iteration_count + 1 >= max_iterations:
                         self._last_stop_reason = "max_steps"
                         final_response_text = await self._finalise_on_limit_async(
                             messages, response_text, temperature=temperature,

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -22,10 +22,16 @@ from pydantic import BaseModel
 import time
 import json
 import xml.etree.ElementTree as ET
-from ..errors import AgentErrorKind, FailoverDecision, IdleTimeoutBreaker
+from ..errors import AgentErrorKind, FailoverDecision, IdleTimeoutBreaker, ToolExecutionError
 # Gap 2: Tool call execution imports
 from ..tools.call_executor import ToolCall, create_tool_call_executor
 from ..tools.schema import build_tool_definition
+
+
+def _durable_iteration_kwargs(execute_tool_fn: Callable, index: int) -> Dict[str, int]:
+    if getattr(execute_tool_fn, "_accepts_durable_iteration", False):
+        return {"_durable_iteration_index": index}
+    return {}
 # Display functions - lazy loaded to avoid importing rich at startup
 # These are only needed when output=verbose
 _display_module = None
@@ -2576,7 +2582,7 @@ Respond with ONLY a valid JSON tool call in this format:
                     )
 
             # Sequential tool calling loop - similar to agent.py
-            max_iterations = self.max_iter  # Use configurable iteration limit
+            max_iterations = kwargs.pop("max_iterations", self.max_iter)
             iteration_count = 0
             tool_call_count = 0  # Track total tool calls for guardrails
             final_response_text = ""
@@ -3530,7 +3536,16 @@ Respond with ONLY a valid JSON tool call in this format:
                             # instead of aborting the whole run (safe-by-default,
                             # matching the async path in execution_mixin.py).
                             try:
-                                tool_result = execute_tool_fn(function_name, arguments, tool_call_id=tool_call_id)
+                                tool_result = execute_tool_fn(
+                                    function_name,
+                                    arguments,
+                                    tool_call_id=tool_call_id,
+                                    **_durable_iteration_kwargs(
+                                        execute_tool_fn, iteration_count
+                                    ),
+                                )
+                            except ToolExecutionError:
+                                raise
                             except Exception as tool_error:
                                 logging.warning(f"Tool '{function_name}' failed: {tool_error}")
                                 tool_result = {"error": str(tool_error)}
@@ -4515,7 +4530,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             formatted_tools = self._format_tools_for_litellm(tools)
 
             # Initialize variables for iteration loop
-            max_iterations = self.max_iter  # Use configurable iteration limit
+            max_iterations = kwargs.pop("max_iterations", self.max_iter)
             iteration_count = 0
             tool_call_count = 0  # Track total tool calls for guardrails
             final_response_text = ""
@@ -4628,9 +4643,23 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             function_name, arguments, tool_call_id = self._extract_tool_call_info(tool_call)
                             logging.debug(f"[RESPONSES_API_ASYNC] Executing tool {function_name}")
                             if asyncio.iscoroutinefunction(execute_tool_fn):
-                                tool_result = await execute_tool_fn(function_name, arguments, tool_call_id=tool_call_id)
+                                tool_result = await execute_tool_fn(
+                                    function_name,
+                                    arguments,
+                                    tool_call_id=tool_call_id,
+                                    **_durable_iteration_kwargs(
+                                        execute_tool_fn, iteration_count
+                                    ),
+                                )
                             else:
-                                tool_result = execute_tool_fn(function_name, arguments, tool_call_id=tool_call_id)
+                                tool_result = execute_tool_fn(
+                                    function_name,
+                                    arguments,
+                                    tool_call_id=tool_call_id,
+                                    **_durable_iteration_kwargs(
+                                        execute_tool_fn, iteration_count
+                                    ),
+                                )
                             tool_call_count += 1  # Increment tool call counter for guardrails
                             accumulated_tool_results.append(tool_result)
 
@@ -4876,7 +4905,14 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         if is_ollama and tools:
                             arguments = self._validate_and_filter_ollama_arguments(function_name, arguments, tools)
 
-                        tool_result = await execute_tool_fn(function_name, arguments)
+                        tool_result = await execute_tool_fn(
+                            function_name,
+                            arguments,
+                            tool_call_id=tool_call_id,
+                            **_durable_iteration_kwargs(
+                                execute_tool_fn, iteration_count
+                            ),
+                        )
                         tool_call_count += 1  # Increment tool call counter for guardrails
                         tool_results.append(tool_result)  # Store the result
                         accumulated_tool_results.append(tool_result)  # Accumulate across iterations

--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -2277,6 +2277,8 @@ class OpenAIClient:
                     # No tool calls, we're done
                     break
                     
+            except ToolExecutionError:
+                raise
             except Exception as e:
                 yield f"Error: {str(e)}"
                 break

--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -17,6 +17,8 @@ from pydantic import BaseModel
 from dataclasses import dataclass
 import inspect
 
+from ..errors import ToolExecutionError
+
 # Graceful "wrap-up" instruction injected when the step budget is nearly
 # exhausted, so the model produces a coherent final answer instead of being
 # hard-cut. Shared by both tool-execution loops for consistent behaviour.
@@ -25,6 +27,12 @@ _MAX_STEPS_WRAPUP_PROMPT = (
     "Stop calling tools now and provide your best final answer, summarising the "
     "work completed so far and clearly noting anything left incomplete."
 )
+
+
+def _durable_iteration_kwargs(execute_tool_fn: Callable, index: int) -> Dict[str, int]:
+    if getattr(execute_tool_fn, "_accepts_durable_iteration", False):
+        return {"_durable_iteration_index": index}
+    return {}
 
 # Lazy imports for optional dependencies
 _openai_module = None
@@ -1702,7 +1710,16 @@ class OpenAIClient:
                     # path chat_completion_with_tools_stream).
                     _tool_call_id = tool_call.id if hasattr(tool_call, 'id') else tool_call.get('id')
                     try:
-                        tool_result = execute_tool_fn(function_name, arguments, tool_call_id=_tool_call_id)
+                        tool_result = execute_tool_fn(
+                            function_name,
+                            arguments,
+                            tool_call_id=_tool_call_id,
+                            **_durable_iteration_kwargs(
+                                execute_tool_fn, iteration_count
+                            ),
+                        )
+                    except ToolExecutionError:
+                        raise
                     except Exception as tool_error:
                         logging.warning(f"Tool '{function_name}' failed: {tool_error}")
                         tool_result = {"error": str(tool_error)}
@@ -1984,7 +2001,14 @@ class OpenAIClient:
                     _tool_call_id = tool_call.id if hasattr(tool_call, 'id') else tool_call.get('id')
                     try:
                         if asyncio.iscoroutinefunction(execute_tool_fn):
-                            tool_result = await execute_tool_fn(function_name, arguments, tool_call_id=_tool_call_id)
+                            tool_result = await execute_tool_fn(
+                                function_name,
+                                arguments,
+                                tool_call_id=_tool_call_id,
+                                **_durable_iteration_kwargs(
+                                    execute_tool_fn, iteration_count
+                                ),
+                            )
                         else:
                             # Run sync function in executor (preserve ContextVars e.g. SessionContext)
                             loop = asyncio.get_running_loop()
@@ -1993,10 +2017,17 @@ class OpenAIClient:
                                 None,
                                 copy_context_to_callable(
                                     lambda fn=function_name, args=arguments, tcid=_tool_call_id: execute_tool_fn(
-                                        fn, args, tool_call_id=tcid
+                                        fn,
+                                        args,
+                                        tool_call_id=tcid,
+                                        **_durable_iteration_kwargs(
+                                            execute_tool_fn, iteration_count
+                                        ),
                                     )
                                 ),
                             )
+                    except ToolExecutionError:
+                        raise
                     except Exception as tool_error:
                         logging.warning(f"Tool '{function_name}' failed: {tool_error}")
                         tool_result = {"error": str(tool_error)}
@@ -2202,8 +2233,17 @@ class OpenAIClient:
                         # Execute the tool with error handling (pass tool_call_id for event correlation)
                         _tool_call_id = tool_call.id if hasattr(tool_call, 'id') else tool_call.get('id')
                         try:
-                            tool_result = execute_tool_fn(function_name, arguments, tool_call_id=_tool_call_id)
+                            tool_result = execute_tool_fn(
+                                function_name,
+                                arguments,
+                                tool_call_id=_tool_call_id,
+                                **_durable_iteration_kwargs(
+                                    execute_tool_fn, iteration_count
+                                ),
+                            )
                             results_str = json.dumps(tool_result) if tool_result else "Function returned an empty output"
+                        except ToolExecutionError:
+                            raise
                         except Exception as e:
                             results_str = f"Error executing function: {str(e)}"
                             if verbose:

--- a/src/praisonai-agents/praisonaiagents/tools/call_executor.py
+++ b/src/praisonai-agents/praisonaiagents/tools/call_executor.py
@@ -13,7 +13,6 @@ Design principles:
 
 import asyncio
 import concurrent.futures
-import contextvars
 import inspect
 import logging
 import threading
@@ -21,6 +20,7 @@ import uuid
 import weakref
 from typing import Any, Callable, Dict, List, Optional, Protocol
 from dataclasses import dataclass, field
+from ..errors import ToolExecutionError
 from ..trace.context_events import copy_context_to_callable
 
 logger = logging.getLogger(__name__)
@@ -123,6 +123,7 @@ class ToolCall:
     arguments: Dict[str, Any]
     tool_call_id: str
     is_ollama: bool = False
+    iteration_index: Optional[int] = None
 
 
 @dataclass 
@@ -324,19 +325,20 @@ def _run_tool_body(
         # Memoised so the signature probe runs once per callable, not per call.
         supports_progress = _accepts_on_progress(execute_tool_fn)
 
+        call_kwargs = {}
         if supports_progress:
-            raw = execute_tool_fn(
-                tool_call.function_name,
-                tool_call.arguments,
-                tool_call.tool_call_id,
-                on_progress=_emit,
-            )
-        else:
-            raw = execute_tool_fn(
-                tool_call.function_name,
-                tool_call.arguments,
-                tool_call.tool_call_id,
-            )
+            call_kwargs["on_progress"] = _emit
+        if (
+            tool_call.iteration_index is not None
+            and getattr(execute_tool_fn, "_accepts_durable_iteration", False)
+        ):
+            call_kwargs["_durable_iteration_index"] = tool_call.iteration_index
+        raw = execute_tool_fn(
+            tool_call.function_name,
+            tool_call.arguments,
+            tool_call.tool_call_id,
+            **call_kwargs,
+        )
 
         result = _resolve_value(raw)
 
@@ -350,6 +352,8 @@ def _run_tool_body(
             progress=collected,
             deferred=deferred,
         )
+    except ToolExecutionError:
+        raise
     except Exception as e:
         logger.error(f"Tool execution error for {tool_call.function_name}: {e}")
         return ToolResult(

--- a/src/praisonai-agents/tests/integration/test_durable_run_real.py
+++ b/src/praisonai-agents/tests/integration/test_durable_run_real.py
@@ -1,0 +1,42 @@
+"""Opt-in real-provider smoke for durable Agent execution."""
+
+import os
+
+import pytest
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_REAL_KEY_TESTS") != "1",
+    reason="requires an explicitly enabled real provider",
+)
+def test_real_agent_records_durable_tool_step(tmp_path):
+    from praisonaiagents import Agent, ExecutionConfig
+    from praisonaiagents.runtime import RunJournal
+    from praisonaiagents.runtime.journal import KIND_TOOL_RESULT
+
+    calls = []
+
+    def durable_echo(text: str) -> str:
+        """Echo text while recording the external side effect."""
+        calls.append(text)
+        return text
+
+    journal_path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-real-smoke",
+        instructions="Call durable_echo once, then report its exact result.",
+        tools=[durable_echo],
+        execution=ExecutionConfig(
+            durable=True,
+            journal_path=journal_path,
+            max_steps=3,
+        ),
+    )
+    result = agent.start("Call durable_echo with the text NEBULA-7.")
+
+    print(result)
+    assert calls == ["NEBULA-7"]
+    journal = RunJournal(journal_path)
+    events = journal.events(agent._last_durable_run_id)
+    journal.close()
+    assert any(event.kind == KIND_TOOL_RESULT for event in events)

--- a/src/praisonai-agents/tests/test_deferred_progress_tools.py
+++ b/src/praisonai-agents/tests/test_deferred_progress_tools.py
@@ -15,7 +15,6 @@ from praisonaiagents.tools.call_executor import (
     ToolCall,
     ToolProgress,
     DeferredToolResult,
-    ToolResult,
     SequentialToolCallExecutor,
     ParallelToolCallExecutor,
     create_tool_call_executor,
@@ -26,10 +25,37 @@ from praisonaiagents.tools.call_executor import (
     register_deferred,
     resolve_deferred,
 )
+from praisonaiagents.errors import ToolExecutionError
 
 
 def _call(name="t", args=None, cid="id-1"):
     return ToolCall(function_name=name, arguments=args or {}, tool_call_id=cid)
+
+
+def test_executor_forwards_durable_iteration_only_to_marked_callback():
+    captured = []
+
+    def execute(name, arguments, tool_call_id, **kwargs):
+        captured.append(kwargs)
+        return "ok"
+
+    execute._accepts_durable_iteration = True
+    call = ToolCall("t", {}, "id-1", iteration_index=7)
+
+    result = SequentialToolCallExecutor().execute_batch([call], execute)[0]
+
+    assert result.result == "ok"
+    assert captured == [{"_durable_iteration_index": 7}]
+
+
+def test_executor_propagates_terminal_tool_error():
+    error = ToolExecutionError("halt", tool_name="t", is_retryable=False)
+
+    def execute(_name, _arguments, _tool_call_id):
+        raise error
+
+    with pytest.raises(ToolExecutionError, match="halt"):
+        SequentialToolCallExecutor().execute_batch([_call()], execute)
 
 
 # --- Protocol surface --------------------------------------------------------

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -94,7 +94,7 @@ def test_parallel_tool_results_count_as_one_model_iteration():
     journal.close()
 
 
-def test_fatal_tool_execution_error_is_not_recorded_as_a_result():
+def test_fatal_tool_execution_error_is_recorded_and_terminal():
     journal = RunJournal(":memory:")
     journal.open_run("run-1", task="task")
     context = DurableRunContext(journal, "run-1", replaying=False)
@@ -106,8 +106,34 @@ def test_fatal_tool_execution_error_is_not_recorded_as_a_result():
         )
 
     kinds = [event.kind for event in journal.events("run-1")]
-    assert KIND_TOOL_RESULT not in kinds
-    assert KIND_ITERATION not in kinds
+    assert KIND_TOOL_RESULT in kinds
+    assert KIND_ITERATION in kinds
+    result = next(
+        event.payload["result"]
+        for event in journal.events("run-1")
+        if event.kind == KIND_TOOL_RESULT
+    )
+    assert result["terminal"] is True
+    assert result["is_retryable"] is False
+    assert journal.run_meta("run-1").status == "failed"
+    assert journal.interrupted_runs() == []
+    journal.close()
+
+
+@pytest.mark.asyncio
+async def test_async_fatal_tool_execution_error_is_terminal():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    context = DurableRunContext(journal, "run-1", replaying=False)
+    error = ToolExecutionError("halt", tool_name="danger", is_retryable=False)
+
+    with pytest.raises(ToolExecutionError, match="halt"):
+        await context.wrap_async(AsyncMock(side_effect=error))(
+            "danger", {}, tool_call_id="call-1"
+        )
+
+    assert journal.run_meta("run-1").status == "failed"
+    assert journal.interrupted_runs() == []
     journal.close()
 
 
@@ -336,6 +362,33 @@ def test_agent_chat_exception_leaves_run_resumable(tmp_path):
     journal = RunJournal(path)
     assert journal.interrupted_runs() == [agent.last_durable_run_id]
     journal.close()
+
+
+def test_agent_chat_tool_failure_finalizes_run_and_rejects_resume(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    error = ToolExecutionError(
+        "terminal tool failure", tool_name="danger", is_retryable=False
+    )
+    with patch.object(agent, "_chat_impl", side_effect=error):
+        with pytest.raises(ToolExecutionError, match="terminal tool failure"):
+            agent.chat("task")
+
+    run_id = agent.last_durable_run_id
+    journal = RunJournal(path)
+    assert journal.run_meta(run_id).status == "failed"
+    assert journal.interrupted_runs() == []
+    journal.close()
+
+    agent.execution.resume_run_id = run_id
+    with pytest.raises(ValueError, match="Cannot resume terminal durable run"):
+        agent.chat("task")
 
 
 def test_agent_chat_interruption_finalizes_run_as_cancelled(tmp_path):

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -388,6 +388,100 @@ def test_agent_chat_exception_leaves_run_resumable(tmp_path):
     journal.close()
 
 
+def test_agent_chat_none_result_finalizes_run(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    with patch.object(agent, "_chat_impl", return_value=None):
+        assert agent.chat("task") is None
+
+    run_id = agent.last_durable_run_id
+    journal = RunJournal(path)
+    assert journal.run_meta(run_id).status == "succeeded"
+    assert journal.interrupted_runs() == []
+    journal.close()
+    assert agent.execution.resume_run_id is None
+
+
+@pytest.mark.asyncio
+async def test_agent_achat_none_result_finalizes_run(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    with patch.object(agent, "_achat_impl", AsyncMock(return_value=None)):
+        assert await agent.achat("task") is None
+
+    run_id = agent.last_durable_run_id
+    journal = RunJournal(path)
+    assert journal.run_meta(run_id).status == "succeeded"
+    assert journal.interrupted_runs() == []
+    journal.close()
+    assert agent.execution.resume_run_id is None
+
+
+def test_custom_llm_fatal_tool_error_reaches_durable_lifecycle(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        llm={"model": "custom/test"},
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    error = ToolExecutionError(
+        "terminal tool failure", tool_name="danger", is_retryable=False
+    )
+    agent.llm_instance = SimpleNamespace(
+        get_response=MagicMock(side_effect=error)
+    )
+
+    with pytest.raises(ToolExecutionError, match="terminal tool failure"):
+        agent.chat("task")
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "failed"
+    journal.close()
+    assert agent.execution.resume_run_id is None
+
+
+@pytest.mark.asyncio
+async def test_async_custom_llm_fatal_error_reaches_durable_lifecycle(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        llm={"model": "custom/test"},
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    error = ToolExecutionError(
+        "terminal tool failure", tool_name="danger", is_retryable=False
+    )
+    agent.llm_instance = SimpleNamespace(
+        get_response_async=AsyncMock(side_effect=error)
+    )
+
+    with pytest.raises(ToolExecutionError, match="terminal tool failure"):
+        await agent.achat("task")
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "failed"
+    journal.close()
+    assert agent.execution.resume_run_id is None
+
+
 def test_agent_chat_tool_failure_finalizes_run_and_rejects_resume(tmp_path):
     from praisonaiagents import Agent
 

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -1,15 +1,17 @@
 """Tests for opt-in RunJournal integration and explicit resume."""
 
+import asyncio
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from praisonaiagents import ExecutionConfig
+from praisonaiagents.errors import ToolExecutionError
 from praisonaiagents.agent.durable import (
     DurableRunContext,
     begin_durable_run,
-    end_durable_run,
 )
 from praisonaiagents.runtime import JournalEvent, RunJournal
 from praisonaiagents.runtime.journal import (
@@ -59,7 +61,10 @@ def test_sync_wrapper_records_completed_tool_step():
 
     assert result == {"charged": True}
     tool.assert_called_once_with(
-        "charge_card", {"amount": 10}, tool_call_id="call-1"
+        "charge_card",
+        {"amount": 10},
+        tool_call_id="call-1",
+        idempotency_key="run-1:0:charge_card",
     )
     assert [event.kind for event in journal.events("run-1")] == [
         KIND_MODEL_DECISION,
@@ -69,6 +74,149 @@ def test_sync_wrapper_records_completed_tool_step():
     ]
     assert journal.last_iteration("run-1") == 0
     journal.close()
+
+
+def test_parallel_tool_results_count_as_one_model_iteration():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    context = DurableRunContext(journal, "run-1", replaying=False)
+    execute = context.wrap_sync(MagicMock(return_value="ok"))
+
+    execute("first", {}, tool_call_id="call-1", _durable_iteration_index=0)
+    execute("second", {}, tool_call_id="call-2", _durable_iteration_index=0)
+
+    assert context.completed_steps == 1
+    assert [
+        event.payload["index"]
+        for event in journal.events("run-1")
+        if event.kind == KIND_ITERATION
+    ] == [0]
+    journal.close()
+
+
+def test_fatal_tool_execution_error_is_not_recorded_as_a_result():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    context = DurableRunContext(journal, "run-1", replaying=False)
+    error = ToolExecutionError("halt", tool_name="danger", is_retryable=False)
+
+    with pytest.raises(ToolExecutionError, match="halt"):
+        context.wrap_sync(MagicMock(side_effect=error))(
+            "danger", {}, tool_call_id="call-1"
+        )
+
+    kinds = [event.kind for event in journal.events("run-1")]
+    assert KIND_TOOL_RESULT not in kinds
+    assert KIND_ITERATION not in kinds
+    journal.close()
+
+
+def test_pending_call_reuses_stable_idempotency_key_after_resume():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    original = DurableRunContext(journal, "run-1", replaying=False)
+
+    with pytest.raises(KeyboardInterrupt):
+        original.wrap_sync(MagicMock(side_effect=KeyboardInterrupt))(
+            "charge_card", {"amount": 10}, tool_call_id="old-call"
+        )
+
+    captured = {}
+
+    def charge(_name, _arguments, *, tool_call_id=None, idempotency_key=None):
+        captured["call_id"] = tool_call_id
+        captured["key"] = idempotency_key
+        return "charged"
+
+    resumed = DurableRunContext(journal, "run-1", replaying=True)
+    result = resumed.wrap_sync(charge)(
+        "charge_card", {"amount": 10}, tool_call_id="new-call"
+    )
+
+    assert result == "charged"
+    assert captured["key"] == "run-1:0:charge_card"
+    assert len([
+        event for event in journal.events("run-1")
+        if event.kind == KIND_TOOL_CALL
+    ]) == 1
+    journal.close()
+
+
+def test_declared_tool_receives_durable_idempotency_key():
+    from praisonaiagents import Agent
+
+    captured = {}
+
+    def charge_card(amount: int, idempotency_key: str):
+        captured["amount"] = amount
+        captured["key"] = idempotency_key
+        return "charged"
+
+    agent = Agent(name="agent", instructions="test", tools=[charge_card])
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    context = DurableRunContext(journal, "run-1", replaying=False)
+
+    result = context.wrap_sync(agent.execute_tool)(
+        "charge_card", {"amount": 10}, tool_call_id="call-1"
+    )
+
+    assert result == "charged"
+    assert captured == {"amount": 10, "key": "run-1:0:charge_card"}
+    journal.close()
+
+
+@pytest.mark.asyncio
+async def test_async_declared_tool_receives_durable_idempotency_key():
+    from praisonaiagents import Agent
+
+    captured = {}
+
+    async def send_email(to: str, idempotency_key: str):
+        captured["to"] = to
+        captured["key"] = idempotency_key
+        return "sent"
+
+    agent = Agent(name="agent", instructions="test", tools=[send_email])
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    context = DurableRunContext(journal, "run-1", replaying=False)
+
+    result = await context.wrap_async(agent.execute_tool_async)(
+        "send_email", {"to": "user@example.com"}, tool_call_id="call-1"
+    )
+
+    assert result == "sent"
+    assert captured == {
+        "to": "user@example.com",
+        "key": "run-1:0:send_email",
+    }
+    journal.close()
+
+
+def test_resumed_dispatcher_uses_only_remaining_iteration_budget():
+    from praisonaiagents.agent import durable as durable_module
+    from praisonaiagents.agent.chat_mixin import ChatMixin
+
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    for index in (0, 1):
+        journal.append(JournalEvent(
+            "run-1", index, KIND_ITERATION, {"index": index}
+        ))
+    context = DurableRunContext(journal, "run-1", replaying=True)
+
+    owner = ChatMixin()
+    owner.execution = ExecutionConfig(
+        durable=True,
+        max_steps=3,
+    )
+    token = durable_module._active_durable_run.set(context)
+    try:
+        assert owner._resolve_max_steps() == 1
+    finally:
+        durable_module._active_durable_run.reset(token)
+        journal.close()
 
 
 def test_explicit_resume_restores_step_and_skips_duplicate_side_effect():
@@ -187,6 +335,83 @@ def test_agent_chat_exception_leaves_run_resumable(tmp_path):
 
     journal = RunJournal(path)
     assert journal.interrupted_runs() == [agent.last_durable_run_id]
+    journal.close()
+
+
+def test_agent_chat_interruption_finalizes_run_as_cancelled(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    with patch.object(agent, "_chat_impl", side_effect=InterruptedError("stop")):
+        with pytest.raises(InterruptedError, match="stop"):
+            agent.chat("task")
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "cancelled"
+    assert journal.interrupted_runs() == []
+    journal.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_achat_task_cancellation_finalizes_run(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    with patch.object(agent, "_achat_impl", side_effect=asyncio.CancelledError):
+        with pytest.raises(asyncio.CancelledError):
+            await agent.achat("task")
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "cancelled"
+    assert journal.interrupted_runs() == []
+    journal.close()
+
+
+def test_stream_generator_owns_and_finalizes_durable_run(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    with patch.object(agent, "_start_stream_impl", return_value=iter(["a", "b"])):
+        assert list(agent._start_stream("task")) == ["a", "b"]
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "succeeded"
+    journal.close()
+
+
+def test_closing_stream_generator_cancels_durable_run(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    with patch.object(
+        agent, "_start_stream_impl", return_value=iter(["a", "b"])
+    ):
+        stream = agent._start_stream("task")
+        assert next(stream) == "a"
+        stream.close()
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "cancelled"
     journal.close()
 
 

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -11,6 +11,7 @@ from praisonaiagents import ExecutionConfig
 from praisonaiagents.errors import ToolExecutionError
 from praisonaiagents.agent.durable import (
     DurableRunContext,
+    _accepts_idempotency_key,
     begin_durable_run,
 )
 from praisonaiagents.runtime import JournalEvent, RunJournal
@@ -118,6 +119,29 @@ def test_fatal_tool_execution_error_is_recorded_and_terminal():
     assert journal.run_meta("run-1").status == "failed"
     assert journal.interrupted_runs() == []
     journal.close()
+
+
+def test_retryable_tool_execution_error_remains_resumable():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    context = DurableRunContext(journal, "run-1", replaying=False)
+    error = ToolExecutionError("retry later", tool_name="api", is_retryable=True)
+
+    with pytest.raises(ToolExecutionError, match="retry later"):
+        context.wrap_sync(MagicMock(side_effect=error))(
+            "api", {}, tool_call_id="call-1"
+        )
+
+    kinds = [event.kind for event in journal.events("run-1")]
+    assert KIND_TOOL_RESULT not in kinds
+    assert journal.run_meta("run-1").status == "running"
+    assert journal.interrupted_runs() == ["run-1"]
+    journal.close()
+
+
+def test_idempotency_signature_probe_fails_closed():
+    with patch("inspect.signature", side_effect=ValueError("opaque callable")):
+        assert _accepts_idempotency_key(MagicMock()) is False
 
 
 @pytest.mark.asyncio

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -1,0 +1,208 @@
+"""Tests for opt-in RunJournal integration and explicit resume."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from praisonaiagents import ExecutionConfig
+from praisonaiagents.agent.durable import (
+    DurableRunContext,
+    begin_durable_run,
+    end_durable_run,
+)
+from praisonaiagents.runtime import JournalEvent, RunJournal
+from praisonaiagents.runtime.journal import (
+    KIND_ITERATION,
+    KIND_MODEL_DECISION,
+    KIND_TOOL_CALL,
+    KIND_TOOL_RESULT,
+)
+
+
+def test_execution_config_durable_defaults_and_round_trip(tmp_path):
+    assert ExecutionConfig().durable is False
+
+    config = ExecutionConfig(
+        durable=True,
+        journal_path=str(tmp_path / "journal.db"),
+        resume_run_id="run-1",
+    )
+    restored = ExecutionConfig.from_dict(config.to_dict())
+
+    assert restored.durable is True
+    assert restored.journal_path == str(tmp_path / "journal.db")
+    assert restored.resume_run_id == "run-1"
+
+
+def test_default_off_never_constructs_journal():
+    agent = SimpleNamespace(
+        execution=ExecutionConfig(durable=False),
+        name="agent",
+    )
+    with patch("praisonaiagents.agent.durable.RunJournal") as journal_cls:
+        context, token = begin_durable_run(agent, "task")
+
+    assert (context, token) == (None, None)
+    journal_cls.assert_not_called()
+
+
+def test_sync_wrapper_records_completed_tool_step():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    context = DurableRunContext(journal, "run-1", replaying=False)
+    tool = MagicMock(return_value={"charged": True})
+
+    result = context.wrap_sync(tool)(
+        "charge_card", {"amount": 10}, tool_call_id="call-1"
+    )
+
+    assert result == {"charged": True}
+    tool.assert_called_once_with(
+        "charge_card", {"amount": 10}, tool_call_id="call-1"
+    )
+    assert [event.kind for event in journal.events("run-1")] == [
+        KIND_MODEL_DECISION,
+        KIND_TOOL_CALL,
+        KIND_TOOL_RESULT,
+        KIND_ITERATION,
+    ]
+    assert journal.last_iteration("run-1") == 0
+    journal.close()
+
+
+def test_explicit_resume_restores_step_and_skips_duplicate_side_effect():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    original = DurableRunContext(journal, "run-1", replaying=False)
+    side_effect = MagicMock(return_value="charged")
+    original.wrap_sync(side_effect)(
+        "charge_card", {"amount": 10}, tool_call_id="call-1"
+    )
+
+    resumed = DurableRunContext(journal, "run-1", replaying=True)
+    messages = [{"role": "user", "content": "task"}]
+    resumed.restore_messages(messages)
+    result = resumed.wrap_sync(side_effect)(
+        "charge_card", {"amount": 10}, tool_call_id="call-1"
+    )
+
+    assert result == "charged"
+    assert side_effect.call_count == 1
+    assert messages[-2]["role"] == "assistant"
+    assert messages[-2]["tool_calls"][0]["id"] == "call-1"
+    assert messages[-1] == {
+        "role": "tool",
+        "tool_call_id": "call-1",
+        "content": '"charged"',
+    }
+    journal.close()
+
+
+@pytest.mark.asyncio
+async def test_async_wrapper_records_and_replays_result():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    original = DurableRunContext(journal, "run-1", replaying=False)
+    side_effect = AsyncMock(return_value={"ok": True})
+
+    first = await original.wrap_async(side_effect)(
+        "send_email", {"to": "user@example.com"}, tool_call_id="call-1"
+    )
+    resumed = DurableRunContext(journal, "run-1", replaying=True)
+    replayed = await resumed.wrap_async(side_effect)(
+        "send_email", {"to": "user@example.com"}, tool_call_id="call-1"
+    )
+
+    assert first == replayed == {"ok": True}
+    side_effect.assert_awaited_once()
+    journal.close()
+
+
+def test_resume_requires_known_running_run_and_matching_prompt(tmp_path):
+    path = str(tmp_path / "journal.db")
+    agent = SimpleNamespace(
+        execution=ExecutionConfig(
+            durable=True,
+            journal_path=path,
+            resume_run_id="missing",
+        ),
+        name="agent",
+    )
+    with pytest.raises(ValueError, match="unknown durable run"):
+        begin_durable_run(agent, "task")
+
+    journal = RunJournal(path)
+    journal.open_run("known", task="original task")
+    journal.close()
+    agent.execution.resume_run_id = "known"
+    with pytest.raises(ValueError, match="does not match"):
+        begin_durable_run(agent, "different task")
+
+
+def test_successful_finalize_removes_run_from_interrupted_candidates():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    context = DurableRunContext(journal, "run-1", replaying=False)
+
+    assert journal.interrupted_runs() == ["run-1"]
+    context.finalize("succeeded")
+
+    assert journal.interrupted_runs() == []
+    assert journal.run_meta("run-1").status == "succeeded"
+    journal.close()
+
+
+def test_agent_chat_lifecycle_closes_successful_durable_run(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    with patch.object(agent, "_chat_impl", return_value="done"):
+        assert agent.chat("task") == "done"
+
+    assert agent.last_durable_run_id
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "succeeded"
+    assert journal.interrupted_runs() == []
+    journal.close()
+
+
+def test_agent_chat_exception_leaves_run_resumable(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+    with patch.object(agent, "_chat_impl", side_effect=RuntimeError("crash")):
+        with pytest.raises(RuntimeError, match="crash"):
+            agent.chat("task")
+
+    journal = RunJournal(path)
+    assert journal.interrupted_runs() == [agent.last_durable_run_id]
+    journal.close()
+
+
+def test_replay_only_restores_completed_steps():
+    journal = RunJournal(":memory:")
+    journal.open_run("run-1", task="task")
+    journal.append(JournalEvent(
+        "run-1",
+        0,
+        KIND_MODEL_DECISION,
+        {"message": {"role": "assistant", "content": "pending"}},
+    ))
+    context = DurableRunContext(journal, "run-1", replaying=True)
+    messages = [{"role": "user", "content": "task"}]
+
+    context.restore_messages(messages)
+
+    assert messages == [{"role": "user", "content": "task"}]
+    journal.close()

--- a/src/praisonai-agents/tests/unit/llm/test_durable_tool_dispatch.py
+++ b/src/praisonai-agents/tests/unit/llm/test_durable_tool_dispatch.py
@@ -1,0 +1,139 @@
+"""Regression tests for durable-aware async tool callback dispatch."""
+
+import contextvars
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from praisonaiagents.llm.llm import _dispatch_async_tool
+from praisonaiagents.errors import ToolExecutionError
+from praisonaiagents.llm.llm import LLM
+
+
+def _responses_llm(monkeypatch):
+    llm = LLM(model="openai/gpt-4o-mini", api_key="test")
+    tool_call = {
+        "id": "call-1",
+        "type": "function",
+        "function": {"name": "noop", "arguments": "{}"},
+    }
+    monkeypatch.setattr(llm, "_supports_responses_api", lambda: True)
+    monkeypatch.setattr(llm, "_build_responses_params", lambda **kwargs: {})
+    monkeypatch.setattr(
+        llm,
+        "_extract_from_responses_output",
+        lambda _response: ("", [tool_call], None),
+    )
+    return llm
+
+
+@pytest.mark.asyncio
+async def test_sync_tool_callback_runs_off_loop_with_context():
+    caller_thread = threading.get_ident()
+    marker = contextvars.ContextVar("durable-dispatch-marker", default="missing")
+    marker.set("present")
+
+    def execute(_name, _arguments, *, tool_call_id=None, **kwargs):
+        return threading.get_ident(), marker.get(), tool_call_id, kwargs
+
+    execute._accepts_durable_iteration = True
+    result = await _dispatch_async_tool(execute, "tool", {}, "call-1", 4)
+
+    assert result[0] != caller_thread
+    assert result[1:] == (
+        "present",
+        "call-1",
+        {"_durable_iteration_index": 4},
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_tool_callback_is_awaited():
+    async def execute(_name, _arguments, *, tool_call_id=None):
+        return f"done:{tool_call_id}"
+
+    assert await _dispatch_async_tool(execute, "tool", {}, "call-2", 2) == (
+        "done:call-2"
+    )
+
+
+def test_sync_response_loop_finalizes_per_call_iteration_limit(monkeypatch):
+    llm = _responses_llm(monkeypatch)
+    monkeypatch.setattr(llm, "_call_responses_api", lambda **kwargs: object())
+    finalise = MagicMock(return_value="finalized")
+    monkeypatch.setattr(llm, "_finalise_on_limit", finalise)
+
+    with patch(
+        "praisonaiagents.llm.llm._get_display_functions",
+        return_value={"execute_sync_callback": MagicMock()},
+    ):
+        result = llm.get_response(
+            prompt="task",
+            tools=[lambda: None],
+            execute_tool_fn=lambda *_args, **_kwargs: "ok",
+            stream=False,
+            verbose=False,
+            max_iterations=1,
+        )
+
+    assert result == "finalized"
+    finalise.assert_called_once()
+    assert llm._last_stop_reason == "max_steps"
+
+
+@pytest.mark.asyncio
+async def test_async_response_loop_finalizes_per_call_iteration_limit(
+    monkeypatch,
+):
+    llm = _responses_llm(monkeypatch)
+    monkeypatch.setattr(
+        llm, "_call_responses_api_async", AsyncMock(return_value=object())
+    )
+    finalise = AsyncMock(return_value="finalized")
+    monkeypatch.setattr(llm, "_finalise_on_limit_async", finalise)
+
+    with patch(
+        "praisonaiagents.llm.llm._get_display_functions",
+        return_value={"execute_sync_callback": MagicMock()},
+    ):
+        result = await llm.get_response_async(
+            prompt="task",
+            tools=[lambda: None],
+            execute_tool_fn=lambda *_args, **_kwargs: "ok",
+            stream=False,
+            verbose=False,
+            max_iterations=1,
+        )
+
+    assert result == "finalized"
+    finalise.assert_awaited_once()
+    assert llm._last_stop_reason == "max_steps"
+
+
+def test_sync_response_loop_preserves_terminal_tool_error(monkeypatch):
+    llm = _responses_llm(monkeypatch)
+    monkeypatch.setattr(llm, "_call_responses_api", lambda **kwargs: object())
+    error = ToolExecutionError("halt", tool_name="noop", is_retryable=False)
+
+    def execute(*_args, **_kwargs):
+        raise error
+
+    with (
+        patch(
+            "praisonaiagents.llm.llm._get_display_functions",
+            return_value={
+                "execute_sync_callback": MagicMock(),
+                "display_error": MagicMock(),
+            },
+        ),
+        pytest.raises(ToolExecutionError, match="halt"),
+    ):
+        llm.get_response(
+            prompt="task",
+            tools=[lambda: None],
+            execute_tool_fn=execute,
+            stream=False,
+            verbose=False,
+            max_iterations=1,
+        )


### PR DESCRIPTION
## Summary
- add default-off durable execution fields to `ExecutionConfig`
- bind explicit durable Agent turns to the existing `RunJournal` and expose the latest run id
- journal model/tool/iteration boundaries on both sync and async tool executors
- restore completed tool steps into the conversation on explicit resume and return recorded results by tool-call id instead of repeating side effects
- leave crashed runs resumable while marking successful/cancelled runs terminal
- add deterministic lifecycle/replay coverage plus an opt-in real-provider smoke test

## Scope
This is the core explicit-resume phase only. It does not add checkpoint/session binding or gateway auto-resume.

## Tests
- `python -m pytest tests/unit/agent/test_durable_run.py tests/unit/runtime/test_journal.py -q` (29 passed)
- `python -m pytest tests/unit/config tests/unit/agent/test_achat_unified_dispatch.py tests/unit/agent/test_interrupt.py tests/unit/test_memory_system_fixes.py -q` (254 passed)
- `python -m pytest tests/integration/test_durable_run_real.py -q` (1 skipped; requires `RUN_REAL_KEY_TESTS=1`)
- API/export subset: 84 passed, 1 existing `__all__ < 29` assertion failure reproduced unchanged on `upstream/main` (current length 31)

Closes #3759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional durable execution for synchronous, asynchronous, custom, and streaming agent workflows.
  * Runs can record progress, replay completed steps, and resume after interruptions.
  * Added configuration for enabling durability, journal storage, and run resumption.
  * Added stable idempotency keys, run tracking, and iteration limits for compatible tools.

* **Bug Fixes**
  * Improved cleanup for successful, cancelled, and interrupted runs.
  * Preserved terminal tool execution errors during workflows.

* **Tests**
  * Added coverage for replay, recovery, streaming, cancellation, and tool execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->