### PR TITLE
fix: classify empty durable turns as failed

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -30,12 +30,18 @@ if TYPE_CHECKING:
 class _TurnCancelToken:
     """Track cancellation observed by one call without shared backend state."""
 
-    def __init__(self, source: Any):
+    def __init__(self, source: Any, *, accept_preexisting: bool):
         self._source = source
         self._observed = False
+        self._accept_preexisting = accept_preexisting
+        self._start_generation = getattr(source, "_request_generation", None)
 
     def is_set(self) -> bool:
-        is_set = bool(getattr(self._source, "is_set", lambda: False)())
+        generation = getattr(self._source, "_request_generation", None)
+        if not self._accept_preexisting and generation is not None:
+            is_set = generation > self._start_generation
+        else:
+            is_set = bool(getattr(self._source, "is_set", lambda: False)())
         self._observed = self._observed or is_set
         return is_set
 
@@ -2718,7 +2724,13 @@ Your Goal: {self.goal}"""
         try:
             # C2 - cooperative cancellation: abort early if a pre-set token is given
             cancel_source = cancel_token if cancel_token is not None else getattr(self, "interrupt_controller", None)
-            _cancel = _TurnCancelToken(cancel_source) if cancel_source is not None else None
+            _cancel = (
+                _TurnCancelToken(
+                    cancel_source, accept_preexisting=cancel_token is not None
+                )
+                if cancel_source is not None
+                else None
+            )
             if _cancel is not None and getattr(_cancel, "is_set", lambda: False)():
                 reason = getattr(_cancel, "reason", None) or "cancelled before LLM call"
                 raise InterruptedError(f"Agent chat cancelled: {reason}")
@@ -3398,7 +3410,13 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         durable_context = None
         durable_token = None
         cancel_source = cancel_token if cancel_token is not None else getattr(self, "interrupt_controller", None)
-        _cancel = _TurnCancelToken(cancel_source) if cancel_source is not None else None
+        _cancel = (
+            _TurnCancelToken(
+                cancel_source, accept_preexisting=cancel_token is not None
+            )
+            if cancel_source is not None
+            else None
+        )
         try:
             if getattr(getattr(self, "execution", None), "durable", False):
                 from .durable import abegin_durable_run

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -27,6 +27,33 @@ if TYPE_CHECKING:
     pass
 
 
+class _TurnCancelToken:
+    """Track cancellation observed by one call without shared backend state."""
+
+    def __init__(self, source: Any):
+        self._source = source
+        self._observed = False
+
+    def is_set(self) -> bool:
+        is_set = bool(getattr(self._source, "is_set", lambda: False)())
+        self._observed = self._observed or is_set
+        return is_set
+
+    @property
+    def reason(self):
+        return getattr(self._source, "reason", None)
+
+    def check(self) -> None:
+        if self.is_set():
+            raise InterruptedError(f"Operation cancelled: {self.reason or 'unknown'}")
+
+    def was_cancelled(self) -> bool:
+        return self._observed or self.is_set()
+
+    def __getattr__(self, name: str):
+        return getattr(self._source, name)
+
+
 class ChatMixin:
     """Mixin providing chat methods for the Agent class."""
 
@@ -42,15 +69,6 @@ class ChatMixin:
         from .durable import get_durable_run
 
         return get_durable_run()
-
-    def _reset_last_stop_reason(self) -> None:
-        """Clear backend stop state before starting a new agent turn."""
-        for backend in (
-            getattr(self, "llm_instance", None),
-            getattr(self, "_Agent__openai_client", None),
-        ):
-            if backend is not None and hasattr(backend, "_last_stop_reason"):
-                backend._last_stop_reason = "completed"
 
     def _durable_sync_tool_executor(self, execute_tool_fn):
         """Wrap tool execution only while an opt-in durable run is active."""
@@ -2697,10 +2715,10 @@ Your Goal: {self.goal}"""
         _trace_emitter.agent_start(self.name, {"role": self.role, "goal": self.goal})
         durable_context = None
         durable_token = None
-        self._reset_last_stop_reason()
         try:
             # C2 - cooperative cancellation: abort early if a pre-set token is given
-            _cancel = cancel_token if cancel_token is not None else getattr(self, "interrupt_controller", None)
+            cancel_source = cancel_token if cancel_token is not None else getattr(self, "interrupt_controller", None)
+            _cancel = _TurnCancelToken(cancel_source) if cancel_source is not None else None
             if _cancel is not None and getattr(_cancel, "is_set", lambda: False)():
                 reason = getattr(_cancel, "reason", None) or "cancelled before LLM call"
                 raise InterruptedError(f"Agent chat cancelled: {reason}")
@@ -2715,7 +2733,7 @@ Your Goal: {self.goal}"""
             if durable_context is not None:
                 outcome = (
                     "cancelled"
-                    if getattr(self, "last_stop_reason", None) == "cancelled"
+                    if _cancel is not None and _cancel.was_cancelled()
                     else ("failed" if result is None else "succeeded")
                 )
                 durable_context.finalize(outcome)
@@ -3379,7 +3397,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         _trace_emitter.agent_start(self.name, {"role": self.role, "goal": self.goal})
         durable_context = None
         durable_token = None
-        self._reset_last_stop_reason()
+        cancel_source = cancel_token if cancel_token is not None else getattr(self, "interrupt_controller", None)
+        _cancel = _TurnCancelToken(cancel_source) if cancel_source is not None else None
         try:
             if getattr(getattr(self, "execution", None), "durable", False):
                 from .durable import abegin_durable_run
@@ -3394,12 +3413,12 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 task_name=task_name, task_description=task_description, task_id=task_id,
                 config=config, force_retrieval=force_retrieval, skip_retrieval=skip_retrieval,
                 attachments=attachments, _trace_emitter=_trace_emitter, tool_choice=tool_choice,
-                seed=seed, cancel_token=cancel_token
+                seed=seed, cancel_token=_cancel
             )
             if durable_context is not None:
                 outcome = (
                     "cancelled"
-                    if getattr(self, "last_stop_reason", None) == "cancelled"
+                    if _cancel is not None and _cancel.was_cancelled()
                     else ("failed" if result is None else "succeeded")
                 )
                 await durable_context.afinalize(outcome)
@@ -4259,7 +4278,6 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         """Own the durable context for the complete streaming generator."""
         durable_context = None
         durable_token = None
-        self._reset_last_stop_reason()
         try:
             if getattr(getattr(self, "execution", None), "durable", False):
                 from .durable import begin_durable_run
@@ -4267,12 +4285,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 durable_context, durable_token = begin_durable_run(self, prompt)
             yield from self._start_stream_impl(prompt, **kwargs)
             if durable_context is not None:
-                outcome = (
-                    "cancelled"
-                    if getattr(self, "last_stop_reason", None) == "cancelled"
-                    else "succeeded"
-                )
-                durable_context.finalize(outcome)
+                durable_context.finalize("succeeded")
                 self.execution.resume_run_id = None
         except ToolExecutionError as exc:
             if durable_context is not None and not exc.is_retryable:

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -43,6 +43,15 @@ class ChatMixin:
 
         return get_durable_run()
 
+    def _reset_last_stop_reason(self) -> None:
+        """Clear backend stop state before starting a new agent turn."""
+        for backend in (
+            getattr(self, "llm_instance", None),
+            getattr(self, "_Agent__openai_client", None),
+        ):
+            if backend is not None and hasattr(backend, "_last_stop_reason"):
+                backend._last_stop_reason = "completed"
+
     def _durable_sync_tool_executor(self, execute_tool_fn):
         """Wrap tool execution only while an opt-in durable run is active."""
         context = self._get_durable_run_context()
@@ -2688,6 +2697,7 @@ Your Goal: {self.goal}"""
         _trace_emitter.agent_start(self.name, {"role": self.role, "goal": self.goal})
         durable_context = None
         durable_token = None
+        self._reset_last_stop_reason()
         try:
             # C2 - cooperative cancellation: abort early if a pre-set token is given
             _cancel = cancel_token if cancel_token is not None else getattr(self, "interrupt_controller", None)
@@ -3369,6 +3379,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         _trace_emitter.agent_start(self.name, {"role": self.role, "goal": self.goal})
         durable_context = None
         durable_token = None
+        self._reset_last_stop_reason()
         try:
             if getattr(getattr(self, "execution", None), "durable", False):
                 from .durable import abegin_durable_run
@@ -4248,6 +4259,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         """Own the durable context for the complete streaming generator."""
         durable_context = None
         durable_token = None
+        self._reset_last_stop_reason()
         try:
             if getattr(getattr(self, "execution", None), "durable", False):
                 from .durable import begin_durable_run

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -11,6 +11,7 @@ import re
 import time
 import json
 import logging
+import threading
 from praisonaiagents._logging import get_logger
 from ..errors import BudgetExceededError, ToolExecutionError
 
@@ -18,6 +19,7 @@ from ..errors import BudgetExceededError, ToolExecutionError
 from ._lazy_display import _get_console, _get_live, _get_display_functions
 
 logger = logging.getLogger(__name__)
+_interrupt_generation_lock = threading.Lock()
 
 
 
@@ -30,19 +32,27 @@ if TYPE_CHECKING:
 class _TurnCancelToken:
     """Track cancellation observed by one call without shared backend state."""
 
-    def __init__(self, source: Any, *, accept_preexisting: bool):
+    def __init__(
+        self,
+        source: Any,
+        *,
+        start_generation: Optional[int] = None,
+        on_observed=None,
+    ):
         self._source = source
         self._observed = False
-        self._accept_preexisting = accept_preexisting
-        self._start_generation = getattr(source, "_request_generation", None)
+        self._start_generation = start_generation
+        self._on_observed = on_observed
 
     def is_set(self) -> bool:
         generation = getattr(self._source, "_request_generation", None)
-        if not self._accept_preexisting and generation is not None:
+        if self._start_generation is not None and generation is not None:
             is_set = generation > self._start_generation
         else:
             is_set = bool(getattr(self._source, "is_set", lambda: False)())
         self._observed = self._observed or is_set
+        if is_set and self._on_observed is not None:
+            self._on_observed(generation)
         return is_set
 
     @property
@@ -75,6 +85,36 @@ class ChatMixin:
         from .durable import get_durable_run
 
         return get_durable_run()
+
+    def _turn_cancel_token(self, source: Any, *, explicit: bool):
+        """Create per-turn cancellation state while consuming default requests once."""
+        if source is None:
+            return None
+        generation = getattr(source, "_request_generation", None)
+        if explicit or generation is None:
+            return _TurnCancelToken(source)
+
+        source_key = id(source)
+        with _interrupt_generation_lock:
+            consumed = getattr(self, "_consumed_interrupt_generations", None)
+            if consumed is None:
+                consumed = {}
+                self._consumed_interrupt_generations = consumed
+            start_generation = consumed.get(source_key, 0)
+
+        def mark_observed(observed_generation):
+            if observed_generation is None:
+                return
+            with _interrupt_generation_lock:
+                consumed[source_key] = max(
+                    consumed.get(source_key, 0), observed_generation
+                )
+
+        return _TurnCancelToken(
+            source,
+            start_generation=start_generation,
+            on_observed=mark_observed,
+        )
 
     def _durable_sync_tool_executor(self, execute_tool_fn):
         """Wrap tool execution only while an opt-in durable run is active."""
@@ -2724,12 +2764,8 @@ Your Goal: {self.goal}"""
         try:
             # C2 - cooperative cancellation: abort early if a pre-set token is given
             cancel_source = cancel_token if cancel_token is not None else getattr(self, "interrupt_controller", None)
-            _cancel = (
-                _TurnCancelToken(
-                    cancel_source, accept_preexisting=cancel_token is not None
-                )
-                if cancel_source is not None
-                else None
+            _cancel = self._turn_cancel_token(
+                cancel_source, explicit=cancel_token is not None
             )
             if _cancel is not None and getattr(_cancel, "is_set", lambda: False)():
                 reason = getattr(_cancel, "reason", None) or "cancelled before LLM call"
@@ -3410,12 +3446,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         durable_context = None
         durable_token = None
         cancel_source = cancel_token if cancel_token is not None else getattr(self, "interrupt_controller", None)
-        _cancel = (
-            _TurnCancelToken(
-                cancel_source, accept_preexisting=cancel_token is not None
-            )
-            if cancel_source is not None
-            else None
+        _cancel = self._turn_cancel_token(
+            cancel_source, explicit=cancel_token is not None
         )
         try:
             if getattr(getattr(self, "execution", None), "durable", False):

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -11,7 +11,6 @@ import re
 import time
 import json
 import logging
-import threading
 from praisonaiagents._logging import get_logger
 from ..errors import BudgetExceededError, ToolExecutionError
 
@@ -19,7 +18,6 @@ from ..errors import BudgetExceededError, ToolExecutionError
 from ._lazy_display import _get_console, _get_live, _get_display_functions
 
 logger = logging.getLogger(__name__)
-_interrupt_generation_lock = threading.Lock()
 
 
 
@@ -36,23 +34,19 @@ class _TurnCancelToken:
         self,
         source: Any,
         *,
-        start_generation: Optional[int] = None,
-        on_observed=None,
+        turn_id: Optional[int] = None,
     ):
         self._source = source
         self._observed = False
-        self._start_generation = start_generation
-        self._on_observed = on_observed
+        self._turn_id = turn_id
 
     def is_set(self) -> bool:
-        generation = getattr(self._source, "_request_generation", None)
-        if self._start_generation is not None and generation is not None:
-            is_set = generation > self._start_generation
+        turn_checker = getattr(self._source, "_turn_is_cancelled", None)
+        if self._turn_id is not None and callable(turn_checker):
+            is_set = bool(turn_checker(self._turn_id))
         else:
             is_set = bool(getattr(self._source, "is_set", lambda: False)())
         self._observed = self._observed or is_set
-        if is_set and self._on_observed is not None:
-            self._on_observed(generation)
         return is_set
 
     @property
@@ -65,6 +59,12 @@ class _TurnCancelToken:
 
     def was_cancelled(self) -> bool:
         return self._observed or self.is_set()
+
+    def close(self) -> None:
+        end_turn = getattr(self._source, "_end_turn", None)
+        if self._turn_id is not None and callable(end_turn):
+            end_turn(self._turn_id)
+            self._turn_id = None
 
     def __getattr__(self, name: str):
         return getattr(self._source, name)
@@ -90,31 +90,10 @@ class ChatMixin:
         """Create per-turn cancellation state while consuming default requests once."""
         if source is None:
             return None
-        generation = getattr(source, "_request_generation", None)
-        if explicit or generation is None:
+        begin_turn = getattr(source, "_begin_turn", None)
+        if explicit or not callable(begin_turn):
             return _TurnCancelToken(source)
-
-        source_key = id(source)
-        with _interrupt_generation_lock:
-            consumed = getattr(self, "_consumed_interrupt_generations", None)
-            if consumed is None:
-                consumed = {}
-                self._consumed_interrupt_generations = consumed
-            start_generation = consumed.get(source_key, 0)
-
-        def mark_observed(observed_generation):
-            if observed_generation is None:
-                return
-            with _interrupt_generation_lock:
-                consumed[source_key] = max(
-                    consumed.get(source_key, 0), observed_generation
-                )
-
-        return _TurnCancelToken(
-            source,
-            start_generation=start_generation,
-            on_observed=mark_observed,
-        )
+        return _TurnCancelToken(source, turn_id=begin_turn())
 
     def _durable_sync_tool_executor(self, execute_tool_fn):
         """Wrap tool execution only while an opt-in durable run is active."""
@@ -2803,7 +2782,11 @@ Your Goal: {self.goal}"""
 
                 end_durable_run(durable_token)
                 durable_context.close()
-            _trace_emitter.agent_end(self.name)
+            try:
+                _trace_emitter.agent_end(self.name)
+            finally:
+                if _cancel is not None:
+                    _cancel.close()
 
     def _chat_impl(self, prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice=None, seed=None, cancel_token=None):
         """Internal chat implementation (extracted for trace wrapping)."""
@@ -3490,7 +3473,11 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
 
                 end_durable_run(durable_token)
                 await durable_context.aclose()
-            _trace_emitter.agent_end(self.name)
+            try:
+                _trace_emitter.agent_end(self.name)
+            finally:
+                if _cancel is not None:
+                    _cancel.close()
 
     async def _achat_impl(self, prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice=None, seed=None, cancel_token=None):
         """Internal async chat implementation (extracted for trace wrapping)."""

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -2704,13 +2704,9 @@ Your Goal: {self.goal}"""
             result = self._chat_impl(prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice, seed=seed, cancel_token=_cancel)
             if durable_context is not None:
                 outcome = (
-                    "failed"
-                    if result is None
-                    else (
-                        "cancelled"
-                        if getattr(self, "last_stop_reason", None) == "cancelled"
-                        else "succeeded"
-                    )
+                    "cancelled"
+                    if getattr(self, "last_stop_reason", None) == "cancelled"
+                    else ("failed" if result is None else "succeeded")
                 )
                 durable_context.finalize(outcome)
                 self.execution.resume_run_id = None
@@ -3391,13 +3387,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             )
             if durable_context is not None:
                 outcome = (
-                    "failed"
-                    if result is None
-                    else (
-                        "cancelled"
-                        if getattr(self, "last_stop_reason", None) == "cancelled"
-                        else "succeeded"
-                    )
+                    "cancelled"
+                    if getattr(self, "last_stop_reason", None) == "cancelled"
+                    else ("failed" if result is None else "succeeded")
                 )
                 await durable_context.afinalize(outcome)
                 self.execution.resume_run_id = None

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -2704,9 +2704,13 @@ Your Goal: {self.goal}"""
             result = self._chat_impl(prompt, temperature, tools, output_json, output_pydantic, reasoning_steps, stream, task_name, task_description, task_id, config, force_retrieval, skip_retrieval, attachments, _trace_emitter, tool_choice, seed=seed, cancel_token=_cancel)
             if durable_context is not None:
                 outcome = (
-                    "cancelled"
-                    if getattr(self, "last_stop_reason", None) == "cancelled"
-                    else "succeeded"
+                    "failed"
+                    if result is None
+                    else (
+                        "cancelled"
+                        if getattr(self, "last_stop_reason", None) == "cancelled"
+                        else "succeeded"
+                    )
                 )
                 durable_context.finalize(outcome)
                 self.execution.resume_run_id = None
@@ -3387,9 +3391,13 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             )
             if durable_context is not None:
                 outcome = (
-                    "cancelled"
-                    if getattr(self, "last_stop_reason", None) == "cancelled"
-                    else "succeeded"
+                    "failed"
+                    if result is None
+                    else (
+                        "cancelled"
+                        if getattr(self, "last_stop_reason", None) == "cancelled"
+                        else "succeeded"
+                    )
                 )
                 await durable_context.afinalize(outcome)
                 self.execution.resume_run_id = None

--- a/src/praisonai-agents/praisonaiagents/agent/interrupt.py
+++ b/src/praisonai-agents/praisonaiagents/agent/interrupt.py
@@ -6,7 +6,7 @@ operations. Follows protocol-driven design with zero overhead when not used.
 """
 
 import threading
-from typing import Optional, Protocol
+from typing import Optional, Protocol, Set
 from dataclasses import dataclass, field
 
 __all__ = ["InterruptControllerProtocol", "InterruptController"]
@@ -57,7 +57,10 @@ class InterruptController:
     
     _flag: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
     _reason: Optional[str] = field(default=None, init=False)
-    _generation: int = field(default=0, init=False, repr=False)
+    _active_turns: Set[int] = field(default_factory=set, init=False, repr=False)
+    _cancelled_turns: Set[int] = field(default_factory=set, init=False, repr=False)
+    _next_turn_id: int = field(default=0, init=False, repr=False)
+    _pending_turn_cancel: bool = field(default=False, init=False, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def request(self, reason: str = "user") -> None:
@@ -67,22 +70,43 @@ class InterruptController:
             reason: Human-readable reason for cancellation
         """
         with self._lock:
-            self._generation += 1
             if not self._flag.is_set():
                 self._reason = reason
                 self._flag.set()
+            if self._active_turns:
+                self._cancelled_turns.update(self._active_turns)
+            else:
+                self._pending_turn_cancel = True
 
-    @property
-    def _request_generation(self) -> int:
-        """Monotonic request counter used to scope cancellation to active turns."""
+    def _begin_turn(self) -> int:
+        """Register an Agent turn and consume any request made while idle."""
         with self._lock:
-            return self._generation
+            self._next_turn_id += 1
+            turn_id = self._next_turn_id
+            self._active_turns.add(turn_id)
+            if self._pending_turn_cancel:
+                self._cancelled_turns.add(turn_id)
+                self._pending_turn_cancel = False
+            return turn_id
+
+    def _turn_is_cancelled(self, turn_id: int) -> bool:
+        """Return whether a registered turn was targeted by a request."""
+        with self._lock:
+            return turn_id in self._cancelled_turns
+
+    def _end_turn(self, turn_id: int) -> None:
+        """Unregister a turn so its request cannot affect a future turn."""
+        with self._lock:
+            self._active_turns.discard(turn_id)
+            self._cancelled_turns.discard(turn_id)
 
     def clear(self) -> None:
         """Clear the cancellation request."""
         with self._lock:
             self._reason = None
             self._flag.clear()
+            self._pending_turn_cancel = False
+            self._cancelled_turns.clear()
 
     def is_set(self) -> bool:
         """Check if cancellation has been requested.

--- a/src/praisonai-agents/praisonaiagents/agent/interrupt.py
+++ b/src/praisonai-agents/praisonaiagents/agent/interrupt.py
@@ -57,6 +57,7 @@ class InterruptController:
     
     _flag: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
     _reason: Optional[str] = field(default=None, init=False)
+    _generation: int = field(default=0, init=False, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def request(self, reason: str = "user") -> None:
@@ -66,9 +67,16 @@ class InterruptController:
             reason: Human-readable reason for cancellation
         """
         with self._lock:
+            self._generation += 1
             if not self._flag.is_set():
                 self._reason = reason
                 self._flag.set()
+
+    @property
+    def _request_generation(self) -> int:
+        """Monotonic request counter used to scope cancellation to active turns."""
+        with self._lock:
+            return self._generation
 
     def clear(self) -> None:
         """Clear the cancellation request."""

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -402,7 +402,7 @@ def test_agent_chat_none_result_finalizes_run(tmp_path):
 
     run_id = agent.last_durable_run_id
     journal = RunJournal(path)
-    assert journal.run_meta(run_id).status == "succeeded"
+    assert journal.run_meta(run_id).status == "failed"
     assert journal.interrupted_runs() == []
     journal.close()
     assert agent.execution.resume_run_id is None
@@ -423,7 +423,7 @@ async def test_agent_achat_none_result_finalizes_run(tmp_path):
 
     run_id = agent.last_durable_run_id
     journal = RunJournal(path)
-    assert journal.run_meta(run_id).status == "succeeded"
+    assert journal.run_meta(run_id).status == "failed"
     assert journal.interrupted_runs() == []
     journal.close()
     assert agent.execution.resume_run_id is None

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -1,6 +1,8 @@
 """Tests for opt-in RunJournal integration and explicit resume."""
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from praisonaiagents import ExecutionConfig
+from praisonaiagents.agent.interrupt import InterruptController
 from praisonaiagents.errors import ToolExecutionError
 from praisonaiagents.agent.durable import (
     DurableRunContext,
@@ -408,7 +411,7 @@ def test_agent_chat_none_result_finalizes_run(tmp_path):
     assert agent.execution.resume_run_id is None
 
 
-def test_agent_chat_resets_stale_cancellation_before_none_result(tmp_path):
+def test_agent_chat_isolates_stop_reason_across_overlapping_turns(tmp_path):
     from praisonaiagents import Agent
 
     path = str(tmp_path / "journal.db")
@@ -420,23 +423,39 @@ def test_agent_chat_resets_stale_cancellation_before_none_result(tmp_path):
 
     backend = SimpleNamespace(_last_stop_reason="completed")
     agent.llm_instance = backend
+    cancelled_token = InterruptController()
+    failed_token = InterruptController()
+    barrier = Barrier(2)
+    run_ids = {}
+    real_begin = begin_durable_run
 
-    def cancelled_result(*args, **kwargs):
-        backend._last_stop_reason = "cancelled"
+    def record_begin(current_agent, task):
+        context, token = real_begin(current_agent, task)
+        run_ids[task] = context.run_id
+        return context, token
+
+    def overlapping_result(prompt, *args, **kwargs):
+        if prompt == "cancelled task":
+            cancelled_token.request("test")
+            backend._last_stop_reason = "cancelled"
+        else:
+            backend._last_stop_reason = "completed"
+        barrier.wait()
         return None
 
-    with patch.object(agent, "_chat_impl", side_effect=cancelled_result):
-        assert agent.chat("task") is None
+    with (
+        patch("praisonaiagents.agent.durable.begin_durable_run", side_effect=record_begin),
+        patch.object(agent, "_chat_impl", side_effect=overlapping_result),
+        ThreadPoolExecutor(max_workers=2) as pool,
+    ):
+        cancelled = pool.submit(agent.chat, "cancelled task", cancel_token=cancelled_token)
+        failed = pool.submit(agent.chat, "failed task", cancel_token=failed_token)
+        assert cancelled.result() is None
+        assert failed.result() is None
 
     journal = RunJournal(path)
-    assert journal.run_meta(agent.last_durable_run_id).status == "cancelled"
-    journal.close()
-
-    with patch.object(agent, "_chat_impl", return_value=None):
-        assert agent.chat("later task") is None
-
-    journal = RunJournal(path)
-    assert journal.run_meta(agent.last_durable_run_id).status == "failed"
+    assert journal.run_meta(run_ids["cancelled task"]).status == "cancelled"
+    assert journal.run_meta(run_ids["failed task"]).status == "failed"
     assert journal.interrupted_runs() == []
     journal.close()
     assert agent.execution.resume_run_id is None
@@ -464,7 +483,7 @@ async def test_agent_achat_none_result_finalizes_run(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_agent_achat_resets_stale_cancellation_before_none_result(tmp_path):
+async def test_agent_achat_isolates_stop_reason_across_overlapping_turns(tmp_path):
     from praisonaiagents import Agent
 
     path = str(tmp_path / "journal.db")
@@ -476,23 +495,44 @@ async def test_agent_achat_resets_stale_cancellation_before_none_result(tmp_path
 
     backend = SimpleNamespace(_last_stop_reason="completed")
     agent.llm_instance = backend
+    cancelled_token = InterruptController()
+    failed_token = InterruptController()
+    cancelled_started = asyncio.Event()
+    failed_finished = asyncio.Event()
+    run_ids = {}
+    from praisonaiagents.agent.durable import abegin_durable_run
 
-    async def cancelled_result(*args, **kwargs):
-        backend._last_stop_reason = "cancelled"
+    async def record_begin(current_agent, task):
+        context, token = await abegin_durable_run(current_agent, task)
+        run_ids[task] = context.run_id
+        return context, token
+
+    async def overlapping_result(prompt, *args, **kwargs):
+        if prompt == "cancelled task":
+            cancelled_token.request("test")
+            backend._last_stop_reason = "cancelled"
+            cancelled_started.set()
+            await failed_finished.wait()
+        else:
+            await cancelled_started.wait()
+            backend._last_stop_reason = "completed"
+            failed_finished.set()
         return None
 
-    with patch.object(agent, "_achat_impl", side_effect=cancelled_result):
-        assert await agent.achat("task") is None
+    with (
+        patch("praisonaiagents.agent.durable.abegin_durable_run", side_effect=record_begin),
+        patch.object(agent, "_achat_impl", side_effect=overlapping_result),
+    ):
+        cancelled, failed = await asyncio.gather(
+            agent.achat("cancelled task", cancel_token=cancelled_token),
+            agent.achat("failed task", cancel_token=failed_token),
+        )
+        assert cancelled is None
+        assert failed is None
 
     journal = RunJournal(path)
-    assert journal.run_meta(agent.last_durable_run_id).status == "cancelled"
-    journal.close()
-
-    with patch.object(agent, "_achat_impl", AsyncMock(return_value=None)):
-        assert await agent.achat("later task") is None
-
-    journal = RunJournal(path)
-    assert journal.run_meta(agent.last_durable_run_id).status == "failed"
+    assert journal.run_meta(run_ids["cancelled task"]).status == "cancelled"
+    assert journal.run_meta(run_ids["failed task"]).status == "failed"
     assert journal.interrupted_runs() == []
     journal.close()
     assert agent.execution.resume_run_id is None

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -408,7 +408,7 @@ def test_agent_chat_none_result_finalizes_run(tmp_path):
     assert agent.execution.resume_run_id is None
 
 
-def test_agent_chat_cancelled_none_result_stays_cancelled(tmp_path):
+def test_agent_chat_resets_stale_cancellation_before_none_result(tmp_path):
     from praisonaiagents import Agent
 
     path = str(tmp_path / "journal.db")
@@ -418,12 +418,25 @@ def test_agent_chat_cancelled_none_result_stays_cancelled(tmp_path):
         execution=ExecutionConfig(durable=True, journal_path=path),
     )
 
-    agent.llm_instance = SimpleNamespace(_last_stop_reason="cancelled")
-    with patch.object(agent, "_chat_impl", return_value=None):
+    backend = SimpleNamespace(_last_stop_reason="completed")
+    agent.llm_instance = backend
+
+    def cancelled_result(*args, **kwargs):
+        backend._last_stop_reason = "cancelled"
+        return None
+
+    with patch.object(agent, "_chat_impl", side_effect=cancelled_result):
         assert agent.chat("task") is None
 
     journal = RunJournal(path)
     assert journal.run_meta(agent.last_durable_run_id).status == "cancelled"
+    journal.close()
+
+    with patch.object(agent, "_chat_impl", return_value=None):
+        assert agent.chat("later task") is None
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "failed"
     assert journal.interrupted_runs() == []
     journal.close()
     assert agent.execution.resume_run_id is None
@@ -451,7 +464,7 @@ async def test_agent_achat_none_result_finalizes_run(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_agent_achat_cancelled_none_result_stays_cancelled(tmp_path):
+async def test_agent_achat_resets_stale_cancellation_before_none_result(tmp_path):
     from praisonaiagents import Agent
 
     path = str(tmp_path / "journal.db")
@@ -461,12 +474,25 @@ async def test_agent_achat_cancelled_none_result_stays_cancelled(tmp_path):
         execution=ExecutionConfig(durable=True, journal_path=path),
     )
 
-    agent.llm_instance = SimpleNamespace(_last_stop_reason="cancelled")
-    with patch.object(agent, "_achat_impl", AsyncMock(return_value=None)):
+    backend = SimpleNamespace(_last_stop_reason="completed")
+    agent.llm_instance = backend
+
+    async def cancelled_result(*args, **kwargs):
+        backend._last_stop_reason = "cancelled"
+        return None
+
+    with patch.object(agent, "_achat_impl", side_effect=cancelled_result):
         assert await agent.achat("task") is None
 
     journal = RunJournal(path)
     assert journal.run_meta(agent.last_durable_run_id).status == "cancelled"
+    journal.close()
+
+    with patch.object(agent, "_achat_impl", AsyncMock(return_value=None)):
+        assert await agent.achat("later task") is None
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "failed"
     assert journal.interrupted_runs() == []
     journal.close()
     assert agent.execution.resume_run_id is None

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -461,6 +461,36 @@ def test_agent_chat_isolates_stop_reason_across_overlapping_turns(tmp_path):
     assert agent.execution.resume_run_id is None
 
 
+def test_agent_chat_does_not_reuse_default_controller_cancellation(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    controller = InterruptController()
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        interrupt_controller=controller,
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+
+    def cancelled_result(*args, **kwargs):
+        controller.request("first turn")
+        return None
+
+    with patch.object(agent, "_chat_impl", side_effect=cancelled_result):
+        assert agent.chat("cancelled task") is None
+    cancelled_run_id = agent.last_durable_run_id
+
+    with patch.object(agent, "_chat_impl", return_value=None):
+        assert agent.chat("later task") is None
+    failed_run_id = agent.last_durable_run_id
+
+    journal = RunJournal(path)
+    assert journal.run_meta(cancelled_run_id).status == "cancelled"
+    assert journal.run_meta(failed_run_id).status == "failed"
+    journal.close()
+
+
 @pytest.mark.asyncio
 async def test_agent_achat_none_result_finalizes_run(tmp_path):
     from praisonaiagents import Agent
@@ -536,6 +566,37 @@ async def test_agent_achat_isolates_stop_reason_across_overlapping_turns(tmp_pat
     assert journal.interrupted_runs() == []
     journal.close()
     assert agent.execution.resume_run_id is None
+
+
+@pytest.mark.asyncio
+async def test_agent_achat_does_not_reuse_default_controller_cancellation(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    controller = InterruptController()
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        interrupt_controller=controller,
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+
+    async def cancelled_result(*args, **kwargs):
+        controller.request("first turn")
+        return None
+
+    with patch.object(agent, "_achat_impl", side_effect=cancelled_result):
+        assert await agent.achat("cancelled task") is None
+    cancelled_run_id = agent.last_durable_run_id
+
+    with patch.object(agent, "_achat_impl", AsyncMock(return_value=None)):
+        assert await agent.achat("later task") is None
+    failed_run_id = agent.last_durable_run_id
+
+    journal = RunJournal(path)
+    assert journal.run_meta(cancelled_run_id).status == "cancelled"
+    assert journal.run_meta(failed_run_id).status == "failed"
+    journal.close()
 
 
 def test_custom_llm_fatal_tool_error_reaches_durable_lifecycle(tmp_path):

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -491,6 +491,24 @@ def test_agent_chat_does_not_reuse_default_controller_cancellation(tmp_path):
     journal.close()
 
 
+def test_agent_chat_consumes_preexisting_default_cancellation():
+    from praisonaiagents import Agent
+
+    controller = InterruptController()
+    controller.request("before turn")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        interrupt_controller=controller,
+    )
+
+    with pytest.raises(InterruptedError, match="before turn"):
+        agent.chat("cancel this turn")
+
+    with patch.object(agent, "_chat_impl", return_value="done"):
+        assert agent.chat("later task") == "done"
+
+
 @pytest.mark.asyncio
 async def test_agent_achat_none_result_finalizes_run(tmp_path):
     from praisonaiagents import Agent

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -509,6 +509,29 @@ def test_agent_chat_consumes_preexisting_default_cancellation():
         assert agent.chat("later task") == "done"
 
 
+def test_agent_chat_does_not_forward_late_default_cancellation():
+    from praisonaiagents import Agent
+
+    controller = InterruptController()
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        interrupt_controller=controller,
+    )
+
+    def late_cancel(*args, cancel_token=None, **kwargs):
+        assert cancel_token is not None
+        assert not cancel_token.is_set()
+        controller.request("too late for this turn")
+        return "done"
+
+    with patch.object(agent, "_chat_impl", side_effect=late_cancel):
+        assert agent.chat("first task") == "done"
+
+    with patch.object(agent, "_chat_impl", return_value="later done"):
+        assert agent.chat("later task") == "later done"
+
+
 @pytest.mark.asyncio
 async def test_agent_achat_none_result_finalizes_run(tmp_path):
     from praisonaiagents import Agent

--- a/src/praisonai-agents/tests/unit/agent/test_durable_run.py
+++ b/src/praisonai-agents/tests/unit/agent/test_durable_run.py
@@ -408,6 +408,27 @@ def test_agent_chat_none_result_finalizes_run(tmp_path):
     assert agent.execution.resume_run_id is None
 
 
+def test_agent_chat_cancelled_none_result_stays_cancelled(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+
+    agent.llm_instance = SimpleNamespace(_last_stop_reason="cancelled")
+    with patch.object(agent, "_chat_impl", return_value=None):
+        assert agent.chat("task") is None
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "cancelled"
+    assert journal.interrupted_runs() == []
+    journal.close()
+    assert agent.execution.resume_run_id is None
+
+
 @pytest.mark.asyncio
 async def test_agent_achat_none_result_finalizes_run(tmp_path):
     from praisonaiagents import Agent
@@ -424,6 +445,28 @@ async def test_agent_achat_none_result_finalizes_run(tmp_path):
     run_id = agent.last_durable_run_id
     journal = RunJournal(path)
     assert journal.run_meta(run_id).status == "failed"
+    assert journal.interrupted_runs() == []
+    journal.close()
+    assert agent.execution.resume_run_id is None
+
+
+@pytest.mark.asyncio
+async def test_agent_achat_cancelled_none_result_stays_cancelled(tmp_path):
+    from praisonaiagents import Agent
+
+    path = str(tmp_path / "journal.db")
+    agent = Agent(
+        name="durable-agent",
+        instructions="test",
+        execution=ExecutionConfig(durable=True, journal_path=path),
+    )
+
+    agent.llm_instance = SimpleNamespace(_last_stop_reason="cancelled")
+    with patch.object(agent, "_achat_impl", AsyncMock(return_value=None)):
+        assert await agent.achat("task") is None
+
+    journal = RunJournal(path)
+    assert journal.run_meta(agent.last_durable_run_id).status == "cancelled"
     assert journal.interrupted_runs() == []
     journal.close()
     assert agent.execution.resume_run_id is None


### PR DESCRIPTION
## Summary
- finalize handled sync and async durable turns that return None as failed
- keep clearing the terminal run from resume state
- update lifecycle regressions for both chat paths

This follows the late review finding on #3898, which was merged before the correction reached its PR head.

## Validation
- python -m pytest src/praisonai-agents/tests/unit/agent/test_durable_run.py src/praisonai-agents/tests/unit/runtime/test_journal.py src/praisonai-agents/tests/test_deferred_progress_tools.py src/praisonai-agents/tests/unit/llm/test_durable_tool_dispatch.py src/praisonai-agents/tests/unit/llm/test_max_steps_budget.py -q
  - 91 passed, 1 skipped
- Ruff targeted E731 check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Durable chat runs now finish with **failed** when no result is returned.
  * Explicitly cancelled runs retain a **cancelled** status.
  * Cancellation is isolated between overlapping chat turns, preventing cross-run interruption.
  * Successfully completed streaming runs consistently finish with **succeeded**.
  * Stale cancellation state no longer affects subsequent chat or streaming turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->