### PR TITLE
test(gateway): credit #3060 contributor for #3050 load-time validation

### DIFF
--- a/examples/python/gateway_example.py
+++ b/examples/python/gateway_example.py
@@ -7,7 +7,8 @@ multiple agents and managing real-time communication.
 
 from praisonaiagents import Agent, GatewayConfig, SessionConfig
 
-# Configure the gateway
+# Configure the gateway using the typed SDK GatewayConfig.
+# In gateway.yaml, the optional ``gateway:`` block is validated at load time (#3050).
 gateway_config = GatewayConfig(
     host="127.0.0.1",
     port=8765,

--- a/src/praisonai/tests/integration/test_websocket_integration.py
+++ b/src/praisonai/tests/integration/test_websocket_integration.py
@@ -135,6 +135,24 @@ class TestWebSocketIntegration:
         assert cfg["channels"]["telegram"]["token"] == "test123"
 
     @pytest.mark.asyncio
+    async def test_gateway_config_rejects_misspelled_server_block(self, tmp_path):
+        """Misspelled ``gateway:`` server settings fail at load time (#3050)."""
+        try:
+            from praisonai.gateway.server import WebSocketGateway
+        except ImportError:
+            pytest.skip("praisonai.gateway not available")
+
+        bad_config = tmp_path / "bad.yaml"
+        bad_config.write_text(
+            "agents:\n  bot:\n    instructions: hi\n"
+            "channels:\n  telegram:\n    token: test123\n"
+            "gateway:\n  drain_timout: 30\n"
+        )
+
+        with pytest.raises(ValueError, match="drain_timout"):
+            WebSocketGateway.load_gateway_config(str(bad_config))
+
+    @pytest.mark.asyncio
     async def test_websocket_connect_and_message(self):
         """Test actual WebSocket connection to gateway server.
 


### PR DESCRIPTION
## Summary
- Adds load_gateway_config integration coverage for misspelled gateway server settings (#3050).
- Documents load-time validation in examples/python/gateway_example.py.
- Credits @botbikamordehai2-sketch via Co-authored-by for the original #3060 contribution.

## Context
The core fix for #3050 already landed in #3079 (GatewayServerSchema in praisonai-bot). #3060 targeted pre-C9 wrapper paths and cannot merge cleanly; this follow-up preserves the contributor integration-test idea without duplicating schema logic.

## Test plan
- [x] pytest src/praisonai/tests/integration/test_websocket_integration.py::TestWebSocketIntegration::test_gateway_config_rejects_misspelled_server_block

Closes #3060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway configuration validation to reject misspelled settings and provide a clear error identifying the invalid key.

* **Documentation**
  * Clarified how to use typed gateway configuration and configure the optional `gateway` section in `gateway.yaml`.

* **Tests**
  * Added integration coverage for invalid gateway configuration keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->