### PR TITLE
fix: initialize recipe serve config before auth check

### DIFF
--- a/src/praisonai/praisonai/cli/commands/recipe.py
+++ b/src/praisonai/praisonai/cli/commands/recipe.py
@@ -563,15 +563,6 @@ def recipe_serve(
     if workers > 1:
         print(f"   Workers: {workers}")
 
-    auth_mode = serve_config.get("auth", "none")
-    if host not in ("127.0.0.1", "localhost") and auth_mode == "none" and not api_key:
-        print(
-            "\n\033[91mError:\033[0m Auth required for non-localhost binding. "
-            "Use --api-key or --auth api-key",
-            file=sys.stderr,
-        )
-        raise typer.Exit(1)
-    
     try:
         from praisonai.recipe.serve import serve, load_config
         
@@ -579,6 +570,19 @@ def recipe_serve(
         serve_config = {}
         if config:
             serve_config = load_config(config)
+
+        auth_mode = serve_config.get("auth", "none")
+        if (
+            host not in ("127.0.0.1", "localhost")
+            and auth_mode == "none"
+            and not api_key
+        ):
+            print(
+                "\n\033[91mError:\033[0m Auth required for non-localhost binding. "
+                "Use --api-key or --auth api-key",
+                file=sys.stderr,
+            )
+            raise typer.Exit(1)
         
         # Override with CLI options
         if api_key:

--- a/src/praisonai/praisonai/cli/commands/recipe.py
+++ b/src/praisonai/praisonai/cli/commands/recipe.py
@@ -551,7 +551,7 @@ def recipe_serve(
     print("\033[93m'praisonai recipe serve' is deprecated and will be removed in a future version.\033[0m", file=sys.stderr)
     print("\033[93mPlease use 'praisonai serve recipe' instead.\033[0m\n", file=sys.stderr)
     
-    print(f"🚀 Starting recipe server...")
+    print("🚀 Starting recipe server...")
     print(f"   Host: {host}")
     print(f"   Port: {port}")
     if recipe:
@@ -559,12 +559,16 @@ def recipe_serve(
     if config:
         print(f"   Config: {config}")
     if api_key:
-        print(f"   Auth: API Key enabled")
+        print("   Auth: API Key enabled")
     if workers > 1:
         print(f"   Workers: {workers}")
 
     try:
-        from praisonai.recipe.serve import serve, load_config
+        from praisonai.recipe.serve import (
+            SUPPORTED_AUTH_TYPES,
+            load_config,
+            serve,
+        )
         
         # Load config from file if provided
         serve_config = {}
@@ -572,13 +576,13 @@ def recipe_serve(
             serve_config = load_config(config)
 
         auth_mode = serve_config.get("auth", "none")
-        supported_auth_modes = ("api-key", "jwt")
+        supported_auth_modes = SUPPORTED_AUTH_TYPES - {"none"}
         if host not in ("127.0.0.1", "localhost") and not api_key:
             if auth_mode not in supported_auth_modes:
                 print(
                     "\n\033[91mError:\033[0m Auth required for non-localhost binding. "
                     "Use --api-key or set a supported auth mode "
-                    f"({', '.join(supported_auth_modes)}) in the config.",
+                    f"({', '.join(sorted(supported_auth_modes))}) in the config.",
                     file=sys.stderr,
                 )
                 raise typer.Exit(1)
@@ -602,7 +606,7 @@ def recipe_serve(
         print(f"   OpenAPI: http://{host}:{port}/openapi.json")
         if metrics:
             print(f"   Metrics: http://{host}:{port}/metrics")
-        print(f"\n   Press Ctrl+C to stop\n")
+        print("\n   Press Ctrl+C to stop\n")
         
         serve(
             host=host,

--- a/src/praisonai/praisonai/cli/commands/recipe.py
+++ b/src/praisonai/praisonai/cli/commands/recipe.py
@@ -572,17 +572,16 @@ def recipe_serve(
             serve_config = load_config(config)
 
         auth_mode = serve_config.get("auth", "none")
-        if (
-            host not in ("127.0.0.1", "localhost")
-            and auth_mode == "none"
-            and not api_key
-        ):
-            print(
-                "\n\033[91mError:\033[0m Auth required for non-localhost binding. "
-                "Use --api-key or --auth api-key",
-                file=sys.stderr,
-            )
-            raise typer.Exit(1)
+        supported_auth_modes = ("api-key", "jwt")
+        if host not in ("127.0.0.1", "localhost") and not api_key:
+            if auth_mode not in supported_auth_modes:
+                print(
+                    "\n\033[91mError:\033[0m Auth required for non-localhost binding. "
+                    "Use --api-key or set a supported auth mode "
+                    f"({', '.join(supported_auth_modes)}) in the config.",
+                    file=sys.stderr,
+                )
+                raise typer.Exit(1)
         
         # Override with CLI options
         if api_key:

--- a/src/praisonai/praisonai/recipe/serve.py
+++ b/src/praisonai/praisonai/recipe/serve.py
@@ -81,6 +81,7 @@ def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
 DEFAULT_MAX_REQUEST_SIZE = 10 * 1024 * 1024  # 10MB
 DEFAULT_RATE_LIMIT = 100  # requests per minute
 DEFAULT_RATE_LIMIT_EXEMPT_PATHS = ["/health", "/metrics"]
+SUPPORTED_AUTH_TYPES = frozenset({"none", "api-key", "jwt"})
 
 
 class RateLimiter:
@@ -424,6 +425,13 @@ def create_app(config: Optional[Dict[str, Any]] = None) -> Any:
         )
     
     config = config or {}
+    auth_type = config.get("auth") or "none"
+    if auth_type not in SUPPORTED_AUTH_TYPES:
+        supported = ", ".join(sorted(SUPPORTED_AUTH_TYPES))
+        raise ValueError(
+            f"Unsupported recipe server auth mode {auth_type!r}. "
+            f"Expected one of: {supported}"
+        )
     
     async def health(request: Request) -> JSONResponse:
         """GET /health - Health check."""
@@ -690,8 +698,7 @@ def create_app(config: Optional[Dict[str, Any]] = None) -> Any:
         )
     
     # Add auth middleware if configured
-    auth_type = config.get("auth")
-    if auth_type and auth_type != "none":
+    if auth_type != "none":
         auth_middleware = create_auth_middleware(
             auth_type,
             api_key=config.get("api_key"),

--- a/src/praisonai/praisonai/recipe/serve.py
+++ b/src/praisonai/praisonai/recipe/serve.py
@@ -425,8 +425,10 @@ def create_app(config: Optional[Dict[str, Any]] = None) -> Any:
         )
     
     config = config or {}
-    auth_type = config.get("auth") or "none"
-    if auth_type not in SUPPORTED_AUTH_TYPES:
+    auth_type = config.get("auth", "none")
+    if auth_type is None:
+        auth_type = "none"
+    if not isinstance(auth_type, str) or auth_type not in SUPPORTED_AUTH_TYPES:
         supported = ", ".join(sorted(SUPPORTED_AUTH_TYPES))
         raise ValueError(
             f"Unsupported recipe server auth mode {auth_type!r}. "

--- a/src/praisonai/tests/unit/recipe/test_recipe_serve_command.py
+++ b/src/praisonai/tests/unit/recipe/test_recipe_serve_command.py
@@ -1,0 +1,48 @@
+"""Regression tests for the deprecated ``recipe serve`` command."""
+
+import importlib
+from unittest.mock import Mock
+
+from praisonai.cli.commands.recipe import recipe_serve
+
+
+def _invoke_recipe_serve(**overrides):
+    options = {
+        "recipe": None,
+        "host": "127.0.0.1",
+        "port": 8765,
+        "reload": False,
+        "workers": 1,
+        "config": None,
+        "api_key": None,
+        "cors": "*",
+        "metrics": False,
+        "admin": False,
+    }
+    options.update(overrides)
+    recipe_serve(**options)
+
+
+def test_recipe_serve_initialises_config_before_auth_check(monkeypatch):
+    serve = Mock()
+    serve_module = importlib.import_module("praisonai.recipe.serve")
+    monkeypatch.setattr(serve_module, "serve", serve)
+
+    _invoke_recipe_serve()
+
+    serve.assert_called_once()
+    assert serve.call_args.kwargs["config"]["cors_origins"] == "*"
+
+
+def test_recipe_serve_honours_auth_from_config(monkeypatch):
+    serve = Mock()
+    load_config = Mock(return_value={"auth": "api-key", "api_key": "configured"})
+    serve_module = importlib.import_module("praisonai.recipe.serve")
+    monkeypatch.setattr(serve_module, "serve", serve)
+    monkeypatch.setattr(serve_module, "load_config", load_config)
+
+    _invoke_recipe_serve(host="0.0.0.0", config="serve.yaml")
+
+    load_config.assert_called_once_with("serve.yaml")
+    serve.assert_called_once()
+    assert serve.call_args.kwargs["config"]["auth"] == "api-key"

--- a/src/praisonai/tests/unit/recipe/test_recipe_serve_command.py
+++ b/src/praisonai/tests/unit/recipe/test_recipe_serve_command.py
@@ -50,6 +50,7 @@ def test_recipe_serve_honours_auth_from_config(monkeypatch):
     load_config.assert_called_once_with("serve.yaml")
     serve.assert_called_once()
     assert serve.call_args.kwargs["config"]["auth"] == "api-key"
+    assert serve.call_args.kwargs["config"]["api_key"] == "configured"
 
 
 def test_recipe_serve_rejects_unsupported_auth_mode(monkeypatch):
@@ -62,6 +63,7 @@ def test_recipe_serve_rejects_unsupported_auth_mode(monkeypatch):
     with pytest.raises(typer.Exit):
         _invoke_recipe_serve(host="0.0.0.0", config="serve.yaml")
 
+    load_config.assert_called_once_with("serve.yaml")
     serve.assert_not_called()
 
 
@@ -74,10 +76,18 @@ def test_recipe_serve_allows_jwt_auth_from_config(monkeypatch):
 
     _invoke_recipe_serve(host="0.0.0.0", config="serve.yaml")
 
+    load_config.assert_called_once_with("serve.yaml")
     serve.assert_called_once()
     assert serve.call_args.kwargs["config"]["auth"] == "jwt"
+    assert serve.call_args.kwargs["config"]["jwt_secret"] == "secret"
 
 
 def test_recipe_server_rejects_unknown_auth_mode():
     with pytest.raises(ValueError, match="Unsupported recipe server auth mode"):
         create_app({"auth": "api-keey"})
+
+
+@pytest.mark.parametrize("auth_mode", ["", False, []])
+def test_recipe_server_rejects_falsey_invalid_auth_modes(auth_mode):
+    with pytest.raises(ValueError, match="Unsupported recipe server auth mode"):
+        create_app({"auth": auth_mode})

--- a/src/praisonai/tests/unit/recipe/test_recipe_serve_command.py
+++ b/src/praisonai/tests/unit/recipe/test_recipe_serve_command.py
@@ -3,6 +3,9 @@
 import importlib
 from unittest.mock import Mock
 
+import pytest
+import typer
+
 from praisonai.cli.commands.recipe import recipe_serve
 
 
@@ -46,3 +49,29 @@ def test_recipe_serve_honours_auth_from_config(monkeypatch):
     load_config.assert_called_once_with("serve.yaml")
     serve.assert_called_once()
     assert serve.call_args.kwargs["config"]["auth"] == "api-key"
+
+
+def test_recipe_serve_rejects_unsupported_auth_mode(monkeypatch):
+    serve = Mock()
+    load_config = Mock(return_value={"auth": "apikey", "api_key": "configured"})
+    serve_module = importlib.import_module("praisonai.recipe.serve")
+    monkeypatch.setattr(serve_module, "serve", serve)
+    monkeypatch.setattr(serve_module, "load_config", load_config)
+
+    with pytest.raises(typer.Exit):
+        _invoke_recipe_serve(host="0.0.0.0", config="serve.yaml")
+
+    serve.assert_not_called()
+
+
+def test_recipe_serve_allows_jwt_auth_from_config(monkeypatch):
+    serve = Mock()
+    load_config = Mock(return_value={"auth": "jwt", "jwt_secret": "secret"})
+    serve_module = importlib.import_module("praisonai.recipe.serve")
+    monkeypatch.setattr(serve_module, "serve", serve)
+    monkeypatch.setattr(serve_module, "load_config", load_config)
+
+    _invoke_recipe_serve(host="0.0.0.0", config="serve.yaml")
+
+    serve.assert_called_once()
+    assert serve.call_args.kwargs["config"]["auth"] == "jwt"

--- a/src/praisonai/tests/unit/recipe/test_recipe_serve_command.py
+++ b/src/praisonai/tests/unit/recipe/test_recipe_serve_command.py
@@ -7,6 +7,7 @@ import pytest
 import typer
 
 from praisonai.cli.commands.recipe import recipe_serve
+from praisonai.recipe.serve import create_app
 
 
 def _invoke_recipe_serve(**overrides):
@@ -75,3 +76,8 @@ def test_recipe_serve_allows_jwt_auth_from_config(monkeypatch):
 
     serve.assert_called_once()
     assert serve.call_args.kwargs["config"]["auth"] == "jwt"
+
+
+def test_recipe_server_rejects_unknown_auth_mode():
+    with pytest.raises(ValueError, match="Unsupported recipe server auth mode"):
+        create_app({"auth": "api-keey"})


### PR DESCRIPTION
## Summary

- initialize recipe serve configuration before checking authentication
- load file-based authentication before validating non-localhost bindings
- share one supported-auth contract between the CLI and application factory
- reject unknown and malformed falsey auth values before middleware setup
- cover localhost, API-key, JWT, and fail-closed configuration paths

## Testing

```console
PYTHONPATH=src/praisonai;src/praisonai-agents python -m pytest src/praisonai/tests/unit/recipe src/praisonai/tests/test_serve_features.py -q --timeout=30
```

69 passed.

Fixes #3922