### PR TITLE
fix: dispatch streaming tool calls

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -4295,7 +4295,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 arguments=arguments, 
                                 tool_call_id=tool_call_id,
                                 is_ollama=is_ollama,
-                                iteration_index=iteration_count,
+                                iteration_index=0,
                             ))
                         
                         # Create appropriate executor based on parallel_tool_calls setting

--- a/src/praisonai-agents/tests/integration/test_stream_tool_dispatch_real.py
+++ b/src/praisonai-agents/tests/integration/test_stream_tool_dispatch_real.py
@@ -1,0 +1,42 @@
+"""Opt-in real-provider coverage for streamed tool dispatch."""
+
+import os
+
+import pytest
+
+
+@pytest.mark.network
+@pytest.mark.skipif(
+    os.environ.get("RUN_REAL_KEY_TESTS") != "1"
+    or not os.environ.get("OPENAI_API_KEY"),
+    reason="Set RUN_REAL_KEY_TESTS=1 and OPENAI_API_KEY for the real agentic test",
+)
+def test_real_agent_dispatches_tool_while_streaming():
+    from praisonaiagents import Agent
+
+    calls = []
+
+    def stream_lookup(code: str) -> str:
+        """Return a stable value for the requested lookup code."""
+        calls.append(code)
+        return f"stream-result:{code}"
+
+    agent = Agent(
+        name="stream-tool-real-smoke",
+        llm="gpt-4o-mini",
+        instructions=(
+            "Always call stream_lookup exactly once before answering. "
+            "Include the tool's complete result in the final answer."
+        ),
+        tools=[stream_lookup],
+    )
+
+    chunks = agent.start(
+        "Call stream_lookup with code NEBULA-7 and report its result.",
+        stream=True,
+    )
+    result = "".join(str(chunk) for chunk in chunks if chunk)
+
+    print(result)
+    assert calls == ["NEBULA-7"]
+    assert "stream-result:NEBULA-7" in result

--- a/src/praisonai-agents/tests/unit/llm/test_stream_tool_dispatch.py
+++ b/src/praisonai-agents/tests/unit/llm/test_stream_tool_dispatch.py
@@ -71,6 +71,10 @@ def test_streaming_tool_call_is_executed_before_follow_up(monkeypatch):
 
     assert chunks == ["final answer"]
     assert [call["stream"] for call in completion_calls] == [True, False]
+    assert completion_calls[1]["messages"][-1] == {
+        "role": "tool",
+        "content": "ok",
+    }
     assert len(batches) == 1
     assert batches[0][0].function_name == "lookup"
     assert batches[0][0].iteration_index == 0

--- a/src/praisonai-agents/tests/unit/llm/test_stream_tool_dispatch.py
+++ b/src/praisonai-agents/tests/unit/llm/test_stream_tool_dispatch.py
@@ -1,0 +1,76 @@
+"""Regression coverage for tool calls returned by the streaming LLM path."""
+
+from types import SimpleNamespace
+
+import praisonaiagents.llm.llm as llm_module
+from praisonaiagents.llm.llm import LLM
+
+
+def test_streaming_tool_call_is_executed_before_follow_up(monkeypatch):
+    llm = LLM.__new__(LLM)
+    llm.model = "gpt-4o"
+    llm.tool_timeout_ms = None
+    llm._build_messages = lambda **kwargs: ([], kwargs["prompt"])
+    llm._format_tools_for_litellm = lambda tools: [{"type": "function"}]
+    llm._supports_streaming_tools = lambda: True
+    llm._build_completion_params = lambda **kwargs: kwargs
+    llm._process_stream_delta = lambda *args, **kwargs: (
+        "",
+        [{"id": "call-1", "function": {"name": "lookup", "arguments": "{}"}}],
+    )
+    llm._is_ollama_provider = lambda: False
+    llm._serialize_tool_calls = lambda calls: calls
+    llm._extract_tool_call_info = lambda call, is_ollama: (
+        "lookup",
+        {},
+        "call-1",
+    )
+    llm._register_deferred_if_any = lambda result: None
+    llm._create_tool_message = lambda *args: {"role": "tool", "content": "ok"}
+
+    completion_calls = []
+
+    def completion(**kwargs):
+        completion_calls.append(kwargs)
+        if kwargs["stream"]:
+            delta = SimpleNamespace(content=None, tool_calls=[object()])
+            return iter([SimpleNamespace(choices=[SimpleNamespace(delta=delta)])])
+        message = SimpleNamespace(content="final answer")
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+    llm._completion_with_retry = completion
+
+    batches = []
+
+    class Executor:
+        def execute_batch(self, tool_calls, execute_tool_fn, timeout_ms=None):
+            batches.append(tool_calls)
+            return [
+                SimpleNamespace(
+                    error=None,
+                    function_name="lookup",
+                    result="ok",
+                    tool_call_id="call-1",
+                    is_ollama=False,
+                )
+            ]
+
+    monkeypatch.setattr(
+        llm_module,
+        "create_tool_call_executor",
+        lambda parallel=False: Executor(),
+    )
+
+    chunks = list(
+        llm.get_response_stream(
+            "question",
+            tools=[lambda: None],
+            execute_tool_fn=lambda *args: None,
+        )
+    )
+
+    assert chunks == ["final answer"]
+    assert [call["stream"] for call in completion_calls] == [True, False]
+    assert len(batches) == 1
+    assert batches[0][0].function_name == "lookup"
+    assert batches[0][0].iteration_index == 0


### PR DESCRIPTION
## Summary

- use the real-time streaming branch's single tool-turn index when constructing internal tool calls
- prevent the undefined `iteration_count` exception from bypassing tool dispatch
- verify that the follow-up completion receives the tool result
- add an opt-in real-agentic streaming/tool regression with a follow-up-only marker

## Testing

```console
python -m pytest tests/unit/llm/test_stream_tool_dispatch.py tests/unit/llm/test_durable_tool_dispatch.py tests/unit/llm/test_loop_cancel_steering.py tests/unit/llm/test_max_steps_budget.py tests/integration/test_stream_tool_dispatch_real.py -q --timeout=30
```

25 passed, 2 skipped. The real-provider test is intentionally gated by `RUN_REAL_KEY_TESTS=1` and `OPENAI_API_KEY`.

Fixes #3923