### PR TITLE
fix: keep memory flush timeouts bounded

### DIFF
--- a/src/praisonai-agents/praisonaiagents/compaction/memory_flush.py
+++ b/src/praisonai-agents/praisonaiagents/compaction/memory_flush.py
@@ -121,15 +121,14 @@ def format_messages_to_flush(
 
 
 class _AtomicCommitGuard:
-    """Serialize cancellation with the final mutation without blocking cancel.
+    """Serialize commit authorization with cancellation without blocking.
 
     Backends must perform all potentially blocking preparation before calling
-    :meth:`commit` and pass only their short, final atomic mutation. Commit and
-    cancellation are mutually exclusive, so a cancellation that wins the race
-    prevents the mutation from starting and a timed-out flush never persists
-    memory. Cancellation itself never waits on backend I/O: if a final mutation
-    is already running it was authorized before the deadline, so :meth:`cancel`
-    records the request without blocking rather than joining the operation.
+    :meth:`commit` and pass only their short, final atomic mutation. Commit
+    authorization is serialized with cancellation and rechecks the deadline.
+    Cancellation prevents a mutation that is not yet authorized. An already-
+    authorized final mutation may persist after timeout; cancellation records
+    the request without waiting for that operation.
     """
 
     def __init__(self) -> None:
@@ -141,9 +140,9 @@ class _AtomicCommitGuard:
         with self._lock:
             return self._cancelled
 
-    def commit(self, operation: Any) -> bool:
+    def commit(self, operation: Any, *, deadline: float) -> bool:
         with self._lock:
-            if self._cancelled:
+            if self._cancelled or time.monotonic() >= deadline:
                 return False
             operation()
             return True

--- a/src/praisonai-agents/praisonaiagents/compaction/memory_flush.py
+++ b/src/praisonai-agents/praisonaiagents/compaction/memory_flush.py
@@ -121,27 +121,29 @@ def format_messages_to_flush(
 
 
 class _AtomicCommitGuard:
-    """Serialize cancellation with the backend's final atomic mutation."""
+    """Cancel commits without making the timeout path wait on backend I/O.
+
+    Backends must perform all potentially blocking preparation before calling
+    :meth:`commit` and pass only their short, final atomic mutation.  A final
+    mutation that has already started cannot be rolled back safely, but a
+    misbehaving backend must not be able to make cancellation block.
+    """
 
     def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._cancelled = False
+        self._cancelled = threading.Event()
 
     @property
     def cancelled(self) -> bool:
-        with self._lock:
-            return self._cancelled
+        return self._cancelled.is_set()
 
     def commit(self, operation: Any) -> bool:
-        with self._lock:
-            if self._cancelled:
-                return False
-            operation()
-            return True
+        if self._cancelled.is_set():
+            return False
+        operation()
+        return True
 
     def cancel(self) -> None:
-        with self._lock:
-            self._cancelled = True
+        self._cancelled.set()
 
 
 class _StagedMemory:
@@ -361,8 +363,10 @@ def run_pre_compaction_flush_sync(
     """Run a bounded sync flush in a worker without blocking past its timeout.
 
     The worker runs in a daemon thread so a stuck provider cannot delay process
-    shutdown. Its memory writes are staged and committed only after successful,
-    in-time completion, so a timed-out worker cannot mutate the parent store.
+    shutdown. Its memory writes are staged and commits that have not been
+    authorized by the deadline are discarded. A final atomic mutation already
+    in progress may finish after timeout, so backends must keep it non-blocking;
+    cancellation never waits for backend I/O.
     """
     resolved, transcript, count, skipped = _prepare_flush(
         parent_agent, messages_to_flush, config

--- a/src/praisonai-agents/praisonaiagents/compaction/memory_flush.py
+++ b/src/praisonai-agents/praisonaiagents/compaction/memory_flush.py
@@ -121,29 +121,44 @@ def format_messages_to_flush(
 
 
 class _AtomicCommitGuard:
-    """Cancel commits without making the timeout path wait on backend I/O.
+    """Serialize cancellation with the final mutation without blocking cancel.
 
     Backends must perform all potentially blocking preparation before calling
-    :meth:`commit` and pass only their short, final atomic mutation.  A final
-    mutation that has already started cannot be rolled back safely, but a
-    misbehaving backend must not be able to make cancellation block.
+    :meth:`commit` and pass only their short, final atomic mutation. Commit and
+    cancellation are mutually exclusive, so a cancellation that wins the race
+    prevents the mutation from starting and a timed-out flush never persists
+    memory. Cancellation itself never waits on backend I/O: if a final mutation
+    is already running it was authorized before the deadline, so :meth:`cancel`
+    records the request without blocking rather than joining the operation.
     """
 
     def __init__(self) -> None:
-        self._cancelled = threading.Event()
+        self._lock = threading.Lock()
+        self._cancelled = False
 
     @property
     def cancelled(self) -> bool:
-        return self._cancelled.is_set()
+        with self._lock:
+            return self._cancelled
 
     def commit(self, operation: Any) -> bool:
-        if self._cancelled.is_set():
-            return False
-        operation()
-        return True
+        with self._lock:
+            if self._cancelled:
+                return False
+            operation()
+            return True
 
     def cancel(self) -> None:
-        self._cancelled.set()
+        # Try to serialize with commit() so an unauthorized mutation can never
+        # start after the deadline. If the lock is already held a commit is
+        # in flight and was authorized before now; do not block on its I/O.
+        if self._lock.acquire(blocking=False):
+            try:
+                self._cancelled = True
+            finally:
+                self._lock.release()
+        else:
+            self._cancelled = True
 
 
 class _StagedMemory:
@@ -364,9 +379,11 @@ def run_pre_compaction_flush_sync(
 
     The worker runs in a daemon thread so a stuck provider cannot delay process
     shutdown. Its memory writes are staged and commits that have not been
-    authorized by the deadline are discarded. A final atomic mutation already
-    in progress may finish after timeout, so backends must keep it non-blocking;
-    cancellation never waits for backend I/O.
+    authorized by the deadline are discarded. Cancellation is serialized with
+    the final atomic mutation, so a flush reported as timed out never starts a
+    new mutation; only a mutation already authorized before the deadline may
+    finish. Backends must therefore keep that final mutation short and
+    non-blocking, and cancellation never waits on backend I/O.
     """
     resolved, transcript, count, skipped = _prepare_flush(
         parent_agent, messages_to_flush, config

--- a/src/praisonai-agents/praisonaiagents/memory/file_memory.py
+++ b/src/praisonai-agents/praisonaiagents/memory/file_memory.py
@@ -379,7 +379,8 @@ class FileMemory:
                         "Memory batch deadline expired before atomic commit"
                     )
                 if not commit_guard.commit(
-                    lambda: os.replace(tmp_path, filepath)
+                    lambda: os.replace(tmp_path, filepath),
+                    deadline=deadline,
                 ):
                     raise TimeoutError("Memory batch was cancelled")
                 tmp_path = None

--- a/src/praisonai-agents/tests/unit/compaction/test_memory_flush.py
+++ b/src/praisonai-agents/tests/unit/compaction/test_memory_flush.py
@@ -334,6 +334,48 @@ def test_sync_timeout_does_not_wait_for_blocked_atomic_backend():
     assert elapsed < 0.25
 
 
+def test_commit_guard_cancel_blocks_unstarted_mutation():
+    from praisonaiagents.compaction.memory_flush import _AtomicCommitGuard
+
+    guard = _AtomicCommitGuard()
+    guard.cancel()
+
+    mutated = []
+    assert guard.commit(lambda: mutated.append(True)) is False
+    assert mutated == []
+    assert guard.cancelled is True
+
+
+def test_commit_guard_cancel_does_not_block_authorized_mutation():
+    import threading
+    import time
+
+    from praisonaiagents.compaction.memory_flush import _AtomicCommitGuard
+
+    guard = _AtomicCommitGuard()
+    in_operation = threading.Event()
+    release = threading.Event()
+    committed = []
+
+    def _slow_operation():
+        in_operation.set()
+        release.wait(1)
+        committed.append(True)
+
+    worker = threading.Thread(target=lambda: guard.commit(_slow_operation))
+    worker.start()
+    assert in_operation.wait(1)
+
+    started = time.monotonic()
+    guard.cancel()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.25
+    release.set()
+    worker.join(1)
+    assert committed == [True]
+
+
 def test_file_memory_batch_is_atomic_across_multiple_stores(tmp_path):
     from praisonaiagents.memory.file_memory import FileMemory
 

--- a/src/praisonai-agents/tests/unit/compaction/test_memory_flush.py
+++ b/src/praisonai-agents/tests/unit/compaction/test_memory_flush.py
@@ -313,24 +313,39 @@ def test_sync_timeout_does_not_wait_for_blocked_atomic_backend():
     def _child(_parent, _config, memory_override=None):
         return _Child(memory_override)
 
-    started_at = time.monotonic()
+    result_holder = {}
+    caller_finished = threading.Event()
+
+    def _run_flush():
+        try:
+            result_holder["result"] = run_pre_compaction_flush_sync(
+                _parent(_Backend()),
+                _messages(),
+                PreCompactionMemoryFlushConfig(
+                    min_turns_to_flush=1, timeout_seconds=0.1
+                ),
+            )
+        finally:
+            caller_finished.set()
+
     with patch(
         "praisonaiagents.compaction.memory_flush.create_memory_flush_agent",
         side_effect=_child,
     ):
-        result = run_pre_compaction_flush_sync(
-            _parent(_Backend()),
-            _messages(),
-            PreCompactionMemoryFlushConfig(
-                min_turns_to_flush=1, timeout_seconds=0.02
-            ),
-        )
-    elapsed = time.monotonic() - started_at
-    release.set()
+        caller = threading.Thread(target=_run_flush)
+        caller.start()
+        try:
+            assert commit_started.wait(1)
+            started_at = time.monotonic()
+            assert caller_finished.wait(0.25)
+            elapsed = time.monotonic() - started_at
+        finally:
+            release.set()
+            caller.join(1)
 
-    assert commit_started.wait(1)
+    assert not caller.is_alive()
     assert commit_finished.wait(1)
-    assert result.reason == "timeout"
+    assert result_holder["result"].reason == "timeout"
     assert elapsed < 0.25
 
 

--- a/src/praisonai-agents/tests/unit/compaction/test_memory_flush.py
+++ b/src/praisonai-agents/tests/unit/compaction/test_memory_flush.py
@@ -286,6 +286,54 @@ def test_sync_timeout_includes_staged_memory_commit():
     assert committed == []
 
 
+def test_sync_timeout_does_not_wait_for_blocked_atomic_backend():
+    import threading
+    import time
+
+    commit_started = threading.Event()
+    release = threading.Event()
+    commit_finished = threading.Event()
+
+    class _Backend:
+        def commit_memory_batch(self, writes, *, deadline, commit_guard):
+            def _blocked_atomic_operation():
+                commit_started.set()
+                release.wait(1)
+                commit_finished.set()
+
+            commit_guard.commit(_blocked_atomic_operation)
+
+    class _Child:
+        def __init__(self, memory):
+            self.memory = memory
+
+        def start(self, _prompt):
+            self.memory.store_long_term("durable fact")
+
+    def _child(_parent, _config, memory_override=None):
+        return _Child(memory_override)
+
+    started_at = time.monotonic()
+    with patch(
+        "praisonaiagents.compaction.memory_flush.create_memory_flush_agent",
+        side_effect=_child,
+    ):
+        result = run_pre_compaction_flush_sync(
+            _parent(_Backend()),
+            _messages(),
+            PreCompactionMemoryFlushConfig(
+                min_turns_to_flush=1, timeout_seconds=0.02
+            ),
+        )
+    elapsed = time.monotonic() - started_at
+    release.set()
+
+    assert commit_started.wait(1)
+    assert commit_finished.wait(1)
+    assert result.reason == "timeout"
+    assert elapsed < 0.25
+
+
 def test_file_memory_batch_is_atomic_across_multiple_stores(tmp_path):
     from praisonaiagents.memory.file_memory import FileMemory
 

--- a/src/praisonai-agents/tests/unit/compaction/test_memory_flush.py
+++ b/src/praisonai-agents/tests/unit/compaction/test_memory_flush.py
@@ -203,7 +203,9 @@ def test_sync_timeout_discards_late_memory_writes():
             self.commits = []
 
         def commit_memory_batch(self, writes, *, deadline, commit_guard):
-            commit_guard.commit(lambda: self.commits.extend(writes))
+            commit_guard.commit(
+                lambda: self.commits.extend(writes), deadline=deadline
+            )
 
     backend = _Backend()
     release = __import__("threading").Event()
@@ -251,7 +253,9 @@ def test_sync_timeout_includes_staged_memory_commit():
         def commit_memory_batch(self, writes, *, deadline, commit_guard):
             commit_started.set()
             release.wait(1)
-            commit_guard.commit(lambda: committed.extend(writes))
+            commit_guard.commit(
+                lambda: committed.extend(writes), deadline=deadline
+            )
             commit_finished.set()
 
     backend = _Backend()
@@ -301,7 +305,7 @@ def test_sync_timeout_does_not_wait_for_blocked_atomic_backend():
                 release.wait(1)
                 commit_finished.set()
 
-            commit_guard.commit(_blocked_atomic_operation)
+            commit_guard.commit(_blocked_atomic_operation, deadline=deadline)
 
     class _Child:
         def __init__(self, memory):
@@ -350,15 +354,33 @@ def test_sync_timeout_does_not_wait_for_blocked_atomic_backend():
 
 
 def test_commit_guard_cancel_blocks_unstarted_mutation():
+    import time
+
     from praisonaiagents.compaction.memory_flush import _AtomicCommitGuard
 
     guard = _AtomicCommitGuard()
     guard.cancel()
 
     mutated = []
-    assert guard.commit(lambda: mutated.append(True)) is False
+    assert guard.commit(
+        lambda: mutated.append(True), deadline=time.monotonic() + 1
+    ) is False
     assert mutated == []
     assert guard.cancelled is True
+
+
+def test_commit_guard_rejects_expired_deadline():
+    import time
+
+    from praisonaiagents.compaction.memory_flush import _AtomicCommitGuard
+
+    guard = _AtomicCommitGuard()
+    mutated = []
+
+    assert guard.commit(
+        lambda: mutated.append(True), deadline=time.monotonic() - 1
+    ) is False
+    assert mutated == []
 
 
 def test_commit_guard_cancel_does_not_block_authorized_mutation():
@@ -374,20 +396,36 @@ def test_commit_guard_cancel_does_not_block_authorized_mutation():
 
     def _slow_operation():
         in_operation.set()
-        release.wait(1)
+        release.wait()
         committed.append(True)
 
-    worker = threading.Thread(target=lambda: guard.commit(_slow_operation))
+    cancel_returned = threading.Event()
+
+    def _cancel():
+        guard.cancel()
+        cancel_returned.set()
+
+    worker = threading.Thread(
+        target=lambda: guard.commit(
+            _slow_operation, deadline=time.monotonic() + 1
+        )
+    )
     worker.start()
-    assert in_operation.wait(1)
+    cancel_worker = None
+    try:
+        assert in_operation.wait(1)
+        cancel_worker = threading.Thread(target=_cancel)
+        cancel_worker.start()
+        assert cancel_returned.wait(1)
+        assert not release.is_set()
+    finally:
+        release.set()
+        worker.join(1)
+        if cancel_worker is not None:
+            cancel_worker.join(1)
 
-    started = time.monotonic()
-    guard.cancel()
-    elapsed = time.monotonic() - started
-
-    assert elapsed < 0.25
-    release.set()
-    worker.join(1)
+    assert not worker.is_alive()
+    assert cancel_worker is not None and not cancel_worker.is_alive()
     assert committed == [True]
 
 
@@ -575,7 +613,9 @@ async def test_async_flush_uses_async_memory_commit_with_shared_deadline():
         async def acommit_memory_batch(
             self, writes, *, deadline, commit_guard
         ):
-            commit_guard.commit(lambda: self.commits.extend(writes))
+            commit_guard.commit(
+                lambda: self.commits.extend(writes), deadline=deadline
+            )
 
     backend = _Backend()
 


### PR DESCRIPTION
## Summary

- keep synchronous memory-flush timeout cancellation non-blocking
- serialize final commit authorization with cancellation
- recheck the shared deadline inside the authorization guard
- preserve the explicit contract for already-authorized final mutations
- add deterministic cancellation, deadline, and blocked-backend regressions

## Testing

```console
python -m pytest tests/unit/compaction/test_memory_flush.py -q --timeout=30
```

30 passed.

Fixes #3924