### PR TITLE
test: verify streamed tool follow-up completion

### DIFF
--- a/src/praisonai-agents/tests/integration/test_stream_tool_dispatch_real.py
+++ b/src/praisonai-agents/tests/integration/test_stream_tool_dispatch_real.py
@@ -26,7 +26,9 @@ def test_real_agent_dispatches_tool_while_streaming():
         llm="gpt-4o-mini",
         instructions=(
             "Always call stream_lookup exactly once before answering. "
-            "Include the tool's complete result in the final answer."
+            "After the tool call, reply with the exact marker "
+            "STREAM-FOLLOW-UP-COMPLETE and include the tool's complete "
+            "result in the final answer."
         ),
         tools=[stream_lookup],
     )
@@ -39,4 +41,5 @@ def test_real_agent_dispatches_tool_while_streaming():
 
     print(result)
     assert calls == ["NEBULA-7"]
+    assert "STREAM-FOLLOW-UP-COMPLETE" in result
     assert "stream-result:NEBULA-7" in result

--- a/src/praisonai-agents/tests/integration/test_stream_tool_dispatch_real.py
+++ b/src/praisonai-agents/tests/integration/test_stream_tool_dispatch_real.py
@@ -1,4 +1,8 @@
-"""Opt-in real-provider coverage for streamed tool dispatch."""
+"""Opt-in real-provider coverage for streamed tool dispatch.
+
+Run with ``RUN_REAL_KEY_TESTS=1`` and ``OPENAI_API_KEY`` set to exercise the
+provider-backed follow-up completion path.
+"""
 
 import os
 


### PR DESCRIPTION
## Summary
- require the opt-in real-provider stream test to observe a distinct follow-up completion marker
- keep the exact streamed tool-result assertion
- document how to enable the provider-backed test

## Context
PR #3927 was merged before the final review fix in discussion_r3783638720 reached the pull request head. The production dispatch fix is already on main; this follow-up carries only the missing regression evidence.

## Validation
- python -m pytest tests/unit/llm/test_stream_tool_dispatch.py tests/integration/test_stream_tool_dispatch_real.py -q (1 passed, 1 skipped because real-provider credentials are opt-in)
- python -m ruff check tests/integration/test_stream_tool_dispatch_real.py