### PR TITLE
fix: coordinate async state access with deepcopy

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/async_safety.py
+++ b/src/praisonai-agents/praisonaiagents/agent/async_safety.py
@@ -110,14 +110,32 @@ class AsyncSafeState:
     def __init__(self, initial_value: Any = None):
         self.value = initial_value
         self._lock = DualLock()
+        self._activity_lock = threading.Lock()
+        self._async_holders = 0
+        self._copying = False
 
     def __deepcopy__(self, memo):
-        """Copy the protected value while replacing all lock state."""
+        """Copy protected state, rejecting overlap with asynchronous access."""
         result = type(self).__new__(type(self))
         memo[id(self)] = result
-        with self.lock():
-            result.value = copy.deepcopy(self.value, memo)
+        with self._activity_lock:
+            if self._async_holders:
+                raise RuntimeError(
+                    "Cannot deepcopy AsyncSafeState during asynchronous access"
+                )
+            if self._copying:
+                raise RuntimeError("AsyncSafeState deepcopy is already in progress")
+            self._copying = True
+        try:
+            with self.lock():
+                result.value = copy.deepcopy(self.value, memo)
+        finally:
+            with self._activity_lock:
+                self._copying = False
         result._lock = DualLock()
+        result._activity_lock = threading.Lock()
+        result._async_holders = 0
+        result._copying = False
         return result
         
     @contextmanager 
@@ -130,7 +148,25 @@ class AsyncSafeState:
     async def async_lock(self):
         """Acquire lock in async context."""
         async with self._lock.async_lock():
-            yield self.value
+            self._begin_async_access()
+            try:
+                yield self.value
+            finally:
+                self._end_async_access()
+
+    def _begin_async_access(self) -> None:
+        """Register async access unless a synchronous copy is in progress."""
+        with self._activity_lock:
+            if self._copying:
+                raise RuntimeError(
+                    "Cannot access AsyncSafeState during synchronous deepcopy"
+                )
+            self._async_holders += 1
+
+    def _end_async_access(self) -> None:
+        """Unregister one active asynchronous accessor."""
+        with self._activity_lock:
+            self._async_holders -= 1
             
     def __enter__(self):
         """Support for synchronous context manager protocol (backward compatibility)."""
@@ -146,12 +182,20 @@ class AsyncSafeState:
         """Support for asynchronous context manager protocol."""
         async_lock = self._lock._get_async_lock()
         await async_lock.acquire()
+        try:
+            self._begin_async_access()
+        except Exception:
+            async_lock.release()
+            raise
         return self.value
         
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Support for asynchronous context manager protocol."""
         async_lock = self._lock._get_async_lock()
-        async_lock.release()
+        try:
+            self._end_async_access()
+        finally:
+            async_lock.release()
         return None
             
     def get(self) -> Any:

--- a/src/praisonai-agents/tests/unit/agent/test_agent_clone.py
+++ b/src/praisonai-agents/tests/unit/agent/test_agent_clone.py
@@ -107,7 +107,15 @@ class TestAgentDeepCopy:
         assert agent._approvals_lock.locked() is True
         assert cloned._approvals_lock.locked() is False
 
-    def test_deepcopy_rejects_active_async_state_access(self):
+    @pytest.mark.parametrize(
+        "use_async_lock_helper",
+        [True, False],
+        ids=["async-lock-helper", "async-context-manager"],
+    )
+    def test_deepcopy_rejects_active_async_state_access(
+        self,
+        use_async_lock_helper,
+    ):
         from praisonaiagents.agent.async_safety import AsyncSafeState
 
         async def _exercise():
@@ -116,7 +124,8 @@ class TestAgentDeepCopy:
             release = asyncio.Event()
 
             async def _hold_state():
-                async with state.async_lock():
+                context = state.async_lock() if use_async_lock_helper else state
+                async with context:
                     entered.set()
                     await release.wait()
 

--- a/src/praisonai-agents/tests/unit/agent/test_agent_clone.py
+++ b/src/praisonai-agents/tests/unit/agent/test_agent_clone.py
@@ -11,6 +11,8 @@ import asyncio
 import copy
 import threading
 
+import pytest
+
 
 class TestAgentDeepCopy:
     """Test Agent.__deepcopy__ and clone_for_channel()."""
@@ -104,3 +106,33 @@ class TestAgentDeepCopy:
         assert cloned._approvals_lock is not agent._approvals_lock
         assert agent._approvals_lock.locked() is True
         assert cloned._approvals_lock.locked() is False
+
+    def test_deepcopy_rejects_active_async_state_access(self):
+        from praisonaiagents.agent.async_safety import AsyncSafeState
+
+        async def _exercise():
+            state = AsyncSafeState(["stable"])
+            entered = asyncio.Event()
+            release = asyncio.Event()
+
+            async def _hold_state():
+                async with state.async_lock():
+                    entered.set()
+                    await release.wait()
+
+            holder = asyncio.create_task(_hold_state())
+            await entered.wait()
+            try:
+                with pytest.raises(
+                    RuntimeError,
+                    match="during asynchronous access",
+                ):
+                    copy.deepcopy(state)
+            finally:
+                release.set()
+                await holder
+
+            cloned = copy.deepcopy(state)
+            assert cloned.value == ["stable"]
+
+        asyncio.run(_exercise())

--- a/src/praisonai-agents/tests/unit/agent/test_agent_clone.py
+++ b/src/praisonai-agents/tests/unit/agent/test_agent_clone.py
@@ -14,6 +14,18 @@ import threading
 import pytest
 
 
+class _BlockingDeepcopyValue:
+    def __init__(self, entered, release):
+        self.entered = entered
+        self.release = release
+
+    def __deepcopy__(self, memo):
+        self.entered.set()
+        if not self.release.wait(timeout=5):
+            raise TimeoutError("timed out waiting to finish deepcopy")
+        return "copied"
+
+
 class TestAgentDeepCopy:
     """Test Agent.__deepcopy__ and clone_for_channel()."""
 
@@ -143,5 +155,45 @@ class TestAgentDeepCopy:
 
             cloned = copy.deepcopy(state)
             assert cloned.value == ["stable"]
+
+        asyncio.run(_exercise())
+
+    @pytest.mark.parametrize(
+        "use_async_lock_helper",
+        [True, False],
+        ids=["async-lock-helper", "async-context-manager"],
+    )
+    def test_async_state_access_rejects_active_deepcopy(
+        self,
+        use_async_lock_helper,
+    ):
+        from praisonaiagents.agent.async_safety import AsyncSafeState
+
+        async def _exercise():
+            copy_entered = threading.Event()
+            copy_release = threading.Event()
+            state = AsyncSafeState(
+                _BlockingDeepcopyValue(copy_entered, copy_release)
+            )
+            copy_task = asyncio.create_task(asyncio.to_thread(copy.deepcopy, state))
+            assert await asyncio.to_thread(copy_entered.wait, 5)
+
+            try:
+                context = state.async_lock() if use_async_lock_helper else state
+                with pytest.raises(
+                    RuntimeError,
+                    match="during synchronous deepcopy",
+                ):
+                    async with context:
+                        pass
+            finally:
+                copy_release.set()
+
+            cloned = await copy_task
+            assert cloned.value == "copied"
+
+            context = state.async_lock() if use_async_lock_helper else state
+            async with context as value:
+                assert value is state.value
 
         asyncio.run(_exercise())


### PR DESCRIPTION
## Summary
- reject synchronous deepcopy while AsyncSafeState has active asynchronous access
- reject new async access while a synchronous deepcopy is in progress
- cover both async_lock() and direct async context-manager entry, plus successful copying after release

## Context
PR #3929 was merged before the accepted fix for discussion_r3783613945 reached the pull request head. Current main still lacks coordination between deepcopy and the per-event-loop async lock, so this is the focused follow-up.

## Validation
- python -m pytest tests/unit/agent/test_agent_clone.py -q (16 passed)
- python -m ruff check tests/unit/agent/test_agent_clone.py praisonaiagents/agent/async_safety.py