### PR TITLE
docs(readme): lead with the five-layer agent stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ agent = Agent(
 )
 ```
 
-> **Isolate** is `handoffs=[specialist]` — a sub-agent inherits a summary and the intersection of your tools, not your whole transcript. [📖 Handoffs](https://docs.praison.ai/docs/concepts/handoffs)
+> **Isolate** is `handoffs=[specialist]` — a sub-agent inherits the last few messages and the intersection of your tools, not your whole transcript. [📖 Handoffs](https://docs.praison.ai/docs/concepts/handoffs)
 
 ### Layer 3 · Harness — *Can it act, and be checked?*
 
@@ -211,7 +211,9 @@ agent = Agent(
 result = agent.run_autonomous("Refactor the auth module", max_iterations=5)
 
 print(result.completion_reason)
-# goal | no_tool_calls | max_iterations | timeout | budget_exhausted | doom_loop | needs_help
+# goal | no_tool_calls | max_iterations | timeout | doom_loop | needs_help | error
+# (with on_budget_exceeded="stop", hitting the cap raises BudgetExceededError,
+#  surfaced here as completion_reason="error")
 ```
 
 > **Doom-loop detection is on by default.** Repeated identical tool calls and A→B→A→B oscillation get caught — while a poller whose output keeps changing does not. [📖 Doom Loop Detection](https://docs.praison.ai/docs/features/doom-loop-detection)
@@ -254,14 +256,15 @@ sandboxed = ManagedAgent(
 )
 agent = Agent(name="builder", backend=sandboxed)
 
-# B. The entire agent loop runs in the cloud
+# B. The entire agent loop runs in the cloud (needs ANTHROPIC_API_KEY;
+#    with no key set, ManagedAgent() falls back to a local loop)
 agent = Agent(name="teacher", backend=ManagedAgent())
 agent.start("Write a Python script that prints the first 10 primes, then run it")
 ```
 
 Sandboxes shut themselves down when idle (`auto_shutdown`, `idle_timeout_s`), and a post-setup snapshot is reused so the next run skips the image pull and dependency install. Commit a `.praisonai/environment.yaml` and the environment travels with the repo.
 
-> 📖 [20 runnable examples](examples/python/managed-agents/) · manage sessions with `praisonai managed sessions list|resume`
+> 📖 [20 runnable examples](examples/python/managed-agents/) · manage sessions with `praisonai managed sessions list <agent-id>` or `praisonai managed sessions resume <session-id> "<prompt>"`
 
 <sub>Stack framing adapted from [The Five-Layer Agent Stack](https://mer.vin/2026/07/five-layer-agent-stack-match-bug-to-right-layer/) and [Agent Harnesses vs Orbs](https://mer.vin/2026/08/agent-harnesses-vs-orbs-why-remote-sandboxes-beat-local-agent-loops/).</sub>
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,167 @@ agent.start("Analyze the top 3 tech trends of 2026 and format as a markdown tabl
 
 ---
 
+## 🧬 The Five-Layer Agent Stack
+
+Most frameworks hand you one or two layers and leave the rest as homework. PraisonAI covers **all five** — plus the outer layer that decides *where* your agent actually runs.
+
+Each layer wraps the one inside it. When an agent misbehaves, the layer tells you where to look.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ ⬡ MANAGED AGENTS — Where does it actually run?                  │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ 5 · GRAPH — Who runs when, and who checks whom?             │ │
+│ │ ┌─────────────────────────────────────────────────────────┐ │ │
+│ │ │ 4 · LOOP — When do we stop?                             │ │ │
+│ │ │ ┌─────────────────────────────────────────────────────┐ │ │ │
+│ │ │ │ 3 · HARNESS — Can it act, and be checked?           │ │ │ │
+│ │ │ │ ┌─────────────────────────────────────────────────┐ │ │ │ │
+│ │ │ │ │ 2 · CONTEXT — Is the right thing in the window? │ │ │ │ │
+│ │ │ │ │ ┌─────────────────────────────────────────────┐ │ │ │ │ │
+│ │ │ │ │ │ 1 · PROMPT — Did I say it clearly?          │ │ │ │ │ │
+│ │ │ │ │ └─────────────────────────────────────────────┘ │ │ │ │ │
+│ │ │ │ └─────────────────────────────────────────────────┘ │ │ │ │
+│ │ │ └─────────────────────────────────────────────────────┘ │ │ │
+│ │ └─────────────────────────────────────────────────────────┘ │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+| Layer | The question it answers | PraisonAI |
+|:--|:--|:--|
+| **1 · Prompt** | Did I say it clearly? | `instructions=`, `role`/`goal`/`backstory`, `output=`, `templates=` |
+| **2 · Context** | Is the right thing in the window? | `memory=`, `knowledge=`, `context=`, handoff `ContextPolicy` |
+| **3 · Harness** | Can it act, and be checked? | `tools=`, `MCP()`, `guardrails=`, `approval=`, `hooks=`, `sandbox=` |
+| **4 · Loop** | When do we stop? | `execution=ExecutionConfig(...)`, `reflection=`, `autonomy=`, doom-loop detection |
+| **5 · Graph** | Who runs when, and who checks whom? | `AgentFlow`, `route()`, `parallel()`, `loop()`, `repeat()` |
+| **⬡ Managed** | *Where does it actually run?* | `backend=ManagedAgent(compute="e2b")` — remote sandbox, or a fully hosted loop |
+
+### Layer 1 · Prompt — *Did I say it clearly?*
+
+Role, instructions, examples, output format.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    role="Senior Data Analyst",
+    goal="Turn raw numbers into decisions",
+    output="verbose",              # markdown-formatted output
+)
+agent.start("Summarise Q3 revenue trends")
+```
+
+### Layer 2 · Context — *Is the right thing in the window?*
+
+Write, select, compress, isolate — the four context operations, one parameter each.
+
+```python
+from praisonaiagents import Agent
+
+agent = Agent(
+    instructions="You are a support engineer.",
+    memory={"user_id": "u-42"},    # write    — persists across runs (needs a user_id)
+    knowledge=["docs/"],           # select   — retrieves only what's relevant
+    context="summarize",           # compress — auto-compacts before the limit
+)
+```
+
+> **Isolate** is `handoffs=[specialist]` — a sub-agent inherits a summary and the intersection of your tools, not your whole transcript. [📖 Handoffs](https://docs.praison.ai/docs/concepts/handoffs)
+
+### Layer 3 · Harness — *Can it act, and be checked?*
+
+*Agent = Model + Harness.* Tool dispatch, plus the guides that steer before acting and the sensors that observe after.
+
+```python
+from praisonaiagents import Agent, MCP, tool
+
+@tool
+def deploy(env: str) -> str:
+    """Deploy the current build to an environment."""
+    return f"Deployed to {env}"
+
+agent = Agent(
+    name="ReleaseEngineer",
+    instructions="You are a release engineer.",
+    tools=[deploy, MCP("npx -y @modelcontextprotocol/server-filesystem /tmp")],
+    approval=True,                 # guide — human gate before risky tools run
+)
+agent.start("Deploy to staging, then list the files you can read")
+```
+
+### Layer 4 · Loop — *When do we stop?*
+
+Hard iteration caps, budget ceilings, no-progress detection and completion checks — every brake is explicit.
+
+```python
+from praisonaiagents import Agent, ExecutionConfig
+
+agent = Agent(
+    instructions="Fix the failing tests.",
+    execution=ExecutionConfig(max_iter=30, max_budget=0.50, on_budget_exceeded="stop"),
+    reflection=True,               # completion check — the agent grades its own answer
+    autonomy=True,                 # required to drive the loop with run_autonomous()
+)
+result = agent.run_autonomous("Refactor the auth module", max_iterations=5)
+
+print(result.completion_reason)
+# goal | no_tool_calls | max_iterations | timeout | budget_exhausted | doom_loop | needs_help
+```
+
+> **Doom-loop detection is on by default.** Repeated identical tool calls and A→B→A→B oscillation get caught — while a poller whose output keeps changing does not. [📖 Doom Loop Detection](https://docs.praison.ai/docs/features/doom-loop-detection)
+
+### Layer 5 · Graph — *Who runs when, and who checks whom?*
+
+Topology as a versionable artifact: prompt chaining, routing, parallelisation, orchestrator-worker.
+
+```python
+from praisonaiagents import AgentFlow
+from praisonaiagents.workflows import route, parallel, repeat
+
+flow = AgentFlow(steps=[
+    classifier,
+    route({"bug": [bug_agent], "feature": [feature_agent], "default": [triage]}),
+    parallel([reviewer, tester]),                      # fan out, join automatically
+    repeat(editor, until=lambda ctx: "approved" in ctx.previous_result.lower(),
+           max_iterations=3),                          # evaluator–optimizer
+])
+flow.run("Ticket #123: login fails on Safari")
+```
+
+> The same graph is expressible in YAML with no Python at all. [📖 AgentFlow](https://docs.praison.ai/docs/concepts/agentflow)
+
+### ⬡ Outside the stack: Managed Agents — *Where does it actually run?*
+
+The harness is commoditising; **where** the agent executes is the next multiplier. Rather than burning your laptop's CPU, hand an agent a short-lived cloud sandbox — repo, tools and tests run there.
+
+```bash
+pip install praisonai
+```
+
+```python
+from praisonai import Agent, ManagedAgent, LocalManagedConfig
+
+# A. Tools run in a remote sandbox; the agent loop stays local
+sandboxed = ManagedAgent(
+    provider="local", compute="e2b",   # or modal | daytona | flyio | docker | tenki
+    config=LocalManagedConfig(model="gpt-4o-mini", name="RemoteTools"),
+)
+agent = Agent(name="builder", backend=sandboxed)
+
+# B. The entire agent loop runs in the cloud
+agent = Agent(name="teacher", backend=ManagedAgent())
+agent.start("Write a Python script that prints the first 10 primes, then run it")
+```
+
+Sandboxes shut themselves down when idle (`auto_shutdown`, `idle_timeout_s`), and a post-setup snapshot is reused so the next run skips the image pull and dependency install. Commit a `.praisonai/environment.yaml` and the environment travels with the repo.
+
+> 📖 [20 runnable examples](examples/python/managed-agents/) · manage sessions with `praisonai managed sessions list|resume`
+
+<sub>Stack framing adapted from [The Five-Layer Agent Stack](https://mer.vin/2026/07/five-layer-agent-stack-match-bug-to-right-layer/) and [Agent Harnesses vs Orbs](https://mer.vin/2026/08/agent-harnesses-vs-orbs-why-remote-sandboxes-beat-local-agent-loops/).</sub>
+
+---
+
 ## 🌌 The PraisonAI Ecosystem
 
 Start simple with the core SDK, or expand to full visual builders and dashboards when you're ready.
@@ -200,9 +361,9 @@ Powered by 100+ LLMs (OpenAI, Anthropic, Gemini & local models).
 | 🧠 | **Planning Mode** — plan → execute → reason | `planning=True` |
 | 🔍 | **Deep Research** — multi-step autonomous research | [Docs](https://docs.praison.ai/docs/agents/deep-research) |
 | 🤖 | **External Agents** — orchestrate Claude Code, Gemini CLI, Codex | [Docs](https://docs.praison.ai/docs/code/external-agents) |
-| 🔄 | **Agent Handoffs** — seamless conversation passing | `handoff=True` |
+| 🔄 | **Agent Handoffs** — seamless conversation passing | `handoffs=[other_agent]` |
 | 🛡️ | **Guardrails** — input/output validation | [Docs](https://docs.praison.ai/docs/concepts/guardrails) |
-|  | **Web Search + Fetch** — native browsing | `web_search=True` |
+|  | **Web Search + Fetch** — native browsing | `web=True` |
 | 🪞 | **Self Reflection** — agent reviews its own output | [Docs](https://docs.praison.ai/docs/concepts/reflection) |
 | 🔀 | **Workflow Patterns** — route, parallel, loop, repeat | [Docs](https://docs.praison.ai/docs/concepts/agentflow) |
 | 🧠 | **Memory (zero deps)** — works out of the box | `memory=True` |
@@ -212,9 +373,9 @@ Powered by 100+ LLMs (OpenAI, Anthropic, Gemini & local models).
 
 | | Feature | How |
 |--|---------|-----|
-| 💡 | **Prompt Caching** — reduce latency + cost | `prompt_caching=True` |
+| 💡 | **Prompt Caching** — reduce latency + cost | `caching=True` |
 | 💾 | **Sessions + Auto-Save** — persistent state across restarts | `auto_save="my-project"` |
-| 💭 | **Thinking Budgets** — control reasoning depth | `thinking_budget=1024` |
+| 💭 | **Thinking Budgets** — control reasoning depth | `agent.thinking_budget = 1024` |
 | 📚 | **RAG + Quality-Based RAG** — auto quality scoring retrieval | [Docs](https://docs.praison.ai/docs/concepts/rag) |
 | 📊 | **Model Router** — auto-routes to cheapest capable model | [Docs](https://docs.praison.ai/docs/features/model-router) |
 | 🧊 | **Shadow Git Checkpoints** — auto-rollback on failure | [Docs](https://docs.praison.ai/docs/features/checkpoints) |
@@ -341,8 +502,10 @@ from praisonaiagents import Agent, db
 
 agent = Agent(
     name="Assistant",
-    db=db(database_url="postgresql://localhost/mydb"),
-    session_id="my-session"
+    memory={
+        "db": db(database_url="postgresql://localhost/mydb"),
+        "session_id": "my-session",
+    },
 )
 agent.chat("Hello!")  # Auto-persists messages, runs, traces
 ```
@@ -891,8 +1054,10 @@ from praisonaiagents import Agent, db
 
 agent = Agent(
     name="Assistant",
-    db=db(database_url="postgresql://localhost/mydb"),
-    session_id="my-session"
+    memory={
+        "db": db(database_url="postgresql://localhost/mydb"),
+        "session_id": "my-session",
+    },
 )
 ```
 
@@ -908,8 +1073,8 @@ from praisonaiagents import Agent
 
 agent = Agent(
     name="Assistant",
-    memory=True,  # Enables file-based memory (no extra deps!)
-    user_id="user123"
+    # Enables file-based memory (no extra deps!)
+    memory={"user_id": "user123"},
 )
 ```
 


### PR DESCRIPTION
## What

Adds a **Five-Layer Agent Stack** section to the README (right after "Meet your first Agent"), showing that PraisonAI covers every layer of the agent stack — not just multi-agent orchestration.

- Concentric-ring ASCII diagram (each layer wraps the one inside it)
- Summary table mapping each layer to its PraisonAI API
- A short example per layer

| Layer | Question | PraisonAI |
|:--|:--|:--|
| 1 · Prompt | Did I say it clearly? | `instructions=`, `role`/`goal`, `output=` |
| 2 · Context | Is the right thing in the window? | `memory=`, `knowledge=`, `context=` |
| 3 · Harness | Can it act, and be checked? | `tools=`, `MCP()`, `approval=` |
| 4 · Loop | When do we stop? | `execution=ExecutionConfig(...)`, `reflection=`, `autonomy=` |
| 5 · Graph | Who runs when, who checks whom? | `AgentFlow`, `route()`, `parallel()`, `repeat()` |
| ⬡ Managed | *Where does it actually run?* | `backend=ManagedAgent(compute="e2b")` |

Framing adapted from [The Five-Layer Agent Stack](https://mer.vin/2026/07/five-layer-agent-stack-match-bug-to-right-layer/) and [Agent Harnesses vs Orbs](https://mer.vin/2026/08/agent-harnesses-vs-orbs-why-remote-sandboxes-beat-local-agent-loops/).

**On the outer layer:** the "Orb" concept maps to what this codebase already calls **Managed Agents**. The word *Orb* appears nowhere in the repo (it's Amp's product term), so the section presents Managed Agents as the equivalent and cites the article for the idea. It keeps the two real shapes distinct — `ManagedAgent(compute="e2b")` runs *tools* remotely with a local loop, while bare `ManagedAgent()` hosts the *entire loop*. Claims are limited to what's implemented (auto-shutdown, snapshot reuse); multi-instance parallel fan-out and instance pause/resume are **not** claimed, because they aren't implemented.

## Also: corrected API claims that raise `TypeError`

`Agent.__init__` takes no `**kwargs`, so these were hard failures for anyone copy-pasting:

| Was | Now |
|:--|:--|
| `handoff=True` | `handoffs=[other_agent]` |
| `web_search=True` | `web=True` |
| `prompt_caching=True` | `caching=True` |
| `thinking_budget=1024` | `agent.thinking_budget = 1024` (property) |
| `Agent(db=…, session_id=…)` | `Agent(memory={"db": …, "session_id": …})` |
| `Agent(memory=True, user_id=…)` | `Agent(memory={"user_id": …})` |

`planning=True` was checked and is valid — left untouched. No existing content removed (175 insertions, 10 deletions; every deleted line is one of the corrections above).

## Verification

Every snippet was **executed** against the local source (`PYTHONPATH=src/praisonai-agents`), not just constructed. Running them surfaced three bugs in my own first draft, now fixed:

- `run_autonomous()` raises without `autonomy=` set → added
- MCP `args=[...]` form yields **0 tools**; the single-string form yields 14 → switched
- `memory=True` alone warns it uses a non-shared auto-id and does *not* persist across runs → now passes `user_id`

Confirmed working end-to-end: L1, L2 (memory + context), L3 (local tool + real MCP filesystem calls), L4 (returns a real `TerminationReason`), L5 (classify → route → parallel → repeat-until-approved).

Not fully verifiable in my environment, stated plainly rather than assumed:
- `knowledge=["docs/"]` — this OpenAI key has no access to any embedding model (403), so indexing silently falls back to general knowledge. The line is the documented API and is used by the repo's own `examples/python/rag/rag_basic.py`.
- Managed Agents — verified to the API boundary only: the hosted loop reaches Anthropic and fails on account credit; the e2b form constructs and reaches the E2B SDK, failing on a missing `E2B_API_KEY`.

## Two pre-existing bugs found while testing (not addressed here)

1. **Agent-level `guardrails=<callable>` is broken** — returns `None` and swallows output. Unnamed agent → `TaskOutput.agent` pydantic error; named agent → `GuardrailResult is not fully defined ... define TokenMetrics, then call model_rebuild()`. Repairing the forward ref still fails the documented `(bool, output)` tuple contract. This also breaks the shipped `examples/guardrails/00_agent_guardrails_basic.py`. I removed `guardrails=` from the README example rather than ship code that returns `None`.
2. **`MCP(..., args=[...])` discovers 0 tools** while the equivalent single-string form discovers 14. `examples/python/mcp/filesystem-mcp.py` uses the broken form.

Happy to open separate issues/PRs for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide to the Five-Layer Agent Stack, including prompts, context, harnesses, loops, graphs, and managed execution.
  * Updated examples for current handoff, web, caching, and thinking-budget APIs.
  * Revised persistence examples to use the latest memory configuration format.
  * Added examples for file-based memory with user-specific settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->