### PR TITLE
docs(readme): move demo GIFs down above the Langfuse section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ curl -fsSL https://praison.ai/install.sh | bash
   <img src=".github/images/dashboard.png" alt="PraisonAI Dashboard" width="800" />
 </p>
 
-<p align="center">
-  <img src=".github/images/agentflow.gif" alt="PraisonAI AgentFlow" width="800" />
-</p>
-
 ```
  ██████╗ ██████╗  █████╗ ██╗███████╗ ██████╗ ███╗   ██╗     █████╗ ██╗
  ██╔══██╗██╔══██╗██╔══██╗██║██╔════╝██╔═══██╗████╗  ██║    ██╔══██╗██║
@@ -55,12 +51,6 @@ curl -fsSL https://praison.ai/install.sh | bash
 
  pip install praisonai
 ```
-
-<p align="center">
-  <img src=".github/images/latest_ai_news_and_crawl_each_url_to_find_info.gif" alt="PraisonAI command execution" width="800" />
-</p>
-
-\* `export TAVILY_API_KEY=xxxxx`
 
 <div align="center">
   <a href="https://docs.praison.ai">
@@ -953,6 +943,16 @@ PraisonAI is built for speed, with agent instantiation in around 14μs. This red
 [![Star History Chart](https://api.star-history.com/svg?repos=MervinPraison/PraisonAI&type=Date)](https://docs.praison.ai)
 
 ---
+
+<p align="center">
+  <img src=".github/images/agentflow.gif" alt="PraisonAI AgentFlow" width="800" />
+</p>
+
+<p align="center">
+  <img src=".github/images/latest_ai_news_and_crawl_each_url_to_find_info.gif" alt="PraisonAI command execution" width="800" />
+</p>
+
+\* `export TAVILY_API_KEY=xxxxx`
 
 ## 🔍 Langfuse Tracing
 


### PR DESCRIPTION
## What

Moves the two demo GIFs out of the hero and down to the bottom, directly above the **Langfuse Tracing** section:

- `agentflow.gif`
- `latest_ai_news_and_crawl_each_url_to_find_info.gif`

The existing layout is otherwise untouched — the five-layer stack section stays exactly where it is (after "Meet your first Agent").

### Before / after (hero)

```
BEFORE                          AFTER
  install curl                    install curl
  [Elon badge]                    [Elon badge]
  dashboard.png                   ## 🧬 Five-Layer Agent Stack
  agentflow.gif          ──┐      dashboard.png
  ASCII art                │      ASCII art
  latest_ai_news.gif     ──┤      [docs badge]
  * TAVILY_API_KEY note  ──┤
  [docs badge]             │
                           └──►  ...bottom, just above ## 🔍 Langfuse Tracing
```

## Note on the Tavily footnote

The `\* export TAVILY_API_KEY=xxxxx` line annotates the *news/crawl* GIF (that demo needs Tavily for web search), so it travels **with** that GIF. Left behind it would have dangled under the ASCII art referring to nothing.

## Note on placement

Placed immediately **before** the `## 🔍 Langfuse Tracing` heading rather than between the Langfuse `pip install` block and `langfuse.png`. Dropping two unrelated demo GIFs inside that section would make them read as Langfuse screenshots. They are still directly above the Langfuse image, as intended.

## Verification

Pure move, no content change:

- Identical line multiset before/after (asserted programmatically)
- Code fences balanced (72)
- Asset order now: `logo` → `dashboard.png` → `elon_musk_praisonai.png` → `agentflow.gif` → `latest_ai_news….gif` → `langfuse.png`
- Tavily footnote confirmed still directly beneath its GIF
- Five-layer section position unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README media content by moving the AgentFlow and command-execution animations to a later section.
  * Relocated the Tavily API key note alongside the moved media content for improved documentation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->