### PR TITLE
feat(managed): share one remote sandbox across a whole team or workflow

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -660,6 +660,13 @@ class AgentTeam(SpawnAnnounceProtocol):
         reflection: Optional[Any] = None,  # Union[bool, ReflectionConfig] - self-reflection
         caching: Optional[Any] = None,  # Union[bool, CachingConfig] - caching
         learn: Optional[Any] = None,  # Union[bool, LearnConfig] - continuous learning
+        # Union[str, ComputeProviderProtocol] - run every agent's shell/file
+        # tools in ONE shared remote sandbox ("docker", "e2b", "modal",
+        # "daytona", "flyio", "tenki", "local"). Agents share /workspace, so
+        # files written by one agent are visible to the others. Orchestration
+        # stays local. Pass a configured provider instance instead of a name to
+        # customise image/resources.
+        compute: Optional[Any] = None,
     ):
         """
         Initialize AgentManager with consolidated feature parameters.
@@ -890,7 +897,9 @@ class AgentTeam(SpawnAnnounceProtocol):
         self.process = process
         self.stream = _stream
         self.name = name
-        
+        # Remote execution: one shared sandbox for every agent on this team.
+        self.compute = compute
+
         # Callbacks for workflow execution
         self.on_task_start = _on_task_start
         self.on_task_complete = _on_task_complete
@@ -1752,6 +1761,21 @@ class AgentTeam(SpawnAnnounceProtocol):
             result = agents.start(output="silent")
             ```
         """
+        # Remote execution: provision ONE sandbox shared by every agent on the
+        # team, and tear it down even if execution raises. Re-enters start()
+        # with compute cleared so the wrapper applies exactly once.
+        if getattr(self, "compute", None) is not None:
+            from ..managed.shared_compute import SharedCompute
+
+            compute, self.compute = self.compute, None
+            try:
+                with SharedCompute(compute) as shared:
+                    shared.attach(list(self.agents or []))
+                    return self.start(content=content, return_dict=return_dict,
+                                      output=output, **kwargs)
+            finally:
+                self.compute = compute
+
         # Track execution via telemetry
         if hasattr(self, '_telemetry') and self._telemetry:
             self._telemetry.track_agent_execution(self.name, success=True)

--- a/src/praisonai-agents/praisonaiagents/managed/_compute_bridge.py
+++ b/src/praisonai-agents/praisonaiagents/managed/_compute_bridge.py
@@ -1,0 +1,80 @@
+"""Lazy access to compute providers from praisonaiagents.
+
+Concrete ``ComputeProviderProtocol`` implementations live in the ``praisonai``
+wrapper package (``praisonai.integrations.compute``). The core SDK only ships
+protocols, so this module resolves a provider by name at call time -- mirroring
+``praisonaiagents.sandbox._sandbox_bridge``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Optional
+
+_INSTALL_HINT = "Remote compute requires the wrapper package: pip install praisonai"
+
+# name -> (module, attribute). Kept in sync with
+# praisonai.integrations.managed_local._resolve_compute
+_PROVIDERS = {
+    "local": ("praisonai.integrations.compute.local", "LocalCompute"),
+    "docker": ("praisonai.integrations.compute.docker", "DockerCompute"),
+    "e2b": ("praisonai.integrations.compute.e2b", "E2BCompute"),
+    "modal": ("praisonai.integrations.compute.modal_compute", "ModalCompute"),
+    "daytona": ("praisonai.integrations.compute.daytona", "DaytonaCompute"),
+    "flyio": ("praisonai.integrations.compute.flyio", "FlyioCompute"),
+    "tenki": ("praisonai.integrations.compute.tenki", "TenkiCompute"),
+}
+
+_EXTRA_HINTS = {
+    "e2b": "pip install praisonai[e2b]",
+    "modal": "pip install praisonai[modal]",
+    "daytona": "pip install praisonai[daytona]",
+}
+
+
+def available_providers() -> list:
+    """Return the compute provider names this bridge can resolve."""
+    return sorted(_PROVIDERS)
+
+
+def compute_package_available() -> bool:
+    """True when the wrapper package supplying compute providers is importable."""
+    import importlib.util
+
+    return importlib.util.find_spec("praisonai") is not None
+
+
+def resolve_compute(compute: Optional[Any]) -> Optional[Any]:
+    """Resolve ``compute`` into a ``ComputeProviderProtocol`` instance.
+
+    Accepts ``None`` (no remote compute), a provider name such as ``"docker"``,
+    or an already-instantiated provider, which is returned unchanged so callers
+    can inject custom or pre-configured backends.
+    """
+    if compute is None:
+        return None
+
+    # Already a provider instance (duck-typed against ComputeProviderProtocol).
+    if not isinstance(compute, str):
+        if hasattr(compute, "provision") and hasattr(compute, "execute"):
+            return compute
+        raise TypeError(
+            f"compute= expects a provider name or a ComputeProviderProtocol "
+            f"instance, got {type(compute).__name__}"
+        )
+
+    name = compute.lower().strip()
+    if name not in _PROVIDERS:
+        raise ValueError(
+            f"Unknown compute provider {name!r}. "
+            f"Available: {', '.join(available_providers())}"
+        )
+
+    module_name, attr = _PROVIDERS[name]
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        hint = _EXTRA_HINTS.get(name, _INSTALL_HINT)
+        raise ImportError(f"compute={name!r} requires {module_name}. {hint}") from exc
+
+    return getattr(module, attr)()

--- a/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
+++ b/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
@@ -15,6 +15,8 @@ import asyncio
 import concurrent.futures
 import logging
 import shlex
+import threading
+import uuid
 from typing import Any, Dict, List, Optional
 
 from ._compute_bridge import resolve_compute
@@ -70,6 +72,10 @@ class SharedCompute:
         self._auto_shutdown = auto_shutdown
         self._idle_timeout_s = idle_timeout_s
         self._patched: List[Any] = []
+        # Serialises lazy provisioning: parallel steps can make their first tool
+        # call concurrently, and without this two threads would each provision
+        # their own sandbox -- splitting the run and leaking one instance.
+        self._provision_lock = threading.Lock()
 
     # ── lifecycle ────────────────────────────────────────────────────────────
     @property
@@ -77,28 +83,38 @@ class SharedCompute:
         return getattr(self.provider, "provider_name", type(self.provider).__name__)
 
     def ensure_provisioned(self) -> str:
-        """Provision on first use and return the instance id."""
+        """Provision on first use and return the instance id.
+
+        Guarded by a lock so concurrent first-use calls (e.g. from a parallel
+        step) share one sandbox instead of racing and provisioning several.
+        """
         if self.instance_id is not None:
             return self.instance_id
 
-        config = self._config
-        if config is None:
-            from .protocols import ComputeConfig
+        with self._provision_lock:
+            # Re-check inside the lock: another thread may have provisioned
+            # while we were waiting.
+            if self.instance_id is not None:
+                return self.instance_id
 
-            config = ComputeConfig(
-                working_dir=self.working_dir,
-                auto_shutdown=self._auto_shutdown,
-                idle_timeout_s=self._idle_timeout_s,
+            config = self._config
+            if config is None:
+                from .protocols import ComputeConfig
+
+                config = ComputeConfig(
+                    working_dir=self.working_dir,
+                    auto_shutdown=self._auto_shutdown,
+                    idle_timeout_s=self._idle_timeout_s,
+                )
+
+            info = _run_sync(self.provider.provision(config))
+            self.instance_id = getattr(info, "instance_id", info)
+            logger.info(
+                "[shared_compute] provisioned %s instance %s",
+                self.provider_name,
+                self.instance_id,
             )
-
-        info = _run_sync(self.provider.provision(config))
-        self.instance_id = getattr(info, "instance_id", info)
-        logger.info(
-            "[shared_compute] provisioned %s instance %s",
-            self.provider_name,
-            self.instance_id,
-        )
-        return self.instance_id
+            return self.instance_id
 
     def shutdown(self) -> None:
         """Tear down the instance and restore any agents we patched."""
@@ -167,7 +183,17 @@ class SharedCompute:
         def write_file(path: str, content: str) -> str:
             """Write a file to the shared remote sandbox."""
             quoted = shlex.quote(path)
-            heredoc = f"mkdir -p $(dirname {quoted}) && cat > {quoted} <<'__PRAISON_EOF__'\n{content}\n__PRAISON_EOF__"
+            # Random per-write delimiter so file content can never terminate the
+            # heredoc early (which would truncate the file and run the remainder
+            # as shell commands). Guard against the astronomically-unlikely case
+            # where the token still appears in the body.
+            delimiter = f"__PRAISON_EOF_{uuid.uuid4().hex}__"
+            while delimiter in content:
+                delimiter = f"__PRAISON_EOF_{uuid.uuid4().hex}__"
+            heredoc = (
+                f"mkdir -p $(dirname {quoted}) && "
+                f"cat > {quoted} <<'{delimiter}'\n{content}\n{delimiter}"
+            )
             result = self.run_command(heredoc)
             if result.get("exit_code"):
                 return self._format(result)

--- a/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
+++ b/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
@@ -1,0 +1,225 @@
+"""Share one remote sandbox across every agent in a team or workflow.
+
+``LocalAgent(compute=...)`` gives a *single* agent remote tools, and each agent
+provisions its own isolated instance. A workflow therefore ends up with N
+sandboxes and no shared filesystem, so agents cannot hand files to each other.
+
+``SharedCompute`` provisions **one** instance for a whole run and binds every
+participating agent's shell/file tools to it, so step 2 can read what step 1
+wrote. Orchestration (routing, parallel, repeat) still runs locally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+import shlex
+from typing import Any, Dict, List, Optional
+
+from ._compute_bridge import resolve_compute
+
+logger = logging.getLogger(__name__)
+
+# Tool names that mean "touch the machine" and so must follow the sandbox.
+BRIDGED_TOOL_NAMES = ("execute_command", "read_file", "write_file", "list_files")
+
+# Models routinely refuse to call bridged tools because nothing in the prompt
+# says remote execution is available -- the sandbox spins up and is never used.
+CAPABILITY_PROMPT = (
+    "You have tools that run on a REMOTE Linux sandbox, not on the user's machine: "
+    "execute_command(command), read_file(path), write_file(path, content), list_files(path). "
+    "Use them for any shell, file, or code-execution request. Never claim you are unable "
+    "to run commands. All agents in this run share the same sandbox and working directory, "
+    "so files written by an earlier step are visible to later steps."
+)
+
+
+def _run_sync(coro):
+    """Run ``coro`` to completion from sync code, even inside a running loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    # Already inside a loop (e.g. called from async workflow code): hand the
+    # coroutine to a private loop on another thread so we never re-enter.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
+class SharedCompute:
+    """One provisioned sandbox instance shared by many agents.
+
+    Provisioning is lazy: nothing is created until a tool is actually called, so
+    a workflow that never touches the sandbox costs nothing.
+    """
+
+    def __init__(
+        self,
+        compute: Any,
+        *,
+        config: Optional[Any] = None,
+        working_dir: str = "/workspace",
+        auto_shutdown: bool = True,
+        idle_timeout_s: int = 300,
+    ):
+        self.provider = resolve_compute(compute)
+        self.working_dir = working_dir
+        self.instance_id: Optional[str] = None
+        self._config = config
+        self._auto_shutdown = auto_shutdown
+        self._idle_timeout_s = idle_timeout_s
+        self._patched: List[Any] = []
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    @property
+    def provider_name(self) -> str:
+        return getattr(self.provider, "provider_name", type(self.provider).__name__)
+
+    def ensure_provisioned(self) -> str:
+        """Provision on first use and return the instance id."""
+        if self.instance_id is not None:
+            return self.instance_id
+
+        config = self._config
+        if config is None:
+            from .protocols import ComputeConfig
+
+            config = ComputeConfig(
+                working_dir=self.working_dir,
+                auto_shutdown=self._auto_shutdown,
+                idle_timeout_s=self._idle_timeout_s,
+            )
+
+        info = _run_sync(self.provider.provision(config))
+        self.instance_id = getattr(info, "instance_id", info)
+        logger.info(
+            "[shared_compute] provisioned %s instance %s",
+            self.provider_name,
+            self.instance_id,
+        )
+        return self.instance_id
+
+    def shutdown(self) -> None:
+        """Tear down the instance and restore any agents we patched."""
+        for agent, original_tools, original_backstory in self._patched:
+            try:
+                agent.tools = original_tools
+                agent.backstory = original_backstory
+                cache = getattr(agent, "_system_prompt_cache", None)
+                if cache is not None and hasattr(cache, "clear"):
+                    cache.clear()
+            except Exception:  # pragma: no cover - restoration is best-effort
+                logger.debug("[shared_compute] could not restore agent %r", agent)
+        self._patched.clear()
+
+        if self.instance_id is None:
+            return
+        try:
+            _run_sync(self.provider.shutdown(self.instance_id))
+            logger.info("[shared_compute] shut down instance %s", self.instance_id)
+        except Exception as exc:  # pragma: no cover - teardown must not mask errors
+            logger.warning("[shared_compute] shutdown failed for %s: %s", self.instance_id, exc)
+        finally:
+            self.instance_id = None
+
+    def __enter__(self) -> "SharedCompute":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.shutdown()
+
+    # ── remote primitives ────────────────────────────────────────────────────
+    def run_command(self, command: str, timeout: Optional[int] = None) -> Dict[str, Any]:
+        """Execute ``command`` inside the shared sandbox."""
+        instance_id = self.ensure_provisioned()
+        result = _run_sync(self.provider.execute(instance_id, command, timeout))
+        if isinstance(result, dict):
+            return result
+        return {"stdout": str(result), "stderr": "", "exit_code": 0}
+
+    @staticmethod
+    def _format(result: Dict[str, Any]) -> str:
+        stdout = (result.get("stdout") or "").rstrip("\n")
+        stderr = (result.get("stderr") or "").rstrip("\n")
+        if result.get("exit_code"):
+            return f"Error (exit {result['exit_code']}): {stderr or stdout or 'command failed'}"
+        if stdout:
+            return stdout
+        if stderr:
+            return stderr
+        # Never return "" -- an empty tool result reads as "no progress" to the
+        # loop guard and the model retries until it trips the stuck detector.
+        return "(command succeeded with no output)"
+
+    # ── tools handed to agents ───────────────────────────────────────────────
+    def build_tools(self) -> List[Any]:
+        """Return shell/file tools bound to this shared instance."""
+
+        def execute_command(command: str) -> str:
+            """Run a shell command on the shared remote sandbox."""
+            return self._format(self.run_command(command))
+
+        def read_file(path: str) -> str:
+            """Read a file from the shared remote sandbox."""
+            return self._format(self.run_command(f"cat {shlex.quote(path)}"))
+
+        def write_file(path: str, content: str) -> str:
+            """Write a file to the shared remote sandbox."""
+            quoted = shlex.quote(path)
+            heredoc = f"mkdir -p $(dirname {quoted}) && cat > {quoted} <<'__PRAISON_EOF__'\n{content}\n__PRAISON_EOF__"
+            result = self.run_command(heredoc)
+            if result.get("exit_code"):
+                return self._format(result)
+            return f"Wrote {path}"
+
+        def list_files(path: str = ".") -> str:
+            """List files in a directory on the shared remote sandbox."""
+            return self._format(self.run_command(f"ls -la {shlex.quote(path)}"))
+
+        return [execute_command, read_file, write_file, list_files]
+
+    def attach(self, agents: List[Any]) -> None:
+        """Give each agent the shared tools and tell it they exist.
+
+        Agents that already carry their own managed ``backend`` are skipped --
+        they have deliberately been pointed at their own runtime.
+        """
+        tools = self.build_tools()
+        by_name = {t.__name__: t for t in tools}
+
+        for agent in agents:
+            if agent is None or getattr(agent, "backend", None) is not None:
+                continue
+
+            original_tools = list(getattr(agent, "tools", None) or [])
+            # Agent.__init__ copies `instructions` into role/goal/backstory and
+            # builds the system prompt from THOSE, so mutating `.instructions`
+            # here would be silently ignored. Patch `backstory`, which leads the
+            # system prompt.
+            original_backstory = getattr(agent, "backstory", None)
+
+            # Replace same-named local tools; keep everything else untouched.
+            merged = [
+                t for t in original_tools
+                if getattr(t, "__name__", getattr(t, "name", None)) not in by_name
+            ]
+            merged.extend(tools)
+
+            try:
+                agent.tools = merged
+                agent.backstory = (
+                    f"{original_backstory}\n\n{CAPABILITY_PROMPT}"
+                    if original_backstory
+                    else CAPABILITY_PROMPT
+                )
+                # The system prompt is memoised per (role, goal, tools); drop the
+                # cache so the capability text is actually rendered.
+                cache = getattr(agent, "_system_prompt_cache", None)
+                if cache is not None and hasattr(cache, "clear"):
+                    cache.clear()
+            except Exception as exc:  # pragma: no cover - never break a run over this
+                logger.warning("[shared_compute] could not attach tools to %r: %s", agent, exc)
+                continue
+
+            self._patched.append((agent, original_tools, original_backstory))

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -627,7 +627,17 @@ class AgentFlow:
     execution: Optional[Any] = None  # Union[str, ExecutionConfig] - execution control
     caching: Optional[Any] = None  # Union[bool, CachingConfig] - caching
     learn: Optional[Any] = None  # Union[bool, LearnConfig] - continuous learning
-    
+
+    # ============================================================
+    # REMOTE EXECUTION
+    # ============================================================
+    # Union[str, ComputeProviderProtocol] - run every step's shell/file tools in
+    # ONE shared remote sandbox ("docker", "e2b", "modal", "daytona", "flyio",
+    # "tenki", "local"). Agents share /workspace, so a file written by one step
+    # is visible to later steps. Orchestration stays local. Pass a configured
+    # provider instance instead of a name to customise image/resources.
+    compute: Optional[Any] = None
+
     # ============================================================
     # ROBUSTNESS PARAMS (debugging & audit trail)
     # ============================================================
@@ -1105,9 +1115,73 @@ class AgentFlow:
                 "separate Workflow instance per concurrent run."
             )
         try:
-            return self._run_impl(input, llm, verbose, stream)
+            if self.compute is None:
+                return self._run_impl(input, llm, verbose, stream)
+            # One sandbox for the whole run; torn down even if a step raises.
+            with self._shared_compute() as shared:
+                shared.attach(self._collect_agents())
+                return self._run_impl(input, llm, verbose, stream)
         finally:
             self._execution_lock.release()
+
+    def _shared_compute(self):
+        """Build the SharedCompute for this run (see the ``compute=`` field)."""
+        from ..managed.shared_compute import SharedCompute
+
+        return SharedCompute(self.compute)
+
+    def _collect_agents(self) -> List[Any]:
+        """Walk steps (including nested route/parallel/loop/repeat/if) for Agents.
+
+        Returns each Agent once, in first-seen order. Anything that is not an
+        Agent -- plain functions, Tasks without an agent -- is ignored.
+        """
+        found: List[Any] = []
+        seen = set()
+
+        def visit(step: Any) -> None:
+            if step is None:
+                return
+            if isinstance(step, (list, tuple)):
+                for item in step:
+                    visit(item)
+                return
+
+            # Nested step containers.
+            if isinstance(step, Route):
+                for branch in step.routes.values():
+                    visit(branch)
+                visit(step.default)
+                return
+            if isinstance(step, Parallel):
+                visit(step.steps)
+                return
+            if isinstance(step, Loop):
+                visit(step.step)
+                visit(step.steps)
+                return
+            if isinstance(step, Repeat):
+                visit(step.step)
+                return
+            if isinstance(step, If):
+                visit(step.then_steps)
+                visit(step.else_steps)
+                return
+
+            # A Task carries the agent that will execute it.
+            agent = getattr(step, "agent", None)
+            candidate = agent if agent is not None else step
+
+            # Duck-type an Agent: has chat() and instructions/role.
+            if hasattr(candidate, "chat") and (
+                hasattr(candidate, "instructions") or hasattr(candidate, "role")
+            ):
+                if id(candidate) not in seen:
+                    seen.add(id(candidate))
+                    found.append(candidate)
+
+        visit(self.steps)
+        return found
 
     def _run_impl(
         self,

--- a/src/praisonai-agents/tests/managed/test_shared_compute.py
+++ b/src/praisonai-agents/tests/managed/test_shared_compute.py
@@ -1,0 +1,203 @@
+"""Tests for the shared-sandbox execution added to AgentFlow / AgentTeam.
+
+These use a fake ComputeProvider so the suite needs no Docker or cloud
+credentials. The Docker path is exercised manually; see the PR description.
+"""
+
+import pytest
+
+from praisonaiagents.managed._compute_bridge import available_providers, resolve_compute
+from praisonaiagents.managed.shared_compute import (
+    CAPABILITY_PROMPT,
+    SharedCompute,
+)
+
+
+class FakeCompute:
+    """Minimal ComputeProviderProtocol stand-in that records what it ran."""
+
+    provider_name = "fake"
+
+    def __init__(self):
+        self.commands = []
+        self.provisioned = 0
+        self.shutdowns = []
+        self.files = {}
+
+    async def provision(self, config):
+        self.provisioned += 1
+        self.last_config = config
+
+        class _Info:
+            instance_id = f"fake_{self.provisioned}"
+
+        return _Info()
+
+    async def execute(self, instance_id, command, timeout=None):
+        self.commands.append((instance_id, command))
+        if command.startswith("cat ") and "<<" not in command:
+            path = command.split(" ", 1)[1].strip("'\"")
+            if path in self.files:
+                return {"stdout": self.files[path], "stderr": "", "exit_code": 0}
+            return {"stdout": "", "stderr": f"cat: {path}: No such file", "exit_code": 1}
+        if "__PRAISON_EOF__" in command:
+            # Real form: mkdir -p ... && cat > 'PATH' <<'__PRAISON_EOF__'\nBODY\n__PRAISON_EOF__
+            path = command.split("cat > ", 1)[1].split(" <<", 1)[0].strip("'\"")
+            body = command.split("<<'__PRAISON_EOF__'\n", 1)[1]
+            body = body.rsplit("\n__PRAISON_EOF__", 1)[0]
+            self.files[path] = body
+            return {"stdout": "", "stderr": "", "exit_code": 0}
+        return {"stdout": "ok", "stderr": "", "exit_code": 0}
+
+    async def shutdown(self, instance_id):
+        self.shutdowns.append(instance_id)
+
+
+class FakeAgent:
+    """Duck-typed Agent: what _collect_agents and attach() look for."""
+
+    def __init__(self, name, tools=None, backend=None):
+        self.name = name
+        self.instructions = f"You are {name}."
+        self.backstory = f"You are {name}."
+        self.role = name
+        self.tools = list(tools or [])
+        self.backend = backend
+
+    def chat(self, *a, **k):  # pragma: no cover - presence is what matters
+        return ""
+
+
+# ── bridge ───────────────────────────────────────────────────────────────────
+def test_resolve_compute_passthrough_and_errors():
+    fake = FakeCompute()
+    assert resolve_compute(fake) is fake          # instance passes through
+    assert resolve_compute(None) is None
+    with pytest.raises(ValueError):
+        resolve_compute("not-a-provider")
+    with pytest.raises(TypeError):
+        resolve_compute(object())                 # not a provider, not a name
+
+
+def test_known_provider_names_listed():
+    for name in ("docker", "e2b", "modal", "daytona", "flyio", "local"):
+        assert name in available_providers()
+
+
+# ── SharedCompute ────────────────────────────────────────────────────────────
+def test_provisioning_is_lazy_and_single():
+    fake = FakeCompute()
+    sc = SharedCompute(fake)
+    assert fake.provisioned == 0, "must not provision until a tool is used"
+
+    ec, _, _, _ = sc.build_tools()
+    ec("echo one")
+    ec("echo two")
+    assert fake.provisioned == 1, "one instance shared across calls"
+    assert len({inst for inst, _ in fake.commands}) == 1
+
+
+def test_shutdown_tears_down_and_is_idempotent():
+    fake = FakeCompute()
+    sc = SharedCompute(fake)
+    sc.build_tools()[0]("echo hi")
+    instance = sc.instance_id
+
+    sc.shutdown()
+    assert fake.shutdowns == [instance]
+    assert sc.instance_id is None
+    sc.shutdown()  # second call must not raise or double-shutdown
+    assert fake.shutdowns == [instance]
+
+
+def test_context_manager_tears_down_on_exception():
+    fake = FakeCompute()
+    with pytest.raises(RuntimeError):
+        with SharedCompute(fake) as sc:
+            sc.build_tools()[0]("echo hi")
+            raise RuntimeError("step blew up")
+    assert fake.shutdowns, "sandbox must be released even when a step raises"
+
+
+def test_write_then_read_shares_state():
+    fake = FakeCompute()
+    with SharedCompute(fake) as sc:
+        _, read_file, write_file, _ = sc.build_tools()
+        write_file("/workspace/a.txt", "SECRET-42")
+        assert read_file("/workspace/a.txt") == "SECRET-42"
+
+
+def test_result_is_never_empty_string():
+    """An empty tool result reads as 'no progress' and trips the loop guard."""
+    fake = FakeCompute()
+    sc = SharedCompute(fake)
+    assert sc._format({"stdout": "", "stderr": "", "exit_code": 0}) != ""
+    assert "Error" in sc._format({"stdout": "", "stderr": "boom", "exit_code": 1})
+
+
+# ── attach ───────────────────────────────────────────────────────────────────
+def test_attach_adds_tools_and_capability_prompt():
+    fake = FakeCompute()
+    agent = FakeAgent("Writer")
+    with SharedCompute(fake) as sc:
+        sc.attach([agent])
+        assert [t.__name__ for t in agent.tools] == [
+            "execute_command", "read_file", "write_file", "list_files",
+        ]
+        # Patched on backstory, not instructions: Agent builds its system
+        # prompt from role/goal/backstory, so .instructions would be ignored.
+        assert CAPABILITY_PROMPT in agent.backstory
+    assert CAPABILITY_PROMPT not in agent.backstory, "must restore on shutdown"
+    assert agent.tools == []
+
+
+def test_attach_skips_agents_with_their_own_backend():
+    fake = FakeCompute()
+    managed = FakeAgent("HasBackend", backend=object())
+    with SharedCompute(fake) as sc:
+        sc.attach([managed])
+    assert managed.tools == [], "agent with its own backend must be left alone"
+
+
+def test_attach_replaces_same_named_tools_but_keeps_others():
+    def execute_command(command: str) -> str:
+        return "LOCAL"
+
+    def custom_tool(x: str) -> str:
+        return x
+
+    fake = FakeCompute()
+    agent = FakeAgent("A", tools=[execute_command, custom_tool])
+    with SharedCompute(fake) as sc:
+        sc.attach([agent])
+        names = [t.__name__ for t in agent.tools]
+        assert names.count("execute_command") == 1
+        assert "custom_tool" in names, "unrelated tools must survive"
+        ec = [t for t in agent.tools if t.__name__ == "execute_command"][0]
+        assert ec("hostname") != "LOCAL", "must be the remote-bound tool"
+
+
+# ── AgentFlow wiring ─────────────────────────────────────────────────────────
+def test_collect_agents_walks_nested_steps_and_dedupes():
+    from praisonaiagents import AgentFlow
+    from praisonaiagents.workflows import parallel, repeat, route, when
+
+    a, b = FakeAgent("A"), FakeAgent("B")
+    flow = AgentFlow(steps=[
+        a,
+        route({"x": [b], "default": [a]}),
+        parallel([a, b]),
+        repeat(b, until=lambda ctx: True),
+        when("{{x}} > 1", [a], [b]),
+        lambda ctx: "plain function is not an agent",
+    ])
+    collected = flow._collect_agents()
+    assert [x.name for x in collected] == ["A", "B"], "each agent exactly once, in order"
+
+
+def test_flow_without_compute_does_not_provision():
+    from praisonaiagents import AgentFlow
+
+    flow = AgentFlow(steps=[FakeAgent("A")])
+    assert flow.compute is None
+    assert flow._collect_agents()[0].tools == []

--- a/src/praisonai-agents/tests/managed/test_shared_compute.py
+++ b/src/praisonai-agents/tests/managed/test_shared_compute.py
@@ -40,11 +40,13 @@ class FakeCompute:
             if path in self.files:
                 return {"stdout": self.files[path], "stderr": "", "exit_code": 0}
             return {"stdout": "", "stderr": f"cat: {path}: No such file", "exit_code": 1}
-        if "__PRAISON_EOF__" in command:
-            # Real form: mkdir -p ... && cat > 'PATH' <<'__PRAISON_EOF__'\nBODY\n__PRAISON_EOF__
+        if "cat > " in command and " <<'" in command:
+            # Real form: mkdir -p ... && cat > 'PATH' <<'DELIM'\nBODY\nDELIM
+            # DELIM is randomised per write, so parse it out of the command.
             path = command.split("cat > ", 1)[1].split(" <<", 1)[0].strip("'\"")
-            body = command.split("<<'__PRAISON_EOF__'\n", 1)[1]
-            body = body.rsplit("\n__PRAISON_EOF__", 1)[0]
+            delimiter = command.split(" <<'", 1)[1].split("'\n", 1)[0]
+            body = command.split(f"<<'{delimiter}'\n", 1)[1]
+            body = body.rsplit(f"\n{delimiter}", 1)[0]
             self.files[path] = body
             return {"stdout": "", "stderr": "", "exit_code": 0}
         return {"stdout": "ok", "stderr": "", "exit_code": 0}
@@ -125,6 +127,46 @@ def test_write_then_read_shares_state():
         _, read_file, write_file, _ = sc.build_tools()
         write_file("/workspace/a.txt", "SECRET-42")
         assert read_file("/workspace/a.txt") == "SECRET-42"
+
+
+def test_concurrent_first_use_provisions_once():
+    """Parallel first-use calls must share one sandbox, not race into several."""
+    import threading
+
+    class SlowCompute(FakeCompute):
+        async def provision(self, config):
+            import time
+            time.sleep(0.05)  # widen the race window
+            return await super().provision(config)
+
+    fake = SlowCompute()
+    sc = SharedCompute(fake)
+    ec, _, _, _ = sc.build_tools()
+
+    barrier = threading.Barrier(8)
+
+    def hit():
+        barrier.wait()
+        ec("echo hi")
+
+    threads = [threading.Thread(target=hit) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert fake.provisioned == 1, "concurrent first use must provision exactly one sandbox"
+    assert len({inst for inst, _ in fake.commands}) == 1
+
+
+def test_write_file_content_containing_delimiter_token_is_preserved():
+    """Content that looks like the heredoc terminator must not truncate/execute."""
+    fake = FakeCompute()
+    with SharedCompute(fake) as sc:
+        _, read_file, write_file, _ = sc.build_tools()
+        payload = "line1\n__PRAISON_EOF__\nrm -rf /\nline4"
+        write_file("/workspace/danger.txt", payload)
+        assert read_file("/workspace/danger.txt") == payload
 
 
 def test_result_is_never_empty_string():


### PR DESCRIPTION
## Problem

Managed execution is **per-`Agent`** today. `backend=` exists on `Agent` but **not** on `AgentTeam` or `AgentFlow`, and there is no YAML path at all. Each `LocalAgent(compute=...)` provisions its **own isolated** instance, so a workflow ends up with N sandboxes and no shared filesystem — agents cannot hand files to each other.

## What this adds

One new param, `compute=`, on `AgentFlow` (and its `Workflow`/`Pipeline` aliases) and `AgentTeam`. A single sandbox is provisioned per run and every participating agent's shell/file tools are bound to it. Orchestration (route / parallel / repeat) stays local.

```python
flow = AgentFlow(compute="docker", steps=[writer, reader])
flow.run("Step 1: write 'SECRET-42' to /workspace/data.txt. Step 2: read it back.")

team = AgentTeam(agents=[w, r], tasks=[...], compute="docker")
```

Accepts `"docker" | "e2b" | "modal" | "daytona" | "flyio" | "tenki" | "local"`, or a pre-configured provider instance for custom image/resources.

**Deliberately one param, not two.** I initially added `compute_working_dir=` as well and removed it — the `/workspace` default plus "pass a provider instance to customise" covers it, and this API already has a lot of params.

## Verified against local Docker

Writer wrote `/workspace/data.txt` and reported hostname `3e73322cdc8e`; **Reader read the same file and reported the same hostname** — proving one shared sandbox. Local host was `Mac.lan` throughout. `AgentTeam` likewise routed both commands to a single instance (`docker_070c17fbd51f`). Zero leftover containers after teardown.

## Three non-obvious things this had to get right

Each was found by actually running it, not by reading code:

1. **Bind to `backstory`, not `instructions`.** `Agent.__init__` copies `instructions` into `role`/`goal`/`backstory` and builds the system prompt from *those*, so patching `.instructions` post-construction is silently ignored. The memoised system-prompt cache also has to be cleared.
2. **The capability prompt is load-bearing.** Without text telling the model its tools run on a remote sandbox, models routinely reply *"I can't execute shell commands"* — the sandbox spins up and is never used. I reproduced this repeatedly with `gpt-4o-mini` before adding it.
3. **Never return an empty tool result.** A silent-but-successful command returning `""` reads as "no progress" and drives the model into retries until the loop guard fires `No progress detected in 8 tool calls`. Empty results now return an explicit success marker.

## Safety / compatibility

- **Opt-in.** No `compute=` means the existing code path runs completely unchanged.
- **Lazy.** Nothing is provisioned until a tool is actually called.
- **Guaranteed teardown** via context manager, even if a step raises; agents are restored to their original tools/backstory afterwards.
- Agents that already carry their own `backend=` are skipped — they were deliberately pointed at their own runtime.

## Tests

12 new tests using a fake compute provider — **no Docker or cloud credentials required**: lazy/single provisioning, teardown idempotency, teardown-on-exception, write→read sharing, never-empty results, tool replacement vs preservation, backend-carrying agents skipped, and nested `route`/`parallel`/`repeat`/`when` agent collection with dedupe.

Managed suite: **275 passed** (was 263 — the 12 new ones), **21 skipped**. The same **6 failures exist on clean `main`** and are unrelated to this change (verified by running the identical selection on `main`). `tests/test_runtime_middleware.py` also fails to import on clean `main` (`get_default_registry`), likewise pre-existing.

## Not included

- `praisonai managed ps` / cost reporting — guaranteed teardown covers the container-leak risk I hit while testing, but the visibility CLI is still worth doing separately.
- Full remote orchestration ("laptop can disconnect"), YAML `compute:` support, parallel fan-out across N instances, and migrating examples off the deprecated `ManagedAgent` factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared compute sandbox support for agent teams and workflows.
  * Agents can share remote or local execution resources for commands and file operations.
  * Added configurable compute providers with availability checks and clear setup guidance.
  * Compute resources are provisioned on demand and automatically cleaned up after execution.
  * Nested workflow agents are supported while avoiding duplicate resource allocation.
  * Improved agent tool integration and state restoration when shared compute is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->