### PR TITLE
fix(acp): wire workspace tools and capability gates

### DIFF
--- a/src/praisonai/praisonai/acp/server.py
+++ b/src/praisonai/praisonai/acp/server.py
@@ -59,10 +59,11 @@ class ACPServer:
         self._sessions: Dict[str, ACPSession] = {}
         self._client = None  # ACP client connection
         self._cancelled_sessions: set = set()
+        self._agents_by_workspace: Dict[str, Any] = {}
         
         _setup_stderr_logging(self.config.debug)
     
-    def _get_agent(self):
+    def _get_agent(self, workspace: Optional[Path] = None):
         """Lazy load or create agent."""
         if self._agent is not None:
             return self._agent
@@ -70,18 +71,85 @@ class ACPServer:
         if self._agents is not None:
             return self._agents
         
-        # Create default agent
+        workspace = Path(workspace or self.config.workspace).resolve()
+        cache_key = str(workspace)
+        if cache_key in self._agents_by_workspace:
+            return self._agents_by_workspace[cache_key]
+
+        # Create a workspace-scoped default agent.
         try:
             from praisonaiagents import Agent
-            self._agent = Agent(
-                name="PraisonAI",
-                instructions="You are a helpful AI coding assistant.",
-                model=self.config.model or "gpt-4o-mini",
+            tools = self._filter_workspace_tools(
+                self._load_workspace_tools(workspace)
             )
-            return self._agent
+            agent = Agent(
+                name="PraisonAI",
+                instructions=(
+                    "You are a coding assistant inside an editor. Use the "
+                    "provided tools to inspect and modify files when permitted. "
+                    "Keep all file operations inside the workspace."
+                ),
+                model=self.config.model or "gpt-4o-mini",
+                tools=tools,
+                output="minimal",
+                approval=True if self.config.approval_mode == "auto" else False,
+            )
+            self._agents_by_workspace[cache_key] = agent
+            return agent
         except ImportError:
             logger.error("praisonaiagents not installed")
             raise RuntimeError("praisonaiagents package required")
+
+    def _load_workspace_tools(self, workspace: Path) -> List[Any]:
+        """Load the canonical coding tools bound to an ACP session workspace."""
+        from praisonai_code.cli.features.interactive_tools import (
+            ToolConfig,
+            get_interactive_tools,
+        )
+
+        tool_config = ToolConfig(
+            workspace=str(workspace),
+            approval_mode=self.config.approval_mode,
+        )
+        return get_interactive_tools(
+            groups=["basic", "acp", "edit", "search", "lsp"],
+            config=tool_config,
+            workspace=str(workspace),
+        )
+
+    def _filter_workspace_tools(self, tools: List[Any]) -> List[Any]:
+        """Apply ACPConfig capability gates before tools reach the model."""
+        read_tools = {
+            "read_file", "list_files", "grep", "glob", "ast_grep_search",
+            "lsp_list_symbols", "lsp_find_definition", "lsp_find_references",
+            "lsp_get_diagnostics",
+        }
+        write_tools = {
+            "write_file", "edit_file", "apply_patch", "acp_create_file",
+            "acp_edit_file", "acp_delete_file",
+        }
+        shell_tools = {"execute_command", "acp_execute_command"}
+        network_tools = {"internet_search", "web_crawl"}
+
+        allowed = set(read_tools)
+        if self.config.can_write():
+            allowed.update(write_tools)
+        if self.config.can_execute_shell():
+            allowed.update(shell_tools)
+        if self.config.allow_network:
+            allowed.update(network_tools)
+        return [
+            tool for tool in tools
+            if getattr(tool, "__name__", "") in allowed
+        ]
+
+    @staticmethod
+    def _reject_unsupported_mcp_servers(mcp_servers: List[Dict[str, Any]]) -> None:
+        """Fail closed until client-provided MCP lifecycle is implemented."""
+        if mcp_servers:
+            raise ValueError(
+                "MCP servers are not supported by the PraisonAI ACP server yet"
+            )
     
     def on_connect(self, client) -> None:
         """Called when client connects."""
@@ -121,6 +189,11 @@ class ACPServer:
                     "http": False,
                     "sse": False,
                 },
+                "sessionCapabilities": {
+                    "fork": {},
+                    "list": {},
+                    "resume": {},
+                },
             },
             "agentInfo": {
                 "name": "praisonai",
@@ -149,6 +222,8 @@ class ACPServer:
             mcp_servers: List of MCP server configurations
         """
         logger.info(f"New session: cwd={cwd}")
+
+        self._reject_unsupported_mcp_servers(mcp_servers)
         
         workspace = Path(cwd).resolve()
         session = ACPSession.create(
@@ -180,6 +255,8 @@ class ACPServer:
         Replays conversation history via session/update notifications.
         """
         logger.info(f"Load session: session_id={session_id}")
+
+        self._reject_unsupported_mcp_servers(mcp_servers)
         
         # Try to load from store
         session = self._session_store.load(session_id)
@@ -286,7 +363,7 @@ class ACPServer:
         
         try:
             # Get agent response
-            agent = self._get_agent()
+            agent = self._get_agent(session.workspace)
             
             # Send thinking update
             await self._send_thought(session_id, "Processing your request...")

--- a/src/praisonai/tests/integration/acp/test_acp_real_llm.py
+++ b/src/praisonai/tests/integration/acp/test_acp_real_llm.py
@@ -106,6 +106,32 @@ class TestACPRealLLM:
         # Log for verification (no secrets)
         print(f"[TEST] Prompt completed: stopReason={prompt_result['stopReason']}")
         print(f"[TEST] Session: {session_id[:20]}...")
+
+    @pytest.mark.asyncio
+    async def test_prompt_writes_file_when_explicitly_allowed(self, tmp_path):
+        """Exercise the real ACP → Agent → workspace tool loop."""
+        from praisonai.acp.config import ACPConfig
+        from praisonai.acp.server import ACPServer
+
+        server = ACPServer(config=ACPConfig(
+            workspace=tmp_path,
+            model="gpt-4o-mini",
+            read_only=False,
+            allow_write=True,
+            approval_mode="auto",
+        ))
+        session = await server.new_session(cwd=str(tmp_path), mcp_servers=[])
+
+        result = await server.prompt(
+            prompt=[{
+                "type": "text",
+                "text": "Create acp_probe.txt containing exactly ACP_TOOLS_OK.",
+            }],
+            session_id=session["sessionId"],
+        )
+
+        assert result["stopReason"] == "end_turn"
+        assert (tmp_path / "acp_probe.txt").read_text(encoding="utf-8").strip() == "ACP_TOOLS_OK"
     
     @pytest.mark.asyncio
     async def test_session_resume(self, acp_server):

--- a/src/praisonai/tests/unit/acp/test_server.py
+++ b/src/praisonai/tests/unit/acp/test_server.py
@@ -38,6 +38,9 @@ class TestACPServer:
         assert result["protocolVersion"] == 1
         assert "agentCapabilities" in result
         assert result["agentCapabilities"]["loadSession"] is True
+        assert set(result["agentCapabilities"]["sessionCapabilities"]) == {
+            "fork", "list", "resume"
+        }
         assert result["agentInfo"]["name"] == "praisonai"
     
     def test_new_session(self):
@@ -54,20 +57,71 @@ class TestACPServer:
         assert result["sessionId"] in server._sessions
     
     def test_new_session_with_mcp_servers(self):
-        """Test new_session with MCP servers."""
+        """Unsupported MCP configs fail closed instead of being ignored."""
+        import pytest
+
         server = ACPServer()
         
         mcp_servers = [
             {"name": "test", "command": "/usr/bin/test", "args": []}
         ]
         
-        result = asyncio.run(server.new_session(
-            cwd="/tmp/test",
-            mcp_servers=mcp_servers,
-        ))
-        
-        session = server._sessions[result["sessionId"]]
-        assert session.mcp_servers == mcp_servers
+        with pytest.raises(ValueError, match="MCP servers are not supported"):
+            asyncio.run(server.new_session(
+                cwd="/tmp/test",
+                mcp_servers=mcp_servers,
+            ))
+
+    def test_read_only_agent_exposes_only_non_mutating_tools(self, monkeypatch):
+        server = ACPServer(config=ACPConfig(read_only=True))
+        tools = self._fake_tools()
+        monkeypatch.setattr(server, "_load_workspace_tools", lambda _workspace: tools)
+
+        agent = server._get_agent()
+        names = {tool.__name__ for tool in agent.tools}
+
+        assert {"read_file", "list_files", "grep"} <= names
+        assert not names & {
+            "write_file", "edit_file", "acp_create_file",
+            "execute_command", "internet_search",
+        }
+
+    def test_permission_flags_control_write_shell_and_network_tools(self, monkeypatch):
+        config = ACPConfig(
+            read_only=False,
+            allow_write=True,
+            allow_shell=True,
+            allow_network=True,
+            approval_mode="auto",
+        )
+        server = ACPServer(config=config)
+        tools = self._fake_tools()
+        monkeypatch.setattr(server, "_load_workspace_tools", lambda _workspace: tools)
+
+        agent = server._get_agent()
+        names = {tool.__name__ for tool in agent.tools}
+
+        assert {
+            "write_file", "edit_file", "acp_create_file",
+            "execute_command", "internet_search",
+        } <= names
+
+    @staticmethod
+    def _fake_tools():
+        def make(name):
+            def tool():
+                return name
+
+            tool.__name__ = name
+            return tool
+
+        return [
+            make(name) for name in (
+                "read_file", "list_files", "grep", "write_file", "edit_file",
+                "acp_create_file", "execute_command", "acp_execute_command",
+                "internet_search", "web_crawl",
+            )
+        ]
     
     def test_set_session_mode(self):
         """Test set_session_mode handler."""


### PR DESCRIPTION
Addresses #3931 with a reviewable permission-safe first slice.

Summary:
- creates workspace-scoped ACP agents with canonical coding tools
- filters read, write, shell, and network tools from ACPConfig before model exposure
- defaults to read and search only
- advertises implemented fork, list, and resume session capabilities
- rejects client MCP configurations explicitly instead of storing and ignoring them
- adds an opt-in real ACP file-write test

Validation:
- 63 ACP unit tests passed
- 9 live ACP tests skipped without credentials
- Ruff and diff checks passed

This is a Draft because client-driven permission prompts, MCP lifecycle, and ACP tool-call update events need maintainer direction before the advertised capability surface is expanded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-aware agent sessions with workspace-specific instructions, tools, output, and approval settings.
  * Added support for session fork, list, and resume capabilities.
  * Added configurable permissions for read, write, shell, and network tools.
  * Added safeguards that reject unsupported client-provided MCP server configurations.

* **Bug Fixes**
  * Improved session and prompt handling to consistently use the selected workspace.

* **Tests**
  * Added coverage for workspace file creation, session capabilities, MCP validation, and permission-controlled tool access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->