### PR TITLE
fix(harbor): configure coding budget and verifier flow

### DIFF
--- a/examples/terminal_bench/job_code_smoke.yaml
+++ b/examples/terminal_bench/job_code_smoke.yaml
@@ -14,9 +14,9 @@ datasets:
     # A small verified subset for a cheap smoke run. Verify against the registry
     # with `harbor datasets list` before editing.
     task_names:
-      - hello-world
-      - fix-permissions
-      - csv-to-parquet
+      - terminal-bench/build-pmars
+      - terminal-bench/bn-fit-modify
+      - terminal-bench/break-filter-js-from-html
 
 agents:
   - import_path: examples.terminal_bench.praisonai_code_agent:PraisonAICodeAgent

--- a/examples/terminal_bench/praisonai_external_agent.py
+++ b/examples/terminal_bench/praisonai_external_agent.py
@@ -34,11 +34,19 @@ except ImportError as e:
 try:
     from praisonaiagents import Agent
     from praisonaiagents.approval import get_approval_registry, AutoApproveBackend
+    from praisonaiagents.config.feature_configs import ExecutionConfig
 except ImportError as e:
     raise ImportError(
         f"PraisonAI not installed: {e}\n"
         "Install with: pip install praisonaiagents"
     ) from e
+
+
+TB_EXECUTION = ExecutionConfig(
+    max_tool_calls_per_turn=80,
+    max_iter=40,
+    max_steps=80,
+)
 
 
 class PraisonAIExternalAgent(BaseAgent):
@@ -142,26 +150,14 @@ class PraisonAIExternalAgent(BaseAgent):
                 ),
                 tools=[bash_tool],
                 llm=self.model_name or "openai/gpt-4o-mini",
+                execution=TB_EXECUTION,
             )
 
-            # Execute the agent with outer loop to handle premature stopping
+            # Execute one deliberately long coding turn. Harbor's hidden verifier
+            # is the only completion authority; model or pytest text is not.
             print(f"🚀 PraisonAI Agent starting task: {instruction[:100]}...")
             result = await agent.achat(instruction)
-            for _iter in range(19):
-                result_str = str(result)
-                # Stop if test passed
-                if any(sig in result_str.lower() for sig in [
-                    " passed", "passed ", "test passed", "all tests pass", "1 passed"
-                ]):
-                    break
-                result = await agent.achat(
-                    "The task is NOT complete yet — keep working. Run bash_tool commands now. "
-                    "If you haven't already: (1) read all files in /app/, "
-                    "(2) run the test to see the exact failure, "
-                    "(3) implement a fix, (4) run the test again. "
-                    "Repeat until the test passes. What is your next bash_tool command?"
-                )
-            print(f"✅ PraisonAI Agent completed task")
+            print("✅ PraisonAI Agent completed task")
             
             # Populate Harbor context with metadata
             self._populate_context(agent, context, result)
@@ -203,11 +199,26 @@ class PraisonAIExternalAgent(BaseAgent):
                 "tools_used": ["bash_tool"],
                 "framework": "praisonai",
                 "version": self.version(),
+                "stop_reason": self._get_stop_reason(agent),
+                "max_tool_calls_per_turn": TB_EXECUTION.max_tool_calls_per_turn,
+                "max_steps": TB_EXECUTION.max_steps,
             }
             
         except Exception as e:
             # Don't fail the whole run if context population fails
             context.metadata = {"context_error": str(e)}
+
+    @staticmethod
+    def _get_stop_reason(agent: Agent) -> Any:
+        """Best-effort extraction of the last runtime stop reason."""
+        for llm in (
+            getattr(agent, "_llm_instance", None),
+            getattr(agent, "llm", None),
+        ):
+            reason = getattr(llm, "_last_stop_reason", None)
+            if reason:
+                return reason
+        return None
 
 
 # Example usage for testing

--- a/examples/terminal_bench/praisonai_external_agent.py
+++ b/examples/terminal_bench/praisonai_external_agent.py
@@ -201,6 +201,7 @@ class PraisonAIExternalAgent(BaseAgent):
                 "version": self.version(),
                 "stop_reason": getattr(agent, "last_stop_reason", None),
                 "max_tool_calls_per_turn": TB_EXECUTION.max_tool_calls_per_turn,
+                "max_iter": TB_EXECUTION.max_iter,
                 "max_steps": TB_EXECUTION.max_steps,
             }
             

--- a/examples/terminal_bench/praisonai_external_agent.py
+++ b/examples/terminal_bench/praisonai_external_agent.py
@@ -199,7 +199,7 @@ class PraisonAIExternalAgent(BaseAgent):
                 "tools_used": ["bash_tool"],
                 "framework": "praisonai",
                 "version": self.version(),
-                "stop_reason": self._get_stop_reason(agent),
+                "stop_reason": getattr(agent, "last_stop_reason", None),
                 "max_tool_calls_per_turn": TB_EXECUTION.max_tool_calls_per_turn,
                 "max_steps": TB_EXECUTION.max_steps,
             }
@@ -207,18 +207,6 @@ class PraisonAIExternalAgent(BaseAgent):
         except Exception as e:
             # Don't fail the whole run if context population fails
             context.metadata = {"context_error": str(e)}
-
-    @staticmethod
-    def _get_stop_reason(agent: Agent) -> Any:
-        """Best-effort extraction of the last runtime stop reason."""
-        for llm in (
-            getattr(agent, "_llm_instance", None),
-            getattr(agent, "llm", None),
-        ):
-            reason = getattr(llm, "_last_stop_reason", None)
-            if reason:
-                return reason
-        return None
 
 
 # Example usage for testing

--- a/examples/terminal_bench/test_adapter_config.py
+++ b/examples/terminal_bench/test_adapter_config.py
@@ -1,0 +1,39 @@
+"""Static regression checks for the in-tree Harbor adapter configuration."""
+
+from pathlib import Path
+
+import yaml
+
+
+EXAMPLES = Path(__file__).parent
+
+
+def test_external_adapter_sets_coding_execution_budget():
+    source = (EXAMPLES / "praisonai_external_agent.py").read_text(encoding="utf-8")
+
+    assert "ExecutionConfig" in source
+    assert "max_tool_calls_per_turn=80" in source
+    assert "max_iter=40" in source
+    assert "max_steps=80" in source
+
+
+def test_external_adapter_does_not_guess_completion_from_pytest_text():
+    source = (EXAMPLES / "praisonai_external_agent.py").read_text(encoding="utf-8")
+
+    assert '"1 passed"' not in source
+    assert '"test passed"' not in source
+
+
+def test_smoke_yaml_uses_terminal_bench_21_registry_ids():
+    job = yaml.safe_load(
+        (EXAMPLES / "job_code_smoke.yaml").read_text(encoding="utf-8")
+    )
+    names = job["datasets"][0]["task_names"]
+
+    assert names
+    assert all(name.startswith("terminal-bench/") for name in names)
+    assert names == [
+        "terminal-bench/build-pmars",
+        "terminal-bench/bn-fit-modify",
+        "terminal-bench/break-filter-js-from-html",
+    ]


### PR DESCRIPTION
Addresses #3932.

Summary:
- gives Terminal-Bench an explicit 80 tool calls per turn, 40 iterations, and 80 steps
- removes the 19-turn pytest substring completion heuristic
- leaves the Harbor hidden verifier as the only success authority
- records the runtime stop reason and configured budget in metadata
- updates the smoke job to three valid Terminal-Bench 2.1 registry IDs

Validation:
- 3 adapter configuration regressions passed
- adapter module compiles
- Ruff and diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Terminal Bench task execution with defined limits for tool calls, iterations, and steps.
  - Added execution metadata showing configured limits and the stop reason when available.
  - Updated the smoke-test subset with three revised benchmark tasks for more consistent evaluation.

- **Tests**
  - Added regression coverage for execution budgets, completion handling, and benchmark configuration.
  - Verified that benchmark runs no longer rely on text-based completion detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->