### PR TITLE
fix(llm): collect token usage with quiet output

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1371,7 +1371,13 @@ Respond with ONLY a valid JSON tool call in this format:
             The completion response from litellm
         """
         import litellm
-        return await self._call_with_retry_async(litellm.acompletion, **completion_params)
+        response = await self._call_with_retry_async(
+            litellm.acompletion,
+            **completion_params,
+        )
+        if not completion_params.get("stream"):
+            self._track_token_usage(response, self.model)
+        return response
 
     def _supports_web_search(self) -> bool:
         """
@@ -2646,7 +2652,11 @@ Respond with ONLY a valid JSON tool call in this format:
                             resp = self._call_responses_api(**responses_params)
                             response_text, tool_calls, _reasoning = self._extract_from_responses_output(resp)
 
-                            # Track token usage
+                            # Usage accounting is independent from metrics display.
+                            # Quiet/default agents must still update the public
+                            # token collector after a paid model call.
+                            self._track_token_usage(resp, self.model)
+
                             if self.metrics and hasattr(resp, 'usage') and resp.usage:
                                 usage = resp.usage
                                 tokens_in = getattr(usage, 'input_tokens', 0) or 0
@@ -2869,9 +2879,9 @@ Respond with ONLY a valid JSON tool call in this format:
                                 is_reasoning=False
                             ))
                         
-                        # Track token usage
-                        if self.metrics:
-                            self._track_token_usage(final_response, self.model)
+                        # Always account for provider usage. ``metrics`` controls
+                        # rendering/callback detail, not whether usage exists.
+                        self._track_token_usage(final_response, self.model)
                         
                         # Trigger llm_end callback with metrics for debug output
                         llm_latency_ms = (time.time() - current_time) * 1000
@@ -3086,9 +3096,10 @@ Respond with ONLY a valid JSON tool call in this format:
                                             response_content = final_response["choices"][0]["message"].get("content")
                                             response_text = response_content if response_content is not None else ""
                                             
-                                            # Track token usage
-                                            if self.metrics:
-                                                self._track_token_usage(final_response, self.model)
+                                            self._track_token_usage(
+                                                final_response,
+                                                self.model,
+                                            )
                                         
                                         # Execute callbacks and display based on verbose setting
                                         if verbose and not interaction_displayed:
@@ -3278,9 +3289,10 @@ Respond with ONLY a valid JSON tool call in this format:
                                 response_content = final_response["choices"][0]["message"].get("content")
                                 response_text = response_content if response_content is not None else ""
                                 
-                                # Track token usage
-                                if self.metrics:
-                                    self._track_token_usage(final_response, self.model)
+                                self._track_token_usage(
+                                    final_response,
+                                    self.model,
+                                )
                             
                             # Execute callbacks and display based on verbose setting
                             if verbose and not interaction_displayed:
@@ -5414,27 +5426,37 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 litellm.callbacks.append(event)
         self._registered_callbacks = list(events)
 
-    def _track_token_usage(self, response: Dict[str, Any], model: str) -> Optional[TokenMetrics]:
+    def _track_token_usage(self, response: Any, model: str) -> Optional[TokenMetrics]:
         """Extract and track token usage from LLM response."""
         if not TokenMetrics or not get_token_collector:
             return None
-        
-        # Note: metrics check moved to call sites for performance
-        # This method should only be called when self.metrics=True
-        
+
         try:
-            usage = response.get("usage", {})
+            if isinstance(response, dict):
+                usage = response.get("usage", {})
+            else:
+                usage = getattr(response, "usage", None)
             if not usage:
                 return None
-            
+
+            def _usage_value(*names: str) -> int:
+                for name in names:
+                    if isinstance(usage, dict):
+                        value = usage.get(name)
+                    else:
+                        value = getattr(usage, name, None)
+                    if value is not None:
+                        return int(value or 0)
+                return 0
+
             # Extract token counts
             metrics = TokenMetrics(
-                input_tokens=usage.get("prompt_tokens", 0),
-                output_tokens=usage.get("completion_tokens", 0),
-                cached_tokens=usage.get("cached_tokens", 0),
-                reasoning_tokens=usage.get("reasoning_tokens", 0),
-                audio_input_tokens=usage.get("audio_input_tokens", 0),
-                audio_output_tokens=usage.get("audio_output_tokens", 0)
+                input_tokens=_usage_value("prompt_tokens", "input_tokens"),
+                output_tokens=_usage_value("completion_tokens", "output_tokens"),
+                cached_tokens=_usage_value("cached_tokens"),
+                reasoning_tokens=_usage_value("reasoning_tokens"),
+                audio_input_tokens=_usage_value("audio_input_tokens"),
+                audio_output_tokens=_usage_value("audio_output_tokens"),
             )
             
             # Store metrics
@@ -5942,7 +5964,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         Returns a ``ResponsesAPIResponse`` object.
         """
         import litellm
-        return await self._call_with_retry_async(litellm.aresponses, **params)
+        response = await self._call_with_retry_async(litellm.aresponses, **params)
+        self._track_token_usage(response, self.model)
+        return response
 
     def _extract_from_responses_output(self, response) -> tuple:
         """

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1356,7 +1356,10 @@ Respond with ONLY a valid JSON tool call in this format:
             The completion response from litellm
         """
         import litellm
-        return self._call_with_retry(litellm.completion, **completion_params)
+        response = self._call_with_retry(litellm.completion, **completion_params)
+        if not completion_params.get("stream"):
+            self._track_token_usage(response, self.model)
+        return response
 
     async def _acompletion_with_retry(self, **completion_params):
         """Execute litellm.acompletion with automatic retry on rate limit errors.
@@ -2879,10 +2882,6 @@ Respond with ONLY a valid JSON tool call in this format:
                                 is_reasoning=False
                             ))
                         
-                        # Always account for provider usage. ``metrics`` controls
-                        # rendering/callback detail, not whether usage exists.
-                        self._track_token_usage(final_response, self.model)
-                        
                         # Trigger llm_end callback with metrics for debug output
                         llm_latency_ms = (time.time() - current_time) * 1000
                         
@@ -3096,10 +3095,6 @@ Respond with ONLY a valid JSON tool call in this format:
                                             response_content = final_response["choices"][0]["message"].get("content")
                                             response_text = response_content if response_content is not None else ""
                                             
-                                            self._track_token_usage(
-                                                final_response,
-                                                self.model,
-                                            )
                                         
                                         # Execute callbacks and display based on verbose setting
                                         if verbose and not interaction_displayed:
@@ -3289,10 +3284,6 @@ Respond with ONLY a valid JSON tool call in this format:
                                 response_content = final_response["choices"][0]["message"].get("content")
                                 response_text = response_content if response_content is not None else ""
                                 
-                                self._track_token_usage(
-                                    final_response,
-                                    self.model,
-                                )
                             
                             # Execute callbacks and display based on verbose setting
                             if verbose and not interaction_displayed:
@@ -5449,14 +5440,43 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         return int(value or 0)
                 return 0
 
+            def _detail_value(detail_names: tuple[str, ...], name: str) -> int:
+                for detail_name in detail_names:
+                    details = (
+                        usage.get(detail_name)
+                        if isinstance(usage, dict)
+                        else getattr(usage, detail_name, None)
+                    )
+                    if details:
+                        value = (
+                            details.get(name)
+                            if isinstance(details, dict)
+                            else getattr(details, name, None)
+                        )
+                        if value is not None:
+                            return int(value or 0)
+                return 0
+
             # Extract token counts
             metrics = TokenMetrics(
                 input_tokens=_usage_value("prompt_tokens", "input_tokens"),
                 output_tokens=_usage_value("completion_tokens", "output_tokens"),
-                cached_tokens=_usage_value("cached_tokens"),
-                reasoning_tokens=_usage_value("reasoning_tokens"),
-                audio_input_tokens=_usage_value("audio_input_tokens"),
-                audio_output_tokens=_usage_value("audio_output_tokens"),
+                cached_tokens=_usage_value("cached_tokens") or _detail_value(
+                    ("prompt_tokens_details", "input_tokens_details"),
+                    "cached_tokens",
+                ),
+                reasoning_tokens=_usage_value("reasoning_tokens") or _detail_value(
+                    ("completion_tokens_details", "output_tokens_details"),
+                    "reasoning_tokens",
+                ),
+                audio_input_tokens=_usage_value("audio_input_tokens") or _detail_value(
+                    ("prompt_tokens_details", "input_tokens_details"),
+                    "audio_tokens",
+                ),
+                audio_output_tokens=_usage_value("audio_output_tokens") or _detail_value(
+                    ("completion_tokens_details", "output_tokens_details"),
+                    "audio_tokens",
+                ),
             )
             
             # Store metrics

--- a/src/praisonai-agents/tests/integration/test_default_token_tracking_real.py
+++ b/src/praisonai-agents/tests/integration/test_default_token_tracking_real.py
@@ -1,0 +1,32 @@
+"""Opt-in real-provider coverage for default token collection."""
+
+import os
+
+import pytest
+
+
+@pytest.mark.network
+@pytest.mark.skipif(
+    os.environ.get("RUN_REAL_KEY_TESTS") != "1"
+    or not os.environ.get("OPENAI_API_KEY"),
+    reason="Set RUN_REAL_KEY_TESTS=1 and OPENAI_API_KEY for the real agentic test",
+)
+def test_default_agent_start_records_real_provider_usage():
+    from praisonaiagents import Agent
+    from praisonaiagents.telemetry.token_collector import get_token_collector
+
+    collector = get_token_collector()
+    collector.reset()
+    result = Agent(
+        name="token-collector-real-smoke",
+        instructions="Reply with the single word OK.",
+        llm="gpt-4o-mini",
+    ).start("Say OK")
+    summary = collector.get_session_summary()
+
+    print(result)
+    print(summary)
+    assert result
+    assert summary["total_interactions"] >= 1
+    assert summary["total_metrics"]["input_tokens"] > 0
+    assert summary["total_metrics"]["output_tokens"] > 0

--- a/src/praisonai-agents/tests/unit/llm/test_default_token_tracking.py
+++ b/src/praisonai-agents/tests/unit/llm/test_default_token_tracking.py
@@ -1,0 +1,74 @@
+"""Regression coverage for token accounting with quiet output defaults."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from collections import defaultdict
+
+from praisonaiagents.llm.llm import LLM
+from praisonaiagents.telemetry.token_collector import get_token_collector
+
+
+def _display_functions():
+    return defaultdict(MagicMock)
+
+
+def test_chat_completion_tracks_tokens_when_metrics_display_is_disabled(
+    monkeypatch,
+):
+    collector = get_token_collector()
+    collector.reset()
+    llm = LLM(model="custom/test-model", api_key="test")
+    llm.metrics = False
+    llm.verbose = False
+    monkeypatch.setattr(llm, "_supports_responses_api", lambda: False)
+    monkeypatch.setattr(
+        llm,
+        "_completion_with_retry",
+        lambda **_kwargs: {
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 3},
+        },
+    )
+
+    with patch(
+        "praisonaiagents.llm.llm._get_display_functions",
+        return_value=_display_functions(),
+    ):
+        assert llm.get_response(prompt="hello", stream=False, verbose=False) == "ok"
+
+    summary = collector.get_session_summary()
+    assert summary["total_interactions"] == 1
+    assert summary["total_metrics"]["input_tokens"] == 12
+    assert summary["total_metrics"]["output_tokens"] == 3
+
+
+def test_responses_api_tracks_tokens_when_metrics_display_is_disabled(
+    monkeypatch,
+):
+    collector = get_token_collector()
+    collector.reset()
+    llm = LLM(model="openai/gpt-4o-mini", api_key="test")
+    llm.metrics = False
+    llm.verbose = False
+    response = SimpleNamespace(
+        usage=SimpleNamespace(input_tokens=8, output_tokens=2)
+    )
+    monkeypatch.setattr(llm, "_supports_responses_api", lambda: True)
+    monkeypatch.setattr(llm, "_build_responses_params", lambda **_kwargs: {})
+    monkeypatch.setattr(llm, "_call_responses_api", lambda **_kwargs: response)
+    monkeypatch.setattr(
+        llm,
+        "_extract_from_responses_output",
+        lambda _response: ("ok", [], None),
+    )
+
+    with patch(
+        "praisonaiagents.llm.llm._get_display_functions",
+        return_value=_display_functions(),
+    ):
+        assert llm.get_response(prompt="hello", stream=False, verbose=False) == "ok"
+
+    summary = collector.get_session_summary()
+    assert summary["total_interactions"] == 1
+    assert summary["total_metrics"]["input_tokens"] == 8
+    assert summary["total_metrics"]["output_tokens"] == 2

--- a/src/praisonai-agents/tests/unit/llm/test_default_token_tracking.py
+++ b/src/praisonai-agents/tests/unit/llm/test_default_token_tracking.py
@@ -23,8 +23,8 @@ def test_chat_completion_tracks_tokens_when_metrics_display_is_disabled(
     monkeypatch.setattr(llm, "_supports_responses_api", lambda: False)
     monkeypatch.setattr(
         llm,
-        "_completion_with_retry",
-        lambda **_kwargs: {
+        "_call_with_retry",
+        lambda _fn, **_kwargs: {
             "choices": [{"message": {"content": "ok"}}],
             "usage": {"prompt_tokens": 12, "completion_tokens": 3},
         },
@@ -40,6 +40,25 @@ def test_chat_completion_tracks_tokens_when_metrics_display_is_disabled(
     assert summary["total_interactions"] == 1
     assert summary["total_metrics"]["input_tokens"] == 12
     assert summary["total_metrics"]["output_tokens"] == 3
+
+
+def test_nested_usage_details_are_collected():
+    collector = get_token_collector()
+    collector.reset()
+    llm = LLM(model="custom/test-model", api_key="test")
+
+    llm._track_token_usage({"usage": {
+        "prompt_tokens": 12,
+        "completion_tokens": 3,
+        "prompt_tokens_details": {"cached_tokens": 4, "audio_tokens": 2},
+        "completion_tokens_details": {"reasoning_tokens": 1, "audio_tokens": 1},
+    }}, llm.model)
+
+    metrics = collector.get_session_summary()["total_metrics"]
+    assert metrics["cached_tokens"] == 4
+    assert metrics["reasoning_tokens"] == 1
+    assert metrics["audio_input_tokens"] == 2
+    assert metrics["audio_output_tokens"] == 1
 
 
 def test_responses_api_tracks_tokens_when_metrics_display_is_disabled(


### PR DESCRIPTION
Addresses #3933.

Summary:
- decouples provider usage collection from metrics display
- covers sync and async Chat Completions and Responses API paths
- accepts both dict and SDK-object usage shapes
- supports prompt/completion and input/output token field names
- adds default quiet-agent regressions and an opt-in real-provider Agent.start test

Validation:
- 19 focused LLM tests passed
- 1 real-provider test skipped without credentials
- Ruff passed for new tests and diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage tracking across standard completions and Responses API calls.
  * Token counts are now recorded consistently for synchronous and asynchronous requests, including varied response formats and nested cached, reasoning, and audio usage.
  * Usage tracking remains active when metrics or verbose display are disabled.

* **Tests**
  * Added coverage for token collection across supported workflows and response formats.
  * Added optional integration testing with a live OpenAI-backed agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->