### PR TITLE
fix(llm): translate multimodal Responses API input

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -6,7 +6,9 @@ supporting both synchronous and asynchronous operations.
 """
 
 import os
+import base64
 import logging
+import mimetypes
 from praisonaiagents._logging import get_logger
 import time
 import json
@@ -16,6 +18,7 @@ from typing import Any, Dict, List, Optional, Union, AsyncIterator, Iterator, Ca
 from pydantic import BaseModel
 from dataclasses import dataclass
 import inspect
+from pathlib import Path
 
 from ..errors import ToolExecutionError
 
@@ -675,7 +678,11 @@ class OpenAIClient:
                         "output": msg.get("content", ""),
                     })
                 else:
-                    input_items.append(msg)
+                    item = dict(msg)
+                    item["content"] = self._build_responses_content(
+                        msg.get("content", "")
+                    )
+                    input_items.append(item)
 
         if instructions:
             params["instructions"] = instructions
@@ -708,6 +715,61 @@ class OpenAIClient:
             params["temperature"] = temperature
 
         return params
+
+    @staticmethod
+    def _normalise_responses_image_url(image_url: Any) -> str:
+        """Return an API-fetchable URL, encoding local image files as data URLs."""
+        if isinstance(image_url, dict):
+            image_url = image_url.get("url", "")
+        if not isinstance(image_url, str) or not image_url:
+            raise ValueError("Image content must include a non-empty URL or local path")
+        if image_url.startswith(("http://", "https://", "data:")):
+            return image_url
+
+        image_path = Path(image_url).expanduser()
+        if not image_path.is_file():
+            raise FileNotFoundError(
+                f"Local image file does not exist: {image_path}"
+            )
+        mime_type = mimetypes.guess_type(image_path.name)[0]
+        if not mime_type or not mime_type.startswith("image/"):
+            raise ValueError(f"Unsupported local image type: {image_path}")
+        encoded = base64.b64encode(image_path.read_bytes()).decode("ascii")
+        return f"data:{mime_type};base64,{encoded}"
+
+    @classmethod
+    def _build_responses_content(cls, content: Any) -> Any:
+        """Translate Chat Completions content parts to Responses API parts."""
+        if not isinstance(content, list):
+            return content
+
+        responses_content: List[Any] = []
+        for part in content:
+            if not isinstance(part, dict):
+                responses_content.append(part)
+                continue
+            part_type = part.get("type")
+            if part_type == "text":
+                responses_content.append({
+                    "type": "input_text",
+                    "text": part.get("text", ""),
+                })
+            elif part_type == "image_url":
+                responses_content.append({
+                    "type": "input_image",
+                    "image_url": cls._normalise_responses_image_url(
+                        part.get("image_url")
+                    ),
+                })
+            elif part_type == "input_image":
+                item = dict(part)
+                item["image_url"] = cls._normalise_responses_image_url(
+                    part.get("image_url")
+                )
+                responses_content.append(item)
+            else:
+                responses_content.append(part)
+        return responses_content
 
     def _responses_to_chat_completion(self, response) -> ChatCompletion:
         """

--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -956,6 +956,8 @@ class OpenAIClient:
                         ))
                     
                     return final_response
+                except (FileNotFoundError, ValueError):
+                    raise
                 except Exception as e:
                     self.logger.warning(f"Responses API streaming failed, falling back: {e}")
                     # Fall through to Chat Completions streaming
@@ -1223,6 +1225,8 @@ class OpenAIClient:
                         ))
                     
                     return final_response
+                except (FileNotFoundError, ValueError):
+                    raise
                 except Exception as e:
                     self.logger.warning(f"Responses API async streaming failed, falling back: {e}")
                     # Fall through to Chat Completions streaming
@@ -1418,6 +1422,8 @@ class OpenAIClient:
                 )
                 raw = self.sync_client.responses.create(**resp_params)
                 return self._responses_to_chat_completion(raw)
+            except (FileNotFoundError, ValueError):
+                raise
             except Exception as e:
                 self.logger.warning(f"Responses API failed, falling back to Chat Completions: {e}")
                 # Fall through to Chat Completions
@@ -1477,6 +1483,8 @@ class OpenAIClient:
                 )
                 raw = await self.async_client.responses.create(**resp_params)
                 return self._responses_to_chat_completion(raw)
+            except (FileNotFoundError, ValueError):
+                raise
             except Exception as e:
                 self.logger.warning(f"Responses API failed, falling back to Chat Completions: {e}")
                 # Fall through to Chat Completions

--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -755,12 +755,16 @@ class OpenAIClient:
                     "text": part.get("text", ""),
                 })
             elif part_type == "image_url":
-                responses_content.append({
+                image_item = {
                     "type": "input_image",
                     "image_url": cls._normalise_responses_image_url(
                         part.get("image_url")
                     ),
-                })
+                }
+                image_value = part.get("image_url")
+                if isinstance(image_value, dict) and image_value.get("detail"):
+                    image_item["detail"] = image_value["detail"]
+                responses_content.append(image_item)
             elif part_type == "input_image":
                 item = dict(part)
                 item["image_url"] = cls._normalise_responses_image_url(

--- a/src/praisonai-agents/tests/integration/test_responses_api.py
+++ b/src/praisonai-agents/tests/integration/test_responses_api.py
@@ -12,8 +12,8 @@ Required environment variables:
     - OPENAI_API_KEY: OpenAI API key
 """
 import os
+import base64
 import sys
-import time
 import pytest
 
 # Note: Only real API tests are gated by RUN_REAL_KEY_TESTS.
@@ -230,6 +230,29 @@ class TestResponsesAPIRealAgent:
         assert len(response) > 100, f"Response too short ({len(response)} chars)"
         print(f"[PASS] gpt-4o-mini - {len(response)} chars")
 
+    def test_bare_model_accepts_local_image_attachment(self, tmp_path):
+        """Exercise Agent.start() through OpenAIClient with a local image."""
+        from praisonaiagents import Agent
+
+        image_path = tmp_path / "pixel.png"
+        image_path.write_bytes(base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+            "/x8AAusB9WlV9ZkAAAAASUVORK5CYII="
+        ))
+        agent = Agent(
+            name="LocalImageAgent",
+            instructions="Answer image questions briefly.",
+            llm="gpt-4o-mini",
+        )
+
+        response = agent.start(
+            "Confirm that you can inspect the attached image.",
+            attachments=[str(image_path)],
+            stream=False,
+        )
+
+        assert response
+
     def test_responses_api_with_tool(self):
         """
         Test that Responses API correctly handles tool calls — the key
@@ -251,7 +274,7 @@ class TestResponsesAPIRealAgent:
 
         assert response is not None
         assert "42" in response, f"Expected '42' in response, got: {response[:200]}"
-        print(f"[PASS] Tool call via Responses API (Path P1) - response contains '42'")
+        print("[PASS] Tool call via Responses API (Path P1) - response contains '42'")
 
     def test_openai_client_path_with_tool(self):
         """
@@ -275,7 +298,7 @@ class TestResponsesAPIRealAgent:
 
         assert response is not None
         assert "42" in response, f"Expected '42' in response, got: {response[:200]}"
-        print(f"[PASS] Tool call via OpenAIClient Responses API (Path P2) - response contains '42'")
+        print("[PASS] Tool call via OpenAIClient Responses API (Path P2) - response contains '42'")
 
 
 # ── OpenAIClient-specific unit tests ───────────────────────────────────
@@ -320,6 +343,67 @@ class TestOpenAIClientResponsesAPI:
         assert params["temperature"] == 0.5
         # Tools should be in Responses API format (flattened)
         assert params["tools"] == [{"type": "function", "name": "add", "description": "Add", "parameters": {}}]
+
+    def test_build_responses_input_maps_chat_multimodal_parts(self):
+        from praisonaiagents.llm.openai_client import OpenAIClient
+
+        client = OpenAIClient.__new__(OpenAIClient)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this image"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"},
+                },
+            ],
+        }]
+
+        params = client._build_responses_input(messages, "gpt-4o-mini")
+
+        assert params["input"] == [{
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Describe this image"},
+                {
+                    "type": "input_image",
+                    "image_url": "https://example.com/image.png",
+                },
+            ],
+        }]
+
+    def test_build_responses_input_encodes_local_image(self, tmp_path):
+        from praisonaiagents.llm.openai_client import OpenAIClient
+
+        image_path = tmp_path / "pixel.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = OpenAIClient.__new__(OpenAIClient)
+
+        params = client._build_responses_input([{
+            "role": "user",
+            "content": [{
+                "type": "image_url",
+                "image_url": {"url": str(image_path)},
+            }],
+        }], "gpt-4o-mini")
+
+        image_url = params["input"][0]["content"][0]["image_url"]
+        assert image_url == "data:image/png;base64,iVBORw0KGgo="
+
+    def test_build_responses_input_rejects_missing_local_image(self, tmp_path):
+        from praisonaiagents.llm.openai_client import OpenAIClient
+
+        client = OpenAIClient.__new__(OpenAIClient)
+        missing_path = tmp_path / "missing.png"
+
+        with pytest.raises(FileNotFoundError, match="Local image file does not exist"):
+            client._build_responses_input([{
+                "role": "user",
+                "content": [{
+                    "type": "image_url",
+                    "image_url": {"url": str(missing_path)},
+                }],
+            }], "gpt-4o-mini")
 
     def test_responses_to_chat_completion(self):
         from praisonaiagents.llm.openai_client import OpenAIClient

--- a/src/praisonai-agents/tests/integration/test_responses_api.py
+++ b/src/praisonai-agents/tests/integration/test_responses_api.py
@@ -354,7 +354,10 @@ class TestOpenAIClientResponsesAPI:
                 {"type": "text", "text": "Describe this image"},
                 {
                     "type": "image_url",
-                    "image_url": {"url": "https://example.com/image.png"},
+                    "image_url": {
+                        "url": "https://example.com/image.png",
+                        "detail": "high",
+                    },
                 },
             ],
         }]
@@ -368,6 +371,7 @@ class TestOpenAIClientResponsesAPI:
                 {
                     "type": "input_image",
                     "image_url": "https://example.com/image.png",
+                    "detail": "high",
                 },
             ],
         }]

--- a/src/praisonai-agents/tests/integration/test_responses_api.py
+++ b/src/praisonai-agents/tests/integration/test_responses_api.py
@@ -252,6 +252,7 @@ class TestResponsesAPIRealAgent:
         )
 
         assert response
+        print(response)
 
     def test_responses_api_with_tool(self):
         """


### PR DESCRIPTION
Addresses #3934.

Summary:
- maps Chat Completions text and image parts to Responses API input types
- flattens nested image URL objects
- converts local image paths into typed data URLs
- fails clearly for missing or unsupported local image files
- adds an opt-in real Agent.start local-image test

Validation:
- 13 Responses API tests passed
- 5 live tests skipped without credentials
- Ruff and diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sending local image files to the OpenAI Responses API.
  * Added support for remote image URLs and data URLs in multimodal messages.
  * Improved conversion of text and image content for Responses API requests.

* **Bug Fixes**
  * Added validation and clear handling for missing local image files and unsupported image types.

* **Tests**
  * Added coverage for local images, multimodal messages, image encoding, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->