### PR TITLE
feat(managed): add `praisonai managed ps`/`stop`, rename compute= to run_on=

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -660,13 +660,12 @@ class AgentTeam(SpawnAnnounceProtocol):
         reflection: Optional[Any] = None,  # Union[bool, ReflectionConfig] - self-reflection
         caching: Optional[Any] = None,  # Union[bool, CachingConfig] - caching
         learn: Optional[Any] = None,  # Union[bool, LearnConfig] - continuous learning
-        # Union[str, ComputeProviderProtocol] - run every agent's shell/file
-        # tools in ONE shared remote sandbox ("docker", "e2b", "modal",
-        # "daytona", "flyio", "tenki", "local"). Agents share /workspace, so
-        # files written by one agent are visible to the others. Orchestration
-        # stays local. Pass a configured provider instance instead of a name to
-        # customise image/resources.
-        compute: Optional[Any] = None,
+        # Union[str, ComputeProviderProtocol] - where every agent's shell/file
+        # tools run: "docker", "e2b", "modal", "daytona", "flyio", "tenki",
+        # "local". The team shares ONE sandbox and /workspace, so files written
+        # by one agent are visible to the others. Orchestration stays local.
+        # Pass a configured provider instance to customise resources.
+        run_on: Optional[Any] = None,
     ):
         """
         Initialize AgentManager with consolidated feature parameters.
@@ -898,7 +897,7 @@ class AgentTeam(SpawnAnnounceProtocol):
         self.stream = _stream
         self.name = name
         # Remote execution: one shared sandbox for every agent on this team.
-        self.compute = compute
+        self.run_on = run_on
 
         # Callbacks for workflow execution
         self.on_task_start = _on_task_start
@@ -1763,18 +1762,18 @@ class AgentTeam(SpawnAnnounceProtocol):
         """
         # Remote execution: provision ONE sandbox shared by every agent on the
         # team, and tear it down even if execution raises. Re-enters start()
-        # with compute cleared so the wrapper applies exactly once.
-        if getattr(self, "compute", None) is not None:
+        # with run_on cleared so the wrapper applies exactly once.
+        if getattr(self, "run_on", None) is not None:
             from ..managed.shared_compute import SharedCompute
 
-            compute, self.compute = self.compute, None
+            run_on, self.run_on = self.run_on, None
             try:
-                with SharedCompute(compute) as shared:
+                with SharedCompute(run_on) as shared:
                     shared.attach(list(self.agents or []))
                     return self.start(content=content, return_dict=return_dict,
                                       output=output, **kwargs)
             finally:
-                self.compute = compute
+                self.run_on = run_on
 
         # Track execution via telemetry
         if hasattr(self, '_telemetry') and self._telemetry:

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -631,12 +631,12 @@ class AgentFlow:
     # ============================================================
     # REMOTE EXECUTION
     # ============================================================
-    # Union[str, ComputeProviderProtocol] - run every step's shell/file tools in
-    # ONE shared remote sandbox ("docker", "e2b", "modal", "daytona", "flyio",
-    # "tenki", "local"). Agents share /workspace, so a file written by one step
-    # is visible to later steps. Orchestration stays local. Pass a configured
-    # provider instance instead of a name to customise image/resources.
-    compute: Optional[Any] = None
+    # Union[str, ComputeProviderProtocol] - where each step's shell/file tools
+    # run: "docker", "e2b", "modal", "daytona", "flyio", "tenki", "local".
+    # Every step shares ONE sandbox and /workspace, so a file written by one
+    # step is visible to later steps. Orchestration stays local. Pass a
+    # configured provider instance instead of a name to customise resources.
+    run_on: Optional[Any] = None
 
     # ============================================================
     # ROBUSTNESS PARAMS (debugging & audit trail)
@@ -1115,7 +1115,7 @@ class AgentFlow:
                 "separate Workflow instance per concurrent run."
             )
         try:
-            if self.compute is None:
+            if self.run_on is None:
                 return self._run_impl(input, llm, verbose, stream)
             # One sandbox for the whole run; torn down even if a step raises.
             with self._shared_compute() as shared:
@@ -1125,10 +1125,10 @@ class AgentFlow:
             self._execution_lock.release()
 
     def _shared_compute(self):
-        """Build the SharedCompute for this run (see the ``compute=`` field)."""
+        """Build the SharedCompute for this run (see the ``run_on=`` field)."""
         from ..managed.shared_compute import SharedCompute
 
-        return SharedCompute(self.compute)
+        return SharedCompute(self.run_on)
 
     def _collect_agents(self) -> List[Any]:
         """Walk steps (including nested route/parallel/loop/repeat/if) for Agents.

--- a/src/praisonai-agents/tests/managed/test_shared_compute.py
+++ b/src/praisonai-agents/tests/managed/test_shared_compute.py
@@ -237,9 +237,9 @@ def test_collect_agents_walks_nested_steps_and_dedupes():
     assert [x.name for x in collected] == ["A", "B"], "each agent exactly once, in order"
 
 
-def test_flow_without_compute_does_not_provision():
+def test_flow_without_run_on_does_not_provision():
     from praisonaiagents import AgentFlow
 
     flow = AgentFlow(steps=[FakeAgent("A")])
-    assert flow.compute is None
+    assert flow.run_on is None
     assert flow._collect_agents()[0].tools == []

--- a/src/praisonai/praisonai/cli/commands/managed.py
+++ b/src/praisonai/praisonai/cli/commands/managed.py
@@ -663,7 +663,13 @@ _PS_PROVIDERS = ("docker", "e2b", "modal", "daytona", "flyio", "tenki")
 
 
 def _discover_instances(provider_filter: Optional[str] = None):
-    """Return [(provider_name, InstanceInfo), ...] for every reachable provider.
+    """Return (instances, errors) for reachable providers.
+
+    ``instances`` is [(provider_name, InstanceInfo), ...].
+    ``errors`` is [(provider_name, message), ...] for providers that were
+    *available* (installed + configured) but failed while listing — those must
+    surface, otherwise ``ps``/``stop --all`` would wrongly report an empty,
+    successful inventory while sandboxes keep running.
 
     Providers that are not installed or not configured are skipped silently --
     absence of an E2B key is a normal state, not an error worth printing.
@@ -674,26 +680,32 @@ def _discover_instances(provider_filter: Optional[str] = None):
 
     names = [provider_filter] if provider_filter else list(_PS_PROVIDERS)
     found = []
+    errors = []
 
     async def _collect():
         for name in names:
             try:
                 provider = resolve_compute(name)
             except Exception:
-                continue  # provider package not installed
+                # Not installed / unknown provider. Silent unless explicitly
+                # requested, where the user deserves to know it went nowhere.
+                if provider_filter:
+                    errors.append((name, "provider not installed or unknown"))
+                continue
             try:
                 if not getattr(provider, "is_available", True):
-                    continue
+                    continue  # daemon down / no credentials — a normal state
             except Exception:
-                continue  # daemon down / no credentials
+                continue
             try:
                 for info in await provider.list_instances():
                     found.append((name, info))
-            except Exception:
-                continue
+            except Exception as e:
+                # Available but listing failed: real error, never hide it.
+                errors.append((name, str(e)))
 
     asyncio.run(_collect())
-    return found
+    return found, errors
 
 
 def _format_uptime(created_at: float) -> str:
@@ -729,36 +741,44 @@ def managed_ps(
         praisonai managed ps --provider docker
         praisonai managed ps --json
     """
-    rows = _discover_instances(provider)
+    rows, errors = _discover_instances(provider)
 
     if as_json:
-        typer.echo(json.dumps([
-            {
-                "provider": name,
-                "instance_id": info.instance_id,
-                "status": getattr(info.status, "value", str(info.status)),
-                "endpoint": info.endpoint,
-                "created_at": info.created_at,
-                "metadata": info.metadata,
-            }
-            for name, info in rows
-        ], indent=2))
-        return
+        typer.echo(json.dumps({
+            "sandboxes": [
+                {
+                    "provider": name,
+                    "instance_id": info.instance_id,
+                    "status": getattr(info.status, "value", str(info.status)),
+                    "endpoint": info.endpoint,
+                    "created_at": info.created_at,
+                    "metadata": info.metadata,
+                }
+                for name, info in rows
+            ],
+            "errors": [{"provider": name, "error": msg} for name, msg in errors],
+        }, indent=2))
+        raise typer.Exit(1 if errors else 0)
 
     if not rows:
         typer.echo("No running sandboxes.")
-        return
+    else:
+        typer.echo(f"{'INSTANCE ID':<26} {'PROVIDER':<10} {'STATUS':<10} {'UPTIME':<8} IMAGE")
+        typer.echo("-" * 78)
+        for name, info in rows:
+            status = getattr(info.status, "value", str(info.status))
+            image = (info.metadata or {}).get("image") or info.endpoint or ""
+            typer.echo(
+                f"{info.instance_id:<26} {name:<10} {status:<10} "
+                f"{_format_uptime(info.created_at):<8} {image}"
+            )
+        typer.echo(f"\n{len(rows)} running. Stop with: praisonai managed stop <instance-id>")
 
-    typer.echo(f"{'INSTANCE ID':<26} {'PROVIDER':<10} {'STATUS':<10} {'UPTIME':<8} IMAGE")
-    typer.echo("-" * 78)
-    for name, info in rows:
-        status = getattr(info.status, "value", str(info.status))
-        image = (info.metadata or {}).get("image") or info.endpoint or ""
-        typer.echo(
-            f"{info.instance_id:<26} {name:<10} {status:<10} "
-            f"{_format_uptime(info.created_at):<8} {image}"
-        )
-    typer.echo(f"\n{len(rows)} running. Stop with: praisonai managed stop <instance-id>")
+    if errors:
+        typer.echo("\nSome providers could not be queried (sandboxes may still be running):")
+        for name, msg in errors:
+            typer.echo(f"  {name}: {msg}")
+        raise typer.Exit(1)
 
 
 @app.command("stop")
@@ -784,14 +804,14 @@ def managed_stop(
         typer.echo("Give an instance ID or --all. See: praisonai managed ps")
         raise typer.Exit(1)
 
-    rows = _discover_instances(provider)
+    rows, errors = _discover_instances(provider)
     if instance_id:
         rows = [r for r in rows if r[1].instance_id == instance_id]
         if not rows:
             typer.echo(f"No running sandbox with ID {instance_id!r}. See: praisonai managed ps")
             raise typer.Exit(1)
 
-    if not rows:
+    if not rows and not errors:
         typer.echo("No running sandboxes.")
         return
 
@@ -806,7 +826,15 @@ def managed_stop(
             failed += 1
 
     typer.echo(f"\n{stopped} stopped" + (f", {failed} failed" if failed else ""))
-    if failed:
+
+    if errors:
+        # A provider we could not even inventory may still hold live sandboxes
+        # we never got the chance to stop. Never claim a clean sweep.
+        typer.echo("\nSome providers could not be queried (sandboxes may still be running):")
+        for name, msg in errors:
+            typer.echo(f"  {name}: {msg}")
+
+    if failed or errors:
         raise typer.Exit(1)
 
 

--- a/src/praisonai/praisonai/cli/commands/managed.py
+++ b/src/praisonai/praisonai/cli/commands/managed.py
@@ -653,6 +653,163 @@ def ids_restore(
 # ─────────────────────────────────────────────────────────────────────────────
 # Register sub-apps onto main app
 # ─────────────────────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
+# sandbox lifecycle: ps / stop
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Providers worth polling for running sandboxes. "local" is excluded: it runs
+# on this machine and has nothing to reclaim.
+_PS_PROVIDERS = ("docker", "e2b", "modal", "daytona", "flyio", "tenki")
+
+
+def _discover_instances(provider_filter: Optional[str] = None):
+    """Return [(provider_name, InstanceInfo), ...] for every reachable provider.
+
+    Providers that are not installed or not configured are skipped silently --
+    absence of an E2B key is a normal state, not an error worth printing.
+    """
+    import asyncio
+
+    from praisonaiagents.managed._compute_bridge import resolve_compute
+
+    names = [provider_filter] if provider_filter else list(_PS_PROVIDERS)
+    found = []
+
+    async def _collect():
+        for name in names:
+            try:
+                provider = resolve_compute(name)
+            except Exception:
+                continue  # provider package not installed
+            try:
+                if not getattr(provider, "is_available", True):
+                    continue
+            except Exception:
+                continue  # daemon down / no credentials
+            try:
+                for info in await provider.list_instances():
+                    found.append((name, info))
+            except Exception:
+                continue
+
+    asyncio.run(_collect())
+    return found
+
+
+def _format_uptime(created_at: float) -> str:
+    import time
+
+    if not created_at:
+        return "-"
+    seconds = max(0, int(time.time() - created_at))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h{(seconds % 3600) // 60:02d}m"
+    return f"{seconds // 86400}d{(seconds % 86400) // 3600:02d}h"
+
+
+@app.command("ps")
+def managed_ps(
+    provider: Optional[str] = typer.Option(
+        None, "--provider", "-p", help="Only this provider (docker, e2b, modal, ...)"
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Machine-readable output"),
+):
+    """List running agent sandboxes.
+
+    Sandboxes normally shut themselves down when a run finishes, but a crashed
+    or killed run can leave one behind. This shows what is still up, so nothing
+    keeps burning resources unnoticed.
+
+    Example:
+        praisonai managed ps
+        praisonai managed ps --provider docker
+        praisonai managed ps --json
+    """
+    rows = _discover_instances(provider)
+
+    if as_json:
+        typer.echo(json.dumps([
+            {
+                "provider": name,
+                "instance_id": info.instance_id,
+                "status": getattr(info.status, "value", str(info.status)),
+                "endpoint": info.endpoint,
+                "created_at": info.created_at,
+                "metadata": info.metadata,
+            }
+            for name, info in rows
+        ], indent=2))
+        return
+
+    if not rows:
+        typer.echo("No running sandboxes.")
+        return
+
+    typer.echo(f"{'INSTANCE ID':<26} {'PROVIDER':<10} {'STATUS':<10} {'UPTIME':<8} IMAGE")
+    typer.echo("-" * 78)
+    for name, info in rows:
+        status = getattr(info.status, "value", str(info.status))
+        image = (info.metadata or {}).get("image") or info.endpoint or ""
+        typer.echo(
+            f"{info.instance_id:<26} {name:<10} {status:<10} "
+            f"{_format_uptime(info.created_at):<8} {image}"
+        )
+    typer.echo(f"\n{len(rows)} running. Stop with: praisonai managed stop <instance-id>")
+
+
+@app.command("stop")
+def managed_stop(
+    instance_id: Optional[str] = typer.Argument(None, help="Instance ID to stop"),
+    all_instances: bool = typer.Option(False, "--all", help="Stop every running sandbox"),
+    provider: Optional[str] = typer.Option(
+        None, "--provider", "-p", help="Only this provider"
+    ),
+):
+    """Stop a running agent sandbox (or all of them).
+
+    Example:
+        praisonai managed stop docker_a1b2c3d4
+        praisonai managed stop --all
+        praisonai managed stop --all --provider docker
+    """
+    import asyncio
+
+    from praisonaiagents.managed._compute_bridge import resolve_compute
+
+    if not instance_id and not all_instances:
+        typer.echo("Give an instance ID or --all. See: praisonai managed ps")
+        raise typer.Exit(1)
+
+    rows = _discover_instances(provider)
+    if instance_id:
+        rows = [r for r in rows if r[1].instance_id == instance_id]
+        if not rows:
+            typer.echo(f"No running sandbox with ID {instance_id!r}. See: praisonai managed ps")
+            raise typer.Exit(1)
+
+    if not rows:
+        typer.echo("No running sandboxes.")
+        return
+
+    stopped, failed = 0, 0
+    for name, info in rows:
+        try:
+            asyncio.run(resolve_compute(name).shutdown(info.instance_id))
+            typer.echo(f"Stopped {info.instance_id} ({name})")
+            stopped += 1
+        except Exception as e:
+            typer.echo(f"Failed to stop {info.instance_id} ({name}): {e}")
+            failed += 1
+
+    typer.echo(f"\n{stopped} stopped" + (f", {failed} failed" if failed else ""))
+    if failed:
+        raise typer.Exit(1)
+
+
 app.add_typer(sessions_app, name="sessions")
 app.add_typer(agents_app,   name="agents")
 app.add_typer(envs_app,     name="envs")

--- a/src/praisonai/praisonai/integrations/compute/docker.py
+++ b/src/praisonai/praisonai/integrations/compute/docker.py
@@ -392,28 +392,53 @@ class DockerCompute:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._shutdown_sync, instance_id)
 
+    def _find_container(self, instance_id: str):
+        """Look up a container by name, for instances this process didn't start.
+
+        ``_containers`` only knows about instances provisioned by *this*
+        process, so a CLI invocation (``praisonai managed stop``) would
+        otherwise find nothing and silently no-op.
+        """
+        try:
+            return self._get_client().containers.get(f"praisonai_{instance_id}")
+        except Exception:
+            return None
+
     def _shutdown_sync(self, instance_id: str) -> None:
         info = self._containers.pop(instance_id, None)
-        if info:
-            container = info["container"]
-            try:
-                container.stop(timeout=10)
-                if info["config"].auto_shutdown:
-                    container.remove(force=True)
-            except Exception as e:
-                logger.warning("[docker_compute] shutdown error: %s", e)
-            logger.info("[docker_compute] shutdown: %s", instance_id)
+        container = info["container"] if info else self._find_container(instance_id)
+        if container is None:
+            # Report rather than silently succeeding: callers (and the CLI)
+            # must be able to tell "stopped it" from "never found it".
+            raise ValueError(f"No docker container found for instance {instance_id!r}")
+
+        # Containers started by another process have no in-process config;
+        # default to removing, matching ComputeConfig.auto_shutdown's default.
+        auto_shutdown = info["config"].auto_shutdown if info else True
+        try:
+            container.stop(timeout=10)
+            if auto_shutdown:
+                container.remove(force=True)
+        except Exception as e:
+            logger.warning("[docker_compute] shutdown error: %s", e)
+            raise
+        logger.info("[docker_compute] shutdown: %s", instance_id)
 
     async def get_status(self, instance_id: str) -> Any:
         from praisonaiagents.managed.protocols import InstanceInfo, InstanceStatus
 
         info = self._containers.get(instance_id)
         if not info:
-            return InstanceInfo(
-                instance_id=instance_id,
-                status=InstanceStatus.STOPPED,
-                provider="docker",
-            )
+            # May have been started by another process; look it up by name
+            # before declaring it stopped.
+            container = self._find_container(instance_id)
+            if container is None:
+                return InstanceInfo(
+                    instance_id=instance_id,
+                    status=InstanceStatus.STOPPED,
+                    provider="docker",
+                )
+            info = {"container": container}
 
         try:
             info["container"].reload()
@@ -528,23 +553,75 @@ class DockerCompute:
             return False
 
     async def list_instances(self) -> list:
+        """List every running praisonai-managed container on this host.
+
+        Enumerates Docker by the ``praisonai=managed`` label rather than the
+        in-process ``_containers`` registry, so instances started by an earlier
+        process (a finished script, a crashed run) are still discoverable --
+        which is the whole point of being able to find and reclaim strays.
+        """
         from praisonaiagents.managed.protocols import InstanceInfo, InstanceStatus
 
-        result = []
-        for iid, info in self._containers.items():
+        import calendar
+        import email.utils
+
+        def _created_at(container, fallback: float) -> float:
+            """Best-effort container start time as a POSIX timestamp."""
+            created = (container.attrs or {}).get("Created")
+            if not isinstance(created, str) or not created:
+                return fallback
             try:
-                info["container"].reload()
-                if info["container"].status == "running":
-                    result.append(InstanceInfo(
-                        instance_id=iid,
-                        status=InstanceStatus.RUNNING,
-                        endpoint=f"docker://{info['container'].id[:12]}",
-                        provider="docker",
-                        created_at=info.get("created_at", 0),
-                    ))
+                # Docker reports RFC3339 with nanosecond precision, which
+                # datetime cannot parse directly; trim to microseconds.
+                text = created.replace("Z", "+00:00")
+                if "." in text:
+                    head, _, tail = text.partition(".")
+                    frac, sign, offset = (
+                        tail.partition("+") if "+" in tail else tail.partition("-")
+                    )
+                    text = f"{head}.{frac[:6]}{sign}{offset}"
+                from datetime import datetime
+
+                return datetime.fromisoformat(text).timestamp()
             except Exception:
-                pass
-        return result
+                try:
+                    return calendar.timegm(email.utils.parsedate(created))
+                except Exception:
+                    return fallback
+
+        def _list_sync():
+            client = self._get_client()
+            containers = client.containers.list(
+                filters={"label": "praisonai=managed", "status": "running"}
+            )
+            found = []
+            for container in containers:
+                instance_id = (container.labels or {}).get("instance_id")
+                if not instance_id:
+                    # Fall back to the naming convention for older containers.
+                    instance_id = (container.name or "").removeprefix("praisonai_")
+                if not instance_id:
+                    continue
+                known = self._containers.get(instance_id, {})
+                found.append(InstanceInfo(
+                    instance_id=instance_id,
+                    status=InstanceStatus.RUNNING,
+                    endpoint=f"docker://{container.id[:12]}",
+                    provider="docker",
+                    created_at=_created_at(container, known.get("created_at", 0)),
+                    metadata={
+                        "image": (container.image.tags or [""])[0] if container.image else "",
+                        "name": container.name or "",
+                    },
+                ))
+            return found
+
+        try:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, _list_sync)
+        except Exception as exc:
+            logger.debug("[docker_compute] list_instances failed: %s", exc)
+            return []
 
     def _install_packages_sync(self, container, packages: Dict[str, list]) -> None:
         pip_pkgs = packages.get("pip", [])

--- a/src/praisonai/praisonai/integrations/managed_agents.py
+++ b/src/praisonai/praisonai/integrations/managed_agents.py
@@ -1087,9 +1087,9 @@ def ManagedAgent(
     - provider="anthropic" → HostedAgent(provider="anthropic", ...)
     - provider in {"openai","gemini","ollama","local"} → LocalAgent(...)
       (DeprecationWarning: "use LocalAgent directly; put LLM name in model=")
-    - provider in {"e2b","modal","flyio","daytona","docker"} → raise ValueError
-      ("Cloud compute belongs on LocalAgent(compute=...). Hosted runtimes for
-       these providers are not yet available.")
+    - provider in {"e2b","modal","flyio","daytona","docker","tenki"} → emits a
+      DeprecationWarning and delegates to LocalManagedAgent(compute=<provider>).
+      (It does NOT raise; prefer LocalAgent(compute="...") directly.)
     
     Returns:
         An instance satisfying ``ManagedBackendProtocol``.

--- a/src/praisonai/praisonai/integrations/managed_agents.py
+++ b/src/praisonai/praisonai/integrations/managed_agents.py
@@ -1092,10 +1092,10 @@ def ManagedAgent(
       (It does NOT raise; prefer LocalAgent(compute="...") directly.)
     
     Returns:
-        An instance satisfying ``ManagedBackendProtocol``.
-        
-    Raises:
-        ValueError: For compute-provider names that should use LocalAgent(compute=).
+        An instance satisfying ``ManagedBackendProtocol``. Compute-provider
+        names ({"e2b","modal","flyio","daytona","docker","tenki"}) do NOT
+        raise — they emit a ``DeprecationWarning`` and delegate to
+        ``LocalManagedAgent(compute=<provider>)``.
     """
     # Track if provider was auto-detected to avoid spurious deprecation warnings
     auto_detected = provider is None

--- a/src/praisonai/praisonai/suite_runner/report_viewer.py
+++ b/src/praisonai/praisonai/suite_runner/report_viewer.py
@@ -190,8 +190,9 @@ def find_latest_report_dir(suite: str, base_dir: Optional[Path] = None) -> Optio
     if not candidates:
         return None
     
-    # Sort by mtime (newest first)
-    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    # Sort by mtime (newest first), breaking ties by name so timestamp-named
+    # dirs (e.g. "20260109_140000") remain deterministic when mtimes collide.
+    candidates.sort(key=lambda p: (p.stat().st_mtime, p.name), reverse=True)
     return candidates[0]
 
 

--- a/src/praisonai/tests/unit/test_managed_ps.py
+++ b/src/praisonai/tests/unit/test_managed_ps.py
@@ -1,0 +1,199 @@
+"""Tests for `praisonai managed ps` / `stop` and cross-process instance lookup.
+
+No Docker required: providers are faked. The real Docker path is exercised
+manually; see the PR description.
+"""
+
+import time
+
+import pytest
+from typer.testing import CliRunner
+
+from praisonai.cli.commands.managed import (
+    _format_uptime,
+    app,
+)
+import praisonai.cli.commands.managed as managed_cli
+
+
+class _Status:
+    def __init__(self, value):
+        self.value = value
+
+
+class _Info:
+    def __init__(self, instance_id, created_at=None, image="python:3.12-slim"):
+        self.instance_id = instance_id
+        self.status = _Status("running")
+        self.endpoint = f"docker://{instance_id[:12]}"
+        self.provider = "docker"
+        self.created_at = created_at if created_at is not None else time.time() - 90
+        self.metadata = {"image": image}
+
+
+class FakeProvider:
+    """Stands in for a ComputeProviderProtocol implementation."""
+
+    def __init__(self, instances=None, available=True):
+        self.is_available = available
+        self._instances = list(instances or [])
+        self.shutdowns = []
+
+    async def list_instances(self):
+        return list(self._instances)
+
+    async def shutdown(self, instance_id):
+        self.shutdowns.append(instance_id)
+        self._instances = [i for i in self._instances if i.instance_id != instance_id]
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def one_docker_instance(monkeypatch):
+    """Route every provider lookup to a single fake docker provider."""
+    provider = FakeProvider([_Info("docker_abc123")])
+
+    def fake_resolve(name):
+        if name == "docker":
+            return provider
+        raise ImportError(f"{name} not installed")
+
+    monkeypatch.setattr(managed_cli, "_PS_PROVIDERS", ("docker", "e2b"))
+    monkeypatch.setattr(
+        "praisonaiagents.managed._compute_bridge.resolve_compute", fake_resolve
+    )
+    return provider
+
+
+# ── uptime formatting ────────────────────────────────────────────────────────
+@pytest.mark.parametrize("seconds,expected", [
+    (0, "-"),          # unknown created_at renders as "-"
+    (5, "5s"),
+    (90, "1m"),
+    (3700, "1h01m"),
+    (90000, "1d01h"),
+])
+def test_format_uptime(seconds, expected):
+    created = 0 if seconds == 0 else time.time() - seconds
+    assert _format_uptime(created) == expected
+
+
+# ── ps ───────────────────────────────────────────────────────────────────────
+def test_ps_lists_running_sandbox(runner, one_docker_instance):
+    result = runner.invoke(app, ["ps"])
+    assert result.exit_code == 0
+    assert "docker_abc123" in result.output
+    assert "python:3.12-slim" in result.output
+    assert "1 running" in result.output
+
+
+def test_ps_json_is_machine_readable(runner, one_docker_instance):
+    import json
+
+    result = runner.invoke(app, ["ps", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload[0]["instance_id"] == "docker_abc123"
+    assert payload[0]["provider"] == "docker"
+    assert payload[0]["status"] == "running"
+
+
+def test_ps_reports_empty_state(runner, monkeypatch):
+    monkeypatch.setattr(managed_cli, "_discover_instances", lambda *a, **k: [])
+    result = runner.invoke(app, ["ps"])
+    assert result.exit_code == 0
+    assert "No running sandboxes" in result.output
+
+
+def test_ps_skips_unavailable_providers(runner, monkeypatch):
+    """A provider with no credentials/daemon is a normal state, not an error."""
+    monkeypatch.setattr(managed_cli, "_PS_PROVIDERS", ("docker",))
+    monkeypatch.setattr(
+        "praisonaiagents.managed._compute_bridge.resolve_compute",
+        lambda name: FakeProvider([_Info("never_shown")], available=False),
+    )
+    result = runner.invoke(app, ["ps"])
+    assert result.exit_code == 0
+    assert "never_shown" not in result.output
+
+
+# ── stop ─────────────────────────────────────────────────────────────────────
+def test_stop_requires_target(runner):
+    result = runner.invoke(app, ["stop"])
+    assert result.exit_code == 1
+    assert "--all" in result.output
+
+
+def test_stop_unknown_id_fails_loudly(runner, one_docker_instance):
+    result = runner.invoke(app, ["stop", "docker_does_not_exist"])
+    assert result.exit_code == 1
+    assert "No running sandbox" in result.output
+    assert one_docker_instance.shutdowns == []
+
+
+def test_stop_by_id(runner, one_docker_instance):
+    result = runner.invoke(app, ["stop", "docker_abc123"])
+    assert result.exit_code == 0
+    assert one_docker_instance.shutdowns == ["docker_abc123"]
+
+
+def test_stop_all(runner, one_docker_instance):
+    result = runner.invoke(app, ["stop", "--all"])
+    assert result.exit_code == 0
+    assert one_docker_instance.shutdowns == ["docker_abc123"]
+    assert "1 stopped" in result.output
+
+
+def test_stop_reports_failure_exit_code(runner, monkeypatch):
+    class Failing(FakeProvider):
+        async def shutdown(self, instance_id):
+            raise RuntimeError("daemon gone")
+
+    provider = Failing([_Info("docker_abc123")])
+    monkeypatch.setattr(managed_cli, "_PS_PROVIDERS", ("docker",))
+    monkeypatch.setattr(
+        "praisonaiagents.managed._compute_bridge.resolve_compute", lambda name: provider
+    )
+    result = runner.invoke(app, ["stop", "--all"])
+    assert result.exit_code == 1
+    assert "Failed to stop" in result.output
+
+
+# ── cross-process lookup (the reason ps/stop work at all) ────────────────────
+def test_docker_shutdown_raises_when_container_missing():
+    """A stop that found nothing must not report success."""
+    docker_mod = pytest.importorskip("praisonai.integrations.compute.docker")
+    compute = docker_mod.DockerCompute()
+    compute._containers = {}
+    compute._find_container = lambda instance_id: None
+
+    with pytest.raises(ValueError, match="No docker container"):
+        compute._shutdown_sync("docker_missing")
+
+
+def test_docker_shutdown_falls_back_to_lookup_by_name():
+    """Instances started by another process must still be stoppable."""
+    docker_mod = pytest.importorskip("praisonai.integrations.compute.docker")
+
+    class FakeContainer:
+        def __init__(self):
+            self.stopped = False
+            self.removed = False
+
+        def stop(self, timeout=None):
+            self.stopped = True
+
+        def remove(self, force=False):
+            self.removed = True
+
+    container = FakeContainer()
+    compute = docker_mod.DockerCompute()
+    compute._containers = {}                       # nothing known in-process
+    compute._find_container = lambda instance_id: container
+
+    compute._shutdown_sync("docker_from_other_process")
+    assert container.stopped and container.removed

--- a/src/praisonai/tests/unit/test_managed_ps.py
+++ b/src/praisonai/tests/unit/test_managed_ps.py
@@ -97,13 +97,15 @@ def test_ps_json_is_machine_readable(runner, one_docker_instance):
     result = runner.invoke(app, ["ps", "--json"])
     assert result.exit_code == 0
     payload = json.loads(result.output)
-    assert payload[0]["instance_id"] == "docker_abc123"
-    assert payload[0]["provider"] == "docker"
-    assert payload[0]["status"] == "running"
+    sandboxes = payload["sandboxes"]
+    assert sandboxes[0]["instance_id"] == "docker_abc123"
+    assert sandboxes[0]["provider"] == "docker"
+    assert sandboxes[0]["status"] == "running"
+    assert payload["errors"] == []
 
 
 def test_ps_reports_empty_state(runner, monkeypatch):
-    monkeypatch.setattr(managed_cli, "_discover_instances", lambda *a, **k: [])
+    monkeypatch.setattr(managed_cli, "_discover_instances", lambda *a, **k: ([], []))
     result = runner.invoke(app, ["ps"])
     assert result.exit_code == 0
     assert "No running sandboxes" in result.output
@@ -119,6 +121,35 @@ def test_ps_skips_unavailable_providers(runner, monkeypatch):
     result = runner.invoke(app, ["ps"])
     assert result.exit_code == 0
     assert "never_shown" not in result.output
+
+
+def test_ps_surfaces_listing_failure(runner, monkeypatch):
+    """An available provider that fails to list must NOT report clean success."""
+    class Broken(FakeProvider):
+        async def list_instances(self):
+            raise RuntimeError("daemon exploded")
+
+    monkeypatch.setattr(managed_cli, "_PS_PROVIDERS", ("docker",))
+    monkeypatch.setattr(
+        "praisonaiagents.managed._compute_bridge.resolve_compute",
+        lambda name: Broken(available=True),
+    )
+    result = runner.invoke(app, ["ps"])
+    assert result.exit_code == 1
+    assert "daemon exploded" in result.output
+
+
+def test_ps_explicit_unknown_provider_is_loud(runner, monkeypatch):
+    """`--provider foo` for an uninstalled/unknown provider should not be silent."""
+    def fake_resolve(name):
+        raise ImportError(f"{name} not installed")
+
+    monkeypatch.setattr(
+        "praisonaiagents.managed._compute_bridge.resolve_compute", fake_resolve
+    )
+    result = runner.invoke(app, ["ps", "--provider", "e2b"])
+    assert result.exit_code == 1
+    assert "e2b" in result.output
 
 
 # ── stop ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #3949, closing the piece left open there plus what reviewing it turned up.

## 1. Sandbox visibility — the open item from #3949

```bash
praisonai managed ps          # list running sandboxes
praisonai managed ps --json   # machine-readable
praisonai managed stop <id>   # reclaim one
praisonai managed stop --all  # reclaim everything
```

```
INSTANCE ID                PROVIDER   STATUS     UPTIME   IMAGE
------------------------------------------------------------------------------
docker_5afaa3bfa704        docker     running    42s      python:3.12-slim

1 running. Stop with: praisonai managed stop <instance-id>
```

Sandboxes self-destruct when a run ends, but a crashed or killed run leaves one behind and there was no way to see or reclaim it. Providers that aren't installed or configured are skipped silently — no E2B key is a normal state, not an error.

## 2. Three cross-process bugs found while building it

`DockerCompute` tracked instances only in an **in-process dict**:

| Method | Bug | Impact |
|---|---|---|
| `list_instances()` | returned only what *this* process started | always empty from a fresh CLI — exactly when you need to find strays |
| `_shutdown_sync()` | popped from the dict, found nothing, **returned silently** | `stop` printed "Stopped …" while the container **kept running** |
| `get_status()` | reported `STOPPED` for any container it didn't start | wrong status for live sandboxes |

All three now fall back to Docker itself (the `praisonai=managed` label and `praisonai_<id>` name), and shutdown **raises** rather than pretending to succeed. The silent-success one is the nasty one: I only caught it because I checked `docker ps` after the CLI said it had stopped everything.

## 3. Naming: `compute=` → `run_on=`

I researched how comparable tools name this, then re-validated my own choice against it.

**Industry tally for this exact concept:**

| Name | Count | Who |
|---|---|---|
| `executor` family | 9 | smolagents, Google ADK, AutoGen, AG2, Airflow, Nextflow, Snakemake, Covalent, Dagster |
| `image`/`template`/`snapshot` | 7 | E2B, Modal, Daytona, Fly, Vercel, Devin |
| `region`/`target`/`placement`/`infra` | 8 | Modal, Fly, Vercel, Daytona, Cloudflare, SkyPilot, Replit |
| `environment` | 4 | OpenAI shell tool, Agents SDK, Anthropic, Codex |
| **`compute`** | **1** | Azure ML only |
| `runtime` | **0 current** | Vercel Sandbox **deprecated** `runtime` → `image` |

**Why not the most popular name.** `executor` wins industry-wide but is already used as a concept inside `workflows.py`. `backend` (3×), `runtime` (3×) and `sandbox` (1×) are all live public `Agent` params, and `provider` has ~147 uses for LLM/vector-store providers. `Agent.__init__` already carries `backend=`, `cli_backend=`, `runtime=` — adding a fourth neighbour was the real risk.

**Why not keep `compute`.** It's free and matches our internal `ComputeConfig`/`ComputeProviderProtocol`, so it was defensible. But the goal is a name a **non-developer** can read, and noun-`compute` is cloud jargon: Wiktionary gives one noun sense labelled *"(chiefly cloud computing)"*. Microsoft's style guide test — *"if you think a term is jargon, it probably is"* — applies.

**`run_on=` wins**: plain English, mass-audience precedent in GitHub Actions `runs-on:`, and **zero** collisions here (verified: 0 hits in the core SDK).

```python
AgentFlow(run_on="docker", steps=[writer, reader])
AgentTeam(agents=[w, r], run_on="docker")
```

`compute` **stays** as the internal vocabulary (`ComputeConfig`, `ComputeProviderProtocol`, `SharedCompute`, `_compute_bridge`) — industry-idiomatic where the audience is contributors.

**No alias, no second param.** `compute=` merged in #3949 but is **not in any published release** — I confirmed PyPI `praisonaiagents==1.6.166` does not contain `shared_compute` (last version bump predates the merge). So this rename breaks nobody, and skipping the alias honours "don't add params for the sake of it."

## 4. Doc discrepancy fixed

The `ManagedAgent` factory docstring claimed compute-provider names **raise `ValueError`**. They actually emit a `DeprecationWarning` and delegate to `LocalManagedAgent`. Verified by running it; docstring corrected.

## Verification

- `run_on="docker"` — write-then-read hit **one** shared instance (`docker_0703547d09a0` → `'RENAMED-OK'`), clean teardown, 0 leftover containers
- `managed ps` — found a real stray container with correct uptime, cross-checked against `docker ps`
- `managed stop --all` — genuinely removed it (ground truth: 0 containers); previously it lied
- **30 tests** (16 CLI + 14 core), none needing Docker or cloud credentials
- Managed suite: **277 passed**, 21 skipped. The same **6 failures exist on clean `main`** (verified by running the identical selection there) and are unrelated.

## Still open

Full remote orchestration (laptop disconnects), YAML `run_on:` support, parallel fan-out across N instances, and migrating README/examples off the deprecated `ManagedAgent` factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed sandbox listing with provider filtering, uptime details, and JSON or table output.
  * Added commands to stop individual or all managed sandboxes, with success and failure reporting.
  * Docker-managed sandboxes can now be discovered across processes.

* **Improvements**
  * Renamed the public execution setting from `compute` to `run_on` for agents and workflows.
  * Improved Docker status, shutdown, and container discovery handling.
  * Added support for the `tenki` provider in managed-agent documentation.
  * Sorted report directories by latest modification time for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->