### PR TITLE
fix(sandbox): make Agent(sandbox=...) actually isolate execution

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -2447,6 +2447,42 @@ Your Goal: {self.goal}
         # Sandbox configuration - initialize SandboxMixin
         super().__init__(sandbox=sandbox)
 
+        # Give the model sandboxed code-execution tools when a sandbox is set.
+        # Without this, `sandbox=` built a SandboxConfig that nothing ever read:
+        # the agent looked isolated and was not. Note this isolates *code the
+        # model writes* -- Python callables passed via `tools=` are ordinary
+        # in-process functions and cannot be retrofitted into a sandbox.
+        if self.sandbox_config is not None:
+            try:
+                existing = {
+                    getattr(t, "__name__", getattr(t, "name", None))
+                    for t in (self.tools or [])
+                }
+                sandbox_tools = [
+                    t for t in self._get_code_execution_tools()
+                    if getattr(t, "__name__", getattr(t, "name", None)) not in existing
+                ]
+                if sandbox_tools:
+                    self.tools = list(self.tools or []) + sandbox_tools
+            except Exception as exc:  # pragma: no cover - never block construction
+                logging.warning(
+                    "Could not attach sandbox code-execution tools to %s: %s",
+                    self.name, exc,
+                )
+
+        # A managed backend takes over the whole turn before any local execution,
+        # so a sandbox set alongside it silently does nothing. Say so.
+        if self.sandbox_config is not None and getattr(self, "backend", None) is not None:
+            import warnings
+
+            warnings.warn(
+                "Agent(sandbox=..., backend=...): the managed backend handles the "
+                "entire turn, so the sandbox= setting is ignored. Configure "
+                "isolation on the backend instead (e.g. LocalAgent(compute='docker')).",
+                FutureWarning,
+                stacklevel=2,
+            )
+
     @staticmethod
     def _resolve_tool_config(tool_config):
         """Resolve tool_config parameter with backward compatibility."""
@@ -2607,7 +2643,10 @@ Your Goal: {self.goal}
             'interrupt_controller': None,  # Let new instance create its own
             
             # Sandbox config
-            'sandbox': getattr(self, '_sandbox_config', None),
+            # SandboxMixin stores this as `sandbox_config`; reading the
+            # underscore name (never assigned) made every clone silently drop
+            # its sandbox and run unisolated.
+            'sandbox': getattr(self, 'sandbox_config', None),
         }
         
         # Handle deprecated parameters for backward compatibility

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -2591,8 +2591,15 @@ Your Goal: {self.goal}
             'api_key': getattr(self, 'api_key', None),
             'auth': getattr(self, 'auth', None),
             
-            # Shallow copy tools to avoid deepcopy issues with nested objects
-            'tools': list(self.tools) if self.tools else None,
+            # Shallow copy tools to avoid deepcopy issues with nested objects.
+            # Drop framework-generated sandbox tools: they close over the source
+            # agent, so the constructor must regenerate clone-bound replacements
+            # (see the sandbox wiring below). User tools with colliding names
+            # lack the tag and are preserved.
+            'tools': (
+                [t for t in self.tools if not getattr(t, "_praison_sandbox_tool", False)]
+                if self.tools else None
+            ),
             
             # Skip handoffs entirely - they shouldn't be shared across channels
             # and can contain nested Agent instances that cause RLock issues

--- a/src/praisonai-agents/praisonaiagents/agent/autonomy.py
+++ b/src/praisonai-agents/praisonaiagents/agent/autonomy.py
@@ -106,8 +106,11 @@ class AutonomyConfig:
         track_changes: Whether to track filesystem changes via shadow git.
             Defaults to True when level="full_auto", False otherwise.
             When enabled, agent.undo()/redo()/diff() become available.
-        sandbox: Optional SandboxConfig for execution isolation.
-            When level="full_auto" and sandbox is None, subprocess sandbox is auto-enabled.
+        sandbox: Optional SandboxConfig, carried for forward compatibility.
+            NOT IMPLEMENTED: nothing currently reads this field, and no sandbox
+            is auto-enabled at any autonomy level. To isolate execution, set it
+            on the agent itself -- Agent(sandbox=...) -- or run the whole
+            workflow remotely with AgentFlow(run_on="docker").
         snapshot_dir: Directory for snapshot storage. Defaults to ~/.praisonai/snapshots.
     
     Usage::

--- a/src/praisonai-agents/praisonaiagents/agent/sandbox_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/sandbox_mixin.py
@@ -79,19 +79,30 @@ class SandboxMixin:
             )
         
         # Security pre-check if enabled
+        security_warnings = None
         if check_security:
             from ..sandbox import check_code_safety, format_warnings
-            warnings = check_code_safety(code, language)
-            if warnings:
-                warning_text = format_warnings(warnings)
+            security_warnings = check_code_safety(code, language)
+            if security_warnings:
+                warning_text = format_warnings(security_warnings)
                 if self.verbose:
                     logger.warning(f"Security warnings for code execution:\n{warning_text}")
-                
-                # Store warnings in result metadata
-                kwargs.setdefault('metadata', {})['security_warnings'] = warnings
-        
+
         manager = self.get_sandbox_manager()
-        return await manager.run_code(code, language=language, **kwargs)
+        result = await manager.run_code(code, language=language, **kwargs)
+
+        # Attach warnings to the result rather than forwarding a `metadata`
+        # kwarg: SandboxProtocol.execute() has no such parameter, so passing it
+        # through raised TypeError for any code that tripped a warning -- i.e.
+        # sandboxed execution failed exactly when the check mattered most.
+        if security_warnings:
+            try:
+                existing = getattr(result, "metadata", None) or {}
+                existing["security_warnings"] = security_warnings
+                result.metadata = existing
+            except Exception:  # pragma: no cover - result may be immutable
+                logger.debug("Could not attach security warnings to sandbox result")
+        return result
     
     def execute_code_sync(
         self,

--- a/src/praisonai-agents/praisonaiagents/agent/sandbox_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/sandbox_mixin.py
@@ -241,5 +241,15 @@ class SandboxMixin:
                 return result.stdout or result.output
             else:
                 return f"Error: {result.error or result.stderr}"
-        
-        return [execute_python_code, execute_shell_command]
+
+        # Tag as framework-generated so clone_for_channel() can drop these
+        # source-bound wrappers and regenerate clone-owned ones. Without the
+        # tag, a clone would inherit tools closing over the *source* agent and
+        # silently share its SandboxManager.
+        generated = [execute_python_code, execute_shell_command]
+        for _t in generated:
+            try:
+                _t._praison_sandbox_tool = True
+            except Exception:  # pragma: no cover - tool object may be immutable
+                pass
+        return generated

--- a/src/praisonai-agents/praisonaiagents/config/feature_configs.py
+++ b/src/praisonai-agents/praisonaiagents/config/feature_configs.py
@@ -847,9 +847,11 @@ class ExecutionConfig:
     code_execution: bool = False
     code_mode: str = "safe"  # "safe" or "unsafe"
     
-    # Code execution sandbox mode - "sandbox" (default) uses subprocess isolation
-    # "direct" runs in current process (legacy, less secure)
-    code_sandbox_mode: str = "sandbox"  # "sandbox" or "direct"
+    # NOT IMPLEMENTED - no execution path reads this field, so setting it
+    # provides NO isolation. Do not rely on it for safety. Use
+    # Agent(sandbox=...) for local isolation, or AgentFlow(run_on="docker")
+    # to run a whole workflow in a remote sandbox.
+    code_sandbox_mode: str = "sandbox"  # "sandbox" or "direct" (inert)
 
     # Code-execution-with-tools (code mode): when True, model-generated code may
     # call the agent's registered tools directly via injected proxies, enabling

--- a/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
+++ b/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
@@ -1,0 +1,129 @@
+"""Regression tests for `Agent(sandbox=...)` actually providing isolation.
+
+Every test here corresponds to a shipped defect where the agent *looked*
+sandboxed and was not. For a security setting, silently doing less than the
+docs promise is the worst failure mode, so these assert behaviour, not config.
+"""
+
+import os
+
+
+import pytest
+
+from praisonaiagents import Agent
+
+
+def _tool_names(agent):
+    return [getattr(t, "__name__", getattr(t, "name", None)) for t in (agent.tools or [])]
+
+
+def a_tool(x: str) -> str:
+    """A plain user tool."""
+    return x
+
+
+# ── sandbox= must give the model sandboxed execution tools ───────────────────
+def test_sandbox_attaches_code_execution_tools():
+    """Previously `sandbox=` built a config nothing read: no tools were added."""
+    agent = Agent(name="T", instructions="x", sandbox=True)
+    names = _tool_names(agent)
+    assert "execute_python_code" in names
+    assert "execute_shell_command" in names
+
+
+def test_sandbox_preserves_user_tools():
+    agent = Agent(name="T", instructions="x", tools=[a_tool], sandbox=True)
+    names = _tool_names(agent)
+    assert "a_tool" in names, "user tools must survive"
+    assert "execute_python_code" in names
+
+
+def test_no_sandbox_adds_nothing():
+    """The default path must be completely unchanged."""
+    agent = Agent(name="T", instructions="x", tools=[a_tool])
+    assert _tool_names(agent) == ["a_tool"]
+    assert agent.sandbox_config is None
+
+
+def test_sandbox_does_not_duplicate_tools_on_name_clash():
+    def execute_python_code(code: str) -> str:
+        """User-supplied tool with a colliding name."""
+        return "user"
+
+    agent = Agent(name="T", instructions="x", tools=[execute_python_code], sandbox=True)
+    assert _tool_names(agent).count("execute_python_code") == 1
+
+
+# ── the tools must genuinely isolate ─────────────────────────────────────────
+def test_sandboxed_code_runs_out_of_process():
+    """The point of the feature: not the same interpreter as the caller."""
+    agent = Agent(name="T", instructions="x", sandbox=True)
+    run = [t for t in agent.tools if getattr(t, "__name__", "") == "execute_python_code"][0]
+    out = str(run("import os; print(os.getpid())"))
+    assert str(os.getpid()) not in out, "code executed in the host process — not sandboxed"
+
+
+def test_security_warning_does_not_break_execution():
+    """`metadata` was forwarded into SandboxProtocol.execute(), which has no such
+    parameter — so flagged code raised TypeError instead of running sandboxed."""
+    agent = Agent(name="T", instructions="x", sandbox=True)
+    run = [t for t in agent.tools if getattr(t, "__name__", "") == "execute_python_code"][0]
+    out = str(run("import os\nprint('flagged-ok')"))  # `import os` trips the checker
+    assert "flagged-ok" in out
+    assert "TypeError" not in out
+
+
+# ── clone must not silently drop isolation ───────────────────────────────────
+def test_clone_keeps_sandbox():
+    """clone_for_channel() read `_sandbox_config`, which is never assigned, so
+    every clone silently ran unisolated."""
+    agent = Agent(name="T", instructions="x", sandbox=True)
+    clone = agent.clone_for_channel()
+    assert agent.sandbox_config is not None
+    assert getattr(clone, "sandbox_config", None) is not None, "clone lost its sandbox"
+
+
+# ── conflicting settings must not be silent ──────────────────────────────────
+class _FakeBackend:
+    async def execute(self, prompt, **kwargs):
+        return ""
+
+
+# Use pytest's warning fixtures rather than warnings.catch_warnings():
+# catch_warnings() restores filters but NOT __warningregistry__, so emitting a
+# warning here would mark that site "already shown" and silently break
+# unrelated deprecation tests later in the same session.
+def test_sandbox_plus_backend_warns():
+    """A managed backend takes the whole turn, making sandbox= inert. Say so."""
+    with pytest.warns(FutureWarning, match="sandbox") as caught:
+        Agent(name="T", instructions="x", sandbox=True, backend=_FakeBackend())
+
+    assert any("backend" in str(w.message) for w in caught), (
+        "the warning must name backend= as the reason sandbox= is ignored"
+    )
+
+
+def test_backend_alone_does_not_warn(recwarn):
+    Agent(name="T", instructions="x", backend=_FakeBackend())
+    assert not [
+        w for w in recwarn
+        if issubclass(w.category, FutureWarning) and "sandbox" in str(w.message)
+    ]
+
+
+# ── docstrings must not promise unimplemented protection ─────────────────────
+def test_inert_fields_are_documented_as_inert():
+    """These fields have zero consumers; their docs must not imply safety."""
+    import inspect
+
+    from praisonaiagents.agent import autonomy
+    from praisonaiagents.config import feature_configs
+
+    assert "NOT IMPLEMENTED" in (autonomy.AutonomyConfig.__doc__ or ""), (
+        "AutonomyConfig.sandbox documented auto-enabling isolation that does not exist"
+    )
+    src = inspect.getsource(feature_configs.ExecutionConfig)
+    idx = src.find("code_sandbox_mode")
+    assert "NOT IMPLEMENTED" in src[max(0, idx - 400):idx], (
+        "code_sandbox_mode is inert and must be labelled as such"
+    )

--- a/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
+++ b/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
@@ -58,9 +58,10 @@ def test_sandbox_does_not_duplicate_tools_on_name_clash():
 def test_sandboxed_code_runs_out_of_process():
     """The point of the feature: not the same interpreter as the caller."""
     agent = Agent(name="T", instructions="x", sandbox=True)
-    run = [t for t in agent.tools if getattr(t, "__name__", "") == "execute_python_code"][0]
+    run = next(t for t in agent.tools if getattr(t, "__name__", "") == "execute_python_code")
     out = str(run("import os; print(os.getpid())"))
-    assert str(os.getpid()) not in out, "code executed in the host process — not sandboxed"
+    child_pid = int(out.strip().splitlines()[-1])
+    assert child_pid != os.getpid(), "code executed in the host process — not sandboxed"
 
 
 def test_security_warning_does_not_break_execution():
@@ -81,6 +82,24 @@ def test_clone_keeps_sandbox():
     clone = agent.clone_for_channel()
     assert agent.sandbox_config is not None
     assert getattr(clone, "sandbox_config", None) is not None, "clone lost its sandbox"
+
+
+def test_clone_regenerates_clone_bound_sandbox_tools():
+    """The generated tools close over the source agent. If the clone merely
+    copied them, invoking a clone tool would run through the *source* agent's
+    SandboxManager — sharing execution state across channels. The clone must
+    own its execution tools."""
+    agent = Agent(name="T", instructions="x", sandbox=True)
+    clone = agent.clone_for_channel()
+
+    src_run = next(t for t in agent.tools if getattr(t, "__name__", "") == "execute_python_code")
+    clone_run = next(t for t in clone.tools if getattr(t, "__name__", "") == "execute_python_code")
+
+    assert clone_run is not src_run, "clone reused the source-bound execution tool"
+
+    src_mgr = agent.get_sandbox_manager()
+    clone_mgr = clone.get_sandbox_manager()
+    assert clone_mgr is not src_mgr, "clone shares the source agent's SandboxManager"
 
 
 # ── conflicting settings must not be silent ──────────────────────────────────


### PR DESCRIPTION
Phase 1 of de-confusing the "where does code run?" surface. Ships the **security fixes alone**, with no renames, so it can be reviewed and merged on its own merits.

## The problem

`Agent(sandbox=...)` built a `SandboxConfig` that **nothing ever read**. The agent looked isolated and was not. For a security setting, silently doing less than the docs promise is the worst possible failure mode.

Proven before the fix:

```python
Agent(tools=[run_cmd], sandbox=True).tools[0] is run_cmd   # True — raw host function
```

## Four defects fixed

**1. `sandbox=` gave the model no sandboxed tools.** `_get_code_execution_tools()` had **zero non-test callers**, so `sandbox=True` added nothing to `agent.tools`. Now attaches `execute_python_code` / `execute_shell_command`, skipping names the user already defined.

Verified isolation is real, not nominal:
```
host pid:    18844
sandbox pid: 18845     # separate process
```

*Scope, stated honestly:* this isolates code the **model writes**. Python callables passed via `tools=` are ordinary in-process functions and **cannot** be retrofitted into a sandbox. That limit is now explicit instead of implied — the previous docs let a user hand an agent a shell tool, set `sandbox=True`, and believe they were protected.

**2. Sandboxed execution crashed exactly when it mattered most.** `execute_code()` injected a `metadata` kwarg that flowed into `SandboxProtocol.execute()`, which has no such parameter. So any code that **tripped a security warning** raised `TypeError` instead of running sandboxed. Found only because wiring (1) made the path reachable. Warnings are now attached to the result.

**3. Clones silently lost their sandbox.** `clone_for_channel()` read `_sandbox_config`; the mixin writes `sandbox_config`. The underscore name is assigned **nowhere** (0 hits), so every clone ran unisolated.

```python
a = Agent(sandbox=True); a.clone_for_channel().sandbox_config   # was None
```

**4. Two docstrings promised protection that does not exist.**
- `AutonomyConfig.sandbox` — *"when level=\"full_auto\" … subprocess sandbox is auto-enabled"*. Implemented nowhere.
- `ExecutionConfig.code_sandbox_mode` — documents subprocess isolation; **0 consumers**.

Both now labelled `NOT IMPLEMENTED`. The **fields are kept deliberately** — removing public dataclass fields would `TypeError` for anyone currently setting them, so deletion belongs in a major version. The lie was the docstring, and that is what's fixed.

**Plus:** `sandbox=` + `backend=` now emits a `FutureWarning`. The managed backend takes the whole turn before any local execution, so `sandbox=` was silently ignored with no signal at all.

## Compatibility

Opt-in and non-breaking. Agents without `sandbox=` are byte-for-byte unchanged — asserted by `test_no_sandbox_adds_nothing`.

## Tests

10 new regression tests, each mapped to a defect above: tools attached, user tools preserved, no duplicate on name clash, **runs out-of-process**, security-warning path doesn't crash, clone keeps sandbox, conflict warns, backend-alone doesn't warn, inert fields labelled.

**Suite: 473 passed vs 463 on clean `main`** (+10, no new failures). Two `test_param_consolidation` warning-registry failures appear in that selection — I verified they **reproduce identically on clean `main`** and are caused by pre-existing cross-test `__warningregistry__` pollution, not this change. (My own tests use `pytest.warns`/`recwarn` rather than `catch_warnings`, which restores filters but not the registry.)

## Follow-ups (deliberately not here)

Phases 2–4 of the plan: unify on one word (`Agent(run_on=)` matching `AgentFlow(run_on=)` — the same concept currently has two names); collapse the duplicate `SandboxConfig`/`ComputeConfig` stacks; retire the dead `cli_backend=`/`runtime=` delegation paths. Also worth noting: `pip install praisonaiagents` alone cannot execute **any** sandbox — `praisonai-sandbox` is required and the README never says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents configured with a sandbox now automatically receive code-execution tools without duplicating existing tools.
  * Sandbox settings remain preserved when creating channel clones.
  * Security warnings from code execution are retained with execution results.

* **Bug Fixes**
  * Improved sandbox isolation and execution reliability.
  * Added warnings when a managed backend may bypass sandbox execution.

* **Documentation**
  * Clarified which sandbox-related configuration options are not currently implemented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->