### PR TITLE
revert(sandbox): stop auto-injecting code-execution tools from sandbox=

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -2447,28 +2447,26 @@ Your Goal: {self.goal}
         # Sandbox configuration - initialize SandboxMixin
         super().__init__(sandbox=sandbox)
 
-        # Give the model sandboxed code-execution tools when a sandbox is set.
-        # Without this, `sandbox=` built a SandboxConfig that nothing ever read:
-        # the agent looked isolated and was not. Note this isolates *code the
-        # model writes* -- Python callables passed via `tools=` are ordinary
-        # in-process functions and cannot be retrofitted into a sandbox.
-        if self.sandbox_config is not None:
-            try:
-                existing = {
-                    getattr(t, "__name__", getattr(t, "name", None))
-                    for t in (self.tools or [])
-                }
-                sandbox_tools = [
-                    t for t in self._get_code_execution_tools()
-                    if getattr(t, "__name__", getattr(t, "name", None)) not in existing
-                ]
-                if sandbox_tools:
-                    self.tools = list(self.tools or []) + sandbox_tools
-            except Exception as exc:  # pragma: no cover - never block construction
-                logging.warning(
-                    "Could not attach sandbox code-execution tools to %s: %s",
-                    self.name, exc,
-                )
+        # NOTE: `sandbox=` deliberately does NOT add code-execution tools.
+        #
+        # An earlier version auto-attached execute_python_code /
+        # execute_shell_command here. That was reverted: `sandbox=` is a
+        # RESTRICTION, and it must never grant a capability the caller did not
+        # ask for. Concretely, the injection
+        #   - escalated privilege: Agent(approval="read_only") exposes no tools,
+        #     but Agent(approval="read_only", sandbox=True) exposed two ungated
+        #     arbitrary-code-execution tools, since the injected names are not in
+        #     the approval registry's dangerous-tool presets; and
+        #   - advertised them to the model as "safely in sandbox" while the
+        #     default subprocess backend enforces none of its own SecurityPolicy
+        #     (network reachable despite allow_network=False; ~/.ssh readable
+        #     despite blocked_paths; `import subprocess` works despite
+        #     blocked_imports).
+        #
+        # `sandbox=` still configures isolation for the explicit, user-invoked
+        # agent.execute_code() / run_shell_command() APIs, which is what it has
+        # always meant. Giving the model a sandboxed execution tool should be an
+        # explicit act by the caller, the way MCP() is.
 
         # A managed backend takes over the whole turn before any local execution,
         # so a sandbox set alongside it silently does nothing. Say so.

--- a/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
+++ b/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
@@ -1,12 +1,12 @@
-"""Regression tests for `Agent(sandbox=...)` actually providing isolation.
+"""Contract tests for `Agent(sandbox=...)`.
 
-Every test here corresponds to a shipped defect where the agent *looked*
-sandboxed and was not. For a security setting, silently doing less than the
-docs promise is the worst failure mode, so these assert behaviour, not config.
+History worth keeping: an earlier version of this file asserted
+`child_pid != os.getpid()` and treated that as proof of isolation. That is a
+false equivalence -- a separate process is not a security boundary -- and it
+let a privilege-escalating change ship on a green suite. These tests assert the
+*contract* instead: `sandbox=` configures isolation for explicit execute_code()
+calls, and never silently grants the model new capabilities.
 """
-
-import os
-
 
 import pytest
 
@@ -22,104 +22,83 @@ def a_tool(x: str) -> str:
     return x
 
 
-# ── sandbox= must give the model sandboxed execution tools ───────────────────
-def test_sandbox_attaches_code_execution_tools():
-    """Previously `sandbox=` built a config nothing read: no tools were added."""
+# ── sandbox= must not grant capabilities ─────────────────────────────────────
+def test_sandbox_does_not_inject_tools():
+    """`sandbox=` is a restriction; it must never add tools the caller didn't ask for."""
+    plain = Agent(name="A", instructions="x", tools=[a_tool])
+    boxed = Agent(name="B", instructions="x", tools=[a_tool], sandbox=True)
+    assert _tool_names(boxed) == _tool_names(plain) == ["a_tool"]
+
+
+def test_sandbox_does_not_bypass_approval_presets():
+    """Regression: approval='read_only' exposed no tools, but adding sandbox=True
+    exposed two ungated arbitrary-code-execution tools, because the injected
+    names are absent from the approval registry's dangerous-tool presets."""
+    read_only = Agent(name="A", instructions="x", approval="read_only")
+    with_sandbox = Agent(name="B", instructions="x", approval="read_only", sandbox=True)
+    assert _tool_names(with_sandbox) == _tool_names(read_only), (
+        "sandbox= must not widen what an approval preset exposes"
+    )
+
+
+def test_sandbox_still_configures_explicit_execution():
+    """The documented meaning of sandbox=: configure agent.execute_code()."""
     agent = Agent(name="T", instructions="x", sandbox=True)
-    names = _tool_names(agent)
-    assert "execute_python_code" in names
-    assert "execute_shell_command" in names
+    assert agent.has_sandbox
+    assert agent.sandbox_config is not None
+    assert agent.get_sandbox_manager() is not None
 
 
-def test_sandbox_preserves_user_tools():
-    agent = Agent(name="T", instructions="x", tools=[a_tool], sandbox=True)
-    names = _tool_names(agent)
-    assert "a_tool" in names, "user tools must survive"
-    assert "execute_python_code" in names
-
-
-def test_no_sandbox_adds_nothing():
-    """The default path must be completely unchanged."""
+def test_no_sandbox_leaves_agent_untouched():
     agent = Agent(name="T", instructions="x", tools=[a_tool])
     assert _tool_names(agent) == ["a_tool"]
     assert agent.sandbox_config is None
+    assert agent.has_sandbox is False
 
 
-def test_sandbox_does_not_duplicate_tools_on_name_clash():
-    def execute_python_code(code: str) -> str:
-        """User-supplied tool with a colliding name."""
-        return "user"
-
-    agent = Agent(name="T", instructions="x", tools=[execute_python_code], sandbox=True)
-    assert _tool_names(agent).count("execute_python_code") == 1
-
-
-# ── the tools must genuinely isolate ─────────────────────────────────────────
-def test_sandboxed_code_runs_out_of_process():
-    """The point of the feature: not the same interpreter as the caller."""
-    agent = Agent(name="T", instructions="x", sandbox=True)
-    run = next(t for t in agent.tools if getattr(t, "__name__", "") == "execute_python_code")
-    out = str(run("import os; print(os.getpid())"))
-    child_pid = int(out.strip().splitlines()[-1])
-    assert child_pid != os.getpid(), "code executed in the host process — not sandboxed"
-
-
+# ── the metadata fix (kept from the reverted change) ─────────────────────────
 def test_security_warning_does_not_break_execution():
     """`metadata` was forwarded into SandboxProtocol.execute(), which has no such
-    parameter — so flagged code raised TypeError instead of running sandboxed."""
+    parameter, so flagged code raised TypeError instead of executing."""
     agent = Agent(name="T", instructions="x", sandbox=True)
-    run = [t for t in agent.tools if getattr(t, "__name__", "") == "execute_python_code"][0]
-    out = str(run("import os\nprint('flagged-ok')"))  # `import os` trips the checker
-    assert "flagged-ok" in out
-    assert "TypeError" not in out
+    result = agent.execute_code_sync("import os\nprint('flagged-ok')")
+    assert "flagged-ok" in (result.stdout or result.output or "")
 
 
-# ── clone must not silently drop isolation ───────────────────────────────────
+def test_security_warnings_are_attached_to_result():
+    agent = Agent(name="T", instructions="x", sandbox=True)
+    result = agent.execute_code_sync("import os\nprint('x')")
+    meta = getattr(result, "metadata", None) or {}
+    assert "security_warnings" in meta, "flagged code should carry its warnings"
+
+
+# ── the clone fix (kept from the reverted change) ────────────────────────────
 def test_clone_keeps_sandbox():
     """clone_for_channel() read `_sandbox_config`, which is never assigned, so
     every clone silently ran unisolated."""
     agent = Agent(name="T", instructions="x", sandbox=True)
     clone = agent.clone_for_channel()
-    assert agent.sandbox_config is not None
-    assert getattr(clone, "sandbox_config", None) is not None, "clone lost its sandbox"
+    assert getattr(clone, "sandbox_config", None) is not None
 
 
-def test_clone_regenerates_clone_bound_sandbox_tools():
-    """The generated tools close over the source agent. If the clone merely
-    copied them, invoking a clone tool would run through the *source* agent's
-    SandboxManager — sharing execution state across channels. The clone must
-    own its execution tools."""
-    agent = Agent(name="T", instructions="x", sandbox=True)
-    clone = agent.clone_for_channel()
-
-    src_run = next(t for t in agent.tools if getattr(t, "__name__", "") == "execute_python_code")
-    clone_run = next(t for t in clone.tools if getattr(t, "__name__", "") == "execute_python_code")
-
-    assert clone_run is not src_run, "clone reused the source-bound execution tool"
-
-    src_mgr = agent.get_sandbox_manager()
-    clone_mgr = clone.get_sandbox_manager()
-    assert clone_mgr is not src_mgr, "clone shares the source agent's SandboxManager"
+def test_clone_does_not_accumulate_tools():
+    agent = Agent(name="T", instructions="x", tools=[a_tool], sandbox=True)
+    once = agent.clone_for_channel()
+    twice = once.clone_for_channel()
+    assert _tool_names(twice) == _tool_names(agent)
 
 
-# ── conflicting settings must not be silent ──────────────────────────────────
+# ── the backend precedence warning (kept) ────────────────────────────────────
 class _FakeBackend:
     async def execute(self, prompt, **kwargs):
         return ""
 
 
-# Use pytest's warning fixtures rather than warnings.catch_warnings():
-# catch_warnings() restores filters but NOT __warningregistry__, so emitting a
-# warning here would mark that site "already shown" and silently break
-# unrelated deprecation tests later in the same session.
 def test_sandbox_plus_backend_warns():
-    """A managed backend takes the whole turn, making sandbox= inert. Say so."""
+    """A managed backend takes the whole turn, making sandbox= inert."""
     with pytest.warns(FutureWarning, match="sandbox") as caught:
         Agent(name="T", instructions="x", sandbox=True, backend=_FakeBackend())
-
-    assert any("backend" in str(w.message) for w in caught), (
-        "the warning must name backend= as the reason sandbox= is ignored"
-    )
+    assert any("backend" in str(w.message) for w in caught)
 
 
 def test_backend_alone_does_not_warn(recwarn):
@@ -130,19 +109,24 @@ def test_backend_alone_does_not_warn(recwarn):
     ]
 
 
-# ── docstrings must not promise unimplemented protection ─────────────────────
+# ── the no-injection contract must stay documented at the call site ──────────
+def test_no_injection_contract_is_documented():
+    import inspect
+
+    from praisonaiagents.agent import agent as agent_mod
+
+    src = inspect.getsource(agent_mod.Agent.__init__)
+    assert "does NOT add code-execution tools" in src
+
+
+# ── inert fields must stay labelled ──────────────────────────────────────────
 def test_inert_fields_are_documented_as_inert():
-    """These fields have zero consumers; their docs must not imply safety."""
     import inspect
 
     from praisonaiagents.agent import autonomy
     from praisonaiagents.config import feature_configs
 
-    assert "NOT IMPLEMENTED" in (autonomy.AutonomyConfig.__doc__ or ""), (
-        "AutonomyConfig.sandbox documented auto-enabling isolation that does not exist"
-    )
+    assert "NOT IMPLEMENTED" in (autonomy.AutonomyConfig.__doc__ or "")
     src = inspect.getsource(feature_configs.ExecutionConfig)
     idx = src.find("code_sandbox_mode")
-    assert "NOT IMPLEMENTED" in src[max(0, idx - 400):idx], (
-        "code_sandbox_mode is inert and must be labelled as such"
-    )
+    assert "NOT IMPLEMENTED" in src[max(0, idx - 400):idx]

--- a/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
+++ b/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
@@ -8,6 +8,8 @@ let a privilege-escalating change ship on a green suite. These tests assert the
 calls, and never silently grants the model new capabilities.
 """
 
+import os
+
 import pytest
 
 from praisonaiagents import Agent
@@ -111,12 +113,17 @@ def test_backend_alone_does_not_warn(recwarn):
 
 # ── the no-injection contract must stay documented at the call site ──────────
 def test_no_injection_contract_is_documented():
+    """The call site should explain *why* sandbox= adds no tools, so the next
+    person does not "fix" the missing injection. Assert on the concepts rather
+    than an exact phrase, so harmless wording edits don't fail the suite."""
     import inspect
 
     from praisonaiagents.agent import agent as agent_mod
 
-    src = inspect.getsource(agent_mod.Agent.__init__)
-    assert "does NOT add code-execution tools" in src
+    src = inspect.getsource(agent_mod.Agent.__init__).lower()
+    assert "sandbox" in src
+    assert "does not add" in src or "not add" in src or "no code-execution" in src
+    assert "restriction" in src
 
 
 # ── inert fields must stay labelled ──────────────────────────────────────────
@@ -130,3 +137,20 @@ def test_inert_fields_are_documented_as_inert():
     src = inspect.getsource(feature_configs.ExecutionConfig)
     idx = src.find("code_sandbox_mode")
     assert "NOT IMPLEMENTED" in src[max(0, idx - 400):idx]
+
+
+# ── real agentic run: sandbox= adds no model-visible execution tools ─────────
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="requires a live LLM key; run locally to exercise the real path",
+)
+def test_sandbox_agent_start_adds_no_execution_tools():
+    """End-to-end guard: build a sandboxed Agent, run a real prompt through the
+    LLM, print the output, and confirm the model-visible tool set never gained
+    execute_python_code / execute_shell_command from `sandbox=` alone."""
+    agent = Agent(name="E2E", instructions="Reply briefly.", sandbox=True)
+    output = agent.start("Say the single word: ok")
+    print(output)
+    names = set(_tool_names(agent))
+    assert "execute_python_code" not in names
+    assert "execute_shell_command" not in names


### PR DESCRIPTION
**I got #3975 wrong.** Adversarial re-review (3 agents + my own verification on this machine) found the tool-injection block is a **net security regression**, not a fix. This reverts that one block and keeps everything else from #3975, which was genuinely correct.

## Why it has to go

### 1. It escalated privilege

`sandbox=` is a **restriction**. The injection made it **grant capability** — and the granted tools sit outside the approval registry, which gates `execute_code`/`execute_command`, not `execute_python_code`/`execute_shell_command`:

```python
Agent(approval="read_only")                # tools: []
Agent(approval="read_only", sandbox=True)  # tools: ['execute_python_code', 'execute_shell_command']
```

A security-labelled flag handed the model two **ungated arbitrary-code-execution tools under the strictest approval preset.**

### 2. It advertised isolation the backend does not provide

The default `subprocess` backend enforces **none** of its own `SecurityPolicy`. Verified live on this machine:

| Declared | Actual |
|---|---|
| `allow_network=False` | `urlopen('https://api.github.com/zen')` → **200** |
| `blocked_paths=['~/.ssh', …]` | read a real SSH private key — **411 bytes** |
| `blocked_imports=['subprocess', …]` | `import subprocess` → ran `whoami` on the host |

Meanwhile the description shown to the model read: *"Execute Python code safely in sandbox."* That is a false statement to the model.

What the subprocess backend *does* provide is real but narrow: env scrubbing (host `OPENAI_API_KEY` is hidden) and a remapped `$HOME`. That is **process separation, not containment**.

### 3. Coexistence made it worse

With `autonomy=True` the agent still carries the host `execute_command` (injected earlier in `__init__`), so the model can just pick the unsandboxed tool — 25 tools, both kinds side by side.

## My own error, and the test that hid it

My PR said *"Verified isolation is real, not nominal"* on the strength of a PID check. **A separate process is not a security boundary** — I asserted `child_pid != os.getpid()` and labelled it isolation. That false equivalence was encoded as a passing test, which is precisely why a privilege escalation shipped green.

The suite is now **contract-based**: `sandbox=` must not add tools, must not widen an approval preset, and must still configure explicit `execute_code()`.

## Kept from #3975 (all correct)

- `metadata` kwarg fix — flagged code no longer raises `TypeError`
- clone fix — `sandbox_config`, not the never-assigned `_sandbox_config`
- `FutureWarning` when `sandbox=` and `backend=` are combined
- `NOT IMPLEMENTED` labels on the inert `autonomy.sandbox` / `code_sandbox_mode` fields

## Verification

```
read_only alone     : []
read_only + sandbox : []        # escalation closed
sandbox still configured for explicit use: True
explicit execute_code: explicit path still works
clone keeps sandbox: True
```

51 sandbox tests pass. Managed suite 296 passed / 5 failed — all 5 pre-exist on clean `main`.

## What should happen instead

No peer framework grants execution capability from a config flag. smolagents' `executor_type=` swaps the *transport* for an already-agreed capability; AutoGen takes an explicit `PythonCodeExecutionTool(executor)`; OpenAI's SDK puts isolation on the tool (`ShellTool(environment=...)`); deepagents *filters out* tools an unsupported backend can't honour rather than advertising them. Claude Code constrains the pre-existing Bash tool rather than creating it.

So the right shape is an explicit `SandboxTool(...)` the caller adds to `tools=`, mirroring `MCP()`, with `sandbox=` only ever configuring *how* it runs. Follow-ups worth filing separately: enforce `SecurityPolicy` on the `execute()` path (today only `run_command()` checks it), register the sandbox tool names in the approval presets, and ship `praisonaiagents[sandbox]` since `praisonai-sandbox` is not currently a dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Sandbox configuration no longer automatically adds code-execution tools that are visible to the agent.
  * Explicit code execution remains available through supported execution methods.
  * Approval restrictions and sandbox isolation are preserved during execution.
  * Cloned agents retain sandbox settings without accumulating execution tools.
  * Clear warnings appear when sandbox settings are ignored by managed backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->