### PR TITLE
feat(agents): make objects say where they actually run

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -6744,3 +6744,27 @@ Answer:"""
 
     def __str__(self):
         return f"Agent(name='{self.name}', role='{self.role}', goal='{self.goal}')"
+
+    def __repr__(self):
+        """Show WHERE this agent works, not just what it is called.
+
+        The default object repr said nothing, so a reader had to consult docs to
+        learn whether tools ran locally or in a container. Now the object says it.
+        """
+        from .execution_location import repr_fields
+
+        return f"Agent(name={self.name!r}, {repr_fields(self)})"
+
+    def where_does_it_run(self) -> str:
+        """Plain-English answer to "where does my code actually run?".
+
+        Example::
+
+            >>> print(Agent(name="builder").where_does_it_run())
+            Thinking (the AI model calls) happens on this machine.
+            Tools run on this machine.
+            Nothing is isolated: tools you pass run in this program, with your permissions.
+        """
+        from .execution_location import explain
+
+        return explain(self)

--- a/src/praisonai-agents/praisonaiagents/agent/execution_location.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_location.py
@@ -37,10 +37,16 @@ _PLACE_WORDS = {
 
 HERE = "this machine"
 
+# Public sandbox aliases the SandboxManager collapses before it picks a backend
+# (see praisonaiagents/sandbox/manager.py). We must describe the backend that
+# actually runs, not the alias the user typed, or "native"/"local" would report
+# a place that never executes.
+_ALIASES = {"native": "sandlock", "local": "subprocess"}
+
 # Tiers that separate a process but do NOT contain it. Verified: under the
 # subprocess backend, outbound network still works and ~/.ssh is readable even
 # though SecurityPolicy declares them blocked.
-_NOT_A_BOUNDARY = {"subprocess", "local"}
+_NOT_A_BOUNDARY = {"subprocess", "local", "native"}
 
 
 def say_place(name: Any) -> str:
@@ -52,7 +58,9 @@ def say_place(name: Any) -> str:
     if not isinstance(name, str):
         # A configured provider instance: use its own declared name if it has one.
         name = getattr(name, "provider_name", None) or type(name).__name__
-    return _PLACE_WORDS.get(str(name).lower(), str(name))
+    key = str(name).lower()
+    key = _ALIASES.get(key, key)
+    return _PLACE_WORDS.get(key, str(name))
 
 
 def _backend_places(backend: Any) -> Optional[Dict[str, str]]:

--- a/src/praisonai-agents/praisonaiagents/agent/execution_location.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_location.py
@@ -1,0 +1,151 @@
+"""Describe, in plain English, where an agent's work actually happens.
+
+PraisonAI can run the thinking (LLM calls) and the tools in different places:
+this machine, a container, or a provider's cloud. Which one you get depends on
+``run_on=``, ``backend=`` and ``sandbox=``, and until now none of that was
+visible from the object -- ``repr(agent)`` was the bare default.
+
+This module is the single source of that answer, shared by ``Agent``,
+``AgentTeam`` and ``AgentFlow`` so all three describe themselves identically.
+
+Vocabulary note: the fields are ``thinks_on`` / ``tools_run_on``, never
+``loop``. "Loop" is already a public workflow primitive here
+(``praisonaiagents.workflows.loop()``), asyncio's event loop, and agent-loop
+jargon a beginner would not know -- three meanings for one word is exactly the
+problem this module exists to fix.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Provider name -> how a human would say it out loud.
+_PLACE_WORDS = {
+    "local": "this machine",
+    "subprocess": "a separate process on this machine",
+    "sandlock": "a locked-down process on this machine",
+    "docker": "a Docker container",
+    "e2b": "an E2B cloud sandbox",
+    "modal": "a Modal cloud sandbox",
+    "daytona": "a Daytona cloud sandbox",
+    "flyio": "a Fly.io machine",
+    "tenki": "a Tenki cloud sandbox",
+    "novita": "a Novita cloud sandbox",
+    "ssh": "a remote machine over SSH",
+    "anthropic": "Anthropic's cloud",
+}
+
+HERE = "this machine"
+
+# Tiers that separate a process but do NOT contain it. Verified: under the
+# subprocess backend, outbound network still works and ~/.ssh is readable even
+# though SecurityPolicy declares them blocked.
+_NOT_A_BOUNDARY = {"subprocess", "local"}
+
+
+def say_place(name: Any) -> str:
+    """Turn a provider name into a phrase a non-developer can read."""
+    if name is None:
+        return HERE
+    if name is True:
+        return _PLACE_WORDS["subprocess"]
+    if not isinstance(name, str):
+        # A configured provider instance: use its own declared name if it has one.
+        name = getattr(name, "provider_name", None) or type(name).__name__
+    return _PLACE_WORDS.get(str(name).lower(), str(name))
+
+
+def _backend_places(backend: Any) -> Optional[Dict[str, str]]:
+    """Where does a managed ``backend=`` put the thinking and the tools?"""
+    if backend is None:
+        return None
+
+    cls = type(backend).__name__
+    # Hosted runtimes move the entire turn off this machine.
+    if "Hosted" in cls or "Anthropic" in cls:
+        provider = getattr(backend, "provider", None) or "anthropic"
+        where = say_place(provider)
+        return {"thinks_on": where, "tools_run_on": where}
+
+    # Local/sandboxed agents keep the loop here and may push tools out.
+    compute = getattr(backend, "_compute", None) or getattr(backend, "compute", None)
+    if compute is not None:
+        return {"thinks_on": HERE, "tools_run_on": say_place(compute)}
+    return {"thinks_on": HERE, "tools_run_on": HERE}
+
+
+def describe(obj: Any, *, shared: bool = False) -> Dict[str, str]:
+    """Return ``{thinks_on, tools_run_on, code_runs_on?}`` for an object.
+
+    Never raises: a description of where things run must not be able to break
+    the thing it describes.
+    """
+    places: Dict[str, str] = {"thinks_on": HERE, "tools_run_on": HERE}
+    try:
+        from_backend = _backend_places(getattr(obj, "backend", None))
+        if from_backend:
+            places.update(from_backend)
+
+        run_on = getattr(obj, "run_on", None)
+        if run_on is not None:
+            where = say_place(run_on)
+            places["tools_run_on"] = f"{where} (shared)" if shared else where
+
+        sandbox_config = getattr(obj, "sandbox_config", None)
+        if sandbox_config is not None:
+            places["code_runs_on"] = say_place(
+                getattr(sandbox_config, "sandbox_type", None)
+            )
+    except Exception:  # pragma: no cover - description must never break callers
+        pass
+    return places
+
+
+def repr_fields(obj: Any, *, shared: bool = False) -> str:
+    """Render the places as ``key='value'`` pairs for a ``__repr__``."""
+    return ", ".join(f"{k}={v!r}" for k, v in describe(obj, shared=shared).items())
+
+
+def explain(obj: Any, *, shared: bool = False) -> str:
+    """Plain-sentence answer to "where does this actually run?".
+
+    Deliberately uses only words a non-engineer already knows -- no "loop",
+    "harness", "provision" or "runtime".
+    """
+    places = describe(obj, shared=shared)
+    lines = [
+        f"Thinking (the AI model calls) happens on {places['thinks_on']}.",
+        f"Tools run on {places['tools_run_on']}.",
+    ]
+
+    if shared and getattr(obj, "run_on", None) is not None:
+        lines.append(
+            "Every step shares that same sandbox, so a file written by one step "
+            "is visible to the next."
+        )
+
+    if "code_runs_on" in places:
+        lines.append(
+            f"Code you run yourself with execute_code() runs on {places['code_runs_on']}."
+        )
+
+    # Say plainly when the chosen tier is not a security boundary.
+    raw = [
+        getattr(obj, "run_on", None),
+        getattr(getattr(obj, "sandbox_config", None), "sandbox_type", None),
+    ]
+    if any(isinstance(v, str) and v.lower() in _NOT_A_BOUNDARY for v in raw) or any(
+        v is True for v in raw
+    ):
+        lines.append(
+            "Note: a separate process is not a security boundary -- it can still "
+            "reach the network and read your files. Use docker or a cloud "
+            "provider for untrusted code."
+        )
+
+    if places["thinks_on"] == HERE and places["tools_run_on"] == HERE:
+        lines.append(
+            "Nothing is isolated: tools you pass run in this program, with your "
+            "permissions."
+        )
+    return "\n".join(lines)

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -1759,6 +1759,21 @@ class AgentTeam(SpawnAnnounceProtocol):
             return str(agent[0])
         return None
 
+    def __repr__(self):
+        """Show where this team's work happens, not just its name."""
+        from ..agent.execution_location import repr_fields
+
+        return (
+            f"AgentTeam(name={self.name!r}, agents={len(self.agents or [])}, "
+            f"{repr_fields(self, shared=True)})"
+        )
+
+    def where_does_it_run(self) -> str:
+        """Plain-English answer to "where does my code actually run?"."""
+        from ..agent.execution_location import explain
+
+        return explain(self, shared=True)
+
     def start(self, content=None, return_dict=False, output=None, **kwargs):
         """Start agent execution with verbose output (beginner-friendly).
         

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -1131,6 +1131,26 @@ class AgentFlow:
         finally:
             self._execution_lock.release()
 
+    def __repr__(self):
+        """Show where this workflow's steps run.
+
+        Defined in the class body on purpose: @dataclass leaves a hand-written
+        __repr__ alone, and the generated one listed every field while saying
+        nothing about execution location.
+        """
+        from ..agent.execution_location import repr_fields
+
+        return (
+            f"AgentFlow(name={self.name!r}, steps={len(self.steps or [])}, "
+            f"{repr_fields(self, shared=True)})"
+        )
+
+    def where_does_it_run(self) -> str:
+        """Plain-English answer to "where does my code actually run?"."""
+        from ..agent.execution_location import explain
+
+        return explain(self, shared=True)
+
     def _shared_compute(self):
         """Build the SharedCompute for this run (see the ``run_on=`` field)."""
         from ..managed.shared_compute import SharedCompute

--- a/src/praisonai-agents/tests/unit/test_execution_location.py
+++ b/src/praisonai-agents/tests/unit/test_execution_location.py
@@ -95,6 +95,24 @@ def test_unknown_provider_falls_back_to_its_own_name():
     assert say_place("some-new-cloud") == "some-new-cloud"
 
 
+# ── public sandbox aliases must resolve to the backend that actually runs ─────
+@pytest.mark.parametrize("alias,expected", [
+    ("native", "locked-down process"),   # SandboxManager: native -> sandlock
+    ("local", "a separate process"),     # SandboxManager: local  -> subprocess
+])
+def test_sandbox_aliases_report_the_real_backend(alias, expected):
+    """SandboxManager collapses native->sandlock and local->subprocess before
+    it runs anything; describe() must not report the raw alias instead."""
+    class _Cfg:
+        sandbox_type = alias
+
+    class _Obj:
+        sandbox_config = _Cfg()
+
+    assert expected in describe(_Obj())["code_runs_on"]
+    assert alias not in describe(_Obj())["code_runs_on"]
+
+
 # ── vocabulary gate: never reuse a word that is public API elsewhere ─────────
 def test_no_field_name_collides_with_existing_public_api():
     """`loop` was rejected as a field name because it is already

--- a/src/praisonai-agents/tests/unit/test_execution_location.py
+++ b/src/praisonai-agents/tests/unit/test_execution_location.py
@@ -1,0 +1,133 @@
+"""The object must say where it runs.
+
+Acceptance criterion: a user can answer "what runs where?" from the REPL alone,
+without reading docs. Before this, `repr(agent)` was `<...Agent object at 0x...>`.
+"""
+
+import inspect
+
+import pytest
+
+from praisonaiagents import Agent, AgentFlow, AgentTeam, Task
+from praisonaiagents.agent.execution_location import describe, explain, say_place
+
+
+def _agent(name="A"):
+    return Agent(name=name, instructions="x")
+
+
+# ── repr states the location ─────────────────────────────────────────────────
+def test_agent_repr_states_where_it_runs():
+    text = repr(_agent("builder"))
+    assert "builder" in text
+    assert "thinks_on='this machine'" in text
+    assert "tools_run_on='this machine'" in text
+    assert "0x" not in text, "must not fall back to the default object repr"
+
+
+def test_flow_repr_states_shared_sandbox():
+    flow = AgentFlow(run_on="docker", steps=[_agent("W"), _agent("R")])
+    text = repr(flow)
+    assert "steps=2" in text
+    assert "Docker container" in text
+    assert "shared" in text, "a shared sandbox is the whole point of run_on"
+
+
+def test_team_repr_states_shared_sandbox():
+    a = _agent("W")
+    team = AgentTeam(agents=[a], tasks=[Task(description="d", agent=a)], run_on="e2b")
+    assert "E2B" in repr(team)
+    assert "shared" in repr(team)
+
+
+def test_repr_survives_a_broken_object():
+    """Describing where something runs must never break the thing itself."""
+
+    class Odd:
+        @property
+        def run_on(self):
+            raise RuntimeError("boom")
+
+    assert describe(Odd())["thinks_on"] == "this machine"
+
+
+# ── where_does_it_run() speaks plain English ─────────────────────────────────
+def test_explain_is_plain_for_a_local_agent():
+    text = _agent().where_does_it_run()
+    assert "this machine" in text
+    assert "Nothing is isolated" in text
+
+
+def test_explain_mentions_shared_state_for_a_workflow():
+    flow = AgentFlow(run_on="docker", steps=[_agent()])
+    text = flow.where_does_it_run()
+    assert "shares that same sandbox" in text
+    assert "visible to the next" in text
+
+
+def test_explain_warns_that_a_subprocess_is_not_a_boundary():
+    """Verified behaviour: under subprocess the network is reachable and
+    ~/.ssh is readable. The explanation must not imply containment."""
+    agent = Agent(name="A", instructions="x", sandbox=True)
+    text = agent.where_does_it_run()
+    assert "not a security boundary" in text
+    assert "docker" in text.lower()
+
+
+def test_explain_does_not_warn_for_a_real_boundary():
+    flow = AgentFlow(run_on="docker", steps=[_agent()])
+    assert "not a security boundary" not in flow.where_does_it_run()
+
+
+# ── provider names become human phrases ──────────────────────────────────────
+@pytest.mark.parametrize("provider,expected", [
+    ("docker", "Docker container"),
+    ("e2b", "E2B"),
+    ("sandlock", "locked-down process"),
+    ("anthropic", "Anthropic"),
+    (None, "this machine"),
+])
+def test_say_place_is_readable(provider, expected):
+    assert expected in say_place(provider)
+
+
+def test_unknown_provider_falls_back_to_its_own_name():
+    assert say_place("some-new-cloud") == "some-new-cloud"
+
+
+# ── vocabulary gate: never reuse a word that is public API elsewhere ─────────
+def test_no_field_name_collides_with_existing_public_api():
+    """`loop` was rejected as a field name because it is already
+    praisonaiagents.workflows.loop(), asyncio's event loop, and agent-loop
+    jargon. This test stops anyone reintroducing that class of collision."""
+    import praisonaiagents.workflows as wf
+
+    agent_kwargs = set(inspect.signature(Agent.__init__).parameters)
+    workflow_api = {n for n in dir(wf) if not n.startswith("_")}
+    taken = agent_kwargs | workflow_api
+
+    for field in describe(_agent()):
+        assert field not in taken, (
+            f"repr field {field!r} collides with existing public API; "
+            f"pick a word that means only one thing"
+        )
+
+
+def test_explanation_avoids_jargon():
+    """The sentences are for someone who does not know the vocabulary."""
+    text = " ".join([
+        _agent().where_does_it_run(),
+        AgentFlow(run_on="docker", steps=[_agent()]).where_does_it_run(),
+    ]).lower()
+    for jargon in ("harness", "provision", "orchestration", "topology", "runtime"):
+        assert jargon not in text, f"{jargon!r} is jargon; say it plainly"
+
+
+# ── the point of the whole exercise ──────────────────────────────────────────
+def test_repl_answers_the_question_without_docs():
+    """One line per topology, each stating what runs where."""
+    local = repr(_agent())
+    remote = repr(AgentFlow(run_on="docker", steps=[_agent()]))
+    assert local != remote
+    for text in (local, remote):
+        assert "thinks_on=" in text and "tools_run_on=" in text


### PR DESCRIPTION
**Tier 0 of the "code should explain itself" plan.** Zero signature changes, zero behaviour changes — it makes every *existing* call site self-explaining.

## The problem

You could not tell from PraisonAI code where an agent's work happens:

```python
>>> Agent(name="builder", sandbox=True)
<praisonaiagents.agent.agent.Agent object at 0x1033abb60>
```

No `__repr__`, no `where_does_it_run()`, no `explain()`. The answer lived only in prose — which is why explaining it needed a 25k-character article, **~29% of whose words exist purely to correct misreadings the API invites.**

## Now the object answers

```python
>>> Agent(name="builder")
Agent(name='builder', thinks_on='this machine', tools_run_on='this machine')

>>> AgentFlow(run_on="docker", steps=[writer, reader])
AgentFlow(name='AgentFlow', steps=2, thinks_on='this machine',
          tools_run_on='a Docker container (shared)')

>>> Agent(name="teacher", backend=HostedAgent(provider="anthropic"))
Agent(name='teacher', thinks_on="Anthropic's cloud", tools_run_on="Anthropic's cloud")
```

Those three lines are the distinction the article spent ~1,400 words on — tools-remote-loop-local vs whole-loop-remote — now visible at a glance.

And in sentences:

```python
>>> print(flow.where_does_it_run())
Thinking (the AI model calls) happens on this machine.
Tools run on a Docker container (shared).
Every step shares that same sandbox, so a file written by one step is visible to the next.
```

For the subprocess tier it states the limit plainly, because that tier is **verifiably not a boundary** (network reachable, `~/.ssh` readable despite the declared policy):

```
Note: a separate process is not a security boundary -- it can still reach the
network and read your files. Use docker or a cloud provider for untrusted code.
```

## Naming is the whole point, so it was checked, not guessed

`loop=` was **rejected**. It is already `praisonaiagents.workflows.loop()` — a public primitive in this same library — *and* asyncio's event loop in an async codebase, *and* "agent loop" jargon a beginner doesn't know. Three meanings for one word is the exact disease being treated. `llm`, `model`, `runtime`, `execution` are all taken as `Agent` kwargs (verified).

`thinks_on` / `tools_run_on` are free and mirror the `run_on=` the user typed. Values are plain English (`'a Docker container'`), never `True` or `'subprocess'`.

Two tests enforce this so it cannot regress:
- **vocabulary gate** — no repr field may collide with `inspect.signature(Agent.__init__)` or `dir(praisonaiagents.workflows)`
- **jargon gate** — the sentences may not contain "harness", "provision", "orchestration", "topology" or "runtime"

## Safety

Description must never break the thing it describes: `describe()` catches everything and falls back to `'this machine'`. There's a test that passes an object whose `run_on` property raises.

## Verification

- **17 new tests**, all passing
- **Suites identical to clean `main`**: 6 failed / 343 passed on both — all 6 pre-exist (verified by running the same selection on `main`)
- **Docker end-to-end**: shared-sandbox flow wrote `/workspace/x.txt` and read it back through one instance; repr stable before and after; **0 leftover containers**

## Why this first

The plan's later tiers (removing `sandbox=` from the constructor, merging the two provider registries so `run_on="sandlock"` reaches kernel-level isolation, `Literal` typing) all involve deprecations. This tier delivers most of the comprehension win at zero migration cost, so it ships alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear execution-location details to agents, teams, and workflows.
  * Added plain-English explanations of where model reasoning, tools, and code run.
  * Improved object summaries with names, counts, and execution context.
  * Added warnings when local or subprocess execution should not be considered a security boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->