### PR TITLE
docs: remove reflection=True from Layer 4 loop README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ from praisonaiagents import Agent, ExecutionConfig
 agent = Agent(
     instructions="Fix the failing tests.",
     execution=ExecutionConfig(max_iter=30, max_budget=0.50, on_budget_exceeded="stop"),
-    reflection=True,               # completion check — the agent grades its own answer
     autonomy=True,                 # required to drive the loop with run_autonomous()
 )
 result = agent.run_autonomous("Refactor the auth module", max_iterations=5)


### PR DESCRIPTION
## Summary
- Removes `reflection=True` from the Layer 4 · Loop README example (`run_autonomous` snippet).
- Reflection grades answers inside each `chat()` turn; it does not drive `run_autonomous()` completion (`completion_reason` comes from loop heuristics like `no_tool_calls`, `tool_completion`, `max_iterations`, etc.).

## Test plan
- [x] Verified example still reads correctly without `reflection=True`
- [x] Validated `run_autonomous()` behaviour with and without reflection in a temp folder outside the repo (same completion heuristics; reflection only adds inner LLM calls)