### PR TITLE
feat(placement): one vocabulary for where agents, tools and code run

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Each layer wraps the one inside it. When an agent misbehaves, the layer tells yo
 | **3 · Harness** | Can it act, and be checked? | `tools=`, `MCP()`, `guardrails=`, `approval=`, `hooks=`, `sandbox=` |
 | **4 · Loop** | When do we stop? | `execution=ExecutionConfig(...)`, `reflection=`, `autonomy=`, doom-loop detection |
 | **5 · Graph** | Who runs when, and who checks whom? | `AgentFlow`, `route()`, `parallel()`, `loop()`, `repeat()` |
-| **⬡ Managed** | *Where does it actually run?* | `run_on="docker"` — one shared remote sandbox, or a fully hosted loop |
+| **⬡ Managed** | *Where does it actually run?* | `tools_run_on="docker"` — one shared sandbox for the tools, or `run_on="anthropic"` for the whole agent |
 
 ### Layer 1 · Prompt — *Did I say it clearly?*
 
@@ -235,7 +235,7 @@ The harness is commoditising; **where** the agent executes is the next multiplie
 pip install praisonai
 ```
 
-The simplest way in is `run_on=` — one whole team or workflow shares **one** sandbox, so a file written by step 1 is there for step 2:
+The simplest way in is `tools_run_on=` — one whole team or workflow shares **one** sandbox, so a file written by step 1 is there for step 2. Thinking stays on your machine:
 
 ```python
 from praisonaiagents import Agent, AgentFlow
@@ -243,7 +243,7 @@ from praisonaiagents import Agent, AgentFlow
 writer = Agent(name="Writer", instructions="You write files.")
 reader = Agent(name="Reader", instructions="You read files.")
 
-flow = AgentFlow(run_on="docker", steps=[writer, reader])   # or e2b | modal | daytona | flyio
+flow = AgentFlow(tools_run_on="docker", steps=[writer, reader])  # or e2b | modal | daytona | flyio
 flow.run("Write 'hello' to /workspace/note.txt, then read it back")
 ```
 
@@ -251,7 +251,7 @@ Same thing with no Python at all:
 
 ```yaml
 name: remote-demo
-run_on: docker            # every step shares one sandbox
+tools_run_on: docker      # every step shares one sandbox
 agents:
   writer: {role: Writer, goal: Write files}
   reader: {role: Reader, goal: Read files}
@@ -262,20 +262,48 @@ steps:
     action: "Read /workspace/note.txt"
 ```
 
-For a single agent, pick the axis you need — remote **tools** or a remote **loop**:
+For a single agent, two words cover it — and they answer different questions:
 
 ```python
-from praisonai import Agent, LocalAgent, LocalAgentConfig, HostedAgent
+from praisonaiagents import Agent
 
-# A. Tools run in a remote sandbox; the agent loop stays local
-agent = Agent(name="builder", backend=LocalAgent(
-    compute="e2b",                     # or modal | daytona | flyio | docker | tenki
-    config=LocalAgentConfig(model="gpt-4o-mini", name="RemoteTools"),
-))
+# A. Only the TOOLS move. Thinking stays on your machine.
+agent = Agent(name="builder", instructions="You build things.",
+              tools_run_on="docker")   # docker | e2b | modal | daytona | flyio
+                                       # tenki | sandlock | ssh | novita | subprocess
 
-# B. The entire agent loop runs in the cloud (needs ANTHROPIC_API_KEY)
-agent = Agent(name="teacher", backend=HostedAgent(provider="anthropic"))
+# B. The WHOLE agent moves — model calls, loop and tools (needs ANTHROPIC_API_KEY)
+agent = Agent(name="teacher", instructions="You teach.", run_on="anthropic")
 agent.start("Write a Python script that prints the first 10 primes, then run it")
+```
+
+Ask any object where it runs, and it will tell you:
+
+```python
+>>> Agent(name="builder", instructions="x", tools_run_on="docker")
+Agent(name='builder', thinks_on='this machine', tools_run_on='a Docker container')
+
+>>> agent.where_does_it_run()
+Thinking (the AI model calls) happens on this machine.
+Tools run on a Docker container.
+Your own tools (check_db) still run on this machine -- only shell, file and
+code tools move. They read and write this machine's files.
+```
+
+Naming a place that cannot do the job is a typo, not a preference, so it says so:
+
+```python
+>>> Agent(name="x", instructions="i", run_on="docker")
+TypeError: Agent(run_on='docker') is not valid: run_on= places the whole agent
+-- model calls, loop and tools -- on a managed runtime, and 'docker' runs
+commands but cannot host an agent loop.
+  To run only the tools there:  Agent(tools_run_on='docker')
+```
+
+To run one block of code somewhere else, name the place on that call:
+
+```python
+agent.execute_code_sync("print(6 * 7)", run_in="sandlock")   # kernel-enforced
 ```
 
 See what is running and reclaim strays:

--- a/examples/yaml/workflows/remote_sandbox_workflow.yaml
+++ b/examples/yaml/workflows/remote_sandbox_workflow.yaml
@@ -2,20 +2,25 @@
 #
 #   praisonai examples/yaml/workflows/remote_sandbox_workflow.yaml
 #
-# `run_on:` is the only line that differs from a normal local workflow. Every
-# step shares the same sandbox and /workspace, so the file the writer creates
-# is there for the reader. Orchestration still runs on your machine, and the
-# sandbox is torn down when the run finishes.
+# `tools_run_on:` is the only line that differs from a normal local workflow.
+# Every step shares the same sandbox and working directory, so the file the
+# writer creates is there for the reader. Thinking and orchestration still run
+# on your machine, and the sandbox is torn down when the run finishes.
 #
-# Providers: docker | e2b | modal | daytona | flyio | tenki | local
+# Places: docker | e2b | modal | daytona | flyio | tenki | local
+#         subprocess | sandlock | ssh | novita
 #   - docker needs a local Docker daemon and nothing else
 #   - e2b / modal / daytona / flyio need that provider's API key
+#   - sandlock is a kernel-enforced local boundary (Linux 6.12+)
+#   - subprocess is process separation only, NOT a security boundary
+#
+# `run_on:` is still accepted here as the old spelling for this key.
 #
 # See what is still running:  praisonai managed ps
 # Reclaim strays:             praisonai managed stop --all
 
 name: remote-sandbox-demo
-run_on: docker
+tools_run_on: docker
 
 agents:
   writer:

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -592,8 +592,8 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
         tool_config: Optional[Union[bool, 'ToolConfig']] = None,  # Tool execution configuration (timeout, retry, parallel)
         learn: Optional[Union[bool, str, Dict[str, Any], 'LearnConfig']] = None,  # Continuous learning (peer to memory)
         backend: Optional[Any] = None,  # External managed agent backend (e.g., ManagedAgentIntegration)
-        run_on: Optional[str] = None,  # Run the WHOLE agent on a managed runtime, e.g. "anthropic"
-        tools_run_on: Optional[Any] = None,  # Run only this agent's TOOLS elsewhere, e.g. "docker"
+        run_on: Optional[Union['ManagedRuntime', str]] = None,  # Run the WHOLE agent on a managed runtime, e.g. "anthropic"
+        tools_run_on: Optional[Union['ToolPlace', str, Any]] = None,  # Run only this agent's TOOLS elsewhere, e.g. "docker"
         runtime: Optional[Union[bool, str, Dict[str, Any], 'AgentRuntimeConfig', 'RuntimeConfig']] = None,  # Model-scoped runtime configuration with capability validation
         interrupt_controller: Optional['InterruptController'] = None,  # G2: Cooperative cancellation
         tool_search: Optional[Union[bool, str, Dict[str, Any], 'ToolSearchConfig']] = False,  # Progressive tool disclosure
@@ -2667,6 +2667,16 @@ Your Goal: {self.goal}
         )
         return mem_inst
 
+
+    def _backstory_without_sandbox_prompt(self):
+        """This agent's backstory as it was before any sandbox was attached."""
+        shared = getattr(self, "_tools_sandbox", None)
+        if shared is not None:
+            for ref, _tools, original_backstory in getattr(shared, "_patched", []):
+                if ref() is self:
+                    return original_backstory
+        return self.backstory
+
     def clone_for_channel(self) -> "Agent":
         """Return a fully independent copy of this agent for a gateway channel.
         
@@ -2687,7 +2697,10 @@ Your Goal: {self.goal}
             'name': self.name,
             'role': self.role, 
             'goal': self.goal,
-            'backstory': self.backstory,
+            # The pre-attach backstory when a sandbox is live: attach() appends
+            # the capability prompt to backstory, so cloning the current value
+            # and then attaching again gives the clone two copies of it.
+            'backstory': self._backstory_without_sandbox_prompt(),
             'instructions': self.instructions,
             
             # LLM configuration 

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -150,6 +150,8 @@ class ServerRegistry:
     # Class-level lock for thread-safe singleton creation
     _instance_lock = threading.Lock()
     
+
+
     @staticmethod
     def get_default_instance():
         """Get default global registry for backward compatibility."""
@@ -512,6 +514,28 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
         logging.debug(f"Generated tool definition: {tool_def}")
         return tool_def
 
+    @staticmethod
+    def _hosted_backend_for(provider: str):
+        """Build the managed backend that ``run_on=<provider>`` is shorthand for.
+
+        ``run_on="anthropic"`` and ``backend=HostedAgent(provider="anthropic")``
+        place the agent identically; the first is the readable spelling for the
+        common case, the second is what you reach for when the runtime needs
+        configuring (model, system prompt, its own tools).
+        """
+        try:
+            from praisonai.integrations import HostedAgent
+        except ImportError as exc:
+            raise ImportError(
+                f"Agent(run_on={provider!r}) runs the whole agent on a managed "
+                f"runtime, which ships in the wrapper package.\n"
+                f"  pip install praisonai\n"
+                f"To keep thinking on this machine and move only the tools, use "
+                f"tools_run_on= instead -- that needs no extra install for "
+                f"local places."
+            ) from exc
+        return HostedAgent(provider=provider)
+
     def __init__(
         self,
         # Core identity
@@ -568,6 +592,8 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
         tool_config: Optional[Union[bool, 'ToolConfig']] = None,  # Tool execution configuration (timeout, retry, parallel)
         learn: Optional[Union[bool, str, Dict[str, Any], 'LearnConfig']] = None,  # Continuous learning (peer to memory)
         backend: Optional[Any] = None,  # External managed agent backend (e.g., ManagedAgentIntegration)
+        run_on: Optional[str] = None,  # Run the WHOLE agent on a managed runtime, e.g. "anthropic"
+        tools_run_on: Optional[Any] = None,  # Run only this agent's TOOLS elsewhere, e.g. "docker"
         runtime: Optional[Union[bool, str, Dict[str, Any], 'AgentRuntimeConfig', 'RuntimeConfig']] = None,  # Model-scoped runtime configuration with capability validation
         interrupt_controller: Optional['InterruptController'] = None,  # G2: Cooperative cancellation
         tool_search: Optional[Union[bool, str, Dict[str, Any], 'ToolSearchConfig']] = False,  # Progressive tool disclosure
@@ -758,6 +784,20 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
         rate_limiter = legacy_kwargs.get("rate_limiter", _legacy_defaults["rate_limiter"])
         verification_hooks = legacy_kwargs.get("verification_hooks", _legacy_defaults["verification_hooks"])
         cli_backend = legacy_kwargs.get("cli_backend", _legacy_defaults["cli_backend"])
+
+        # ── where does this agent run? ───────────────────────────────────────
+        # Resolved before anything else is built so a contradiction fails at the
+        # call site, with the parameter name the user actually wanted, instead
+        # of surfacing later as tools mysteriously running on the wrong machine.
+        from .placement import resolve_placement
+
+        _placement = resolve_placement(
+            "Agent", run_on=run_on, tools_run_on=tools_run_on, backend=backend
+        )
+        if _placement.whole is not None:
+            backend = self._hosted_backend_for(_placement.whole)
+        self.tools_run_on = _placement.tools
+        self._tools_sandbox = None
 
         # Add check at start if memory is requested.
         # Skip the probe for values that resolve to the zero-dependency FileMemory
@@ -2720,6 +2760,13 @@ Your Goal: {self.goal}
             # underscore name (never assigned) made every clone silently drop
             # its sandbox and run unisolated.
             'sandbox': getattr(self, 'sandbox_config', None),
+
+            # Where the tools run must survive cloning for the same reason the
+            # sandbox must: a gateway-channel clone that quietly drops it runs
+            # every tool on the host while its repr still claims otherwise.
+            # The clone gets its own sandbox instance -- placement is a choice,
+            # not a live connection to share.
+            'tools_run_on': getattr(self, 'tools_run_on', None),
         }
         
         # Handle deprecated parameters for backward compatibility

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -2901,6 +2901,14 @@ Your Goal: {self.goal}"""
                         'required' forces the LLM to call a tool before responding.
             ...other args...
         """
+        # Tools go to their sandbox before the first model call, once per
+        # agent. Placed on chat/achat/_start_stream rather than run/start
+        # because AgentTeam and AgentFlow call these three directly -- an
+        # agent used inside a team would otherwise run its tools locally.
+        if getattr(self, 'tools_run_on', None) is not None:
+            from .tools_placement import ensure_tools_placed
+            ensure_tools_placed(self)
+
         # Slash-command invocation: /skill-name [args] renders the skill
         # body before any backend/LLM call.
         prompt = self._resolve_skill_invocation(prompt)
@@ -3586,6 +3594,14 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             attachments: Optional list of image/file paths that are ephemeral
                         (used for THIS turn only, NEVER stored in history).
         """
+        # Tools go to their sandbox before the first model call, once per
+        # agent. Placed on chat/achat/_start_stream rather than run/start
+        # because AgentTeam and AgentFlow call these three directly -- an
+        # agent used inside a team would otherwise run its tools locally.
+        if getattr(self, 'tools_run_on', None) is not None:
+            from .tools_placement import ensure_tools_placed
+            ensure_tools_placed(self)
+
         # Slash-command invocation: /skill-name [args] renders the skill body.
         prompt = self._resolve_skill_invocation(prompt)
 
@@ -4545,6 +4561,14 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
 
     def _start_stream(self, prompt: str, **kwargs) -> Generator[str, None, None]:
         """Own the durable context for the complete streaming generator."""
+        # Tools go to their sandbox before the first model call, once per
+        # agent. Placed on chat/achat/_start_stream rather than run/start
+        # because AgentTeam and AgentFlow call these three directly -- an
+        # agent used inside a team would otherwise run its tools locally.
+        if getattr(self, 'tools_run_on', None) is not None:
+            from .tools_placement import ensure_tools_placed
+            ensure_tools_placed(self)
+
         durable_context = None
         durable_token = None
         try:

--- a/src/praisonai-agents/praisonaiagents/agent/execution_location.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_location.py
@@ -94,10 +94,20 @@ def describe(obj: Any, *, shared: bool = False) -> Dict[str, str]:
         if from_backend:
             places.update(from_backend)
 
-        run_on = getattr(obj, "run_on", None)
-        if run_on is not None:
-            where = say_place(run_on)
+        where_tools = getattr(obj, "tools_run_on", None)
+        if where_tools is not None:
+            where = say_place(where_tools)
             places["tools_run_on"] = f"{where} (shared)" if shared else where
+
+        # run_on= puts the WHOLE agent on a managed runtime, so it moves the
+        # thinking as well. _backend_places() already reports that (run_on= is
+        # turned into a backend at construction); this only covers an object
+        # that carries the name without a built backend.
+        whole = getattr(obj, "run_on", None)
+        if whole is not None and not from_backend:
+            everywhere = say_place(whole)
+            places["thinks_on"] = everywhere
+            places["tools_run_on"] = everywhere
 
         sandbox_config = getattr(obj, "sandbox_config", None)
         if sandbox_config is not None:
@@ -107,6 +117,42 @@ def describe(obj: Any, *, shared: bool = False) -> Dict[str, str]:
     except Exception:  # pragma: no cover - description must never break callers
         pass
     return places
+
+
+def _tools_staying_here(obj: Any) -> list:
+    """Names of the object's own tools, which do NOT move to the sandbox.
+
+    Only four tool names are bridged (``execute_command``, ``read_file``,
+    ``write_file``, ``list_files``); everything else the user passed keeps
+    running in this process, against this filesystem. The capability prompt
+    tells the model the sandbox is where things happen, so anything staying
+    behind has to be said out loud.
+
+    Reads the pre-attach tool list when a sandbox is already attached: by then
+    ``agent.tools`` has been rewritten and the originals live in the sandbox's
+    restore record.
+    """
+    try:
+        from ..managed.shared_compute import BRIDGED_TOOL_NAMES
+    except Exception:
+        BRIDGED_TOOL_NAMES = ("execute_command", "read_file", "write_file", "list_files")
+
+    tools = None
+    shared = getattr(obj, "_tools_sandbox", None)
+    if shared is not None:
+        for patched, original_tools, _ in getattr(shared, "_patched", []):
+            if patched is obj:
+                tools = original_tools
+                break
+    if tools is None:
+        tools = getattr(obj, "tools", None) or []
+
+    names = []
+    for tool in tools:
+        name = getattr(tool, "__name__", None) or getattr(tool, "name", None)
+        if isinstance(name, str) and name not in BRIDGED_TOOL_NAMES:
+            names.append(name)
+    return names
 
 
 def repr_fields(obj: Any, *, shared: bool = False) -> str:
@@ -126,10 +172,18 @@ def explain(obj: Any, *, shared: bool = False) -> str:
         f"Tools run on {places['tools_run_on']}.",
     ]
 
-    if shared and getattr(obj, "run_on", None) is not None:
+    if shared and getattr(obj, "tools_run_on", None) is not None:
         lines.append(
             "Every step shares that same sandbox, so a file written by one step "
             "is visible to the next."
+        )
+
+    staying = _tools_staying_here(obj)
+    if staying and places["tools_run_on"] != places["thinks_on"]:
+        listed = ", ".join(staying[:6]) + ("..." if len(staying) > 6 else "")
+        lines.append(
+            f"Your own tools ({listed}) still run on {HERE} -- only shell, file "
+            f"and code tools move. They read and write this machine's files."
         )
 
     if "code_runs_on" in places:
@@ -139,6 +193,7 @@ def explain(obj: Any, *, shared: bool = False) -> str:
 
     # Say plainly when the chosen tier is not a security boundary.
     raw = [
+        getattr(obj, "tools_run_on", None),
         getattr(obj, "run_on", None),
         getattr(getattr(obj, "sandbox_config", None), "sandbox_type", None),
     ]

--- a/src/praisonai-agents/praisonaiagents/agent/execution_location.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_location.py
@@ -202,7 +202,8 @@ def explain(obj: Any, *, shared: bool = False) -> str:
     ):
         lines.append(
             "Note: a separate process is not a security boundary -- it can still "
-            "reach the network and read your files. Use docker or a cloud "
+            "reach the network and read your files, and its blocked-command "
+            "list can be worked around by ordinary shell syntax. Use docker or a cloud "
             "provider for untrusted code."
         )
 

--- a/src/praisonai-agents/praisonaiagents/agent/placement.py
+++ b/src/praisonai-agents/praisonaiagents/agent/placement.py
@@ -1,0 +1,168 @@
+"""One vocabulary for "where does this run?", shared by Agent, AgentFlow and AgentTeam.
+
+Two questions get asked about placement and they have different answers:
+
+``run_on=``
+    Where the **whole agent** runs -- the model calls, the loop, the tools, all
+    of it on someone else's machine. Only a *managed runtime* can answer this,
+    because running the loop remotely means something has to host the loop.
+
+``tools_run_on=``
+    Where **the tools** run. Thinking stays on this machine; only the shell,
+    the file writes and the code execution move. Any sandbox or compute place
+    can answer this, because all it has to do is run a command.
+
+Keeping the two words apart is the entire point. The old surface used one word
+(``run_on=``) on ``AgentFlow``/``AgentTeam`` for the tools-only meaning, another
+(``compute=``) on ``LocalAgent`` for exactly the same meaning, and a third
+(``backend=``) for the whole-agent meaning -- so the same concept had two names
+and one name had two concepts.
+
+Because the two questions have disjoint answer sets, a wrong pairing is a typo
+worth catching rather than a preference worth honouring. ``run_on="docker"``
+cannot mean anything: Docker does not host agent loops. It gets a ``TypeError``
+naming the parameter the user actually wanted, not a silent fallback.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple, Optional
+
+# Runtimes that can host an entire agent loop. Resolved from the wrapper's
+# entry-point registry when it is installed so third-party backends work with
+# `run_on=` too; the literal is the floor, not the ceiling.
+_FALLBACK_MANAGED = ("anthropic",)
+
+
+def managed_runtimes() -> tuple:
+    """Names that ``run_on=`` accepts -- places that host a whole agent."""
+    try:
+        from praisonai.integrations.backend_registry import get_backend_registry
+
+        names = tuple(get_backend_registry().list_all_names())
+        if names:
+            return tuple(sorted(set(names) | set(_FALLBACK_MANAGED)))
+    except Exception:
+        pass
+    return _FALLBACK_MANAGED
+
+
+def tool_places() -> list:
+    """Names that ``tools_run_on=`` accepts -- places that can run a command."""
+    try:
+        from ..managed._compute_bridge import available_providers
+
+        return available_providers()
+    except Exception:
+        return ["local", "docker"]
+
+
+class Placement(NamedTuple):
+    """The resolved answer to "where does this run?"."""
+
+    whole: Optional[Any] = None   # managed runtime name/object, or None
+    tools: Optional[Any] = None   # tools place name/object, or None
+
+
+def _name_of(value: Any) -> Optional[str]:
+    """The comparable name of a placement value, or None if it is an object.
+
+    Objects (a built provider, a live ``SSHSandbox``) carry their own config and
+    are never second-guessed -- only bare strings get routed by name.
+    """
+    return value.lower() if isinstance(value, str) else None
+
+
+def _quote_list(names) -> str:
+    return ", ".join(repr(n) for n in names)
+
+
+def resolve_placement(
+    owner: str,
+    *,
+    run_on: Any = None,
+    tools_run_on: Any = None,
+    backend: Any = None,
+    supports_run_on: bool = True,
+) -> Placement:
+    """Validate placement arguments and return where things should run.
+
+    ``owner`` is the class name, used only to make errors read naturally.
+    ``supports_run_on`` is False for AgentFlow/AgentTeam, which can place tools
+    but cannot (yet) hand a whole multi-agent run to a managed runtime.
+
+    Raises:
+        TypeError: on any combination that names two different places for the
+            same thing, or a place that cannot do the job asked of it.
+    """
+    managed = managed_runtimes()
+    places = tool_places()
+
+    # ── a place that cannot do the job asked of it ───────────────────────────
+    run_on_name = _name_of(run_on)
+    if run_on_name is not None and run_on_name not in managed:
+        if run_on_name in places:
+            raise TypeError(
+                f"{owner}(run_on={run_on!r}) is not valid: run_on= places the "
+                f"whole agent -- model calls, loop and tools -- on a managed "
+                f"runtime, and {run_on_name!r} runs commands but cannot host an "
+                f"agent loop.\n"
+                f"  To run only the tools there:  {owner}(tools_run_on={run_on!r})\n"
+                f"  Runtimes that host a whole agent: {_quote_list(managed)}"
+            )
+        raise TypeError(
+            f"{owner}(run_on={run_on!r}) is not a known managed runtime.\n"
+            f"  Runtimes that host a whole agent: {_quote_list(managed)}\n"
+            f"  Places that can run tools:        {_quote_list(places)} "
+            f"(pass those as tools_run_on=)"
+        )
+
+    tools_name = _name_of(tools_run_on)
+    if tools_name is not None and tools_name in managed and tools_name not in places:
+        raise TypeError(
+            f"{owner}(tools_run_on={tools_run_on!r}) is not valid: {tools_name!r} "
+            f"hosts an entire agent, not individual tools.\n"
+            f"  Did you mean:  {owner}(run_on={tools_run_on!r})"
+        )
+
+    # ── two names for the same thing ─────────────────────────────────────────
+    if run_on is not None and backend is not None:
+        raise TypeError(
+            f"{owner}(run_on=..., backend=...) sets the agent's runtime twice. "
+            f"run_on={run_on!r} is the short form of backend=HostedAgent("
+            f"provider={run_on!r}); pass one or the other.\n"
+            f"  Use backend= only when you need to configure the runtime "
+            f"(model, system prompt, tools)."
+        )
+
+    if run_on is not None and tools_run_on is not None:
+        raise TypeError(
+            f"{owner}(run_on={run_on!r}, tools_run_on={tools_run_on!r}) points "
+            f"the tools at two machines. run_on= already runs everything -- "
+            f"including tools -- on {run_on!r}.\n"
+            f"  Whole agent remote:  {owner}(run_on={run_on!r})\n"
+            f"  Only tools remote:   {owner}(tools_run_on={tools_run_on!r})"
+        )
+
+    if backend is not None and tools_run_on is not None:
+        raise TypeError(
+            f"{owner}(backend=..., tools_run_on={tools_run_on!r}) points the "
+            f"tools at two machines: backend= runs the whole agent (tools "
+            f"included) on its managed runtime, so the tools cannot also run on "
+            f"{tools_run_on!r}.\n"
+            f"  Drop tools_run_on= to keep the hosted runtime, or drop backend= "
+            f"to keep local thinking with remote tools."
+        )
+
+    # ── a class that cannot answer this question ─────────────────────────────
+    if run_on is not None and not supports_run_on:
+        raise TypeError(
+            f"{owner}(run_on={run_on!r}) is not supported: run_on= hands one "
+            f"agent's whole loop to a managed runtime, and a {owner} "
+            f"orchestrates several agents locally.\n"
+            f"  To run every step's tools in one shared sandbox:\n"
+            f"      {owner}(tools_run_on={run_on!r})\n"
+            f"  To host a single agent's loop, put run_on= on that Agent."
+        )
+
+    return Placement(whole=run_on, tools=tools_run_on)

--- a/src/praisonai-agents/praisonaiagents/agent/placement.py
+++ b/src/praisonai-agents/praisonaiagents/agent/placement.py
@@ -26,12 +26,24 @@ naming the parameter the user actually wanted, not a silent fallback.
 
 from __future__ import annotations
 
-from typing import Any, NamedTuple, Optional
+from typing import Any, Literal, NamedTuple, Optional, Union
 
 # Runtimes that can host an entire agent loop. Resolved from the wrapper's
 # entry-point registry when it is installed so third-party backends work with
 # `run_on=` too; the literal is the floor, not the ceiling.
 _FALLBACK_MANAGED = ("anthropic",)
+
+# Static spellings so editors can autocomplete and type-checkers can reject a
+# typo at the call site rather than at the first model turn. The runtime
+# functions below stay the authority for validation -- these exist for tooling,
+# which cannot call a function to learn a set.
+# Keep in sync with _compute_bridge._PROVIDERS | _sandbox_adapter.SANDBOX_ONLY.
+ManagedRuntime = Literal["anthropic"]
+
+ToolPlace = Literal[
+    "local", "subprocess", "sandlock", "docker", "e2b",
+    "modal", "daytona", "flyio", "tenki", "novita", "ssh",
+]
 
 
 def managed_runtimes() -> tuple:
@@ -124,6 +136,31 @@ def resolve_placement(
             f"hosts an entire agent, not individual tools.\n"
             f"  Did you mean:  {owner}(run_on={tools_run_on!r})"
         )
+
+    # A typo here used to survive construction and only surface on the first
+    # model turn -- after the prompt was built and, for a real run, after the
+    # API spend. run_on= validates at the call site and YAML validates at load
+    # time; this is the same standard for the third spelling.
+    if tools_name is not None and tools_name not in places:
+        raise TypeError(
+            f"{owner}(tools_run_on={tools_run_on!r}) is not a known place.\n"
+            f"  Places that can run tools: {_quote_list(places)}\n"
+            f"  Runtimes that host a whole agent: {_quote_list(managed)} "
+            f"(pass those as run_on=)"
+        )
+
+    # Names that cannot work as a bare string, because the connection details
+    # live in the object. Catch it now rather than at first use.
+    if tools_name is not None:
+        try:
+            from ..managed._sandbox_adapter import NEEDS_INSTANCE
+        except Exception:
+            NEEDS_INSTANCE = {}
+        if tools_name in NEEDS_INSTANCE:
+            raise TypeError(
+                f"{owner}(tools_run_on={tools_run_on!r}) needs more than a name: "
+                f"{NEEDS_INSTANCE[tools_name]}"
+            )
 
     # ── two names for the same thing ─────────────────────────────────────────
     if run_on is not None and backend is not None:

--- a/src/praisonai-agents/praisonaiagents/agent/sandbox_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/sandbox_mixin.py
@@ -52,19 +52,61 @@ class SandboxMixin:
         
         return self._sandbox_manager
     
+
+    def _manager_for(self, run_in: Optional[Union[bool, str, 'SandboxConfig']]):
+        """Return the sandbox manager for a ``run_in=`` argument.
+
+        ``run_in=`` names where a single ``execute_code()`` call runs, so the
+        place lives on the call that uses it rather than on the constructor.
+        ``Agent(sandbox=...)`` still sets the default for every call.
+
+        Managers are cached per place: a fresh ``SandboxManager`` per call would
+        start and tear down a container each time, which for Docker is seconds
+        of latency and for any backend means the previous call's files are gone.
+        """
+        if run_in is None:
+            if not self.has_sandbox:
+                raise RuntimeError(
+                    "No sandbox configured. Either name a place on the call --\n"
+                    "    agent.execute_code_sync(code, run_in='docker')\n"
+                    "or set a default for every call with Agent(sandbox='docker')."
+                )
+            return self.get_sandbox_manager()
+
+        from ..sandbox import SandboxConfig, SandboxManager
+
+        if run_in is True:
+            config = SandboxConfig.subprocess()
+        elif isinstance(run_in, str):
+            config = SandboxConfig(sandbox_type=run_in)
+        else:
+            config = run_in
+
+        key = getattr(config, "sandbox_type", None) or repr(config)
+        cache = getattr(self, "_sandbox_managers", None)
+        if cache is None:
+            cache = self._sandbox_managers = {}
+        if key not in cache:
+            cache[key] = SandboxManager(config)
+        return cache[key]
+
     async def execute_code(
         self,
         code: str,
         language: str = "python",
         check_security: bool = True,
+        run_in: Optional[Union[bool, str, 'SandboxConfig']] = None,
         **kwargs
     ) -> 'SandboxResult':
-        """Execute code safely in configured sandbox.
+        """Execute code safely in a sandbox.
         
         Args:
             code: Code to execute
             language: Programming language (python, bash, etc.)
             check_security: Whether to run security pre-checks
+            run_in: Where to run this call -- "docker", "sandlock",
+                "subprocess", a SandboxConfig, or True for the default local
+                sandbox. Overrides Agent(sandbox=...) for this call only.
             **kwargs: Additional arguments passed to sandbox.execute()
             
         Returns:
@@ -73,10 +115,7 @@ class SandboxMixin:
         Raises:
             RuntimeError: If no sandbox is configured
         """
-        if not self.has_sandbox:
-            raise RuntimeError(
-                "No sandbox configured. Set sandbox=True or provide SandboxConfig to Agent()"
-            )
+        manager = self._manager_for(run_in)
         
         # Security pre-check if enabled
         security_warnings = None
@@ -88,7 +127,6 @@ class SandboxMixin:
                 if self.verbose:
                     logger.warning(f"Security warnings for code execution:\n{warning_text}")
 
-        manager = self.get_sandbox_manager()
         result = await manager.run_code(code, language=language, **kwargs)
 
         # Attach warnings to the result rather than forwarding a `metadata`
@@ -109,6 +147,7 @@ class SandboxMixin:
         code: str,
         language: str = "python", 
         check_security: bool = True,
+        run_in: Optional[Union[bool, str, 'SandboxConfig']] = None,
         **kwargs
     ) -> 'SandboxResult':
         """Synchronous wrapper for execute_code.
@@ -123,12 +162,15 @@ class SandboxMixin:
             SandboxResult with execution details
         """
         from ..approval.utils import run_coroutine_safely
-        return run_coroutine_safely(self.execute_code(code, language, check_security, **kwargs))
+        return run_coroutine_safely(
+            self.execute_code(code, language, check_security, run_in=run_in, **kwargs)
+        )
     
     async def run_shell_command(
         self,
         command: Union[str, list],
         check_security: bool = True,
+        run_in: Optional[Union[bool, str, 'SandboxConfig']] = None,
         **kwargs
     ) -> 'SandboxResult':
         """Run a shell command in the sandbox.
@@ -141,8 +183,7 @@ class SandboxMixin:
         Returns:
             SandboxResult with execution details
         """
-        if not self.has_sandbox:
-            raise RuntimeError("No sandbox configured")
+        manager = self._manager_for(run_in)
         
         # Convert command to string for security checking
         if isinstance(command, list):
@@ -159,7 +200,7 @@ class SandboxMixin:
                 if self.verbose:
                     logger.warning(f"Security warnings for command:\n{warning_text}")
         
-        async with self.get_sandbox_manager() as sandbox:
+        async with manager as sandbox:
             return await sandbox.run_command(command, **kwargs)
     
     def get_sandbox_status(self) -> Dict[str, Any]:

--- a/src/praisonai-agents/praisonaiagents/agent/tools_placement.py
+++ b/src/praisonai-agents/praisonaiagents/agent/tools_placement.py
@@ -1,0 +1,86 @@
+"""Give a single Agent's tools a sandbox, without touching its thinking.
+
+``AgentFlow``/``AgentTeam`` already share one sandbox across a run and tear it
+down when the run ends. A lone ``Agent(tools_run_on=...)`` has no "run" to hang
+that lifetime on -- it is just an object someone calls ``chat()`` on, possibly
+many times -- so the sandbox is created on first use and kept for the agent's
+lifetime. That is deliberate: a file written in turn 1 is still there in turn 2,
+which is what anyone who asked for a working directory expects.
+
+Attachment is idempotent and happens at the top of ``chat``/``achat``/
+``_start_stream``. Doing it once, rather than wrapping each call in a context
+manager, sidesteps two real hazards in this codebase:
+
+* ``_start_stream`` is a **generator**; a context manager around the call would
+  exit before the caller consumed a single token, tearing down the sandbox while
+  the model was still using it.
+* ``_start_stream`` falls back to ``self.chat``, so a wrapper would **re-enter**
+  itself and provision a second sandbox.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import threading
+import weakref
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Agents with a live sandbox, so the interpreter shutdown hook can close them.
+# Weak so holding an agent here never keeps it alive.
+_LIVE: "weakref.WeakSet" = weakref.WeakSet()
+_LIVE_LOCK = threading.Lock()
+_ATEXIT_REGISTERED = False
+
+
+def _close_all() -> None:
+    for agent in list(_LIVE):
+        try:
+            close_tools_sandbox(agent)
+        except Exception:  # pragma: no cover - shutdown must stay quiet
+            pass
+
+
+def ensure_tools_placed(agent: Any) -> None:
+    """Attach the sandbox tools to ``agent`` if it asked for them. Idempotent.
+
+    Called at the top of every entry point, so it must be cheap when there is
+    nothing to do -- which is the overwhelmingly common case.
+    """
+    place = getattr(agent, "tools_run_on", None)
+    if place is None or getattr(agent, "_tools_sandbox", None) is not None:
+        return
+
+    global _ATEXIT_REGISTERED
+
+    from ..managed.shared_compute import SharedCompute
+
+    with _LIVE_LOCK:
+        # Re-check under the lock: two threads calling chat() at once must not
+        # each provision a sandbox and leak one.
+        if getattr(agent, "_tools_sandbox", None) is not None:
+            return
+        shared = SharedCompute(place)
+        # override_declared: this sandbox exists *because* the agent named a
+        # place, so the skip-if-declared rule must not skip the agent itself.
+        shared.attach([agent], override_declared=True)
+        agent._tools_sandbox = shared
+        _LIVE.add(agent)
+        if not _ATEXIT_REGISTERED:
+            atexit.register(_close_all)
+            _ATEXIT_REGISTERED = True
+
+    logger.info("[tools_placement] %r tools now run on %s", getattr(agent, "name", agent), place)
+
+
+def close_tools_sandbox(agent: Any) -> None:
+    """Tear down the agent's sandbox and put its original tools back."""
+    shared = getattr(agent, "_tools_sandbox", None)
+    if shared is None:
+        return
+    agent._tools_sandbox = None
+    with _LIVE_LOCK:
+        _LIVE.discard(agent)
+    shared.shutdown()

--- a/src/praisonai-agents/praisonaiagents/agent/tools_placement.py
+++ b/src/praisonai-agents/praisonaiagents/agent/tools_placement.py
@@ -3,12 +3,13 @@
 ``AgentFlow``/``AgentTeam`` already share one sandbox across a run and tear it
 down when the run ends. A lone ``Agent(tools_run_on=...)`` has no "run" to hang
 that lifetime on -- it is just an object someone calls ``chat()`` on, possibly
-many times -- so the sandbox is created on first use and kept for the agent's
-lifetime. That is deliberate: a file written in turn 1 is still there in turn 2,
-which is what anyone who asked for a working directory expects.
+many times -- so the sandbox is created on first use and lives as long as the
+agent does. That is deliberate: a file written in turn 1 is still there in turn
+2, which is what anyone who asked for a working directory expects.
 
 Attachment is idempotent and happens at the top of ``chat``/``achat``/
-``_start_stream``. Doing it once, rather than wrapping each call in a context
+``_start_stream``, and in ``AgentTeam`` before the task's tool list is
+snapshotted. Doing it once, rather than wrapping each call in a context
 manager, sidesteps two real hazards in this codebase:
 
 * ``_start_stream`` is a **generator**; a context manager around the call would
@@ -16,11 +17,16 @@ manager, sidesteps two real hazards in this codebase:
   the model was still using it.
 * ``_start_stream`` falls back to ``self.chat``, so a wrapper would **re-enter**
   itself and provision a second sandbox.
+
+Lifetime is tied to the agent by ``weakref.finalize`` rather than a process-exit
+hook over a weak set. The weak set leaked: an agent and its ``SharedCompute``
+reference each other, so a dropped agent was reclaimed by the cycle collector,
+vanished from the set, and its sandbox was never shut down. Gateways clone an
+agent **per request**, so that was one orphaned container per request.
 """
 
 from __future__ import annotations
 
-import atexit
 import logging
 import threading
 import weakref
@@ -28,19 +34,45 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Agents with a live sandbox, so the interpreter shutdown hook can close them.
-# Weak so holding an agent here never keeps it alive.
-_LIVE: "weakref.WeakSet" = weakref.WeakSet()
-_LIVE_LOCK = threading.Lock()
-_ATEXIT_REGISTERED = False
+# One lock per agent, so two unrelated agents never wait on each other and no
+# lock is ever held while another agent's provider is being imported. Held only
+# by ensure_tools_placed/close_tools_sandbox for that one agent.
+_AGENT_LOCKS: "weakref.WeakKeyDictionary" = weakref.WeakKeyDictionary()
+_LOCKS_GUARD = threading.Lock()
 
 
-def _close_all() -> None:
-    for agent in list(_LIVE):
-        try:
-            close_tools_sandbox(agent)
-        except Exception:  # pragma: no cover - shutdown must stay quiet
-            pass
+def _lock_for(agent: Any) -> threading.Lock:
+    """The placement lock for ``agent``, created on demand.
+
+    ``_LOCKS_GUARD`` covers only this dictionary lookup -- microseconds -- never
+    provider construction or attachment. An earlier version held one global lock
+    across ``SharedCompute(...)``, which imports the provider SDK: unrelated
+    agents serialised behind each other, and a slow import could stall
+    interpreter exit.
+    """
+    with _LOCKS_GUARD:
+        lock = _AGENT_LOCKS.get(agent)
+        if lock is None:
+            lock = threading.Lock()
+            try:
+                _AGENT_LOCKS[agent] = lock
+            except TypeError:  # pragma: no cover - unhashable/non-weakrefable
+                pass
+        return lock
+
+
+def _shutdown_orphan(shared: Any, name: str) -> None:
+    """Tear down a sandbox whose agent is gone.
+
+    Registered with ``weakref.finalize``, so it runs when the agent is collected
+    *and* at interpreter exit. It must not close over the agent -- that would
+    keep it alive and defeat the whole point.
+    """
+    try:
+        shared.shutdown()
+        logger.debug("[tools_placement] released the sandbox belonging to %s", name)
+    except Exception:  # pragma: no cover - teardown must stay quiet
+        logger.debug("[tools_placement] could not release the sandbox for %s", name)
 
 
 def ensure_tools_placed(agent: Any) -> None:
@@ -53,34 +85,41 @@ def ensure_tools_placed(agent: Any) -> None:
     if place is None or getattr(agent, "_tools_sandbox", None) is not None:
         return
 
-    global _ATEXIT_REGISTERED
-
     from ..managed.shared_compute import SharedCompute
 
-    with _LIVE_LOCK:
+    with _lock_for(agent):
         # Re-check under the lock: two threads calling chat() at once must not
         # each provision a sandbox and leak one.
         if getattr(agent, "_tools_sandbox", None) is not None:
             return
+
         shared = SharedCompute(place)
         # override_declared: this sandbox exists *because* the agent named a
         # place, so the skip-if-declared rule must not skip the agent itself.
         shared.attach([agent], override_declared=True)
         agent._tools_sandbox = shared
-        _LIVE.add(agent)
-        if not _ATEXIT_REGISTERED:
-            atexit.register(_close_all)
-            _ATEXIT_REGISTERED = True
+        agent._tools_sandbox_finalizer = weakref.finalize(
+            agent, _shutdown_orphan, shared, str(getattr(agent, "name", agent))
+        )
 
     logger.info("[tools_placement] %r tools now run on %s", getattr(agent, "name", agent), place)
 
 
 def close_tools_sandbox(agent: Any) -> None:
     """Tear down the agent's sandbox and put its original tools back."""
-    shared = getattr(agent, "_tools_sandbox", None)
-    if shared is None:
-        return
-    agent._tools_sandbox = None
-    with _LIVE_LOCK:
-        _LIVE.discard(agent)
-    shared.shutdown()
+    with _lock_for(agent):
+        # Everything happens under the lock. Clearing the marker first and
+        # shutting down afterwards left a window where a concurrent chat()
+        # re-attached and the in-flight shutdown then restored over it, leaving
+        # the agent marked as sandboxed while holding no sandbox tools -- a
+        # state ensure_tools_placed() could never repair, because its idempotent
+        # early return sees the marker and does nothing.
+        shared = getattr(agent, "_tools_sandbox", None)
+        if shared is None:
+            return
+        finalizer = getattr(agent, "_tools_sandbox_finalizer", None)
+        if finalizer is not None:
+            finalizer.detach()          # we are shutting down explicitly
+            agent._tools_sandbox_finalizer = None
+        shared.shutdown()
+        agent._tools_sandbox = None

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -3,6 +3,7 @@ import time
 import json
 import logging
 import contextlib
+import contextvars
 import threading
 from praisonaiagents._logging import get_logger
 from typing import Any, Dict, Optional, List, Tuple, Callable
@@ -1574,8 +1575,8 @@ class AgentTeam(SpawnAnnounceProtocol):
 
 
     # ── shared sandbox lifetime ──────────────────────────────────────────────
-    # Thread-local rather than an instance attribute: the previous version set
-    # `self.run_on = None` for the duration of the run, so a second thread
+    # A ContextVar, not an instance attribute: the previous version set
+    # `self.run_on = None` for the duration of the run, so a second caller
     # inspecting the team mid-run saw "no sandbox" and any concurrent start()
     # executed every tool on the host. Depth lives with the caller, not on the
     # shared object, so the team's declared placement is always readable.
@@ -1584,22 +1585,27 @@ class AgentTeam(SpawnAnnounceProtocol):
     # meant any team started while another team's run was on the stack saw
     # depth==1 and skipped its own sandbox entirely -- so a nested team ran on
     # the host, and a team sharing an agent with the outer run executed on the
-    # OUTER team's sandbox. Two teams in one asyncio.gather hit the same thing.
-    _tools_scope_state = threading.local()
-
-    def _scope_depths(self) -> dict:
-        """This thread's per-team scope depths, keyed by team identity."""
-        depths = getattr(self._tools_scope_state, "depths", None)
-        if depths is None:
-            depths = {}
-            self._tools_scope_state.depths = depths
-        return depths
+    # OUTER team's sandbox.
+    #
+    # ContextVar, not threading.local: two coroutines that `astart()` the SAME
+    # team under one asyncio.gather run on one thread, so thread-local state is
+    # shared between them -- the second saw the first's depth==1, skipped its
+    # own sandbox, and ran against a sandbox the first could tear down mid-flight.
+    # A ContextVar is copied per task at gather/create_task time, so each run
+    # gets its own depth map; it is also per-thread, so sync callers stay
+    # isolated too. The value is an immutable frozen mapping replaced via .set()
+    # (never mutated in place), because a copied context shares the *reference*
+    # to a mutable dict and in-place mutation would leak straight back across
+    # the tasks the copy was meant to separate.
+    _tools_scope_depths: "contextvars.ContextVar" = contextvars.ContextVar(
+        "praisonai_tools_scope_depths", default=()
+    )
 
     def _needs_tools_scope(self) -> bool:
         """True when this call should provision the team's shared sandbox."""
         if getattr(self, "tools_run_on", None) is None:
             return False
-        return self._scope_depths().get(id(self), 0) == 0
+        return dict(self._tools_scope_depths.get()).get(id(self), 0) == 0
 
     @contextlib.contextmanager
     def _shared_tools_scope(self):
@@ -1612,19 +1618,16 @@ class AgentTeam(SpawnAnnounceProtocol):
         """
         from ..managed.shared_compute import SharedCompute
 
-        depths = self._scope_depths()
         key = id(self)
+        depths = dict(self._tools_scope_depths.get())
         depths[key] = depths.get(key, 0) + 1
+        token = self._tools_scope_depths.set(tuple(sorted(depths.items())))
         try:
             with SharedCompute(self.tools_run_on) as shared:
                 shared.attach(list(self.agents or []))
                 yield shared
         finally:
-            depths[key] -= 1
-            if depths[key] <= 0:
-                # Drop the key so the dict cannot grow without bound across
-                # many short-lived teams on a long-lived worker thread.
-                depths.pop(key, None)
+            self._tools_scope_depths.reset(token)
 
     async def astart(self, content=None, return_dict=False, **kwargs):
         """Async version of start method.

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -2,6 +2,7 @@ import os
 import time
 import json
 import logging
+import contextlib
 import threading
 from praisonaiagents._logging import get_logger
 from typing import Any, Dict, Optional, List, Tuple, Callable
@@ -662,9 +663,12 @@ class AgentTeam(SpawnAnnounceProtocol):
         learn: Optional[Any] = None,  # Union[bool, LearnConfig] - continuous learning
         # Union[str, ComputeProviderProtocol] - where every agent's shell/file
         # tools run: "docker", "e2b", "modal", "daytona", "flyio", "tenki",
-        # "local". The team shares ONE sandbox and /workspace, so files written
-        # by one agent are visible to the others. Orchestration stays local.
+        # "local", "subprocess", "sandlock", "ssh", "novita". The team shares
+        # ONE sandbox and one working directory, so files written by one agent
+        # are visible to the others. Orchestration and thinking stay local.
         # Pass a configured provider instance to customise resources.
+        tools_run_on: Optional[Any] = None,
+        # Accepted only to fail with a useful message -- see resolve_placement.
         run_on: Optional[Any] = None,
     ):
         """
@@ -910,7 +914,13 @@ class AgentTeam(SpawnAnnounceProtocol):
         self.stream = _stream
         self.name = name
         # Remote execution: one shared sandbox for every agent on this team.
-        self.run_on = run_on
+        from ..agent.placement import resolve_placement
+
+        resolve_placement(
+            "AgentTeam", run_on=run_on, tools_run_on=tools_run_on,
+            supports_run_on=False,
+        )
+        self.tools_run_on = tools_run_on
 
         # Callbacks for workflow execution
         self.on_task_start = _on_task_start
@@ -1544,6 +1554,41 @@ class AgentTeam(SpawnAnnounceProtocol):
             except StopAsyncIteration:
                 pass
 
+
+    # ── shared sandbox lifetime ──────────────────────────────────────────────
+    # Thread-local rather than an instance attribute: the previous version set
+    # `self.run_on = None` for the duration of the run, so a second thread
+    # inspecting the team mid-run saw "no sandbox" and any concurrent start()
+    # executed every tool on the host. Depth lives with the caller, not on the
+    # shared object, so the team's declared placement is always readable.
+    _tools_scope_state = threading.local()
+
+    def _needs_tools_scope(self) -> bool:
+        """True when this call should provision the team's shared sandbox."""
+        if getattr(self, "tools_run_on", None) is None:
+            return False
+        return getattr(self._tools_scope_state, "depth", 0) == 0
+
+    @contextlib.contextmanager
+    def _shared_tools_scope(self):
+        """Hold one sandbox for everything nested inside.
+
+        Re-entrant by design: ``start_for_each`` opens the scope once for the
+        whole batch, so the ``start()`` call it makes per input row finds the
+        scope already open and reuses that sandbox instead of provisioning and
+        destroying one per row.
+        """
+        from ..managed.shared_compute import SharedCompute
+
+        state = self._tools_scope_state
+        state.depth = getattr(state, "depth", 0) + 1
+        try:
+            with SharedCompute(self.tools_run_on) as shared:
+                shared.attach(list(self.agents or []))
+                yield shared
+        finally:
+            state.depth -= 1
+
     async def astart(self, content=None, return_dict=False, **kwargs):
         """Async version of start method.
         
@@ -1552,6 +1597,12 @@ class AgentTeam(SpawnAnnounceProtocol):
             return_dict: If True, returns the full results dictionary instead of only the final response
             **kwargs: Additional arguments
         """
+        # Same shared sandbox as start(). Without this, an async team with
+        # tools_run_on= ran every tool on the host and said nothing.
+        if self._needs_tools_scope():
+            with self._shared_tools_scope():
+                return await self.astart(content=content, return_dict=return_dict, **kwargs)
+
         # Track execution via telemetry
         if hasattr(self, '_telemetry') and self._telemetry:
             self._telemetry.track_agent_execution(self.name, success=True, async_mode=True)
@@ -1812,19 +1863,11 @@ class AgentTeam(SpawnAnnounceProtocol):
             ```
         """
         # Remote execution: provision ONE sandbox shared by every agent on the
-        # team, and tear it down even if execution raises. Re-enters start()
-        # with run_on cleared so the wrapper applies exactly once.
-        if getattr(self, "run_on", None) is not None:
-            from ..managed.shared_compute import SharedCompute
-
-            run_on, self.run_on = self.run_on, None
-            try:
-                with SharedCompute(run_on) as shared:
-                    shared.attach(list(self.agents or []))
-                    return self.start(content=content, return_dict=return_dict,
-                                      output=output, **kwargs)
-            finally:
-                self.run_on = run_on
+        # team, and tear it down even if execution raises.
+        if self._needs_tools_scope():
+            with self._shared_tools_scope():
+                return self.start(content=content, return_dict=return_dict,
+                                  output=output, **kwargs)
 
         # Track execution via telemetry
         if hasattr(self, '_telemetry') and self._telemetry:
@@ -2140,6 +2183,15 @@ class AgentTeam(SpawnAnnounceProtocol):
         if on_error not in ("continue", "fail_fast"):
             raise ValueError("on_error must be 'continue' or 'fail_fast'")
 
+        # One sandbox for the whole batch. Without this the per-row start()
+        # call provisions and destroys its own, so a 50-row batch paid for 50
+        # sandboxes and no row could see what an earlier row wrote.
+        if self._needs_tools_scope():
+            with self._shared_tools_scope():
+                return self.start_for_each(
+                    inputs, on_error=on_error, output=output, **kwargs
+                )
+
         batch_id = f"batch_{uuid.uuid4().hex[:12]}"
         saved_variables = self.variables
         task_snapshot = self._snapshot_task_state()
@@ -2175,6 +2227,13 @@ class AgentTeam(SpawnAnnounceProtocol):
         """Async twin of :meth:`start_for_each` (sequential per-item execution)."""
         if on_error not in ("continue", "fail_fast"):
             raise ValueError("on_error must be 'continue' or 'fail_fast'")
+
+        # One sandbox for the whole batch -- see start_for_each.
+        if self._needs_tools_scope():
+            with self._shared_tools_scope():
+                return await self.astart_for_each(
+                    inputs, on_error=on_error, **kwargs
+                )
 
         batch_id = f"batch_{uuid.uuid4().hex[:12]}"
         saved_variables = self.variables

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -376,6 +376,18 @@ def _build_execution_context(agents_instance, task_id, skip_memory_init=False):
     if llm and hasattr(llm, 'set_current_agent'):
         llm.set_current_agent(executor_agent.display_name)
 
+    # Place the agent's tools BEFORE snapshotting them. This snapshot is passed
+    # to chat() as an explicit `tools=`, which wins over `agent.tools` -- so if
+    # the sandbox attaches later (inside chat()), the model is handed the
+    # pre-attach list and every tool runs on the host while a sandbox sits
+    # provisioned and unused. Silent, and worse than it sounds: in
+    # start_for_each() row 1 got local tools and row 2 got the bridged set,
+    # because row 1's chat() mutated agent.tools in time for row 2's snapshot.
+    if executor_agent is not None and getattr(executor_agent, "tools_run_on", None) is not None:
+        from ..agent.tools_placement import ensure_tools_placed
+
+        ensure_tools_placed(executor_agent)
+
     # Ensure tools are available from both task and agent (create copy to avoid mutation)
     tools = list(task.tools or [])
     if executor_agent and executor_agent.tools:
@@ -1561,13 +1573,27 @@ class AgentTeam(SpawnAnnounceProtocol):
     # inspecting the team mid-run saw "no sandbox" and any concurrent start()
     # executed every tool on the host. Depth lives with the caller, not on the
     # shared object, so the team's declared placement is always readable.
+    #
+    # The depth is keyed PER TEAM, not shared class-wide. A single integer here
+    # meant any team started while another team's run was on the stack saw
+    # depth==1 and skipped its own sandbox entirely -- so a nested team ran on
+    # the host, and a team sharing an agent with the outer run executed on the
+    # OUTER team's sandbox. Two teams in one asyncio.gather hit the same thing.
     _tools_scope_state = threading.local()
+
+    def _scope_depths(self) -> dict:
+        """This thread's per-team scope depths, keyed by team identity."""
+        depths = getattr(self._tools_scope_state, "depths", None)
+        if depths is None:
+            depths = {}
+            self._tools_scope_state.depths = depths
+        return depths
 
     def _needs_tools_scope(self) -> bool:
         """True when this call should provision the team's shared sandbox."""
         if getattr(self, "tools_run_on", None) is None:
             return False
-        return getattr(self._tools_scope_state, "depth", 0) == 0
+        return self._scope_depths().get(id(self), 0) == 0
 
     @contextlib.contextmanager
     def _shared_tools_scope(self):
@@ -1580,14 +1606,19 @@ class AgentTeam(SpawnAnnounceProtocol):
         """
         from ..managed.shared_compute import SharedCompute
 
-        state = self._tools_scope_state
-        state.depth = getattr(state, "depth", 0) + 1
+        depths = self._scope_depths()
+        key = id(self)
+        depths[key] = depths.get(key, 0) + 1
         try:
             with SharedCompute(self.tools_run_on) as shared:
                 shared.attach(list(self.agents or []))
                 yield shared
         finally:
-            state.depth -= 1
+            depths[key] -= 1
+            if depths[key] <= 0:
+                # Drop the key so the dict cannot grow without bound across
+                # many short-lived teams on a long-lived worker thread.
+                depths.pop(key, None)
 
     async def astart(self, content=None, return_dict=False, **kwargs):
         """Async version of start method.

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -933,6 +933,12 @@ class AgentTeam(SpawnAnnounceProtocol):
             supports_run_on=False,
         )
         self.tools_run_on = tools_run_on
+        # Kept readable rather than removed. `team.run_on` used to exist, and
+        # code doing getattr(team, "run_on", None) for introspection or
+        # serialisation would otherwise start raising AttributeError. None is
+        # the honest value: a team orchestrates locally, so nothing about it
+        # runs wholly on a managed runtime.
+        self.run_on = None
 
         # Callbacks for workflow execution
         self.on_task_start = _on_task_start

--- a/src/praisonai-agents/praisonaiagents/config/feature_configs.py
+++ b/src/praisonai-agents/praisonaiagents/config/feature_configs.py
@@ -847,12 +847,6 @@ class ExecutionConfig:
     code_execution: bool = False
     code_mode: str = "safe"  # "safe" or "unsafe"
     
-    # NOT IMPLEMENTED - no execution path reads this field, so setting it
-    # provides NO isolation. Do not rely on it for safety. Use
-    # Agent(sandbox=...) for local isolation, or AgentFlow(run_on="docker")
-    # to run a whole workflow in a remote sandbox.
-    code_sandbox_mode: str = "sandbox"  # "sandbox" or "direct" (inert)
-
     # Code-execution-with-tools (code mode): when True, model-generated code may
     # call the agent's registered tools directly via injected proxies, enabling
     # multi-step tool pipelines in a single turn (intermediate results stay out
@@ -995,7 +989,6 @@ class ExecutionConfig:
             "retry_jitter": self.retry_jitter,
             "code_execution": self.code_execution,
             "code_mode": self.code_mode,
-            "code_sandbox_mode": self.code_sandbox_mode,
             "code_tools": self.code_tools,
             "code_tools_allow": self.code_tools_allow,
             "context_compaction": (
@@ -1047,7 +1040,6 @@ class ExecutionConfig:
             retry_jitter=data.get("retry_jitter", 0.1),
             code_execution=data.get("code_execution", False),
             code_mode=data.get("code_mode", "safe"),
-            code_sandbox_mode=data.get("code_sandbox_mode", "sandbox"),
             code_tools=data.get("code_tools", False),
             code_tools_allow=data.get("code_tools_allow", None),
             context_compaction=context_compaction,

--- a/src/praisonai-agents/praisonaiagents/managed/_compute_bridge.py
+++ b/src/praisonai-agents/praisonaiagents/managed/_compute_bridge.py
@@ -32,9 +32,18 @@ _EXTRA_HINTS = {
 }
 
 
+# Places that live only in praisonai-sandbox. They speak SandboxProtocol
+# (one object IS one environment) rather than ComputeProviderProtocol (one
+# object hands out many), so an adapter supplies the missing half.
+from ._sandbox_adapter import NEEDS_INSTANCE, SANDBOX_ONLY  # noqa: E402
+
+# Spellings users already have in their code, mapped to the canonical name.
+_ALIASES = {"native": "sandlock"}
+
+
 def available_providers() -> list:
-    """Return the compute provider names this bridge can resolve."""
-    return sorted(_PROVIDERS)
+    """Every place ``tools_run_on=`` / ``run_in=`` accepts, from both registries."""
+    return sorted(set(_PROVIDERS) | set(SANDBOX_ONLY))
 
 
 def compute_package_available() -> bool:
@@ -58,15 +67,34 @@ def resolve_compute(compute: Optional[Any]) -> Optional[Any]:
     if not isinstance(compute, str):
         if hasattr(compute, "provision") and hasattr(compute, "execute"):
             return compute
+        # A SandboxProtocol instance -- e.g. SSHSandbox(host=...) -- is adapted,
+        # which is the only way to pass connection details.
+        if hasattr(compute, "run_command") and hasattr(compute, "start"):
+            from ._sandbox_adapter import wrap_sandbox_instance
+
+            return wrap_sandbox_instance(compute)
         raise TypeError(
             f"compute= expects a provider name or a ComputeProviderProtocol "
             f"instance, got {type(compute).__name__}"
         )
 
     name = compute.lower().strip()
+    name = _ALIASES.get(name, name)
+
+    # A sandbox-only place: adapt it to the compute-provider shape.
+    if name in SANDBOX_ONLY:
+        if name in NEEDS_INSTANCE:
+            raise ValueError(
+                f"{name!r} needs connection details a bare name cannot carry. "
+                f"Instead, {NEEDS_INSTANCE[name]}"
+            )
+        from ._sandbox_adapter import SandboxComputeAdapter
+
+        return SandboxComputeAdapter(name)
+
     if name not in _PROVIDERS:
         raise ValueError(
-            f"Unknown compute provider {name!r}. "
+            f"Unknown place {name!r}. "
             f"Available: {', '.join(available_providers())}"
         )
 

--- a/src/praisonai-agents/praisonaiagents/managed/_sandbox_adapter.py
+++ b/src/praisonai-agents/praisonaiagents/managed/_sandbox_adapter.py
@@ -1,0 +1,204 @@
+"""Expose a single sandbox environment as a one-instance compute provider.
+
+There are two execution stacks in this project and they are *not* duplicates:
+
+* ``SandboxProtocol`` (praisonai-sandbox) -- one object **is** one environment:
+  ``start / stop / execute / run_command / reset``.
+* ``ComputeProviderProtocol`` -- one object **hands out** many environments:
+  ``provision / execute(instance_id, ...) / shutdown / list_instances``.
+
+``tools_run_on=`` speaks the second protocol, so four backends that only exist
+as sandboxes -- ``subprocess``, ``sandlock``, ``ssh``, ``novita`` -- were
+unreachable through it. This adapter is the missing half: it holds exactly one
+environment and presents the manager-shaped API over it.
+
+Deliberate limitation: ``list_instances()`` can only report what *this process*
+provisioned, so adapter-backed places never appear in ``praisonai managed ps``.
+A single environment has no cross-process registry to consult, and pretending
+otherwise would be worse than saying so.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Backends that exist only as SandboxProtocol implementations.
+SANDBOX_ONLY = ("subprocess", "sandlock", "ssh", "novita")
+
+# Names that need connection details no bare string can carry.
+NEEDS_INSTANCE = {
+    "ssh": (
+        "run on a remote machine over SSH by passing the object, so it can "
+        "carry the host: SSHSandbox(host='...', user='...')"
+    ),
+}
+
+
+class SandboxComputeAdapter:
+    """One ``SandboxProtocol`` environment, wearing the compute-provider shape."""
+
+    def __init__(self, sandbox_type: str, config: Optional[Any] = None,
+                 sandbox: Optional[Any] = None):
+        self._type = sandbox_type
+        self._config = config
+        self._sandbox = sandbox          # pre-built instance, if supplied
+        self._owns_sandbox = sandbox is None
+        self._instance_id: Optional[str] = None
+
+    # ── identity ─────────────────────────────────────────────────────────────
+    @property
+    def provider_name(self) -> str:
+        return self._type
+
+    @property
+    def is_available(self) -> bool:
+        if self._sandbox is not None:
+            return bool(getattr(self._sandbox, "is_available", True))
+        try:
+            from ..sandbox._sandbox_bridge import resolve_sandbox_class
+
+            cls = resolve_sandbox_class(self._type)
+            probe = cls() if self._type not in NEEDS_INSTANCE else None
+            return bool(getattr(probe, "is_available", False)) if probe else False
+        except Exception:
+            return False
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    async def provision(self, config: Any) -> Any:
+        from .protocols import InstanceInfo, InstanceStatus
+
+        if self._sandbox is None:
+            from ..sandbox import SandboxConfig
+            from ..sandbox.manager import SandboxManager
+
+            cfg = self._config
+            if cfg is None:
+                # "/workspace" is the convention for *container* sandboxes and
+                # does not exist on a Mac or a bare Linux box -- creating it
+                # fails with "Read-only file system". Local backends pick their
+                # own private temp dir, so only pass a working_dir through when
+                # the caller actually chose one.
+                wanted_dir = getattr(config, "working_dir", None)
+                local_place = self._type in ("subprocess", "sandlock")
+                if local_place and wanted_dir in (None, "", "/workspace"):
+                    wanted_dir = None
+                cfg = SandboxConfig(
+                    sandbox_type=self._type,
+                    env=dict(getattr(config, "env", None) or {}),
+                    **({"working_dir": wanted_dir} if wanted_dir else {}),
+                )
+                # This sandbox exists to back the model's execute_command tool,
+                # which IS a shell. The default policy sets allow_subprocess=
+                # False, which makes `sh -c` -- and therefore every pipe,
+                # redirect and && the model writes -- fail as "disabled by
+                # security policy". Blocking the shell inside a shell tool is a
+                # contradiction, not a protection; blocked_commands and
+                # blocked_paths still apply.
+                if getattr(cfg, "security_policy", None) is not None:
+                    cfg.security_policy.allow_subprocess = True
+            if getattr(config, "image", None):
+                cfg.image = config.image
+            self._manager = SandboxManager(cfg)
+            self._sandbox = await self._manager.__aenter__()
+        else:
+            self._manager = None
+            starter = getattr(self._sandbox, "start", None)
+            if starter is not None:
+                await starter()
+
+        self._instance_id = f"{self._type}_{uuid.uuid4().hex[:12]}"
+        logger.info("[sandbox_adapter] provisioned %s as %s", self._type, self._instance_id)
+        return InstanceInfo(
+            instance_id=self._instance_id,
+            status=InstanceStatus.RUNNING,
+            endpoint=f"{self._type}://local",
+            provider=self._type,
+            metadata={"adapter": True, "discoverable": False},
+        )
+
+    async def execute(self, instance_id: str, command: str,
+                      timeout: Optional[int] = 300) -> Dict[str, Any]:
+        if self._sandbox is None:
+            raise RuntimeError(
+                f"{self._type} sandbox is not running; provision() was not called"
+            )
+        # The bridged execute_command tool hands us a shell command string, and
+        # models write pipes, redirects and && constantly. Without shell=True
+        # `echo x > f` is argv-split and "> f" arrives as a literal argument.
+        try:
+            result = await self._sandbox.run_command(command, shell=True)
+        except TypeError:
+            # Backends predating the shell= parameter.
+            result = await self._sandbox.run_command(command)
+        # A policy denial arrives as result.error with exit_code=None. Dropping
+        # it would turn "blocked by security policy" into a silent success --
+        # the caller would see exit 0 and empty output.
+        error = getattr(result, "error", None)
+        exit_code = getattr(result, "exit_code", None)
+        stderr = getattr(result, "stderr", "") or ""
+        if error:
+            stderr = f"{stderr}\n{error}".strip() if stderr else str(error)
+            if exit_code in (None, 0):
+                exit_code = 1
+        return {
+            "stdout": getattr(result, "stdout", "") or "",
+            "stderr": stderr,
+            "exit_code": exit_code or 0,
+        }
+
+    async def shutdown(self, instance_id: str) -> None:
+        try:
+            if getattr(self, "_manager", None) is not None:
+                await self._manager.__aexit__(None, None, None)
+            elif self._sandbox is not None:
+                stopper = getattr(self._sandbox, "stop", None)
+                if stopper is not None:
+                    await stopper()
+        finally:
+            if self._owns_sandbox:
+                self._sandbox = None
+            self._manager = None
+            self._instance_id = None
+
+    async def get_status(self, instance_id: str) -> Any:
+        from .protocols import InstanceInfo, InstanceStatus
+
+        running = self._sandbox is not None and instance_id == self._instance_id
+        return InstanceInfo(
+            instance_id=instance_id,
+            status=InstanceStatus.RUNNING if running else InstanceStatus.STOPPED,
+            provider=self._type,
+        )
+
+    async def list_instances(self) -> List[Any]:
+        """Only what this process provisioned -- see the module docstring."""
+        from .protocols import InstanceInfo, InstanceStatus
+
+        if self._instance_id is None:
+            return []
+        return [InstanceInfo(
+            instance_id=self._instance_id,
+            status=InstanceStatus.RUNNING,
+            provider=self._type,
+            metadata={"adapter": True, "discoverable": False},
+        )]
+
+    # ── file transfer ────────────────────────────────────────────────────────
+    async def upload_file(self, instance_id: str, local_path: str, remote_path: str) -> None:
+        with open(local_path, "r") as handle:
+            await self._sandbox.write_file(remote_path, handle.read())
+
+    async def download_file(self, instance_id: str, remote_path: str, local_path: str) -> None:
+        content = await self._sandbox.read_file(remote_path)
+        with open(local_path, "w") as handle:
+            handle.write(content if isinstance(content, str) else str(content))
+
+
+def wrap_sandbox_instance(sandbox: Any) -> SandboxComputeAdapter:
+    """Adapt an already-constructed sandbox (e.g. ``SSHSandbox(host=...)``)."""
+    name = getattr(sandbox, "sandbox_type", None) or type(sandbox).__name__.lower()
+    return SandboxComputeAdapter(str(name), sandbox=sandbox)

--- a/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
+++ b/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
@@ -120,6 +120,8 @@ class SharedCompute:
         """Tear down the instance and restore any agents we patched."""
         for agent, original_tools, original_backstory in self._patched:
             try:
+                if getattr(agent, "_tools_sandbox", None) is self:
+                    agent._tools_sandbox = None
                 agent.tools = original_tools
                 agent.backstory = original_backstory
                 cache = getattr(agent, "_system_prompt_cache", None)
@@ -205,17 +207,46 @@ class SharedCompute:
 
         return [execute_command, read_file, write_file, list_files]
 
-    def attach(self, agents: List[Any]) -> None:
+    def attach(self, agents: List[Any], *, override_declared: bool = False) -> None:
         """Give each agent the shared tools and tell it they exist.
 
         Agents that already carry their own managed ``backend`` are skipped --
         they have deliberately been pointed at their own runtime.
+
+        ``override_declared`` is set only by the agent's *own* placement, which
+        is this sandbox's whole reason for existing. A run-level sandbox leaves
+        it False so an agent that named its own place keeps it.
         """
         tools = self.build_tools()
         by_name = {t.__name__: t for t in tools}
 
         for agent in agents:
             if agent is None or getattr(agent, "backend", None) is not None:
+                continue
+            # An agent that named its own place, or already has a sandbox, must
+            # not be attached again. A second attach appends CAPABILITY_PROMPT
+            # twice and, if the two teardowns do not happen in LIFO order,
+            # permanently restores the wrong tools: the agent is left holding
+            # four tools bound to a shut-down instance.
+            #
+            # `tools_run_on` is checked as well as `_tools_sandbox` because of
+            # ordering: a flow attaches at the start of the run, before the
+            # agent's first chat() has created its own sandbox. Checking only
+            # the live sandbox would attach here and let the agent attach again
+            # on its first turn. An explicit per-agent choice outranks the run's
+            # default, so the flow leaves it alone.
+            declared_own = (
+                not override_declared
+                and getattr(agent, "tools_run_on", None) is not None
+            )
+            if getattr(agent, "_tools_sandbox", None) is not None or declared_own:
+                logger.debug(
+                    "[shared_compute] %r already runs its tools on %s; leaving it alone",
+                    getattr(agent, "name", agent),
+                    getattr(agent, "tools_run_on", "its own sandbox"),
+                )
+                continue
+            if any(agent is patched for patched, _, _ in self._patched):
                 continue
 
             original_tools = list(getattr(agent, "tools", None) or [])
@@ -248,4 +279,10 @@ class SharedCompute:
                 logger.warning("[shared_compute] could not attach tools to %r: %s", agent, exc)
                 continue
 
+            # Mark where this agent's tools now run, so a nested attach (or a
+            # later ensure_tools_placed) can see it is already bound.
+            try:
+                agent._tools_sandbox = self
+            except Exception:  # pragma: no cover - exotic agent objects
+                pass
             self._patched.append((agent, original_tools, original_backstory))

--- a/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
+++ b/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
@@ -17,6 +17,7 @@ import logging
 import shlex
 import threading
 import uuid
+import weakref
 from typing import Any, Dict, List, Optional
 
 from ._compute_bridge import resolve_compute
@@ -118,7 +119,10 @@ class SharedCompute:
 
     def shutdown(self) -> None:
         """Tear down the instance and restore any agents we patched."""
-        for agent, original_tools, original_backstory in self._patched:
+        for ref, original_tools, original_backstory in self._patched:
+            agent = ref()
+            if agent is None:
+                continue          # already collected; nothing left to restore
             try:
                 if getattr(agent, "_tools_sandbox", None) is self:
                     agent._tools_sandbox = None
@@ -246,7 +250,7 @@ class SharedCompute:
                     getattr(agent, "tools_run_on", "its own sandbox"),
                 )
                 continue
-            if any(agent is patched for patched, _, _ in self._patched):
+            if any(agent is ref() for ref, _, _ in self._patched):
                 continue
 
             original_tools = list(getattr(agent, "tools", None) or [])
@@ -285,4 +289,12 @@ class SharedCompute:
                 agent._tools_sandbox = self
             except Exception:  # pragma: no cover - exotic agent objects
                 pass
-            self._patched.append((agent, original_tools, original_backstory))
+            # Weakly: an agent points at its SharedCompute and the SharedCompute
+            # pointed back, so a dropped agent was reclaimed as a cycle and its
+            # sandbox was never shut down. Holding the agent weakly lets
+            # weakref.finalize see the agent die and release the sandbox.
+            try:
+                ref = weakref.ref(agent)
+            except TypeError:  # pragma: no cover - non-weakrefable agent
+                ref = lambda _agent=agent: _agent
+            self._patched.append((ref, original_tools, original_backstory))

--- a/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
+++ b/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
@@ -214,7 +214,15 @@ class SharedCompute:
             """List files in a directory on the shared remote sandbox."""
             return self._format(self.run_command(f"ls -la {shlex.quote(path)}"))
 
-        return [execute_command, read_file, write_file, list_files]
+        bridged = [execute_command, read_file, write_file, list_files]
+        # Tag them so Agent.clone_for_channel() drops them: each closes over
+        # THIS sandbox, so a clone inheriting them would talk to the original
+        # agent's instance and then attach a second sandbox of its own --
+        # duplicating the capability prompt and splitting its work across two
+        # machines. The clone regenerates its own on first use.
+        for tool in bridged:
+            tool._praison_sandbox_tool = True
+        return bridged
 
     def attach(self, agents: List[Any], *, override_declared: bool = False) -> None:
         """Give each agent the shared tools and tell it they exist.

--- a/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
+++ b/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
@@ -193,9 +193,14 @@ class SharedCompute:
             # heredoc early (which would truncate the file and run the remainder
             # as shell commands). Guard against the astronomically-unlikely case
             # where the token still appears in the body.
-            delimiter = f"__PRAISON_EOF_{uuid.uuid4().hex}__"
+            # Uppercase hex on purpose. uuid4().hex is lowercase, and the
+            # security policy substring-matches blocked_commands against the
+            # whole command -- "dd" is one of them, and appears in 9.6% of
+            # random lowercase hex strings. One write in ten failed with
+            # "Blocked command pattern: dd" for no reason the caller could see.
+            delimiter = f"__PRAISON_EOF_{uuid.uuid4().hex.upper()}__"
             while delimiter in content:
-                delimiter = f"__PRAISON_EOF_{uuid.uuid4().hex}__"
+                delimiter = f"__PRAISON_EOF_{uuid.uuid4().hex.upper()}__"
             heredoc = (
                 f"mkdir -p $(dirname {quoted}) && "
                 f"cat > {quoted} <<'{delimiter}'\n{content}\n{delimiter}"

--- a/src/praisonai-agents/praisonaiagents/sandbox/manager.py
+++ b/src/praisonai-agents/praisonaiagents/sandbox/manager.py
@@ -79,9 +79,42 @@ class SandboxManager:
                 f"Unknown sandbox type: {sandbox_type!r}. {e}"
             ) from e
 
-        kwargs: Dict[str, Any] = {"config": self.config}
-        if sandbox_type == "docker":
+        # Not every backend takes a SandboxConfig: SSHSandbox and ModalSandbox
+        # carry their own connection details instead, so passing config= to them
+        # raised "unexpected keyword argument 'config'" before the sandbox was
+        # ever built. Ask the constructor what it accepts.
+        import inspect
+
+        params = inspect.signature(sandbox_cls.__init__).parameters
+        takes = lambda name: name in params or any(
+            p.kind is p.VAR_KEYWORD for p in params.values()
+        )
+
+        kwargs: Dict[str, Any] = {}
+        if takes("config"):
+            kwargs["config"] = self.config
+        if sandbox_type == "docker" and takes("image"):
             kwargs["image"] = self.config.image
+
+        # A required argument we cannot supply from a config object -- SSH needs
+        # a host. Say so instead of raising TypeError from deep inside.
+        missing = [
+            name for name, prm in params.items()
+            if name != "self"
+            and prm.default is prm.empty
+            and prm.kind not in (prm.VAR_POSITIONAL, prm.VAR_KEYWORD)
+            and name not in kwargs
+        ]
+        if missing:
+            raise TypeError(
+                f"The {sandbox_type!r} sandbox needs {', '.join(missing)}, which a "
+                f"SandboxConfig cannot carry. Build it directly and pass the "
+                f"object:\n"
+                f"    from praisonai_sandbox.{sandbox_type} import "
+                f"{sandbox_cls.__name__}\n"
+                f"    sandbox = {sandbox_cls.__name__}("
+                f"{'=..., '.join(missing)}=...)"
+            )
 
         sandbox = sandbox_cls(**kwargs)
 

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -632,10 +632,17 @@ class AgentFlow:
     # REMOTE EXECUTION
     # ============================================================
     # Union[str, ComputeProviderProtocol] - where each step's shell/file tools
-    # run: "docker", "e2b", "modal", "daytona", "flyio", "tenki", "local".
-    # Every step shares ONE sandbox and /workspace, so a file written by one
-    # step is visible to later steps. Orchestration stays local. Pass a
-    # configured provider instance instead of a name to customise resources.
+    # run: "docker", "e2b", "modal", "daytona", "flyio", "tenki", "local",
+    # "subprocess", "sandlock", "ssh", "novita".
+    # Every step shares ONE sandbox and one working directory, so a file written
+    # by one step is visible to later steps. Orchestration -- routing, parallel,
+    # repeat -- stays local, and so does the thinking. Pass a configured
+    # provider instance instead of a name to customise resources.
+    tools_run_on: Optional[Any] = None
+
+    # Accepted only to fail with a useful message: on an Agent, run_on= moves
+    # the whole agent to a managed runtime, so honouring it here as a synonym
+    # for tools_run_on= would make one word mean two things.
     run_on: Optional[Any] = None
 
     # ============================================================
@@ -692,6 +699,14 @@ class AgentFlow:
 
     def __post_init__(self):
         """Resolve consolidated params to internal values."""
+        from ..agent.placement import resolve_placement
+
+        resolve_placement(
+            "AgentFlow",
+            run_on=self.run_on,
+            tools_run_on=self.tools_run_on,
+            supports_run_on=False,
+        )
         from .workflow_configs import (
             resolve_output_config, resolve_planning_config,
             resolve_memory_config, resolve_hooks_config,
@@ -1115,7 +1130,7 @@ class AgentFlow:
                 "separate Workflow instance per concurrent run."
             )
         try:
-            if self.run_on is None:
+            if self.tools_run_on is None:
                 return self._run_impl(input, llm, verbose, stream)
             # One sandbox for the whole run; torn down even if a step raises.
             with self._shared_compute() as shared:
@@ -1152,10 +1167,10 @@ class AgentFlow:
         return explain(self, shared=True)
 
     def _shared_compute(self):
-        """Build the SharedCompute for this run (see the ``run_on=`` field)."""
+        """Build the SharedCompute for this run (see ``tools_run_on=``)."""
         from ..managed.shared_compute import SharedCompute
 
-        return SharedCompute(self.run_on)
+        return SharedCompute(self.tools_run_on)
 
     def _collect_agents(self) -> List[Any]:
         """Walk steps (including nested route/parallel/loop/repeat/if) for Agents.

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -638,7 +638,7 @@ class AgentFlow:
     # by one step is visible to later steps. Orchestration -- routing, parallel,
     # repeat -- stays local, and so does the thinking. Pass a configured
     # provider instance instead of a name to customise resources.
-    tools_run_on: Optional[Any] = None
+    tools_run_on: Optional[Union['ToolPlace', str, Any]] = None
 
     # Accepted only to fail with a useful message: on an Agent, run_on= moves
     # the whole agent to a managed runtime, so honouring it here as a synonym

--- a/src/praisonai-agents/praisonaiagents/workflows/yaml_parser.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/yaml_parser.py
@@ -348,23 +348,30 @@ class YAMLWorkflowParser:
         # Parse history flag for execution tracing (robustness feature)
         history_enabled = data.get('history', False)
 
-        # Remote execution: `run_on: docker` gives every step's shell/file tools
-        # one shared sandbox. Validated here so a typo fails at load time with
-        # the list of valid names, rather than at first tool call.
-        run_on = data.get('run_on')
-        if run_on is not None:
-            if not isinstance(run_on, str):
+        # Remote execution: `tools_run_on: docker` gives every step's shell and
+        # file tools one shared sandbox. Validated here so a typo fails at load
+        # time with the list of valid names, rather than at first tool call.
+        #
+        # `run_on:` is accepted silently as the old spelling. Unlike the Python
+        # kwarg -- which now raises, because on an Agent run_on= means something
+        # different -- a YAML file is data someone already wrote and shipped,
+        # and there is no Agent-level run_on: key in YAML for it to be confused
+        # with. Breaking those files would buy nothing.
+        tools_run_on = data.get('tools_run_on', data.get('run_on'))
+        if tools_run_on is not None:
+            if not isinstance(tools_run_on, str):
                 raise ValueError(
-                    f"'run_on' must be a provider name string, got {type(run_on).__name__}"
+                    f"'tools_run_on' must be a provider name string, "
+                    f"got {type(tools_run_on).__name__}"
                 )
             from ..managed._compute_bridge import available_providers
 
-            if run_on.lower().strip() not in available_providers():
+            if tools_run_on.lower().strip() not in available_providers():
                 raise ValueError(
-                    f"Unknown run_on provider {run_on!r}. "
+                    f"Unknown tools_run_on place {tools_run_on!r}. "
                     f"Available: {', '.join(available_providers())}"
                 )
-            run_on = run_on.lower().strip()
+            tools_run_on = tools_run_on.lower().strip()
 
         workflow = Workflow(
             name=name,
@@ -378,7 +385,7 @@ class YAMLWorkflowParser:
             memory=memory_value,  # Pass memory config to Workflow
             context=context_value,  # Pass context management config to Workflow
             history=history_enabled,  # Enable execution history tracking (robustness)
-            run_on=run_on,  # Shared remote sandbox for every step (None = local)
+            tools_run_on=tools_run_on,  # One shared sandbox for every step (None = local)
         )
         
         # Store additional attributes for feature parity with agents.yaml

--- a/src/praisonai-agents/pyproject.toml
+++ b/src/praisonai-agents/pyproject.toml
@@ -21,6 +21,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Isolated code execution backends (docker, sandlock, ssh, novita, e2b, modal,
+# daytona) used by Agent(tools_run_on=...) and execute_code(run_in=...).
+#
+# praisonai-sandbox depends on praisonaiagents, so this extra closes a cycle.
+# That is deliberate and safe here: it is an *optional* edge, so nothing
+# installing plain praisonaiagents ever walks it, and pip resolves the pair
+# without pinning either to the other's version. Do not promote it to a
+# hard dependency, which would make the cycle mandatory.
+sandbox = [
+    "praisonai-sandbox>=0.0.13",
+]
+
 mcp = [
     "mcp>=1.20.0",
     "fastapi>=0.115.0",
@@ -115,6 +127,7 @@ a2ui = [
 # Declarative agent UI (Google A2UI SDK — lazy loaded)
 all = [
     "praisonaiagents[memory]",
+    "praisonaiagents[sandbox]",
     "praisonaiagents[knowledge]",
     "praisonaiagents[graph]",
     "praisonaiagents[llm]",

--- a/src/praisonai-agents/tests/managed/test_managed_factory.py
+++ b/src/praisonai-agents/tests/managed/test_managed_factory.py
@@ -640,10 +640,25 @@ class TestComputeProviderWiring:
         assert agent.compute_provider.provider_name == "flyio"
 
     def test_resolve_unknown_raises(self):
+        """An unknown place still raises -- and now names the valid ones.
+
+        This class used to carry its own hardcoded provider list, which is why
+        LocalAgent(tools_run_on="sandlock") failed for a place the rest of the
+        library resolves. It delegates to the merged resolver now, so the
+        message changed from "Unknown compute provider" to "Unknown place",
+        listing every place both registries offer.
+        """
         import pytest
         from praisonai.integrations.managed_local import LocalManagedAgent
-        with pytest.raises(ValueError, match="Unknown compute provider"):
+        with pytest.raises(ValueError, match="Unknown place"):
             LocalManagedAgent(provider="local", compute="unknown_provider")
+
+    def test_resolve_accepts_sandbox_only_places(self):
+        """The whole point of the merged registry: one vocabulary everywhere."""
+        from praisonai.integrations.managed_local import LocalManagedAgent
+        for place in ("sandlock", "subprocess", "novita"):
+            agent = LocalManagedAgent(provider="local", tools_run_on=place)
+            assert agent.compute_provider is not None, place
 
     def test_resolve_instance(self):
         from praisonai.integrations.managed_local import LocalManagedAgent

--- a/src/praisonai-agents/tests/managed/test_run_on_temp_agent.py
+++ b/src/praisonai-agents/tests/managed/test_run_on_temp_agent.py
@@ -33,7 +33,7 @@ def _build_workflow(monkeypatch):
     wf = Workflow(
         name="temp-agent-run-on",
         steps=[Task(name="s1", action="write a file to /workspace")],
-        run_on="docker",
+        tools_run_on="docker",
     )
     monkeypatch.setattr(wf, "_shared_compute", lambda: shared)
     return wf, shared

--- a/src/praisonai-agents/tests/managed/test_shared_compute.py
+++ b/src/praisonai-agents/tests/managed/test_shared_compute.py
@@ -241,5 +241,5 @@ def test_flow_without_run_on_does_not_provision():
     from praisonaiagents import AgentFlow
 
     flow = AgentFlow(steps=[FakeAgent("A")])
-    assert flow.run_on is None
+    assert flow.tools_run_on is None
     assert flow._collect_agents()[0].tools == []

--- a/src/praisonai-agents/tests/managed/test_yaml_run_on.py
+++ b/src/praisonai-agents/tests/managed/test_yaml_run_on.py
@@ -25,22 +25,22 @@ def _parse(extra="", name="wf"):
 
 
 def test_run_on_is_parsed():
-    assert _parse("run_on: docker\n").run_on == "docker"
+    assert _parse("run_on: docker\n").tools_run_on == "docker"
 
 
 def test_run_on_defaults_to_none():
     """Omitting run_on must leave the workflow running locally, as before."""
-    assert _parse().run_on is None
+    assert _parse().tools_run_on is None
 
 
 def test_run_on_is_case_and_space_insensitive():
-    assert _parse("run_on: DOCKER\n").run_on == "docker"
-    assert _parse('run_on: "  docker  "\n').run_on == "docker"
+    assert _parse("run_on: DOCKER\n").tools_run_on == "docker"
+    assert _parse('run_on: "  docker  "\n').tools_run_on == "docker"
 
 
 @pytest.mark.parametrize("provider", ["docker", "e2b", "modal", "daytona", "flyio", "local"])
 def test_all_known_providers_accepted(provider):
-    assert _parse(f"run_on: {provider}\n").run_on == provider
+    assert _parse(f"run_on: {provider}\n").tools_run_on == provider
 
 
 def test_unknown_provider_fails_at_load_time():
@@ -59,5 +59,5 @@ def test_non_string_run_on_rejected():
 def test_run_on_reaches_the_workflow_object():
     """The parsed value must land on the field AgentFlow.run() actually reads."""
     wf = _parse("run_on: docker\n")
-    assert "run_on" in getattr(type(wf), "__dataclass_fields__", {})
-    assert wf.run_on == "docker"
+    assert "tools_run_on" in getattr(type(wf), "__dataclass_fields__", {})
+    assert wf.tools_run_on == "docker"

--- a/src/praisonai-agents/tests/unit/sandbox/test_sandbox_manager.py
+++ b/src/praisonai-agents/tests/unit/sandbox/test_sandbox_manager.py
@@ -218,3 +218,46 @@ class TestSandboxManager:
             await manager._create_sandbox()
 
         mock_resolve.assert_called_once_with("sandlock")
+
+
+class TestConstructorIntrospection:
+    """SandboxManager passed config= to every backend, including the two that
+    do not accept it -- so ssh and modal raised "unexpected keyword argument
+    'config'" before the sandbox was ever built."""
+
+    @pytest.mark.asyncio
+    async def test_a_backend_that_takes_no_config_is_not_handed_one(self):
+        import inspect
+
+        from praisonaiagents.sandbox._sandbox_bridge import resolve_sandbox_class
+
+        for name in ("ssh", "modal"):
+            params = inspect.signature(resolve_sandbox_class(name).__init__).parameters
+            assert "config" not in params, (
+                f"{name} grew a config= parameter; this guard can be simplified"
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_missing_required_argument_says_what_to_build(self):
+        """SSH needs a host, which a SandboxConfig cannot carry. Say that,
+        rather than raising TypeError from deep inside the constructor."""
+        from praisonaiagents.sandbox import SandboxConfig, SandboxManager
+
+        with pytest.raises(TypeError) as exc:
+            await SandboxManager(SandboxConfig(sandbox_type="ssh"))._create_sandbox()
+
+        message = str(exc.value)
+        assert "host" in message
+        assert "SSHSandbox" in message
+        assert "unexpected keyword" not in message, "the raw TypeError leaked through"
+
+    @pytest.mark.asyncio
+    async def test_a_backend_that_takes_config_still_receives_it(self):
+        from praisonaiagents.sandbox import SandboxConfig, SandboxManager
+
+        config = SandboxConfig(sandbox_type="subprocess")
+        sandbox = await SandboxManager(config)._create_sandbox()
+        try:
+            assert sandbox.config is config
+        finally:
+            await sandbox.stop()

--- a/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
+++ b/src/praisonai-agents/tests/unit/sandbox/test_sandbox_wiring.py
@@ -134,9 +134,14 @@ def test_inert_fields_are_documented_as_inert():
     from praisonaiagents.config import feature_configs
 
     assert "NOT IMPLEMENTED" in (autonomy.AutonomyConfig.__doc__ or "")
+
+    # code_sandbox_mode is gone rather than labelled. It defaulted to
+    # "sandbox" while no execution path read it, so its own default told
+    # every reader they had isolation they did not have. An inert field can
+    # be documented; a field whose default misstates a security property
+    # cannot. Real isolation is execute_code(run_in=...) or tools_run_on=.
     src = inspect.getsource(feature_configs.ExecutionConfig)
-    idx = src.find("code_sandbox_mode")
-    assert "NOT IMPLEMENTED" in src[max(0, idx - 400):idx]
+    assert "code_sandbox_mode" not in src
 
 
 # ── real agentic run: sandbox= adds no model-visible execution tools ─────────

--- a/src/praisonai-agents/tests/unit/test_context_compaction_policy.py
+++ b/src/praisonai-agents/tests/unit/test_context_compaction_policy.py
@@ -158,10 +158,17 @@ def test_execution_config_round_trip_preserves_retry_and_strategy():
     assert restored.compaction_strategy == ConfigCompactionStrategy.SUMMARIZE
 
 
-def test_execution_config_from_dict_defaults_sandbox_mode():
-    """Omitted code_sandbox_mode should fall back to the dataclass default 'sandbox'."""
-    restored = ExecutionConfig.from_dict({})
-    assert restored.code_sandbox_mode == "sandbox"
+def test_execution_config_from_dict_ignores_the_removed_sandbox_mode():
+    """A config persisted before code_sandbox_mode was removed must still load.
+
+    The field is gone because it read as a security control while no execution
+    path consulted it. Dropping the key silently is right here: it never did
+    anything, so ignoring it changes no behaviour -- but a stored dict
+    containing it must not fail to load.
+    """
+    restored = ExecutionConfig.from_dict({"code_sandbox_mode": "direct"})
+    assert not hasattr(restored, "code_sandbox_mode")
+    assert "code_sandbox_mode" not in restored.to_dict()
 
 
 def test_mutable_singleton_fix():

--- a/src/praisonai-agents/tests/unit/test_execution_location.py
+++ b/src/praisonai-agents/tests/unit/test_execution_location.py
@@ -26,7 +26,7 @@ def test_agent_repr_states_where_it_runs():
 
 
 def test_flow_repr_states_shared_sandbox():
-    flow = AgentFlow(run_on="docker", steps=[_agent("W"), _agent("R")])
+    flow = AgentFlow(tools_run_on="docker", steps=[_agent("W"), _agent("R")])
     text = repr(flow)
     assert "steps=2" in text
     assert "Docker container" in text
@@ -35,7 +35,7 @@ def test_flow_repr_states_shared_sandbox():
 
 def test_team_repr_states_shared_sandbox():
     a = _agent("W")
-    team = AgentTeam(agents=[a], tasks=[Task(description="d", agent=a)], run_on="e2b")
+    team = AgentTeam(agents=[a], tasks=[Task(description="d", agent=a)], tools_run_on="e2b")
     assert "E2B" in repr(team)
     assert "shared" in repr(team)
 
@@ -59,7 +59,7 @@ def test_explain_is_plain_for_a_local_agent():
 
 
 def test_explain_mentions_shared_state_for_a_workflow():
-    flow = AgentFlow(run_on="docker", steps=[_agent()])
+    flow = AgentFlow(tools_run_on="docker", steps=[_agent()])
     text = flow.where_does_it_run()
     assert "shares that same sandbox" in text
     assert "visible to the next" in text
@@ -75,7 +75,7 @@ def test_explain_warns_that_a_subprocess_is_not_a_boundary():
 
 
 def test_explain_does_not_warn_for_a_real_boundary():
-    flow = AgentFlow(run_on="docker", steps=[_agent()])
+    flow = AgentFlow(tools_run_on="docker", steps=[_agent()])
     assert "not a security boundary" not in flow.where_does_it_run()
 
 
@@ -114,15 +114,32 @@ def test_sandbox_aliases_report_the_real_backend(alias, expected):
 
 
 # ── vocabulary gate: never reuse a word that is public API elsewhere ─────────
+#: Words the repr uses that are ALSO parameters, on purpose: you set the place
+#: with the same word the repr reports it with. That mirroring is the feature.
+_DELIBERATE_MIRRORS = {"tools_run_on", "run_on"}
+
+
 def test_no_field_name_collides_with_existing_public_api():
     """`loop` was rejected as a field name because it is already
     praisonaiagents.workflows.loop(), asyncio's event loop, and agent-loop
-    jargon. This test stops anyone reintroducing that class of collision."""
+    jargon -- one word, three meanings. This test stops that class of collision.
+
+    It deliberately exempts the placement words. `tools_run_on` appearing both
+    as a kwarg and as a repr field is the opposite failure mode: one word, one
+    meaning, in both directions --
+
+        >>> Agent(name='w', instructions='x', tools_run_on='docker')
+        Agent(name='w', thinks_on='this machine', tools_run_on='a Docker container')
+
+    A user reads the repr and knows exactly what to type. Renaming one side to
+    satisfy a blanket no-overlap rule would break that, so the rule is narrowed
+    to what it was actually protecting: words that mean something *else*.
+    """
     import praisonaiagents.workflows as wf
 
     agent_kwargs = set(inspect.signature(Agent.__init__).parameters)
     workflow_api = {n for n in dir(wf) if not n.startswith("_")}
-    taken = agent_kwargs | workflow_api
+    taken = (agent_kwargs | workflow_api) - _DELIBERATE_MIRRORS
 
     for field in describe(_agent()):
         assert field not in taken, (
@@ -131,11 +148,19 @@ def test_no_field_name_collides_with_existing_public_api():
         )
 
 
+def test_mirrored_words_mean_the_same_thing_on_both_sides():
+    """Guards the exemption above: a mirrored word must describe what the
+    parameter of that name actually does, or the exemption is being abused."""
+    agent = Agent(name="w", instructions="x", tools_run_on="docker")
+    assert describe(agent)["tools_run_on"] == say_place("docker")
+    assert "Docker" in repr(agent)
+
+
 def test_explanation_avoids_jargon():
     """The sentences are for someone who does not know the vocabulary."""
     text = " ".join([
         _agent().where_does_it_run(),
-        AgentFlow(run_on="docker", steps=[_agent()]).where_does_it_run(),
+        AgentFlow(tools_run_on="docker", steps=[_agent()]).where_does_it_run(),
     ]).lower()
     for jargon in ("harness", "provision", "orchestration", "topology", "runtime"):
         assert jargon not in text, f"{jargon!r} is jargon; say it plainly"
@@ -145,7 +170,7 @@ def test_explanation_avoids_jargon():
 def test_repl_answers_the_question_without_docs():
     """One line per topology, each stating what runs where."""
     local = repr(_agent())
-    remote = repr(AgentFlow(run_on="docker", steps=[_agent()]))
+    remote = repr(AgentFlow(tools_run_on="docker", steps=[_agent()]))
     assert local != remote
     for text in (local, remote):
         assert "thinks_on=" in text and "tools_run_on=" in text

--- a/src/praisonai-agents/tests/unit/test_placement.py
+++ b/src/praisonai-agents/tests/unit/test_placement.py
@@ -336,6 +336,44 @@ def test_one_teams_run_does_not_suppress_another_teams_sandbox():
     assert outer._needs_tools_scope()
 
 
+def test_two_concurrent_runs_of_one_team_each_get_their_own_scope():
+    """Two coroutines that run the SAME team under one asyncio.gather share the
+    event-loop thread. Thread-local scope state made the second see the first's
+    depth==1 and skip provisioning -- so it ran against a sandbox the first
+    could tear down mid-flight. A ContextVar is copied per task, so each run's
+    depth is its own.
+    """
+    team = _team(tools_run_on="subprocess")
+    provisioned = []
+
+    async def one_run(hold):
+        # Mirror astart()'s guard without a live model: only the scope logic.
+        if team._needs_tools_scope():
+            depths = dict(team._tools_scope_depths.get())
+            depths[id(team)] = depths.get(id(team), 0) + 1
+            token = team._tools_scope_depths.set(tuple(sorted(depths.items())))
+            try:
+                provisioned.append(id(asyncio.current_task()))
+                await asyncio.sleep(hold)
+                # Nested check inside our own scope must reuse, never re-provision.
+                assert not team._needs_tools_scope()
+            finally:
+                team._tools_scope_depths.reset(token)
+            return "own"
+        await asyncio.sleep(hold)
+        return "borrowed"
+
+    async def drive():
+        # Stagger so the first run is mid-flight when the second starts.
+        return await asyncio.gather(one_run(0.05), one_run(0.0))
+
+    results = asyncio.run(drive())
+    assert results == ["own", "own"], results
+    assert len(set(provisioned)) == 2, "each concurrent run must own its scope"
+    # The map is clean once both runs finish (no leaked depth for this team).
+    assert dict(team._tools_scope_depths.get()).get(id(team), 0) == 0
+
+
 def test_a_dropped_agent_releases_its_sandbox():
     """Gateways clone an agent per request. An agent and its SharedCompute
     referenced each other, so a dropped agent was collected as a cycle and its

--- a/src/praisonai-agents/tests/unit/test_placement.py
+++ b/src/praisonai-agents/tests/unit/test_placement.py
@@ -1,0 +1,283 @@
+"""Where things run, and what happens when you ask for two places at once.
+
+The vocabulary under test:
+
+    run_on=        the WHOLE agent moves to a managed runtime
+    tools_run_on=  only the tools move; thinking stays here
+    run_in=        one execute_code() call, this call only
+
+The rule these tests exist to protect: **one word means one thing**. A place
+that cannot do the job asked of it is a typo, not a preference, so it raises
+with the parameter name the user actually wanted.
+"""
+
+import pytest
+
+from praisonaiagents import Agent, AgentFlow, AgentTeam, Task
+from praisonaiagents.agent.placement import (
+    managed_runtimes,
+    resolve_placement,
+    tool_places,
+)
+
+
+def _agent(name="A", **kw):
+    return Agent(name=name, instructions="x", **kw)
+
+
+# ── the two registries stay disjoint in meaning ──────────────────────────────
+def test_a_managed_runtime_is_not_a_tool_place():
+    """If these sets ever overlap, every error message below becomes a lie."""
+    assert set(managed_runtimes()).isdisjoint(tool_places())
+
+
+def test_the_sandbox_only_backends_are_reachable():
+    """sandlock is the only real local boundary and was unreachable before."""
+    for place in ("sandlock", "subprocess", "ssh", "novita"):
+        assert place in tool_places(), f"{place} must be selectable"
+
+
+# ── asking a place to do a job it cannot do ──────────────────────────────────
+def test_run_on_a_tool_place_names_the_right_parameter():
+    with pytest.raises(TypeError) as exc:
+        _agent(run_on="docker")
+    message = str(exc.value)
+    assert "tools_run_on='docker'" in message, "must name the parameter they wanted"
+    assert "cannot host an agent loop" in message
+
+
+def test_tools_run_on_a_managed_runtime_names_the_right_parameter():
+    with pytest.raises(TypeError) as exc:
+        _agent(tools_run_on="anthropic")
+    assert "run_on='anthropic'" in str(exc.value)
+
+
+def test_an_unknown_place_lists_both_registries():
+    with pytest.raises(TypeError) as exc:
+        _agent(run_on="dokcer")
+    message = str(exc.value)
+    assert "anthropic" in message and "docker" in message
+
+
+# ── two names for one thing ──────────────────────────────────────────────────
+@pytest.mark.parametrize("kwargs", [
+    {"run_on": "anthropic", "tools_run_on": "docker"},
+    {"run_on": "anthropic", "backend": object()},
+    {"backend": object(), "tools_run_on": "docker"},
+])
+def test_two_places_for_the_same_work_is_a_type_error(kwargs):
+    """Never "last one wins" -- that ships tools to a machine nobody chose."""
+    with pytest.raises(TypeError):
+        resolve_placement("Agent", **kwargs)
+
+
+# ── a class that cannot answer the question ──────────────────────────────────
+@pytest.mark.parametrize("build", [
+    lambda: AgentFlow(run_on="docker", steps=[_agent()]),
+    lambda: AgentTeam(agents=[_agent()], tasks=[], run_on="docker"),
+])
+def test_run_on_is_refused_on_orchestrators(build):
+    """`run_on=` on a Flow/Team used to mean tools-only. It now means the whole
+    agent, so honouring the old meaning would give one word two meanings across
+    adjacent classes. Refuse, and say what to type instead."""
+    with pytest.raises(TypeError) as exc:
+        build()
+    assert "tools_run_on='docker'" in str(exc.value)
+
+
+# ── the happy paths ──────────────────────────────────────────────────────────
+def test_tools_run_on_is_recorded_without_provisioning_anything():
+    """Nothing is created until a tool is actually called: an agent that never
+    touches its sandbox must cost nothing."""
+    agent = _agent(tools_run_on="subprocess")
+    assert agent.tools_run_on == "subprocess"
+    assert agent._tools_sandbox is None
+
+
+def test_a_plain_agent_is_untouched():
+    agent = _agent()
+    assert agent.tools_run_on is None
+    assert agent._tools_sandbox is None
+
+
+def _team(**kw):
+    worker = _agent("W")
+    return AgentTeam(agents=[worker], tasks=[Task(description="d", agent=worker)], **kw)
+
+
+@pytest.mark.parametrize("build,expected", [
+    (lambda: AgentFlow(tools_run_on="docker", steps=[_agent()]), "Docker"),
+    (lambda: _team(tools_run_on="e2b"), "E2B"),
+])
+def test_orchestrators_take_tools_run_on(build, expected):
+    obj = build()
+    assert expected in repr(obj)
+    assert "shared" in repr(obj), "the shared sandbox is the whole point"
+
+
+# ── the object says where it runs ────────────────────────────────────────────
+def test_repr_uses_the_same_word_you_typed():
+    agent = _agent(tools_run_on="docker")
+    assert "tools_run_on='a Docker container'" in repr(agent)
+
+
+def test_explain_names_the_tools_that_do_not_move():
+    """The capability prompt tells the model the sandbox is where things
+    happen. Any tool staying behind has to be said out loud, or the model is
+    being lied to about its own reach."""
+
+    def check_db(query: str) -> str:
+        """Query the production database."""
+        return "ok"
+
+    text = _agent(tools=[check_db], tools_run_on="docker").where_does_it_run()
+    assert "check_db" in text
+    assert "still run on this machine" in text
+
+
+def test_explain_says_nothing_about_local_tools_when_nothing_moves():
+    def check_db(query: str) -> str:
+        """Query the production database."""
+        return "ok"
+
+    assert "still run on" not in _agent(tools=[check_db]).where_does_it_run()
+
+
+# ── run_in=: the place lives on the call that uses it ────────────────────────
+def test_run_in_needs_no_constructor_argument():
+    result = _agent().execute_code_sync("print(6 * 7)", run_in="subprocess")
+    assert result.stdout.strip() == "42"
+
+
+def test_run_in_reuses_one_sandbox_across_calls():
+    """A fresh manager per call would restart a container every time and lose
+    the previous call's files."""
+    agent = _agent()
+    agent.execute_code_sync("print(1)", run_in="subprocess")
+    agent.execute_code_sync("print(2)", run_in="subprocess")
+    assert list(agent._sandbox_managers) == ["subprocess"]
+
+
+def test_no_place_at_all_says_how_to_name_one():
+    with pytest.raises(RuntimeError) as exc:
+        _agent().execute_code_sync("print(1)")
+    assert "run_in='docker'" in str(exc.value)
+
+
+def test_constructor_sandbox_still_sets_the_default():
+    """`sandbox=` stays: clone_for_channel() passes it, and it is a legitimate
+    per-agent default. `run_in=` overrides it per call."""
+    agent = _agent(sandbox=True)
+    assert agent.execute_code_sync("print('default')").stdout.strip() == "default"
+
+
+# ── the shared sandbox contract ──────────────────────────────────────────────
+# The point of a shared sandbox is that step 2 can read what step 1 wrote. These
+# drive the tools directly rather than through a model, so they assert the
+# contract itself and need no API key.
+def test_every_agent_in_a_flow_shares_one_sandbox():
+    from praisonaiagents.managed.shared_compute import SharedCompute
+
+    writer, reader = _agent("W"), _agent("R")
+    with SharedCompute("subprocess") as shared:
+        shared.attach([writer, reader])
+        w = {t.__name__: t for t in writer.tools}
+        r = {t.__name__: t for t in reader.tools}
+
+        w["write_file"]("handoff.txt", "written by the first agent")
+        assert r["read_file"]("handoff.txt").strip() == "written by the first agent"
+
+        # ...and it really is one instance, not two that happen to agree.
+        assert w["execute_command"]("pwd") == r["execute_command"]("pwd")
+
+    # teardown restores both agents
+    assert writer.tools == [] and reader.tools == []
+
+
+def test_an_agent_with_its_own_sandbox_is_left_alone_by_a_flow():
+    """Attaching twice appended the capability prompt twice and, on non-LIFO
+    teardown, left the agent holding tools bound to a dead instance."""
+    from praisonaiagents.agent.tools_placement import (
+        close_tools_sandbox,
+        ensure_tools_placed,
+    )
+    from praisonaiagents.managed.shared_compute import SharedCompute
+
+    own = _agent("own", tools_run_on="subprocess")
+    ensure_tools_placed(own)
+    inner = own._tools_sandbox
+
+    try:
+        with SharedCompute("subprocess") as flow_sandbox:
+            flow_sandbox.attach([own])
+            assert own._tools_sandbox is inner, "the agent's own choice wins"
+            assert own.backstory.count("REMOTE Linux sandbox") == 1
+    finally:
+        close_tools_sandbox(own)
+
+    assert own.tools == []
+
+
+def test_a_batch_provisions_one_sandbox_not_one_per_row():
+    """start_for_each() calls start() per input; each used to provision and
+    destroy its own sandbox, so a 50-row batch paid for 50 of them."""
+    team = _team(tools_run_on="subprocess")
+    assert team._needs_tools_scope()
+    with team._shared_tools_scope():
+        # inside the batch scope, a nested start() must not open a second one
+        assert not team._needs_tools_scope()
+    assert team._needs_tools_scope(), "scope must reopen for the next batch"
+
+
+# ── run_on= moves the thinking too ───────────────────────────────────────────
+def test_a_hosted_agent_says_its_thinking_moved():
+    """describe() used to report thinks_on='this machine' for a hosted agent --
+    the diagnostic lying about the one thing it exists to answer."""
+    from praisonaiagents.agent.execution_location import describe
+
+    pytest.importorskip("praisonai.integrations")
+    agent = _agent("teacher", run_on="anthropic")
+    places = describe(agent)
+    assert places["thinks_on"] == places["tools_run_on"]
+    assert "Anthropic" in places["thinks_on"]
+
+
+def test_run_on_builds_the_same_thing_backend_would():
+    pytest.importorskip("praisonai.integrations")
+    from praisonai.integrations import HostedAgent
+
+    assert isinstance(_agent("t", run_on="anthropic").backend, HostedAgent)
+
+
+def test_a_flow_does_not_clobber_an_agent_that_named_its_own_place():
+    """Ordering matters: a flow attaches at the start of the run, before the
+    agent's first turn. Checking only for a *live* sandbox would let the flow
+    attach first and the agent attach again on its first chat() -- two sandboxes
+    and two copies of the capability prompt on one agent.
+    """
+    from praisonaiagents.agent.tools_placement import (
+        close_tools_sandbox,
+        ensure_tools_placed,
+    )
+    from praisonaiagents.managed.shared_compute import SharedCompute
+
+    own = _agent("own", tools_run_on="subprocess")
+    plain = _agent("plain")
+
+    try:
+        with SharedCompute("subprocess") as flow:
+            flow.attach([own, plain])
+            assert own._tools_sandbox is None, "the flow must skip a declared place"
+            assert plain._tools_sandbox is flow, "the flow still places plain agents"
+
+            ensure_tools_placed(own)                       # the agent's first turn
+            assert own._tools_sandbox not in (None, flow)  # its own, not the flow's
+            assert own.backstory.count("REMOTE Linux sandbox") == 1
+            assert plain.backstory.count("REMOTE Linux sandbox") == 1
+            assert [t.__name__ for t in own.tools] == [
+                "execute_command", "read_file", "write_file", "list_files",
+            ]
+    finally:
+        close_tools_sandbox(own)
+
+    assert own.tools == [] and plain.tools == []

--- a/src/praisonai-agents/tests/unit/test_placement.py
+++ b/src/praisonai-agents/tests/unit/test_placement.py
@@ -11,6 +11,9 @@ that cannot do the job asked of it is a typo, not a preference, so it raises
 with the parameter name the user actually wanted.
 """
 
+import asyncio
+import itertools
+
 import pytest
 
 from praisonaiagents import Agent, AgentFlow, AgentTeam, Task
@@ -281,3 +284,223 @@ def test_a_flow_does_not_clobber_an_agent_that_named_its_own_place():
         close_tools_sandbox(own)
 
     assert own.tools == [] and plain.tools == []
+
+
+# ── regressions found by adversarial validation ──────────────────────────────
+def test_a_placed_agent_inside_a_team_gets_its_sandbox_tools():
+    """The sandbox was provisioned and the model never saw it.
+
+    AgentTeam snapshots agent.tools and passes it to chat() as an explicit
+    `tools=`, which wins over agent.tools. Placing after that snapshot meant
+    every tool ran on the host while a real sandbox sat unused.
+    """
+    from praisonaiagents.agent.agent import Agent as _A
+
+    def mytool(x: str) -> str:
+        """A local tool."""
+        return x
+
+    seen = []
+    original = _A.chat
+    _A.chat = lambda self, prompt, *a, **k: (
+        seen.append(sorted(getattr(t, "__name__", str(t)) for t in (k.get("tools") or []))),
+        "done",
+    )[1]
+    try:
+        agent = _agent("TA", tools=[mytool], tools_run_on="subprocess")
+        team = AgentTeam(
+            agents=[agent],
+            tasks=[Task(name="t", description="d", expected_output="o", agent=agent)],
+        )
+        team.start()
+    finally:
+        _A.chat = original
+
+    assert seen, "chat() was never reached"
+    assert "mytool" in seen[0], "the agent's own tool must survive"
+    for bridged in ("execute_command", "read_file", "write_file", "list_files"):
+        assert bridged in seen[0], f"{bridged} never reached the model"
+
+
+def test_one_teams_run_does_not_suppress_another_teams_sandbox():
+    """The scope depth was a single class-level integer, so any team started
+    while another team's run was on the stack saw depth==1 and silently skipped
+    its own sandbox."""
+    outer = _team(tools_run_on="subprocess")
+    inner = _team(tools_run_on="subprocess")
+
+    assert inner._needs_tools_scope()
+    with outer._shared_tools_scope():
+        assert not outer._needs_tools_scope(), "outer must not re-enter its own scope"
+        assert inner._needs_tools_scope(), "a different team still needs its own sandbox"
+    assert outer._needs_tools_scope()
+
+
+def test_a_dropped_agent_releases_its_sandbox():
+    """Gateways clone an agent per request. An agent and its SharedCompute
+    referenced each other, so a dropped agent was collected as a cycle and its
+    sandbox was never shut down -- one orphaned container per request."""
+    import gc
+
+    from praisonaiagents.agent.tools_placement import ensure_tools_placed
+
+    agent = _agent("throwaway", tools_run_on="subprocess")
+    ensure_tools_placed(agent)
+    shared = agent._tools_sandbox
+    {t.__name__: t for t in agent.tools}["execute_command"]("true")   # force provisioning
+    assert shared.instance_id is not None
+
+    del agent
+    gc.collect()
+    assert shared.instance_id is None, "the sandbox outlived the agent that owned it"
+
+
+@pytest.mark.parametrize("bad", ["dokcer", "sandbox", "ec2"])
+def test_an_unknown_tools_place_fails_at_construction(bad):
+    """It used to construct fine and only fail on the first model turn -- after
+    the prompt was built and, in a real run, after the API spend."""
+    with pytest.raises(TypeError) as exc:
+        _agent(tools_run_on=bad)
+    assert "known place" in str(exc.value)
+
+
+def test_ssh_says_it_needs_more_than_a_name():
+    with pytest.raises(TypeError) as exc:
+        _agent(tools_run_on="ssh")
+    assert "SSHSandbox" in str(exc.value)
+
+
+def test_writing_a_file_that_mentions_a_blocked_pattern_still_works():
+    """The policy substring-scanned the heredoc BODY, which is file content --
+    so saving a tutorial containing "rm -rf" was rejected as running it."""
+    from praisonaiagents.managed.shared_compute import SharedCompute
+
+    with SharedCompute("subprocess") as shared:
+        tools = {t.__name__: t for t in shared.build_tools()}
+        for body in ("never run rm -rf / at home", "/etc/passwd lists users", "dd if=/dev/zero"):
+            assert tools["write_file"]("/tmp/praison_policy_test.txt", body).startswith("Wrote")
+        # ...and the boundary still holds for actual commands
+        assert "blocked" in tools["execute_command"]("cat /etc/passwd").lower()
+        assert "blocked" in tools["execute_command"]("rm -rf /").lower()
+
+
+def test_the_write_delimiter_cannot_trip_a_blocked_pattern():
+    """uuid4().hex is lowercase and contains "dd" in ~9.6% of cases; "dd" is a
+    blocked command, so one write in ten failed for no visible reason."""
+    from praisonaiagents.managed.shared_compute import SharedCompute
+
+    with SharedCompute("subprocess") as shared:
+        write = {t.__name__: t for t in shared.build_tools()}["write_file"]
+        for i in range(40):
+            assert write("/tmp/praison_delim_test.txt", f"payload {i}").startswith("Wrote")
+
+
+# ── the paths that actually move work ────────────────────────────────────────
+# Mutation testing showed the earlier tests covered argument validation and repr
+# strings well, and every path that actually moves work to a sandbox not at all:
+# deleting the ensure_tools_placed() call sites, or reverting the AgentTeam
+# provisioning fixes, left the whole suite green. These bite instead.
+
+def _counting_provider(monkeypatch):
+    """Install a fake place and return the list of provisioned instance ids."""
+    import praisonaiagents.managed.shared_compute as sc
+    from praisonaiagents.managed.protocols import InstanceInfo, InstanceStatus
+
+    provisioned, shut = [], []
+
+    class Counting:
+        provider_name = "counting"
+
+        def __init__(self, ident):
+            self.ident = ident
+
+        async def provision(self, config):
+            provisioned.append(self.ident)
+            return InstanceInfo(instance_id=self.ident, status=InstanceStatus.RUNNING,
+                                provider="counting")
+
+        async def execute(self, instance_id, command, timeout=None):
+            return {"stdout": "", "stderr": "", "exit_code": 0}
+
+        async def shutdown(self, instance_id):
+            shut.append(self.ident)
+
+    seq = itertools.count(1)
+    # "subprocess" is a real place, so construction-time validation passes;
+    # only the resolver underneath is swapped for the counting fake.
+    monkeypatch.setattr(sc, "resolve_compute", lambda place: Counting(f"inst-{next(seq)}"))
+    return provisioned, shut
+
+
+@pytest.mark.parametrize("drive", [
+    pytest.param(lambda a: a.chat("hi"), id="chat"),
+    pytest.param(lambda a: asyncio.run(a.achat("hi")), id="achat"),
+    pytest.param(lambda a: next(iter(a._start_stream("hi")), None), id="_start_stream"),
+])
+def test_every_entry_point_places_tools_before_the_first_turn(drive):
+    """Deleting the ensure_tools_placed() call sites left the suite green.
+
+    Whatever happens downstream -- no API key, a stubbed model, an outright
+    error -- the hook runs at the top, so the sandbox must exist afterwards.
+    """
+    from praisonaiagents.agent.tools_placement import close_tools_sandbox
+
+    agent = _agent("driver", tools_run_on="subprocess")
+    try:
+        try:
+            drive(agent)
+        except Exception:
+            pass          # the turn itself may fail; placement must not
+        assert agent._tools_sandbox is not None, "this entry point never placed the tools"
+        assert "execute_command" in [t.__name__ for t in agent.tools]
+    finally:
+        close_tools_sandbox(agent)
+
+
+def test_a_team_run_provisions_exactly_one_sandbox(monkeypatch):
+    """Reverting the AgentTeam.start() provisioning changed nothing in the
+    suite, because the old test only poked the private _needs_tools_scope()."""
+    provisioned, shut = _counting_provider(monkeypatch)
+    team = _team(tools_run_on="subprocess")
+    team.start()
+    assert len(provisioned) == 1, f"expected one sandbox, got {provisioned}"
+    assert shut == provisioned, "the sandbox must be torn down with the run"
+
+
+def test_an_async_team_run_provisions_its_sandbox(monkeypatch):
+    """astart() used to provision nothing at all -- every tool ran on the host
+    and nothing said so."""
+    provisioned, _ = _counting_provider(monkeypatch)
+    team = _team(tools_run_on="subprocess")
+    asyncio.run(team.astart())
+    assert len(provisioned) == 1, f"astart() provisioned {provisioned}"
+
+
+def test_a_batch_shares_one_sandbox_across_every_row(monkeypatch):
+    """start_for_each() provisioned one per row: a 50-row batch paid for 50,
+    and no row could see what an earlier row wrote."""
+    provisioned, _ = _counting_provider(monkeypatch)
+    team = _team(tools_run_on="subprocess")
+    team.start_for_each([{"i": 1}, {"i": 2}, {"i": 3}])
+    assert len(provisioned) == 1, f"expected one sandbox for the batch, got {provisioned}"
+
+
+def test_a_clone_does_not_inherit_the_source_agents_sandbox():
+    """The clone got tools bound to the ORIGINAL's instance and then attached
+    its own, ending up with two copies of the capability prompt and its work
+    split across two machines."""
+    from praisonaiagents.agent.tools_placement import close_tools_sandbox, ensure_tools_placed
+
+    source = _agent("source", tools_run_on="subprocess")
+    ensure_tools_placed(source)
+    clone = source.clone_for_channel()
+    try:
+        assert (clone.backstory or "").count("REMOTE Linux sandbox") == 0
+        assert not [t for t in (clone.tools or []) if t.__name__ == "execute_command"]
+
+        ensure_tools_placed(clone)
+        assert (clone.backstory or "").count("REMOTE Linux sandbox") == 1
+        assert clone._tools_sandbox is not source._tools_sandbox
+    finally:
+        close_tools_sandbox(source)
+        close_tools_sandbox(clone)

--- a/src/praisonai-agents/tests/unit/test_sandbox_adapter.py
+++ b/src/praisonai-agents/tests/unit/test_sandbox_adapter.py
@@ -1,0 +1,126 @@
+"""The adapter that makes sandbox-only backends reachable as places.
+
+``tools_run_on=`` speaks ``ComputeProviderProtocol`` (one object hands out many
+environments). ``subprocess``, ``sandlock``, ``ssh`` and ``novita`` only ever
+spoke ``SandboxProtocol`` (one object *is* one environment), so they could not
+be selected at all. ``SandboxComputeAdapter`` supplies the missing half.
+
+These tests exist because mutation testing found the adapter had none: dropping
+``result.error`` -- which turns "blocked by security policy" into exit 0 with
+empty output -- left the whole suite green.
+"""
+
+import asyncio
+
+import pytest
+
+from praisonaiagents.managed._compute_bridge import available_providers, resolve_compute
+from praisonaiagents.managed._sandbox_adapter import (
+    NEEDS_INSTANCE,
+    SANDBOX_ONLY,
+    SandboxComputeAdapter,
+)
+from praisonaiagents.managed.protocols import ComputeConfig
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _with_instance(name, fn):
+    provider = resolve_compute(name)
+    info = await provider.provision(ComputeConfig())
+    try:
+        return await fn(provider, info.instance_id)
+    finally:
+        await provider.shutdown(info.instance_id)
+
+
+# ── reachability: the point of the adapter ───────────────────────────────────
+def test_sandbox_only_backends_are_selectable_as_places():
+    for name in SANDBOX_ONLY:
+        assert name in available_providers()
+
+
+def test_the_registry_is_the_union_of_both_stacks():
+    places = available_providers()
+    assert "docker" in places, "compute registry"
+    assert "sandlock" in places, "sandbox registry"
+    assert places == sorted(set(places)), "no duplicates, stable order"
+
+
+def test_a_sandbox_only_name_resolves_to_the_adapter():
+    assert isinstance(resolve_compute("subprocess"), SandboxComputeAdapter)
+
+
+def test_a_name_that_needs_connection_details_says_so():
+    """`ssh` cannot work as a bare string -- the host lives in the object."""
+    with pytest.raises((TypeError, ValueError)) as exc:
+        resolve_compute("ssh")
+    assert NEEDS_INSTANCE["ssh"].split(",")[0][:20] in str(exc.value) or "SSHSandbox" in str(exc.value)
+
+
+# ── the failure mode that survived mutation ──────────────────────────────────
+def test_a_policy_denial_is_reported_as_a_failure():
+    """Dropping result.error turned a refusal into exit 0 with empty output --
+    the caller could not tell "blocked" from "succeeded and printed nothing"."""
+
+    async def check(provider, instance_id):
+        return await provider.execute(instance_id, "cat /etc/passwd")
+
+    result = _run(_with_instance("subprocess", check))
+    assert result["exit_code"] != 0, "a blocked command must not report success"
+    assert "blocked" in result["stderr"].lower()
+    assert "root:" not in result["stdout"], "the file must not have been read"
+
+
+def test_a_successful_command_reports_success():
+    async def check(provider, instance_id):
+        return await provider.execute(instance_id, "echo hello")
+
+    result = _run(_with_instance("subprocess", check))
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == "hello"
+
+
+# ── shell semantics: the bridged tool IS a shell ─────────────────────────────
+@pytest.mark.parametrize("command,expected", [
+    ("echo a | tr a-z A-Z", "A"),
+    ("echo x > f.txt && cat f.txt", "x"),
+    ("echo $((6*7))", "42"),
+])
+def test_pipes_redirects_and_expansion_work(command, expected):
+    """Without shell semantics the model's `echo x > f` is argv-split and
+    "> f" arrives as a literal argument."""
+
+    async def check(provider, instance_id):
+        return await provider.execute(instance_id, command)
+
+    assert _run(_with_instance("subprocess", check))["stdout"].strip() == expected
+
+
+def test_state_persists_across_calls():
+    """One environment held open, not one per call: a manager opened and closed
+    per command would lose the previous command's files."""
+
+    async def check(provider, instance_id):
+        await provider.execute(instance_id, "echo persisted > note.txt")
+        first = await provider.execute(instance_id, "pwd")
+        read = await provider.execute(instance_id, "cat note.txt")
+        second = await provider.execute(instance_id, "pwd")
+        return first, read, second
+
+    first, read, second = _run(_with_instance("subprocess", check))
+    assert read["stdout"].strip() == "persisted"
+    assert first["stdout"] == second["stdout"], "each call landed in a different place"
+
+
+def test_it_reports_that_its_instances_are_not_discoverable():
+    """A single environment has no cross-process registry, so it never shows up
+    in `praisonai managed ps`. Saying so beats pretending otherwise."""
+
+    async def check(provider, instance_id):
+        return await provider.list_instances()
+
+    listed = _run(_with_instance("subprocess", check))
+    assert listed and listed[0].metadata.get("discoverable") is False

--- a/src/praisonai-sandbox/praisonai_sandbox/_shell.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/_shell.py
@@ -36,3 +36,21 @@ def build_argv(command: Union[str, List[str]], shell: bool = False) -> List[str]
         else:
             # Direct argv execution - no shell
             return cmd_list
+
+
+def policy_scan_parts(cmd: list) -> list:
+    """Expand a `sh -c "..."` argv into the tokens a policy check should see.
+
+    With shell=True an argv is ``["sh", "-c", "cat /etc/passwd"]``. A path scan
+    that iterates argv sees one opaque string starting with "cat", so
+    ``blocked_paths`` silently stops matching. Splitting the payload back out
+    restores the check without changing how the command runs.
+    """
+    parts = list(cmd)
+    for i, token in enumerate(cmd):
+        if token == "-c" and i + 1 < len(cmd):
+            try:
+                parts.extend(shlex.split(cmd[i + 1]))
+            except ValueError:
+                parts.extend(cmd[i + 1].split())
+    return parts

--- a/src/praisonai-sandbox/praisonai_sandbox/_shell.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/_shell.py
@@ -1,5 +1,6 @@
 """Shared utilities for safe shell command handling across sandbox backends."""
 
+import re
 import shlex
 from typing import List, Union
 
@@ -54,3 +55,20 @@ def policy_scan_parts(cmd: list) -> list:
             except ValueError:
                 parts.extend(cmd[i + 1].split())
     return parts
+
+
+def strip_heredoc_bodies(command: str) -> str:
+    """Remove ``<<'DELIM' ... DELIM`` bodies from a command before policy checks.
+
+    A quoted heredoc body is never executed -- it is the literal bytes of a
+    file. Scanning it as if it were a command means you cannot write a file
+    that merely *mentions* a blocked pattern: saving a shell tutorial
+    containing "rm -rf" was rejected as an attempt to run it, and a file whose
+    text contained "/etc/passwd" was rejected as an attempt to read it.
+
+    Only the quoted form (``<<'EOF'``) is stripped. An unquoted heredoc still
+    undergoes shell expansion, so its contents can execute and must stay in
+    scope for the checks.
+    """
+    pattern = re.compile(r"<<'([^']+)'\n.*?\n\1", re.DOTALL)
+    return pattern.sub("<<'HEREDOC'", command)

--- a/src/praisonai-sandbox/praisonai_sandbox/subprocess.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/subprocess.py
@@ -92,7 +92,12 @@ class SubprocessSandbox:
         if not cmd:
             return "Empty command"
 
-        cmd_str = " ".join(cmd)
+        from ._shell import strip_heredoc_bodies
+
+        # A quoted heredoc body is file content, not a command. Leaving it in
+        # made write_file() reject any file whose text happened to contain a
+        # blocked pattern.
+        cmd_str = strip_heredoc_bodies(" ".join(cmd))
         for blocked in policy.blocked_commands:
             if blocked and blocked in cmd_str:
                 return f"Blocked command pattern: {blocked}"
@@ -112,7 +117,7 @@ class SubprocessSandbox:
         # inside `sh -c "..."`, where a plain argv walk cannot see it.
         from ._shell import policy_scan_parts
 
-        for part in policy_scan_parts(cmd):
+        for part in policy_scan_parts([strip_heredoc_bodies(c) for c in cmd]):
             if not part.startswith(("/", "~", ".")):
                 continue
             expanded = os.path.realpath(os.path.expanduser(part))

--- a/src/praisonai-sandbox/praisonai_sandbox/subprocess.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/subprocess.py
@@ -108,7 +108,11 @@ class SubprocessSandbox:
             if os.path.basename(cmd[0]) in shell_bins:
                 return "Subprocess execution is disabled by security policy"
 
-        for part in cmd:
+        # Scan the shell payload too: with shell=True the real path lives
+        # inside `sh -c "..."`, where a plain argv walk cannot see it.
+        from ._shell import policy_scan_parts
+
+        for part in policy_scan_parts(cmd):
             if not part.startswith(("/", "~", ".")):
                 continue
             expanded = os.path.realpath(os.path.expanduser(part))
@@ -134,18 +138,43 @@ class SubprocessSandbox:
             
         try:
             import resource
-            if limits.memory_mb and limits.memory_mb > 0:
-                bytes_ = limits.memory_mb * 1024 * 1024
-                resource.setrlimit(resource.RLIMIT_AS, (bytes_, bytes_))
-            if limits.max_processes and limits.max_processes > 0:
-                resource.setrlimit(resource.RLIMIT_NPROC, (limits.max_processes, limits.max_processes))
-            if limits.max_open_files and limits.max_open_files > 0:
-                resource.setrlimit(resource.RLIMIT_NOFILE, (limits.max_open_files, limits.max_open_files))
-            # Note: RLIMIT_CPU is process CPU time, not wall clock time - timeout is handled separately
         except ImportError:
             logger.warning("Resource module not available - resource limits not enforced")
-        except (OSError, ValueError) as e:
-            logger.warning(f"Failed to set resource limits: {e}")
+            return
+
+        import sys
+
+        # Each limit gets its own try/except. One shared block meant the first
+        # failure skipped the rest -- and RLIMIT_AS always fails on macOS, so a
+        # single unsupported limit silently voided NPROC and NOFILE too.
+        wanted = []
+        if limits.memory_mb and limits.memory_mb > 0:
+            # RLIMIT_AS is unlimited-by-default on Darwin and raises
+            # "current limit exceeds maximum limit"; skip rather than warn.
+            if sys.platform != "darwin":
+                bytes_ = limits.memory_mb * 1024 * 1024
+                wanted.append(("RLIMIT_AS", resource.RLIMIT_AS, (bytes_, bytes_)))
+        # RLIMIT_NPROC is deliberately NOT set. POSIX defines it per *real user
+        # ID*, not per process tree, so a value like max_processes=10 counts
+        # every process the user already has running -- the sandbox then cannot
+        # fork at all and even `echo a | tr a-z A-Z` dies with
+        # "sh: fork: Resource temporarily unavailable".
+        # This was latent before: RLIMIT_AS raised first and skipped the rest,
+        # so NPROC never applied. Capping a sandbox's process count needs a
+        # cgroup or a container, not setrlimit.
+        if limits.max_open_files and limits.max_open_files > 0:
+            wanted.append(("RLIMIT_NOFILE", resource.RLIMIT_NOFILE,
+                           (limits.max_open_files, limits.max_open_files)))
+        # Note: RLIMIT_CPU is process CPU time, not wall clock - timeout is separate.
+
+        for label, which, value in wanted:
+            try:
+                resource.setrlimit(which, value)
+            except (OSError, ValueError) as e:
+                # This runs inside the forked child, so a warning here lands in
+                # the sandbox's stderr and is returned to the model as tool
+                # output. Stay silent; the limit simply does not apply.
+                logger.debug("Could not set %s: %s", label, e)
     
     @property
     def is_available(self) -> bool:

--- a/src/praisonai-sandbox/tests/test_subprocess_security.py
+++ b/src/praisonai-sandbox/tests/test_subprocess_security.py
@@ -149,7 +149,7 @@ class TestEnvironmentIsolation:
 class TestResourceLimits:
     """Tests for POSIX resource limits enforcement."""
 
-    def test_apply_rlimits_sets_memory_limit(self):
+    def test_apply_rlimits_sets_memory_and_file_limits(self):
         """Resource limits should be applied via setrlimit on POSIX systems."""
         if os.name != "posix":
             pytest.skip("Resource limits only supported on POSIX systems")
@@ -169,10 +169,54 @@ class TestResourceLimits:
                     with patch("resource.RLIMIT_NOFILE", 8, create=True):
                         sandbox._apply_rlimits(limits)
 
-            expected_memory = 128 * 1024 * 1024
-            mock_setrlimit.assert_any_call(9, (expected_memory, expected_memory))
-            mock_setrlimit.assert_any_call(7, (10, 10))
             mock_setrlimit.assert_any_call(8, (50, 50))
+
+            # RLIMIT_AS is skipped on macOS, where it is unlimited by default
+            # and setting it raises "current limit exceeds maximum limit".
+            # Everywhere else it carries the memory cap.
+            import sys as _sys
+
+            applied = [call.args[0] for call in mock_setrlimit.call_args_list]
+            expected_memory = 128 * 1024 * 1024
+            if _sys.platform == "darwin":
+                assert 9 not in applied, "RLIMIT_AS cannot be set on Darwin"
+            else:
+                mock_setrlimit.assert_any_call(9, (expected_memory, expected_memory))
+
+            # RLIMIT_NPROC (7) is deliberately NOT set. POSIX scopes it to the
+            # real USER ID, not the process tree, so max_processes=10 counts
+            # every process the user already has running and the sandbox cannot
+            # fork at all -- `echo a | tr a-z A-Z` dies with
+            # "sh: fork: Resource temporarily unavailable".
+            # Capping a sandbox's process count needs a cgroup or a container.
+            assert not any(
+                call.args[0] == 7 for call in mock_setrlimit.call_args_list
+            ), "RLIMIT_NPROC is per-user; setting it breaks the sandbox entirely"
+
+    def test_apply_rlimits_applies_each_limit_independently(self):
+        """One unsupported limit must not silently skip the rest.
+
+        The limits shared a single try/except, so RLIMIT_AS -- which always
+        raises on macOS -- swallowed every later setrlimit call. NOFILE was
+        never applied on Darwin as a result.
+        """
+        if os.name != "posix":
+            pytest.skip("Resource limits only supported on POSIX systems")
+
+        sandbox = SubprocessSandbox()
+        limits = ResourceLimits(memory_mb=128, timeout_seconds=30, max_open_files=50)
+
+        def fail_on_memory(which, _limits):
+            if which == 9:
+                raise ValueError("current limit exceeds maximum limit")
+
+        with patch("resource.setrlimit", side_effect=fail_on_memory) as mock_setrlimit:
+            with patch("resource.RLIMIT_AS", 9, create=True):
+                with patch("resource.RLIMIT_NOFILE", 8, create=True):
+                    sandbox._apply_rlimits(limits)
+
+            applied = [call.args[0] for call in mock_setrlimit.call_args_list]
+            assert 8 in applied, "a failing RLIMIT_AS must not skip RLIMIT_NOFILE"
 
     def test_apply_rlimits_handles_missing_resource_module(self):
         """Should handle gracefully when resource module is not available."""
@@ -390,3 +434,53 @@ class TestSecurityRegressions:
         
         # The fallback is defensive - normally start() sets _temp_dir
         # This test documents that /tmp is an acceptable fallback for HOME
+
+class TestShellPayloadScanning:
+    """blocked_paths must still match when the path is inside `sh -c`.
+
+    With shell semantics an argv is ``["sh", "-c", "cat /etc/passwd"]``. A
+    policy walk over argv sees one opaque string starting with "cat", so the
+    path check silently stopped matching -- literal `cat /etc/passwd` ran.
+    """
+
+    def test_a_shell_payload_is_expanded_for_scanning(self):
+        from praisonai_sandbox._shell import policy_scan_parts
+
+        assert "/etc/passwd" in policy_scan_parts(["sh", "-c", "cat /etc/passwd"])
+
+    def test_unbalanced_quotes_fall_back_instead_of_raising(self):
+        from praisonai_sandbox._shell import policy_scan_parts
+
+        parts = policy_scan_parts(["sh", "-c", "cat /etc/passwd 'oops"])
+        assert "/etc/passwd" in parts
+
+    def test_a_quoted_heredoc_body_is_not_scanned_as_a_command(self):
+        """A quoted heredoc body is the literal bytes of a file. Scanning it
+        rejected any file whose text merely mentioned a blocked pattern."""
+        from praisonai_sandbox._shell import strip_heredoc_bodies
+
+        command = "cat > f.txt <<'EOF'\nplease run rm -rf /tmp\nEOF"
+        assert "rm -rf" not in strip_heredoc_bodies(command)
+
+    def test_an_unquoted_heredoc_body_is_still_scanned(self):
+        """Unquoted heredocs undergo shell expansion, so their contents really
+        can execute and must stay in scope."""
+        from praisonai_sandbox._shell import strip_heredoc_bodies
+
+        command = "cat > f.txt <<EOF\nrm -rf /tmp\nEOF"
+        assert "rm -rf" in strip_heredoc_bodies(command)
+
+    @pytest.mark.asyncio
+    async def test_a_blocked_path_inside_sh_c_is_refused(self):
+        from praisonai_sandbox import SubprocessSandbox
+        from praisonaiagents.sandbox import SandboxConfig, SecurityPolicy
+
+        policy = SecurityPolicy(allow_subprocess=True, blocked_paths=["/etc/passwd"])
+        sandbox = SubprocessSandbox(config=SandboxConfig(security_policy=policy))
+        await sandbox.start()
+        try:
+            result = await sandbox.run_command("cat /etc/passwd", shell=True)
+            assert result.error, "a blocked path must be refused, not executed"
+            assert "root:" not in (result.stdout or ""), "the file was actually read"
+        finally:
+            await sandbox.stop()

--- a/src/praisonai/README.md
+++ b/src/praisonai/README.md
@@ -130,7 +130,7 @@ Each layer wraps the one inside it. When an agent misbehaves, the layer tells yo
 | **3 · Harness** | Can it act, and be checked? | `tools=`, `MCP()`, `guardrails=`, `approval=`, `hooks=`, `sandbox=` |
 | **4 · Loop** | When do we stop? | `execution=ExecutionConfig(...)`, `reflection=`, `autonomy=`, doom-loop detection |
 | **5 · Graph** | Who runs when, and who checks whom? | `AgentFlow`, `route()`, `parallel()`, `loop()`, `repeat()` |
-| **⬡ Managed** | *Where does it actually run?* | `run_on="docker"` — one shared remote sandbox, or a fully hosted loop |
+| **⬡ Managed** | *Where does it actually run?* | `tools_run_on="docker"` — one shared sandbox for the tools, or `run_on="anthropic"` for the whole agent |
 
 ### Layer 1 · Prompt — *Did I say it clearly?*
 
@@ -235,7 +235,7 @@ The harness is commoditising; **where** the agent executes is the next multiplie
 pip install praisonai
 ```
 
-The simplest way in is `run_on=` — one whole team or workflow shares **one** sandbox, so a file written by step 1 is there for step 2:
+The simplest way in is `tools_run_on=` — one whole team or workflow shares **one** sandbox, so a file written by step 1 is there for step 2. Thinking stays on your machine:
 
 ```python
 from praisonaiagents import Agent, AgentFlow
@@ -243,7 +243,7 @@ from praisonaiagents import Agent, AgentFlow
 writer = Agent(name="Writer", instructions="You write files.")
 reader = Agent(name="Reader", instructions="You read files.")
 
-flow = AgentFlow(run_on="docker", steps=[writer, reader])   # or e2b | modal | daytona | flyio
+flow = AgentFlow(tools_run_on="docker", steps=[writer, reader])  # or e2b | modal | daytona | flyio
 flow.run("Write 'hello' to /workspace/note.txt, then read it back")
 ```
 
@@ -251,7 +251,7 @@ Same thing with no Python at all:
 
 ```yaml
 name: remote-demo
-run_on: docker            # every step shares one sandbox
+tools_run_on: docker      # every step shares one sandbox
 agents:
   writer: {role: Writer, goal: Write files}
   reader: {role: Reader, goal: Read files}
@@ -262,20 +262,48 @@ steps:
     action: "Read /workspace/note.txt"
 ```
 
-For a single agent, pick the axis you need — remote **tools** or a remote **loop**:
+For a single agent, two words cover it — and they answer different questions:
 
 ```python
-from praisonai import Agent, LocalAgent, LocalAgentConfig, HostedAgent
+from praisonaiagents import Agent
 
-# A. Tools run in a remote sandbox; the agent loop stays local
-agent = Agent(name="builder", backend=LocalAgent(
-    compute="e2b",                     # or modal | daytona | flyio | docker | tenki
-    config=LocalAgentConfig(model="gpt-4o-mini", name="RemoteTools"),
-))
+# A. Only the TOOLS move. Thinking stays on your machine.
+agent = Agent(name="builder", instructions="You build things.",
+              tools_run_on="docker")   # docker | e2b | modal | daytona | flyio
+                                       # tenki | sandlock | ssh | novita | subprocess
 
-# B. The entire agent loop runs in the cloud (needs ANTHROPIC_API_KEY)
-agent = Agent(name="teacher", backend=HostedAgent(provider="anthropic"))
+# B. The WHOLE agent moves — model calls, loop and tools (needs ANTHROPIC_API_KEY)
+agent = Agent(name="teacher", instructions="You teach.", run_on="anthropic")
 agent.start("Write a Python script that prints the first 10 primes, then run it")
+```
+
+Ask any object where it runs, and it will tell you:
+
+```python
+>>> Agent(name="builder", instructions="x", tools_run_on="docker")
+Agent(name='builder', thinks_on='this machine', tools_run_on='a Docker container')
+
+>>> agent.where_does_it_run()
+Thinking (the AI model calls) happens on this machine.
+Tools run on a Docker container.
+Your own tools (check_db) still run on this machine -- only shell, file and
+code tools move. They read and write this machine's files.
+```
+
+Naming a place that cannot do the job is a typo, not a preference, so it says so:
+
+```python
+>>> Agent(name="x", instructions="i", run_on="docker")
+TypeError: Agent(run_on='docker') is not valid: run_on= places the whole agent
+-- model calls, loop and tools -- on a managed runtime, and 'docker' runs
+commands but cannot host an agent loop.
+  To run only the tools there:  Agent(tools_run_on='docker')
+```
+
+To run one block of code somewhere else, name the place on that call:
+
+```python
+agent.execute_code_sync("print(6 * 7)", run_in="sandlock")   # kernel-enforced
 ```
 
 See what is running and reclaim strays:

--- a/src/praisonai/praisonai/integrations/local_agent.py
+++ b/src/praisonai/praisonai/integrations/local_agent.py
@@ -14,7 +14,7 @@ Usage::
 
     # Local loop, tools optional-sandboxed in cloud compute
     agent = Agent(name="b", backend=LocalAgent(
-        compute="e2b",                           # or "modal", "flyio", "daytona", "docker", None
+        tools_run_on="e2b",                      # or "modal", "flyio", "daytona", "docker", None
         config=LocalAgentConfig(
             model="gpt-4o-mini",                 # LLM choice here — not provider=
             system="You are a concise assistant.",
@@ -29,7 +29,7 @@ Usage::
 Architecture:
     - Agent loop runs locally in the current process
     - LLM selection via model= (supports litellm routing like "gemini/...", "ollama/...")
-    - Optional compute= for cloud tool sandboxing (E2B, Modal, Docker, etc.)
+    - Optional tools_run_on= for cloud tool sandboxing (E2B, Modal, Docker, etc.)
     - No provider= overload — clean separation of concerns
 """
 
@@ -64,8 +64,33 @@ class LocalAgent(LocalManagedAgent):
         self,
         compute: Optional[Any] = None,
         config: Optional[Any] = None,
+        tools_run_on: Optional[Any] = None,
         **kwargs,
     ):
+        # `compute=` and `tools_run_on=` name the same thing: where this agent's
+        # shell/file tools run. `tools_run_on=` is the spelling used by Agent,
+        # AgentFlow and AgentTeam, so one word now covers every class. Kept as a
+        # FutureWarning rather than removed because `compute=` is the shipped
+        # public name here -- and FutureWarning, not DeprecationWarning, because
+        # PEP 565 hides the latter from the end users who actually wrote this
+        # call (see praisonaiagents/utils/deprecation.py for the same choice).
+        if compute is not None and tools_run_on is not None:
+            raise TypeError(
+                f"LocalAgent(compute={compute!r}, tools_run_on={tools_run_on!r}) "
+                f"names the same thing twice -- where this agent's tools run. "
+                f"Pass tools_run_on= only."
+            )
+        if compute is not None:
+            warnings.warn(
+                f"LocalAgent(compute={compute!r}) is now "
+                f"LocalAgent(tools_run_on={compute!r}). Same behaviour, and the "
+                f"same word Agent, AgentFlow and AgentTeam already use for "
+                f"'where the tools run'. compute= keeps working for now.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        elif tools_run_on is not None:
+            compute = tools_run_on
         # Reject the provider= overload pattern to force clean usage
         provider_for_routing = "local"  # Default provider for model routing
         if 'provider' in kwargs:

--- a/src/praisonai/praisonai/integrations/managed_agents.py
+++ b/src/praisonai/praisonai/integrations/managed_agents.py
@@ -1114,7 +1114,7 @@ def ManagedAgent(
     elif provider in {"e2b", "modal", "flyio", "daytona", "docker", "tenki"}:
         warnings.warn(
             f"ManagedAgent(provider='{provider}') for compute providers is deprecated. "
-            f"Use LocalAgent(compute='{provider}', config=LocalAgentConfig(...)) instead.",
+            f"Use LocalAgent(tools_run_on='{provider}', config=LocalAgentConfig(...)) instead.",
             DeprecationWarning,
             stacklevel=2
         )

--- a/src/praisonai/praisonai/integrations/managed_local.py
+++ b/src/praisonai/praisonai/integrations/managed_local.py
@@ -220,6 +220,7 @@ class LocalManagedAgent:
         on_tool_confirmation: Optional[Callable[[Dict[str, Any]], bool]] = None,
         on_custom_tool: Optional[Callable[[str, Dict[str, Any]], Any]] = None,
         compute: Optional[Any] = None,
+        tools_run_on: Optional[Any] = None,
         session_store: Optional[Any] = None,
         db: Optional[Any] = None,
     ):
@@ -272,8 +273,20 @@ class LocalManagedAgent:
         # Custom tool definitions from Anthropic-format config
         self._custom_tool_defs: List[Dict[str, Any]] = []
 
+        # Where this agent's tools run. `tools_run_on=` is the spelling the
+        # rest of the library uses; `compute=` is the older name for the same
+        # thing and still works. LocalAgent (the subclass) warns on compute=;
+        # this base class is reached directly by older code, so it accepts both
+        # quietly rather than adding a second warning to the same call.
+        if compute is not None and tools_run_on is not None:
+            raise TypeError(
+                f"compute={compute!r} and tools_run_on={tools_run_on!r} name the "
+                f"same thing -- where this agent's tools run. Pass tools_run_on= only."
+            )
         # Compute provider (optional — for remote tool execution)
-        self._compute = self._resolve_compute(compute)
+        self._compute = self._resolve_compute(
+            tools_run_on if compute is None else compute
+        )
         self._compute_instance_id: Optional[str] = None
 
     # ------------------------------------------------------------------
@@ -1037,42 +1050,22 @@ class LocalManagedAgent:
     # ------------------------------------------------------------------
     @staticmethod
     def _resolve_compute(compute: Optional[Any]) -> Optional[Any]:
-        """Resolve a compute provider from a string name or instance.
+        """Resolve a place from a name or an instance.
 
-        Accepts:
-        - None → no remote compute
-        - A string: ``"local"``, ``"docker"``, ``"e2b"``, ``"modal"``,
-          ``"daytona"``, ``"flyio"``, ``"tenki"``
-        - An already-instantiated compute provider object
+        Delegates to the core SDK's merged resolver so this class accepts
+        exactly what ``Agent(tools_run_on=...)`` accepts. It used to carry its
+        own hardcoded if/elif chain over seven names, which is why
+        ``LocalAgent(tools_run_on="sandlock")`` raised "Unknown compute
+        provider" for a place the rest of the library resolves happily -- the
+        same word with a smaller vocabulary, which is the drift this whole
+        change exists to remove.
         """
         if compute is None:
             return None
-        if isinstance(compute, str):
-            name = compute.lower()
-            if name == "local":
-                from praisonai.integrations.compute.local import LocalCompute
-                return LocalCompute()
-            elif name == "docker":
-                from praisonai.integrations.compute.docker import DockerCompute
-                return DockerCompute()
-            elif name == "e2b":
-                from praisonai.integrations.compute.e2b import E2BCompute
-                return E2BCompute()
-            elif name == "modal":
-                from praisonai.integrations.compute.modal_compute import ModalCompute
-                return ModalCompute()
-            elif name == "daytona":
-                from praisonai.integrations.compute.daytona import DaytonaCompute
-                return DaytonaCompute()
-            elif name == "flyio":
-                from praisonai.integrations.compute.flyio import FlyioCompute
-                return FlyioCompute()
-            elif name == "tenki":
-                from praisonai.integrations.compute.tenki import TenkiCompute
-                return TenkiCompute()
-            else:
-                raise ValueError(f"Unknown compute provider: {name}")
-        return compute  # Already an instance
+
+        from praisonaiagents.managed._compute_bridge import resolve_compute
+
+        return resolve_compute(compute)
 
     @property
     def compute_provider(self) -> Optional[Any]:

--- a/src/praisonai/praisonai/integrations/sandboxed_agent.py
+++ b/src/praisonai/praisonai/integrations/sandboxed_agent.py
@@ -1,8 +1,8 @@
 """
 Sandboxed Agent Backend — local agent loop with OPTIONAL tool sandboxing.
 
-Tools are sandboxed when compute= is provided (E2B, Modal, etc.).
-Without compute=, tools run locally. Agent loop always stays local.
+Tools are sandboxed when tools_run_on= is provided (E2B, Modal, etc.).
+Without it, tools run locally. Agent loop always stays local.
 
 Renamed from "LocalManagedAgent" to accurately communicate that only TOOLS
 run in sandbox — the agent loop (LLM calls, event handling, memory) stays local.
@@ -20,7 +20,7 @@ Usage::
     from praisonaiagents import Agent
 
     sandboxed = SandboxedAgent(
-        compute="e2b",  # Tools run in E2B, loop stays local
+        tools_run_on="e2b",  # Tools run in E2B, loop stays local
         config=SandboxedAgentConfig(
             model="gpt-4o",
             system="You are a coding assistant.",


### PR DESCRIPTION
## One vocabulary for "where does this run?"

Three parameters meant "somewhere else" and none of them said which somewhere:
`run_on=` (tools only, on Flow/Team), `compute=` (tools only, on LocalAgent) and
`backend=` (the whole agent). One concept had two names and one name had two
concepts — so the docs had to keep correcting the API.

Now two words, each answering a different question:

| | Moves | Accepts |
|---|---|---|
| `run_on=` | the **whole agent** — model calls, loop, tools | managed runtimes (`anthropic`) |
| `tools_run_on=` | **only the tools**; thinking stays local | 11 places, both registries |
| `run_in=` | one `execute_code()` call | any sandbox |

```python
Agent(name="builder", instructions="...", tools_run_on="docker")   # tools move
Agent(name="teacher", instructions="...", run_on="anthropic")      # everything moves
agent.execute_code_sync("print(6*7)", run_in="sandlock")           # this call only
```

Because the two questions have disjoint answer sets, a wrong pairing is a typo
rather than a preference. It raises, naming the parameter you wanted — never
"last one wins", which would ship work to a machine nobody chose:

```
>>> Agent(name="x", instructions="i", run_on="docker")
TypeError: Agent(run_on='docker') is not valid: run_on= places the whole agent
-- model calls, loop and tools -- on a managed runtime, and 'docker' runs
commands but cannot host an agent loop.
  To run only the tools there:  Agent(tools_run_on='docker')
```

The object also says where it runs, including which of *your* tools stay behind
— only four tool names are bridged, and the capability prompt tells the model the
sandbox is where things happen:

```
>>> agent.where_does_it_run()
Thinking (the AI model calls) happens on this machine.
Tools run on a Docker container.
Your own tools (check_db) still run on this machine -- only shell, file and
code tools move. They read and write this machine's files.
```

### Reachability: `sandlock` finally works

`tools_run_on=` speaks `ComputeProviderProtocol` (one object hands out many
environments). `subprocess`, `sandlock`, `ssh` and `novita` only ever spoke
`SandboxProtocol` (one object *is* one environment), so they could not be
selected at all. A small adapter supplies the missing half — the registry goes
from 7 places to 11.

That matters most for **`sandlock`**: kernel-enforced Landlock + seccomp-bpf, the
only real local boundary in the project, previously unreachable.

## Shipped bugs found and fixed

Most of these were found by adversarial validation, not by writing the feature.

- **`AgentTeam.astart()` never provisioned a sandbox at all** — every async team
  ran its tools on the host, silently.
- **`start_for_each()` provisioned one sandbox per row** — a 50-row batch paid for
  50, and no row could see what an earlier row wrote.
- **Team sandboxes were provisioned but never reached the model.**
  `_build_execution_context` snapshots `agent.tools` and passes it as an explicit
  `tools=`, which wins — so the model got the pre-attach list while a real sandbox
  sat unused. It read as flaky, not broken: row 1 got local tools, row 2 got the
  bridged set.
- **One team's run suppressed another team's sandbox.** The scope depth was a
  single class-level integer, so a nested team ran on the host and a team sharing
  an agent executed on the *outer* team's sandbox.
- **A dropped agent leaked its sandbox.** Agent and `SharedCompute` referenced each
  other, so the agent was reclaimed as a cycle and never shut down. Gateways clone
  per request: measured 5 requests → 5 provisioned, 0 shut down. Now 5 → 5 → 0
  leaked.
- **A clone inherited tools bound to the source agent's sandbox**, then attached its
  own — two copies of the capability prompt, work split across two machines.
- **`SandboxManager` passed `config=` to backends that reject it** (`ssh`, `modal`).
- **`RLIMIT_NPROC` was applied per *real user ID***, not per sandbox, so
  `max_processes=10` counted the user's existing processes and the sandbox could
  not `fork` at all.
- **`write_file` failed ~10% of the time**, and on ordinary English. The policy
  substring-matched `blocked_commands` against the whole heredoc: `dd` appears in
  9.6% of random lowercase hex delimiters, and file *content* mentioning `rm -rf`
  was rejected as an attempt to run it.
- **`blocked_paths` stopped matching under `sh -c`** — fixed, and this is a net
  security *improvement* over `main`, which never inspected shell payloads at all:

  | Attack | `main` | this branch |
  |---|---|---|
  | `cat /etc/passwd` | allowed | **blocked** |
  | `'cat' "/etc/passwd"` | allowed | **blocked** |
  | `cat < /etc/passwd` | allowed | **blocked** |

- Removed `ExecutionConfig.code_sandbox_mode`: it defaulted to `"sandbox"` while no
  execution path read it, so its own default told readers they had isolation they
  did not have.

## Honest limitation

`subprocess` is **not** a security boundary. Its blocked-command list is
bypassable by ordinary shell syntax (`cat $(echo /etc/passwd)` was demonstrated
reading the file), which is inherent to a blocklist over a real shell.
`where_does_it_run()` now says so out loud. Use `docker`, a cloud place, or
`sandlock` for untrusted code.

## Migration

- **YAML `run_on:` stays a silent alias** — it is data people already shipped, and
  there is no Agent-level `run_on:` key in YAML to confuse it with.
- **Python `run_on=` on Flow/Team raises** with a directed message. It would
  otherwise mean the opposite of `run_on=` on `Agent`. This is a breaking change
  with no deprecation window, but it fails loudly at construction.
- **`compute=` warns** (`FutureWarning`, which PEP 565 shows to end users).
  `LocalAgent`/`LocalManagedAgent` now accept `tools_run_on=` and resolve through
  the merged registry, so they accept exactly what `Agent` accepts.
- **`Agent(sandbox=)` is kept, not removed** — `clone_for_channel()` passes it and
  it is a legitimate per-agent default. `run_in=` overrides it per call.

## Testing

- **New:** `tests/unit/test_placement.py` (43), `tests/unit/test_sandbox_adapter.py`
  (11), plus shell-payload and `SandboxManager` introspection tests.
- **Mutation-tested.** An earlier round of these tests let 7 of 14 deliberate
  breakages pass — validation and repr strings were covered, the paths that
  actually move work were not. The current tests catch every one: deleting the
  placement hooks fails 3, reverting the team fixes fails 5, dropping the adapter's
  error handling fails 2, removing the finalizer fails 1.
- **Full suite vs a clean `origin/main` worktree:** no new failures; 12 tests that
  fail on `main` pass here. Remaining failures are pre-existing and identical on
  both trees.
- **Not tested:** the Docker end-to-end. Docker's daemon was unresponsive on this
  machine, so `tools_run_on="docker"` against a real container is unverified — the
  identical code path was exercised on the local backends. Worth running in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configure agents to run entirely in managed environments or place only their tools in sandboxes.
  - Select from multiple sandbox providers, including Docker and other supported environments.
  - Override sandbox location for individual code or shell execution calls.
  - Share tool sandboxes across teams and workflows.

- **Bug Fixes**
  - Improved placement validation, cleanup, cloning, concurrency, and backend compatibility.
  - Strengthened shell-policy checks for embedded commands, heredocs, and restricted paths.

- **Documentation**
  - Clarified `tools_run_on`, runtime inspection, errors, and legacy configuration support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->