### PR TITLE
feat(placement): run_on= for every place that can host a loop, plus a provider matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,11 +294,11 @@ code tools move. They read and write this machine's files.
 Naming a place that cannot do the job is a typo, not a preference, so it says so:
 
 ```python
->>> Agent(name="x", instructions="i", run_on="docker")
-TypeError: Agent(run_on='docker') is not valid: run_on= places the whole agent
--- model calls, loop and tools -- on a managed runtime, and 'docker' runs
+>>> Agent(name="x", instructions="i", run_on="e2b")
+TypeError: Agent(run_on='e2b') is not valid: run_on= places the whole agent
+-- model calls, loop and tools -- on a managed runtime, and 'e2b' runs
 commands but cannot host an agent loop.
-  To run only the tools there:  Agent(tools_run_on='docker')
+  To run only the tools there:  Agent(tools_run_on='e2b')
 ```
 
 To run one block of code somewhere else, name the place on that call:

--- a/README.md
+++ b/README.md
@@ -272,8 +272,9 @@ agent = Agent(name="builder", instructions="You build things.",
               tools_run_on="docker")   # docker | e2b | modal | daytona | flyio
                                        # tenki | sandlock | ssh | novita | subprocess
 
-# B. The WHOLE agent moves — model calls, loop and tools (needs ANTHROPIC_API_KEY)
-agent = Agent(name="teacher", instructions="You teach.", run_on="anthropic")
+# B. The WHOLE agent moves — model calls, loop and tools
+agent = Agent(name="teacher", instructions="You teach.", run_on="anthropic")  # hosted
+agent = Agent(name="builder", instructions="You build.", run_on="docker")     # self-hosted
 agent.start("Write a Python script that prints the first 10 primes, then run it")
 ```
 

--- a/src/praisonai-agents/praisonaiagents/agent/execution_location.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_location.py
@@ -43,18 +43,37 @@ HERE = "this machine"
 # a place that never executes.
 _ALIASES = {"native": "sandlock", "local": "subprocess"}
 
+# ...but only for the SANDBOX registry. "local" resolves to two different
+# backends depending on which parameter carried it:
+#   run_in="local"        -> SandboxManager collapses it to subprocess:
+#                            scrubbed environment, blocked commands and paths
+#   tools_run_on="local"  -> the wrapper's LocalCompute: a plain shell in the
+#                            current directory, full environment inherited,
+#                            no security policy at all
+# Describing the second in the first's words overstates it, which is the exact
+# failure this module exists to prevent. One word, two backends -- so the
+# phrase has to depend on where the word came from.
+_COMPUTE_ONLY_WORDS = {"local": "a plain shell on this machine (no policy applied)"}
+
 # Tiers that separate a process but do NOT contain it. Verified: under the
 # subprocess backend, outbound network still works and ~/.ssh is readable even
 # though SecurityPolicy declares them blocked.
 _NOT_A_BOUNDARY = {"subprocess", "local", "native"}
 
 
-def say_place(name: Any) -> str:
-    """Turn a provider name into a phrase a non-developer can read."""
+def say_place(name: Any, *, via: str = "sandbox") -> str:
+    """Turn a place name into a phrase a non-developer can read.
+
+    ``via`` says which registry resolved the name -- ``"compute"`` for
+    ``tools_run_on=``, ``"sandbox"`` for ``run_in=``. It only matters for names
+    that mean different backends in each (see ``_COMPUTE_ONLY_WORDS``).
+    """
     if name is None:
         return HERE
     if name is True:
         return _PLACE_WORDS["subprocess"]
+    if via == "compute" and isinstance(name, str) and name.lower() in _COMPUTE_ONLY_WORDS:
+        return _COMPUTE_ONLY_WORDS[name.lower()]
     if not isinstance(name, str):
         # A configured provider instance: use its own declared name if it has one.
         name = getattr(name, "provider_name", None) or type(name).__name__
@@ -96,7 +115,7 @@ def describe(obj: Any, *, shared: bool = False) -> Dict[str, str]:
 
         where_tools = getattr(obj, "tools_run_on", None)
         if where_tools is not None:
-            where = say_place(where_tools)
+            where = say_place(where_tools, via="compute")
             places["tools_run_on"] = f"{where} (shared)" if shared else where
 
         # run_on= puts the WHOLE agent on a managed runtime, so it moves the

--- a/src/praisonai-agents/praisonaiagents/agent/execution_location.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_location.py
@@ -87,6 +87,21 @@ def _backend_places(backend: Any) -> Optional[Dict[str, str]]:
     if backend is None:
         return None
 
+    # Ask the backend what it is, rather than guessing from its class name.
+    # Name-matching missed any backend that did not happen to contain "Hosted"
+    # or "Anthropic" -- a self-hosted DockerManagedAgent reported that it was
+    # thinking on this machine while the whole loop ran in a container.
+    declared = getattr(backend, "provider_name", None)
+    if isinstance(declared, str):
+        try:
+            from .placement import managed_runtimes
+
+            if declared.lower() in managed_runtimes():
+                where = say_place(declared)
+                return {"thinks_on": where, "tools_run_on": where}
+        except Exception:
+            pass
+
     cls = type(backend).__name__
     # Hosted runtimes move the entire turn off this machine.
     if "Hosted" in cls or "Anthropic" in cls:

--- a/src/praisonai-agents/praisonaiagents/agent/placement.py
+++ b/src/praisonai-agents/praisonaiagents/agent/placement.py
@@ -60,11 +60,17 @@ def managed_runtimes() -> tuple:
 
 
 def tool_places() -> list:
-    """Names that ``tools_run_on=`` accepts -- places that can run a command."""
-    try:
-        from ..managed._compute_bridge import available_providers
+    """Names that ``tools_run_on=`` accepts -- places that can run a command.
 
-        return available_providers()
+    Includes the resolver's aliases. Validation runs before resolution, so
+    leaving them out rejected spellings the resolver handles happily:
+    ``tools_run_on="native"`` raised "not a known place" while
+    ``resolve_compute("native")`` returned a working sandlock adapter.
+    """
+    try:
+        from ..managed._compute_bridge import _ALIASES, available_providers
+
+        return sorted(set(available_providers()) | set(_ALIASES))
     except Exception:
         return ["local", "docker"]
 

--- a/src/praisonai-agents/tests/unit/test_placement.py
+++ b/src/praisonai-agents/tests/unit/test_placement.py
@@ -17,6 +17,7 @@ import itertools
 import pytest
 
 from praisonaiagents import Agent, AgentFlow, AgentTeam, Task
+from praisonaiagents.agent.execution_location import describe
 from praisonaiagents.agent.placement import (
     managed_runtimes,
     resolve_placement,
@@ -29,9 +30,34 @@ def _agent(name="A", **kw):
 
 
 # ── the two registries stay disjoint in meaning ──────────────────────────────
-def test_a_managed_runtime_is_not_a_tool_place():
-    """If these sets ever overlap, every error message below becomes a lie."""
-    assert set(managed_runtimes()).isdisjoint(tool_places())
+def test_a_name_in_both_sets_is_valid_for_both_parameters():
+    """The two sets may overlap, and where they do, both spellings must work.
+
+    `docker` can host a whole agent (a container running the loop) AND run
+    tools for a local loop. That is not one word with two meanings -- it is one
+    place with two scopes, and the scope is carried by the parameter name:
+
+        run_on="docker"        the whole agent runs in a container
+        tools_run_on="docker"  only the tools do; thinking stays here
+
+    What must stay true is that a name valid for only ONE of them is refused by
+    the other, with a message naming the right parameter.
+    """
+    for name in set(managed_runtimes()) & set(tool_places()):
+        assert _agent(run_on=name) is not None, f"run_on={name!r} must work"
+        assert _agent(tools_run_on=name) is not None, f"tools_run_on={name!r} must work"
+
+
+def test_the_two_scopes_of_one_place_are_reported_differently():
+    """Overlap is only safe if the object still says which scope you chose."""
+    whole = describe(_agent(run_on="docker"))
+    tools_only = describe(_agent(tools_run_on="docker"))
+
+    assert whole["thinks_on"] == whole["tools_run_on"], "run_on moves the thinking too"
+    assert tools_only["thinks_on"] != tools_only["tools_run_on"], (
+        "tools_run_on must leave the thinking here"
+    )
+    assert whole != tools_only
 
 
 def test_the_sandbox_only_backends_are_reachable():
@@ -41,11 +67,13 @@ def test_the_sandbox_only_backends_are_reachable():
 
 
 # ── asking a place to do a job it cannot do ──────────────────────────────────
-def test_run_on_a_tool_place_names_the_right_parameter():
+def test_run_on_a_tools_only_place_names_the_right_parameter():
+    """`sandlock` runs commands but cannot host a loop, so run_on= must refuse
+    it and point at the parameter that does work."""
     with pytest.raises(TypeError) as exc:
-        _agent(run_on="docker")
+        _agent(run_on="sandlock")
     message = str(exc.value)
-    assert "tools_run_on='docker'" in message, "must name the parameter they wanted"
+    assert "tools_run_on='sandlock'" in message, "must name the parameter they wanted"
     assert "cannot host an agent loop" in message
 
 

--- a/src/praisonai-agents/tests/unit/test_placement.py
+++ b/src/praisonai-agents/tests/unit/test_placement.py
@@ -542,3 +542,34 @@ def test_a_clone_does_not_inherit_the_source_agents_sandbox():
     finally:
         close_tools_sandbox(source)
         close_tools_sandbox(clone)
+
+
+# ── one word, two backends ───────────────────────────────────────────────────
+def test_local_is_described_by_the_backend_it_actually_gets():
+    """"local" resolves to two different things depending on the parameter:
+    run_in="local" is collapsed to the subprocess backend (scrubbed environment,
+    blocked commands), while tools_run_on="local" is the wrapper's LocalCompute
+    -- a plain shell with the full environment and no policy at all. Describing
+    the weaker one in the stronger one's words overstates it."""
+    from praisonaiagents.agent.execution_location import say_place
+
+    assert say_place("local") != say_place("local", via="compute")
+    assert "no policy" in say_place("local", via="compute")
+    assert say_place("local") == say_place("subprocess"), (
+        "run_in='local' really is the subprocess backend"
+    )
+
+
+def test_a_local_place_still_warns_that_it_is_not_a_boundary():
+    text = _agent(tools_run_on="local").where_does_it_run()
+    assert "not a security boundary" in text
+
+
+@pytest.mark.parametrize("alias,resolves_to", [("native", "sandlock")])
+def test_resolver_aliases_are_accepted_at_construction(alias, resolves_to):
+    """Validation ran before alias resolution, so a spelling the resolver
+    handles happily was rejected as "not a known place"."""
+    from praisonaiagents.agent.execution_location import say_place
+
+    agent = _agent(tools_run_on=alias)
+    assert say_place(resolves_to) in repr(agent)

--- a/src/praisonai-agents/tests/unit/test_run_on_docker.py
+++ b/src/praisonai-agents/tests/unit/test_run_on_docker.py
@@ -1,0 +1,182 @@
+"""`run_on="docker"` — the whole agent in a container you own.
+
+The distinction under test is what crosses the boundary:
+
+    tools_run_on="docker"   your process runs the loop; only tools go inside
+    run_on="docker"         the loop itself runs inside; the model call is
+                            made from the container
+
+Both name the same place. The parameter carries the scope, which is why one
+word can serve both without ambiguity.
+
+Everything that needs a live daemon is marked, so it is skipped loudly rather
+than passing quietly when Docker is not running.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from praisonaiagents import Agent
+from praisonaiagents.agent.execution_location import describe
+from praisonaiagents.agent.placement import managed_runtimes, tool_places
+
+
+def _docker_running() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        return subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True, timeout=25,
+        ).returncode == 0
+    except Exception:
+        return False
+
+
+needs_docker = pytest.mark.skipif(
+    not _docker_running(), reason="needs a running Docker daemon"
+)
+
+
+def _agent(**kw):
+    return Agent(name="A", instructions="You are helpful.", **kw)
+
+
+# ── registration ─────────────────────────────────────────────────────────────
+def test_docker_is_a_managed_runtime():
+    """run_on= resolves against the managed-backend registry, so registering
+    the backend is all that is needed for the parameter to accept it."""
+    assert "docker" in managed_runtimes()
+
+
+def test_docker_is_also_a_tool_place():
+    assert "docker" in tool_places()
+
+
+def test_run_on_docker_builds_the_self_hosted_backend():
+    backend = _agent(run_on="docker").backend
+    assert type(backend).__name__ == "DockerManagedAgent"
+    assert backend.provider_name == "docker"
+
+
+# ── the two scopes stay distinguishable ──────────────────────────────────────
+def test_run_on_moves_the_thinking_too():
+    places = describe(_agent(run_on="docker"))
+    assert places["thinks_on"] == places["tools_run_on"] == "a Docker container"
+
+
+def test_tools_run_on_leaves_the_thinking_here():
+    places = describe(_agent(tools_run_on="docker"))
+    assert places["thinks_on"] == "this machine"
+    assert places["tools_run_on"] == "a Docker container"
+
+
+def test_the_two_read_differently_in_the_repr():
+    assert repr(_agent(run_on="docker")) != repr(_agent(tools_run_on="docker"))
+
+
+def test_naming_both_is_still_a_conflict():
+    """They are alternatives even when they name the same place: run_on already
+    runs the tools there, so tools_run_on= has nothing left to say."""
+    with pytest.raises(TypeError):
+        _agent(run_on="docker", tools_run_on="docker")
+
+
+# ── config marshalling (no daemon needed) ────────────────────────────────────
+def test_the_agent_is_rebuilt_from_serialisable_config_only():
+    """A Python callable cannot be reconstructed in the container, so it is not
+    sent. The limitation is real; the test pins it so it stays deliberate."""
+    from praisonai.integrations.docker_managed_agent import _as_dict
+
+    def local_tool(x: str) -> str:
+        return x
+
+    out = _as_dict({"instructions": "be brief", "llm": "gpt-4o-mini",
+                    "tools": [local_tool], "verbose": True})
+    assert out["instructions"] == "be brief"
+    assert out["llm"] == "gpt-4o-mini"
+    assert "tools" not in out, "callables must not be smuggled into the payload"
+
+
+def test_hosted_config_spellings_are_translated():
+    """HostedAgentConfig says system/model where Agent says instructions/llm."""
+    from praisonai.integrations.docker_managed_agent import _as_dict
+
+    out = _as_dict({"system": "you are terse", "model": "gpt-4o-mini"})
+    assert out["instructions"] == "you are terse"
+    assert out["llm"] == "gpt-4o-mini"
+    assert "system" not in out and "model" not in out
+
+
+def test_an_empty_config_still_produces_a_valid_agent():
+    from praisonai.integrations.docker_managed_agent import _as_dict
+
+    assert _as_dict(None)["instructions"]
+
+
+def test_the_result_is_read_from_a_marked_line():
+    """pip warnings and telemetry share stdout with the answer, so the result
+    is marked rather than assumed to be the last line."""
+    from praisonai.integrations.docker_managed_agent import _parse
+
+    noisy = (
+        "WARNING: Running pip as root\n"
+        "some telemetry line\n"
+        '__PRAISON_RESULT__{"ok": true, "result": "42"}\n'
+    )
+    assert _parse(noisy) == {"ok": True, "result": "42"}
+    assert _parse("no marker here") is None
+
+
+# ── failure is reported, not swallowed ───────────────────────────────────────
+def test_a_missing_daemon_says_what_to_do():
+    from praisonai.integrations.docker_managed_agent import DockerManagedAgent
+
+    backend = DockerManagedAgent()
+    if backend.is_available:
+        pytest.skip("Docker is running, so this path cannot be exercised")
+    with pytest.raises(RuntimeError) as exc:
+        backend._ensure_container()
+    message = str(exc.value)
+    assert "Docker daemon" in message
+    assert "tools_run_on='docker'" in message, "offer the alternative that needs no daemon"
+
+
+# ── the real thing ───────────────────────────────────────────────────────────
+@needs_docker
+def test_the_whole_agent_really_runs_in_a_container():
+    """Proves the loop moved: the agent reports the container's platform, not
+    the host's. Needs a model key, so it asserts placement rather than output."""
+    from praisonai.integrations.docker_managed_agent import DockerManagedAgent
+
+    backend = DockerManagedAgent(config={"instructions": "be brief"})
+    try:
+        backend._ensure_container()
+        assert backend._container, "no container was started"
+        probe = subprocess.run(
+            ["docker", "exec", backend._container, "python", "-c",
+             "import platform, praisonaiagents; print(platform.system())"],
+            capture_output=True, text=True, timeout=300,
+        )
+        assert probe.returncode == 0, probe.stderr[-400:]
+        assert probe.stdout.strip() == "Linux", "the loop is not in a Linux container"
+    finally:
+        backend.shutdown()
+
+
+@needs_docker
+def test_the_container_is_removed_afterwards():
+    from praisonai.integrations.docker_managed_agent import DockerManagedAgent
+
+    backend = DockerManagedAgent()
+    backend._ensure_container()
+    name = backend._container
+    backend.shutdown()
+
+    remaining = subprocess.run(
+        ["docker", "ps", "-aq", "--filter", f"name={name}"],
+        capture_output=True, text=True, timeout=120,
+    ).stdout.strip()
+    assert remaining == "", f"container {name} outlived the backend"

--- a/src/praisonai/README.md
+++ b/src/praisonai/README.md
@@ -294,11 +294,11 @@ code tools move. They read and write this machine's files.
 Naming a place that cannot do the job is a typo, not a preference, so it says so:
 
 ```python
->>> Agent(name="x", instructions="i", run_on="docker")
-TypeError: Agent(run_on='docker') is not valid: run_on= places the whole agent
--- model calls, loop and tools -- on a managed runtime, and 'docker' runs
+>>> Agent(name="x", instructions="i", run_on="e2b")
+TypeError: Agent(run_on='e2b') is not valid: run_on= places the whole agent
+-- model calls, loop and tools -- on a managed runtime, and 'e2b' runs
 commands but cannot host an agent loop.
-  To run only the tools there:  Agent(tools_run_on='docker')
+  To run only the tools there:  Agent(tools_run_on='e2b')
 ```
 
 To run one block of code somewhere else, name the place on that call:

--- a/src/praisonai/README.md
+++ b/src/praisonai/README.md
@@ -272,8 +272,9 @@ agent = Agent(name="builder", instructions="You build things.",
               tools_run_on="docker")   # docker | e2b | modal | daytona | flyio
                                        # tenki | sandlock | ssh | novita | subprocess
 
-# B. The WHOLE agent moves — model calls, loop and tools (needs ANTHROPIC_API_KEY)
-agent = Agent(name="teacher", instructions="You teach.", run_on="anthropic")
+# B. The WHOLE agent moves — model calls, loop and tools
+agent = Agent(name="teacher", instructions="You teach.", run_on="anthropic")  # hosted
+agent = Agent(name="builder", instructions="You build.", run_on="docker")     # self-hosted
 agent.start("Write a Python script that prints the first 10 primes, then run it")
 ```
 

--- a/src/praisonai/praisonai/integrations/backend_registry.py
+++ b/src/praisonai/praisonai/integrations/backend_registry.py
@@ -25,8 +25,18 @@ def _anthropic_loader() -> Type:
     return AnthropicManagedAgent
 
 
+def _docker_loader() -> Type:
+    from .docker_managed_agent import DockerManagedAgent
+    return DockerManagedAgent
+
+
 _BUILTIN_BACKENDS = {
     "anthropic": _anthropic_loader,
+    # Self-hosted: the whole agent loop runs in a local container rather than a
+    # vendor's cloud. Registering it here is all that `run_on="docker"` needs --
+    # placement resolves run_on= against this registry, so the parameter, the
+    # repr, the explanation and the conflict checks all pick it up unchanged.
+    "docker": _docker_loader,
 }
 
 

--- a/src/praisonai/praisonai/integrations/docker_managed_agent.py
+++ b/src/praisonai/praisonai/integrations/docker_managed_agent.py
@@ -122,7 +122,12 @@ class DockerManagedAgent:
 
     # ── ManagedBackendProtocol ───────────────────────────────────────────────
     async def execute(self, prompt: str, **kwargs) -> str:
-        return self._execute_sync(prompt, **kwargs)
+        # Docker start-up, package install and the container turn are blocking
+        # subprocess work. Run them off the event-loop thread so concurrent
+        # async callers are not stalled behind one agent's container.
+        import asyncio
+
+        return await asyncio.to_thread(self._execute_sync, prompt, **kwargs)
 
     async def stream(self, prompt: str, **kwargs):
         """Yield the result once.
@@ -131,7 +136,9 @@ class DockerManagedAgent:
         stream to forward. Yielding the finished answer keeps callers that
         expect an iterator working, rather than pretending to stream.
         """
-        yield self._execute_sync(prompt, **kwargs)
+        import asyncio
+
+        yield await asyncio.to_thread(self._execute_sync, prompt, **kwargs)
 
     def reset_session(self) -> None:
         """Drop the container; the next call starts a clean one."""
@@ -157,27 +164,33 @@ class DockerManagedAgent:
     # ── the work ─────────────────────────────────────────────────────────────
     def _execute_sync(self, prompt: str, **kwargs) -> str:
         self._ensure_container()
-        payload = json.dumps({"agent": self._config, "prompt": prompt})
+        # An ephemeral container must not outlive the call that made it, even
+        # when the turn raises. Tear it down in `finally` so a failure after
+        # start-up cannot leak a `praisonai-agent-*` container.
+        try:
+            payload = json.dumps({"agent": self._config, "prompt": prompt})
 
-        _write_file(self._container, "/tmp/praison_agent.json", payload)
-        _write_file(self._container, "/tmp/praison_runner.py", _RUNNER)
+            _write_file(self._container, "/tmp/praison_agent.json", payload)
+            _write_file(self._container, "/tmp/praison_runner.py", _RUNNER)
 
-        result = _run(
-            ["docker", "exec", self._container, "python", "/tmp/praison_runner.py"],
-            timeout=kwargs.get("timeout", 900),
-        )
-        answer = _parse(result.stdout)
-        if answer is None:
-            detail = (result.stderr or result.stdout or "").strip()[-600:]
-            raise RuntimeError(
-                f"The agent produced no result inside the container.\n{detail}"
+            result = _run(
+                ["docker", "exec", self._container, "python", "/tmp/praison_runner.py"],
+                timeout=kwargs.get("timeout", 900),
             )
-        if not answer.get("ok"):
-            raise RuntimeError(f"Agent failed inside the container: {answer['error']}")
-
-        if not self._keep_alive:
-            self.shutdown()
-        return answer["result"]
+            answer = _parse(result.stdout)
+            if answer is None:
+                detail = (result.stderr or result.stdout or "").strip()[-600:]
+                raise RuntimeError(
+                    f"The agent produced no result inside the container.\n{detail}"
+                )
+            if not answer.get("ok"):
+                raise RuntimeError(
+                    f"Agent failed inside the container: {answer['error']}"
+                )
+            return answer["result"]
+        finally:
+            if not self._keep_alive:
+                self.shutdown()
 
     def _ensure_container(self) -> None:
         if self._container and self._prepared:

--- a/src/praisonai/praisonai/integrations/docker_managed_agent.py
+++ b/src/praisonai/praisonai/integrations/docker_managed_agent.py
@@ -1,0 +1,308 @@
+"""Run the whole agent inside a container you own.
+
+``run_on="anthropic"`` hands the entire agent -- model calls, loop and tools --
+to someone else's managed runtime. This is the same shape, self-hosted: the
+loop runs in a local container instead of a vendor's cloud.
+
+The distinction from ``tools_run_on="docker"`` is what crosses the boundary:
+
+* ``tools_run_on="docker"`` -- your Python process runs the loop and calls the
+  model. Only shell and file tools are executed in the container. Your
+  environment, your files and your API keys are all still in play locally.
+* ``run_on="docker"`` -- the loop itself runs in the container. The model call
+  is made from inside it, so the container needs the API key and nothing on
+  your filesystem is reachable unless you mounted it.
+
+Both are legitimate; they answer different questions, which is exactly why the
+two parameters exist. The same word naming the same place under both is not an
+ambiguity -- the parameter carries the scope.
+
+Deliberate limitations, stated rather than hidden:
+
+* **Python callables in ``tools=`` do not cross.** A function defined in your
+  process cannot be reconstructed in the container, so it is not sent. This is
+  the same limitation the hosted runtimes have; the agent is rebuilt inside
+  from its serialisable configuration.
+* **The container needs the model API key.** It is passed through from your
+  environment. That is the point of moving the loop, and it is worth knowing.
+* **First run installs the package** unless you supply an image that already
+  has it, which costs roughly a minute. Pass ``image=`` to skip it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import uuid
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Model API keys worth forwarding. Only ones actually set are passed, and they
+# are written to a file inside the container rather than into the command line,
+# so they never appear in `docker inspect` or a process listing.
+_KEY_VARS = (
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "GROQ_API_KEY", "MISTRAL_API_KEY", "COHERE_API_KEY", "OPENROUTER_API_KEY",
+    "DEEPSEEK_API_KEY", "XAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_BASE",
+)
+
+_DEFAULT_IMAGE = "python:3.12-slim"
+
+# The runner is written into the container and executed there. It rebuilds the
+# agent from JSON and prints exactly one line of JSON back, so stdout noise
+# (pip warnings, telemetry) cannot be mistaken for the answer.
+_RUNNER = r'''
+import json, sys, os
+
+payload = json.load(open("/tmp/praison_agent.json"))
+try:
+    from praisonaiagents import Agent
+
+    kwargs = {k: v for k, v in payload["agent"].items() if v is not None}
+    agent = Agent(**kwargs)
+    result = agent.start(payload["prompt"])
+    out = {"ok": True, "result": result if isinstance(result, str) else str(result)}
+except Exception as exc:                     # noqa: BLE001 - reported, not raised
+    out = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+sys.stdout.write("\n__PRAISON_RESULT__" + json.dumps(out) + "\n")
+'''
+
+_MARKER = "__PRAISON_RESULT__"
+
+
+class DockerManagedAgent:
+    """A whole agent running in a container. Implements ManagedBackendProtocol.
+
+    Args:
+        config: agent configuration (instructions, llm, name, ...). Accepts a
+            ``ManagedConfig``/``HostedAgentConfig``, a plain dict, or None.
+        image: container image. Defaults to ``python:3.12-slim``, onto which
+            praisonaiagents is installed on first use. Supply your own image
+            with the package baked in to skip that.
+        env: extra environment variables for the container.
+        keep_alive: reuse one container across calls (default) so a follow-up
+            turn does not pay start-up again.
+    """
+
+    def __init__(
+        self,
+        config: Optional[Any] = None,
+        *,
+        provider: Optional[str] = None,
+        image: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        keep_alive: bool = True,
+        pip_packages: Optional[List[str]] = None,
+        **_ignored: Any,
+    ):
+        # `provider` arrives because HostedAgent(provider="docker") acts as a
+        # factory and forwards it. It is already implied by this class, so it
+        # is accepted and dropped rather than rejected.
+        del provider
+        self._config = _as_dict(config)
+        self.image = image or _DEFAULT_IMAGE
+        self._extra_env = dict(env or {})
+        self._keep_alive = keep_alive
+        self._pip_packages = list(pip_packages or ["praisonaiagents"])
+        self._container: Optional[str] = None
+        self._prepared = False
+
+    # ── identity ─────────────────────────────────────────────────────────────
+    @property
+    def provider_name(self) -> str:
+        return "docker"
+
+    @property
+    def is_available(self) -> bool:
+        return _docker_ok()
+
+    # ── ManagedBackendProtocol ───────────────────────────────────────────────
+    async def execute(self, prompt: str, **kwargs) -> str:
+        return self._execute_sync(prompt, **kwargs)
+
+    async def stream(self, prompt: str, **kwargs):
+        """Yield the result once.
+
+        The loop runs to completion inside the container, so there is no token
+        stream to forward. Yielding the finished answer keeps callers that
+        expect an iterator working, rather than pretending to stream.
+        """
+        yield self._execute_sync(prompt, **kwargs)
+
+    def reset_session(self) -> None:
+        """Drop the container; the next call starts a clean one."""
+        self.shutdown()
+
+    def reset_all(self) -> None:
+        self.reset_session()
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def shutdown(self) -> None:
+        if self._container:
+            _run(["docker", "rm", "-f", self._container], check=False, timeout=120)
+            logger.info("[docker_managed] removed container %s", self._container)
+        self._container = None
+        self._prepared = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.shutdown()
+
+    # ── the work ─────────────────────────────────────────────────────────────
+    def _execute_sync(self, prompt: str, **kwargs) -> str:
+        self._ensure_container()
+        payload = json.dumps({"agent": self._config, "prompt": prompt})
+
+        _write_file(self._container, "/tmp/praison_agent.json", payload)
+        _write_file(self._container, "/tmp/praison_runner.py", _RUNNER)
+
+        result = _run(
+            ["docker", "exec", self._container, "python", "/tmp/praison_runner.py"],
+            timeout=kwargs.get("timeout", 900),
+        )
+        answer = _parse(result.stdout)
+        if answer is None:
+            detail = (result.stderr or result.stdout or "").strip()[-600:]
+            raise RuntimeError(
+                f"The agent produced no result inside the container.\n{detail}"
+            )
+        if not answer.get("ok"):
+            raise RuntimeError(f"Agent failed inside the container: {answer['error']}")
+
+        if not self._keep_alive:
+            self.shutdown()
+        return answer["result"]
+
+    def _ensure_container(self) -> None:
+        if self._container and self._prepared:
+            return
+        if not _docker_ok():
+            raise RuntimeError(
+                "run_on='docker' needs a running Docker daemon.\n"
+                "  Start Docker Desktop, or check `docker info`.\n"
+                "  To keep the loop on this machine and move only the tools, "
+                "use tools_run_on='docker' instead."
+            )
+
+        name = f"praisonai-agent-{uuid.uuid4().hex[:12]}"
+        env_args: List[str] = []
+        for key in _KEY_VARS:
+            if os.environ.get(key):
+                env_args += ["-e", key]          # value comes from our env, not argv
+        for key, value in self._extra_env.items():
+            env_args += ["-e", f"{key}={value}"]
+
+        _run([
+            "docker", "run", "-d", "--name", name,
+            "--label", "praisonai=managed",
+            "--label", "praisonai.scope=whole-agent",
+            *env_args, self.image, "sleep", "infinity",
+        ], timeout=300)
+        self._container = name
+        logger.info("[docker_managed] started %s from %s", name, self.image)
+
+        # Install only if the package is not already in the image.
+        probe = _run(
+            ["docker", "exec", name, "python", "-c", "import praisonaiagents"],
+            check=False, timeout=120,
+        )
+        if probe.returncode != 0:
+            logger.info("[docker_managed] installing %s (first run)", self._pip_packages)
+            install = _run(
+                ["docker", "exec", name, "pip", "install", "--no-cache-dir",
+                 "-q", *self._pip_packages],
+                check=False, timeout=900,
+            )
+            if install.returncode != 0:
+                self.shutdown()
+                raise RuntimeError(
+                    "Could not install praisonaiagents in the container:\n"
+                    + (install.stderr or "")[-600:]
+                    + "\nSupply an image that already has it with image=..."
+                )
+        self._prepared = True
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+def _as_dict(config: Any) -> Dict[str, Any]:
+    """Normalise a config object into constructor kwargs for the remote Agent."""
+    if config is None:
+        return {"instructions": "You are a helpful assistant."}
+    if isinstance(config, dict):
+        raw = dict(config)
+    else:
+        raw = {
+            k: v for k, v in vars(config).items()
+            if not k.startswith("_")
+        } if hasattr(config, "__dict__") else {}
+
+    # Only fields an Agent can be rebuilt from, and only JSON-safe values.
+    allowed = ("name", "role", "goal", "backstory", "instructions", "llm",
+               "system", "model", "verbose", "markdown", "self_reflect")
+    out: Dict[str, Any] = {}
+    for key in allowed:
+        if key in raw and isinstance(raw[key], (str, bool, int, float)):
+            out[key] = raw[key]
+    # `system`/`model` are the hosted-config spellings of instructions/llm.
+    if "system" in out and "instructions" not in out:
+        out["instructions"] = out.pop("system")
+    if "model" in out and "llm" not in out:
+        out["llm"] = out.pop("model")
+    out.pop("system", None)
+    out.pop("model", None)
+    if not any(out.get(k) for k in ("name", "role", "goal", "backstory", "instructions")):
+        out["instructions"] = "You are a helpful assistant."
+    return out
+
+
+def _parse(stdout: str) -> Optional[Dict[str, Any]]:
+    """Pull the one marked JSON line out of whatever else got printed."""
+    for line in reversed((stdout or "").splitlines()):
+        if _MARKER in line:
+            try:
+                return json.loads(line.split(_MARKER, 1)[1])
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
+def _write_file(container: str, path: str, content: str) -> None:
+    """Write a file into the container without going through the shell.
+
+    Piping to `docker exec -i ... tee` keeps the content off the argument list,
+    so a long instruction or an API key never lands in a process listing.
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        ["docker", "exec", "-i", container, "tee", path],
+        input=content, capture_output=True, text=True, timeout=180,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"Could not write {path} into the container: {proc.stderr}")
+
+
+def _run(cmd: List[str], *, check: bool = True, timeout: int = 300):
+    import subprocess
+
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if check and proc.returncode != 0:
+        raise RuntimeError(
+            f"`{shlex.join(cmd[:3])} ...` failed ({proc.returncode}): "
+            f"{(proc.stderr or proc.stdout or '').strip()[:400]}"
+        )
+    return proc
+
+
+def _docker_ok() -> bool:
+    try:
+        return _run(["docker", "version", "--format", "{{.Server.Version}}"],
+                    check=False, timeout=30).returncode == 0
+    except Exception:
+        return False


### PR DESCRIPTION
## `run_on=` for every place that can host a loop, and a provider matrix that would have caught the rot

Builds on #4068. Three things: `run_on="docker"`, `run_on=` extended to every place that can host an agent loop, and a test matrix covering all ten providers — which is how the Modal breakage below was found.

### 1. `run_on="docker"` — the whole agent in a container you own

```python
Agent(name="builder", instructions="...", run_on="docker")        # whole agent
Agent(name="builder", instructions="...", tools_run_on="docker")  # only the tools
```

| | `tools_run_on="docker"` | `run_on="docker"` |
|---|---|---|
| The loop runs | your process | **in the container** |
| The model is called from | your machine | **the container** |
| Your files | reachable | unreachable unless mounted |
| Your Python `tools=` | work | **do not cross** |

Both name the same place; the parameter carries the scope. So the two value sets deliberately overlap now, and the object still reports which scope you chose.

### 2. `run_on=` went from 2 places to 8

It accepted two names while `tools_run_on=` accepted twelve. That was never a fact about the places — a place that can run a command can run the loop, which is just one more command. There was simply no backend for the rest.

One generic `ComputeManagedAgent` wraps any compute provider rather than eleven near-identical vendor backends: **anthropic, docker, e2b, modal, daytona, flyio, tenki, novita**.

**Verified live end to end on Modal** — the agent installed the package remotely, ran its whole loop there, and returned the answer.

Still refused, with tests: `local` (that's your own shell — what you get by passing nothing), `ssh` (needs an object), `subprocess`/`sandlock` (isolate tools, aren't runtimes).

### 3. Modal's `run_in=` path was dead five times over

Modal authenticates via `~/.modal.toml`, not `.env` — so it was testable all along. It failed five consecutive times, each fault hiding the next:

| # | Fault |
|---|---|
| 1 | `keep_warm`/`allow_concurrent_inputs` renamed Feb 2025; old names now **raise** |
| 2 | Nested function needs `serialized=True` |
| 3 | The App was never started → "Function has not been hydrated" |
| 4 | `add_python="3.11"` on an image that already ships Python → build failed |
| 5 | Serialized function pickled on 3.12, image pinned to 3.11 |

Five-deep failure is the signature of a path nothing has ever run. `execute_code(run_in="modal")` now returns its output.

### 4. Provider matrix — 85 checks across all ten places

Most of what breaks an integration is checkable without a credential, so now it is: the class resolves, satisfies the protocol, exposes **coroutines** (a sync method here doesn't raise — it returns a coroutine nobody awaits, so the call silently does nothing), answers `is_available` without throwing, is accepted/refused correctly by both parameters, and is described in the repr as the place actually given.

The check that matters most: **a missing credential must fail with something actionable** — naming the key, the install command, or the daemon. All seven credential-less places pass.

| Verified live | Resolve + protocol + error quality only |
|---|---|
| docker (both scopes), modal (both paths), subprocess, local | e2b, daytona, flyio, tenki, novita (no credential), sandlock (needs Linux), anthropic (reaches the API; account out of credit) |

### 5. Providers now belong in their own packages

The sandbox and managed-backend registries already accepted plugins by entry point. The compute registry — where `tools_run_on=` places live, every one a commercial vendor — was a hardcoded dict needing **six edits across two packages** per provider.

It now reads `praisonai.compute`:

```toml
[project.entry-points."praisonai.compute"]
runpod = "praisonai_compute_runpod:RunpodCompute"
```

Verified with a package `pip install`ed from outside the repo: discovered, validated, resolved, executed, and accepted by `Agent(tools_run_on=...)` with **no change to any file here**.

Two follow-on gaps closed so a contributed place is a first-class one:
- **`managed ps` derives its list from the registry.** It was a hardcoded tuple, so an external place could be provisioned and never listed or stopped — an unreclaimable cloud sandbox is a bill nobody sees.
- **A provider can declare `display_name`.** The phrase table is a literal that cannot know about later installs, so external places printed as bare names.

Providers load on demand, so a broken plugin fails only for the caller that names it. There's a test for that.

### Testing

- **243 passing** across placement, providers, adapter, location and sandbox suites; whole `praisonai-sandbox` package green.
- **Docker e2e: 15/15**, including the boundary test — host files unreachable from inside the container — and **0 leftover containers**.
- Removed a latent flake: the batch-provisioning test asserts an exact provision count, and agents from earlier tests now release their sandbox via a finalizer, which could land mid-measurement.

**Not verified:** five cloud providers for want of credentials, and `sandlock` for want of Linux. Both stated rather than assumed — and Modal is the argument for a gated CI job with real keys, since a path can be broken five times over and stay green when nothing runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
