### PR TITLE
fix(placement): one word still meant two backends, and the repr hid it

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/execution_location.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_location.py
@@ -72,11 +72,15 @@ def say_place(name: Any, *, via: str = "sandbox") -> str:
         return HERE
     if name is True:
         return _PLACE_WORDS["subprocess"]
-    if via == "compute" and isinstance(name, str) and name.lower() in _COMPUTE_ONLY_WORDS:
-        return _COMPUTE_ONLY_WORDS[name.lower()]
     if not isinstance(name, str):
-        # A configured provider instance: use its own declared name if it has one.
+        # A configured provider instance: use its own declared name if it has
+        # one. Normalise BEFORE the compute-only check, or a backend holding a
+        # LocalCompute object (provider_name="local") skips the branch and gets
+        # described in the subprocess backend's stronger words -- the exact
+        # overstatement this module exists to prevent.
         name = getattr(name, "provider_name", None) or type(name).__name__
+    if via == "compute" and name.lower() in _COMPUTE_ONLY_WORDS:
+        return _COMPUTE_ONLY_WORDS[name.lower()]
     key = str(name).lower()
     key = _ALIASES.get(key, key)
     return _PLACE_WORDS.get(key, str(name))
@@ -109,10 +113,13 @@ def _backend_places(backend: Any) -> Optional[Dict[str, str]]:
         where = say_place(provider)
         return {"thinks_on": where, "tools_run_on": where}
 
-    # Local/sandboxed agents keep the loop here and may push tools out.
+    # Local/sandboxed agents keep the loop here and may push tools out. A
+    # backend's compute object is a COMPUTE-registry provider, so it is read
+    # with the compute vocabulary: a LocalCompute here is the unrestricted
+    # shell, not the subprocess backend "local" collapses to under run_in=.
     compute = getattr(backend, "_compute", None) or getattr(backend, "compute", None)
     if compute is not None:
-        return {"thinks_on": HERE, "tools_run_on": say_place(compute)}
+        return {"thinks_on": HERE, "tools_run_on": say_place(compute, via="compute")}
     return {"thinks_on": HERE, "tools_run_on": HERE}
 
 

--- a/src/praisonai-agents/tests/unit/test_placement.py
+++ b/src/praisonai-agents/tests/unit/test_placement.py
@@ -601,3 +601,25 @@ def test_resolver_aliases_are_accepted_at_construction(alias, resolves_to):
 
     agent = _agent(tools_run_on=alias)
     assert say_place(resolves_to) in repr(agent)
+
+
+def test_a_backend_holding_a_local_compute_object_is_not_overstated():
+    """A managed backend can carry a LocalCompute PROVIDER OBJECT, not a string.
+    Its provider_name is "local", and reading it through the sandbox vocabulary
+    let the alias table collapse it to "subprocess" -- describing the
+    unrestricted shell in the locked-down backend's words. A backend's compute
+    is a compute-registry provider, so it must be read as one."""
+    from praisonaiagents.agent.execution_location import _backend_places, say_place
+
+    class _LocalComputeObject:
+        provider_name = "local"
+
+    class _Backend:
+        _compute = _LocalComputeObject()
+
+    places = _backend_places(_Backend())
+    assert places["tools_run_on"] == say_place("local", via="compute")
+    assert "no policy" in places["tools_run_on"]
+    assert places["tools_run_on"] != say_place("subprocess"), (
+        "the unrestricted local shell must not borrow the subprocess backend's words"
+    )

--- a/src/praisonai-bot/gateway.yaml
+++ b/src/praisonai-bot/gateway.yaml
@@ -1,16 +1,14 @@
 gateway:
-  host: "127.0.0.1"
+  host: 127.0.0.1
   port: 8765
-
 agents:
   personal:
-    instructions: "You are a helpful personal assistant"
+    instructions: You are a helpful personal assistant
     model: gpt-4o-mini
     memory: false
   support:
-    instructions: "You are a customer support agent"
+    instructions: You are a customer support agent
     model: gpt-4o-mini
-
 channels:
   telegram:
     token: ${TELEGRAM_BOT_TOKEN}
@@ -18,3 +16,5 @@ channels:
       dm: personal
       group: support
       default: personal
+    group_policy: mention_only
+config_version: 1

--- a/src/praisonai-bot/tests/unit/cli/test_gateway_exit_codes.py
+++ b/src/praisonai-bot/tests/unit/cli/test_gateway_exit_codes.py
@@ -158,10 +158,19 @@ def test_bot_gateway_start_command_propagates_fatal_exit_code(monkeypatch):
     assert excinfo.value.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
 
-def test_bot_gateway_start_command_clean_shutdown_exits_zero(monkeypatch):
+def test_bot_gateway_start_command_clean_shutdown_exits_zero(monkeypatch, tmp_path):
     import typer
 
     from praisonai_bot.cli.commands import gateway as bot_gateway_cmd
+
+    # Pass an explicit channel-less config so this test asserts ONLY exit-code
+    # propagation. With config=None it would auto-discover a ``./gateway.yaml``
+    # and run the verify-turn pre-flight (a real agent turn) before the patched
+    # start(); a channels-less config skips every pre-flight and reaches it
+    # deterministically, in any cwd, without a live LLM call (#4042/#4070).
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text("agents:\n  personal:\n    instructions: hi\n    model: gpt-4o-mini\n")
+    monkeypatch.chdir(tmp_path)
 
     def fake_start(self, **kwargs):
         return GATEWAY_OK_EXIT_CODE
@@ -173,6 +182,6 @@ def test_bot_gateway_start_command_clean_shutdown_exits_zero(monkeypatch):
     with pytest.raises(typer.Exit) as excinfo:
         bot_gateway_cmd.gateway_start(
             host="127.0.0.1", port=8765, agents=None,
-            config=None, preflight=False, openai_api=False, mcp=False,
+            config=str(cfg), preflight=False, openai_api=False, mcp=False,
         )
     assert excinfo.value.exit_code == GATEWAY_OK_EXIT_CODE

--- a/src/praisonai-bot/tests/unit/gateway/test_gateway_watchdog_wiring.py
+++ b/src/praisonai-bot/tests/unit/gateway/test_gateway_watchdog_wiring.py
@@ -153,30 +153,44 @@ def _patch_handler(monkeypatch, captured):
     monkeypatch.setattr(features_gateway, "GatewayHandler", _StubHandler)
 
 
-def test_typer_start_forwards_watchdog_to_handler(monkeypatch):
+def _write_channelless_config(tmp_path):
+    # A channels-less config skips every start-time pre-flight (credential, tool,
+    # and verify-turn), so the command reaches the patched handler deterministically
+    # without a live LLM call. Passing it explicitly also avoids discovering the
+    # repo's ``src/praisonai-bot/gateway.yaml`` in the CI workdir (#4042/#4070).
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text("agents:\n  personal:\n    instructions: hi\n    model: gpt-4o-mini\n")
+    return str(cfg)
+
+
+def test_typer_start_forwards_watchdog_to_handler(monkeypatch, tmp_path):
     from typer.testing import CliRunner
     from praisonai_bot.cli.commands import gateway as gateway_cmd
 
+    cfg = _write_channelless_config(tmp_path)
     captured = {}
     _patch_handler(monkeypatch, captured)
 
     result = CliRunner().invoke(
         gateway_cmd.app,
-        ["start", "--watchdog", "--watchdog-timeout", "20", "--no-preflight"],
+        ["start", "--config", cfg, "--watchdog", "--watchdog-timeout", "20", "--no-preflight"],
     )
     assert result.exit_code == 0
     assert captured.get("watchdog") is True
     assert captured.get("watchdog_timeout") == 20.0
 
 
-def test_typer_start_watchdog_unset_is_none(monkeypatch):
+def test_typer_start_watchdog_unset_is_none(monkeypatch, tmp_path):
     from typer.testing import CliRunner
     from praisonai_bot.cli.commands import gateway as gateway_cmd
 
+    cfg = _write_channelless_config(tmp_path)
     captured = {}
     _patch_handler(monkeypatch, captured)
 
-    result = CliRunner().invoke(gateway_cmd.app, ["start", "--no-preflight"])
+    result = CliRunner().invoke(
+        gateway_cmd.app, ["start", "--config", cfg, "--no-preflight"]
+    )
     assert result.exit_code == 0
     # Unset flag must not clobber a YAML ``gateway.watchdog.enabled: true``.
     assert captured.get("watchdog") is None


### PR DESCRIPTION
Two gaps found while documenting every accepted value.

"local" resolves differently depending on which parameter carried it: run_in="local" is collapsed by SandboxManager to the subprocess backend -- scrubbed environment, blocked commands and paths -- while tools_run_on="local" is the wrapper's LocalCompute, a plain shell in the current directory with the full environment inherited and no security policy at all. Both printed "a separate process on this machine", so the weaker of the two was described in the stronger one's words. That is precisely the failure this module exists to prevent, hiding in the one place the rest of the work did not look. say_place() now takes the registry that resolved the name.

Resolver aliases were rejected at construction. Validation ran before alias resolution, so tools_run_on="native" raised "not a known place" while resolve_compute("native") returned a working sandlock adapter. tool_places() now includes the alias table it validates against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved placement descriptions to clearly distinguish local sandbox execution from unrestricted compute execution.
  - Added support for recognizing managed runtime providers and native tool-placement aliases.
  - Added Telegram group configuration with mention-only message handling.

- **Bug Fixes**
  - Backend-held local compute objects now display accurate compute-placement details.

- **Tests**
  - Expanded coverage for execution placement, gateway shutdown behavior, and watchdog option forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->