### PR TITLE
fix(sandbox): the two docker implementations handed you different Pythons

### DIFF
--- a/src/praisonai-agents/praisonaiagents/sandbox/config.py
+++ b/src/praisonai-agents/praisonaiagents/sandbox/config.py
@@ -106,7 +106,11 @@ class SandboxConfig:
     """
     
     sandbox_type: str = "subprocess"
-    image: str = "python:3.11-slim"
+    # Kept in step with the compute-side DockerCompute default. The two
+    # implementations of "docker" disagreed -- 3.11 here, 3.12 there -- so
+    # tools_run_on="docker" and run_in="docker" handed you different Pythons
+    # for the same word. Nobody chose that; they drifted apart.
+    image: str = "python:3.12-slim"
     working_dir: str = "/workspace"
     env: Dict[str, str] = field(default_factory=dict)
     resource_limits: ResourceLimits = field(default_factory=ResourceLimits)
@@ -133,7 +137,7 @@ class SandboxConfig:
         }
     
     @classmethod
-    def docker(cls, image: str = "python:3.11-slim") -> "SandboxConfig":
+    def docker(cls, image: str = "python:3.12-slim") -> "SandboxConfig":
         """Create a Docker sandbox configuration."""
         return cls(
             sandbox_type="docker",

--- a/src/praisonai-agents/praisonaiagents/sandbox/manager.py
+++ b/src/praisonai-agents/praisonaiagents/sandbox/manager.py
@@ -29,7 +29,7 @@ class SandboxManager:
     Example:
         from praisonaiagents.sandbox import SandboxManager, SandboxConfig
 
-        config = SandboxConfig.docker("python:3.11-slim")
+        config = SandboxConfig.docker("python:3.12-slim")
         manager = SandboxManager(config)
         result = await manager.run_code("print('Hello, World!')")
     """

--- a/src/praisonai-agents/praisonaiagents/sandbox/protocols.py
+++ b/src/praisonai-agents/praisonaiagents/sandbox/protocols.py
@@ -206,7 +206,7 @@ class SandboxProtocol(Protocol):
 
         from praisonai_sandbox import DockerSandbox
         
-        sandbox = DockerSandbox(image="python:3.11-slim")
+        sandbox = DockerSandbox(image="python:3.12-slim")
         result = await sandbox.execute("print('Hello, World!')")
         print(result.stdout)
     """

--- a/src/praisonai-agents/tests/unit/test_provider_matrix.py
+++ b/src/praisonai-agents/tests/unit/test_provider_matrix.py
@@ -497,3 +497,27 @@ def test_modal_honours_a_non_default_image_from_the_registry(monkeypatch):
     assert recorded.get("debian_slim") and "from_registry" not in recorded, (
         "the default image must keep Modal on debian_slim"
     )
+
+
+def test_the_two_docker_implementations_agree_on_their_image():
+    """`docker` has an implementation in each package, and they drifted: one
+    defaulted to python:3.11-slim and the other to 3.12-slim, so
+    tools_run_on="docker" and run_in="docker" handed you different Pythons for
+    the same word. Nobody chose that, which is exactly why it needs a test.
+
+    Both sides are read as the *effective runtime default* -- the value a caller
+    actually gets when they name no image -- not a docstring or a comment. An
+    earlier version scanned the DockerCompute docstring for `image="python:`,
+    which would keep passing even after the real default drifted, because the
+    example is prose the provisioning path never consults.
+    """
+    from praisonaiagents.managed.protocols import ComputeConfig
+    from praisonaiagents.sandbox import SandboxConfig
+
+    sandbox_default = SandboxConfig.docker().image
+    compute_default = ComputeConfig().image
+
+    assert sandbox_default == compute_default, (
+        f"the two docker implementations disagree: sandbox={sandbox_default!r} "
+        f"compute={compute_default!r} -- same name, different container"
+    )

--- a/src/praisonai-sandbox/README.md
+++ b/src/praisonai-sandbox/README.md
@@ -14,7 +14,7 @@ pip install praisonai-sandbox[docker]
 from praisonai_sandbox import DockerSandbox
 from praisonaiagents.sandbox import SandboxConfig
 
-config = SandboxConfig.docker("python:3.11-slim")
+config = SandboxConfig.docker("python:3.12-slim")
 sandbox = DockerSandbox(image=config.image, config=config)
 ```
 

--- a/src/praisonai-sandbox/e2e-validation/MANUAL-E2E-GUIDE.md
+++ b/src/praisonai-sandbox/e2e-validation/MANUAL-E2E-GUIDE.md
@@ -63,7 +63,7 @@ Expected stdout: `manager-ok`.
 
 ## 4. Docker path (optional)
 
-Requires a running Docker daemon and the `python:3.11-slim` image.
+Requires a running Docker daemon and the `python:3.12-slim` image.
 
 ```python
 import asyncio
@@ -71,7 +71,7 @@ from praisonai_sandbox import DockerSandbox
 
 
 async def main():
-    sandbox = DockerSandbox(image="python:3.11-slim")
+    sandbox = DockerSandbox(image="python:3.12-slim")
     await sandbox.start()
     try:
         result = await sandbox.execute("print('docker-ok')")

--- a/src/praisonai-sandbox/e2e-validation/run_e2e.py
+++ b/src/praisonai-sandbox/e2e-validation/run_e2e.py
@@ -115,7 +115,7 @@ async def _check_docker() -> Result:
     try:
         from praisonai_sandbox import DockerSandbox
 
-        sandbox = DockerSandbox(image="python:3.11-slim")
+        sandbox = DockerSandbox(image="python:3.12-slim")
         # Pulling the image can stall (slow/unavailable registry); bound it so
         # the optional check never hangs the whole run.
         await asyncio.wait_for(sandbox.start(), timeout=_DOCKER_TIMEOUT)

--- a/src/praisonai-sandbox/praisonai_sandbox/docker.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/docker.py
@@ -34,7 +34,7 @@ class DockerSandbox:
     Example:
         from praisonai_sandbox import DockerSandbox
         
-        sandbox = DockerSandbox(image="python:3.11-slim")
+        sandbox = DockerSandbox(image="python:3.12-slim")
         result = await sandbox.execute("print('Hello, World!')")
         print(result.stdout)  # Hello, World!
     
@@ -43,7 +43,11 @@ class DockerSandbox:
     
     def __init__(
         self,
-        image: str = "python:3.11-slim",
+        # Kept in step with the compute-side DockerCompute default. The two
+        # implementations of "docker" disagreed -- 3.11 here, 3.12 there -- so
+        # tools_run_on="docker" and run_in="docker" handed you different
+        # Pythons for the same word. Nobody chose that; they drifted.
+        image: str = "python:3.12-slim",
         config: Optional[SandboxConfig] = None,
     ):
         """Initialize the Docker sandbox.

--- a/src/praisonai/tests/unit/integrations/test_backend_semantics.py
+++ b/src/praisonai/tests/unit/integrations/test_backend_semantics.py
@@ -41,7 +41,8 @@ def test_hosted_agent_rejects_unregistered_providers():
     docker, flyio, ...) are registered managed runtimes via the backend
     registry, so ``HostedAgent(provider=...)`` resolves them. The guarantee
     that still matters is that a provider with no registered backend (an LLM
-    routing name like ``openai``/``gemini``) raises a helpful ``ValueError``.
+    routing name like ``openai``/``gemini``/``ollama``) raises a helpful
+    ``ValueError`` pointing the caller at ``LocalAgent``.
     """
     from praisonai.integrations import HostedAgent, HostedAgentConfig
     from praisonai.integrations.backend_registry import get_backend_registry
@@ -55,8 +56,8 @@ def test_hosted_agent_rejects_unregistered_providers():
     assert registry.is_available("modal")
     assert registry.is_available("e2b")
 
-    # Providers with no registered backend must still raise a helpful error
-    for provider in ("openai", "gemini"):
+    # LLM-routing providers have no registered backend -> raise and point at LocalAgent.
+    for provider in ("openai", "gemini", "ollama"):
         assert not registry.is_available(provider)
         with pytest.raises(ValueError) as exc_info:
             HostedAgent(provider=provider)


### PR DESCRIPTION
## The bug

`docker` is implemented twice — once as a compute provider in the wrapper, once as a sandbox backend in `praisonai-sandbox` — and their defaults had drifted a minor version apart:

```
tools_run_on="docker"  ->  Python 3.12.14
run_in="docker"        ->  Python 3.11.16
```

Same word, different container. Nobody decided this; two independent implementations of one idea diverged, and unifying the vocabulary made the divergence *easier* to reach rather than harder — both spellings now look like the same thing, so nothing warns you they aren't.

## The fix

The sandbox side moves to `python:3.12-slim` to match, along with the docs and examples quoting the old default. Verified against a live daemon:

```
tools_run_on='docker' -> Python 3.12.14
run_in='docker'       -> Python 3.12.14
```

A test asserts the two implementations agree, since the only reason this went unnoticed is that nothing ever compared them.

## What this does not fix

Roughly **3,000 lines implementing four vendors twice** across two packages — `docker`, `e2b`, `modal` and `daytona` each have a complete, independent implementation in both. This PR just stops the sharpest edge from cutting anyone today.

Full analysis of where those implementations should live, with the measurements behind it: https://claude.ai/code/artifact/b22a2d5f-ec59-4d3b-815f-fc85dfd09a35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Docker-based sandboxes now use Python 3.12 Slim by default.

- **Bug Fixes**
  - Updated sandbox configuration, constructors, examples, and validation workflows to consistently use the Python 3.12 Slim image.
  - Improved provider validation so supported compute providers resolve correctly while unsupported LLM-routing providers provide clearer guidance.

- **Tests**
  - Added regression coverage for default sandbox image consistency and provider handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->