### PR TITLE
fix(daytona): asking for 1024 GiB of RAM, and uploading files backwards

### DIFF
--- a/src/praisonai-agents/tests/unit/test_provider_matrix.py
+++ b/src/praisonai-agents/tests/unit/test_provider_matrix.py
@@ -249,3 +249,38 @@ def test_a_plugin_sandbox_reaches_both_parameters(monkeypatch):
     from praisonaiagents.managed._compute_bridge import available_providers
 
     assert "contributed-box" in available_providers()
+
+
+# ── the two implementations must agree on vendor CONVENTIONS, not just names ──
+def test_daytona_asks_for_memory_in_the_unit_the_sdk_documents():
+    """Daytona's Resources.memory is GiB. The compute side passed megabytes
+    straight through, so the default config asked for 1024 GiB of RAM and
+    could not provision. The sandbox side had learned the unit; the compute
+    side never did -- which is what two implementations of one vendor costs."""
+    import inspect
+
+    pytest.importorskip("praisonai.integrations.compute.daytona")
+    from praisonai.integrations.compute.daytona import DaytonaCompute
+
+    source = inspect.getsource(DaytonaCompute)
+    assert "memory_gib" in source or "/ 1024" in source, (
+        "the compute side must convert MB to GiB before calling Daytona"
+    )
+    assert "memory=config.memory_mb" not in source, (
+        "megabytes are being passed where the SDK documents GiB"
+    )
+
+
+def test_daytona_uploads_content_then_destination():
+    """`FileSystem.upload_file(src, dst)` -- content first. The arguments were
+    reversed on the compute side, so an upload wrote the path into a file
+    named after the content."""
+    import inspect
+
+    pytest.importorskip("praisonai.integrations.compute.daytona")
+    from praisonai.integrations.compute.daytona import DaytonaCompute
+
+    source = inspect.getsource(DaytonaCompute)
+    assert "upload_file(remote_path, content)" not in source, (
+        "upload_file takes (src, dst): content first, path second"
+    )

--- a/src/praisonai-agents/tests/unit/test_provider_matrix.py
+++ b/src/praisonai-agents/tests/unit/test_provider_matrix.py
@@ -252,35 +252,95 @@ def test_a_plugin_sandbox_reaches_both_parameters(monkeypatch):
 
 
 # ── the two implementations must agree on vendor CONVENTIONS, not just names ──
-def test_daytona_asks_for_memory_in_the_unit_the_sdk_documents():
+#
+# These exercise the SDK boundary rather than reading source text: a wrong
+# conversion or a reversed upload with different phrasing would still slip past
+# a substring check, and a harmless refactor could fail one. We mock the vendor
+# SDK and assert the value Daytona actually receives.
+def _daytona_with_recorded_provision(monkeypatch, config):
+    """Provision against a fake Daytona SDK and return the Resources it built."""
+    import sys
+    import types
+
+    recorded = {}
+
+    class _Resources:
+        def __init__(self, cpu=None, memory=None, **kw):
+            recorded["cpu"] = cpu
+            recorded["memory"] = memory
+
+    class _CreateParams:
+        def __init__(self, **kw):
+            recorded["params"] = kw
+
+    class _Sandbox:
+        id = "sbx-1"
+        class process:
+            @staticmethod
+            def exec(*a, **k):
+                return types.SimpleNamespace(exit_code=0, result="")
+
+    class _Client:
+        def create(self, params, timeout=120):
+            return _Sandbox()
+
+    fake = types.ModuleType("daytona_sdk")
+    fake.Daytona = lambda cfg: _Client()
+    fake.DaytonaConfig = lambda **kw: None
+    fake.Resources = _Resources
+    fake.CreateSandboxFromImageParams = _CreateParams
+    monkeypatch.setitem(sys.modules, "daytona_sdk", fake)
+
+    from praisonai.integrations.compute.daytona import DaytonaCompute
+
+    provider = DaytonaCompute(api_key="test-key")
+    provider._provision_sync(config)
+    return recorded
+
+
+def test_daytona_asks_for_memory_in_the_unit_the_sdk_documents(monkeypatch):
     """Daytona's Resources.memory is GiB. The compute side passed megabytes
     straight through, so the default config asked for 1024 GiB of RAM and
-    could not provision. The sandbox side had learned the unit; the compute
-    side never did -- which is what two implementations of one vendor costs."""
-    import inspect
-
+    could not provision. Assert the actual value handed to the SDK, not the
+    source that produces it."""
     pytest.importorskip("praisonai.integrations.compute.daytona")
-    from praisonai.integrations.compute.daytona import DaytonaCompute
+    from praisonaiagents.managed.protocols import ComputeConfig
 
-    source = inspect.getsource(DaytonaCompute)
-    assert "memory_gib" in source or "/ 1024" in source, (
-        "the compute side must convert MB to GiB before calling Daytona"
+    recorded = _daytona_with_recorded_provision(
+        monkeypatch, ComputeConfig(memory_mb=2048)
     )
-    assert "memory=config.memory_mb" not in source, (
-        "megabytes are being passed where the SDK documents GiB"
+    assert recorded["memory"] == 2, (
+        f"2048 MB must become 2 GiB, got {recorded['memory']}"
+    )
+
+    recorded = _daytona_with_recorded_provision(
+        monkeypatch, ComputeConfig(memory_mb=512)
+    )
+    assert recorded["memory"] == 1, (
+        f"sub-GiB requests must floor to 1 GiB, not 0, got {recorded['memory']}"
     )
 
 
-def test_daytona_uploads_content_then_destination():
+def test_daytona_uploads_content_then_destination(monkeypatch, tmp_path):
     """`FileSystem.upload_file(src, dst)` -- content first. The arguments were
     reversed on the compute side, so an upload wrote the path into a file
-    named after the content."""
-    import inspect
-
+    named after the content. Assert the order the SDK actually receives."""
     pytest.importorskip("praisonai.integrations.compute.daytona")
     from praisonai.integrations.compute.daytona import DaytonaCompute
 
-    source = inspect.getsource(DaytonaCompute)
-    assert "upload_file(remote_path, content)" not in source, (
-        "upload_file takes (src, dst): content first, path second"
-    )
+    calls = {}
+
+    class _FS:
+        def upload_file(self, src, dst, timeout=1800):
+            calls["src"] = src
+            calls["dst"] = dst
+
+    provider = DaytonaCompute(api_key="test-key")
+    provider._sandboxes["i"] = {"sandbox": type("S", (), {"fs": _FS()})()}
+
+    local = tmp_path / "payload.txt"
+    local.write_bytes(b"real-content")
+    assert provider._upload_sync("i", str(local), "/remote/dest.txt") is True
+
+    assert calls["src"] == b"real-content", "file content must be the src argument"
+    assert calls["dst"] == "/remote/dest.txt", "remote path must be the dst argument"

--- a/src/praisonai/praisonai/integrations/compute/daytona.py
+++ b/src/praisonai/praisonai/integrations/compute/daytona.py
@@ -88,7 +88,13 @@ class DaytonaCompute:
         except ImportError:
             raise ImportError("Daytona SDK required. Install with: pip install daytona-sdk")
 
-        resources = Resources(cpu=config.cpu, memory=config.memory_mb)
+        # Daytona's Resources.memory is in GiB, not MB -- "Amount of memory in
+        # GiB to allocate" per the SDK. Passing megabytes straight through
+        # asked for 1024 GiB of RAM on the default config, which fails to
+        # provision. The sandbox-side implementation already converted; this
+        # one never learned the unit.
+        memory_gib = max(1, round((config.memory_mb or 1024) / 1024))
+        resources = Resources(cpu=config.cpu, memory=memory_gib)
 
         params = CreateSandboxFromImageParams(
             image=config.image,
@@ -199,7 +205,10 @@ class DaytonaCompute:
         try:
             with open(local_path, "rb") as f:
                 content = f.read()
-            info["sandbox"].fs.upload_file(remote_path, content)
+            # upload_file(src, dst) -- content first, destination second.
+            # These were the wrong way round, so an upload wrote the path into
+            # a file named after the content.
+            info["sandbox"].fs.upload_file(content, remote_path)
             return True
         except Exception as e:
             logger.error("[daytona_compute] upload failed: %s", e)

--- a/src/praisonai/tests/unit/integrations/test_backend_semantics.py
+++ b/src/praisonai/tests/unit/integrations/test_backend_semantics.py
@@ -34,27 +34,34 @@ def test_local_agent_imports():
     assert TopLevelLocalAgentConfig is not None
 
 
-def test_hosted_agent_only_accepts_anthropic():
-    """Test that HostedAgent only accepts 'anthropic' as provider."""
+def test_hosted_agent_rejects_unregistered_providers():
+    """HostedAgent resolves registered runtimes and rejects unregistered ones.
+
+    Since the ``run_on=`` placement feature, compute backends (modal, e2b,
+    docker, flyio, ...) are registered managed runtimes via the backend
+    registry, so ``HostedAgent(provider=...)`` resolves them. The guarantee
+    that still matters is that a provider with no registered backend (an LLM
+    routing name like ``openai``/``gemini``) raises a helpful ``ValueError``.
+    """
     from praisonai.integrations import HostedAgent, HostedAgentConfig
-    
-    # Should work
+    from praisonai.integrations.backend_registry import get_backend_registry
+
+    # anthropic remains the builtin hosted runtime
     hosted = HostedAgent(provider="anthropic")
     assert hosted.provider == "anthropic"
-    
-    # Should raise ValueError for non-existent managed runtimes
-    with pytest.raises(ValueError) as exc_info:
-        HostedAgent(provider="modal")
-    assert "not yet available" in str(exc_info.value)
-    assert "LocalAgent" in str(exc_info.value)
-    
-    with pytest.raises(ValueError) as exc_info:
-        HostedAgent(provider="e2b")
-    assert "not yet available" in str(exc_info.value)
-    
-    with pytest.raises(ValueError) as exc_info:
-        HostedAgent(provider="openai")
-    assert "not yet available" in str(exc_info.value)
+
+    # Registered compute runtimes resolve rather than raise (placement feature)
+    registry = get_backend_registry()
+    assert registry.is_available("modal")
+    assert registry.is_available("e2b")
+
+    # Providers with no registered backend must still raise a helpful error
+    for provider in ("openai", "gemini"):
+        assert not registry.is_available(provider)
+        with pytest.raises(ValueError) as exc_info:
+            HostedAgent(provider=provider)
+        assert "not yet available" in str(exc_info.value)
+        assert "LocalAgent" in str(exc_info.value)
 
 
 def test_local_agent_rejects_provider_overload():


### PR DESCRIPTION
Two live defects on the **compute** side of Daytona. Both were found by comparing it against the **sandbox** side, which had already learned the conventions.

## 1. Memory units — asks for 1024 GiB

`daytona_sdk` documents `Resources.memory` as *"Amount of memory in GiB to allocate"*. The compute provider passed `ComputeConfig.memory_mb` straight through:

```python
Resources(cpu=config.cpu, memory=config.memory_mb)   # 1024 -> 1024 GiB
```

With the default config that requests **1024 GiB of RAM** — a provisioning failure, not a rounding error. The sandbox implementation converts correctly and always has:

```python
memory_gib = max(1, round(self.memory_mb / 1024))
```

## 2. Upload arguments reversed

`FileSystem.upload_file(src, dst)` — content first, destination second. Verified against the installed SDK:

```
FileSystem.upload_file(self, src: 'str | bytes', dst: 'str', timeout: int = 1800)
```

The compute side called `upload_file(remote_path, content)`, so an upload wrote the *path* into a file named after the *content*. The sandbox side calls it correctly.

## Why both survived

Neither is a typo in the ordinary sense. They are the same class of failure: **one of two implementations of a single vendor learned a convention and the other never did**, and nothing compared them. The wrapper's Daytona tests only assert `provider_name` and that the constructor exists — nothing exercises `provision()` or upload.

Tests now assert both conventions on the compute side, because a shared vendor *name* is not a shared understanding of that vendor.

Context: this sits inside a wider pattern where four vendors have two implementations each — analysed, with the duplication figures corrected, here: https://claude.ai/code/artifact/b22a2d5f-ec59-4d3b-815f-fc85dfd09a35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Daytona sandbox memory allocation to use the expected GiB units, with a minimum allocation of 1 GiB.
  * Fixed file uploads so content is sent to the intended remote destination correctly.

* **Improvements**
  * Registered compute runtimes such as Modal and E2B can now be resolved for hosted agents.
  * Hosted agents continue to reject providers that are not currently available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->