### PR TITLE
fix: handle Windows carriage returns and Unicode encoding in tests

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/features/examples.py
+++ b/src/praisonai-code/praisonai_code/cli/features/examples.py
@@ -541,7 +541,7 @@ class ReportGenerator:
                 lines.append("")
         
         md_path = self.output_dir / "report.md"
-        md_path.write_text('\n'.join(lines))
+        md_path.write_text('\n'.join(lines), encoding='utf-8')
         return md_path
     
     def save_logs(self, report: RunReport) -> Path:

--- a/src/praisonai/tests/unit/cli/test_custom_definitions.py
+++ b/src/praisonai/tests/unit/cli/test_custom_definitions.py
@@ -407,7 +407,7 @@ class TestShellSubstitution:
                 _os.environ.pop(SHELL_SUBSTITUTION_ENV, None)
                 assert _config_allows_shell() is True
                 result = interpolate_command_template("diff")
-                assert result == "Output: hi"
+                assert result.strip() == "Output: hi" 
 
 
 class TestIntegrationFunctions:

--- a/src/praisonai/tests/unit/cli/test_examples_runner.py
+++ b/src/praisonai/tests/unit/cli/test_examples_runner.py
@@ -388,12 +388,12 @@ class TestReportGenerator:
         md_path = generator.generate_markdown(report)
         
         assert md_path.exists()
-        content = md_path.read_text()
+        content = md_path.read_text(encoding='utf-8')  # ← Add encoding='utf-8' here
         
         assert "# Examples Run Report" in content
         assert "test1.py" in content
         assert "passed" in content.lower()
-    
+
     def test_save_log_files(self, tmp_path):
         """Test log files are saved correctly."""
         from praisonai.cli.features.examples import ReportGenerator, ExampleResult, RunReport


### PR DESCRIPTION
# Fix: Handle Windows Carriage Returns and Unicode Encoding in Tests

## What This PR Fixes

- Adds `.strip()` to `test_config_allow_shell_enables` for Windows compatibility
- Adds `encoding="utf-8"` to `write_text()` in `generate_markdown`
- Adds `encoding="utf-8"` to `read_text()` in `test_generate_markdown_report`
- Fixes cross-platform test failures caused by Windows carriage returns and default `cp1252` encoding

## Problem

Some tests were failing on Windows due to platform-specific behavior.

### 1. Windows Carriage Returns

The shell substitution test output contains Windows carriage returns (`\r`), causing the assertion to fail even though the actual output is correct.

### 2. Unicode Encoding

The Markdown report contains Unicode characters such as emojis (`✅`, `❌`).

Windows may use `cp1252` as the default encoding, which can cause encoding/decoding errors when writing or reading the generated Markdown file.

## Solution

### Shell Test

Added `.strip()` to remove platform-specific whitespace and carriage returns:

```python
assert result.strip() == "Output: hi"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for generated Markdown reports by ensuring consistent UTF-8 encoding.

* **Tests**
  * Updated command output validation to ignore surrounding whitespace.
  * Updated report verification to read generated Markdown files with UTF-8 encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->