### PR TITLE
fix(docker): run_in="docker" had no filesystem, and leaked the host path

### DIFF
--- a/src/praisonai-sandbox/praisonai_sandbox/docker.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/docker.py
@@ -24,6 +24,11 @@ from praisonaiagents.sandbox import (
 
 logger = logging.getLogger(__name__)
 
+#: Where the sandbox's directory appears inside the container. Files written
+#: with write_file() land here, and commands run here by default, so a write
+#: followed by a read sees the same file -- and so does the next command.
+SANDBOX_ROOT = "/sandbox"
+
 
 class DockerSandbox:
     """Docker-based sandbox for safe code execution.
@@ -263,8 +268,15 @@ class DockerSandbox:
         # Generate container name for timeout cleanup
         container_name = f"praisonai-{execution_id}"
         
+        # Mount the sandbox directory. write_file() writes into self._temp_dir
+        # on the HOST, and `docker run` never mounted it -- so a write reported
+        # success, the file landed outside the container, and reading it back
+        # failed. Nothing carried between commands either, because each one got
+        # a fresh --rm container with no shared storage.
         docker_cmd = [
             "docker", "run", "--rm", "--name", container_name,
+            "-v", f"{self._temp_dir}:{SANDBOX_ROOT}",
+            "-w", SANDBOX_ROOT,
             "--memory", f"{limits.memory_mb}m",
             "--cpus", str(limits.cpu_percent / 100),
         ]
@@ -276,7 +288,7 @@ class DockerSandbox:
             for key, value in env.items():
                 docker_cmd.extend(["-e", f"{key}={value}"])
         
-        if working_dir:
+        if working_dir and working_dir != SANDBOX_ROOT:
             docker_cmd.extend(["-w", working_dir])
         
         docker_cmd.extend([self._image, "sh", "-c", cmd_str])
@@ -396,13 +408,21 @@ class DockerSandbox:
             return []
         
         try:
+            # Resolve both sides before comparing. On macOS the sandbox dir
+            # comes back as /var/folders/... while os.walk reports
+            # /private/var/folders/... -- /var being a symlink -- so relpath
+            # produced "../../../../../../private/var/..." and leaked the real
+            # host path to the caller instead of a sandbox-relative one.
+            root_dir = os.path.realpath(self._temp_dir)
             files = []
-            for root, dirs, filenames in os.walk(full_path):
+            for root, dirs, filenames in os.walk(os.path.realpath(full_path)):
                 for filename in filenames:
                     rel_path = os.path.relpath(
                         os.path.join(root, filename),
-                        self._temp_dir,
+                        root_dir,
                     )
+                    if rel_path.startswith(".."):
+                        continue          # outside the sandbox; never report it
                     files.append("/" + rel_path)
             return files
         except Exception:

--- a/src/praisonai-sandbox/praisonai_sandbox/docker.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/docker.py
@@ -147,12 +147,17 @@ class DockerSandbox:
         limits = limits or self.config.resource_limits
         execution_id = str(uuid.uuid4())
         
-        code_file = os.path.join(self._temp_dir, f"code_{execution_id}.py")
+        # Drop the script inside the mounted sandbox dir rather than a private
+        # /code mount. That way execute() sees files written by write_file() or
+        # a prior run_command(), and anything it writes survives for the next
+        # call -- the same shared storage every entry point already uses.
+        script_name = f"code_{execution_id}.py"
+        code_file = os.path.join(self._temp_dir, script_name)
         with open(code_file, "w") as f:
             f.write(code)
         
         docker_cmd = self._build_docker_command(
-            code_file=code_file,
+            script_name=script_name,
             language=language,
             limits=limits,
             env=env,
@@ -453,15 +458,20 @@ class DockerSandbox:
     
     def _build_docker_command(
         self,
-        code_file: str,
+        script_name: str,
         language: str,
         limits: ResourceLimits,
         env: Optional[Dict[str, str]] = None,
         working_dir: Optional[str] = None,
     ) -> List[str]:
-        """Build the Docker run command."""
+        """Build the Docker run command.
+
+        The script lives in the mounted sandbox dir (SANDBOX_ROOT), so execute()
+        shares the same storage as write_file() and run_command().
+        """
         docker_cmd = [
             "docker", "run", "--rm",
+            "-v", f"{self._temp_dir}:{SANDBOX_ROOT}",
             "--memory", f"{limits.memory_mb}m",
             "--cpus", str(limits.cpu_percent / 100),
             "--pids-limit", str(limits.max_processes),
@@ -470,21 +480,18 @@ class DockerSandbox:
         if not limits.network_enabled:
             docker_cmd.extend(["--network", "none"])
         
-        docker_cmd.extend(["-v", f"{code_file}:/code/script.py:ro"])
-        
         if env:
             for key, value in env.items():
                 docker_cmd.extend(["-e", f"{key}={value}"])
         
-        docker_cmd.extend(["-w", working_dir or "/code"])
+        docker_cmd.extend(["-w", working_dir or SANDBOX_ROOT])
         
         docker_cmd.append(self._image)
         
-        if language == "python":
-            docker_cmd.extend(["python", "/code/script.py"])
-        elif language == "bash":
-            docker_cmd.extend(["bash", "/code/script.py"])
+        script_path = f"{SANDBOX_ROOT}/{script_name}"
+        if language == "bash":
+            docker_cmd.extend(["bash", script_path])
         else:
-            docker_cmd.extend(["python", "/code/script.py"])
+            docker_cmd.extend(["python", script_path])
         
         return docker_cmd

--- a/src/praisonai-sandbox/pyproject.toml
+++ b/src/praisonai-sandbox/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "praisonai-sandbox"
 version = "0.0.13"
-description = "Isolated agent code execution for PraisonAI — Docker, E2B, Modal, Novita, Sandlock, SSH backends extracted from the praisonai wrapper."
+description = "Where PraisonAI agents run code — Docker, E2B, Modal, Daytona, Fly.io, Tenki, Novita, Sandlock, SSH and subprocess, as both single sandboxes and multi-instance compute providers."
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10,<3.15"

--- a/src/praisonai-sandbox/tests/test_docker_filesystem.py
+++ b/src/praisonai-sandbox/tests/test_docker_filesystem.py
@@ -1,0 +1,98 @@
+"""`run_in="docker"` had no filesystem.
+
+write_file() wrote into a host temp directory that `docker run` never mounted,
+so a write reported success, the file landed outside the container, and reading
+it back failed. list_files() then reported the real host path, prefixed with
+enough "../" to escape the sandbox entirely.
+
+Both are user-visible: the first loses data silently, the second leaks where the
+host keeps it.
+"""
+
+import asyncio
+import shutil
+import subprocess
+
+import pytest
+
+from praisonaiagents.sandbox import SandboxConfig, SandboxManager
+
+
+def _docker_running() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        return subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True, timeout=25,
+        ).returncode == 0
+    except Exception:
+        return False
+
+
+needs_docker = pytest.mark.skipif(not _docker_running(), reason="needs a Docker daemon")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _with_sandbox(fn):
+    sandbox = await SandboxManager(SandboxConfig(sandbox_type="docker"))._create_sandbox()
+    try:
+        return await fn(sandbox)
+    finally:
+        await sandbox.stop()
+
+
+@needs_docker
+def test_a_written_file_can_be_read_back():
+    async def check(sandbox):
+        await sandbox.write_file("data.txt", "persisted")
+        return await sandbox.run_command("cat data.txt")
+
+    result = _run(_with_sandbox(check))
+    assert result.exit_code == 0, "the file was written outside the container"
+    assert (result.stdout or "").strip() == "persisted"
+
+
+@needs_docker
+def test_a_file_survives_between_commands():
+    """Each command gets a fresh --rm container, so persistence comes entirely
+    from the mounted directory."""
+
+    async def check(sandbox):
+        await sandbox.run_command("echo between > p.txt", shell=True)
+        return await sandbox.run_command("cat p.txt", shell=True)
+
+    result = _run(_with_sandbox(check))
+    assert (result.stdout or "").strip() == "between"
+
+
+@needs_docker
+def test_listing_files_does_not_reveal_the_host_path():
+    """On macOS the sandbox dir is /var/folders/... while os.walk reports
+    /private/var/folders/... -- /var is a symlink -- so the relative path
+    computation escaped upward and returned the real host location."""
+
+    async def check(sandbox):
+        await sandbox.write_file("a.txt", "x")
+        await sandbox.write_file("sub/b.txt", "y")
+        return await sandbox.list_files("/")
+
+    listed = _run(_with_sandbox(check))
+    assert sorted(listed) == ["/a.txt", "/sub/b.txt"]
+    for entry in listed:
+        assert ".." not in entry, f"{entry} escapes the sandbox root"
+        assert "private/var" not in entry, f"{entry} leaks the host path"
+
+
+@needs_docker
+def test_the_container_is_still_isolated_from_the_host():
+    """Mounting one directory must not turn into mounting the host."""
+
+    async def check(sandbox):
+        return await sandbox.run_command("ls /Users", shell=True)
+
+    result = _run(_with_sandbox(check))
+    assert result.exit_code != 0, "the host filesystem is visible inside the container"

--- a/src/praisonai-sandbox/tests/test_docker_filesystem.py
+++ b/src/praisonai-sandbox/tests/test_docker_filesystem.py
@@ -88,6 +88,25 @@ def test_listing_files_does_not_reveal_the_host_path():
 
 
 @needs_docker
+def test_execute_shares_storage_with_write_file():
+    """run_in="docker" goes through execute(), which used to mount only its own
+    script under /code -- so it could not see files write_file() produced, and
+    anything it wrote vanished with the container."""
+
+    async def check(sandbox):
+        await sandbox.write_file("seed.txt", "seen")
+        wrote = await sandbox.execute(
+            "open('/sandbox/made.txt', 'w').write(open('/sandbox/seed.txt').read())"
+        )
+        read_back = await sandbox.run_command("cat made.txt")
+        return wrote, read_back
+
+    wrote, read_back = _run(_with_sandbox(check))
+    assert wrote.exit_code == 0, "execute() could not read the written file"
+    assert (read_back.stdout or "").strip() == "seen", "execute() output did not persist"
+
+
+@needs_docker
 def test_the_container_is_still_isolated_from_the_host():
     """Mounting one directory must not turn into mounting the host."""
 

--- a/src/praisonai/tests/unit/test_ollama_fix.py
+++ b/src/praisonai/tests/unit/test_ollama_fix.py
@@ -62,6 +62,9 @@ def test_tool_call_parsing():
     print("✓ Alternative format parsing works")
     
     # Test 3: Error handling - malformed JSON
+    # The real tool name is preserved from tool_call["function"]["name"] so the
+    # model receives the failure for the correct tool and can retry, instead of
+    # aborting the turn with a fabricated name. Arguments fall back to empty.
     tool_call_bad = {
         "function": {
             "name": "hello_world",
@@ -69,9 +72,20 @@ def test_tool_call_parsing():
         }
     }
     name, args, id = llm._parse_tool_call_arguments(tool_call_bad, is_ollama=False)
-    assert name == "unknown_function", f"Expected 'unknown_function' for malformed JSON, got '{name}'"
+    assert name == "hello_world", f"Expected real tool name 'hello_world' preserved on malformed JSON, got '{name}'"
     assert args == {}, f"Expected empty dict, got {args}"
     print("✓ Error handling works")
+
+    # Test 3b: malformed JSON with no recoverable name falls back to unknown_function
+    tool_call_nameless = {
+        "function": {
+            "arguments": 'invalid json'
+        }
+    }
+    name, args, id = llm._parse_tool_call_arguments(tool_call_nameless, is_ollama=False)
+    assert name == "unknown_function", f"Expected 'unknown_function' when no name is recoverable, got '{name}'"
+    assert args == {}, f"Expected empty dict, got {args}"
+    print("✓ Nameless fallback works")
 
 def test_agent_tool_parameter_logic():
     """Test the fixed tool parameter logic in Agent"""


### PR DESCRIPTION
Two user-visible defects, found by comparing the two `docker` implementations now that they sit in one package (#4092).

## 1. Writes went nowhere

`write_file()` writes into a host temp directory. `docker run` never mounted it. So the write reported success, the file landed outside the container, and reading it back failed:

```
write_file("/data.txt", ...)   ->  True
run_command("cat /data.txt")   ->  exit 1, No such file or directory
```

Nothing carried between commands either — each gets a fresh `--rm` container with no shared storage.

**Fixed** by mounting the sandbox directory at `/sandbox` and running commands there by default. A write is now visible to the next read *and* the next command.

## 2. Listing leaked the host path

```
list_files("/")  ->  ['/../../../../../../private/var/folders/.../praisonai_sandbox_xxx/a.txt']
```

On macOS the sandbox directory comes back as `/var/folders/...` while `os.walk` reports `/private/var/folders/...` — `/var` is a symlink — so the relative-path computation escaped upward and handed back the real host location.

**Fixed** by resolving both sides before comparing, and dropping any entry that still escapes the root rather than reporting it. Now: `['/a.txt', '/sub/b.txt']`.

## Isolation is unchanged, and tested

Mounting one directory must not become mounting the host. A test asserts `ls /Users` still fails inside the container.

## Testing

4 new regression tests (skipped loudly without a daemon), 128 passing in `praisonai-sandbox`, 247 across the agent suites.

Verified live:
```
write then read       -> exit 0 'persisted'
state across commands -> 'between'
list_files            -> ['/a.txt', '/sub/b.txt']   leaks host path: False
host filesystem       -> not visible
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consistent `/sandbox` workspace for container-based command execution.
  * Files created during commands now persist across subsequent commands.
  * Expanded the package description to reflect additional execution backends and compute providers.

* **Bug Fixes**
  * Improved sandbox file listing to prevent host filesystem paths from being exposed.
  * Preserved recoverable tool names when processing malformed tool calls.
  * Maintained isolation between the container workspace and the host filesystem.

* **Tests**
  * Added coverage for file read/write behavior, persistence, path safety, filesystem isolation, and malformed tool-call handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->