### PR TITLE
fix(sandbox): a container could escape to the host, and every run leaked one

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/execution_location.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_location.py
@@ -58,7 +58,11 @@ _COMPUTE_ONLY_WORDS = {"local": "a plain shell on this machine (no policy applie
 # Tiers that separate a process but do NOT contain it. Verified: under the
 # subprocess backend, outbound network still works and ~/.ssh is readable even
 # though SecurityPolicy declares them blocked.
-_NOT_A_BOUNDARY = {"subprocess", "local", "native"}
+# `native` is deliberately absent: it aliases sandlock, which applies Landlock,
+# seccomp, a scrubbed environment and deny-all networking. Listing it here made
+# tools_run_on="native" and tools_run_on="sandlock" -- the same backend --
+# disagree about whether they contain anything.
+_NOT_A_BOUNDARY = {"subprocess", "local"}
 
 
 def say_place(name: Any, *, via: str = "sandbox") -> str:

--- a/src/praisonai-agents/praisonaiagents/agent/tools_placement.py
+++ b/src/praisonai-agents/praisonaiagents/agent/tools_placement.py
@@ -71,8 +71,12 @@ def _shutdown_orphan(shared: Any, name: str) -> None:
     try:
         shared.shutdown()
         logger.debug("[tools_placement] released the sandbox belonging to %s", name)
-    except Exception:  # pragma: no cover - teardown must stay quiet
-        logger.debug("[tools_placement] could not release the sandbox for %s", name)
+    except Exception as exc:  # pragma: no cover - teardown must stay quiet
+        # Loud enough to notice: a failed release means a container, or a
+        # billed cloud instance, is still running after the agent is gone.
+        logger.warning(
+            "[tools_placement] could not release the sandbox for %s: %s", name, exc
+        )
 
 
 def ensure_tools_placed(agent: Any) -> None:

--- a/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
+++ b/src/praisonai-agents/praisonaiagents/managed/shared_compute.py
@@ -142,6 +142,8 @@ class SharedCompute:
             logger.info("[shared_compute] shut down instance %s", self.instance_id)
         except Exception as exc:  # pragma: no cover - teardown must not mask errors
             logger.warning("[shared_compute] shutdown failed for %s: %s", self.instance_id, exc)
+            self.instance_id = None
+            raise            # the caller logs whether the sandbox was released
         finally:
             self.instance_id = None
 

--- a/src/praisonai-sandbox/praisonai_sandbox/_compat.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/_compat.py
@@ -6,6 +6,19 @@ import os
 
 logger = logging.getLogger(__name__)
 
+# The descriptor-relative walk relies on POSIX-only openat semantics:
+# O_DIRECTORY / O_NOFOLLOW and os.open()'s dir_fd argument. Windows has none of
+# them -- referencing os.O_DIRECTORY there is an AttributeError, and dir_fd is
+# unsupported -- so the whole approach is guarded behind this flag. Docker on
+# Windows talks to a Linux daemon, so the container-side race these helpers
+# defend against does not exist on the host; falling back to the resolved-string
+# guard there is both correct and the only thing that runs.
+_HAS_OPENAT = (
+    hasattr(os, "O_NOFOLLOW")
+    and hasattr(os, "O_DIRECTORY")
+    and os.open in getattr(os, "supports_dir_fd", set())
+)
+
 
 def safe_sandbox_path(temp_dir: str | None, path: str) -> str | None:
     """Resolve a caller-supplied path to an absolute path inside temp_dir.
@@ -66,6 +79,19 @@ def open_in_sandbox(temp_dir: str | None, path: str, flags: int, mode: int = 0o6
         logger.warning("Path traversal attempt blocked: %s", path)
         return None
 
+    if not _HAS_OPENAT:
+        # No openat here (Windows). The container-side symlink race this walk
+        # defends against cannot occur -- Docker Desktop runs Linux containers
+        # in a VM, so nothing shares this host directory -- so the resolved
+        # string guard is sufficient and is the only thing that can run.
+        resolved = safe_sandbox_path(temp_dir, path)
+        if resolved is None:
+            return None
+        try:
+            return os.open(resolved, flags, mode)
+        except OSError:
+            return None
+
     try:
         root_fd = os.open(temp_dir, os.O_RDONLY | os.O_DIRECTORY)
     except OSError:
@@ -106,6 +132,20 @@ def makedirs_in_sandbox(temp_dir: str | None, path: str) -> bool:
     parts = _components(path)
     if parts is None:
         return False
+
+    if not _HAS_OPENAT:
+        # Windows fallback: no openat, and no host-shared directory to race.
+        # Create the parent chain through the resolved string guard.
+        if len(parts) <= 1:
+            return True
+        resolved = safe_sandbox_path(temp_dir, "/".join(parts[:-1]))
+        if resolved is None:
+            return False
+        try:
+            os.makedirs(resolved, exist_ok=True)
+            return True
+        except OSError:
+            return False
 
     try:
         dir_fd = os.open(temp_dir, os.O_RDONLY | os.O_DIRECTORY)

--- a/src/praisonai-sandbox/praisonai_sandbox/_compat.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/_compat.py
@@ -1,5 +1,6 @@
 """Path-safety helper for sandbox backends."""
 
+import errno
 import logging
 import os
 
@@ -27,3 +28,111 @@ def safe_sandbox_path(temp_dir: str | None, path: str) -> str | None:
         logger.warning("Path traversal attempt blocked: %s", path)
         return None
     return candidate
+
+
+def _components(path: str) -> list | None:
+    """Split a caller path into components, rejecting anything that climbs."""
+    parts = [p for p in path.lstrip("/").split("/") if p not in ("", ".")]
+    if any(p == ".." for p in parts):
+        return None
+    return parts
+
+
+def open_in_sandbox(temp_dir: str | None, path: str, flags: int, mode: int = 0o600):
+    """Open a path strictly inside ``temp_dir``, refusing symlinks at every level.
+
+    ``safe_sandbox_path`` validates a path *string* and the caller then opens
+    that string -- two syscalls with a gap between them. That was harmless while
+    only the host could write to the sandbox directory. Once the directory is
+    bind-mounted into the container, code inside it can swap a name between a
+    regular file and a symlink and win the race: a loop of
+    ``ln -s /etc/passwd notes.txt`` against repeated writes escaped to arbitrary
+    host files within a few hundred attempts, and leaked a host secret on the
+    fourth read.
+
+    Resolving the string more carefully cannot fix that -- any check performed
+    before the open can be invalidated after it. So this never re-opens by name.
+    It walks the path one component at a time relative to an open directory
+    descriptor, with ``O_NOFOLLOW`` on each step, so a symlink substituted at
+    any level fails the open instead of redirecting it.
+
+    Returns an open file descriptor, or None if the path escapes or a component
+    is a symlink. The caller owns the descriptor.
+    """
+    if not temp_dir:
+        return None
+    parts = _components(path)
+    if parts is None or not parts:
+        logger.warning("Path traversal attempt blocked: %s", path)
+        return None
+
+    try:
+        root_fd = os.open(temp_dir, os.O_RDONLY | os.O_DIRECTORY)
+    except OSError:
+        return None
+
+    opened = [root_fd]
+    try:
+        dir_fd = root_fd
+        for part in parts[:-1]:
+            try:
+                dir_fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=dir_fd,
+                )
+            except OSError:
+                logger.warning("Blocked traversal through %r in %s", part, path)
+                return None
+            opened.append(dir_fd)
+        try:
+            return os.open(parts[-1], flags | os.O_NOFOLLOW, mode, dir_fd=dir_fd)
+        except OSError as exc:
+            if exc.errno in (errno.ELOOP, errno.EMLINK):
+                logger.warning("Refused to follow a symlink at %s", path)
+            return None
+    finally:
+        for fd in opened:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def makedirs_in_sandbox(temp_dir: str | None, path: str) -> bool:
+    """Create the parent directories of ``path`` without following symlinks."""
+    if not temp_dir:
+        return False
+    parts = _components(path)
+    if parts is None:
+        return False
+
+    try:
+        dir_fd = os.open(temp_dir, os.O_RDONLY | os.O_DIRECTORY)
+    except OSError:
+        return False
+
+    opened = [dir_fd]
+    try:
+        for part in parts[:-1]:
+            try:
+                os.mkdir(part, 0o700, dir_fd=dir_fd)
+            except FileExistsError:
+                pass
+            except OSError:
+                return False
+            try:
+                dir_fd = os.open(
+                    part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=dir_fd
+                )
+            except OSError:
+                logger.warning("Blocked traversal through %r in %s", part, path)
+                return False
+            opened.append(dir_fd)
+        return True
+    finally:
+        for fd in opened:
+            try:
+                os.close(fd)
+            except OSError:
+                pass

--- a/src/praisonai-sandbox/praisonai_sandbox/compute/_sync_base.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/compute/_sync_base.py
@@ -34,9 +34,25 @@ class SyncComputeProvider:
     """
 
     async def _offload(self, fn, *args):
-        """Run a blocking SDK call without stalling the event loop."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, fn, *args)
+        """Run a blocking SDK call without stalling the event loop.
+
+        Falls back to calling inline when the default executor is gone.
+        Teardown often runs during interpreter shutdown -- a weakref finalizer
+        reclaiming a sandbox as the process ends -- and by then
+        concurrent.futures has already set its own atexit flag, so
+        run_in_executor raises "cannot schedule new futures after interpreter
+        shutdown". That failure was swallowed and logged as a successful
+        release, so every run leaked its container while reporting otherwise.
+
+        Blocking is fine on that path: there is no event loop left to starve.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, fn, *args)
+        except RuntimeError as exc:
+            if "interpreter shutdown" not in str(exc) and "no running event loop" not in str(exc):
+                raise
+            return fn(*args)
 
     # ── the protocol, in terms of the sync half ──────────────────────────────
     async def provision(self, config) -> Any:

--- a/src/praisonai-sandbox/praisonai_sandbox/compute/docker.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/compute/docker.py
@@ -325,13 +325,20 @@ class DockerCompute(SyncComputeProvider):
             return None
         try:
             repository, _, tag = ref.partition(":")
-            # Scrub the forwarded secrets out of the committed image. `docker
-            # commit` preserves Config.Env, so every model API key handed to
-            # the container was baked into an image that persists for days --
-            # readable by anyone who can run `docker inspect`. The capture is
-            # meant to reuse the installed *packages*, not the credentials that
-            # happened to be in the environment when they were installed.
-            scrub = [f"ENV {name}=" for name in sorted(_FORWARDED_SECRETS)]
+            # Scrub every forwarded env value out of the committed image.
+            # `docker commit` preserves Config.Env, so anything handed to the
+            # container -- a model API key, or an arbitrary secret the caller
+            # put in ComputeConfig.env -- was baked into an image that persists
+            # for days, readable by anyone who can run `docker inspect`. The
+            # capture is meant to reuse the installed *packages*, not the
+            # credentials that happened to be in the environment when they were
+            # installed. The known-secret set is only a floor; the config's own
+            # env names are the values actually injected into THIS container, so
+            # scrub their union rather than trusting a fixed list to be complete.
+            config = info.get("config")
+            config_env = getattr(config, "env", None) or {}
+            names = _FORWARDED_SECRETS | {str(name) for name in config_env}
+            scrub = [f"ENV {name}=" for name in sorted(names)]
             info["container"].commit(
                 repository=repository, tag=tag or "latest", changes=scrub
             )

--- a/src/praisonai-sandbox/praisonai_sandbox/compute/docker.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/compute/docker.py
@@ -7,6 +7,7 @@ sandbox execution. Supports auto-shutdown after idle timeout.
 Requires: ``pip install docker``
 """
 
+from ._sync_base import SyncComputeProvider
 import asyncio
 import contextlib
 import json
@@ -17,6 +18,17 @@ import uuid
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 logger = logging.getLogger(__name__)
+
+#: Environment variables treated as secrets: forwarded into a container so the
+#: agent can reach its model, and scrubbed back out of any image committed from
+#: that container. Keep in step with ComputeManagedAgent._KEY_VARS.
+_FORWARDED_SECRETS = frozenset({
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "GROQ_API_KEY", "MISTRAL_API_KEY", "COHERE_API_KEY", "OPENROUTER_API_KEY",
+    "DEEPSEEK_API_KEY", "XAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_BASE",
+    "E2B_API_KEY", "DAYTONA_API_KEY", "NOVITA_API_KEY", "TENKI_API_KEY",
+    "FLY_API_TOKEN", "MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET",
+})
 
 # Local image namespace for post-setup captures (``docker commit``).
 _CAPTURE_IMAGE = "praisonai-env"
@@ -102,7 +114,7 @@ def _update_registry(
         _save_registry(registry)
 
 
-class DockerCompute:
+class DockerCompute(SyncComputeProvider):
     """Docker container-based compute provider.
 
     Satisfies ``ComputeProviderProtocol`` (Core SDK).
@@ -156,7 +168,7 @@ class DockerCompute:
 
     async def provision(self, config) -> Any:
         loop = asyncio.get_running_loop()
-        info = await loop.run_in_executor(None, self._provision_sync, config)
+        info = await self._offload(self._provision_sync, config)
         return info
 
     def _provision_sync(self, config) -> Any:
@@ -313,7 +325,16 @@ class DockerCompute:
             return None
         try:
             repository, _, tag = ref.partition(":")
-            info["container"].commit(repository=repository, tag=tag or "latest")
+            # Scrub the forwarded secrets out of the committed image. `docker
+            # commit` preserves Config.Env, so every model API key handed to
+            # the container was baked into an image that persists for days --
+            # readable by anyone who can run `docker inspect`. The capture is
+            # meant to reuse the installed *packages*, not the credentials that
+            # happened to be in the environment when they were installed.
+            scrub = [f"ENV {name}=" for name in sorted(_FORWARDED_SECRETS)]
+            info["container"].commit(
+                repository=repository, tag=tag or "latest", changes=scrub
+            )
         except Exception as e:
             logger.warning(
                 "[docker_compute] capture failed for %s (ephemeral fallback): %s",
@@ -390,7 +411,7 @@ class DockerCompute:
 
     async def shutdown(self, instance_id: str) -> None:
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._shutdown_sync, instance_id)
+        await self._offload(self._shutdown_sync, instance_id)
 
     def _find_container(self, instance_id: str):
         """Look up a container by name, for instances this process didn't start.
@@ -469,10 +490,7 @@ class DockerCompute:
         command: str,
         timeout: int = 300,
     ) -> Dict[str, Any]:
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            None, self._execute_sync, instance_id, command, timeout,
-        )
+        return await self._offload(self._execute_sync, instance_id, command, timeout)
 
     def _execute_sync(
         self, instance_id: str, command: str, timeout: int,
@@ -618,7 +636,7 @@ class DockerCompute:
 
         try:
             loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(None, _list_sync)
+            return await self._offload(_list_sync)
         except Exception as exc:
             logger.debug("[docker_compute] list_instances failed: %s", exc)
             return []

--- a/src/praisonai-sandbox/praisonai_sandbox/docker.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/docker.py
@@ -29,6 +29,10 @@ logger = logging.getLogger(__name__)
 #: followed by a read sees the same file -- and so does the next command.
 SANDBOX_ROOT = "/sandbox"
 
+#: Lowest pids cap a container can run a shell under. Below roughly this,
+#: `docker run` dies before the command starts rather than limiting it.
+MIN_CONTAINER_PIDS = 128
+
 
 class DockerSandbox:
     """Docker-based sandbox for safe code execution.
@@ -285,6 +289,22 @@ class DockerSandbox:
             "--memory", f"{limits.memory_mb}m",
             "--cpus", str(limits.cpu_percent / 100),
         ]
+
+        # max_processes was accepted and ignored here while the other execution
+        # path applied it, so a fork bomb ran unbounded through the bridged
+        # execute_command tool. Docker enforces pids per CONTAINER, so unlike
+        # setrlimit's per-user RLIMIT_NPROC it means what it says.
+        #
+        # The floor matters though. max_processes defaults to 10, a number
+        # chosen for the rlimit world, and `--pids-limit 10` kills the
+        # container before the shell finishes starting -- `docker run` exits
+        # 125 with "No such container". A shell, its pipeline and the command
+        # itself need more than that, so the cap is raised to something a
+        # container can actually live within. It still bounds a fork bomb,
+        # which is the point; it just stops the bound from being the bug.
+        if limits.max_processes and limits.max_processes > 0:
+            pids = max(limits.max_processes, MIN_CONTAINER_PIDS)
+            docker_cmd.extend(["--pids-limit", str(pids)])
         
         if not limits.network_enabled:
             docker_cmd.extend(["--network", "none"])
@@ -363,44 +383,55 @@ class DockerSandbox:
         path: str,
         content: Union[str, bytes],
     ) -> bool:
-        """Write a file to the sandbox."""
-        from ._compat import safe_sandbox_path
-        
-        full_path = safe_sandbox_path(self._temp_dir, path)
-        if full_path is None:
+        """Write a file to the sandbox.
+
+        Opened through open_in_sandbox rather than by path string: the sandbox
+        directory is bind-mounted into the container, so anything that
+        validates a name and then re-opens it can be raced by code inside.
+        """
+        from ._compat import makedirs_in_sandbox, open_in_sandbox
+
+        if not makedirs_in_sandbox(self._temp_dir, path):
             return False
-        
-        os.makedirs(os.path.dirname(full_path), exist_ok=True)
-        
+
+        payload = content if isinstance(content, bytes) else content.encode()
+        fd = open_in_sandbox(
+            self._temp_dir, path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        )
+        if fd is None:
+            return False
         try:
-            mode = "wb" if isinstance(content, bytes) else "w"
-            with open(full_path, mode) as f:
-                f.write(content)
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
             return True
-        except Exception as e:
-            logger.error(f"Failed to write file: {e}")
+        except OSError as exc:
+            logger.warning("Failed to write %s in sandbox: %s", path, exc)
             return False
-    
+
     async def read_file(
         self,
         path: str,
     ) -> Optional[Union[str, bytes]]:
-        """Read a file from the sandbox."""
-        from ._compat import safe_sandbox_path
-        
-        full_path = safe_sandbox_path(self._temp_dir, path)
-        if full_path is None or not os.path.exists(full_path):
+        """Read a file from the sandbox.
+
+        Symlink-proof for the same reason as write_file: a name validated a
+        moment ago can point somewhere else by the time it is opened.
+        """
+        from ._compat import open_in_sandbox
+
+        fd = open_in_sandbox(self._temp_dir, path, os.O_RDONLY)
+        if fd is None:
             return None
-        
         try:
-            with open(full_path, "r") as f:
-                return f.read()
-        except UnicodeDecodeError:
-            with open(full_path, "rb") as f:
-                return f.read()
-        except Exception:
+            with os.fdopen(fd, "rb") as handle:
+                raw = handle.read()
+        except OSError:
             return None
-    
+        try:
+            return raw.decode()
+        except UnicodeDecodeError:
+            return raw
+
     async def list_files(
         self,
         path: str = "/",

--- a/src/praisonai-sandbox/praisonai_sandbox/docker.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/docker.py
@@ -505,8 +505,17 @@ class DockerSandbox:
             "-v", f"{self._temp_dir}:{SANDBOX_ROOT}",
             "--memory", f"{limits.memory_mb}m",
             "--cpus", str(limits.cpu_percent / 100),
-            "--pids-limit", str(limits.max_processes),
         ]
+
+        # Same floor as run_command(): --pids-limit is per CONTAINER, and the
+        # default max_processes of 10 was chosen for setrlimit's per-user world.
+        # A raw 10 here kills the container before python even starts (exit 125),
+        # so raise it to something a container can live within. Still bounds a
+        # fork bomb; just stops the bound from being the bug.
+        if limits.max_processes and limits.max_processes > 0:
+            docker_cmd.extend(
+                ["--pids-limit", str(max(limits.max_processes, MIN_CONTAINER_PIDS))]
+            )
         
         if not limits.network_enabled:
             docker_cmd.extend(["--network", "none"])

--- a/src/praisonai-sandbox/praisonai_sandbox/docker.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/docker.py
@@ -34,6 +34,26 @@ SANDBOX_ROOT = "/sandbox"
 MIN_CONTAINER_PIDS = 128
 
 
+
+def _sandbox_relative(path: str) -> str:
+    """Accept both spellings of a sandbox path.
+
+    The directory is mounted at SANDBOX_ROOT, so that is the path a user sees
+    from inside the container and the one they naturally type. But the file API
+    treats "/" as the sandbox root, so "/sandbox/report.txt" was joined onto the
+    root again and landed at "/sandbox/sandbox/report.txt" -- write_file
+    returned True, and `cat /sandbox/report.txt` could not find it.
+
+    Both spellings now mean the same file. Only the exact prefix is stripped, so
+    a genuine subdirectory that happens to be called "sandbox" still works.
+    """
+    if path == SANDBOX_ROOT:
+        return "/"
+    prefix = SANDBOX_ROOT + "/"
+    if path.startswith(prefix):
+        return "/" + path[len(prefix):]
+    return path
+
 class DockerSandbox:
     """Docker-based sandbox for safe code execution.
     
@@ -391,6 +411,8 @@ class DockerSandbox:
         """
         from ._compat import makedirs_in_sandbox, open_in_sandbox
 
+        path = _sandbox_relative(path)
+
         if not makedirs_in_sandbox(self._temp_dir, path):
             return False
 
@@ -419,7 +441,7 @@ class DockerSandbox:
         """
         from ._compat import open_in_sandbox
 
-        fd = open_in_sandbox(self._temp_dir, path, os.O_RDONLY)
+        fd = open_in_sandbox(self._temp_dir, _sandbox_relative(path), os.O_RDONLY)
         if fd is None:
             return None
         try:
@@ -438,8 +460,8 @@ class DockerSandbox:
     ) -> List[str]:
         """List files in a sandbox directory."""
         from ._compat import safe_sandbox_path
-        
-        full_path = safe_sandbox_path(self._temp_dir, path)
+
+        full_path = safe_sandbox_path(self._temp_dir, _sandbox_relative(path))
         if full_path is None or not os.path.exists(full_path):
             return []
         

--- a/src/praisonai-sandbox/tests/test_docker_filesystem.py
+++ b/src/praisonai-sandbox/tests/test_docker_filesystem.py
@@ -115,3 +115,42 @@ def test_the_container_is_still_isolated_from_the_host():
 
     result = _run(_with_sandbox(check))
     assert result.exit_code != 0, "the host filesystem is visible inside the container"
+
+
+@needs_docker
+def test_both_spellings_of_a_sandbox_path_mean_the_same_file():
+    """The directory is mounted at /sandbox, so that is what a user sees from
+    inside the container and the one they naturally type. But the file API
+    treats "/" as the sandbox root, so "/sandbox/report.txt" was joined onto
+    the root again and landed at "/sandbox/sandbox/report.txt" -- write_file
+    returned True and `cat /sandbox/report.txt` could not find it.
+    """
+
+    async def check(sandbox):
+        await sandbox.write_file("/sandbox/report.txt", "written via the container path")
+        found = await sandbox.run_command("cat /sandbox/report.txt", shell=True)
+
+        await sandbox.run_command("echo REMOTE > /sandbox/out.txt", shell=True)
+        bare = await sandbox.read_file("out.txt")
+        prefixed = await sandbox.read_file("/sandbox/out.txt")
+        listed = await sandbox.list_files("/sandbox")
+        return found, bare, prefixed, listed
+
+    found, bare, prefixed, listed = _run(_with_sandbox(check))
+    assert found.exit_code == 0, "a file written through the container path was not there"
+    assert bare == prefixed, "the two spellings disagree about the same file"
+    assert sorted(listed) == ["/out.txt", "/report.txt"]
+
+
+@needs_docker
+def test_a_directory_genuinely_called_sandbox_still_works():
+    """Only the exact mount prefix is stripped, so a real subdirectory of that
+    name is not swallowed."""
+
+    async def check(sandbox):
+        await sandbox.write_file("sandbox/nested.txt", "kept")
+        return await sandbox.read_file("sandbox/nested.txt"), await sandbox.list_files("/")
+
+    content, listed = _run(_with_sandbox(check))
+    assert content == "kept"
+    assert "/sandbox/nested.txt" in listed

--- a/src/praisonai-sandbox/tests/test_sandbox_escape.py
+++ b/src/praisonai-sandbox/tests/test_sandbox_escape.py
@@ -1,0 +1,198 @@
+"""The sandbox directory is bind-mounted into the container, so code inside it
+can race the host's file operations.
+
+`safe_sandbox_path()` validates a path *string*; the caller then opens that
+string. Two syscalls, with a gap. That was harmless while only the host could
+write to the directory. Once it is mounted, a loop of
+
+    ln -s /etc/passwd notes.txt   /   : > notes.txt
+
+substituted between the check and the open redirects the write. Measured before
+the fix: an escape on write attempt 375, and a host secret disclosed on read
+attempt 4.
+
+No amount of stricter string checking fixes that -- anything verified before the
+open can be invalidated after it. These tests pin the property that does: the
+file is never re-opened by name.
+"""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from praisonai_sandbox._compat import (
+    makedirs_in_sandbox,
+    open_in_sandbox,
+    safe_sandbox_path,
+)
+
+
+@pytest.fixture
+def sandbox(tmp_path):
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    return str(root)
+
+
+def test_a_symlink_in_place_of_a_file_is_refused(sandbox, tmp_path):
+    """The core of the escape: the final component becomes a symlink."""
+    target = tmp_path / "outside.txt"
+    target.write_text("HOST-ONLY")
+    os.symlink(target, os.path.join(sandbox, "notes.txt"))
+
+    assert open_in_sandbox(sandbox, "notes.txt", os.O_RDONLY) is None
+    assert open_in_sandbox(sandbox, "notes.txt", os.O_WRONLY | os.O_CREAT) is None
+    assert target.read_text() == "HOST-ONLY", "the host file was written through"
+
+
+def test_a_symlinked_directory_component_is_refused(sandbox, tmp_path):
+    """O_NOFOLLOW on the last component alone is not enough -- an intermediate
+    directory can be swapped just as easily."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "f.txt").write_text("HOST-ONLY")
+    os.symlink(outside, os.path.join(sandbox, "sub"))
+
+    assert open_in_sandbox(sandbox, "sub/f.txt", os.O_RDONLY) is None
+
+
+@pytest.mark.parametrize("path", [
+    "../escape.txt", "../../etc/passwd", "a/../../../etc/hosts", "/../../etc/shadow",
+])
+def test_climbing_out_is_refused(sandbox, path):
+    assert open_in_sandbox(sandbox, path, os.O_RDONLY) is None
+
+
+def test_ordinary_files_still_work(sandbox):
+    """The guard must not break the thing it protects."""
+    assert makedirs_in_sandbox(sandbox, "sub/deep/note.txt")
+    fd = open_in_sandbox(sandbox, "sub/deep/note.txt", os.O_WRONLY | os.O_CREAT)
+    assert fd is not None
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(b"kept")
+
+    fd = open_in_sandbox(sandbox, "sub/deep/note.txt", os.O_RDONLY)
+    assert fd is not None
+    with os.fdopen(fd, "rb") as handle:
+        assert handle.read() == b"kept"
+
+
+def test_the_string_guard_is_no_longer_load_bearing(sandbox, tmp_path):
+    """safe_sandbox_path still resolves paths, and still cannot be trusted on
+    its own -- it answers about a name, and names can change. This test records
+    why the descriptor-based path exists rather than deleting the old helper."""
+    target = tmp_path / "outside.txt"
+    target.write_text("HOST-ONLY")
+    link = os.path.join(sandbox, "swapped.txt")
+
+    # a plain file: the string guard approves it
+    open(link, "w").close()
+    assert safe_sandbox_path(sandbox, "swapped.txt") is not None
+
+    # ...and the moment it becomes a symlink, the same name is unsafe
+    os.unlink(link)
+    os.symlink(target, link)
+    assert open_in_sandbox(sandbox, "swapped.txt", os.O_RDONLY) is None
+
+
+# ── the container-side property, where the race actually lives ───────────────
+def _docker_running() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        return subprocess.run(["docker", "version", "--format", "{{.Server.Version}}"],
+                              capture_output=True, timeout=25).returncode == 0
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _docker_running(), reason="needs a Docker daemon")
+def test_a_racing_container_cannot_reach_a_host_file(tmp_path):
+    """The end-to-end version: symlink-swap from inside the container while the
+    host writes. This escaped before the fix."""
+    import asyncio
+
+    from praisonaiagents.sandbox import SandboxConfig, SandboxManager
+
+    target = tmp_path / "host_target.txt"
+    target.write_text("ORIGINAL")
+
+    async def attack():
+        sandbox = await SandboxManager(SandboxConfig(sandbox_type="docker"))._create_sandbox()
+        racer = (
+            "for i in $(seq 1 4); do (while true; do rm -f /sandbox/n.txt; "
+            f"ln -s {target} /sandbox/n.txt; rm -f /sandbox/n.txt; "
+            ": > /sandbox/n.txt; done) & done; sleep 20"
+        )
+        task = asyncio.create_task(sandbox.run_command(racer, shell=True))
+        try:
+            await asyncio.sleep(1)
+            for _ in range(1500):
+                await sandbox.write_file("n.txt", "PWNED")
+        finally:
+            task.cancel()
+            await sandbox.stop()
+
+    asyncio.run(attack())
+    assert target.read_text() == "ORIGINAL", "a racing container overwrote a host file"
+
+
+# ── teardown must survive interpreter shutdown ───────────────────────────────
+def test_offload_falls_back_when_the_executor_is_gone():
+    """A sandbox is usually released by a weakref finalizer as the process
+    ends. By then concurrent.futures has set its own atexit flag, so
+    run_in_executor raises "cannot schedule new futures after interpreter
+    shutdown" -- and that failure was swallowed and logged as a successful
+    release, leaking a container on every run.
+
+    Blocking inline is correct there: no event loop is left to starve.
+    """
+    import asyncio
+
+    from praisonai_sandbox.compute._sync_base import SyncComputeProvider
+
+    class Dying(SyncComputeProvider):
+        def _shutdown_sync(self, instance_id):
+            return f"released {instance_id}"
+
+    provider = Dying()
+
+    async def drive():
+        loop = asyncio.get_running_loop()
+
+        def refuse(*_a, **_kw):
+            raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+        loop.run_in_executor = refuse
+        return await provider.shutdown("inst-1")
+
+    assert asyncio.run(drive()) == "released inst-1"
+
+
+def test_offload_still_raises_unrelated_runtime_errors():
+    """The fallback must not swallow a genuine bug."""
+    import asyncio
+
+    import pytest as _pytest
+
+    from praisonai_sandbox.compute._sync_base import SyncComputeProvider
+
+    class Broken(SyncComputeProvider):
+        def _shutdown_sync(self, instance_id):
+            return None
+
+    provider = Broken()
+
+    async def drive():
+        loop = asyncio.get_running_loop()
+
+        def explode(*_a, **_kw):
+            raise RuntimeError("something else entirely")
+
+        loop.run_in_executor = explode
+        return await provider.shutdown("inst-1")
+
+    with _pytest.raises(RuntimeError, match="something else entirely"):
+        asyncio.run(drive())


### PR DESCRIPTION
Four defects found by adversarial review of the merged consolidation. **The first two are mine**, introduced by earlier PRs in this series.

## 1. Container escape (HIGH) — introduced by the bind mount in #4106

The mount added so `write_file()` actually reaches the container turned a harmless check-then-use into an exploitable race. `safe_sandbox_path()` validates a path **string**; the caller then opens that string — two syscalls with a gap. Nothing but the host could write to that directory before it was mounted.

```sh
# running inside the container
for i in $(seq 1 6); do (while true; do
  rm -f /sandbox/notes.txt; ln -s /etc/passwd /sandbox/notes.txt
  rm -f /sandbox/notes.txt; : > /sandbox/notes.txt
done) & done
```

| | Before |
|---|---|
| Host file overwritten | **attempt 375** |
| Host secret disclosed | **attempt 4** |

Arbitrary host read and write, from code `where_does_it_run()` calls "a Docker container".

**No amount of stricter string checking fixes this** — anything verified before the open can be invalidated after it. So the file is never re-opened by name: `open_in_sandbox()` walks the path one component at a time against an open directory descriptor with `O_NOFOLLOW` at each step. A symlink substituted at any level fails the open rather than redirecting it.

Re-running the attack: host file untouched, secret not disclosed, ordinary writes unaffected (2983 succeeded).

## 2. Every run leaked a container (HIGH) — introduced by the extraction in #4077

`tools_run_on=` releases its sandbox from a `weakref.finalize`, which usually runs as the process ends. By then `concurrent.futures` has set its own atexit flag, so `run_in_executor` raises *"cannot schedule new futures after interpreter shutdown"*. **The failure was swallowed and logged as a successful release** — so every run left a container up while reporting it had cleaned up. Docker and Fly.io have no idle reaper, so those were indefinite.

`_offload()` now falls back to calling inline when the executor is gone — correct there, since no event loop is left to starve. Unrelated `RuntimeError`s still propagate. `DockerCompute` was never converted to the shared base in the earlier extraction, so it had the same bug in four more places; it inherits now.

Verified from a confirmed-zero baseline: **0 containers left after exit** (was 1 per run).

## 3. Model API keys baked into a committed image (HIGH)

`docker commit` preserves `Config.Env`, so keys forwarded into a container were baked into an image persisting for days, readable via `docker inspect`. The capture exists to reuse installed *packages*, not the credentials present while installing them. Now scrubbed — verified: `OPENAI_API_KEY=` empty in the committed image.

## 4. Fork bombs unbounded on one path (MEDIUM)

`run_command()` accepted `max_processes` and ignored it. Docker's `--pids-limit` is per **container**, so unlike `RLIMIT_NPROC` it means what it says — but the default of `10` was chosen for the rlimit world and kills the container before the shell starts (`exit 125`). The cap now has a floor a container can live within: still bounds a fork bomb, just stops the bound from being the bug.

Also drops `native` from the not-a-boundary list — it aliases `sandlock`, which applies Landlock and seccomp, so the two spellings of one backend were giving **opposite** security advice.

## Testing

140 passing in `praisonai-sandbox` (7 new escape/teardown tests), 267 across the agent suites. The escape test runs the real attack against a live container and asserts the host file is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened sandbox file access to prevent symlink-based escapes and path traversal.
  * Enforced process limits for Docker workloads and improved credential handling in captured images.
  * Native/sandlocked execution is now correctly recognized as a containment boundary.

* **Reliability**
  * Improved cleanup when compute shutdown encounters errors.
  * Sandbox shutdown failures now provide visible warning details.
  * Blocking operations can complete safely during interpreter shutdown.
  * Sandbox paths resolve consistently across supported formats.

* **Tests**
  * Added coverage for sandbox escapes, Docker isolation, cleanup fallback, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->