### PR TITLE
fix(llm): stop failover rotation from mutating shared instance state

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1005,18 +1005,21 @@ Respond with ONLY a valid JSON tool call in this format:
         if profile is None:
             return
 
-    def _active_profile_values(self) -> dict:
-        """Return the current profile's overrides (or {} if none active)."""
-        if self._current_profile is not None:
-            values = {}
-            if self._current_profile.api_key:
-                values["api_key"] = self._current_profile.api_key
-            if self._current_profile.base_url:
-                values["base_url"] = self._current_profile.base_url
-            if self._current_profile.model:
-                values["model"] = self._current_profile.model
-            return values
-        return {}
+    def _response_model_for_tracking(self, response: Any) -> str:
+        """Model to attribute token usage to for a completed call.
+
+        Prefers the model carried on the response itself, which reflects the
+        provider/profile that actually served the request. This is race-free
+        under concurrency (unlike reading the shared ``self._current_profile``)
+        and stays correct after a failover rotation. Falls back to
+        ``self.model`` when the response does not expose a model.
+        """
+        model = None
+        if isinstance(response, dict):
+            model = response.get("model")
+        else:
+            model = getattr(response, "model", None)
+        return model or self.model
 
     def _apply_profile_to_kwargs(self, profile: "AuthProfile", kwargs: dict) -> dict:
         """Return a new kwargs dict with profile overrides applied.
@@ -1103,7 +1106,7 @@ Respond with ONLY a valid JSON tool call in this format:
             )
             return None
 
-    def _handle_retry_exception(self, e, attempt, kwargs, refreshed_creds=None):
+    def _handle_retry_exception(self, e, attempt, kwargs, refreshed_creds=None, active_profile=None):
         """Decide retry vs raise from a failover decision. No sleep/await.
 
         Shared decision logic used by both the sync (`_call_with_retry`) and
@@ -1117,21 +1120,34 @@ Respond with ONLY a valid JSON tool call in this format:
         blocks the event loop. The already-refreshed credentials (if any) are
         passed in via ``refreshed_creds``.
 
+        The active failover profile is a *per-call* value threaded in via
+        ``active_profile`` and returned back in the result tuple. It is never
+        read from or written to ``self._current_profile`` here, so concurrent
+        requests sharing one ``LLM`` instance cannot corrupt each other's
+        failover bookkeeping or cost attribution (issue #3613 gap 2).
+
         Args:
             e: The exception raised by the wrapped call.
             attempt: Zero-based attempt index for the current iteration.
             kwargs: Keyword arguments for the wrapped call (may be updated).
             refreshed_creds: Credentials already refreshed by the caller (off
                 the event loop for async), or ``None`` if no refresh was done.
+            active_profile: The profile this call is currently using, or
+                ``None``. Defaults to the initial profile for backward compat.
 
         Returns:
-            Tuple of (should_raise, category, retry_delay, error_str, kwargs):
+            Tuple of (should_raise, category, retry_delay, error_str, kwargs,
+            active_profile):
                 should_raise: Whether the caller should re-raise immediately.
                 category: The error category/reason from the decision.
                 retry_delay: Seconds to wait before the next attempt.
                 error_str: String form of the exception.
                 kwargs: The (possibly updated) keyword arguments.
+                active_profile: The (possibly rotated) profile for the next
+                    attempt.
         """
+        if active_profile is None:
+            active_profile = self._current_profile
         # A turn is "side-effecting" when it exposes tools the model may call:
         # a post-dispatch failure on such a turn could have already run a
         # side-effecting tool, so it must not be silently replayed. A turn with
@@ -1183,18 +1199,21 @@ Respond with ONLY a valid JSON tool call in this format:
         # immediately with fresh credentials and skip profile rotation so we
         # neither mark the current profile failed nor overwrite the new creds.
         if refreshed_auth:
-            return False, category, retry_delay, error_str, kwargs
+            return False, category, retry_delay, error_str, kwargs, active_profile
 
-        # Handle different failover decision actions
+        # Handle different failover decision actions. Rotation is a per-call
+        # concern: the active profile is a local threaded in/out of this method,
+        # never self._current_profile, so concurrent calls on one shared LLM
+        # cannot mark each other's profiles failed/healthy (issue #3613 gap 2).
         if decision.action == "rotate_profile" and self._failover_manager:
-            if self._current_profile:
+            if active_profile:
                 is_rate_limit = (category == "rate_limit")
                 self._failover_manager.mark_failure(
-                    self._current_profile, error_str, is_rate_limit=is_rate_limit
+                    active_profile, error_str, is_rate_limit=is_rate_limit
                 )
             next_profile = self._failover_manager.get_next_profile()
-            if next_profile and next_profile != self._current_profile:
-                self._current_profile = next_profile
+            if next_profile and next_profile != active_profile:
+                active_profile = next_profile
                 # Thread the active profile through the per-call kwargs so the
                 # shared instance state is never mutated (issue #3613 gap 2).
                 kwargs = self._apply_profile_to_kwargs(next_profile, kwargs)
@@ -1204,14 +1223,14 @@ Respond with ONLY a valid JSON tool call in this format:
                 # same failing profile, so surface the error instead.
                 can_retry = False
         # Legacy failover for compatibility (when decision is retry but failover is configured)
-        elif self._failover_manager and self._current_profile and decision.action == "retry":
+        elif self._failover_manager and active_profile and decision.action == "retry":
             is_rate_limit = (category == "rate_limit")
             self._failover_manager.mark_failure(
-                self._current_profile, error_str, is_rate_limit=is_rate_limit
+                active_profile, error_str, is_rate_limit=is_rate_limit
             )
             next_profile = self._failover_manager.get_next_profile()
-            if next_profile and next_profile != self._current_profile:
-                self._current_profile = next_profile
+            if next_profile and next_profile != active_profile:
+                active_profile = next_profile
                 # Thread the active profile through the per-call kwargs so the
                 # shared instance state is never mutated (issue #3613 gap 2).
                 kwargs = self._apply_profile_to_kwargs(next_profile, kwargs)
@@ -1221,7 +1240,7 @@ Respond with ONLY a valid JSON tool call in this format:
                 logging.info(f"Failover: switched to profile '{next_profile.name}'")
 
         should_raise = decision.action == "surface_error" or not can_retry
-        return should_raise, category, retry_delay, error_str, kwargs
+        return should_raise, category, retry_delay, error_str, kwargs, active_profile
 
     def _call_with_retry(self, func, *args, **kwargs):
         """Call a function with automatic retry on rate limit errors and failover support.
@@ -1238,6 +1257,10 @@ Respond with ONLY a valid JSON tool call in this format:
             The original exception if max retries exceeded
         """
         last_error = None
+        # Track the failover profile per call (never self._current_profile) so
+        # concurrent calls on one shared LLM cannot corrupt each other's
+        # failover bookkeeping (issue #3613 gap 2).
+        active_profile = self._current_profile
 
         for attempt in range(self._max_retries + 1):
             try:
@@ -1248,8 +1271,8 @@ Respond with ONLY a valid JSON tool call in this format:
                 result = func(*args, **kwargs)
                 
                 # Mark success if failover is configured
-                if self._failover_manager and self._current_profile:
-                    self._failover_manager.mark_success(self._current_profile)
+                if self._failover_manager and active_profile:
+                    self._failover_manager.mark_success(active_profile)
                 
                 # Reset idle timeout circuit breaker on success
                 self._idle_timeout_breaker.reset()
@@ -1264,8 +1287,12 @@ Respond with ONLY a valid JSON tool call in this format:
                 if self._should_attempt_auth_refresh(e, attempt):
                     refreshed_creds = self._try_refresh_subscription_creds()
 
-                should_raise, category, retry_delay, error_str, kwargs = (
-                    self._handle_retry_exception(e, attempt, kwargs, refreshed_creds=refreshed_creds)
+                should_raise, category, retry_delay, error_str, kwargs, active_profile = (
+                    self._handle_retry_exception(
+                        e, attempt, kwargs,
+                        refreshed_creds=refreshed_creds,
+                        active_profile=active_profile,
+                    )
                 )
 
                 if should_raise:
@@ -1314,6 +1341,10 @@ Respond with ONLY a valid JSON tool call in this format:
             The original exception if max retries exceeded
         """
         last_error = None
+        # Track the failover profile per call (never self._current_profile) so
+        # concurrent coroutines on one shared LLM cannot corrupt each other's
+        # failover bookkeeping (issue #3613 gap 2).
+        active_profile = self._current_profile
 
         for attempt in range(self._max_retries + 1):
             try:
@@ -1324,8 +1355,8 @@ Respond with ONLY a valid JSON tool call in this format:
                 result = await func(*args, **kwargs)
                 
                 # Mark success if failover is configured
-                if self._failover_manager and self._current_profile:
-                    self._failover_manager.mark_success(self._current_profile)
+                if self._failover_manager and active_profile:
+                    self._failover_manager.mark_success(active_profile)
                 
                 # Reset idle timeout circuit breaker on success
                 self._idle_timeout_breaker.reset()
@@ -1343,8 +1374,12 @@ Respond with ONLY a valid JSON tool call in this format:
                         self._try_refresh_subscription_creds
                     )
 
-                should_raise, category, retry_delay, error_str, kwargs = (
-                    self._handle_retry_exception(e, attempt, kwargs, refreshed_creds=refreshed_creds)
+                should_raise, category, retry_delay, error_str, kwargs, active_profile = (
+                    self._handle_retry_exception(
+                        e, attempt, kwargs,
+                        refreshed_creds=refreshed_creds,
+                        active_profile=active_profile,
+                    )
                 )
 
                 if should_raise:
@@ -1396,8 +1431,7 @@ Respond with ONLY a valid JSON tool call in this format:
         import litellm
         response = self._call_with_retry(litellm.completion, **completion_params)
         if not completion_params.get("stream"):
-            active = self._active_profile_values()
-            self._track_token_usage(response, active.get("model") or self.model)
+            self._track_token_usage(response, self._response_model_for_tracking(response))
         return response
 
     async def _acompletion_with_retry(self, **completion_params):
@@ -1418,8 +1452,7 @@ Respond with ONLY a valid JSON tool call in this format:
             **completion_params,
         )
         if not completion_params.get("stream"):
-            active = self._active_profile_values()
-            self._track_token_usage(response, active.get("model") or self.model)
+            self._track_token_usage(response, self._response_model_for_tracking(response))
         return response
 
     def _supports_web_search(self) -> bool:
@@ -6038,8 +6071,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         """
         import litellm
         response = await self._call_with_retry_async(litellm.aresponses, **params)
-        active = self._active_profile_values()
-        self._track_token_usage(response, active.get("model") or self.model)
+        self._track_token_usage(response, self._response_model_for_tracking(response))
         return response
 
     def _extract_from_responses_output(self, response) -> tuple:

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -534,7 +534,18 @@ Respond with ONLY a valid JSON tool call in this format:
         if self._failover_manager:
             self._current_profile = self._failover_manager.get_next_profile()
             if self._current_profile:
-                self._switch_to_profile(self._current_profile)
+                # Apply the initial profile's values to the instance attributes
+                # (backward compatible with the documented llm.api_key/model
+                # surface). Later failover rotations are per-call only and do
+                # not mutate these attributes (issue #3613 gap 2).
+                profile = self._current_profile
+                if profile.api_key:
+                    self.api_key = profile.api_key
+                if profile.base_url:
+                    self.base_url = profile.base_url
+                if profile.model and profile.model != self.model:
+                    logging.info(f"Failover: using profile model {profile.model}")
+                    self.model = profile.model
 
         # Cache for formatted tools and messages
         self._formatted_tools_cache = {}
@@ -974,18 +985,55 @@ Respond with ONLY a valid JSON tool call in this format:
 
     def _switch_to_profile(self, profile: "AuthProfile") -> None:
         """Switch to a new auth profile for failover.
-        
+
+        The profile's credentials are threaded through the per-call kwargs of
+        the retry loop instead of being written onto the shared instance. The
+        old behaviour mutated ``self.api_key``/``self.base_url``/``self.model``
+        on a shared ``LLM`` (issue #3613 gap 2), so concurrent requests on one
+        instance could silently cross-talk credentials and model after a
+        failover rotation. Keeping the instance attributes on the initial
+        profile preserves single-profile behaviour and the documented
+        ``llm.api_key``/``llm.model`` surface.
+
         Args:
             profile: AuthProfile to switch to
         """
+        # NOTE: profile values are applied to the per-call kwargs by
+        # _handle_retry_exception when it rotates. This method is kept as a
+        # no-op placeholder so any out-of-tree callers that invoke it directly
+        # keep working; it intentionally no longer mutates shared state.
+        if profile is None:
+            return
+
+    def _active_profile_values(self) -> dict:
+        """Return the current profile's overrides (or {} if none active)."""
+        if self._current_profile is not None:
+            values = {}
+            if self._current_profile.api_key:
+                values["api_key"] = self._current_profile.api_key
+            if self._current_profile.base_url:
+                values["base_url"] = self._current_profile.base_url
+            if self._current_profile.model:
+                values["model"] = self._current_profile.model
+            return values
+        return {}
+
+    def _apply_profile_to_kwargs(self, profile: "AuthProfile", kwargs: dict) -> dict:
+        """Return a new kwargs dict with profile overrides applied.
+
+        Never mutates ``self``: the active profile is a per-call concern, so
+        its credentials travel in the request kwargs only. Callers that pass
+        an explicit per-call override (e.g. ``api_key=``) keep it; profile
+        values fill in the gaps.
+        """
+        kwargs = dict(kwargs)
         if profile.api_key:
-            self.api_key = profile.api_key
+            kwargs["api_key"] = profile.api_key
         if profile.base_url:
-            self.base_url = profile.base_url
-        if profile.model and profile.model != self.model:
-            # Only log if model actually changes
-            logging.info(f"Failover: switching from {self.model} to {profile.model}")
-            self.model = profile.model
+            kwargs["base_url"] = profile.base_url
+        if profile.model:
+            kwargs["model"] = profile.model
+        return kwargs
 
     def _resolve_subscription_creds(self):
         """Lazy resolve + cache subscription credentials, checking expiration."""
@@ -1146,15 +1194,10 @@ Respond with ONLY a valid JSON tool call in this format:
                 )
             next_profile = self._failover_manager.get_next_profile()
             if next_profile and next_profile != self._current_profile:
-                self._switch_to_profile(next_profile)
                 self._current_profile = next_profile
-                # Update the kwargs with new profile values for the next retry
-                if "api_key" in kwargs:
-                    kwargs["api_key"] = self.api_key
-                if "base_url" in kwargs:
-                    kwargs["base_url"] = self.base_url
-                if "model" in kwargs:
-                    kwargs["model"] = self.model
+                # Thread the active profile through the per-call kwargs so the
+                # shared instance state is never mutated (issue #3613 gap 2).
+                kwargs = self._apply_profile_to_kwargs(next_profile, kwargs)
                 logging.info(f"Failover: switched to profile '{next_profile.name}'")
             else:
                 # No alternate profile available - retrying would just hit the
@@ -1168,15 +1211,10 @@ Respond with ONLY a valid JSON tool call in this format:
             )
             next_profile = self._failover_manager.get_next_profile()
             if next_profile and next_profile != self._current_profile:
-                self._switch_to_profile(next_profile)
                 self._current_profile = next_profile
-                # Update the kwargs with new profile values for the next retry
-                if "api_key" in kwargs:
-                    kwargs["api_key"] = self.api_key
-                if "base_url" in kwargs:
-                    kwargs["base_url"] = self.base_url
-                if "model" in kwargs:
-                    kwargs["model"] = self.model
+                # Thread the active profile through the per-call kwargs so the
+                # shared instance state is never mutated (issue #3613 gap 2).
+                kwargs = self._apply_profile_to_kwargs(next_profile, kwargs)
                 # Enable retry for profile switch even if originally non-retryable
                 can_retry = True
                 retry_delay = 0.0
@@ -1358,7 +1396,8 @@ Respond with ONLY a valid JSON tool call in this format:
         import litellm
         response = self._call_with_retry(litellm.completion, **completion_params)
         if not completion_params.get("stream"):
-            self._track_token_usage(response, self.model)
+            active = self._active_profile_values()
+            self._track_token_usage(response, active.get("model") or self.model)
         return response
 
     async def _acompletion_with_retry(self, **completion_params):
@@ -1379,7 +1418,8 @@ Respond with ONLY a valid JSON tool call in this format:
             **completion_params,
         )
         if not completion_params.get("stream"):
-            self._track_token_usage(response, self.model)
+            active = self._active_profile_values()
+            self._track_token_usage(response, active.get("model") or self.model)
         return response
 
     def _supports_web_search(self) -> bool:
@@ -5998,7 +6038,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         """
         import litellm
         response = await self._call_with_retry_async(litellm.aresponses, **params)
-        self._track_token_usage(response, self.model)
+        active = self._active_profile_values()
+        self._track_token_usage(response, active.get("model") or self.model)
         return response
 
     def _extract_from_responses_output(self, response) -> tuple:

--- a/src/praisonai-agents/tests/unit/llm/test_failover_profile_isolation.py
+++ b/src/praisonai-agents/tests/unit/llm/test_failover_profile_isolation.py
@@ -117,3 +117,74 @@ class TestFailoverRetryUsesProfileCredentials:
         assert llm.api_key == "sk-primary"
         assert llm.base_url is None
         assert llm.model == "gpt-4o-mini"
+
+
+class TestFailoverBookkeepingIsPerCall:
+    """Concurrent calls must not corrupt each other's failover bookkeeping.
+
+    A rotation in one call must not move the shared ``_current_profile`` that a
+    second in-flight call reads for its own ``mark_failure``/``mark_success``.
+    """
+
+    def test_rotation_does_not_mutate_shared_current_profile(self):
+        """A failure-driven rotation leaves ``self._current_profile`` intact."""
+        llm, _ = _make_llm_with_profiles()
+        llm._max_retries = 2
+        llm._retry_delay = 0.01
+        initial_profile = llm._current_profile
+
+        mock_func = Mock(
+            side_effect=[
+                Exception("AuthenticationError: 401 Unauthorized"),
+                "ok",
+            ]
+        )
+
+        with patch("time.sleep"):
+            llm._call_with_retry(mock_func, model="gpt-4o-mini", api_key="sk-primary")
+
+        # The shared pointer still references the initial profile: rotation was
+        # a per-call local, so a concurrent call would not observe the switch.
+        assert llm._current_profile is initial_profile
+        assert llm._current_profile.name == "primary"
+
+    def test_success_marks_the_call_local_profile_after_rotation(self):
+        """mark_success targets the rotated profile that served the call."""
+        llm, manager = _make_llm_with_profiles()
+        llm._max_retries = 2
+        llm._retry_delay = 0.01
+        # Spy without replacing behaviour: the real health tracking must still
+        # run so get_next_profile() rotates to the backup.
+        manager.mark_success = Mock(wraps=manager.mark_success)
+        manager.mark_failure = Mock(wraps=manager.mark_failure)
+
+        mock_func = Mock(
+            side_effect=[
+                Exception("AuthenticationError: 401 Unauthorized"),
+                "ok",
+            ]
+        )
+
+        with patch("time.sleep"):
+            llm._call_with_retry(mock_func, model="gpt-4o-mini", api_key="sk-primary")
+
+        # Failure marked the primary; success marked the rotated backup, not
+        # whatever the shared pointer happened to be.
+        assert manager.mark_failure.call_args_list[0].args[0].name == "primary"
+        assert manager.mark_success.call_args.args[0].name == "backup"
+
+
+class TestTokenTrackingFollowsServingModel:
+    """Token usage is attributed to the model that actually served the call."""
+
+    def test_tracking_uses_response_model_not_shared_profile(self):
+        """A rotated call tracks the serving model from the response."""
+        llm, _ = _make_llm_with_profiles()
+        response = Mock(model="backup-model")
+        assert llm._response_model_for_tracking(response) == "backup-model"
+
+    def test_tracking_falls_back_to_self_model(self):
+        """Responses without a model fall back to the instance model."""
+        llm, _ = _make_llm_with_profiles()
+        response = Mock(spec=[])  # no ``model`` attribute
+        assert llm._response_model_for_tracking(response) == llm.model

--- a/src/praisonai-agents/tests/unit/llm/test_failover_profile_isolation.py
+++ b/src/praisonai-agents/tests/unit/llm/test_failover_profile_isolation.py
@@ -1,0 +1,119 @@
+"""
+Tests for failover profile isolation in LLM.
+
+Covers the fix for issue #3613 Gap 2: ``LLM._switch_to_profile`` mutated
+shared instance state (``self.api_key`` / ``self.base_url`` / ``self.model``)
+without a lock, so concurrent requests on one shared ``LLM`` instance could
+cross-talk credentials and model after a failover rotation.
+
+The fix threads the active profile through per-call kwargs instead of
+mutating shared attributes, so an in-flight request on another coroutine can
+never observe another request's failover credentials.
+"""
+
+from unittest.mock import Mock, patch
+
+from praisonaiagents.llm.failover import AuthProfile, FailoverManager
+from praisonaiagents.llm.llm import LLM
+
+
+def _make_llm_with_profiles():
+    """Build an LLM with a failover manager holding two profiles."""
+    manager = FailoverManager()
+    manager.add_profile(
+        AuthProfile(name="primary", provider="openai", api_key="sk-primary", priority=0)
+    )
+    manager.add_profile(
+        AuthProfile(
+            name="backup",
+            provider="openai",
+            api_key="sk-backup",
+            base_url="https://backup.example.com/v1",
+            model="backup-model",
+            priority=1,
+        )
+    )
+    return LLM(model="gpt-4o-mini", failover_manager=manager), manager
+
+
+class TestProfileSwitchDoesNotMutateSharedState:
+    """The core regression: _switch_to_profile must not leak into self.*"""
+
+    def test_initial_profile_applied_to_instance(self):
+        """Init still applies the first available profile to the instance."""
+        llm, _ = _make_llm_with_profiles()
+        assert llm._current_profile is not None
+        assert llm._current_profile.name == "primary"
+        # Instance attributes reflect the initial profile (backward compat).
+        assert llm.api_key == "sk-primary"
+
+    def test_rotate_after_failure_keeps_instance_state_intact(self):
+        """After failover rotation, self.* must keep the initial values."""
+        llm, manager = _make_llm_with_profiles()
+        original_api_key = llm.api_key
+        original_base_url = llm.base_url
+        original_model = llm.model
+
+        primary = manager.get_profile("primary")
+        backup = manager.get_profile("backup")
+        manager.mark_failure(primary, "401 Unauthorized")
+        next_profile = manager.get_next_profile()
+        assert next_profile is not None and next_profile.name == "backup"
+
+        # The fix: _switch_to_profile is gone; rotation is per-call kwargs.
+        # The old behaviour mutated llm.api_key/base_url/model here.
+        if hasattr(llm, "_switch_to_profile"):
+            llm._switch_to_profile(next_profile)
+
+        assert llm.api_key == original_api_key, "api_key leaked to shared instance"
+        assert llm.base_url == original_base_url, "base_url leaked to shared instance"
+        assert llm.model == original_model, "model leaked to shared instance"
+
+
+class TestFailoverRetryUsesProfileCredentials:
+    """End-to-end: the retry loop sends the rotated profile's credentials."""
+
+    def test_retry_call_uses_backup_credentials(self):
+        """A 401 on the primary profile retries with the backup's creds."""
+        llm, _ = _make_llm_with_profiles()
+        llm._max_retries = 2
+        llm._retry_delay = 0.01
+
+        # First call raises an auth error; second call succeeds.
+        mock_func = Mock(
+            side_effect=[
+                Exception("AuthenticationError: 401 Unauthorized"),
+                "ok",
+            ]
+        )
+
+        with patch("time.sleep"):
+            result = llm._call_with_retry(mock_func, model="gpt-4o-mini", api_key="sk-primary")
+
+        assert result == "ok"
+        # The retried call must carry the backup profile's credentials.
+        assert mock_func.call_count == 2
+        second_call_kwargs = mock_func.call_args_list[1].kwargs
+        assert second_call_kwargs["api_key"] == "sk-backup"
+        assert second_call_kwargs["base_url"] == "https://backup.example.com/v1"
+        assert second_call_kwargs["model"] == "backup-model"
+
+    def test_retry_call_backup_credentials_do_not_leak_to_instance(self):
+        """Even after a rotated retry, self.* stays on the initial profile."""
+        llm, _ = _make_llm_with_profiles()
+        llm._max_retries = 2
+        llm._retry_delay = 0.01
+
+        mock_func = Mock(
+            side_effect=[
+                Exception("AuthenticationError: 401 Unauthorized"),
+                "ok",
+            ]
+        )
+
+        with patch("time.sleep"):
+            llm._call_with_retry(mock_func, model="gpt-4o-mini", api_key="sk-primary")
+
+        assert llm.api_key == "sk-primary"
+        assert llm.base_url is None
+        assert llm.model == "gpt-4o-mini"


### PR DESCRIPTION
Fixes #3613

## Summary

`LLM._switch_to_profile` wrote the rotated profile's `api_key`, `base_url`, and `model` onto the shared `LLM` instance. When one instance is reused for concurrent requests (the normal `asyncio.gather` pattern, or a cached per-session agent), a failover rotation triggered by request A changed the credentials that request B read on its next completion build. Request B then silently went to the wrong provider, with no error raised.

The rotation is now a per-call concern. The retry loop threads the active profile through the request kwargs via `_apply_profile_to_kwargs`, and the instance attributes keep the initial profile values. `_switch_to_profile` stays as a no-op so any direct callers keep working, and token tracking uses the model of the profile that actually served the call.

## Changes

- `src/praisonai-agents/praisonaiagents/llm/llm.py`
  - Added `_apply_profile_to_kwargs` (returns a new kwargs dict with profile overrides, never mutates `self`)
  - Both failover branches in `_handle_retry_exception` now update `kwargs` from the next profile instead of calling `_switch_to_profile` and re-reading `self.*`
  - Init still applies the first profile's values to the instance, so the documented `llm.api_key` / `llm.model` surface is unchanged
  - Token usage tracking reads the active profile's model so cost accounting matches the provider that served the request
- `src/praisonai-agents/tests/unit/llm/test_failover_profile_isolation.py` (new)
  - Regression: after a failure-driven rotation, instance attributes keep their initial values
  - End-to-end: a 401 on the primary profile retries with the backup profile's `api_key` / `base_url` / `model`

## How to test

```
pytest tests/unit/llm/test_failover_profile_isolation.py tests/unit/test_failover.py -q
```

## Backward compatibility

No public API changes. A profile-less `LLM` behaves exactly as before; a single-profile failover manager behaves as before. The only behavioural difference is that a rotated profile no longer leaks onto the shared instance, which is the point of the fix.

I left the lock-based alternative alone. Mutating shared attributes under a lock would still leave other readers (capability checks, compactor model, cost tracking) racing against the writer. Per-call kwargs sidestep that entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved failover handling so the initial profile is applied correctly.
  - Ensured backup profiles use their own credentials, endpoints, and models during retries.
  - Prevented concurrent failover requests from affecting one another or changing shared configuration.
  - Corrected token tracking to reflect the model that served each request.

- **Tests**
  - Added coverage for profile isolation, failover retries, credential handling, and per-request bookkeeping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->