### PR TITLE
feat(scheduler): first-class external CLI-backend jobs + CLI-backend robustness fixes

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -6685,7 +6685,10 @@ Answer:"""
         backend = cli_backend or self._cli_backend
         if not backend:
             raise RuntimeError("CLI backend not configured")
-        
+
+        # Bound before the try so the failure hook can carry the backend's
+        # result (and its audit metadata) when execution returned an error.
+        result = None
         try:
             # Import backend types
             from ..cli_backend import CliSessionBinding
@@ -6780,26 +6783,37 @@ Answer:"""
             session_lock.release()
             lock_held = False
 
-            await self._emit_cli_backend_hook(
-                backend=backend,
-                session_id=session_id,
-                result=result,
-            )
+            # The external command has completed at this point. Hook emission
+            # and history bookkeeping failures are contained here so they are
+            # never reported as backend-execution failures — that mislabel
+            # invites callers to retry work the CLI already finished.
+            try:
+                await self._emit_cli_backend_hook(
+                    backend=backend,
+                    session_id=session_id,
+                    result=result,
+                )
 
-            # Update chat history with the exchange
-            if hasattr(self, '_append_to_chat_history'):
-                self._append_to_chat_history({
-                    "role": "user", 
-                    "content": prompt
-                })
-                if result.content:
+                # Update chat history with the exchange
+                if hasattr(self, '_append_to_chat_history'):
                     self._append_to_chat_history({
-                        "role": "assistant", 
-                        "content": result.content
+                        "role": "user",
+                        "content": prompt
                     })
-            
-            return result.content if result else None
-            
+                    if result.content:
+                        self._append_to_chat_history({
+                            "role": "assistant",
+                            "content": result.content
+                        })
+            except Exception as post_exc:
+                logging.warning(
+                    f"Post-execution bookkeeping failed after successful CLI "
+                    f"backend turn (agent={self.display_name!r}, "
+                    f"session_id={session_id!r}): {post_exc}"
+                )
+
+            return result.content
+
         except asyncio.CancelledError:
             # Cancellation is BaseException: it bypasses ``except Exception``,
             # so release here or later turns on this session block forever.
@@ -6820,10 +6834,13 @@ Answer:"""
                     session_lock.release()
             except (NameError, UnboundLocalError, RuntimeError):
                 pass
+            # ``result`` carries the backend's error result (and its audit
+            # metadata) when execution completed with an error; it is None when
+            # the failure preceded execution.
             await self._emit_cli_backend_hook(
                 backend=backend,
                 session_id=session_id,
-                result=None,
+                result=result,
                 error=str(e),
             )
             raise RuntimeError(

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -6717,6 +6717,7 @@ Answer:"""
                 session_lock = asyncio.Lock()
                 session_locks[session_id] = session_lock
                 await session_lock.acquire()
+            lock_held = True
             session_binding = CliSessionBinding(
                 session_id=session_id,
                 is_resume=session_id in started_sessions,
@@ -6779,6 +6780,7 @@ Answer:"""
             # turns under the same session_id are resumes.
             started_sessions.add(session_id)
             session_lock.release()
+            lock_held = False
 
             # Update chat history with the exchange
             if hasattr(self, '_append_to_chat_history'):
@@ -6794,11 +6796,23 @@ Answer:"""
             
             return result.content if result else None
             
+        except asyncio.CancelledError:
+            # Cancellation is BaseException: it bypasses ``except Exception``,
+            # so release here or later turns on this session block forever.
+            # ``lock_held`` guards against releasing a lock a concurrent turn
+            # has since acquired; names may be unbound if cancellation preceded
+            # their assignment.
+            try:
+                if lock_held and session_lock.locked():
+                    session_lock.release()
+            except (NameError, UnboundLocalError, RuntimeError):
+                pass
+            raise
         except Exception as e:
             # Release the per-session lock on any failure path; ``session_lock``
             # may be unbound when the exception preceded its assignment.
             try:
-                if session_lock.locked():
+                if lock_held and session_lock.locked():
                     session_lock.release()
             except (NameError, UnboundLocalError, RuntimeError):
                 pass

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -6758,13 +6758,9 @@ Answer:"""
                 system_prompt=system_prompt
             )
 
-            await self._emit_cli_backend_hook(
-                backend=backend,
-                session_id=session_id,
-                result=result,
-            )
-            
-            # Check for CLI backend errors
+            # Check for CLI backend errors BEFORE the (cancellable) hook and
+            # before marking the session started, so a failed turn never
+            # records a resumable session.
             if result is None:
                 raise RuntimeError(
                     f"CLI backend returned no result for agent={self.display_name!r}, "
@@ -6777,10 +6773,18 @@ Answer:"""
                 )
 
             # A successful turn establishes the CLI-side session; subsequent
-            # turns under the same session_id are resumes.
+            # turns under the same session_id are resumes. Recorded (and the
+            # lock released) BEFORE the hook await: cancellation during the
+            # hook must not lose the resume state or hold the lock.
             started_sessions.add(session_id)
             session_lock.release()
             lock_held = False
+
+            await self._emit_cli_backend_hook(
+                backend=backend,
+                session_id=session_id,
+                result=result,
+            )
 
             # Update chat history with the exchange
             if hasattr(self, '_append_to_chat_history'):

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -6699,6 +6699,24 @@ Answer:"""
             if started_sessions is None:
                 started_sessions = set()
                 self._cli_backend_sessions_started = started_sessions
+            # Serialise session establishment per session id: without the
+            # lock, concurrent turns could both observe "not started" and
+            # spawn two fresh CLI conversations for one session.
+            session_locks = getattr(self, '_cli_backend_session_locks', None)
+            if session_locks is None:
+                session_locks = {}
+                self._cli_backend_session_locks = session_locks
+            session_lock = session_locks.setdefault(session_id, asyncio.Lock())
+            try:
+                await session_lock.acquire()
+            except RuntimeError:
+                # The stored lock is bound to a previous (closed) event loop —
+                # common when sync callers wrap each turn in its own loop.
+                # Re-key a fresh lock for this loop; cross-loop turns are
+                # serial by construction, so mutual exclusion is preserved.
+                session_lock = asyncio.Lock()
+                session_locks[session_id] = session_lock
+                await session_lock.acquire()
             session_binding = CliSessionBinding(
                 session_id=session_id,
                 is_resume=session_id in started_sessions,
@@ -6760,6 +6778,7 @@ Answer:"""
             # A successful turn establishes the CLI-side session; subsequent
             # turns under the same session_id are resumes.
             started_sessions.add(session_id)
+            session_lock.release()
 
             # Update chat history with the exchange
             if hasattr(self, '_append_to_chat_history'):
@@ -6776,6 +6795,13 @@ Answer:"""
             return result.content if result else None
             
         except Exception as e:
+            # Release the per-session lock on any failure path; ``session_lock``
+            # may be unbound when the exception preceded its assignment.
+            try:
+                if session_lock.locked():
+                    session_lock.release()
+            except (NameError, UnboundLocalError, RuntimeError):
+                pass
             await self._emit_cli_backend_hook(
                 backend=backend,
                 session_id=session_id,

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -6690,9 +6690,19 @@ Answer:"""
             # Import backend types
             from ..cli_backend import CliSessionBinding
             
-            # Build session binding for state management
+            # Build session binding for state management. A session the agent
+            # has already delegated a turn for is a resume: the backend then
+            # continues the CLI-side conversation (and skips re-sending the
+            # system prompt where configured) instead of starting fresh.
             session_id = getattr(self, '_session_id', None) or f"agent-{self.agent_id}"
-            session_binding = CliSessionBinding(session_id=session_id)
+            started_sessions = getattr(self, '_cli_backend_sessions_started', None)
+            if started_sessions is None:
+                started_sessions = set()
+                self._cli_backend_sessions_started = started_sessions
+            session_binding = CliSessionBinding(
+                session_id=session_id,
+                is_resume=session_id in started_sessions,
+            )
             
             # Get system prompt from agent configuration
             system_prompt = None
@@ -6746,7 +6756,11 @@ Answer:"""
                     f"CLI backend failed for agent={self.display_name!r}, "
                     f"session_id={session_id!r}: {result.error}"
                 )
-            
+
+            # A successful turn establishes the CLI-side session; subsequent
+            # turns under the same session_id are resumes.
+            started_sessions.add(session_id)
+
             # Update chat history with the exchange
             if hasattr(self, '_append_to_chat_history'):
                 self._append_to_chat_history({

--- a/src/praisonai-agents/praisonaiagents/scheduler/models.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/models.py
@@ -298,6 +298,21 @@ class ScheduleJob:
                  killed (with its process group on POSIX) and the tick is
                  recorded as ``failed``. Bounds the action so a hung command
                  cannot stall the ticker. Defaults to 60s.
+        backend: Optional external coding-CLI backend id (e.g.
+                 ``"claude-code"``, ``"codex-cli"``). When set, the job's
+                 ``message`` is executed as one headless turn through the
+                 named backend from the backend registry — no native agent is
+                 resolved and no in-process model turn is taken. Like
+                 ``command``, this is a trusted operator-configured action:
+                 it spawns a host CLI subprocess and is deliberately not
+                 exposed on the LLM-callable scheduling tools. Additive and
+                 backward-compatible: jobs without a ``backend`` are
+                 unchanged.
+        backend_options: Optional mapping of overrides for the backend run.
+                 Recognised keys are validated by the executor/backend (e.g.
+                 ``cwd`` for the working directory, ``timeout_ms`` for the
+                 subprocess bound); unknown config overrides are rejected at
+                 resolution time rather than silently ignored.
         provider: Optional model *provider* snapshotted when the job was
                  created (e.g. ``"openai"``). Advisory metadata paired with
                  ``model`` so a drift check can report both. ``None`` means no
@@ -376,6 +391,8 @@ class ScheduleJob:
     context_from: Optional[List[str]] = None
     context_max_chars: int = 4000
     on_missing_context: Literal["run", "skip"] = "run"
+    backend: Optional[str] = None
+    backend_options: Dict[str, Any] = field(default_factory=dict)
 
     # ── serialisation ────────────────────────────────────────────────
 
@@ -432,6 +449,13 @@ class ScheduleJob:
                 d["context_max_chars"] = self.context_max_chars
             if self.on_missing_context != "run":
                 d["on_missing_context"] = self.on_missing_context
+        # External CLI backend action. Only persist when configured so agent
+        # and command jobs stay byte-for-byte unchanged; options are opaque to
+        # the core (the executor validates them against the backend registry).
+        if self.backend is not None:
+            d["backend"] = self.backend
+            if self.backend_options:
+                d["backend_options"] = dict(self.backend_options)
         # Atomic-claim lease metadata (set dynamically by stores that support
         # ``claim_due``). Persisted so a lease is visible across processes and
         # survives a restart; omitted when no lease is held.
@@ -480,6 +504,12 @@ class ScheduleJob:
             context_from=context_from,
             context_max_chars=d.get("context_max_chars", 4000),
             on_missing_context=d.get("on_missing_context", "run"),
+            backend=d.get("backend"),
+            backend_options=(
+                dict(d["backend_options"])
+                if isinstance(d.get("backend_options"), dict)
+                else {}
+            ),
         )
         # Restore atomic-claim lease metadata if present (see ``to_dict``).
         job._lease_until = d.get("lease_until", 0.0) or 0.0

--- a/src/praisonai-bot/praisonai_bot/scheduler/executor.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/executor.py
@@ -633,8 +633,18 @@ class ScheduledAgentExecutor:
         # spawned; gate context is appended to the prompt like the agent path.
         gate = self._resolve_condition(job)
         if gate is not None:
+            # State-aware like the native-agent path: a monitor gate's cursor /
+            # watermark must be loaded, passed when the gate supports it, and
+            # persisted on both the skip and go paths — otherwise a backend
+            # monitor job re-reads the same "new" items every tick.
+            prior_state = self._get_job_state(job)
             try:
-                decision = await asyncio.to_thread(gate.should_run, job)
+                if self._gate_accepts_state(gate):
+                    decision = await asyncio.to_thread(
+                        gate.should_run, job, state=prior_state,
+                    )
+                else:
+                    decision = await asyncio.to_thread(gate.should_run, job)
             except Exception as e:  # pragma: no cover - defensive
                 logger.warning(
                     "Pre-run gate raised for backend job '%s': %s; running anyway",
@@ -644,6 +654,9 @@ class ScheduledAgentExecutor:
             if decision is not None and not getattr(decision, "run", True):
                 reason = getattr(decision, "reason", None) or "pre-run gate: nothing to do"
                 logger.info("Backend job '%s' skipped by pre-run gate: %s", job.id, reason)
+                self._persist_job_state(
+                    job, prior_state, getattr(decision, "state_updates", None),
+                )
                 duration = time.time() - started
                 self._runner.mark_run(job, status="skipped", error=reason, duration=duration)
                 return JobResult(job=job, status="skipped", error=reason, duration=duration)
@@ -651,6 +664,9 @@ class ScheduledAgentExecutor:
                 context = getattr(decision, "context", None)
                 if context:
                     message = f"{message}\n\n{context}"
+                updates = getattr(decision, "state_updates", None)
+                if isinstance(updates, dict) and updates:
+                    self._persist_job_state(job, prior_state, updates)
 
         # Run-scoped policy: the message is the untrusted portion of a backend
         # turn (there is no in-process agent whose skills could load content),

--- a/src/praisonai-bot/praisonai_bot/scheduler/executor.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/executor.py
@@ -664,7 +664,7 @@ class ScheduledAgentExecutor:
                 if self._on_failure:
                     self._on_failure(job, err)
                 result = JobResult(job=job, status="failed", error=err, duration=duration)
-                self._audit_output(job, result)
+                await asyncio.to_thread(self._audit_output, job, result)
                 await self._maybe_deliver_failure(job, result)
                 return result
 
@@ -685,7 +685,7 @@ class ScheduledAgentExecutor:
             if self._on_failure:
                 self._on_failure(job, err)
             result = JobResult(job=job, status="failed", error=err, duration=duration)
-            self._audit_output(job, result)
+            await asyncio.to_thread(self._audit_output, job, result)
             await self._maybe_deliver_failure(job, result)
             return result
 
@@ -724,7 +724,7 @@ class ScheduledAgentExecutor:
             if self._on_failure:
                 self._on_failure(job, err)
             result = JobResult(job=job, status="failed", error=err, duration=duration)
-            self._audit_output(job, result)
+            await asyncio.to_thread(self._audit_output, job, result)
             await self._maybe_deliver_failure(job, result)
             return result
         except Exception as e:
@@ -735,7 +735,7 @@ class ScheduledAgentExecutor:
             if self._on_failure:
                 self._on_failure(job, err)
             result = JobResult(job=job, status="failed", error=err, duration=duration)
-            self._audit_output(job, result)
+            await asyncio.to_thread(self._audit_output, job, result)
             await self._maybe_deliver_failure(job, result)
             return result
 
@@ -796,7 +796,7 @@ class ScheduledAgentExecutor:
             delivered=delivered,
             delivery_error=delivery_error,
         )
-        self._audit_output(job, result)
+        await asyncio.to_thread(self._audit_output, job, result)
         if not succeeded:
             await self._maybe_deliver_failure(job, result)
         return result

--- a/src/praisonai-bot/praisonai_bot/scheduler/executor.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/executor.py
@@ -631,12 +631,13 @@ class ScheduledAgentExecutor:
         # they honour the same cheap go/no-go gate as native-agent jobs. On
         # "nothing to do" the tick is recorded ``skipped`` with no subprocess
         # spawned; gate context is appended to the prompt like the agent path.
+        pending_state_updates = None
         gate = self._resolve_condition(job)
         if gate is not None:
             # State-aware like the native-agent path: a monitor gate's cursor /
             # watermark must be loaded, passed when the gate supports it, and
-            # persisted on both the skip and go paths — otherwise a backend
-            # monitor job re-reads the same "new" items every tick.
+            # persisted on the skip path; go-path updates are held back until
+            # the backend turn succeeds (see below).
             prior_state = self._get_job_state(job)
             try:
                 if self._gate_accepts_state(gate):
@@ -664,9 +665,13 @@ class ScheduledAgentExecutor:
                 context = getattr(decision, "context", None)
                 if context:
                     message = f"{message}\n\n{context}"
+                # Defer go-path watermark persistence until the backend turn
+                # actually succeeds — persisting here would advance the cursor
+                # past unprocessed work when the run is later blocked by
+                # policy, fails to resolve, times out, or errors.
                 updates = getattr(decision, "state_updates", None)
                 if isinstance(updates, dict) and updates:
-                    self._persist_job_state(job, prior_state, updates)
+                    pending_state_updates = updates
 
         # Run-scoped policy: the message is the untrusted portion of a backend
         # turn (there is no in-process agent whose skills could load content),
@@ -791,6 +796,9 @@ class ScheduledAgentExecutor:
                 logger.warning(
                     "Delivery failed for backend job '%s': %s", job.id, e,
                 )
+
+        if succeeded and pending_state_updates:
+            self._persist_job_state(job, prior_state, pending_state_updates)
 
         status = "succeeded" if succeeded else "failed"
         self._runner.mark_run(

--- a/src/praisonai-bot/praisonai_bot/scheduler/executor.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/executor.py
@@ -254,6 +254,20 @@ class ScheduledAgentExecutor:
         # so a deterministic watchdog (``df -h``, ``uptime``, a health-check
         # ``curl``) costs no tokens and cannot be reformatted by a model.
         command = str(getattr(job, "command", "") or "").strip()
+        # Defensive: a persisted job carrying BOTH model-free actions is
+        # ambiguous — fail loudly instead of silently preferring one. (The CLI
+        # rejects this combination at creation; this guards hand-edited or
+        # legacy store payloads.)
+        if command and str(getattr(job, "backend", "") or "").strip():
+            err = (
+                "Job configures both 'command' and 'backend'; exactly one "
+                "model-free action is allowed. Remove one and re-save."
+            )
+            duration = time.time() - started
+            self._runner.mark_run(job, status="failed", error=err, duration=duration)
+            if self._on_failure:
+                self._on_failure(job, err)
+            return JobResult(job=job, status="failed", error=err, duration=duration)
         if command:
             return await self._execute_command(job, command, started)
 
@@ -609,6 +623,50 @@ class ScheduledAgentExecutor:
         """
         options = dict(getattr(job, "backend_options", None) or {})
         cwd = options.pop("cwd", None)
+
+        # Pre-run condition gate: backend turns are real (expensive) turns, so
+        # they honour the same cheap go/no-go gate as native-agent jobs. On
+        # "nothing to do" the tick is recorded ``skipped`` with no subprocess
+        # spawned; gate context is appended to the prompt like the agent path.
+        gate = self._resolve_condition(job)
+        if gate is not None:
+            try:
+                decision = await asyncio.to_thread(gate.should_run, job)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    "Pre-run gate raised for backend job '%s': %s; running anyway",
+                    job.id, e,
+                )
+                decision = None
+            if decision is not None and not getattr(decision, "run", True):
+                reason = getattr(decision, "reason", None) or "pre-run gate: nothing to do"
+                logger.info("Backend job '%s' skipped by pre-run gate: %s", job.id, reason)
+                duration = time.time() - started
+                self._runner.mark_run(job, status="skipped", error=reason, duration=duration)
+                return JobResult(job=job, status="skipped", error=reason, duration=duration)
+            if decision is not None:
+                context = getattr(decision, "context", None)
+                if context:
+                    message = f"{message}\n\n{context}"
+
+        # Run-scoped policy: the message is the untrusted portion of a backend
+        # turn (there is no in-process agent whose skills could load content),
+        # so scan it with the same policy as native-agent jobs.
+        if self._run_policy is not None:
+            scan = self._run_policy.scan_prompt(message)
+            if not scan.ok:
+                err = f"Blocked by run policy: {scan.reason}"
+                logger.warning(
+                    "Backend job '%s' blocked by run policy: %s", job.id, scan.reason,
+                )
+                duration = time.time() - started
+                self._runner.mark_run(job, status="failed", error=err, duration=duration)
+                if self._on_failure:
+                    self._on_failure(job, err)
+                result = JobResult(job=job, status="failed", error=err, duration=duration)
+                self._audit_output(job, result)
+                await self._maybe_deliver_failure(job, result)
+                return result
 
         try:
             from praisonai_bot._code_bridge import import_code_module

--- a/src/praisonai-bot/praisonai_bot/scheduler/executor.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/executor.py
@@ -276,6 +276,15 @@ class ScheduledAgentExecutor:
                 duration=duration,
             )
 
+        # Model-free external-backend action: when the job names a CLI
+        # backend, the message runs as one headless turn through that backend
+        # — no native agent is resolved and no in-process model turn is taken.
+        # Checked after the empty-message guard (the message IS the prompt)
+        # and before agent resolution, mirroring the ``command`` action.
+        backend_id = str(getattr(job, "backend", "") or "").strip()
+        if backend_id:
+            return await self._execute_backend(job, backend_id, message, started)
+
         # Resolve the agent
         try:
             agent = self._resolve(agent_id)
@@ -583,6 +592,153 @@ class ScheduledAgentExecutor:
         return job_result
 
     # ── command-action helpers ───────────────────────────────────────
+
+    async def _execute_backend(
+        self, job: "ScheduleJob", backend_id: str, message: str, started: float,
+    ) -> JobResult:
+        """Run the job's message as one headless turn through a CLI backend.
+
+        Resolution goes through the sanctioned ``_code_bridge`` seam so the bot
+        package never hard-depends on ``praisonai-code``; when the optional
+        code package is unavailable the tick is recorded as ``failed`` with a
+        clear remediation instead of crashing the ticker. The job's pinned
+        ``model`` is passed straight to the backend (the pin is an input here,
+        not a drift guard — there is no in-process agent to compare against),
+        output is bounded like command output, and failures flow through the
+        same run-record, audit, and failure-delivery plumbing as agent turns.
+        """
+        options = dict(getattr(job, "backend_options", None) or {})
+        cwd = options.pop("cwd", None)
+
+        try:
+            from praisonai_bot._code_bridge import import_code_module
+            backends_mod = import_code_module("praisonai_code.cli_backends")
+            spec = {"id": backend_id, "overrides": options} if options else backend_id
+            backend = backends_mod.resolve_cli_backend_config(spec)
+        except Exception as e:
+            err = (
+                f"CLI backend {backend_id!r} unavailable: {e}. "
+                "Backend jobs require the praisonai-code package "
+                "(pip install praisonai-code)."
+            )
+            logger.warning("Job '%s' %s", job.id, err)
+            duration = time.time() - started
+            self._runner.mark_run(job, status="failed", error=err, duration=duration)
+            if self._on_failure:
+                self._on_failure(job, err)
+            result = JobResult(job=job, status="failed", error=err, duration=duration)
+            await self._maybe_deliver_failure(job, result)
+            return result
+
+        try:
+            from praisonaiagents.cli_backend.protocols import CliSessionBinding
+            session = CliSessionBinding(session_id=f"cron_{job.id}")
+        except Exception:  # pragma: no cover - core primitive always present
+            session = None
+
+        # Belt-and-braces bound on top of the backend's own timeout_ms
+        # enforcement, so a wedged subprocess can never stall the ticker.
+        timeout_ms = getattr(getattr(backend, "config", None), "timeout_ms", 300_000)
+        try:
+            timeout_s = float(timeout_ms) / 1000.0
+            if not math.isfinite(timeout_s) or timeout_s <= 0:
+                timeout_s = 300.0
+        except (TypeError, ValueError):
+            timeout_s = 300.0
+
+        exec_kwargs: Dict[str, Any] = {"session": session}
+        if cwd:
+            exec_kwargs["cwd"] = str(cwd)
+        model = getattr(job, "model", None)
+        if model:
+            exec_kwargs["model"] = model
+
+        try:
+            result_obj = await asyncio.wait_for(
+                backend.execute(message, **exec_kwargs), timeout=timeout_s + 30.0,
+            )
+        except asyncio.TimeoutError:
+            err = f"backend turn timed out after {timeout_s + 30.0:.0f}s"
+            logger.warning("Job '%s' %s", job.id, err)
+            duration = time.time() - started
+            self._runner.mark_run(job, status="failed", error=err, duration=duration)
+            if self._on_failure:
+                self._on_failure(job, err)
+            result = JobResult(job=job, status="failed", error=err, duration=duration)
+            await self._maybe_deliver_failure(job, result)
+            return result
+        except Exception as e:
+            err = f"backend turn failed to launch: {e}"
+            logger.warning("Job '%s' %s", job.id, err)
+            duration = time.time() - started
+            self._runner.mark_run(job, status="failed", error=err, duration=duration)
+            if self._on_failure:
+                self._on_failure(job, err)
+            result = JobResult(job=job, status="failed", error=err, duration=duration)
+            await self._maybe_deliver_failure(job, result)
+            return result
+
+        duration = time.time() - started
+        error = getattr(result_obj, "error", None)
+        text = str(getattr(result_obj, "content", "") or "")
+        if len(text) > _MAX_COMMAND_OUTPUT_CHARS:
+            text = text[:_MAX_COMMAND_OUTPUT_CHARS] + "\n…[output truncated]"
+        succeeded = not error
+
+        # Honour the intentional-silence contract like agent turns do: the
+        # backend ran fine but chose to say nothing worth delivering.
+        silent = False
+        if succeeded:
+            try:
+                from praisonaiagents.bots.silence import is_intentional_silence_response
+                silent = is_intentional_silence_response(text)
+            except Exception:  # pragma: no cover - core primitive always present
+                silent = False
+
+        delivered = False
+        delivery_error: Optional[str] = None
+        delivery = getattr(job, "delivery", None)
+        if succeeded and text and not silent and delivery and self._can_deliver(delivery):
+            try:
+                await self._dispatch_delivery(delivery, text)
+                delivered = True
+                logger.info(
+                    "Delivered backend job '%s' output to %s:%s",
+                    job.id, delivery.channel, delivery.channel_id,
+                )
+            except Exception as e:
+                delivery_error = str(e)
+                logger.warning(
+                    "Delivery failed for backend job '%s': %s", job.id, e,
+                )
+
+        status = "succeeded" if succeeded else "failed"
+        self._runner.mark_run(
+            job,
+            status=status,
+            result=text if succeeded else None,
+            error=None if succeeded else str(error),
+            duration=duration,
+            delivered=delivered,
+        )
+        if succeeded and self._on_success:
+            self._on_success(job, text)
+        elif not succeeded and self._on_failure:
+            self._on_failure(job, str(error))
+
+        result = JobResult(
+            job=job,
+            result=text if succeeded else None,
+            status=status,
+            error=None if succeeded else str(error),
+            duration=duration,
+            delivered=delivered,
+            delivery_error=delivery_error,
+        )
+        self._audit_output(job, result)
+        if not succeeded:
+            await self._maybe_deliver_failure(job, result)
+        return result
 
     async def _execute_command(
         self, job: "ScheduleJob", command: str, started: float,

--- a/src/praisonai-bot/praisonai_bot/scheduler/executor.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/executor.py
@@ -267,7 +267,10 @@ class ScheduledAgentExecutor:
             self._runner.mark_run(job, status="failed", error=err, duration=duration)
             if self._on_failure:
                 self._on_failure(job, err)
-            return JobResult(job=job, status="failed", error=err, duration=duration)
+            result = JobResult(job=job, status="failed", error=err, duration=duration)
+            await asyncio.to_thread(self._audit_output, job, result)
+            await self._maybe_deliver_failure(job, result)
+            return result
         if command:
             return await self._execute_command(job, command, started)
 

--- a/src/praisonai-bot/praisonai_bot/scheduler/executor.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/executor.py
@@ -627,6 +627,7 @@ class ScheduledAgentExecutor:
             if self._on_failure:
                 self._on_failure(job, err)
             result = JobResult(job=job, status="failed", error=err, duration=duration)
+            self._audit_output(job, result)
             await self._maybe_deliver_failure(job, result)
             return result
 
@@ -665,6 +666,7 @@ class ScheduledAgentExecutor:
             if self._on_failure:
                 self._on_failure(job, err)
             result = JobResult(job=job, status="failed", error=err, duration=duration)
+            self._audit_output(job, result)
             await self._maybe_deliver_failure(job, result)
             return result
         except Exception as e:
@@ -675,6 +677,7 @@ class ScheduledAgentExecutor:
             if self._on_failure:
                 self._on_failure(job, err)
             result = JobResult(job=job, status="failed", error=err, duration=duration)
+            self._audit_output(job, result)
             await self._maybe_deliver_failure(job, result)
             return result
 

--- a/src/praisonai-code/praisonai_code/cli/app.py
+++ b/src/praisonai-code/praisonai_code/cli/app.py
@@ -214,6 +214,7 @@ _LAZY_COMMANDS: Dict[str, Tuple[str, str, str]] = {
     "audit": (".commands.audit", "audit", "Compliance auditing"),
     "managed": (".commands.managed", "app", "Managed Agents (Anthropic cloud-hosted backend)"),
     "models": (".commands.models", "app", "List and describe available models"),
+    "backends": (".commands.backends", "app", "List registered CLI backends"),
 
     # Wrapper-resident commands — see ``_WRAPPER_RESIDENT_COMMANDS`` below. These entries keep
     # relative ``.commands.*`` paths so they are advertised in ``--help``, but

--- a/src/praisonai-code/praisonai_code/cli/commands/backends.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/backends.py
@@ -1,0 +1,32 @@
+"""List registered external CLI backends.
+
+Typer surface for the backend registry so ``praisonai backends`` works on a
+standalone ``praisonai-code`` install (the legacy argparse ``backends list``
+path is wrapper-resident and unreachable without the wrapper).
+"""
+
+from __future__ import annotations
+
+import typer
+
+app = typer.Typer(
+    help="External coding-CLI backends (delegate agent turns to a CLI)",
+    invoke_without_command=True,
+    no_args_is_help=False,
+)
+
+
+@app.callback()
+def _default(ctx: typer.Context) -> None:
+    """Default action: list registered backends."""
+    if ctx.invoked_subcommand is None:
+        list_backends()
+
+
+@app.command("list")
+def list_backends() -> None:
+    """List registered CLI backend ids (built-ins plus entry-point plugins)."""
+    from praisonai_code.cli_backends import list_cli_backends
+
+    for backend_id in list_cli_backends():
+        typer.echo(backend_id)

--- a/src/praisonai-code/praisonai_code/cli_backends/_errors.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/_errors.py
@@ -1,0 +1,24 @@
+"""Shared error formatting for CLI backends."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def called_process_error_message(exc: subprocess.CalledProcessError) -> str:
+    """Render a subprocess failure with its captured stderr.
+
+    ``str(CalledProcessError)`` only reports the exit status; the CLI's actual
+    diagnostic lives in ``exc.stderr`` (populated as ``str`` or ``bytes`` by
+    each backend's ``_execute_subprocess``).
+    """
+    stderr = getattr(exc, "stderr", None)
+    if stderr:
+        try:
+            text = stderr.decode() if isinstance(stderr, bytes) else str(stderr)
+        except AttributeError:
+            text = str(stderr)
+        text = text.strip()
+        if text:
+            return text
+    return str(exc)

--- a/src/praisonai-code/praisonai_code/cli_backends/claude.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/claude.py
@@ -126,7 +126,8 @@ class ClaudeCodeBackend:
             # Use execute mode (not streaming)
             result = await self._execute_subprocess(
                 cmd,
-                stdin_data=prompt if self.config.input == "stdin" else None
+                stdin_data=prompt if self.config.input == "stdin" else None,
+                cwd=kwargs.get("cwd"),
             )
             
             # Parse result based on output format
@@ -174,6 +175,12 @@ class ClaudeCodeBackend:
                 content="",
                 error=f"Claude CLI failed: {error_msg}",
                 metadata={"command": cmd, "return_code": getattr(e, 'returncode', -1)}
+            )
+        except TimeoutError as e:
+            return CliBackendResult(
+                content="",
+                error=f"Claude CLI failed: {e}",
+                metadata={"command": cmd, "timeout_ms": self.config.timeout_ms}
             )
     
     async def stream(self, prompt: str, **kwargs) -> AsyncIterator[CliBackendDelta]:
@@ -325,13 +332,15 @@ class ClaudeCodeBackend:
         
         return cmd
     
-    async def _execute_subprocess(self, cmd: List[str], stdin_data: Optional[str] = None) -> str:
+    async def _execute_subprocess(self, cmd: List[str], stdin_data: Optional[str] = None,
+                                  cwd: Optional[str] = None) -> str:
         """Execute subprocess and return stdout."""
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdin=asyncio.subprocess.PIPE if stdin_data is not None else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
             env=self._get_env()
         )
         

--- a/src/praisonai-code/praisonai_code/cli_backends/codex.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/codex.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import json
 import os
 import subprocess
 from typing import AsyncIterator, List, Optional
+
+from ._errors import called_process_error_message
 
 try:
     from praisonaiagents import (
@@ -67,8 +70,14 @@ class CodexBackend:
         except subprocess.CalledProcessError as exc:
             return CliBackendResult(
                 content="",
-                error=f"Codex CLI failed: {exc}",
+                error=f"Codex CLI failed: {called_process_error_message(exc)}",
                 metadata={"command": cmd, "return_code": getattr(exc, "returncode", -1)},
+            )
+        except TimeoutError as exc:
+            return CliBackendResult(
+                content="",
+                error=f"Codex CLI failed: {exc}",
+                metadata={"command": cmd, "timeout_ms": self.config.timeout_ms},
             )
 
     async def stream(self, prompt: str, **kwargs) -> AsyncIterator[CliBackendDelta]:
@@ -87,15 +96,26 @@ class CodexBackend:
         system_prompt: Optional[str] = None,
         **kwargs,
     ) -> List[str]:
-        cmd = [self.config.command, *self.config.args]
-
+        # ``resume`` is a subcommand of ``exec`` and must come immediately
+        # after it, before exec's own flags (``codex exec resume <id> ...``).
         if session and session.session_id and getattr(session, "is_resume", False):
-            cmd.extend(["resume", session.session_id])
+            args = list(self.config.args)
+            insert_at = args.index("exec") + 1 if "exec" in args else 0
+            args[insert_at:insert_at] = ["resume", session.session_id]
+            cmd = [self.config.command, *args]
+        else:
+            cmd = [self.config.command, *self.config.args]
 
-        cmd.extend(["-C", os.getcwd()])
+        cmd.extend(["-C", kwargs.get("cwd") or os.getcwd()])
+
+        model = kwargs.get("model")
+        if model:
+            cmd.extend(["-m", str(model)])
 
         if system_prompt:
-            cmd.extend(["-c", f'instructions="{system_prompt}"'])
+            # The value is parsed by the CLI as a TOML scalar; JSON string
+            # escaping is TOML-basic-string compatible.
+            cmd.extend(["-c", f"instructions={json.dumps(system_prompt)}"])
 
         if images:
             for image_path in images:

--- a/src/praisonai-code/praisonai_code/cli_backends/gemini.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/gemini.py
@@ -8,6 +8,8 @@ import os
 import subprocess
 from typing import AsyncIterator, List, Optional
 
+from ._errors import called_process_error_message
+
 try:
     from praisonaiagents import (
         CliBackendConfig,
@@ -57,7 +59,7 @@ class GeminiBackend:
             **kwargs,
         )
         try:
-            content = await self._execute_subprocess(cmd)
+            content = await self._execute_subprocess(cmd, cwd=kwargs.get("cwd"))
             return CliBackendResult(
                 content=content.strip(),
                 session_id=session.session_id if session else None,
@@ -66,8 +68,14 @@ class GeminiBackend:
         except subprocess.CalledProcessError as exc:
             return CliBackendResult(
                 content="",
-                error=f"Gemini CLI failed: {exc}",
+                error=f"Gemini CLI failed: {called_process_error_message(exc)}",
                 metadata={"command": cmd, "return_code": getattr(exc, "returncode", -1)},
+            )
+        except TimeoutError as exc:
+            return CliBackendResult(
+                content="",
+                error=f"Gemini CLI failed: {exc}",
+                metadata={"command": cmd, "timeout_ms": self.config.timeout_ms},
             )
 
     async def stream(self, prompt: str, **kwargs) -> AsyncIterator[CliBackendDelta]:
@@ -88,6 +96,10 @@ class GeminiBackend:
     ) -> List[str]:
         cmd = [self.config.command, *self.config.args]
 
+        model = kwargs.get("model")
+        if model:
+            cmd.extend(["-m", str(model)])
+
         if session and session.session_id and getattr(session, "is_resume", False):
             cmd.extend(["--resume", session.session_id])
 
@@ -97,12 +109,12 @@ class GeminiBackend:
         cmd.extend(["-p", prompt])
         return cmd
 
-    async def _execute_subprocess(self, cmd: List[str]) -> str:
+    async def _execute_subprocess(self, cmd: List[str], cwd: Optional[str] = None) -> str:
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=os.getcwd(),
+            cwd=cwd or os.getcwd(),
             env=self._get_env(),
         )
         try:

--- a/src/praisonai-code/praisonai_code/cli_backends/grok.py
+++ b/src/praisonai-code/praisonai_code/cli_backends/grok.py
@@ -8,6 +8,8 @@ import os
 import subprocess
 from typing import AsyncIterator, List, Optional
 
+from ._errors import called_process_error_message
+
 try:
     from praisonaiagents import (
         CliBackendConfig,
@@ -66,8 +68,14 @@ class GrokBackend:
         except subprocess.CalledProcessError as exc:
             return CliBackendResult(
                 content="",
-                error=f"Grok CLI failed: {exc}",
+                error=f"Grok CLI failed: {called_process_error_message(exc)}",
                 metadata={"command": cmd, "return_code": getattr(exc, "returncode", -1)},
+            )
+        except TimeoutError as exc:
+            return CliBackendResult(
+                content="",
+                error=f"Grok CLI failed: {exc}",
+                metadata={"command": cmd, "timeout_ms": self.config.timeout_ms},
             )
 
     async def stream(self, prompt: str, **kwargs) -> AsyncIterator[CliBackendDelta]:
@@ -86,7 +94,11 @@ class GrokBackend:
         system_prompt: Optional[str] = None,
         **kwargs,
     ) -> List[str]:
-        cmd = [self.config.command, *self.config.args, "--cwd", os.getcwd()]
+        cmd = [self.config.command, *self.config.args, "--cwd", kwargs.get("cwd") or os.getcwd()]
+
+        model = kwargs.get("model")
+        if model:
+            cmd.extend(["--model", str(model)])
 
         if session and session.session_id and getattr(session, "is_resume", False):
             cmd.extend(["--resume", session.session_id])

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -1399,6 +1399,29 @@ class AgentsGenerator:
         # 'praisonai'.
         self._validate_cli_backend_compatibility(config, workflow_framework or 'praisonai')
 
+        # The framework-level check above passes for 'praisonai' because the
+        # sequential/hierarchical adapter does support cli_backend — but
+        # workflow YAMLs run through YAMLWorkflowParser, which builds agents
+        # natively and has no cli_backend wiring. Fail fast instead of
+        # silently executing on the native LLM path with different tools,
+        # credentials, and workspace behavior than the declared backend.
+        workflow_entities = {
+            **(config.get('roles') or {}),
+            **(config.get('agents') or {}),
+        }
+        cli_backend_entities = sorted(
+            name
+            for name, details in workflow_entities.items()
+            if isinstance(details, dict) and details.get('cli_backend')
+        )
+        if cli_backend_entities:
+            raise ValueError(
+                f"cli_backend (declared by: {', '.join(cli_backend_entities)}) is not "
+                "supported for 'process: workflow' YAMLs; the workflow engine runs "
+                "agents natively. Remove cli_backend or convert to a "
+                "sequential/hierarchical process."
+            )
+
         # tool_timeout is enforced by _wrap_tool_with_timeout on the
         # sequential/hierarchical path via tools_dict. The native workflow engine
         # resolves its own tools by name, so that wrapper hook does not apply

--- a/src/praisonai/praisonai/cli/commands/schedule.py
+++ b/src/praisonai/praisonai/cli/commands/schedule.py
@@ -53,6 +53,9 @@ def schedule_add_cmd(
     condition: str = typer.Option("", "--condition", help="Natural-language / expression alias for the pre-run gate"),
     command: str = typer.Option("", "--command", "--script", help="No-LLM action: run this shell command on schedule and deliver its stdout verbatim (no agent, no model turn)"),
     command_timeout: float = typer.Option(60.0, "--command-timeout", help="Max seconds the --command may run before it is killed (default 60)"),
+    backend: str = typer.Option("", "--backend", help="External coding-CLI backend action: run the message as one headless turn via a registered backend (see 'praisonai backends'), e.g. claude-code, codex-cli. No native agent, no in-process model turn"),
+    backend_cwd: str = typer.Option("", "--backend-cwd", help="Working directory for the --backend turn (default: the scheduler process cwd)"),
+    backend_timeout: float = typer.Option(0.0, "--backend-timeout", help="Max seconds the --backend turn may run (default: the backend's own timeout, 300s)"),
     model: str = typer.Option("", "--model", help="Pin this job to a specific model (e.g. 'openai/gpt-4o-mini'). Snapshotted so unattended runs stay stable and drift fails closed. Pass an explicit model to capture a snapshot"),
     pin: bool = typer.Option(True, "--pin/--no-pin", help="Enforce the model snapshot so drift fails closed (default; only takes effect once a snapshot exists via --model). --no-pin follows whatever the default becomes"),
     once: bool = typer.Option(False, "--once", help="One-shot job: auto-remove after its single fire (maps to delete_after_run). Ideal for 'at:'/'in ...' reminders"),
@@ -68,6 +71,7 @@ def schedule_add_cmd(
         praisonai schedule add "tg-reminder" -s daily -m "check email" --agent support --channel telegram --channel-id 12345
         praisonai schedule add "inbox-watch" -s "*/5m" -m "Summarise new emails" --pre-run "scripts/new_mail.sh" --deliver telegram
         praisonai schedule add "disk-watch" -s hourly --command "df -h /" --deliver telegram:-100123
+        praisonai schedule add "nightly-refactor" -s "cron:0 2 * * *" -m "tidy utils.py, run tests" --backend claude-code --backend-cwd ~/proj --deliver telegram
     """
     output = get_output_controller()
     try:
@@ -101,8 +105,8 @@ def schedule_add_cmd(
             **delivery_kwargs
         )
 
-        # ``pre_run``/``condition``/``command`` run an arbitrary host shell
-        # command, so they are NOT part of the LLM-callable schedule_add
+        # ``pre_run``/``condition``/``command``/``backend`` run an arbitrary
+        # host process, so they are NOT part of the LLM-callable schedule_add
         # surface. The CLI is a trusted, human-driven surface, so set them on
         # the stored job here. A ``--command`` job runs verbatim with no agent
         # and no model turn, delivering its stdout to the delivery target.
@@ -110,7 +114,7 @@ def schedule_add_cmd(
         # an unattended run stays pinned and drift fails closed. A model-free
         # ``--command`` job takes no model turn, so pinning is skipped for it.
         want_pin_update = bool(model) or (not pin and not command)
-        if (pre_run or condition or command or want_pin_update) and "Error" not in result:
+        if (pre_run or condition or command or backend or want_pin_update) and "Error" not in result:
             try:
                 from praisonaiagents.tools.schedule_tools import _get_store
                 store = _get_store()
@@ -121,6 +125,18 @@ def schedule_add_cmd(
                     job.command = command or None
                     if command:
                         job.command_timeout = command_timeout
+                    if backend:
+                        job.backend = backend
+                        backend_options = {}
+                        if backend_cwd:
+                            backend_options["cwd"] = backend_cwd
+                        if backend_timeout and backend_timeout > 0:
+                            backend_options["timeout_ms"] = int(backend_timeout * 1000)
+                        job.backend_options = backend_options
+                        # A backend turn uses the pinned model as an input
+                        # (passed to the CLI), not as a drift guard.
+                        if model:
+                            job.model = model
                     if not command:
                         if model:
                             job.model = model

--- a/src/praisonai/praisonai/cli/commands/schedule.py
+++ b/src/praisonai/praisonai/cli/commands/schedule.py
@@ -74,6 +74,12 @@ def schedule_add_cmd(
         praisonai schedule add "nightly-refactor" -s "cron:0 2 * * *" -m "tidy utils.py, run tests" --backend claude-code --backend-cwd ~/proj --deliver telegram
     """
     output = get_output_controller()
+    if command and backend:
+        output.print_error(
+            "--command and --backend are mutually exclusive: a job runs exactly "
+            "one model-free action. Configure one or the other."
+        )
+        raise typer.Exit(1)
     try:
         from praisonaiagents.tools.schedule_tools import schedule_add as _schedule_add
 

--- a/src/praisonai/praisonai/cli/commands/schedule.py
+++ b/src/praisonai/praisonai/cli/commands/schedule.py
@@ -157,11 +157,19 @@ def schedule_add_cmd(
                 output.print_error(f"Failed to set command/pre-run gate: {e}")
                 raise typer.Exit(1)
 
+        # A duplicate-name response is a rejection: report it as an error and
+        # exit non-zero so scripts/CI never treat a rejected add (which created
+        # nothing and mutated nothing) as success. Match the two rejection
+        # shapes ``schedule_add`` can return precisely so a genuine success
+        # message is never misclassified.
+        add_failed = ("Error" in result) or ("already exists" in result)
         if json_output:
             import json as _json
             print(_json.dumps({"result": result}))
+            if add_failed:
+                raise typer.Exit(1)
         else:
-            if "Error" in result:
+            if add_failed:
                 output.print_error(result)
                 raise typer.Exit(1)
             else:

--- a/src/praisonai/praisonai/cli/commands/schedule.py
+++ b/src/praisonai/praisonai/cli/commands/schedule.py
@@ -113,8 +113,13 @@ def schedule_add_cmd(
         # ``--model``/``--no-pin`` snapshot the model/pin policy onto the job so
         # an unattended run stays pinned and drift fails closed. A model-free
         # ``--command`` job takes no model turn, so pinning is skipped for it.
+        # Only apply trusted post-add options when THIS invocation actually
+        # created the job. A duplicate-name response ("already exists") is a
+        # rejection: mutating the existing job here would let a rejected add
+        # reconfigure a live schedule (e.g. attach a new --command/--backend).
+        job_created = f"Schedule '{name}' added" in result
         want_pin_update = bool(model) or (not pin and not command)
-        if (pre_run or condition or command or backend or want_pin_update) and "Error" not in result:
+        if (pre_run or condition or command or backend or want_pin_update) and job_created:
             try:
                 from praisonaiagents.tools.schedule_tools import _get_store
                 store = _get_store()

--- a/src/praisonai/praisonai/cli/commands/schedule.py
+++ b/src/praisonai/praisonai/cli/commands/schedule.py
@@ -6,6 +6,8 @@ Provides scheduler management.
 
 from typing import Optional
 
+import math
+
 import typer
 
 from ..output.console import get_output_controller
@@ -74,6 +76,16 @@ def schedule_add_cmd(
         praisonai schedule add "nightly-refactor" -s "cron:0 2 * * *" -m "tidy utils.py, run tests" --backend claude-code --backend-cwd ~/proj --deliver telegram
     """
     output = get_output_controller()
+    if (
+        backend
+        and isinstance(backend_timeout, (int, float))
+        and backend_timeout
+        and not (math.isfinite(backend_timeout) and backend_timeout >= 0)
+    ):
+        output.print_error(
+            "--backend-timeout must be a finite, non-negative number of seconds."
+        )
+        raise typer.Exit(1)
     if command and backend:
         output.print_error(
             "--command and --backend are mutually exclusive: a job runs exactly "
@@ -146,7 +158,7 @@ def schedule_add_cmd(
                             # positive instead of collapsing to 0 (which the
                             # executor would replace with the 300s default).
                             backend_options["timeout_ms"] = max(
-                                1, int(round(backend_timeout * 1000))
+                                1, round(backend_timeout * 1000)
                             )
                         job.backend_options = backend_options
                         # A backend turn uses the pinned model as an input
@@ -162,12 +174,13 @@ def schedule_add_cmd(
                 output.print_error(f"Failed to set command/pre-run gate: {e}")
                 raise typer.Exit(1)
 
-        # A duplicate-name response is a rejection: report it as an error and
-        # exit non-zero so scripts/CI never treat a rejected add (which created
-        # nothing and mutated nothing) as success. Match the two rejection
-        # shapes ``schedule_add`` can return precisely so a genuine success
-        # message is never misclassified.
-        add_failed = ("Error" in result) or ("already exists" in result)
+        # A rejected add (duplicate name or error) must exit non-zero so
+        # scripts/CI never treat it as success. Detect failure as the absence
+        # of the producer-owned success confirmation rather than substring
+        # matching on error words — a schedule *named* "Error monitor" or
+        # "already exists" appears inside the success message and must not be
+        # misclassified as a failure.
+        add_failed = not job_created
         if json_output:
             import json as _json
             print(_json.dumps({"result": result}))

--- a/src/praisonai/praisonai/cli/commands/schedule.py
+++ b/src/praisonai/praisonai/cli/commands/schedule.py
@@ -142,7 +142,12 @@ def schedule_add_cmd(
                         if backend_cwd:
                             backend_options["cwd"] = backend_cwd
                         if backend_timeout and backend_timeout > 0:
-                            backend_options["timeout_ms"] = int(backend_timeout * 1000)
+                            # Round up so a positive sub-millisecond value stays
+                            # positive instead of collapsing to 0 (which the
+                            # executor would replace with the 300s default).
+                            backend_options["timeout_ms"] = max(
+                                1, int(round(backend_timeout * 1000))
+                            )
                         job.backend_options = backend_options
                         # A backend turn uses the pinned model as an input
                         # (passed to the CLI), not as a drift guard.

--- a/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
@@ -387,10 +387,11 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
             # Agent-level ``cli_backend`` in YAML delegates this agent's turns
             # to an external coding CLI. Core Agent refuses raw string ids, so
             # resolve to an instance here in the wrapper layer.
-            if 'cli_backend' in details:
+            cli_backend_config = details.get('cli_backend')
+            if cli_backend_config is not None:
                 from praisonai.agents_generator import _resolve_yaml_cli_backend
                 resolved_backend = _resolve_yaml_cli_backend(
-                    details.get('cli_backend'), logger
+                    cli_backend_config, logger
                 )
                 if resolved_backend is None:
                     # Fail closed: an explicitly requested backend that cannot
@@ -398,7 +399,7 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
                     # LLM path (different tools, credentials, and billing).
                     raise ValueError(
                         f"Agent {role_filled!r} requests cli_backend="
-                        f"{details.get('cli_backend')!r} but it could not be "
+                        f"{cli_backend_config!r} but it could not be "
                         "resolved. Install praisonai-code and use an id from "
                         "'praisonai backends', or remove the cli_backend field."
                     )

--- a/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
@@ -153,17 +153,10 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
         if 'backend' in global_config:
             return global_config['backend']
         
-        # 7. Check CLI backend override (legacy with warning)
-        if 'cli_backend' in details:
-            import warnings
-            warnings.warn(
-                "Agent-level 'cli_backend' in YAML is deprecated. "
-                "Use 'runtime' parameter or model-scoped runtime configuration instead.",
-                DeprecationWarning,
-                stacklevel=3
-            )
-            return details['cli_backend']
-        
+        # 7. ``cli_backend`` is NOT a runtime id — it is resolved to a backend
+        # instance and passed as the ``cli_backend`` kwarg instead (see the
+        # agent construction path). Returning it here would send a CLI-backend
+        # id into the runtime registry, which fails closed on unknown ids.
         return None
     
     def _resolve_agent_approval(self, details: Dict[str, Any], config: Dict[str, Any]):
@@ -390,6 +383,17 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
                 'toolsets': agent_toolsets,
                 'runtime': agent_runtime,
             }
+
+            # Agent-level ``cli_backend`` in YAML delegates this agent's turns
+            # to an external coding CLI. Core Agent refuses raw string ids, so
+            # resolve to an instance here in the wrapper layer.
+            if 'cli_backend' in details:
+                from praisonai.agents_generator import _resolve_yaml_cli_backend
+                resolved_backend = _resolve_yaml_cli_backend(
+                    details.get('cli_backend'), logger
+                )
+                if resolved_backend is not None:
+                    agent_kwargs['cli_backend'] = resolved_backend
             
             # Forward agent-level fields that core Agent already accepts as-is
             # so CLI/YAML flags (--planning, --web, --autonomy, ...) are

--- a/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
@@ -392,8 +392,17 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
                 resolved_backend = _resolve_yaml_cli_backend(
                     details.get('cli_backend'), logger
                 )
-                if resolved_backend is not None:
-                    agent_kwargs['cli_backend'] = resolved_backend
+                if resolved_backend is None:
+                    # Fail closed: an explicitly requested backend that cannot
+                    # be resolved must not silently fall back to the native
+                    # LLM path (different tools, credentials, and billing).
+                    raise ValueError(
+                        f"Agent {role_filled!r} requests cli_backend="
+                        f"{details.get('cli_backend')!r} but it could not be "
+                        "resolved. Install praisonai-code and use an id from "
+                        "'praisonai backends', or remove the cli_backend field."
+                    )
+                agent_kwargs['cli_backend'] = resolved_backend
             
             # Forward agent-level fields that core Agent already accepts as-is
             # so CLI/YAML flags (--planning, --web, --autonomy, ...) are

--- a/src/praisonai/tests/unit/scheduler/test_backend_action.py
+++ b/src/praisonai/tests/unit/scheduler/test_backend_action.py
@@ -252,13 +252,16 @@ def test_backend_resolution_failure_is_audited(monkeypatch):
 
 
 def test_command_and_backend_conflict_fails(fake_backend):
-    """A persisted job with both model-free actions fails loudly."""
+    """A persisted job with both model-free actions fails loudly and is audited."""
     backend, _ = fake_backend
     delivered: list = []
     ex = _executor(delivered)
+    audited: list = []
+    ex._audit_output = lambda job, result: audited.append(result)
     job = _backend_job()
     job.command = "df -h"
     result = _run(ex._execute_one(job))
     assert result.status == "failed"
     assert "exactly one" in result.error
     assert backend.calls == []
+    assert audited and audited[0].error == result.error

--- a/src/praisonai/tests/unit/scheduler/test_backend_action.py
+++ b/src/praisonai/tests/unit/scheduler/test_backend_action.py
@@ -172,6 +172,44 @@ def test_backend_empty_message_skipped(fake_backend):
     assert backend.calls == []
 
 
+def test_schedule_add_duplicate_is_rejected_no_mutation(monkeypatch):
+    """A duplicate-name ``schedule add --backend`` must be a genuine no-op:
+    it neither mutates the pre-existing same-named job nor exits 0."""
+    import typer
+    from praisonai.cli.commands import schedule as sched_cmd
+    import praisonaiagents.tools.schedule_tools as tools
+
+    duplicate_msg = (
+        "A schedule named 'nightly' already exists (id: abc123). "
+        "Remove it first or choose a different name."
+    )
+    monkeypatch.setattr(tools, "schedule_add", lambda **kw: duplicate_msg)
+
+    class FakeStore:
+        def __init__(self):
+            self.updated = []
+
+        def get_by_name(self, name):  # pragma: no cover - must not be reached
+            raise AssertionError("existing job must not be fetched for mutation")
+
+        def update(self, job):  # pragma: no cover - must not be reached
+            self.updated.append(job)
+
+    store = FakeStore()
+    monkeypatch.setattr(tools, "_get_store", lambda: store)
+
+    with pytest.raises(typer.Exit) as exc:
+        sched_cmd.schedule_add_cmd(
+            name="nightly",
+            schedule="cron:0 2 * * *",
+            message="tidy",
+            backend="claude-code",
+            json_output=False,
+        )
+    assert exc.value.exit_code == 1
+    assert store.updated == []
+
+
 def test_backend_fields_round_trip():
     job = _backend_job(options={"cwd": "/tmp/ws"})
     data = job.to_dict()

--- a/src/praisonai/tests/unit/scheduler/test_backend_action.py
+++ b/src/praisonai/tests/unit/scheduler/test_backend_action.py
@@ -1,0 +1,196 @@
+"""
+Unit tests for the external CLI-backend action on scheduled jobs.
+
+A job carrying a ``backend`` runs its message as one headless turn through the
+named backend from the registry — no native agent resolved, no in-process
+model turn. Covers:
+
+- success: backend content delivered, status ``succeeded``
+- backend error result: status ``failed`` with the backend's error
+- praisonai-code unavailable: recorded ``failed`` with remediation, no crash
+- options plumbing: ``cwd`` and ``model`` reach ``backend.execute``,
+  remaining ``backend_options`` become config overrides
+- empty message: recorded ``skipped`` before the backend is resolved
+- serialisation: ``backend``/``backend_options`` round-trip ``to_dict``;
+  jobs without a backend stay byte-for-byte unchanged
+"""
+
+import asyncio
+import sys
+import types
+from typing import List
+
+import pytest
+
+from praisonaiagents.scheduler.models import (
+    ScheduleJob,
+    Schedule,
+    DeliveryTarget,
+)
+from praisonai.scheduler.executor import ScheduledAgentExecutor
+
+
+class FakeRunner:
+    def __init__(self):
+        self.runs: List[dict] = []
+
+    def mark_run(self, job, **kwargs):
+        self.runs.append({"job": job, **kwargs})
+
+
+class FakeResult:
+    def __init__(self, content="", error=None):
+        self.content = content
+        self.error = error
+        self.metadata = {}
+        self.session_id = None
+
+
+class FakeBackend:
+    def __init__(self):
+        self.calls: List[dict] = []
+        self.result = FakeResult(content="done")
+        self.config = types.SimpleNamespace(timeout_ms=300_000)
+
+    async def execute(self, prompt, **kwargs):
+        self.calls.append({"prompt": prompt, **kwargs})
+        return self.result
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _executor(delivered):
+    async def deliver(target, text):
+        delivered.append((target, text))
+
+    return ScheduledAgentExecutor(
+        runner=FakeRunner(),
+        agent_resolver=lambda aid: None,
+        delivery_handler=deliver,
+    )
+
+
+def _backend_job(message="do the thing", backend="claude-code", options=None,
+                 deliver="telegram:-100"):
+    return ScheduleJob(
+        name="backend-job",
+        schedule=Schedule(kind="every", every_seconds=1),
+        message=message,
+        backend=backend,
+        backend_options=options or {},
+        delivery=DeliveryTarget.parse(deliver),
+    )
+
+
+@pytest.fixture
+def fake_backend(monkeypatch):
+    """Route the executor's bridge import at a fake backends module."""
+    backend = FakeBackend()
+    fake_module = types.SimpleNamespace()
+    fake_module.resolved_specs = []
+
+    def resolve_cli_backend_config(spec):
+        fake_module.resolved_specs.append(spec)
+        return backend
+
+    fake_module.resolve_cli_backend_config = resolve_cli_backend_config
+
+    import praisonai_bot._code_bridge as bridge
+
+    def fake_import(name):
+        assert name == "praisonai_code.cli_backends"
+        return fake_module
+
+    monkeypatch.setattr(bridge, "import_code_module", fake_import)
+    return backend, fake_module
+
+
+def test_backend_success_delivered(fake_backend):
+    backend, _ = fake_backend
+    delivered: list = []
+    ex = _executor(delivered)
+    result = _run(ex._execute_one(_backend_job()))
+    assert result.status == "succeeded"
+    assert result.result == "done"
+    assert result.delivered is True
+    assert delivered[-1][1] == "done"
+    assert backend.calls[0]["prompt"] == "do the thing"
+
+
+def test_backend_error_result_failed(fake_backend):
+    backend, _ = fake_backend
+    backend.result = FakeResult(error="Claude CLI failed: boom")
+    delivered: list = []
+    ex = _executor(delivered)
+    result = _run(ex._execute_one(_backend_job()))
+    assert result.status == "failed"
+    assert "boom" in result.error
+    assert result.delivered is False
+    runs = ex._runner.runs
+    assert runs[-1]["status"] == "failed"
+
+
+def test_backend_unavailable_records_failed(monkeypatch):
+    import praisonai_bot._code_bridge as bridge
+
+    def broken_import(name):
+        raise ImportError("praisonai-code not installed")
+
+    monkeypatch.setattr(bridge, "import_code_module", broken_import)
+    delivered: list = []
+    ex = _executor(delivered)
+    result = _run(ex._execute_one(_backend_job()))
+    assert result.status == "failed"
+    assert "praisonai-code" in result.error
+
+
+def test_backend_options_plumbing(fake_backend):
+    backend, fake_module = fake_backend
+    delivered: list = []
+    ex = _executor(delivered)
+    job = _backend_job(options={"cwd": "/tmp/ws", "timeout_ms": 120_000})
+    job.model = "claude-sonnet-4-5"
+    result = _run(ex._execute_one(job))
+    assert result.status == "succeeded"
+    call = backend.calls[0]
+    assert call["cwd"] == "/tmp/ws"
+    assert call["model"] == "claude-sonnet-4-5"
+    # cwd is consumed by the executor; only config overrides reach resolution
+    assert fake_module.resolved_specs == [
+        {"id": "claude-code", "overrides": {"timeout_ms": 120_000}}
+    ]
+
+
+def test_backend_empty_message_skipped(fake_backend):
+    backend, _ = fake_backend
+    delivered: list = []
+    ex = _executor(delivered)
+    result = _run(ex._execute_one(_backend_job(message="")))
+    assert result.status == "skipped"
+    assert backend.calls == []
+
+
+def test_backend_fields_round_trip():
+    job = _backend_job(options={"cwd": "/tmp/ws"})
+    data = job.to_dict()
+    assert data["backend"] == "claude-code"
+    assert data["backend_options"] == {"cwd": "/tmp/ws"}
+    restored = ScheduleJob.from_dict(data)
+    assert restored.backend == "claude-code"
+    assert restored.backend_options == {"cwd": "/tmp/ws"}
+
+
+def test_backendless_job_payload_unchanged():
+    job = ScheduleJob(
+        name="plain",
+        schedule=Schedule(kind="every", every_seconds=1),
+        message="hello",
+    )
+    data = job.to_dict()
+    assert "backend" not in data
+    assert "backend_options" not in data
+    restored = ScheduleJob.from_dict(data)
+    assert restored.backend is None
+    assert restored.backend_options == {}

--- a/src/praisonai/tests/unit/scheduler/test_backend_action.py
+++ b/src/praisonai/tests/unit/scheduler/test_backend_action.py
@@ -211,3 +211,16 @@ def test_backend_resolution_failure_is_audited(monkeypatch):
     result = _run(ex._execute_one(_backend_job()))
     assert result.status == "failed"
     assert audited and audited[0].error == result.error
+
+
+def test_command_and_backend_conflict_fails(fake_backend):
+    """A persisted job with both model-free actions fails loudly."""
+    backend, _ = fake_backend
+    delivered: list = []
+    ex = _executor(delivered)
+    job = _backend_job()
+    job.command = "df -h"
+    result = _run(ex._execute_one(job))
+    assert result.status == "failed"
+    assert "exactly one" in result.error
+    assert backend.calls == []

--- a/src/praisonai/tests/unit/scheduler/test_backend_action.py
+++ b/src/praisonai/tests/unit/scheduler/test_backend_action.py
@@ -194,3 +194,20 @@ def test_backendless_job_payload_unchanged():
     restored = ScheduleJob.from_dict(data)
     assert restored.backend is None
     assert restored.backend_options == {}
+
+
+def test_backend_resolution_failure_is_audited(monkeypatch):
+    """Early failures (resolution/timeout/launch) must hit the audit path."""
+    import praisonai_bot._code_bridge as bridge
+
+    def broken_import(name):
+        raise ImportError("praisonai-code not installed")
+
+    monkeypatch.setattr(bridge, "import_code_module", broken_import)
+    delivered: list = []
+    ex = _executor(delivered)
+    audited: list = []
+    ex._audit_output = lambda job, result: audited.append(result)
+    result = _run(ex._execute_one(_backend_job()))
+    assert result.status == "failed"
+    assert audited and audited[0].error == result.error

--- a/src/praisonai/tests/unit/scheduler/test_backend_action.py
+++ b/src/praisonai/tests/unit/scheduler/test_backend_action.py
@@ -265,3 +265,35 @@ def test_command_and_backend_conflict_fails(fake_backend):
     assert "exactly one" in result.error
     assert backend.calls == []
     assert audited and audited[0].error == result.error
+
+
+def test_gate_go_path_state_persists_only_on_success(fake_backend, monkeypatch):
+    """A go-path gate watermark must not advance when the backend turn fails."""
+    backend, _ = fake_backend
+
+    class Decision:
+        run = True
+        context = None
+        state_updates = {"cursor": "42"}
+
+    class Gate:
+        def should_run(self, job):
+            return Decision()
+
+    persisted: list = []
+    delivered: list = []
+    ex = _executor(delivered)
+    ex._condition_resolver = lambda job: Gate()
+    monkeypatch.setattr(
+        ex, "_persist_job_state", lambda job, prior, updates: persisted.append(updates)
+    )
+
+    backend.result = FakeResult(error="boom")
+    result = _run(ex._execute_one(_backend_job()))
+    assert result.status == "failed"
+    assert persisted == []  # failed run: cursor NOT advanced
+
+    backend.result = FakeResult(content="ok")
+    result = _run(ex._execute_one(_backend_job()))
+    assert result.status == "succeeded"
+    assert persisted == [{"cursor": "42"}]  # success: cursor advanced once

--- a/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
+++ b/src/praisonai/tests/unit/scheduler/test_timezone_surface.py
@@ -156,7 +156,7 @@ def test_schedule_add_cli_passes_timezone(monkeypatch):
 
     def fake_add(**kwargs):
         captured.update(kwargs)
-        return "Schedule added"
+        return f"Schedule '{kwargs['name']}' added (id: 1)"
 
     monkeypatch.setattr(tools, "schedule_add", fake_add)
     result = CliRunner().invoke(

--- a/src/praisonai/tests/unit/test_cli_backend_fixes.py
+++ b/src/praisonai/tests/unit/test_cli_backend_fixes.py
@@ -1,0 +1,119 @@
+"""Regression tests for CLI backend robustness fixes.
+
+Covers:
+- timeout is returned as a ``CliBackendResult`` error, not raised (all four)
+- ``CalledProcessError`` stderr text reaches the error message (codex/gemini/grok)
+- codex resume subcommand order: ``codex exec resume <id> ...``
+- codex system prompt is TOML-escaped
+- ``is_resume`` is set on the second delegated turn for one session
+"""
+
+import asyncio
+import subprocess
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from praisonaiagents.cli_backend.protocols import CliSessionBinding
+from praisonai_code.cli_backends.claude import ClaudeCodeBackend
+from praisonai_code.cli_backends.codex import CodexBackend
+from praisonai_code.cli_backends.gemini import GeminiBackend
+from praisonai_code.cli_backends.grok import GrokBackend
+from praisonai_code.cli_backends._errors import called_process_error_message
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.mark.parametrize("backend_cls", [ClaudeCodeBackend, CodexBackend, GeminiBackend, GrokBackend])
+def test_timeout_returns_error_result(backend_cls, monkeypatch):
+    backend = backend_cls()
+
+    async def timing_out(*args, **kwargs):
+        raise TimeoutError("CLI timed out after 1ms")
+
+    monkeypatch.setattr(backend, "_execute_subprocess", timing_out)
+    result = _run(backend.execute("hello"))
+    assert result.error is not None
+    assert "timed out" in result.error
+    assert result.content == ""
+
+
+@pytest.mark.parametrize("backend_cls", [CodexBackend, GeminiBackend, GrokBackend])
+def test_stderr_reaches_error_message(backend_cls, monkeypatch):
+    backend = backend_cls()
+
+    async def failing(*args, **kwargs):
+        raise subprocess.CalledProcessError(2, ["cli"], stderr="auth expired: run login")
+
+    monkeypatch.setattr(backend, "_execute_subprocess", failing)
+    result = _run(backend.execute("hello"))
+    assert result.error is not None
+    assert "auth expired: run login" in result.error
+
+
+def test_called_process_error_message_bytes():
+    exc = subprocess.CalledProcessError(1, ["x"], stderr=b"broken pipe")
+    assert called_process_error_message(exc) == "broken pipe"
+
+
+def test_codex_resume_order():
+    backend = CodexBackend()
+    session = CliSessionBinding(session_id="sess-1", is_resume=True)
+    cmd = backend._build_command("do it", session=session)
+    exec_idx = cmd.index("exec")
+    assert cmd[exec_idx + 1] == "resume"
+    assert cmd[exec_idx + 2] == "sess-1"
+    # exec's own flags come after the resume subcommand
+    assert cmd.index("--skip-git-repo-check") > exec_idx + 2
+
+
+def test_codex_instructions_escaped():
+    backend = CodexBackend()
+    cmd = backend._build_command("go", system_prompt='say "hi"\nthen stop')
+    cfg = cmd[cmd.index("-c") + 1]
+    assert cfg.startswith("instructions=")
+    # JSON escaping: embedded quote and newline must be escaped
+    assert '\\"hi\\"' in cfg
+    assert "\\n" in cfg
+    assert '\n' not in cfg
+
+
+def test_codex_model_and_cwd_flags():
+    backend = CodexBackend()
+    cmd = backend._build_command("go", model="gpt-5-codex", cwd="/tmp/ws")
+    assert cmd[cmd.index("-m") + 1] == "gpt-5-codex"
+    assert cmd[cmd.index("-C") + 1] == "/tmp/ws"
+
+
+def test_is_resume_set_on_second_turn():
+    """The agent marks a CLI session started after a successful turn."""
+    from praisonaiagents.agent import Agent
+
+    captured = []
+
+    class RecordingBackend:
+        def __init__(self):
+            from praisonaiagents.cli_backend.protocols import CliBackendConfig
+            self.config = CliBackendConfig(command="fake")
+
+        def capabilities(self):  # pragma: no cover - protocol completeness
+            return None
+
+        async def execute(self, prompt, *, session=None, **kwargs):
+            captured.append(bool(session and session.is_resume))
+            from praisonaiagents.cli_backend.protocols import CliBackendResult
+            return CliBackendResult(content="ok")
+
+        async def stream(self, prompt, **kwargs):  # pragma: no cover
+            yield None
+
+    agent = Agent(name="t", role="t", goal="t", backstory="t", llm="openai/gpt-4o-mini")
+    backend = RecordingBackend()
+    _run(agent._chat_via_cli_backend("first", cli_backend=backend))
+    _run(agent._chat_via_cli_backend("second", cli_backend=backend))
+    assert captured == [False, True]

--- a/src/praisonai/tests/unit/test_cli_backend_fixes.py
+++ b/src/praisonai/tests/unit/test_cli_backend_fixes.py
@@ -131,3 +131,87 @@ def test_yaml_backend_resolution_failure_fails_closed(monkeypatch):
     # omitting the kwarg (full generator run needs YAML fixtures; the guard
     # clause is the unit under test).
     assert "could not be" in source and "raise ValueError" in source
+
+
+def test_workflow_yaml_cli_backend_rejected():
+    """A workflow YAML that declares cli_backend must fail fast: the workflow
+    engine builds agents natively and would silently drop the field."""
+    from praisonai.agents_generator import AgentsGenerator
+
+    gen = AgentsGenerator.__new__(AgentsGenerator)
+    gen.framework = "praisonai"
+    gen.config_list = []
+    config = {
+        "framework": "praisonai",
+        "process": "workflow",
+        "name": "wf",
+        "agents": {
+            "coder": {"instructions": "write code", "cli_backend": "claude-code"},
+        },
+        "steps": [{"agent": "coder", "action": "do the thing"}],
+    }
+    with pytest.raises(ValueError, match="cli_backend"):
+        gen._build_yaml_workflow(config)
+
+
+class _SucceedingBackend:
+    def __init__(self):
+        from praisonaiagents.cli_backend.protocols import CliBackendConfig
+        self.config = CliBackendConfig(command="fake")
+
+    def capabilities(self):  # pragma: no cover - protocol completeness
+        return None
+
+    async def execute(self, prompt, *, session=None, **kwargs):
+        from praisonaiagents.cli_backend.protocols import CliBackendResult
+        return CliBackendResult(content="ok", metadata={"command": ["fake"]})
+
+    async def stream(self, prompt, **kwargs):  # pragma: no cover
+        yield None
+
+
+def test_post_execution_hook_failure_does_not_fail_turn():
+    """Once the external command has completed, a failing success hook must not
+    be reported as a backend-execution failure (that invites retries of
+    finished work) and must not fire the failure hook."""
+    from praisonaiagents.agent import Agent
+
+    agent = Agent(name="t", role="t", goal="t", backstory="t", llm="openai/gpt-4o-mini")
+    hook_calls = []
+
+    async def exploding_hook(**hook_kwargs):
+        hook_calls.append(hook_kwargs)
+        raise RuntimeError("hook exploded")
+
+    agent._emit_cli_backend_hook = exploding_hook
+    out = _run(agent._chat_via_cli_backend("go", cli_backend=_SucceedingBackend()))
+    assert out == "ok"
+    assert len(hook_calls) == 1
+    assert "error" not in hook_calls[0]
+
+
+def test_backend_error_result_reaches_failure_hook():
+    """A backend-returned error result keeps its audit metadata: the failure
+    hook receives the result itself, not None."""
+    from praisonaiagents.agent import Agent
+
+    class ErroringBackend(_SucceedingBackend):
+        async def execute(self, prompt, *, session=None, **kwargs):
+            from praisonaiagents.cli_backend.protocols import CliBackendResult
+            return CliBackendResult(
+                content="", error="boom", metadata={"command": ["fake"]}
+            )
+
+    agent = Agent(name="t", role="t", goal="t", backstory="t", llm="openai/gpt-4o-mini")
+    hook_calls = []
+
+    async def recording_hook(**hook_kwargs):
+        hook_calls.append(hook_kwargs)
+
+    agent._emit_cli_backend_hook = recording_hook
+    with pytest.raises(RuntimeError, match="boom"):
+        _run(agent._chat_via_cli_backend("go", cli_backend=ErroringBackend()))
+    assert len(hook_calls) == 1
+    assert hook_calls[0]["result"] is not None
+    assert hook_calls[0]["result"].metadata == {"command": ["fake"]}
+    assert "boom" in hook_calls[0]["error"]

--- a/src/praisonai/tests/unit/test_cli_backend_fixes.py
+++ b/src/praisonai/tests/unit/test_cli_backend_fixes.py
@@ -117,3 +117,17 @@ def test_is_resume_set_on_second_turn():
     _run(agent._chat_via_cli_backend("first", cli_backend=backend))
     _run(agent._chat_via_cli_backend("second", cli_backend=backend))
     assert captured == [False, True]
+
+
+def test_yaml_backend_resolution_failure_fails_closed(monkeypatch):
+    """An explicitly requested YAML cli_backend that cannot resolve must raise,
+    never silently fall back to the native LLM path."""
+    import praisonai.agents_generator as ag
+    monkeypatch.setattr(ag, "_resolve_yaml_cli_backend", lambda cfg, log: None)
+    import inspect
+    from praisonai.framework_adapters.praisonai_adapter import PraisonAIAdapter
+    source = inspect.getsource(PraisonAIAdapter)
+    # Contract check: the adapter raises on unresolved cli_backend rather than
+    # omitting the kwarg (full generator run needs YAML fixtures; the guard
+    # clause is the unit under test).
+    assert "could not be" in source and "raise ValueError" in source


### PR DESCRIPTION
## Summary

Scheduled jobs can now run **through an external coding-CLI backend** as a first-class action, and six previously-silent defects in the CLI-backend layer are fixed. Everything was validated adversarially against `main` before implementation (each defect confirmed with exact anchors), and the placement follows the monorepo tier rules — **no new package**: the bot executor reaches `praisonai-code` only through the sanctioned `_code_bridge` lazy seam, verified by the `check_bot_code_imports.sh` gate.

```bash
praisonai schedule add nightly-tidy -s "cron:0 2 * * *" \
  -m "tidy utils.py and run the tests" \
  --backend claude-code --backend-cwd ~/proj --deliver telegram
```

## What's new

- **`ScheduleJob.backend` + `backend_options`** (`praisonaiagents/scheduler/models.py`): optional, sparse-serialised — jobs without a backend stay byte-for-byte unchanged. Documented in the dataclass docstring.
- **Executor action** (`praisonai_bot/scheduler/executor.py::_execute_backend`): slots after the empty-message guard, mirroring the `command` action. Resolves via `_code_bridge → praisonai_code.cli_backends.resolve_cli_backend_config` (bare id or id+overrides); passes the job's pinned `model` and `cwd` to the backend; belt-and-braces `asyncio.wait_for` bound on top of the backend's own `timeout_ms`; output bounded to the same 8000-char cap as command output; honours the intentional-silence contract; failures flow through `mark_run`, `_audit_output`, and `_maybe_deliver_failure`. When `praisonai-code` isn't installed the tick records `failed` with a clear remediation instead of crashing the ticker.
- **CLI**: `praisonai schedule add --backend / --backend-cwd / --backend-timeout` (trusted post-add mutation path, deliberately NOT exposed on the LLM-callable `schedule_add` tool — same posture as `--command`/`--pre-run`); new Typer **`praisonai backends`** command so standalone `praisonai-code` installs can list registered backends (the legacy argparse path is wrapper-resident).

## Defect fixes (each independently user-visible)

1. **Timeout escaped as an exception** in all four backends — `execute()` caught only `CalledProcessError` while `_execute_subprocess` raises bare `TimeoutError`; now returned as `CliBackendResult(error=...)`.
2. **stderr silently dropped** on failure in codex/gemini/grok (`str(CalledProcessError)` renders only the exit status) — shared `_errors.called_process_error_message` now surfaces the CLI's actual diagnostic, matching claude's behaviour.
3. **Codex resume subcommand order**: emitted `codex exec --skip-git-repo-check resume <id>`; `resume` must follow `exec` directly — now spliced correctly.
4. **Codex system prompt TOML injection**: `-c 'instructions="{text}"'` broke on any quote/newline — now JSON-escaped (TOML-basic-string compatible).
5. **`CliSessionBinding.is_resume` was never set** anywhere, making every backend's resume branch dead code and re-sending the system prompt each turn — the agent now marks a session started after a successful delegated turn, so the second turn resumes.
6. **YAML `cli_backend:` misrouting**: the shipped `examples/yaml/cli_backend.yaml` failed with `RuntimeError` because the adapter returned the backend id into the *runtime* registry; it now resolves through the (previously dead) `_resolve_yaml_cli_backend` into the `cli_backend` kwarg that core `Agent` expects.
7. Model + cwd flags threaded through codex (`-m`/`-C`), gemini (`-m`, subprocess cwd), grok (`--model`, `--cwd`), claude (cwd on the subprocess) so scheduled runs can pin a model and run in a workspace.

## Packaging decision (evaluated first, as requested)

A dedicated package was considered and rejected: ~1.5k LOC of subprocess wrappers with no standalone product value, and it would force a Tier-2a↔2b PyPI dependency the architecture forbids. Placement instead follows the tier rules — data fields in `praisonaiagents` (Tier 1), executor action in `praisonai-bot` (Tier 2b, bridge-resolved), backend fixes + `backends` command in `praisonai-code` (Tier 2a), CLI flags + YAML fix in the wrapper (Tier 3). `praisonai-bot`'s pyproject is untouched.

## Verification

- **19 new tests pass**: `tests/unit/scheduler/test_backend_action.py` (action success/error/unavailable-package/options plumbing/skip/serialisation round-trip/byte-stable legacy payloads) and `tests/unit/test_cli_backend_fixes.py` (timeout-as-result ×4, stderr ×3, codex resume order, TOML escaping, model/cwd flags, `is_resume` second-turn behaviour).
- **No regressions**: full failure-set diff of `tests/unit/scheduler/ + test_claude_backend.py + test_yaml_cli_backend.py + test_cli_backend_flag.py` between clean main and this branch is empty (remaining failures are pre-existing environment issues, identical on both).
- **Tier gate**: `bash scripts/check_bot_code_imports.sh` → ok.
- **Smoke**: registry resolves with overrides; codex command builds as `codex exec --skip-git-repo-check -C /tmp -m gpt-5-codex hi`; `ScheduleJob` round-trips backend fields; `praisonai backends` lists all four ids.

Related analysis: this implements the plan from the cross-CLI scheduling gap analysis (Phase 1 + Phase 2 + the Phase-3 model/cwd plumbing); Cursor backend registration and per-tick session continuity for recurring jobs remain as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pwwvk68iPoNnGw6ov5Lpga

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pwwvk68iPoNnGw6ov5Lpga)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scheduled messages can run through external CLI backends with configurable working directories, timeouts, and models.
  - Added `praisonai backends` to list available CLI backends.
  - CLI conversations can resume across agent turns.
  - Scheduled jobs preserve backend settings and update state only after successful execution.

- **Bug Fixes**
  - Improved timeout, cancellation, and subprocess error handling with clearer messages.
  - Fixed YAML backend configuration and working-directory, model, and prompt handling.
  - Scheduled backend failures are audited without advancing saved state.
  - Prevented conflicting schedule configurations and unintended duplicate updates.

- **Tests**
  - Added coverage for scheduling, backend failures, conversation resuming, timeouts, and configuration compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->