### PR TITLE
feat(scheduler): add command and URL change-detection monitors

### DIFF
--- a/src/praisonai-bot/praisonai_bot/scheduler/condition_gate.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/condition_gate.py
@@ -39,6 +39,7 @@ import socket
 import ssl
 import subprocess
 import threading
+import time
 from collections.abc import Mapping
 from typing import Any
 from urllib import parse
@@ -314,6 +315,12 @@ class MonitorGate:
         if ":" in host:
             host = f"[{host}]"
         host_header = host if port == default_port else f"{host}:{port}"
+        # Total wall-clock deadline for the whole probe: the per-socket
+        # ``timeout`` only bounds each individual recv, so a server that
+        # drip-feeds a byte just inside every socket window could keep the
+        # synchronous body read alive indefinitely and stall the sequential
+        # scheduler tick. Enforce an absolute deadline across connect + read.
+        deadline = time.monotonic() + self._timeout
         try:
             connection.request(
                 "GET",
@@ -327,9 +334,31 @@ class MonitorGate:
             response = connection.getresponse()
             if not 200 <= response.status < 300:
                 raise RuntimeError(f"HTTP {response.status}")
-            return response.read(_MAX_MONITOR_BYTES + 1)
+            return self._read_bounded(response, deadline)
         finally:
             connection.close()
+
+    @staticmethod
+    def _read_bounded(response: Any, deadline: float) -> bytes:
+        """Read up to the byte cap while enforcing a total wall-clock deadline.
+
+        Reads in bounded chunks and checks an absolute ``deadline`` between
+        each so a slow drip-feed cannot keep the synchronous read (and thus
+        the scheduler tick) alive past the monitor timeout. Stops once the
+        response is exhausted or one byte past the cap is seen (so the caller
+        can detect an over-limit body).
+        """
+        chunks: list[bytes] = []
+        remaining = _MAX_MONITOR_BYTES + 1
+        while remaining > 0:
+            if time.monotonic() >= deadline:
+                raise TimeoutError("monitor URL read exceeded total deadline")
+            chunk = response.read(min(remaining, 65536))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
 
 
 class ShellConditionGate:

--- a/src/praisonai-bot/praisonai_bot/scheduler/condition_gate.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/condition_gate.py
@@ -28,11 +28,20 @@ supply any object implementing ``JobConditionProtocol`` — the executor accepts
 
 from __future__ import annotations
 
+import difflib
+import hashlib
+import http.client
+import ipaddress
 import logging
 import os
 import shlex
+import socket
+import ssl
 import subprocess
+import threading
+from collections.abc import Mapping
 from typing import Any
+from urllib import parse
 
 from praisonaiagents.scheduler.protocols import GateResult
 
@@ -46,6 +55,281 @@ _POSIX = os.name == "posix"
 _MAX_CONTEXT_CHARS = 8000
 # Cap stderr surfaced in the skip ``reason`` so an audit record stays compact.
 _MAX_REASON_CHARS = 500
+_MAX_MONITOR_CHARS = 8000
+_MAX_MONITOR_BYTES = 64 * 1024
+_MAX_MONITOR_PREVIEW_BYTES = 2048
+
+
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, host: str, address: str, port: int, timeout: float) -> None:
+        super().__init__(host, port=port, timeout=timeout)
+        self._address = address
+
+    def connect(self) -> None:
+        self.sock = socket.create_connection(
+            (self._address, self.port), self.timeout, self.source_address,
+        )
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(self, host: str, address: str, port: int, timeout: float) -> None:
+        super().__init__(
+            host,
+            port=port,
+            timeout=timeout,
+            context=ssl.create_default_context(),
+        )
+        self._address = address
+
+    def connect(self) -> None:
+        raw_socket = socket.create_connection(
+            (self._address, self.port), self.timeout, self.source_address,
+        )
+        try:
+            self.sock = self._context.wrap_socket(
+                raw_socket, server_hostname=self.host,
+            )
+        except Exception:
+            raw_socket.close()
+            raise
+
+
+class MonitorGate:
+    """Stateful change-detection gate for a job's monitor source."""
+
+    def __init__(self, *, timeout: float = 30.0) -> None:
+        self._timeout = timeout
+
+    def should_run(
+        self, job: Any, *, state: dict[str, Any] | None = None,
+    ) -> GateResult:
+        spec = getattr(job, "monitor", None) or {}
+        if not isinstance(spec, Mapping):
+            return GateResult(run=False, reason="monitor spec must be a mapping")
+        command = spec.get("command")
+        url = spec.get("url")
+        has_command = isinstance(command, str) and bool(command.strip())
+        has_url = isinstance(url, str) and bool(url.strip())
+        if has_command == has_url:
+            return GateResult(
+                run=False,
+                reason="monitor requires exactly one command or URL",
+            )
+
+        try:
+            if has_command:
+                output, stderr, code, timed_out, exceeded = self._run_command(
+                    command,
+                )
+                if timed_out:
+                    return GateResult(
+                        run=False,
+                        reason=f"monitor command timed out (>{self._timeout:.0f}s)",
+                    )
+                if exceeded:
+                    return GateResult(
+                        run=False,
+                        reason="monitor command output exceeded 8000 character limit",
+                    )
+                if code != 0:
+                    stderr = stderr.strip()
+                    detail = f": {stderr}" if stderr else ""
+                    return GateResult(
+                        run=False,
+                        reason=(
+                            "monitor command failed "
+                            f"(exit {code}{detail})"
+                        ),
+                    )
+            else:
+                output = self._fetch_url(url)
+        except ValueError as e:
+            return GateResult(run=False, reason=f"invalid monitor URL: {e}")
+        except Exception as e:  # noqa: BLE001  # pragma: no cover - defensive
+            logger.warning(
+                "Monitor probe failed for job '%s': %s",
+                getattr(job, "id", "?"), e,
+            )
+            return GateResult(run=False, reason=f"monitor probe error: {e}")
+
+        digest = hashlib.sha256(output.encode("utf-8")).hexdigest()
+        prior_state = state or {}
+        if prior_state.get("monitor_sha256") == digest:
+            return GateResult(no_change=True, reason="monitor source unchanged")
+
+        stored_output = self._bounded_preview(output)
+        previous = prior_state.get("monitor_output")
+        context = stored_output
+        if isinstance(previous, str):
+            context = "\n".join(
+                difflib.unified_diff(
+                    previous.splitlines(),
+                    stored_output.splitlines(),
+                    fromfile="previous",
+                    tofile="current",
+                    lineterm="",
+                )
+            )
+            context = context[:_MAX_MONITOR_CHARS]
+            if not context:
+                context = "Monitor output changed outside retained preview."
+        return GateResult(
+            run=True,
+            context=context or None,
+            state_updates={
+                "monitor_sha256": digest,
+                "monitor_output": stored_output,
+            },
+        )
+
+    @staticmethod
+    def _bounded_preview(output: str) -> str:
+        encoded = output.encode("utf-8")[:_MAX_MONITOR_PREVIEW_BYTES]
+        return encoded.decode("utf-8", errors="ignore")
+
+    def _run_command(self, command: str) -> tuple[str, str, int, bool, bool]:
+        popen_kwargs: dict = {}
+        if _POSIX:
+            popen_kwargs["start_new_session"] = True
+
+        proc = subprocess.Popen(
+            command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            **popen_kwargs,
+        )
+        stdout_chunks: list[str] = []
+        stderr_chunks: list[str] = []
+        output_exceeded = threading.Event()
+
+        def drain(stream, chunks: list[str], cap: int, *, stop_on_limit: bool) -> None:
+            retained = 0
+            while True:
+                chunk = stream.read(4096)
+                if not chunk:
+                    break
+                room = cap - retained
+                if room > 0:
+                    chunks.append(chunk[:room])
+                    retained += min(len(chunk), room)
+                if len(chunk) > room and stop_on_limit:
+                    output_exceeded.set()
+                    self._kill_process(proc)
+                    break
+
+        stdout_reader = threading.Thread(
+            target=drain,
+            args=(proc.stdout, stdout_chunks, _MAX_MONITOR_CHARS),
+            kwargs={"stop_on_limit": True},
+            daemon=True,
+        )
+        stderr_reader = threading.Thread(
+            target=drain,
+            args=(proc.stderr, stderr_chunks, _MAX_REASON_CHARS),
+            kwargs={"stop_on_limit": False},
+            daemon=True,
+        )
+        stdout_reader.start()
+        stderr_reader.start()
+        timed_out = False
+        try:
+            proc.wait(timeout=self._timeout)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            self._kill_process(proc)
+            proc.wait(timeout=5)
+        finally:
+            stdout_reader.join(timeout=5)
+            stderr_reader.join(timeout=5)
+            if proc.stdout is not None:
+                proc.stdout.close()
+            if proc.stderr is not None:
+                proc.stderr.close()
+
+        return (
+            "".join(stdout_chunks),
+            "".join(stderr_chunks),
+            proc.returncode if proc.returncode is not None else 0,
+            timed_out,
+            output_exceeded.is_set(),
+        )
+
+    @staticmethod
+    def _kill_process(proc: subprocess.Popen) -> None:
+        try:
+            if _POSIX:
+                os.killpg(os.getpgid(proc.pid), 9)
+            else:  # pragma: no cover - non-POSIX
+                proc.kill()
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+
+    def _fetch_url(self, url: str) -> str:
+        parsed = parse.urlsplit(url)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError("scheme must be http or https")
+        if not parsed.hostname:
+            raise ValueError("hostname is required")
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("embedded credentials are not allowed")
+
+        try:
+            addresses = socket.getaddrinfo(
+                parsed.hostname,
+                parsed.port or (443 if parsed.scheme == "https" else 80),
+                type=socket.SOCK_STREAM,
+            )
+        except OSError as e:
+            raise ValueError(f"hostname could not be resolved: {e}") from e
+        public_addresses = []
+        for address in addresses:
+            ip = ipaddress.ip_address(address[4][0])
+            if not ip.is_global:
+                raise ValueError("target must resolve only to public addresses")
+            public_addresses.append(str(ip))
+
+        body = self._request_url(parsed, public_addresses[0])
+        if len(body) > _MAX_MONITOR_BYTES:
+            raise ValueError("response exceeded 64 KiB limit")
+        return body.decode("utf-8", errors="replace")
+
+    def _request_url(self, parsed: parse.SplitResult, address: str) -> bytes:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        connection_class = (
+            _PinnedHTTPSConnection
+            if parsed.scheme == "https"
+            else _PinnedHTTPConnection
+        )
+        connection = connection_class(
+            parsed.hostname or "", address, port, self._timeout,
+        )
+        path = parse.urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
+        default_port = 443 if parsed.scheme == "https" else 80
+        host = parsed.hostname or ""
+        if ":" in host:
+            host = f"[{host}]"
+        host_header = host if port == default_port else f"{host}:{port}"
+        try:
+            connection.request(
+                "GET",
+                path,
+                headers={
+                    "Host": host_header,
+                    "User-Agent": "PraisonAI-Monitor/1",
+                    "Accept-Encoding": "identity",
+                },
+            )
+            response = connection.getresponse()
+            if not 200 <= response.status < 300:
+                raise RuntimeError(f"HTTP {response.status}")
+            return response.read(_MAX_MONITOR_BYTES + 1)
+        finally:
+            connection.close()
 
 
 class ShellConditionGate:

--- a/src/praisonai-bot/praisonai_bot/scheduler/condition_gate.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/condition_gate.py
@@ -74,11 +74,12 @@ class _PinnedHTTPConnection(http.client.HTTPConnection):
 
 class _PinnedHTTPSConnection(http.client.HTTPSConnection):
     def __init__(self, host: str, address: str, port: int, timeout: float) -> None:
+        self._ssl_context = ssl.create_default_context()
         super().__init__(
             host,
             port=port,
             timeout=timeout,
-            context=ssl.create_default_context(),
+            context=self._ssl_context,
         )
         self._address = address
 
@@ -87,7 +88,7 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
             (self._address, self.port), self.timeout, self.source_address,
         )
         try:
-            self.sock = self._context.wrap_socket(
+            self.sock = self._ssl_context.wrap_socket(
                 raw_socket, server_hostname=self.host,
             )
         except Exception:

--- a/src/praisonai-bot/praisonai_bot/scheduler/condition_gate.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/condition_gate.py
@@ -321,6 +321,11 @@ class MonitorGate:
         # synchronous body read alive indefinitely and stall the sequential
         # scheduler tick. Enforce an absolute deadline across connect + read.
         deadline = time.monotonic() + self._timeout
+        watchdog = threading.Timer(
+            self._timeout, self._abort_connection, args=(connection,),
+        )
+        watchdog.daemon = True
+        watchdog.start()
         try:
             connection.request(
                 "GET",
@@ -335,8 +340,25 @@ class MonitorGate:
             if not 200 <= response.status < 300:
                 raise RuntimeError(f"HTTP {response.status}")
             return self._read_bounded(response, deadline)
+        except Exception as e:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    "monitor URL probe exceeded total deadline"
+                ) from e
+            raise
         finally:
+            watchdog.cancel()
             connection.close()
+
+    @staticmethod
+    def _abort_connection(connection: Any) -> None:
+        sock = getattr(connection, "sock", None)
+        if sock is not None:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+        connection.close()
 
     @staticmethod
     def _read_bounded(response: Any, deadline: float) -> bytes:

--- a/src/praisonai-bot/praisonai_bot/scheduler/executor.py
+++ b/src/praisonai-bot/praisonai_bot/scheduler/executor.py
@@ -77,7 +77,8 @@ class JobResult:
     Attributes:
         job: The ScheduleJob that was executed.
         result: Agent response (str) or None on failure.
-        status: ``"succeeded"``, ``"failed"``, or ``"skipped"``.
+        status: ``"succeeded"``, ``"failed"``, ``"skipped"``, or
+            ``"no_change"``.
         error: Error message if status is ``"failed"``.
         duration: Wall-clock seconds for agent execution.
         delivered: Whether the result was delivered to a channel bot.
@@ -128,8 +129,10 @@ class ScheduledAgentExecutor:
             ``run=False`` the tick is recorded as ``skipped`` (no tokens spent,
             no delivery); when it returns ``run=True`` with ``context`` the
             context is appended to the job message. Defaults to a resolver that
-            returns a :class:`~praisonai.scheduler.condition_gate.ShellConditionGate`
-            for jobs with a ``pre_run`` command. Pass ``condition_resolver=False``
+            returns a :class:`~praisonai.scheduler.condition_gate.MonitorGate`
+            for jobs with ``monitor`` configured, or a
+            :class:`~praisonai.scheduler.condition_gate.ShellConditionGate` for
+            jobs with a ``pre_run`` command. Pass ``condition_resolver=False``
             (or a resolver returning ``None``) to disable gating entirely.
             This is a *cost/efficiency* gate, complementary to the *safety*
             ``run_policy``.
@@ -424,11 +427,16 @@ class ScheduledAgentExecutor:
                     job, prior_state, getattr(decision, "state_updates", None),
                 )
                 duration = time.time() - started
+                status = (
+                    "no_change"
+                    if getattr(decision, "no_change", False)
+                    else "skipped"
+                )
                 self._runner.mark_run(
-                    job, status="skipped", error=reason, duration=duration,
+                    job, status=status, error=reason, duration=duration,
                 )
                 return JobResult(
-                    job=job, status="skipped", error=reason, duration=duration,
+                    job=job, status=status, error=reason, duration=duration,
                 )
             if decision is not None:
                 context = getattr(decision, "context", None)
@@ -668,8 +676,13 @@ class ScheduledAgentExecutor:
                     job, prior_state, getattr(decision, "state_updates", None),
                 )
                 duration = time.time() - started
-                self._runner.mark_run(job, status="skipped", error=reason, duration=duration)
-                return JobResult(job=job, status="skipped", error=reason, duration=duration)
+                status = (
+                    "no_change"
+                    if getattr(decision, "no_change", False)
+                    else "skipped"
+                )
+                self._runner.mark_run(job, status=status, error=reason, duration=duration)
+                return JobResult(job=job, status=status, error=reason, duration=duration)
             if decision is not None:
                 context = getattr(decision, "context", None)
                 if context:
@@ -1045,13 +1058,13 @@ class ScheduledAgentExecutor:
     # ── condition-gate helpers ───────────────────────────────────────
 
     def _resolve_condition(self, job: "ScheduleJob") -> Optional["JobConditionProtocol"]:
-        """Resolve the pre-run gate for ``job`` (or ``None`` for no gate).
+        """Resolve the condition gate for ``job`` (or ``None`` for no gate).
 
         Resolution order:
         - ``condition_resolver is False`` → gating disabled, return ``None``.
         - a user-supplied callable → call it with the job and return its result.
-        - default (``None``) → return a :class:`ShellConditionGate` when the
-          job declares a ``pre_run`` command, else ``None``.
+                - default (``None``) → return a :class:`MonitorGate` for ``monitor``,
+                    otherwise a :class:`ShellConditionGate` for ``pre_run``, else ``None``.
         """
         resolver = self._condition_resolver
         if resolver is False:
@@ -1065,7 +1078,11 @@ class ScheduledAgentExecutor:
                     getattr(job, "id", "?"), e,
                 )
                 return None
-        # Default resolver: only build a gate when there is something to gate on.
+        # A stateful monitor is the default gate when configured.
+        if getattr(job, "monitor", None) is not None:
+            from .condition_gate import MonitorGate
+            return MonitorGate()
+        # Otherwise only build a gate when there is something to gate on.
         if not (getattr(job, "pre_run", None) or "").strip():
             return None
         from .condition_gate import ShellConditionGate

--- a/src/praisonai/praisonai/cli/commands/schedule.py
+++ b/src/praisonai/praisonai/cli/commands/schedule.py
@@ -149,8 +149,11 @@ def schedule_add_cmd(
         # created the job. A duplicate-name response ("already exists") is a
         # rejection: mutating the existing job here would let a rejected add
         # reconfigure a live schedule (e.g. attach a new --command/--backend).
-        job_created = f"Schedule '{name}' added" in result
-        job_id_match = re.search(r"\(id: ([^,\s)]+)(?:,|\))", result)
+        success_prefix = f"Schedule '{name}' added (id: "
+        job_id_match = re.match(
+            rf"^{re.escape(success_prefix)}([^,\s)]+)(?:,|\))", result,
+        )
+        job_created = job_id_match is not None
         want_pin_update = bool(model) or (not pin and not command)
         if (
             pre_run

--- a/src/praisonai/praisonai/cli/commands/schedule.py
+++ b/src/praisonai/praisonai/cli/commands/schedule.py
@@ -4,9 +4,9 @@ Schedule command group for PraisonAI CLI.
 Provides scheduler management.
 """
 
-from typing import Optional
-
 import math
+import re
+from typing import Optional
 
 import typer
 
@@ -53,6 +53,8 @@ def schedule_add_cmd(
     continuable: bool = typer.Option(True, "--continuable/--no-continuable", help="Seed a resumable session on delivery so a reply resumes the job with context (default); --no-continuable for fire-and-forget notices"),
     pre_run: str = typer.Option("", "--pre-run", help="Cheap pre-run gate command: exit 0 + output => run (output seeds the prompt); non-zero => skip (no model tokens, no delivery)"),
     condition: str = typer.Option("", "--condition", help="Natural-language / expression alias for the pre-run gate"),
+    monitor_command: str = typer.Option("", "--monitor-command", help="Run the agent only when this command's stdout changes"),
+    monitor_url: str = typer.Option("", "--monitor-url", help="Run the agent only when this public HTTP(S) response changes"),
     command: str = typer.Option("", "--command", "--script", help="No-LLM action: run this shell command on schedule and deliver its stdout verbatim (no agent, no model turn)"),
     command_timeout: float = typer.Option(60.0, "--command-timeout", help="Max seconds the --command may run before it is killed (default 60)"),
     backend: str = typer.Option("", "--backend", help="External coding-CLI backend action: run the message as one headless turn via a registered backend (see 'praisonai backends'), e.g. claude-code, codex-cli. No native agent, no in-process model turn"),
@@ -72,6 +74,7 @@ def schedule_add_cmd(
         praisonai schedule add "report" -s hourly -m "status report" --deliver all
         praisonai schedule add "tg-reminder" -s daily -m "check email" --agent support --channel telegram --channel-id 12345
         praisonai schedule add "inbox-watch" -s "*/5m" -m "Summarise new emails" --pre-run "scripts/new_mail.sh" --deliver telegram
+        praisonai schedule add "price-watch" -s "*/15m" -m "Summarise the change" --monitor-url "https://example.com/api/price" --deliver telegram
         praisonai schedule add "disk-watch" -s hourly --command "df -h /" --deliver telegram:-100123
         praisonai schedule add "nightly-refactor" -s "cron:0 2 * * *" -m "tidy utils.py, run tests" --backend claude-code --backend-cwd ~/proj --deliver telegram
     """
@@ -90,6 +93,17 @@ def schedule_add_cmd(
         output.print_error(
             "--command and --backend are mutually exclusive: a job runs exactly "
             "one model-free action. Configure one or the other."
+        )
+        raise typer.Exit(1)
+    if monitor_command and monitor_url:
+        output.print_error(
+            "--monitor-command and --monitor-url are mutually exclusive."
+        )
+        raise typer.Exit(1)
+    if (monitor_command or monitor_url) and (pre_run or command or backend):
+        output.print_error(
+            "Monitor options cannot be combined with --pre-run, --command, "
+            "or --backend."
         )
         raise typer.Exit(1)
     try:
@@ -123,7 +137,7 @@ def schedule_add_cmd(
             **delivery_kwargs
         )
 
-        # ``pre_run``/``condition``/``command``/``backend`` run an arbitrary
+        # ``pre_run``/``monitor``/``condition``/``command``/``backend`` run an arbitrary
         # host process, so they are NOT part of the LLM-callable schedule_add
         # surface. The CLI is a trusted, human-driven surface, so set them on
         # the stored job here. A ``--command`` job runs verbatim with no agent
@@ -136,15 +150,30 @@ def schedule_add_cmd(
         # rejection: mutating the existing job here would let a rejected add
         # reconfigure a live schedule (e.g. attach a new --command/--backend).
         job_created = f"Schedule '{name}' added" in result
+        job_id_match = re.search(r"\(id: ([^,\s)]+)(?:,|\))", result)
         want_pin_update = bool(model) or (not pin and not command)
-        if (pre_run or condition or command or backend or want_pin_update) and job_created:
+        if (
+            pre_run
+            or condition
+            or monitor_command
+            or monitor_url
+            or command
+            or backend
+            or want_pin_update
+        ) and job_created:
             try:
                 from praisonaiagents.tools.schedule_tools import _get_store
                 store = _get_store()
-                job = store.get_by_name(name)
+                if job_id_match is None:
+                    raise ValueError("schedule_add success response omitted the job id")
+                job = store.get(job_id_match.group(1))
                 if job is not None:
                     job.pre_run = pre_run or None
                     job.condition = condition or None
+                    if monitor_command:
+                        job.monitor = {"command": monitor_command}
+                    elif monitor_url:
+                        job.monitor = {"url": monitor_url}
                     job.command = command or None
                     if command:
                         job.command_timeout = command_timeout
@@ -171,7 +200,7 @@ def schedule_add_cmd(
                         job.pin_model = pin
                     store.update(job)
             except Exception as e:
-                output.print_error(f"Failed to set command/pre-run gate: {e}")
+                output.print_error(f"Failed to set trusted schedule options: {e}")
                 raise typer.Exit(1)
 
         # A rejected add (duplicate name or error) must exit non-zero so

--- a/src/praisonai/praisonai/scheduler/condition_gate.py
+++ b/src/praisonai/praisonai/scheduler/condition_gate.py
@@ -3,6 +3,6 @@
 from praisonai._bootstrap import ensure_praisonai_bot
 
 ensure_praisonai_bot()
-from praisonai_bot.scheduler.condition_gate import ShellConditionGate
+from praisonai_bot.scheduler.condition_gate import MonitorGate, ShellConditionGate
 
-__all__ = ["ShellConditionGate"]
+__all__ = ["MonitorGate", "ShellConditionGate"]

--- a/src/praisonai/tests/unit/scheduler/test_backend_action.py
+++ b/src/praisonai/tests/unit/scheduler/test_backend_action.py
@@ -172,6 +172,24 @@ def test_backend_empty_message_skipped(fake_backend):
     assert backend.calls == []
 
 
+def test_backend_monitor_no_change_has_distinct_status(fake_backend):
+    backend, _ = fake_backend
+    ex = _executor([])
+
+    class NoChangeGate:
+        def should_run(self, job, *, state=None):
+            from praisonaiagents.scheduler.protocols import GateResult
+
+            return GateResult(no_change=True, reason="monitor source unchanged")
+
+    ex._condition_resolver = lambda _job: NoChangeGate()
+    result = _run(ex._execute_one(_backend_job(message="summarise")))
+
+    assert result.status == "no_change"
+    assert ex._runner.runs[-1]["status"] == "no_change"
+    assert backend.calls == []
+
+
 def test_schedule_add_duplicate_is_rejected_no_mutation(monkeypatch):
     """A duplicate-name ``schedule add --backend`` must be a genuine no-op:
     it neither mutates the pre-existing same-named job nor exits 0."""

--- a/src/praisonai/tests/unit/scheduler/test_condition_gate.py
+++ b/src/praisonai/tests/unit/scheduler/test_condition_gate.py
@@ -11,6 +11,7 @@ Covers:
 import asyncio
 import inspect
 import socket
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -248,6 +249,32 @@ class TestMonitorGate:
             "hostname": "example.com",
             "address": "93.184.216.34",
         }
+
+    def test_read_bounded_enforces_total_deadline(self):
+        class _DripResponse:
+            def read(self, _amount):
+                return b"x"
+
+        gate = MonitorGate()
+        with pytest.raises(TimeoutError):
+            gate._read_bounded(_DripResponse(), deadline=time.monotonic() - 1)
+
+    def test_read_bounded_returns_full_body(self):
+        class _OneShotResponse:
+            def __init__(self):
+                self._sent = False
+
+            def read(self, _amount):
+                if self._sent:
+                    return b""
+                self._sent = True
+                return b"payload"
+
+        gate = MonitorGate()
+        body = gate._read_bounded(
+            _OneShotResponse(), deadline=time.monotonic() + 30,
+        )
+        assert body == b"payload"
 
     @pytest.mark.parametrize(
         "url",

--- a/src/praisonai/tests/unit/scheduler/test_condition_gate.py
+++ b/src/praisonai/tests/unit/scheduler/test_condition_gate.py
@@ -11,6 +11,7 @@ Covers:
 import asyncio
 import inspect
 import socket
+import sys
 import threading
 import time
 from dataclasses import dataclass
@@ -198,11 +199,13 @@ class TestMonitorGate:
         assert decision.state_updates is None
 
     def test_command_output_limit_does_not_replace_watermark(self):
+        command = (
+            f'"{sys.executable}" -c '
+            '"import sys; sys.stdout.write(\'x\' * 9000)"'
+        )
         decision = MonitorGate().should_run(
             FakeJob(
-                monitor={
-                    "command": "head -c 9000 /dev/zero | tr '\\0' x",
-                },
+                monitor={"command": command},
             ),
             state={"monitor_sha256": "keep-me"},
         )
@@ -478,6 +481,42 @@ class TestPreRunNotAgentCallable:
 
 
 class TestMonitorCli:
+    def test_monitor_update_uses_id_after_full_success_prefix(self, monkeypatch):
+        import praisonaiagents.tools.schedule_tools as tools
+        from praisonai.cli.commands.schedule import app
+        from typer.testing import CliRunner
+
+        name = "watch (id: wrong-id)"
+        job = FakeJob(id="real-id")
+
+        class FakeStore:
+            def get(self, job_id):
+                assert job_id == "real-id"
+                return job
+
+            def update(self, _job):
+                return None
+
+        monkeypatch.setattr(
+            tools,
+            "schedule_add",
+            lambda **_kwargs: (
+                f"Schedule '{name}' added (id: real-id, hourly)."
+            ),
+        )
+        monkeypatch.setattr(tools, "_get_store", lambda: FakeStore())
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "add", name, "--schedule", "hourly",
+                "--monitor-command", "printf value",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert job.monitor == {"command": "printf value"}
+
     def test_monitor_command_is_persisted_by_trusted_cli(self, monkeypatch):
         import praisonaiagents.tools.schedule_tools as tools
         from praisonai.cli.commands.schedule import app

--- a/src/praisonai/tests/unit/scheduler/test_condition_gate.py
+++ b/src/praisonai/tests/unit/scheduler/test_condition_gate.py
@@ -11,6 +11,7 @@ Covers:
 import asyncio
 import inspect
 import socket
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -258,6 +259,37 @@ class TestMonitorGate:
         gate = MonitorGate()
         with pytest.raises(TimeoutError):
             gate._read_bounded(_DripResponse(), deadline=time.monotonic() - 1)
+
+    def test_url_total_deadline_covers_response_headers(self, monkeypatch):
+        from praisonai_bot.scheduler import condition_gate
+
+        closed = threading.Event()
+
+        class _SlowHeadersConnection:
+            def __init__(self, *_args, **_kwargs):
+                self.sock = None
+
+            def request(self, *_args, **_kwargs):
+                return None
+
+            def getresponse(self):
+                if not closed.wait(0.2):
+                    raise AssertionError("header read was not interrupted")
+                raise OSError("connection closed")
+
+            def close(self):
+                closed.set()
+
+        monkeypatch.setattr(
+            condition_gate, "_PinnedHTTPConnection", _SlowHeadersConnection,
+        )
+        gate = MonitorGate(timeout=0.02)
+        parsed = condition_gate.parse.urlsplit("http://example.com/value")
+
+        started = time.monotonic()
+        with pytest.raises(TimeoutError, match="total deadline"):
+            gate._request_url(parsed, "93.184.216.34")
+        assert time.monotonic() - started < 0.15
 
     def test_read_bounded_returns_full_body(self):
         class _OneShotResponse:

--- a/src/praisonai/tests/unit/scheduler/test_condition_gate.py
+++ b/src/praisonai/tests/unit/scheduler/test_condition_gate.py
@@ -9,15 +9,15 @@ Covers:
 """
 
 import asyncio
+import inspect
+import socket
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import pytest
-
+from praisonai.scheduler.condition_gate import MonitorGate, ShellConditionGate
+from praisonai.scheduler.executor import ScheduledAgentExecutor
 from praisonaiagents.scheduler.protocols import GateResult, JobConditionProtocol
-from praisonai.scheduler.condition_gate import ShellConditionGate
-from praisonai.scheduler.executor import ScheduledAgentExecutor, JobResult
-
 
 # ── lightweight fakes ────────────────────────────────────────────────
 
@@ -27,11 +27,12 @@ class FakeJob:
     id: str = "job1"
     name: str = "test-job"
     message: str = "do the thing"
-    agent_id: Optional[str] = None
+    agent_id: str | None = None
     session_target: str = "isolated"
     delivery: Any = None
-    pre_run: Optional[str] = None
-    condition: Optional[str] = None
+    pre_run: str | None = None
+    condition: str | None = None
+    monitor: dict | None = None
 
 
 class FakeAgent:
@@ -97,6 +98,184 @@ class TestShellConditionGate:
 
     def test_is_job_condition_protocol(self):
         assert isinstance(ShellConditionGate(), JobConditionProtocol)
+
+
+class TestMonitorGate:
+    @pytest.mark.parametrize("monitor", ["command", [], {}, {"command": "x", "url": "https://example.com"}])
+    def test_invalid_monitor_spec_fails_closed(self, monitor):
+        decision = MonitorGate().should_run(FakeJob(monitor=monitor), state={})
+
+        assert decision.run is False
+        assert decision.no_change is False
+        assert "monitor" in (decision.reason or "")
+        assert decision.state_updates is None
+
+    def test_first_command_observation_runs_and_stores_watermark(self):
+        gate = MonitorGate()
+        decision = gate.should_run(
+            FakeJob(monitor={"command": "printf watched-value"}), state={},
+        )
+
+        assert decision.run is True
+        assert decision.context == "watched-value"
+        assert decision.state_updates == {
+            "monitor_sha256": (
+                "0e05219c99c1ee894858c495940c8d745b61ae77dc2430568a31df2d3932b2c3"
+            ),
+            "monitor_output": "watched-value",
+        }
+
+    def test_unchanged_command_suppresses_tick(self):
+        gate = MonitorGate()
+        first = gate.should_run(
+            FakeJob(monitor={"command": "printf watched-value"}), state={},
+        )
+        decision = gate.should_run(
+            FakeJob(monitor={"command": "printf watched-value"}),
+            state=first.state_updates,
+        )
+
+        assert decision.run is False
+        assert decision.no_change is True
+        assert decision.reason == "monitor source unchanged"
+        assert decision.state_updates is None
+
+    def test_changed_command_runs_with_previous_and_current_context(self):
+        gate = MonitorGate()
+        decision = gate.should_run(
+            FakeJob(monitor={"command": "printf new-value"}),
+            state={
+                "monitor_sha256": "old-digest",
+                "monitor_output": "old-value",
+            },
+        )
+
+        assert decision.run is True
+        assert "--- previous" in (decision.context or "")
+        assert "+++ current" in (decision.context or "")
+        assert "-old-value" in (decision.context or "")
+        assert "+new-value" in (decision.context or "")
+        assert len(decision.context or "") <= 8000
+        assert decision.state_updates["monitor_output"] == "new-value"
+
+    def test_change_beyond_retained_preview_has_context(self, monkeypatch):
+        gate = MonitorGate()
+        previous = "x" * 2048
+        monkeypatch.setattr(gate, "_fetch_url", lambda _url: previous + "new")
+
+        decision = gate.should_run(
+            FakeJob(monitor={"url": "https://example.com/value"}),
+            state={
+                "monitor_sha256": "old-digest",
+                "monitor_output": previous,
+            },
+        )
+
+        assert decision.run is True
+        assert decision.context == "Monitor output changed outside retained preview."
+
+    def test_persisted_preview_is_bounded_by_utf8_bytes(self, monkeypatch):
+        gate = MonitorGate()
+        monkeypatch.setattr(gate, "_fetch_url", lambda _url: "界" * 3000)
+
+        decision = gate.should_run(
+            FakeJob(monitor={"url": "https://example.com/value"}), state={},
+        )
+
+        preview = decision.state_updates["monitor_output"]
+        assert len(preview.encode("utf-8")) <= 2048
+
+    def test_command_timeout_does_not_replace_watermark(self):
+        decision = MonitorGate(timeout=0.05).should_run(
+            FakeJob(monitor={"command": "sleep 5"}),
+            state={"monitor_sha256": "keep-me"},
+        )
+
+        assert decision.run is False
+        assert "timed out" in (decision.reason or "")
+        assert decision.state_updates is None
+
+    def test_command_output_limit_does_not_replace_watermark(self):
+        decision = MonitorGate().should_run(
+            FakeJob(
+                monitor={
+                    "command": "head -c 9000 /dev/zero | tr '\\0' x",
+                },
+            ),
+            state={"monitor_sha256": "keep-me"},
+        )
+
+        assert decision.run is False
+        assert "exceeded" in (decision.reason or "")
+        assert decision.state_updates is None
+
+    def test_url_observation_uses_same_change_contract(self, monkeypatch):
+        gate = MonitorGate()
+        monkeypatch.setattr(gate, "_fetch_url", lambda _url: "url-value")
+
+        first = gate.should_run(
+            FakeJob(monitor={"url": "https://example.com/value"}), state={},
+        )
+        second = gate.should_run(
+            FakeJob(monitor={"url": "https://example.com/value"}),
+            state=first.state_updates,
+        )
+
+        assert first.run is True
+        assert first.context == "url-value"
+        assert second.no_change is True
+
+    def test_url_connects_to_validated_address(self, monkeypatch):
+        gate = MonitorGate()
+        captured = {}
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *_args, **_kwargs: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+            ],
+        )
+        monkeypatch.setattr(
+            gate,
+            "_request_url",
+            lambda parsed, address: captured.update(
+                hostname=parsed.hostname, address=address,
+            ) or b"value",
+        )
+
+        assert gate._fetch_url("https://example.com/value") == "value"
+        assert captured == {
+            "hostname": "example.com",
+            "address": "93.184.216.34",
+        }
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "http://127.0.0.1/private",
+            "http://169.254.169.254/latest/meta-data",
+            "http://user:password@example.com/",
+        ],
+    )
+    def test_url_rejects_unsafe_targets(self, url):
+        decision = MonitorGate().should_run(
+            FakeJob(monitor={"url": url}), state={},
+        )
+
+        assert decision.run is False
+        assert "invalid monitor URL" in (decision.reason or "")
+        assert decision.state_updates is None
+
+    def test_failed_probe_does_not_replace_watermark(self):
+        decision = MonitorGate().should_run(
+            FakeJob(monitor={"command": "exit 2"}),
+            state={"monitor_sha256": "keep-me"},
+        )
+
+        assert decision.run is False
+        assert decision.no_change is False
+        assert decision.state_updates is None
 
 
 # ── executor enforcement ─────────────────────────────────────────────
@@ -224,9 +403,120 @@ class TestPreRunNotAgentCallable:
         An LLM under prompt injection should be unable to persist a host-side
         shell command via the tool surface; ``pre_run`` is CLI/Python-only.
         """
-        import inspect
         from praisonaiagents.tools.schedule_tools import schedule_add
 
         params = inspect.signature(schedule_add).parameters
         assert "pre_run" not in params
         assert "condition" not in params
+
+    def test_schedule_add_does_not_expose_monitor_sources(self):
+        from praisonaiagents.tools.schedule_tools import schedule_add
+
+        params = inspect.signature(schedule_add).parameters
+        assert "monitor" not in params
+        assert "monitor_command" not in params
+        assert "monitor_url" not in params
+
+
+class TestMonitorCli:
+    def test_monitor_command_is_persisted_by_trusted_cli(self, monkeypatch):
+        import praisonaiagents.tools.schedule_tools as tools
+        from praisonai.cli.commands.schedule import app
+        from typer.testing import CliRunner
+
+        job = FakeJob()
+        job.id = "new-job-id"
+
+        class FakeStore:
+            def get(self, job_id):
+                assert job_id == "new-job-id"
+                return job
+
+            def update(self, _job):
+                return None
+
+        monkeypatch.setattr(
+            tools,
+            "schedule_add",
+            lambda **kwargs: f"Schedule '{kwargs['name']}' added (id: new-job-id, */5m)",
+        )
+        monkeypatch.setattr(tools, "_get_store", lambda: FakeStore())
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "add", "price-watch", "--schedule", "*/5m",
+                "--message", "summarise the change",
+                "--monitor-command", "printf price",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert job.monitor == {"command": "printf price"}
+
+    def test_monitor_url_is_persisted_by_trusted_cli(self, monkeypatch):
+        import praisonaiagents.tools.schedule_tools as tools
+        from praisonai.cli.commands.schedule import app
+        from typer.testing import CliRunner
+
+        job = FakeJob()
+        job.id = "new-job-id"
+
+        class FakeStore:
+            def get(self, job_id):
+                assert job_id == "new-job-id"
+                return job
+
+            def update(self, _job):
+                return None
+
+        monkeypatch.setattr(
+            tools,
+            "schedule_add",
+            lambda **kwargs: f"Schedule '{kwargs['name']}' added (id: new-job-id, */5m)",
+        )
+        monkeypatch.setattr(tools, "_get_store", lambda: FakeStore())
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "add", "price-watch", "--schedule", "*/5m",
+                "--message", "summarise the change",
+                "--monitor-url", "https://example.com/price",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert job.monitor == {"url": "https://example.com/price"}
+
+    def test_monitor_sources_are_mutually_exclusive(self):
+        from praisonai.cli.commands.schedule import app
+        from typer.testing import CliRunner
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "add", "watch", "--schedule", "hourly",
+                "--monitor-command", "printf value",
+                "--monitor-url", "https://example.com/value",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.stdout
+
+    @pytest.mark.parametrize("conflict", ["--pre-run", "--command", "--backend"])
+    def test_monitor_rejects_conflicting_execution_modes(self, conflict):
+        from praisonai.cli.commands.schedule import app
+        from typer.testing import CliRunner
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "add", "watch", "--schedule", "hourly",
+                "--monitor-command", "printf value", conflict, "other",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "cannot be combined" in result.stdout

--- a/src/praisonai/tests/unit/scheduler/test_job_state_wiring.py
+++ b/src/praisonai/tests/unit/scheduler/test_job_state_wiring.py
@@ -27,6 +27,7 @@ class FakeJob:
     session_target: str = "isolated"
     delivery: Any = None
     pre_run: Optional[str] = None
+    monitor: Optional[Dict[str, Any]] = None
     delete_after_run: bool = False
 
 
@@ -150,7 +151,28 @@ class TestAgentEmittedState:
 
 
 class TestGateState:
-    def test_stateful_gate_persists_on_no_change_skip(self):
+    def test_default_monitor_gate_suppresses_unchanged_tick(self):
+        store = FakeStateStore()
+        agent = FakeAgent()
+        runner = FakeRunner(store)
+        executor = ScheduledAgentExecutor(
+            runner=runner, agent_resolver=lambda _id: agent,
+        )
+        job = FakeJob(
+            message="watch",
+            monitor={"command": "printf stable-value"},
+        )
+
+        first = _run(executor, job)
+        agent.last_message = None
+        second = _run(executor, job)
+
+        assert first.status == "succeeded"
+        assert second.status == "no_change"
+        assert agent.last_message is None
+        assert runner.runs[-1]["status"] == "no_change"
+
+    def test_stateful_gate_persists_on_no_change_suppression(self):
         store = FakeStateStore()
         agent = FakeAgent()
 
@@ -168,7 +190,7 @@ class TestGateState:
             condition_resolver=lambda job: MonitorGate(),
         )
         result = _run(executor, FakeJob(message="watch"))
-        assert result.status == "skipped"
+        assert result.status == "no_change"
         assert agent.last_message is None
         # watermark carried forward even though the tick was suppressed
         assert store.get_state("job1") == {"hash": "deadbeef"}


### PR DESCRIPTION
## Summary

Implement the concrete scheduler monitor functionality requested in #3872.

The scheduler core already provides the monitor contract and durable per-job
state through ScheduleJob.monitor, GateResult.no_change,
GateResult.state_updates, and JobStateStoreProtocol. This PR builds on those
existing primitives instead of introducing another model or persistence layer.

This PR adds:

- a stateful MonitorGate for shell command and HTTP(S) sources
- SHA-256 comparison using the existing per-job state
- bounded change context for scheduled agent runs
- suppression of unchanged ticks without an LLM call or delivery
- distinct no_change run records
- trusted CLI options:
  - --monitor-command
  - --monitor-url
- compatibility export through praisonai.scheduler.condition_gate

## Behavior

On the first successful observation, the monitor stores its fingerprint and
allows the scheduled run to proceed.

On subsequent ticks:

- unchanged output is recorded as no_change
- no agent or backend turn is started
- no delivery is performed
- changed output updates the watermark and provides a bounded unified diff
- failed probes preserve the previous watermark

The behavior is consistent across native-agent and external-backend execution
paths.

## Safety

Command monitors:

- enforce an execution timeout
- bound captured stdout and stderr
- terminate the process group on timeout or output overflow
- do not update monitor state after a failed probe

URL monitors:

- only allow HTTP and HTTPS
- reject embedded credentials and non-public network addresses
- validate all resolved addresses
- connect to the validated IP while preserving the original hostname for the
  Host header, TLS SNI, and certificate validation
- bypass environment proxy settings
- do not follow redirects
- limit response bodies to 64 KiB
- retain only a bounded UTF-8 preview in scheduler state

Monitor sources are restricted to trusted operator-facing surfaces and are not
exposed through the LLM-callable schedule_add tool.

## CLI Examples

Command monitor:

```bash
praisonai schedule add service-watch \
  --schedule "*/5m" \
  --monitor-command "systemctl is-active my-service" \
  --message "The service status changed. Summarise the change." \
  --deliver telegram
```

URL monitor:

```bash
praisonai schedule add price-watch \
  --schedule "*/15m" \
  --monitor-url "https://example.com/api/price" \
  --message "The watched price changed. Summarise the difference." \
  --deliver telegram
```

--monitor-command and --monitor-url are mutually exclusive. Monitor options
cannot be combined with --pre-run, --command, or --backend.

## Tests

- Scheduler suite: `345 passed, 8 skipped`
- Focused and compatibility suite: `101 passed`
- C5 backward compatibility: `36 passed`
- `py_compile`: passed
- `git diff --check`: passed
- no new Ruff findings compared with `upstream/main`

Fixes #3872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scheduler monitors using shell commands or HTTP(S) URLs.
  - Jobs now detect unchanged results and avoid unnecessary execution.
  - Added CLI options for configuring monitor commands or URLs.
  - Changed output is retained as a bounded preview or unified diff.

- **Updates**
  - Added a distinct `no_change` status for monitor-gated runs.
  - Monitor settings are validated and saved during schedule creation.
  - Added timeout, output-size limits, secure URL validation, and failure reporting.
  - Monitor sources cannot be combined with conflicting execution options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->