### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -130,3 +130,12 @@ These examples comply with MCP Protocol Version 2025-11-25:
   - `destructiveHint`: true
   - `idempotentHint`: false
   - `openWorldHint`: true
+
+
+## Build Remote Agent (`gbr_pair.py`)
+
+Pair a phone running [Build Remote Agent](https://grokbuildremote.com/) to a PraisonAI agent via MCP stdio `gbr-mcp` (protocol `gbr/1`). Requires `gbr-agent pair && gbr-agent run`. Phone is spectator. Never put mailbox keys in the example.
+
+```bash
+python gbr_pair.py
+```

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -1,5 +1,32 @@
 # MCP Server Examples
 
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
+
 Examples demonstrating the MCP Server v2 features per MCP Protocol Version 2025-11-25.
 
 ## Features Demonstrated
@@ -139,3 +166,10 @@ Pair a phone running [Build Remote Agent](https://grokbuildremote.com/) to a Pra
 ```bash
 python gbr_pair.py
 ```
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/examples/mcp/gbr_pair.py
+++ b/examples/mcp/gbr_pair.py
@@ -22,6 +22,33 @@ https://grokbuildremote.com/
 from praisonaiagents import Agent, MCP
 
 # Clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
 # then point args at mcp/gbr-mcp/bin/gbr-mcp.js (loopback stdio).
 gbr = Agent(
     instructions=(
@@ -40,3 +67,10 @@ if __name__ == "__main__":
     gbr.start(
         "Check Build Remote Agent health on 127.0.0.1:8788 and list sessions."
     )
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/examples/mcp/gbr_pair.py
+++ b/examples/mcp/gbr_pair.py
@@ -1,0 +1,42 @@
+"""
+Build Remote Agent pairing example.
+
+Pair a phone (Build Remote Agent) to this PraisonAI session through the
+free MIT gbr-agent. Protocol gbr/1. Phone is spectator + veto.
+
+Requirements:
+    - gbr-agent v0.6.0+ (`gbr-agent pair && gbr-agent run`)
+    - GrokBuildRemote-Agents cloned; `npm install` in mcp/gbr-mcp
+    - pip install praisonaiagents[mcp]
+
+Usage:
+    python gbr_pair.py
+
+Never put mailbox keys in this file. Phone Settings → Bot API is the
+only place the relay key is copied.
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+https://grokbuildremote.com/
+"""
+
+from praisonaiagents import Agent, MCP
+
+# Clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+# then point args at mcp/gbr-mcp/bin/gbr-mcp.js (loopback stdio).
+gbr = Agent(
+    instructions=(
+        "You can attach a phone spectator via Build Remote Agent. "
+        "Use GBR tools only to diagnose or attach the local Bot API "
+        "at 127.0.0.1:8788. Do not request mailbox keys."
+    ),
+    llm="gpt-4o-mini",
+    tools=MCP(
+        "node",
+        args=["GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"],
+    ),
+)
+
+if __name__ == "__main__":
+    gbr.start(
+        "Check Build Remote Agent health on 127.0.0.1:8788 and list sessions."
+    )


### PR DESCRIPTION
Add **Build Remote Agent** as a pairing device for this desktop agent.

The paid iOS/Android app spectates (and can inject into) the local session through the free MIT [`gbr-agent`](https://github.com/LinespottingOrg/GrokBuildRemote-Agents). Protocol `gbr/1`. Phone is spectator + veto, not orchestrator.

Independent product by Linespotting AB. **Not affiliated with xAI or SpaceX.**

## Pair (unchanged)

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
gbr-agent version          # v0.6.0+
gbr-agent pair             # QR in browser + printed 8-char code
gbr-agent run              # leave running
```

Phone: open [Build Remote Agent](https://grokbuildremote.com/) → scan the QR or type the 8-char code. Unpair in Settings before changing PCs.

## Attach (only these)

| How | Where |
|-----|--------|
| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
| MCP | stdio `gbr-mcp` (`node mcp/gbr-mcp/bin/gbr-mcp.js`) |

```bash
curl -sS http://127.0.0.1:8788/health
curl -sS http://127.0.0.1:8788/v1/sessions
```

This PR is docs/example only. No mailbox keys, no `X-GBR-Key`, no `device.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an example for connecting PraisonAI to Build Remote Agent through the GBR MCP server.
  - Included setup guidance, pairing requirements, relay-key handling, safety restrictions, and execution instructions.
  - Added a health and session check when the example runs directly.

- **Documentation**
  - Documented protocol details, usage steps, vendor affiliation, and what appears on the phone during pairing.
  - Added pinned `gbr-agent` v0.6.0 installation instructions with SHA-256 verification and related pairing and run commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->