### PR TITLE
fix(agui): stop silently dropping 13 of 16 stream event types

### DIFF
--- a/src/praisonai-agents/praisonaiagents/ui/agui/streaming.py
+++ b/src/praisonai-agents/praisonaiagents/ui/agui/streaming.py
@@ -40,15 +40,35 @@ class EventBuffer:
     current_text_message_id: str = ""
     next_text_message_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     pending_tool_calls_parent_id: str = ""
+    current_tool_call_id: str = ""
     
     def start_tool_call(self, tool_call_id: str) -> None:
         """Start a new tool call."""
         self.active_tool_call_ids.add(tool_call_id)
+        self.current_tool_call_id = tool_call_id
     
     def end_tool_call(self, tool_call_id: str) -> None:
         """End a tool call."""
         self.active_tool_call_ids.discard(tool_call_id)
         self.ended_tool_call_ids.add(tool_call_id)
+        if self.current_tool_call_id == tool_call_id:
+            self.current_tool_call_id = ""
+    
+    def resolve_tool_call_id(self, provided_id: Optional[str]) -> str:
+        """Resolve the tool_call_id for a delta that may omit it.
+
+        Providers commonly send the id only on the first chunk of a tool call
+        and omit it on subsequent argument deltas. Falling back to the last
+        started tool call keeps every chunk correlated to one invocation instead
+        of minting an orphan UUID per chunk.
+        """
+        if provided_id:
+            return provided_id
+        if self.current_tool_call_id:
+            return self.current_tool_call_id
+        new_id = str(uuid.uuid4())
+        self.current_tool_call_id = new_id
+        return new_id
     
     def start_text_message(self) -> str:
         """Start a new text message and return its ID."""
@@ -346,9 +366,10 @@ def stream_event_to_agui_events(
             )
         return events
 
-    if event.type == StreamEventType.DELTA_TOOL_CALL and event.tool_call:
-        tool_call_id = event.tool_call.get("id") or str(uuid.uuid4())
-        delta = event.tool_call.get("arguments", event.content or "")
+    if event.type == StreamEventType.DELTA_TOOL_CALL:
+        tool_call = event.tool_call or {}
+        tool_call_id = buffer.resolve_tool_call_id(tool_call.get("id"))
+        delta = tool_call.get("arguments", event.content or "")
         return [
             ToolCallArgsEvent(
                 tool_call_id=tool_call_id,
@@ -356,8 +377,9 @@ def stream_event_to_agui_events(
             )
         ]
 
-    if event.type == StreamEventType.TOOL_CALL_END and event.tool_call:
-        tool_call_id = event.tool_call.get("id") or str(uuid.uuid4())
+    if event.type == StreamEventType.TOOL_CALL_END:
+        tool_call = event.tool_call or {}
+        tool_call_id = buffer.resolve_tool_call_id(tool_call.get("id"))
         buffer.end_tool_call(tool_call_id)
         return [ToolCallEndEvent(tool_call_id=tool_call_id)]
 

--- a/src/praisonai-agents/praisonaiagents/ui/agui/streaming.py
+++ b/src/praisonai-agents/praisonaiagents/ui/agui/streaming.py
@@ -28,6 +28,7 @@ from praisonaiagents.ui.agui.types import (
     StateSnapshotEvent,
 )
 from praisonaiagents.ui.protocols import A2UI_MIME_TYPE
+from praisonaiagents.streaming.events import StreamEventType as _SE
 
 
 @dataclass
@@ -260,6 +261,38 @@ async def async_stream_response(
         yield create_run_error_event(str(e))
 
 
+# --- AG-UI disposition of every StreamEventType -------------------------------
+# Membership in these tables is a decision, not an omission. The adapter raises on
+# any type absent from all three, so adding a StreamEventType without choosing a
+# disposition fails tests/agui/test_streaming_completeness.py rather than silently
+# dropping the event at runtime.
+
+# Process-local timing and lifecycle markers with no AG-UI counterpart.
+# RUN_FINISHED is emitted by the enclosing run loop, so STREAM_END would double it.
+NOT_WIRE_VISIBLE = frozenset({
+    _SE.REQUEST_START,
+    _SE.HEADERS_RECEIVED,
+    _SE.FIRST_TOKEN,
+    _SE.LAST_TOKEN,
+    _SE.STREAM_END,
+})
+
+# The run continues, but a client that is never told cannot explain a stall or a
+# silently changed model. Carried as CustomEvent, not RunErrorEvent, because
+# RunErrorEvent is terminal in AG-UI and these are recovered conditions.
+_RECOVERABLE_EVENTS = {
+    _SE.RETRY: "praisonai.retry",
+    _SE.MODEL_FALLBACK: "praisonai.model_fallback",
+    _SE.STREAM_UNAVAILABLE: "praisonai.stream_unavailable",
+}
+
+# User-visible progress that AG-UI has no first-class frame for.
+_PROGRESS_EVENTS = {
+    _SE.TOOL_PROGRESS: "praisonai.tool_progress",
+    _SE.TODO_UPDATED: "praisonai.todo_updated",
+}
+
+
 def stream_event_to_agui_events(
     event: Any,
     message_id: str,
@@ -313,7 +346,58 @@ def stream_event_to_agui_events(
             )
         return events
 
-    return []
+    if event.type == StreamEventType.DELTA_TOOL_CALL and event.tool_call:
+        tool_call_id = event.tool_call.get("id") or str(uuid.uuid4())
+        delta = event.tool_call.get("arguments", event.content or "")
+        return [
+            ToolCallArgsEvent(
+                tool_call_id=tool_call_id,
+                delta=delta if isinstance(delta, str) else json.dumps(delta),
+            )
+        ]
+
+    if event.type == StreamEventType.TOOL_CALL_END and event.tool_call:
+        tool_call_id = event.tool_call.get("id") or str(uuid.uuid4())
+        buffer.end_tool_call(tool_call_id)
+        return [ToolCallEndEvent(tool_call_id=tool_call_id)]
+
+    if event.type == StreamEventType.ERROR:
+        return [create_run_error_event(event.error or event.content or "unknown error")]
+
+    # Recoverable conditions. These are not RunErrorEvent: the run continues, but
+    # a client that is never told cannot explain a stall or a changed model.
+    if event.type in _RECOVERABLE_EVENTS:
+        return [
+            CustomEvent(
+                name=_RECOVERABLE_EVENTS[event.type],
+                value={
+                    "message": event.error or event.content or "",
+                    "metadata": event.metadata or {},
+                },
+            )
+        ]
+
+    if event.type in _PROGRESS_EVENTS:
+        return [
+            CustomEvent(
+                name=_PROGRESS_EVENTS[event.type],
+                value={
+                    "content": event.content,
+                    "tool_call": event.tool_call,
+                    "metadata": event.metadata or {},
+                },
+            )
+        ]
+
+    if event.type in NOT_WIRE_VISIBLE:
+        return []
+
+    # Fail loudly rather than dropping: an unmapped type reaching here means a new
+    # StreamEventType was added without deciding its disposition.
+    raise ValueError(
+        f"StreamEventType.{getattr(event.type, 'name', event.type)} has no AG-UI "
+        "mapping and is not declared in NOT_WIRE_VISIBLE"
+    )
 
 
 def _infer_a2ui_surface_id(result: Dict[str, Any]) -> str:

--- a/src/praisonai-agents/tests/agui/test_streaming_completeness.py
+++ b/src/praisonai-agents/tests/agui/test_streaming_completeness.py
@@ -1,0 +1,74 @@
+"""Every StreamEventType must have a declared AG-UI disposition.
+
+The adapter's fall-through `return []` means an unmapped event type is dropped
+with no error and no log. That is invisible for cosmetic events and data loss
+for ERROR, RETRY, MODEL_FALLBACK and STREAM_UNAVAILABLE: the client sees a run
+that ends cleanly having never been told anything went wrong.
+
+This suite pins the disposition of all sixteen members. Adding a new
+StreamEventType without deciding whether it crosses the wire fails the first
+test, by construction.
+"""
+
+import pytest
+
+from praisonaiagents.streaming.events import StreamEvent, StreamEventType
+from praisonaiagents.ui.agui.streaming import (
+    EventBuffer,
+    NOT_WIRE_VISIBLE,
+    stream_event_to_agui_events,
+)
+
+
+def _event(event_type: StreamEventType) -> StreamEvent:
+    """A populated event, so a drop is never merely an empty payload."""
+    return StreamEvent(
+        type=event_type,
+        content="text",
+        tool_call={"id": "call-1", "name": "f", "arguments": {}, "result": "r"},
+        error="boom",
+    )
+
+
+def test_every_event_type_has_a_declared_disposition():
+    undeclared = [
+        t.name
+        for t in StreamEventType
+        if not stream_event_to_agui_events(_event(t), "m1", EventBuffer())
+        and t not in NOT_WIRE_VISIBLE
+    ]
+    assert not undeclared, (
+        "these StreamEventTypes are silently dropped by the AG-UI adapter and are "
+        f"not declared in NOT_WIRE_VISIBLE: {undeclared}"
+    )
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        StreamEventType.ERROR,
+        StreamEventType.STREAM_UNAVAILABLE,
+        StreamEventType.RETRY,
+        StreamEventType.MODEL_FALLBACK,
+    ],
+)
+def test_failure_events_reach_the_client(event_type):
+    """A failure the engine recovered from is still news the client must get."""
+    out = stream_event_to_agui_events(_event(event_type), "m1", EventBuffer())
+    assert out, f"{event_type.name} produced no AG-UI event: the client is never told"
+
+
+def test_not_wire_visible_is_a_closed_set_of_real_members():
+    """Guards against silencing a type by adding a typo to the allowlist."""
+    for member in NOT_WIRE_VISIBLE:
+        assert isinstance(member, StreamEventType)
+
+
+def test_mapped_events_still_map():
+    """Positive control: the three handled types must keep working."""
+    for event_type in (
+        StreamEventType.DELTA_TEXT,
+        StreamEventType.TOOL_CALL_START,
+        StreamEventType.TOOL_CALL_RESULT,
+    ):
+        assert stream_event_to_agui_events(_event(event_type), "m1", EventBuffer())

--- a/src/praisonai-agents/tests/agui/test_streaming_completeness.py
+++ b/src/praisonai-agents/tests/agui/test_streaming_completeness.py
@@ -72,3 +72,30 @@ def test_mapped_events_still_map():
         StreamEventType.TOOL_CALL_RESULT,
     ):
         assert stream_event_to_agui_events(_event(event_type), "m1", EventBuffer())
+
+
+def test_tool_call_delta_id_survives_id_less_chunks():
+    """Providers send the id once; later argument chunks must keep that id.
+
+    A fresh UUID per chunk would orphan the arguments from the invocation the
+    AG-UI client is assembling.
+    """
+    buffer = EventBuffer()
+
+    start = StreamEvent(
+        type=StreamEventType.TOOL_CALL_START,
+        tool_call={"id": "call-42", "name": "f", "arguments": {}},
+    )
+    (start_out := stream_event_to_agui_events(start, "m1", buffer))
+    assert any(getattr(e, "tool_call_id", None) == "call-42" for e in start_out)
+
+    chunk = StreamEvent(
+        type=StreamEventType.DELTA_TOOL_CALL,
+        tool_call={"arguments": '{"x":'},
+    )
+    chunk_out = stream_event_to_agui_events(chunk, "m1", buffer)
+    assert [e.tool_call_id for e in chunk_out] == ["call-42"]
+
+    end = StreamEvent(type=StreamEventType.TOOL_CALL_END, tool_call={})
+    end_out = stream_event_to_agui_events(end, "m1", buffer)
+    assert [e.tool_call_id for e in end_out] == ["call-42"]


### PR DESCRIPTION
## The defect

`stream_event_to_agui_events` handles three event types and ends with a bare `return []`. `StreamEventType` has sixteen members, so **thirteen are discarded with no error and no log**.

Reproduced with a positive control proving the harness detects the healthy case:

```
--- POSITIVE CONTROLS (must be non-empty) ---
  DELTA_TEXT         -> 2 event(s)
  TOOL_CALL_START    -> 3 event(s)
  TOOL_CALL_RESULT   -> 1 event(s)
CONTROL: PASS

--- FULL SWEEP (populated payloads) ---
MAPPED : 3
DROPPED: 13
    REQUEST_START  HEADERS_RECEIVED  FIRST_TOKEN  DELTA_TOOL_CALL
    TOOL_CALL_END  TOOL_PROGRESS     TODO_UPDATED LAST_TOKEN
    STREAM_END     ERROR             STREAM_UNAVAILABLE
    RETRY          MODEL_FALLBACK
```

**`ERROR` is on that list.** A mid-stream provider failure produces a run that ends cleanly having never told the client anything went wrong.

## The fix

Every type now carries an explicit disposition:

- mapped to AG-UI events (`DELTA_TOOL_CALL`, `TOOL_CALL_END`, `ERROR`);
- carried as `CustomEvent` where AG-UI has no frame (`RETRY`, `MODEL_FALLBACK`, `STREAM_UNAVAILABLE`, `TOOL_PROGRESS`, `TODO_UPDATED`) — deliberately not `RunErrorEvent`, which is terminal in AG-UI while these are recovered conditions;
- or listed in `NOT_WIRE_VISIBLE` for process-local markers with no counterpart.

Anything absent from all three **raises**, so adding a seventeenth member fails a test rather than dropping a frame in production.

## Tests

`tests/agui/test_streaming_completeness.py` — 7 tests, including a positive control that the three previously-mapped types still map, and a guard that `NOT_WIRE_VISIBLE` contains only real enum members so a typo cannot silence a type.

Mutation-checked: deleting the `ERROR` mapping is caught by 2 tests.

## Blast radius

Behaviour changes only for types that previously produced nothing. The strongest argument against: clients that assumed silence for these types now receive `CustomEvent`s they may not recognise — but AG-UI clients are expected to ignore unknown custom events, and the alternative is continuing to hide errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool-call updates and completions are now surfaced through AG-UI events, with improved correlation across streamed chunks.
  * Errors and recoverable progress events are delivered with clearer event types.
  * Previously unrecognized stream events now produce explicit errors instead of being silently ignored.

* **Bug Fixes**
  * Failure conditions, including unavailable streams, retries, and model fallbacks, now reliably reach the client.

* **Tests**
  * Added coverage to verify complete and consistent handling of all stream event types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->