### PR TITLE
fix(gateway): classify the four unscoped WebSocket lifecycle methods

### DIFF
--- a/src/praisonai-agents/praisonaiagents/gateway/protocols.py
+++ b/src/praisonai-agents/praisonaiagents/gateway/protocols.py
@@ -6275,8 +6275,16 @@ def resolve_required_scope(
 # status/read needs READ. Anything unregistered defaults to ADMIN (deny).
 def _register_core_gateway_methods() -> None:
     core: Dict[str, OperatorScope] = {
+        # Connection lifecycle. These run before a client can hold any scope, so
+        # they must not require one -- classifying them ADMIN by omission is what
+        # kept resolve_required_scope() from ever being wired into dispatch.
+        "hello": OperatorScope.READ,
+        "join": OperatorScope.READ,
+        "leave": OperatorScope.READ,
         "agent.message": OperatorScope.WRITE,
         "message": OperatorScope.WRITE,
+        # Aborting a turn mutates it, so it carries the same scope as sending one.
+        "abort": OperatorScope.WRITE,
         "session.status": OperatorScope.READ,
         "session.transcript": OperatorScope.READ,
         "approvals.resolve": OperatorScope.APPROVALS,

--- a/src/praisonai-agents/tests/unit/test_gateway_scope_lockstep.py
+++ b/src/praisonai-agents/tests/unit/test_gateway_scope_lockstep.py
@@ -1,0 +1,75 @@
+"""Every WebSocket message type the gateway dispatches must be scope-classified.
+
+`resolve_required_scope` fails closed to ADMIN for anything it does not know, which
+is the right default and is why it cannot simply be switched on: four of the six
+message types the dispatcher handles today are unregistered, so enabling it would
+demand ADMIN for the connection handshake and lock out every client.
+
+This suite pins the two lists together. It is a lockstep test in jan's style --
+it does not exercise behaviour, it asserts that two independently-maintained lists
+agree, which is a failure mode no behavioural test can see: the code compiles, the
+unit tests pass, and the omission only appears as a permission error at runtime.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from praisonaiagents.gateway.protocols import (
+    GATEWAY_METHODS,
+    OperatorScope,
+    resolve_required_scope,
+)
+
+_SERVER = (
+    Path(__file__).resolve().parents[3]
+    / "praisonai-bot"
+    / "praisonai_bot"
+    / "gateway"
+    / "server.py"
+)
+
+# Types handled by the transport itself, before any authorization decision.
+_TRANSPORT_TYPES = {"pong", "ping"}
+
+
+def _dispatched_message_types() -> set[str]:
+    """Extract the msg_type branches from the gateway's WS dispatcher."""
+    source = _SERVER.read_text()
+    found: set[str] = set()
+    found.update(re.findall(r'msg_type == "([a-z_.]+)"', source))
+    for group in re.findall(r"msg_type in \(([^)]*)\)", source):
+        found.update(re.findall(r'"([a-z_.]+)"', group))
+    return found - _TRANSPORT_TYPES
+
+
+@pytest.mark.skipif(not _SERVER.exists(), reason="praisonai-bot not present in this checkout")
+def test_the_dispatcher_handles_types_this_test_can_see():
+    """Positive control: if the extraction breaks, every other test here passes vacuously."""
+    types = _dispatched_message_types()
+    assert len(types) >= 4, f"extraction found only {types}; the regex has drifted from the source"
+    assert "message" in types, "the most basic message type was not extracted"
+
+
+@pytest.mark.skipif(not _SERVER.exists(), reason="praisonai-bot not present in this checkout")
+def test_every_dispatched_message_type_is_scope_classified():
+    unregistered = sorted(t for t in _dispatched_message_types() if t not in GATEWAY_METHODS)
+    assert not unregistered, (
+        "these WebSocket message types are dispatched but carry no scope classification, "
+        f"so resolve_required_scope() would fail them closed to ADMIN: {unregistered}. "
+        "Register each via register_gateway_method() before wiring the resolver into dispatch."
+    )
+
+
+def test_an_unknown_method_still_fails_closed():
+    """The property the whole design rests on. Must survive any registration change."""
+    for unknown in ("sessions.list", "config.write", "definitely.not.a.method", ""):
+        assert resolve_required_scope(unknown) is OperatorScope.ADMIN
+
+
+def test_the_handshake_is_not_accidentally_admin():
+    """`hello` runs before a client can hold any scope; requiring ADMIN would lock everyone out."""
+    if "hello" not in GATEWAY_METHODS:
+        pytest.skip("hello not yet registered")
+    assert resolve_required_scope("hello") is not OperatorScope.ADMIN

--- a/src/praisonai-agents/tests/unit/test_gateway_scope_lockstep.py
+++ b/src/praisonai-agents/tests/unit/test_gateway_scope_lockstep.py
@@ -18,6 +18,7 @@ import pytest
 
 from praisonaiagents.gateway.protocols import (
     GATEWAY_METHODS,
+    EventType,
     OperatorScope,
     resolve_required_scope,
 )
@@ -34,13 +35,69 @@ _SERVER = (
 _TRANSPORT_TYPES = {"pong", "ping"}
 
 
+_OPERAND = r'"[a-z_.]+"|EventType\.[A-Z_]+\.value'
+
+
+def _resolve_operand(token: str) -> str | None:
+    """Map one ``msg_type`` comparison operand to the wire string it matches.
+
+    A string literal is its own wire value; an ``EventType.<NAME>.value``
+    reference resolves through the enum exactly as Python would at runtime.
+    Anything else (an unknown enum member, a non-literal expression) yields
+    ``None`` so it can be surfaced rather than silently dropped.
+    """
+    literal = re.fullmatch(r'"([a-z_.]+)"', token)
+    if literal:
+        return literal.group(1)
+    enum_ref = re.fullmatch(r"EventType\.([A-Z_]+)\.value", token)
+    if enum_ref:
+        member = getattr(EventType, enum_ref.group(1), None)
+        if member is not None:
+            return member.value
+    return None
+
+
 def _dispatched_message_types() -> set[str]:
-    """Extract the msg_type branches from the gateway's WS dispatcher."""
+    """Extract the msg_type branches the gateway's WS dispatcher acts on.
+
+    The dispatcher compares ``msg_type`` in two interchangeable styles:
+
+      * string literals — ``msg_type == "hello"``, ``msg_type in ("abort", ...)``;
+      * enum-derived     — ``msg_type == EventType.PING.value``,
+        ``msg_type in ("abort", EventType.MESSAGE_ABORT.value)``.
+
+    Recognising only the first style would let a branch written purely in the
+    second (as ``ping``/``pong`` already are) drift past this lockstep — a
+    classified method could go unregistered and surface only as a runtime
+    permission error. So every ``EventType.<NAME>.value`` operand is resolved
+    through the enum to its wire value and considered alongside the literals.
+
+    Within a single ``in (...)`` branch the operands are *aliases* for one
+    dispatch path (``"abort"`` and ``EventType.MESSAGE_ABORT.value`` route to
+    the same handler). The registry classifies the canonical name, so each
+    branch contributes one representative — the literal if present, else the
+    resolved enum value — rather than every alias as a distinct method.
+    """
     source = _SERVER.read_text()
     found: set[str] = set()
-    found.update(re.findall(r'msg_type == "([a-z_.]+)"', source))
+
+    for token in re.findall(rf"msg_type == ({_OPERAND})", source):
+        resolved = _resolve_operand(token)
+        if resolved is not None:
+            found.add(resolved)
+
     for group in re.findall(r"msg_type in \(([^)]*)\)", source):
-        found.update(re.findall(r'"([a-z_.]+)"', group))
+        operands = [_resolve_operand(t) for t in re.findall(_OPERAND, group)]
+        resolved = [o for o in operands if o is not None]
+        if not resolved:
+            continue
+        literals = [
+            re.fullmatch(r'"([a-z_.]+)"', t).group(1)
+            for t in re.findall(_OPERAND, group)
+            if re.fullmatch(r'"[a-z_.]+"', t)
+        ]
+        found.add(literals[0] if literals else resolved[0])
+
     return found - _TRANSPORT_TYPES
 
 
@@ -50,6 +107,11 @@ def test_the_dispatcher_handles_types_this_test_can_see():
     types = _dispatched_message_types()
     assert len(types) >= 4, f"extraction found only {types}; the regex has drifted from the source"
     assert "message" in types, "the most basic message type was not extracted"
+    # ``abort`` is dispatched via a mixed-style branch
+    # (``msg_type in ("abort", EventType.MESSAGE_ABORT.value)``); seeing it
+    # proves the enum-derived operand resolution works, so a future branch
+    # written enum-only cannot silently drift past this lockstep.
+    assert "abort" in types, "the enum-derived branch resolution has drifted from the source"
 
 
 @pytest.mark.skipif(not _SERVER.exists(), reason="praisonai-bot not present in this checkout")


### PR DESCRIPTION
## Context

`resolve_required_scope()` promises that an unclassified method fails **closed** to `ADMIN`. The lattice is careful — incomparable sibling scopes escalate rather than picking one — and it is tested.

It also has **zero production callers**. Real enforcement is scattered per-handler, which is the pattern the docstring says it replaced.

Before it can be wired into dispatch, the existing methods have to be classified. They were not:

```
these WebSocket message types are dispatched but carry no scope
classification: ['abort', 'hello', 'join', 'leave']
```

Switching the resolver on today would demand `ADMIN` for the connection handshake and lock out every client. **That is why it was never wired.**

## The fix

- `hello`, `join`, `leave` → `READ`. These run before a client can hold any scope, so requiring one is incoherent.
- `abort` → `WRITE`. Aborting a turn mutates it exactly as sending one does.

## Tests

`tests/unit/test_gateway_scope_lockstep.py` — a lockstep test asserting the dispatcher's message types and the registry agree. It does not exercise behaviour; it asserts two independently-maintained lists match, which is a failure no behavioural test can see: the code compiles, unit tests pass, and the omission appears only as a runtime permission error.

Includes a positive control that the extraction still finds the branches, so the other assertions cannot pass vacuously if the regex drifts from the source.

The 8 existing scope tests still pass.

## Follow-up, deliberately not in this PR

Wiring `resolve_required_scope` into a single dispatch wrapper. That is the change that makes fail-closed a deployed property rather than a pure function — and it should land **before** new endpoints are added, not after. Also unaddressed here: `/health`, `/ready`, `/live` and `/hooks` have no auth check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected gateway access handling for connection lifecycle actions.
  - Handshake actions now use read-level access, while abort actions require write-level access.
  - Prevented valid connection operations from being incorrectly blocked by administrator-only restrictions.

- **Tests**
  - Added coverage to verify gateway message types are consistently registered and unknown actions remain denied by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->