### PR TITLE
fix(streaming): request the answer after tools run

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -5097,6 +5097,39 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         # Flush deferred media follow-ups after all tool replies.
                         for _m in _deferred_media_followups:
                             self._append_to_chat_history(_m)
+
+                        # Ask the model for the answer now that the tools have
+                        # run. Without this the generator ends here: the tool
+                        # results sit in chat history, nothing is yielded, and
+                        # the caller receives an empty stream with no error --
+                        # indistinguishable from a model that had nothing to
+                        # say. The non-streaming path already does this round
+                        # trip, so the two disagreed about whether an answer
+                        # existed at all.
+                        followup_args = dict(completion_args)
+                        followup_args['messages'] = self.chat_history
+                        followup_args['stream'] = True
+                        # No tools on the follow-up: the model has its results
+                        # and should now answer, not call another tool. That
+                        # also bounds the turn to a single round of tools.
+                        followup_args.pop('tools', None)
+                        followup_args.pop('tool_choice', None)
+                        followup_args.pop('parallel_tool_calls', None)
+
+                        followup_text = ""
+                        for followup_chunk in self._openai_client.sync_client.chat.completions.create(
+                            **followup_args
+                        ):
+                            if not followup_chunk.choices:
+                                continue
+                            piece = followup_chunk.choices[0].delta.content
+                            if piece:
+                                followup_text += piece
+                                yield piece
+                        if followup_text:
+                            self._append_to_chat_history(
+                                {"role": "assistant", "content": followup_text}
+                            )
                     else:
                         # Add complete response to chat history (text-only response)
                         if response_text:

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -5004,6 +5004,10 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     
                     # Handle any tool calls that were accumulated
                     if tool_calls_data:
+                        # Mark where the tool turns begin so the follow-up can
+                        # append exactly the assistant tool-call and tool-result
+                        # messages onto the original request context below.
+                        tool_turn_start = len(self.chat_history)
                         # Add assistant message with tool calls to chat history
                         assistant_message = {"role": "assistant", "content": response_text}
                         if tool_calls_data:
@@ -5106,8 +5110,18 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         # say. The non-streaming path already does this round
                         # trip, so the two disagreed about whether an answer
                         # existed at all.
+                        #
+                        # Reuse the original `messages` (system prompt, output
+                        # constraints, memory context and the user turn) rather
+                        # than `self.chat_history`, which omits the system turn
+                        # and would let the follow-up ignore the agent role and
+                        # output format. Append only the tool turns produced by
+                        # this round -- everything added to chat history since
+                        # the completion began.
                         followup_args = dict(completion_args)
-                        followup_args['messages'] = self.chat_history
+                        followup_args['messages'] = (
+                            list(messages) + self.chat_history[tool_turn_start:]
+                        )
                         followup_args['stream'] = True
                         # No tools on the follow-up: the model has its results
                         # and should now answer, not call another tool. That
@@ -5116,7 +5130,22 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         followup_args.pop('tool_choice', None)
                         followup_args.pop('parallel_tool_calls', None)
 
+                        # Bracket the follow-up with stream events so consumers
+                        # see request/terminal telemetry for the answer too --
+                        # the STREAM_END above referred only to the tool-call
+                        # round, before any answer existed.
+                        self.stream_emitter.emit(StreamEvent(
+                            type=StreamEventType.REQUEST_START,
+                            timestamp=time_module.perf_counter(),
+                            metadata={
+                                "model": self.llm,
+                                "message_count": len(followup_args['messages']),
+                                "phase": "post_tool_answer",
+                            }
+                        ))
+
                         followup_text = ""
+                        followup_last_content_time = None
                         for followup_chunk in self._openai_client.sync_client.chat.completions.create(
                             **followup_args
                         ):
@@ -5125,7 +5154,18 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             piece = followup_chunk.choices[0].delta.content
                             if piece:
                                 followup_text += piece
+                                followup_last_content_time = time_module.perf_counter()
                                 yield piece
+                        if followup_last_content_time:
+                            self.stream_emitter.emit(StreamEvent(
+                                type=StreamEventType.LAST_TOKEN,
+                                timestamp=followup_last_content_time
+                            ))
+                        self.stream_emitter.emit(StreamEvent(
+                            type=StreamEventType.STREAM_END,
+                            timestamp=time_module.perf_counter(),
+                            metadata={"response_length": len(followup_text)}
+                        ))
                         if followup_text:
                             self._append_to_chat_history(
                                 {"role": "assistant", "content": followup_text}

--- a/src/praisonai-agents/tests/unit/agent/test_streaming_with_tools.py
+++ b/src/praisonai-agents/tests/unit/agent/test_streaming_with_tools.py
@@ -45,12 +45,21 @@ def test_a_plain_turn_streams():
 
 
 def test_a_tool_using_turn_still_streams_an_answer():
-    """The regression: a tool round-trip must not swallow the reply."""
-    chunks = [c for c in _agent().start(
-        "Call sentinel_tool and tell me exactly what it returned.", stream=True) if c]
-    assert chunks, (
+    """The regression: a tool round-trip must not swallow the reply.
+
+    Asserting the sentinel flows through the streamed answer proves the tool
+    branch actually ran -- a plain answer that never called the tool cannot
+    reproduce the marker, so a green test here cannot be a coincidence.
+    """
+    streamed = "".join(c for c in _agent().start(
+        "Call sentinel_tool and tell me exactly what it returned.", stream=True) if c)
+    assert streamed, (
         "streaming yielded nothing after a tool call; the follow-up completion "
         "that produces the final answer was never requested"
+    )
+    assert SENTINEL in streamed, (
+        "the sentinel never reached the streamed answer; the tool result was "
+        "not carried into the follow-up completion's request context"
     )
 
 

--- a/src/praisonai-agents/tests/unit/agent/test_streaming_with_tools.py
+++ b/src/praisonai-agents/tests/unit/agent/test_streaming_with_tools.py
@@ -1,0 +1,63 @@
+"""Streaming must still produce an answer when a tool is invoked.
+
+The streaming path collects tool calls, executes them, appends the results to
+chat history -- and then ends. It never asks the model for the final answer, so
+`start(stream=True)` yields nothing while the identical non-streaming call
+answers normally.
+
+There is no error. The caller sees an empty generator and cannot tell "the model
+had nothing to say" from "the answer was never requested".
+
+Exercised against the real path rather than a mocked client: the defect lives in
+the interaction between tool execution and the follow-up completion, which is
+precisely what a hand-built mock of that client would define away.
+"""
+
+import os
+
+import pytest
+
+from praisonaiagents import Agent
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="exercises the real streaming path; needs a provider credential",
+)
+
+SENTINEL = "PRAISONAI-TOOL-SENTINEL"
+
+
+def sentinel_tool() -> str:
+    """Return a fixed marker so a passing assertion cannot be a coincidence."""
+    return SENTINEL
+
+
+def _agent():
+    return Agent(name="T", role="Assistant", goal="Answer using your tools.",
+                 llm="gpt-4o-mini", tools=[sentinel_tool])
+
+
+def test_a_plain_turn_streams():
+    """Positive control: without tools the path must be unaffected."""
+    chunks = [c for c in Agent(name="P", role="Assistant", goal="Answer.",
+                               llm="gpt-4o-mini").start("Say hi", stream=True) if c]
+    assert chunks, "a plain streamed turn produced nothing; the harness is broken"
+
+
+def test_a_tool_using_turn_still_streams_an_answer():
+    """The regression: a tool round-trip must not swallow the reply."""
+    chunks = [c for c in _agent().start(
+        "Call sentinel_tool and tell me exactly what it returned.", stream=True) if c]
+    assert chunks, (
+        "streaming yielded nothing after a tool call; the follow-up completion "
+        "that produces the final answer was never requested"
+    )
+
+
+def test_streaming_and_non_streaming_agree_when_a_tool_runs():
+    """The two paths must not disagree about whether an answer exists."""
+    blocking = _agent().start("Call sentinel_tool and report its output.")
+    streamed = "".join(c for c in _agent().start(
+        "Call sentinel_tool and report its output.", stream=True) if c)
+    assert blocking, "non-streaming produced nothing; the harness is broken"
+    assert streamed, "streaming produced nothing while non-streaming answered"


### PR DESCRIPTION
## The defect

When a tool is invoked, `start(stream=True)` yields **zero chunks**. The identical non-streaming call answers normally.

```
agent WITHOUT tools, stream=True          : 9 chunks
agent WITH tools, stream=True, no tool    : 9 chunks
agent WITH tools, stream=True, tool USED  : 0 chunks   <-- answer lost
non-streaming, tool USED                  : 'The current time is 10:16:49.'
```

Chat history after the streamed call shows the shape exactly:

```
user       What time is it? Use your tool.
assistant  (empty)
tool       2026-08-25 10:32:40 BST
```

The tool ran, its result was appended — and the generator ended. **There is no error.** The caller receives an empty generator and cannot tell "the model had nothing to say" from "the answer was never requested".

## Root cause

```python
if tool_calls_data:
    ... execute tools, append results to chat history ...
    # generator ends here — no follow-up completion, no yield
else:
    ... text-only response ...
```

The non-streaming path always did that second round trip. Streaming didn't, so the two disagreed about whether an answer existed at all.

## The fix

After the tools run, ask the model for the answer with the updated history and yield its chunks.

The follow-up deliberately carries **no tools** (`tools`, `tool_choice`, `parallel_tool_calls` are dropped): the model has its results and should answer rather than call another tool, which also bounds the turn to a single round of tools.

## Tests

`tests/unit/agent/test_streaming_with_tools.py` — 3 tests against the **real** path rather than a mocked client, because the defect lives in the interaction between tool execution and the follow-up completion, which is precisely what a hand-built mock of that client would define away. Skipped without a provider credential.

Includes a positive control (a plain streamed turn is unaffected) and a test that the streaming and non-streaming paths agree about whether an answer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming responses that could remain empty after tools were executed.
  * Ensured streamed interactions continue with a final response based on the current request and tool results.
  * Improved streaming event handling so follow-up responses begin and end consistently.

* **Tests**
  * Added coverage for standard streaming, tool-assisted streaming, and consistency with non-streaming responses.
  * Verified that tool results appear in the final streamed answer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->