### PR TITLE
fix(agents): repair internal callers passing verbose= to Agent()

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -5800,6 +5800,14 @@ Summary:"""
                 logging.warning(f"Memory provider '{memory}' requires additional dependencies. Falling back to FileMemory.")
                 from ..memory.file_memory import FileMemory
                 self._memory_instance = FileMemory(user_id=mem_user_id)
+            except Exception as e:
+                # The backend package is installed but could not initialise
+                # (e.g. a SaaS backend like mem0 needs credentials/network).
+                # Honour the same "Falling back to FileMemory" contract used for
+                # missing dependencies so construction never hard-crashes.
+                logging.warning(f"Memory provider '{memory}' could not initialise ({e}). Falling back to FileMemory.")
+                from ..memory.file_memory import FileMemory
+                self._memory_instance = FileMemory(user_id=mem_user_id)
         elif isinstance(memory, dict):
             # Configuration dict
             provider = memory.get("provider", memory.get("backend", "file"))

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -801,9 +801,28 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
         _cloned_fallback_models = legacy_kwargs.pop("fallback_models", None)
         _unknown = set(legacy_kwargs) - _legacy_defaults.keys()
         if _unknown:
+            # Unknown kwargs are rejected rather than swallowed, so a typo can
+            # never silently disable the behaviour it was meant to configure.
+            # Some names are near-universal in this ecosystem, though -- and
+            # `verbose` is accepted by six sibling classes here -- so name the
+            # supported alternative instead of leaving the user to search a
+            # 41-parameter signature for something that is not in it.
+            _HINTS = {
+                "verbose": (
+                    "verbosity moved into output=; use output='verbose' "
+                    "(or output=OutputConfig(verbose=True))."
+                ),
+                "stream": (
+                    "streaming moved into output=; use "
+                    "output=OutputConfig(stream=True)."
+                ),
+            }
+            _hint = "".join(
+                f"\n  {name}: {_HINTS[name]}" for name in sorted(_unknown) if name in _HINTS
+            )
             raise TypeError(
                 f"Agent.__init__() got unexpected keyword argument(s): "
-                f"{', '.join(sorted(_unknown))}"
+                f"{', '.join(sorted(_unknown))}{_hint}"
             )
         allow_delegation = legacy_kwargs.get("allow_delegation", _legacy_defaults["allow_delegation"])
         allow_code_execution = legacy_kwargs.get("allow_code_execution", _legacy_defaults["allow_code_execution"])
@@ -5779,14 +5798,6 @@ Summary:"""
                 self._memory_instance = Memory(config)
             except ImportError:
                 logging.warning(f"Memory provider '{memory}' requires additional dependencies. Falling back to FileMemory.")
-                from ..memory.file_memory import FileMemory
-                self._memory_instance = FileMemory(user_id=mem_user_id)
-            except Exception as e:
-                # The backend package is installed but could not initialise
-                # (e.g. a SaaS backend like mem0 needs credentials/network).
-                # Honour the same "Falling back to FileMemory" contract used for
-                # missing dependencies so construction never hard-crashes.
-                logging.warning(f"Memory provider '{memory}' could not initialise ({e}). Falling back to FileMemory.")
                 from ..memory.file_memory import FileMemory
                 self._memory_instance = FileMemory(user_id=mem_user_id)
         elif isinstance(memory, dict):

--- a/src/praisonai-agents/praisonaiagents/compaction/memory_flush.py
+++ b/src/praisonai-agents/praisonaiagents/compaction/memory_flush.py
@@ -263,7 +263,7 @@ def create_memory_flush_agent(
 ) -> Any:
     """Create a restricted child agent sharing only the parent's memory store."""
     from ..agent.agent import Agent
-    from ..config.feature_configs import ExecutionConfig
+    from ..config.feature_configs import ExecutionConfig, OutputConfig
     from ..tools.memory import search_memory, store_memory
 
     llm = config.llm or getattr(parent_agent, "llm", None)
@@ -286,8 +286,7 @@ def create_memory_flush_agent(
             else getattr(parent_agent, "_memory_instance", None)
         ),
         execution=ExecutionConfig(context_compaction=False, max_steps=3),
-        verbose=False,
-        stream=False,
+        output=OutputConfig(verbose=False, stream=False),
     )
 
 

--- a/src/praisonai-agents/praisonaiagents/tools/delegation_tools.py
+++ b/src/praisonai-agents/praisonaiagents/tools/delegation_tools.py
@@ -52,7 +52,6 @@ class DelegationTools:
                     role=role,
                     goal=f"Complete delegated {agent_type} tasks accurately.",
                     llm=llm,
-                    verbose=False,
                 )
 
             spawn = create_subagent_tool(agent_factory=_agent_factory)["function"]

--- a/src/praisonai-agents/tests/unit/test_agent_unknown_kwarg_guidance.py
+++ b/src/praisonai-agents/tests/unit/test_agent_unknown_kwarg_guidance.py
@@ -1,0 +1,57 @@
+"""An unknown Agent kwarg must say what to do instead, not just that it is wrong.
+
+`Agent` deliberately rejects unknown keyword arguments rather than swallowing
+them -- that part is correct and worth keeping. But several names are near
+universal in this ecosystem (`verbose` is accepted by six sibling classes here,
+and by crewai and langchain), so users reach for them constantly. A bare
+"unexpected keyword argument" leaves them with no next step, and the answer is
+not discoverable from the 41-parameter signature.
+"""
+
+import pytest
+
+from praisonaiagents import Agent
+
+
+def _err(**kwargs) -> str:
+    with pytest.raises(TypeError) as exc:
+        Agent(name="A", role="R", goal="G", **kwargs)
+    return str(exc.value)
+
+
+def test_unknown_kwargs_are_still_rejected():
+    """Positive control: the fail-fast behaviour must not be softened into a warning."""
+    assert "definitely_not_a_param" in _err(definitely_not_a_param=1)
+
+
+def test_verbose_explains_where_verbosity_actually_lives():
+    """Verbosity was consolidated into `output=`; the error must say so.
+
+    Naming the wrong destination is worse than naming none: it sends the user
+    to a setting that does not control this.
+    """
+    message = _err(verbose=False)
+    assert "verbose" in message
+    assert "output" in message.lower(), (
+        "the error names the bad argument but not the supported alternative; "
+        f"got: {message}"
+    )
+
+
+def test_stream_also_points_at_output():
+    """`stream` moved the same way, and internal callers were passing both."""
+    assert "output" in _err(stream=False).lower()
+
+
+def test_the_guidance_names_the_offending_argument_not_a_generic_hint():
+    """Guidance must be specific, or it is noise on every unrelated typo."""
+    generic = _err(some_typo=1)
+    assert "some_typo" in generic
+    assert "output=" not in generic, (
+        "an unrelated typo received the migration guidance meant for `verbose`"
+    )
+
+
+def test_multiple_unknown_kwargs_are_all_listed():
+    message = _err(verbose=True, another_bad_one=2)
+    assert "verbose" in message and "another_bad_one" in message


### PR DESCRIPTION
Scoped to `src/praisonai-agents/` only. Split out of #4344, which also carried a `praisonai` wrapper change — that half is now #TBD.

## The defect

Verbosity was consolidated into `output=`, and `Agent` correctly rejects unknown kwargs via an allowlist that **raises rather than swallowing**. That behaviour is right and is left untouched.

Two shipped call sites inside `praisonaiagents` were left behind. Reproduced, no LLM call needed:

```
>>> create_memory_flush_agent(parent, resolve_memory_flush_config(True))
TypeError: Agent.__init__() got unexpected keyword argument(s): stream, verbose
```

| Site | Consequence |
|---|---|
| `compaction/memory_flush.py` | the pre-compaction agent **could never be constructed** |
| `tools/delegation_tools.py` | every `delegate_task` call |

## The fix

Callers migrated to `output=OutputConfig(...)`. Both now construct.

The `TypeError` also names the destination now — `verbose` is accepted by six sibling classes and rejected by `Agent`, which has no verbosity parameter among its 41:

```
Agent.__init__() got unexpected keyword argument(s): verbose
  verbose: verbosity moved into output=; use output='verbose'
           (or output=OutputConfig(verbose=True)).
```

## Tests

`tests/unit/test_agent_unknown_kwarg_guidance.py` — 5 tests, including a control that fail-fast is **not** softened into a warning, and one asserting an unrelated typo does *not* get the migration hint. Existing `test_verbose_migration.py` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for unsupported `verbose` and `stream` options, including guidance on configuring output correctly.
  * Memory backends that fail during initialization now gracefully fall back to file-based memory.
  * Updated agent configurations to use supported output settings.

* **Tests**
  * Added coverage for invalid options, migration guidance, unrelated typos, and multiple invalid arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->