### PR TITLE
fix(scheduler): stop passing verbose= to Agent() from the YAML loader

### DIFF
--- a/src/praisonai/praisonai/scheduler/yaml_loader.py
+++ b/src/praisonai/praisonai/scheduler/yaml_loader.py
@@ -174,7 +174,7 @@ def create_agent_from_config(agent_config: Dict[str, Any]) -> Any:
         goal=goal,
         instructions=instructions,
         tools=tools,
-        verbose=verbose
+        output="verbose" if verbose else "silent",
     )
     
     return agent


### PR DESCRIPTION
Scoped to `src/praisonai/` only. Split out of #4344.

## The defect

`praisonai/scheduler/yaml_loader.py` documents `verbose: true` in its example `agents.yaml`, reads it, and passes it to `Agent()` **unconditionally** with a default of `False`.

`Agent` has no `verbose` parameter, so **every scheduled YAML agent raises `TypeError` on construction — whether or not the key appears in the YAML.** Verified live via `create_agent_from_config({...})`.

## The fix

`verbose=verbose` → `output="verbose" if verbose else "silent"`, which is where verbosity was consolidated.

## Note

The companion fix for the two `praisonaiagents`-internal callers is a separate PR so each package can be reviewed and released on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent configuration loading to correctly apply verbosity settings.
  * Agents now reliably produce either detailed or silent output as configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->