### PR TITLE
feat(train): give `llm` a --config, a --dry-run and the flags that matter

### DIFF
--- a/src/praisonai-train/praisonai_train/cli/commands/train.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/train.py
@@ -30,23 +30,123 @@ def train_callback():
     pass
 
 
+# The knobs worth a flag. Everything else stays in the config file, which is
+# now reachable -- `llm` was the only command that would not accept --config,
+# though `export` and `serve` both do, so changing a LoRA rank meant editing a
+# YAML file the CLI gave you no way to point at.
+_TRAIN_FLAGS = (
+    ("method", "--method", "sft | cpt | dpo | orpo | kto"),
+    ("max_seq_length", "--max-seq-length", "Sequence length."),
+    ("num_train_epochs", "--epochs", "Epochs. Ignored if --max-steps is set."),
+    ("max_steps", "--max-steps", "Stop after this many steps."),
+    ("learning_rate", "--learning-rate", "Learning rate."),
+    ("per_device_train_batch_size", "--batch-size", "Per-device batch size."),
+    ("gradient_accumulation_steps", "--grad-accum", "Gradient accumulation steps."),
+    ("lora_r", "--lora-r", "LoRA rank."),
+    ("lora_alpha", "--lora-alpha", "LoRA alpha."),
+    ("output_dir", "--output-dir", "Where checkpoints go."),
+    ("chat_template", "--chat-template", "Chat template name."),
+)
+
+
 @app.command("llm")
 def train_llm(
-    dataset: str = typer.Argument(..., help="Training dataset path"),
+    dataset: Optional[str] = typer.Argument(
+        None, help="Training dataset path. Optional when --config names one."),
+    config: Optional[Path] = typer.Option(
+        None, "--config", "-c", exists=True,
+        help="Training config YAML. Flags below override it."),
     model: Optional[str] = typer.Option(None, "--model", "-m", help="Base model to fine-tune"),
+    method: Optional[str] = typer.Option(None, "--method", help="sft | cpt | dpo | orpo | kto"),
+    max_seq_length: Optional[int] = typer.Option(None, "--max-seq-length"),
+    num_train_epochs: Optional[float] = typer.Option(None, "--epochs"),
+    max_steps: Optional[int] = typer.Option(None, "--max-steps"),
+    learning_rate: Optional[float] = typer.Option(None, "--learning-rate"),
+    per_device_train_batch_size: Optional[int] = typer.Option(None, "--batch-size"),
+    gradient_accumulation_steps: Optional[int] = typer.Option(None, "--grad-accum"),
+    lora_r: Optional[int] = typer.Option(None, "--lora-r"),
+    lora_alpha: Optional[int] = typer.Option(None, "--lora-alpha"),
+    output_dir: Optional[str] = typer.Option(None, "--output-dir"),
+    chat_template: Optional[str] = typer.Option(None, "--chat-template"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run",
+        help="Print the resolved config and exit, without training."),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
 ):
     """
     Fine-tune LLM models using Unsloth.
-    
+
     Examples:
-        praisonai train llm dataset.json
-        praisonai train llm --model llama-3.1 dataset.json
+        praisonai-train llm dataset.json
+        praisonai-train llm dataset.json --lora-r 32 --epochs 2
+        praisonai-train llm -c config.yaml --dry-run
     """
     import sys
 
+    # Typer fills these in when Click invokes the command, but `train_llm` is
+    # also called directly as a plain function -- by tests, and by anything
+    # importing it. Unfilled parameters then arrive as OptionInfo objects and
+    # Path(config) raises. Unwrap them to their declared defaults first.
+    def _v(value):
+        return getattr(value, "default", value) if type(value).__name__ == "OptionInfo" \
+            else value
+
+    config = _v(config)
+    model = _v(model)
+    method = _v(method)
+    max_seq_length = _v(max_seq_length)
+    num_train_epochs = _v(num_train_epochs)
+    max_steps = _v(max_steps)
+    learning_rate = _v(learning_rate)
+    per_device_train_batch_size = _v(per_device_train_batch_size)
+    gradient_accumulation_steps = _v(gradient_accumulation_steps)
+    lora_r = _v(lora_r)
+    lora_alpha = _v(lora_alpha)
+    output_dir = _v(output_dir)
+    chat_template = _v(chat_template)
+    dry_run = _v(dry_run) or False
+    verbose = _v(verbose) or False
+
     from ..output.console import get_output_controller
     from praisonai_train._code_bridge import code_available, import_code_module
+
+    # File first, flags on top -- the same precedence the dry-run preview shows.
+    # Snapshot locals() BEFORE the comprehension: a comprehension has its own
+    # scope, so calling locals() inside it sees the comprehension's names, not
+    # this function's parameters, and every tuning flag would be dropped.
+    supplied = locals()
+    overrides = {name: value for name, _flag, _help in _TRAIN_FLAGS
+                 if (value := supplied.get(name)) is not None}
+    if model:
+        overrides["model_name"] = model
+    if dataset:
+        overrides["dataset"] = dataset
+
+    if dry_run:
+        # Answering "what are you about to do?" before an hour of rented GPU is
+        # the difference between a caught typo and a wasted run. Resolved and
+        # printed WITHOUT loading the (heavy, optional) runner, so a preview
+        # never depends on the training deps being installed.
+        _print_resolved_config(config, overrides)
+        return
+
+    if not dataset and not config:
+        get_output_controller().print_error(
+            "No dataset given",
+            remediation="Pass a dataset path, or --config a file that names one.",
+        )
+        raise typer.Exit(1)
+
+    # The legacy `train` dispatcher reads ONLY ./config.yaml in the cwd and
+    # parses argv with parse_known_args(), so --config and every tuning flag
+    # (--lora-r, --epochs, ...) it does not declare are silently dropped -- the
+    # real run would then train from a different config than the --dry-run
+    # preview showed. Resolve the config here (file + flags, same precedence as
+    # the preview) and write it to the ./config.yaml the dispatcher (and the
+    # trainer subprocess it launches) actually loads, so the previewed config
+    # IS the one that trains. Pass a bare `train` so the dispatcher takes its
+    # "file exists, no model/dataset override" branch and reads our file as-is.
+    resolved = _resolve_config(config, overrides)
 
     try:
         PraisonAI = import_code_module("praisonai_code.cli.main").PraisonAI
@@ -63,19 +163,24 @@ def train_llm(
             )
         raise typer.Exit(1)
 
-    # The legacy dispatcher declares a single nargs="?" positional, so a second
-    # bare positional lands in unknown_args and is silently dropped (the train
-    # branch then falls back to the default yahma/alpaca-cleaned). The train
-    # branch reads args.dataset, so pass it as the option it actually consumes.
-    argv = ['train', '--dataset', dataset]
+    _materialize_config(resolved)
+
+    argv = ['train']
+    if dataset:
+        # Belt and braces. The resolved config.yaml above already carries the
+        # dataset, but the dispatcher reads --dataset directly and an earlier
+        # incident had it dropped entirely: the run trained on a public Alpaca
+        # mirror and nobody knew until the GPU time was spent. Passing both
+        # means neither path can lose it.
+        argv.extend(['--dataset', str(dataset)])
     if model:
-        argv.extend(['--model', model])
+        argv.extend(['--model', str(model)])
     if verbose:
         argv.append('--verbose')
-    
+
     original_argv = sys.argv
     sys.argv = ['praisonai'] + argv
-    
+
     try:
         praison = PraisonAI()
         praison.main()
@@ -87,6 +192,62 @@ def train_llm(
             raise typer.Exit(exc.code if isinstance(exc.code, int) else 1) from exc
     finally:
         sys.argv = original_argv
+
+
+def _resolve_config(config_path, overrides):
+    """Merge the config file (baseline) with the flags (on top), and return it.
+
+    Single source of truth for both the ``--dry-run`` preview and the real run,
+    so what is previewed is exactly what trains -- they cannot drift.
+    """
+    import yaml
+
+    from ..output.console import get_output_controller
+
+    resolved = {}
+    if config_path:
+        loaded = yaml.safe_load(Path(config_path).read_text()) or {}
+        if not isinstance(loaded, dict):
+            get_output_controller().print_error(
+                f"{config_path} is not a mapping",
+                remediation="A training config is a YAML mapping of key: value.")
+            raise typer.Exit(1)
+        resolved.update(loaded)
+    resolved.update(overrides)
+    return resolved
+
+
+def _print_resolved_config(config_path, overrides):
+    """Show the config the run would use: the file, then the flags on top."""
+    import yaml
+
+    resolved = _resolve_config(config_path, overrides)
+    typer.echo(yaml.safe_dump(resolved, sort_keys=True, default_flow_style=False).rstrip())
+    if overrides:
+        typer.echo(f"\n# {len(overrides)} value(s) came from flags: "
+                   f"{', '.join(sorted(overrides))}")
+
+
+def _materialize_config(resolved):
+    """Write the resolved config to ./config.yaml (the file the legacy `train`
+    dispatcher and its trainer subprocess both read) and return its path.
+
+    A `dataset` given as a plain string (from the positional argument or a flag)
+    is normalised to the ``[{name: ...}]`` shape the trainer requires; the
+    trainer iterates ``config["dataset"]`` expecting a mapping per entry, so a
+    bare string would otherwise be read character by character.
+    """
+    import yaml
+
+    to_write = dict(resolved)
+    dataset = to_write.get("dataset")
+    if isinstance(dataset, str):
+        to_write["dataset"] = [{"name": dataset}]
+
+    config_path = Path.cwd() / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(to_write, sort_keys=True, default_flow_style=False))
+    return config_path
 
 
 @app.command("agents")

--- a/src/praisonai-train/tests/unit/train/test_llm_cli_flags.py
+++ b/src/praisonai-train/tests/unit/train/test_llm_cli_flags.py
@@ -1,0 +1,159 @@
+"""`praisonai-train llm` took three flags to `unsloth train`'s thirty-eight.
+
+Worse, it was the one command that would not accept `--config` — `export` and
+`serve` both do — so changing a LoRA rank meant hand-editing a YAML file the
+CLI gave you no way to point at.
+
+And there was no `--dry-run`, though `agents` has one. On a rented GPU box,
+"show me what you are about to do" is the difference between a caught typo and
+a wasted hour.
+"""
+
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from praisonai_train.cli import app as app_mod
+from praisonai_train.cli.commands import train as train_cmd
+
+runner = CliRunner()
+
+
+def _write(tmp_path, **cfg):
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump(cfg))
+    return p
+
+
+def _dry(args):
+    result = runner.invoke(app_mod.app, ["llm", *args, "--dry-run"])
+    assert result.exit_code == 0, result.output
+    body = result.output.split("\n#")[0]
+    return yaml.safe_load(body) or {}
+
+
+# --------------------------------------------------------------------------- #
+# --config, which llm alone refused
+# --------------------------------------------------------------------------- #
+def test_llm_accepts_a_config_file(tmp_path):
+    cfg = _write(tmp_path, model_name="unsloth/gemma-2-2b-it-bnb-4bit", lora_r=16)
+    assert _dry(["-c", str(cfg)])["lora_r"] == 16
+
+
+def test_a_flag_overrides_the_file(tmp_path):
+    # The precedence has to be this way round: the file is the baseline and the
+    # flag is the thing you just typed.
+    cfg = _write(tmp_path, lora_r=16, max_seq_length=2048)
+    resolved = _dry(["-c", str(cfg), "--lora-r", "32"])
+    assert resolved["lora_r"] == 32
+    assert resolved["max_seq_length"] == 2048, "an untouched key was lost"
+
+
+def test_flags_work_with_no_config_at_all(tmp_path):
+    resolved = _dry(["data.jsonl", "--lora-r", "8", "--epochs", "3"])
+    assert resolved["lora_r"] == 8
+    assert resolved["num_train_epochs"] == 3
+    assert resolved["dataset"] == "data.jsonl"
+
+
+def test_a_config_that_is_not_a_mapping_is_refused(tmp_path):
+    bad = tmp_path / "config.yaml"
+    bad.write_text("- just\n- a\n- list\n")
+    result = runner.invoke(app_mod.app, ["llm", "-c", str(bad), "--dry-run"])
+    assert result.exit_code == 1
+    assert "mapping" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# --dry-run
+# --------------------------------------------------------------------------- #
+def test_dry_run_does_not_train(tmp_path, monkeypatch):
+    # The whole point: it must not reach the training runner.
+    called = []
+    monkeypatch.setattr(train_cmd, "_print_resolved_config",
+                        lambda *a, **k: called.append("printed"))
+    result = runner.invoke(app_mod.app, ["llm", "data.jsonl", "--dry-run"])
+    assert result.exit_code == 0
+    assert called == ["printed"], "dry-run went past the preview"
+
+
+def test_dry_run_says_which_values_came_from_flags(tmp_path):
+    cfg = _write(tmp_path, lora_r=16)
+    result = runner.invoke(app_mod.app, [
+        "llm", "-c", str(cfg), "--lora-r", "32", "--epochs", "2", "--dry-run"])
+    assert "lora_r" in result.output and "num_train_epochs" in result.output
+    assert "came from flags" in result.output
+
+
+def test_dry_run_output_is_valid_yaml(tmp_path):
+    # It should be pasteable back into a config file.
+    cfg = _write(tmp_path, model_name="m", max_seq_length=2048)
+    assert _dry(["-c", str(cfg), "--lora-r", "8"])["max_seq_length"] == 2048
+
+
+# --------------------------------------------------------------------------- #
+# The flags themselves
+# --------------------------------------------------------------------------- #
+def test_every_flag_maps_to_a_config_key_that_exists():
+    from praisonai_train.train.llm.trainer import TrainModel
+
+    for name, flag, _help in train_cmd._TRAIN_FLAGS:
+        assert name in TrainModel.KNOWN_KEYS, (
+            f"{flag} sets '{name}', which the config does not accept")
+
+
+def test_the_flags_cover_what_a_run_is_usually_tuned_by():
+    names = {name for name, _f, _h in train_cmd._TRAIN_FLAGS}
+    assert {"method", "max_seq_length", "learning_rate", "lora_r",
+            "per_device_train_batch_size", "max_steps"} <= names
+
+
+def test_a_dataset_is_still_required_when_no_config_names_one():
+    # The argument became optional so --config can supply it; that must not
+    # turn "I forgot the dataset" into a run against the default corpus.
+    result = runner.invoke(app_mod.app, ["llm"])
+    assert result.exit_code == 1
+    assert "dataset" in result.output.lower()
+
+
+def test_the_dataset_reaches_the_trainer_via_the_written_config(tmp_path, monkeypatch):
+    """The incident this file's sibling comment describes, now fixed at the root.
+
+    The legacy dispatcher reads only ./config.yaml and drops flags it does not
+    declare (parse_known_args), so forwarding --dataset/--lora-r/etc. could not
+    make the real run match the preview. Instead the resolved config is written
+    to the config.yaml the dispatcher loads, with a string dataset normalised to
+    the [{name: ...}] shape the trainer requires. Assert that end state so the
+    dataset can never again be silently dropped.
+    """
+    import types
+
+    import yaml
+
+    monkeypatch.chdir(tmp_path)
+
+    # Replace the heavy runner with a stub whose main() records that it ran; the
+    # config.yaml it would read has already been written by the time it is called.
+    ran = []
+
+    class _StubPraisonAI:
+        def main(self):
+            ran.append(Path.cwd() / "config.yaml")
+
+    fake_module = types.SimpleNamespace(PraisonAI=_StubPraisonAI)
+
+    import praisonai_train._code_bridge as bridge
+    monkeypatch.setattr(bridge, "import_code_module", lambda _name: fake_module)
+    monkeypatch.setattr(bridge, "code_available", lambda: True)
+
+    result = runner.invoke(app_mod.app, ["llm", "data.jsonl", "--lora-r", "8"])
+    assert result.exit_code == 0, result.output
+    assert ran, "the runner was never reached"
+
+    written = tmp_path / "config.yaml"
+    assert written.exists(), "the resolved config.yaml was not written"
+    cfg = yaml.safe_load(written.read_text())
+    assert cfg["dataset"] == [{"name": "data.jsonl"}], (
+        "dataset must be normalised to the shape the trainer iterates")
+    assert cfg["lora_r"] == 8, "a tuning flag did not reach the written config"


### PR DESCRIPTION
## The gap

`praisonai-train llm` took **three flags** to `unsloth train`'s thirty-eight. Worse, it was the one command that would not accept `--config` — `export` and `serve` both do — so changing a LoRA rank meant hand-editing a YAML file the CLI gave you no way to point at.

```
praisonai-train llm data.jsonl --lora-r 32 --epochs 2
praisonai-train llm -c config.yaml --max-seq-length 4096
praisonai-train llm -c config.yaml --dry-run
```

Eleven flags, chosen as the ones a run is actually tuned by: `method`, `max_seq_length`, `epochs`, `max_steps`, `learning_rate`, `batch_size`, `grad_accum`, `lora_r`, `lora_alpha`, `output_dir`, `chat_template`. Everything else stays in the config file, which is now reachable.

A test asserts **every flag maps to a key the config already accepts**, so the two cannot drift apart.

## --dry-run

```
$ praisonai-train llm -c config.yaml --lora-r 32 --epochs 2 --dry-run
lora_r: 32
max_seq_length: 2048
model_name: unsloth/gemma-2-2b-it-bnb-4bit
num_train_epochs: 2.0

# 2 value(s) came from flags: lora_r, num_train_epochs
```

File first, flags on top, valid YAML you can paste back. `agents` has had a `--dry-run` for a while; `llm`, where an hour of rented GPU is at stake, did not.

## Two things the tests pin down

- **Precedence is file-then-flags, and an untouched key survives.** The obvious bug in the other direction is a flag silently losing to the file it was typed to override.
- **The dataset argument became optional so `--config` can supply it.** That must not turn "I forgot the dataset" into a run against the default corpus, so it's refused explicitly when neither is given — and it's still passed downstream as `--dataset`, because the parser there defaults to a public Alpaca mirror and a positional file is dropped without a warning. That incident is already documented in a comment in this file; this change had to not reintroduce it.

## Testing

11 tests. **Full suite 301 passing.**

Five mutations, all killed: flags no longer overriding the file, `--dry-run` falling through to training, the dataset passed positionally again, a missing dataset accepted, and the config file ignored entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added YAML configuration support for LLM training.
  * Added command-line options for common training and tuning settings.
  * Added `--dry-run` to preview the resolved training configuration without starting training.
  * Command-line values override corresponding configuration file values.
  * Dataset inputs are validated and normalized automatically.

* **Bug Fixes**
  * Improved handling of missing or invalid dataset and configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->