### PR TITLE
feat(train): answer the two questions a fine-tune ends with

### DIFF
--- a/src/praisonai-train/praisonai_train/cli/app.py
+++ b/src/praisonai-train/praisonai_train/cli/app.py
@@ -15,6 +15,7 @@ from praisonai_train.cli.commands import data as _data  # noqa: F401  registers 
 from praisonai_train.cli.commands import benchmark as _benchmark  # noqa: F401  registers benchmark
 from praisonai_train.cli.commands import serve as _serve  # noqa: F401  registers serve
 from praisonai_train.cli.commands import catalog as _catalog  # noqa: F401  registers models
+from praisonai_train.cli.commands import run as _run  # noqa: F401  registers checkpoints/infer
 from praisonai_train.cli.commands import remote as _remote  # noqa: F401  registers remote
 
 __all__ = ["app"]

--- a/src/praisonai-train/praisonai_train/cli/commands/run.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/run.py
@@ -1,0 +1,115 @@
+"""``praisonai-train checkpoints`` and ``generate`` — what to do after a run.
+
+Two questions every fine-tune ends with, neither of which had an answer:
+
+* **What did it save?** After an interrupted run there was no way to find the
+  checkpoints without `ls`, and ``export --model-dir`` requires you to already
+  know the path.
+* **Did it work?** ``TrainModel.inference()`` has existed for a while with no
+  caller anywhere in the package, and ``serve --benchmark`` measures tokens per
+  second without showing a single token. The only way to see output was to
+  write Python.
+
+    praisonai-train checkpoints
+    praisonai-train checkpoints -d outputs --json
+    praisonai-train infer -d lora_model "Summarise this release."
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from praisonai_train.cli.commands.train import app
+
+_CHECKPOINT = re.compile(r"^checkpoint-(\d+)$")
+
+
+def _out():
+    from praisonai_train.cli.output.console import get_output_controller
+    return get_output_controller()
+
+
+def find_checkpoints(root: Path):
+    """Saved checkpoints under `root`, newest step first.
+
+    Matches `checkpoint-<n>` exactly, so a directory a user happened to call
+    `checkpoint-final` is not reported as step 0.
+    """
+    if not root.is_dir():
+        return []
+    found = []
+    for child in sorted(root.iterdir()):
+        m = _CHECKPOINT.match(child.name)
+        if not m or not child.is_dir():
+            continue
+        size = sum(f.stat().st_size for f in child.rglob("*") if f.is_file())
+        found.append({"step": int(m.group(1)), "path": str(child), "bytes": size})
+    return sorted(found, key=lambda c: c["step"], reverse=True)
+
+
+@app.command("checkpoints")
+def checkpoints(
+    model_dir: Path = typer.Option(Path("outputs"), "--model-dir", "-d",
+                                   help="Directory the run wrote to."),
+    as_json: bool = typer.Option(False, "--json", "-j"),
+):
+    """List the checkpoints a run saved."""
+    found = find_checkpoints(model_dir)
+    if as_json:
+        typer.echo(json.dumps(found, indent=2))
+        return
+    if not found:
+        _out().print_error(
+            f"No checkpoints in {model_dir}",
+            remediation="Set save_steps in the config, or pass --model-dir to "
+                        "the directory the run used (output_dir).")
+        raise typer.Exit(1)
+    for c in found:
+        typer.echo(f"  checkpoint-{c['step']:<8} {c['bytes'] / 1e9:6.2f} GB  {c['path']}")
+    typer.echo(f"\n{len(found)} checkpoint(s); newest is step {found[0]['step']}.")
+
+
+@app.command("infer")
+def infer(
+    prompt: str = typer.Argument(..., help="What to send the model."),
+    model_dir: Path = typer.Option(Path("lora_model"), "--model-dir", "-d",
+                                   exists=True, help="A trained adapter or model."),
+    max_new_tokens: int = typer.Option(256, "--max-new-tokens"),
+    temperature: float = typer.Option(0.7, "--temperature"),
+    max_seq_length: int = typer.Option(2048, "--max-seq-length"),
+    load_in_4bit: bool = typer.Option(True, "--load-in-4bit/--no-load-in-4bit"),
+):
+    """Generate once from a model you just trained."""
+    try:
+        from unsloth import FastLanguageModel
+        from transformers import TextStreamer
+    except ImportError as exc:
+        _out().print_error(
+            "Inference dependencies not installed",
+            remediation='pip install "praisonai-train[llm]"')
+        raise typer.Exit(1) from exc
+
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        model_name=str(model_dir),
+        max_seq_length=max_seq_length,
+        load_in_4bit=load_in_4bit,
+    )
+    FastLanguageModel.for_inference(model)
+    inputs = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}],
+        tokenize=True, add_generation_prompt=True, return_tensors="pt",
+    ).to(model.device)
+    # Streamed rather than returned in one lump: the first token is the answer
+    # to "is this model alive", and on a large model it arrives long before the
+    # last one.
+    model.generate(
+        input_ids=inputs,
+        streamer=TextStreamer(tokenizer, skip_prompt=True),
+        max_new_tokens=max_new_tokens,
+        temperature=temperature,
+        use_cache=True,
+    )

--- a/src/praisonai-train/praisonai_train/train/llm/trainer.py
+++ b/src/praisonai-train/praisonai_train/train/llm/trainer.py
@@ -910,7 +910,10 @@ class TrainModel:
             "report_to": self.config.get("report_to", default_report),
             "dataset_text_field": self.config.get("dataset_text_field", "text"),
             "max_length": self.config["max_seq_length"],
-            "dataset_num_proc": self.config.get("dataset_num_proc", 1),
+            # None, not 1: unsloth sizes this from available memory
+            # (rl.py:3396-3420). An explicit 1 defeated that policy and made
+            # map() single-process on every corpus, however large.
+            "dataset_num_proc": self.config.get("dataset_num_proc"),
             "packing": self._flag(self.config.get("packing"), default=False),
         }
         if self.config.get("run_name") or os.getenv("PRAISON_WANDB_RUN_NAME"):

--- a/src/praisonai-train/tests/unit/train/test_post_training_cli.py
+++ b/src/praisonai-train/tests/unit/train/test_post_training_cli.py
@@ -1,0 +1,148 @@
+"""Two questions every fine-tune ends with, neither of which had an answer.
+
+**What did it save?** After an interrupted run there was no way to find the
+checkpoints without `ls`, and `export --model-dir` requires you to already know
+the path.
+
+**Did it work?** `TrainModel.inference()` has existed for a while with no
+caller anywhere in the package — dead code for the single most common thing a
+user wants next. `serve --benchmark` measures tokens per second without showing
+a single token, and `benchmark` measures remote API deployments, not the model
+you just trained. The only way to see output was to write Python.
+
+Also here: a command-name collision that silently replaced one command with
+another, caught by asserting both survive registration.
+"""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from praisonai_train.cli import app as app_mod
+from praisonai_train.cli.commands import run as run_cmd
+
+runner = CliRunner()
+
+
+def _make(root, *steps, junk=()):
+    for s in steps:
+        d = root / f"checkpoint-{s}"
+        d.mkdir(parents=True)
+        (d / "adapter_model.safetensors").write_bytes(b"x" * 1024)
+    for name in junk:
+        (root / name).mkdir(parents=True)
+    return root
+
+
+# --------------------------------------------------------------------------- #
+# Registration
+# --------------------------------------------------------------------------- #
+def test_both_new_commands_are_registered():
+    names = {c.name or c.callback.__name__ for c in app_mod.app.registered_commands}
+    assert {"checkpoints", "infer"} <= names
+
+
+def test_infer_did_not_displace_dataset_generation():
+    """A collision here is silent.
+
+    `generate` was already dataset generation. Registering a second command of
+    the same name replaces one with the other and nothing says so.
+    """
+    names = [c.name or c.callback.__name__ for c in app_mod.app.registered_commands]
+    assert "generate" in names, "dataset generation was displaced"
+    assert len(names) == len(set(names)), f"duplicate command names: {names}"
+
+
+# --------------------------------------------------------------------------- #
+# checkpoints
+# --------------------------------------------------------------------------- #
+def test_checkpoints_are_listed_newest_first(tmp_path):
+    _make(tmp_path, 100, 500, 200)
+    found = run_cmd.find_checkpoints(tmp_path)
+    assert [c["step"] for c in found] == [500, 200, 100]
+
+
+def test_steps_sort_numerically_not_lexically(tmp_path):
+    # "checkpoint-1000" sorts before "checkpoint-200" as a string.
+    _make(tmp_path, 200, 1000)
+    assert [c["step"] for c in run_cmd.find_checkpoints(tmp_path)] == [1000, 200]
+
+
+def test_only_real_checkpoint_directories_count(tmp_path):
+    # A directory someone called "checkpoint-final" must not be reported as
+    # step 0, and unrelated output must not be listed at all.
+    _make(tmp_path, 50, junk=("checkpoint-final", "runs", "logs"))
+    found = run_cmd.find_checkpoints(tmp_path)
+    assert [c["step"] for c in found] == [50]
+
+
+def test_a_missing_directory_is_empty_rather_than_an_exception(tmp_path):
+    assert run_cmd.find_checkpoints(tmp_path / "never-existed") == []
+
+
+def test_the_size_is_measured_not_guessed(tmp_path):
+    _make(tmp_path, 10)
+    assert run_cmd.find_checkpoints(tmp_path)[0]["bytes"] == 1024
+
+
+def test_no_checkpoints_exits_non_zero_with_a_remedy(tmp_path):
+    result = runner.invoke(app_mod.app, ["checkpoints", "-d", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "save_steps" in result.output, "the remedy does not say how to get any"
+
+
+def test_json_output_is_machine_readable(tmp_path):
+    _make(tmp_path, 300)
+    result = runner.invoke(app_mod.app, ["checkpoints", "-d", str(tmp_path), "--json"])
+    assert json.loads(result.output)[0]["step"] == 300
+
+
+def test_the_human_listing_names_the_newest(tmp_path):
+    _make(tmp_path, 100, 900)
+    result = runner.invoke(app_mod.app, ["checkpoints", "-d", str(tmp_path)])
+    assert "step 900" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# infer
+# --------------------------------------------------------------------------- #
+def test_infer_streams_rather_than_returning_one_lump():
+    import inspect
+
+    src = inspect.getsource(run_cmd.infer)
+    assert "TextStreamer" in src, (
+        "output is not streamed; on a large model the first token is the answer "
+        "to 'is this alive' and arrives long before the last")
+    assert "skip_prompt=True" in src, "the prompt is echoed back at the user"
+
+
+def test_infer_refuses_a_directory_that_is_not_there(tmp_path):
+    result = runner.invoke(app_mod.app, [
+        "infer", "hello", "-d", str(tmp_path / "nope")])
+    assert result.exit_code != 0
+
+
+def test_infer_exposes_the_knobs_that_change_the_answer():
+    import inspect
+
+    params = inspect.signature(run_cmd.infer).parameters
+    for knob in ("max_new_tokens", "temperature", "max_seq_length", "load_in_4bit"):
+        assert knob in params, f"{knob} is hardcoded"
+
+
+def test_the_defaults_are_usable_rather_than_experimental():
+    import inspect
+
+    params = inspect.signature(run_cmd.infer).parameters
+    # Typer wraps a default in OptionInfo, so the value is one level down --
+    # reading .default directly compares against the wrapper and passes for
+    # any number at all.
+    def value(name):
+        d = params[name].default
+        return getattr(d, "default", d)
+
+    # The dead inference() used temperature=1.5 and max_new_tokens=64 — good
+    # for a demo, wrong for "did my fine-tune take".
+    assert value("temperature") <= 1.0
+    assert value("max_new_tokens") >= 128


### PR DESCRIPTION
**What did it save, and did it work?** Neither had an answer.

```
praisonai-train checkpoints
praisonai-train checkpoints -d outputs --json
praisonai-train infer -d lora_model "Summarise this release."
```

## `checkpoints`

After an interrupted run there was no way to find what had been saved without `ls`, and `export --model-dir` requires you to already know the path.

Matches `checkpoint-<n>` **exactly**, so a directory someone called `checkpoint-final` isn't reported as step 0. Sorts numerically — `checkpoint-1000` sorts before `checkpoint-200` as a string, and both tests are in.

## `infer`

`TrainModel.inference()` has existed with **no caller anywhere in the package** — dead code for the single most common thing a user wants next. `serve --benchmark` measures tokens per second without showing a token, and `benchmark` measures *remote API deployments*, not the model you just trained. The only way to see output was to write Python.

Streamed rather than returned in one lump: on a large model the first token answers "is this alive" long before the last one.

The defaults are usable rather than demo values. The dead `inference()` used `temperature=1.5, max_new_tokens=64` — fine for a demo, wrong for "did my fine-tune take". There's a test asserting the defaults stay in the usable range.

**Named `infer`, not `generate`.** `generate` is already dataset generation, and registering a second command of that name silently replaces one with the other — I hit exactly that while writing this, and there's now a test asserting both survive registration and that no two commands share a name.

## One line elsewhere

`dataset_num_proc` now defaults to `None` rather than `1`. Unsloth sizes it from available memory (`rl.py:3396-3420`); sending an explicit `1` defeated that policy and made `map()` single-process on every corpus, however large.

## Testing

14 tests. **Full suite 315 passing.**

Five mutations, all killed: lexical step sorting, counting `checkpoint-final` as a checkpoint, colliding with dataset generation, restoring the demo temperature, and dropping the streamer.

One test needed fixing before it meant anything — Typer wraps a default in `OptionInfo`, so reading `.default` compared against the wrapper and would have passed for any value at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to list training checkpoints with human-readable or JSON output.
  * Added model inference with configurable prompt, token, temperature, context, and quantization options.
  * Registered remote training and run command groups.

* **Improvements**
  * Enhanced model publishing options and authentication handling.
  * Added actionable guidance for GPU out-of-memory errors.

* **Tests**
  * Added coverage for checkpoint discovery, output formats, command registration, and inference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->