### PR TITLE
feat(train): validate model names against unsloth's own catalog

### DIFF
--- a/src/praisonai-train/praisonai_train/cli/app.py
+++ b/src/praisonai-train/praisonai_train/cli/app.py
@@ -14,6 +14,7 @@ from praisonai_train.cli.commands.train import app
 from praisonai_train.cli.commands import data as _data  # noqa: F401  registers generate/validate
 from praisonai_train.cli.commands import benchmark as _benchmark  # noqa: F401  registers benchmark
 from praisonai_train.cli.commands import serve as _serve  # noqa: F401  registers serve
+from praisonai_train.cli.commands import catalog as _catalog  # noqa: F401  registers models
 from praisonai_train.cli.commands import remote as _remote  # noqa: F401  registers remote
 
 __all__ = ["app"]

--- a/src/praisonai-train/praisonai_train/cli/commands/catalog.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/catalog.py
@@ -1,0 +1,48 @@
+"""``praisonai-train models`` — what this can actually load.
+
+`model_name` was free text with no validation, so a typo was caught by Hugging
+Face after a download, and nothing told a new user which models work.
+
+In its own module rather than alongside the post-training commands, so the
+catalog does not depend on them.
+"""
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import typer
+
+from praisonai_train.cli.commands.train import app
+
+
+@app.command("models")
+def models(
+    search: Optional[str] = typer.Argument(None, help="Filter, e.g. 'gemma' or '7b'."),
+    as_json: bool = typer.Option(False, "--json", "-j"),
+    limit: int = typer.Option(40, "--limit", "-n", help="0 for all."),
+):
+    """Models unsloth knows how to load."""
+    from praisonai_train.cli.output.console import get_output_controller
+    from praisonai_train.models import CURATED, known_models
+
+    catalog = known_models()
+    if search:
+        needle = search.lower()
+        catalog = tuple(m for m in catalog if needle in m.lower())
+    if as_json:
+        typer.echo(json.dumps(list(catalog), indent=2))
+        return
+    if not catalog:
+        get_output_controller().print_error(
+            f"Nothing matches '{search}'",
+            remediation="Try a family name (gemma, qwen, llama) or a size (7b).")
+        raise typer.Exit(1)
+    shown = catalog if limit == 0 else catalog[:limit]
+    for name in shown:
+        mark = "*" if name in CURATED else " "
+        typer.echo(f" {mark} {name}")
+    if len(shown) < len(catalog):
+        typer.echo(f"\n{len(shown)} of {len(catalog)}; -n 0 for all.")
+    else:
+        typer.echo(f"\n{len(catalog)} model(s). * = a good starting point.")

--- a/src/praisonai-train/praisonai_train/models.py
+++ b/src/praisonai-train/praisonai_train/models.py
@@ -1,0 +1,87 @@
+"""What models this actually supports.
+
+`model_name` was a free-text string with no validation anywhere. A typo was
+caught by Hugging Face — after the CLI had accepted it, after the environment
+was built, sometimes after a partial download. And nothing told a new user
+which models work: `config.yaml` offers exactly one example, from the
+Llama-3.1 era.
+
+Unsloth already maintains the list — `unsloth/models/mapper.py` has 246
+distinct 4-bit repos and is updated with every release. So this reads that at
+runtime rather than vendoring a copy, because a hand-written catalog is stale
+the day it is written. `CURATED` is the fallback for when unsloth is not
+installed (the CLI is importable without the training extra) and the starting
+point for `praisonai-train models` with no filter.
+"""
+
+from __future__ import annotations
+
+import difflib
+import functools
+
+# A small, deliberately opinionated starting set: one current model per family,
+# sized to fit a single 24 GB card in 4-bit. Not a substitute for the mapper --
+# a signpost for someone who has not chosen yet.
+CURATED = (
+    "unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit",
+    "unsloth/Qwen2.5-7B-Instruct-bnb-4bit",
+    "unsloth/gemma-2-9b-it-bnb-4bit",
+    "unsloth/mistral-7b-instruct-v0.3-bnb-4bit",
+    "unsloth/Phi-3.5-mini-instruct-bnb-4bit",
+    "unsloth/Qwen2.5-3B-Instruct-bnb-4bit",
+    "unsloth/gemma-2-2b-it-bnb-4bit",
+)
+
+
+@functools.lru_cache(maxsize=1)
+def known_models() -> tuple:
+    """Every model unsloth maps, or the curated set if it is not installed.
+
+    Cached: the mapper is a large module-level dict and this is consulted on
+    every config validation.
+    """
+    try:
+        from unsloth.models.mapper import INT_TO_FLOAT_MAPPER, FLOAT_TO_INT_MAPPER
+    except ImportError:
+        return tuple(CURATED)
+    names = set(INT_TO_FLOAT_MAPPER) | set(FLOAT_TO_INT_MAPPER)
+    names.update(v for v in INT_TO_FLOAT_MAPPER.values() if isinstance(v, str))
+    return tuple(sorted(n for n in names if isinstance(n, str) and "/" in n))
+
+
+def is_known(name: str) -> bool:
+    return bool(name) and name in known_models()
+
+
+def suggest(name: str, n: int = 3) -> list:
+    """Close matches for a name that is not in the catalog.
+
+    Matched on the repo name rather than the full id, so a right model under
+    the wrong org still surfaces -- `meta-llama/...` should suggest the unsloth
+    mirror of the same thing.
+    """
+    if not name:
+        return []
+    target = name.rsplit("/", 1)[-1].lower()
+    catalog = known_models()
+    by_repo = {n.rsplit("/", 1)[-1].lower(): n for n in catalog}
+    hits = difflib.get_close_matches(target, list(by_repo), n=n, cutoff=0.6)
+    return [by_repo[h] for h in hits]
+
+
+def describe_unknown(name: str) -> str:
+    """The message for a model we cannot vouch for.
+
+    Deliberately a warning rather than a refusal: unsloth loads plenty of
+    models it does not map (loader.py falls through to the generic path), so
+    refusing would block working configurations. It says what it does not know
+    and offers the nearest thing.
+    """
+    lines = [f"'{name}' is not in unsloth's model list, so it may not load."]
+    close = suggest(name)
+    if close:
+        lines.append("Did you mean: " + ", ".join(close) + "?")
+    else:
+        lines.append("Known-good starting points: " + ", ".join(CURATED[:3]) + ".")
+    lines.append("Run `praisonai-train models` to see the full list.")
+    return " ".join(lines)

--- a/src/praisonai-train/praisonai_train/train/llm/trainer.py
+++ b/src/praisonai-train/praisonai_train/train/llm/trainer.py
@@ -432,6 +432,16 @@ class TrainModel:
     def validate_config(self):
         self.resolve_method(self.config)
 
+        # A warning, not a refusal: unsloth loads plenty of models it does not
+        # map (loader.py falls through to a generic path), so refusing would
+        # block working configurations. But "I typed it wrong" should not cost
+        # a download to discover.
+        name = self.config.get("model_name")
+        if name:
+            from praisonai_train.models import describe_unknown, is_known
+            if not is_known(name):
+                print(f"WARNING: {describe_unknown(name)}")
+
         required = ["model_name", "max_seq_length", "dataset"]
         missing = [k for k in required if not self.config.get(k)]
         if missing:

--- a/src/praisonai-train/tests/unit/train/test_model_catalog.py
+++ b/src/praisonai-train/tests/unit/train/test_model_catalog.py
@@ -1,0 +1,188 @@
+"""`model_name` was a free-text string with no validation anywhere.
+
+A typo was caught by Hugging Face — after the CLI accepted it, after the
+environment was built, sometimes after a partial download. And nothing told a
+new user which models work: `config.yaml` offers exactly one example, from the
+Llama-3.1 era.
+
+Unsloth already maintains the list (`unsloth/models/mapper.py`, 246 distinct
+4-bit repos, updated every release), so this reads it at runtime rather than
+vendoring a copy that would be stale the day it was written.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+from praisonai_train import models as cat
+from praisonai_train.cli import app as app_mod
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cat.known_models.cache_clear()
+    yield
+    cat.known_models.cache_clear()
+
+
+# --------------------------------------------------------------------------- #
+# The catalog
+# --------------------------------------------------------------------------- #
+def test_the_catalog_is_never_empty():
+    # Even with unsloth absent there must be something to suggest, or the
+    # error message degrades to "that's wrong" with no way forward.
+    assert len(cat.known_models()) > 0
+
+
+def test_it_reads_unsloths_mapper_when_available(monkeypatch):
+    """The whole design: not a vendored copy.
+
+    A hand-written catalog is stale the day it ships. unsloth updates its
+    mapper every release, and it is already a dependency.
+    """
+    import sys
+    import types
+
+    fake = types.ModuleType("unsloth.models.mapper")
+    # The 16-bit mirror appears ONLY as a value, so a catalog built from keys
+    # alone would miss it -- and a user who names the 16-bit repo would be
+    # warned their perfectly valid model is unknown.
+    fake.INT_TO_FLOAT_MAPPER = {"unsloth/fake-4bit": "unsloth/fake-16bit-mirror"}
+    fake.FLOAT_TO_INT_MAPPER = {"unsloth/fake": "unsloth/fake-4bit"}
+    monkeypatch.setitem(sys.modules, "unsloth.models.mapper", fake)
+    cat.known_models.cache_clear()
+    assert "unsloth/fake-4bit" in cat.known_models()
+    assert "unsloth/fake" in cat.known_models()
+    assert "unsloth/fake-16bit-mirror" in cat.known_models(), (
+        "a model that appears only as a mapper value is reported as unknown")
+
+
+def test_a_missing_unsloth_falls_back_rather_than_raising(monkeypatch):
+    # The CLI is importable without the training extra; `models` and config
+    # validation must still work there.
+    import builtins
+
+    real = builtins.__import__
+
+    def _no_unsloth(name, *a, **k):
+        if name.startswith("unsloth"):
+            raise ImportError("no unsloth here")
+        return real(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_unsloth)
+    cat.known_models.cache_clear()
+    assert cat.known_models() == tuple(cat.CURATED)
+
+
+def test_the_curated_set_is_a_real_starting_point():
+    # One current model per major family, so "I have not chosen yet" has an
+    # answer that is not just the first alphabetically.
+    families = {"llama", "qwen", "gemma", "mistral", "phi"}
+    joined = " ".join(cat.CURATED).lower()
+    for family in families:
+        assert family in joined, f"nothing curated for {family}"
+
+
+# --------------------------------------------------------------------------- #
+# Suggestions
+# --------------------------------------------------------------------------- #
+def test_a_typo_suggests_the_model_meant():
+    hits = cat.suggest("unsloth/Meta-Llama-3.1-8B-Instrct-bnb-4bit")
+    assert "unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit" in hits
+
+
+def test_the_right_model_under_the_wrong_org_is_found(monkeypatch):
+    """Matched on the repo name, not the full id.
+
+    The org prefix has to be discarded before comparing, or a long enough one
+    drowns the part that identifies the model. `meta-llama/...` is short enough
+    that difflib finds it either way, so this uses an org long enough that
+    full-id matching demonstrably fails.
+    """
+    import sys
+    import types
+
+    fake = types.ModuleType("unsloth.models.mapper")
+    fake.INT_TO_FLOAT_MAPPER = {"unsloth/gemma-2-9b-it-bnb-4bit": "unsloth/gemma-2-9b-it"}
+    fake.FLOAT_TO_INT_MAPPER = {}
+    monkeypatch.setitem(sys.modules, "unsloth.models.mapper", fake)
+    cat.known_models.cache_clear()
+
+    wrong_org = "some-very-long-organisation-name-here/gemma-2-9b-it-bnb-4bit"
+    hits = cat.suggest(wrong_org)
+    # The 16-bit mirror is in the catalog too and is a near match, so assert on
+    # the ordering: the exact repo name has to lead.
+    assert hits and hits[0] == "unsloth/gemma-2-9b-it-bnb-4bit", hits
+
+
+def test_something_unrelated_suggests_nothing_rather_than_anything():
+    # A confident wrong suggestion is worse than none.
+    assert cat.suggest("completely-unrelated/xyzzy-9000") == []
+
+
+def test_an_empty_name_is_handled():
+    assert cat.suggest("") == []
+    assert cat.is_known("") is False
+
+
+# --------------------------------------------------------------------------- #
+# The message
+# --------------------------------------------------------------------------- #
+def test_an_unknown_model_warns_without_refusing():
+    # unsloth loads plenty of models it does not map, so refusing would block
+    # working configurations.
+    msg = cat.describe_unknown("some-org/brand-new-model")
+    assert "may not load" in msg
+    assert "praisonai-train models" in msg, "no way to find the right name"
+
+
+def test_a_near_miss_leads_with_the_correction():
+    msg = cat.describe_unknown("unsloth/Meta-Llama-3.1-8B-Instrct-bnb-4bit")
+    assert "Did you mean" in msg
+    assert "Instruct" in msg
+
+
+def test_a_wild_miss_offers_a_starting_point_instead():
+    msg = cat.describe_unknown("completely-unrelated/xyzzy-9000")
+    assert "Did you mean" not in msg
+    assert "starting points" in msg
+
+
+def test_validation_warns_but_does_not_raise():
+    import inspect
+
+    from praisonai_train.train.llm.trainer import TrainModel
+
+    src = inspect.getsource(TrainModel.validate_config)
+    block = src[src.index("describe_unknown") - 200:src.index("required = [")]
+    assert "print(" in block, "the unknown-model path does not warn"
+    assert "raise" not in block, "an unmapped model is refused, blocking valid configs"
+
+
+# --------------------------------------------------------------------------- #
+# The command
+# --------------------------------------------------------------------------- #
+def test_models_is_registered():
+    names = {c.name or c.callback.__name__ for c in app_mod.app.registered_commands}
+    assert "models" in names
+
+
+def test_models_filters(monkeypatch):
+    result = runner.invoke(app_mod.app, ["models", "gemma"])
+    assert result.exit_code == 0
+    assert "gemma" in result.output.lower()
+    assert "qwen" not in result.output.lower(), "the filter did not filter"
+
+
+def test_a_filter_matching_nothing_exits_non_zero():
+    result = runner.invoke(app_mod.app, ["models", "definitely-not-a-family"])
+    assert result.exit_code == 1
+    assert "Try a family name" in result.output
+
+
+def test_json_output_is_a_list():
+    import json
+
+    result = runner.invoke(app_mod.app, ["models", "--json"])
+    assert isinstance(json.loads(result.output), list)


### PR DESCRIPTION
## The gap

`model_name` was a free-text string with **no validation anywhere**. A typo was caught by Hugging Face — after the CLI accepted it, after the environment was built, sometimes after a partial download. And nothing told a new user which models work: `config.yaml` offers exactly one example, from the Llama-3.1 era.

```
praisonai-train models
praisonai-train models gemma
praisonai-train models --json
```

## Read, not vendored

The catalog comes from **unsloth's own mapper at runtime**. `unsloth/models/mapper.py` carries 246 distinct 4-bit repos and is updated every release; a hand-written copy here would be stale the day it shipped.

`CURATED` is the fallback for when unsloth isn't installed — the CLI is importable without the training extra, and `models` has to work there — and doubles as the starting point shown to someone who hasn't chosen yet.

## Three decisions worth review

- **An unknown model warns, it doesn't refuse.** unsloth loads plenty of models it doesn't map (`loader.py` falls through to a generic path), so refusing would block working configurations. A test asserts the validation path contains no `raise`.
- **Suggestions match the repo name, not the full id**, so `meta-llama/Meta-Llama-3.1-8B-Instruct` surfaces the unsloth mirror. A long enough org prefix otherwise drowns the part that identifies the model.
- **The catalog includes mapper *values*, not just keys.** A 16-bit mirror appears only as a value — a user naming one would have been told their perfectly valid model was unknown.

## Testing

16 tests. **Full suite 331 passing.**

Five mutations, all killed: dropping repo-name matching, lowering the suggestion cutoff so anything matches, emptying the fallback catalog, dropping the 16-bit mirrors, removing the pointer to `praisonai-train models`.

**Two of those needed the tests fixed first.** They passed against the mutation because the fixtures didn't discriminate — the wrong-org case used an org short enough that difflib found it either way, and the mapper fixture had every value also present as a key. Both are noted in the test docstrings, since that's the failure mode this whole sweep keeps turning up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `models` command to browse the available training model catalog.
  - Supports case-insensitive filtering, configurable result limits, JSON output, and curated-model indicators.
  - Provides suggestions and helpful guidance for unfamiliar model names.

- **Bug Fixes**
  - Training configuration validation now warns about unknown models without blocking training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->