### PR TITLE
fix(train): check the versions, and look at the GPU before pinning CUDA

### DIFF
--- a/src/praisonai-train/praisonai_train/preflight.py
+++ b/src/praisonai-train/praisonai_train/preflight.py
@@ -1,0 +1,88 @@
+"""Check the environment before the GPU time is spent.
+
+The floors were pip metadata only. `pyproject.toml` declares `torch>=2.6.0`,
+`transformers>=4.51.3`, `trl>=0.18.2` and so on, but nothing checked them at
+runtime — and pip is routinely bypassed. `pip install --no-deps`, a conda
+environment assembled by hand, `setup_conda_env.sh` pinning its own torch: all
+produce an environment whose versions were never enforced.
+
+praisonai-train does inherit unsloth's own import-time checks, but only once
+`from unsloth import FastLanguageModel` runs, deep inside a lazy helper. By
+then the CLI has parsed arguments and the user sees a raw traceback rather than
+a CLI-shaped error naming the package to upgrade.
+"""
+
+from __future__ import annotations
+
+# Kept in step with pyproject.toml's [project.optional-dependencies] llm extra.
+# A test asserts they match, so the two cannot drift.
+FLOORS = {
+    "torch": "2.6.0",
+    "transformers": "4.51.3",
+    "unsloth": "2025.9.1",
+    "trl": "0.18.2",
+    "peft": "0.13.0",
+    "bitsandbytes": "0.45.0",
+}
+
+
+def _parse(version: str) -> tuple:
+    """Compare release segments only.
+
+    A dev or rc suffix on a matching release counts as satisfying the floor:
+    refusing `2.6.0rc1` when the floor is `2.6.0` blocks people testing
+    upstream, and unsloth's own checks are release-level too.
+    """
+    out = []
+    for part in str(version).split(".")[:4]:
+        digits = ""
+        for ch in part:
+            if not ch.isdigit():
+                break
+            digits += ch
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+def satisfies(installed: str, floor: str) -> bool:
+    if not installed:
+        return False
+    return _parse(installed) >= _parse(floor)
+
+
+def installed_version(package: str) -> "str | None":
+    try:
+        from importlib.metadata import version
+        return version(package)
+    except Exception:
+        return None
+
+
+def check(floors=None) -> list:
+    """Packages that are missing or too old, as (name, installed, floor).
+
+    `installed` is None when the package is absent, which needs a different
+    remedy from a version that is merely behind.
+    """
+    problems = []
+    for package, floor in (floors or FLOORS).items():
+        found = installed_version(package)
+        if found is None:
+            problems.append((package, None, floor))
+        elif not satisfies(found, floor):
+            problems.append((package, found, floor))
+    return problems
+
+
+def describe(problems) -> str:
+    """One actionable message naming exactly what to install."""
+    missing = [p for p in problems if p[1] is None]
+    stale = [p for p in problems if p[1] is not None]
+    lines = []
+    if missing:
+        lines.append("Missing: " + ", ".join(p[0] for p in missing))
+    for package, found, floor in stale:
+        lines.append(f"{package} {found} is older than the required {floor}")
+    specs = " ".join(f'"{p[0]}>={p[2]}"' for p in problems)
+    lines.append(f"Install with: pip install -U {specs}")
+    return "\n".join(lines)

--- a/src/praisonai-train/praisonai_train/setup/setup_conda_env.sh
+++ b/src/praisonai-train/praisonai_train/setup/setup_conda_env.sh
@@ -53,6 +53,53 @@ else
     exit 1
 fi
 
+# --- What GPU is actually here? --------------------------------------------
+#
+# Every Linux host got `pytorch-cuda=12.4` regardless of hardware. On an AMD
+# box or a Blackwell card that produces a working-LOOKING environment which
+# fails at the first kernel; on a CPU-only host it installs a CUDA build that
+# can never run. Probe before pinning.
+detect_accelerator() {
+    if command -v nvidia-smi &> /dev/null && nvidia-smi -L 2>/dev/null | grep -q GPU; then
+        echo "cuda"; return
+    fi
+    # nvidia-smi can be absent on a machine that does have the driver.
+    if [ -d /proc/driver/nvidia/gpus ] && [ -n "$(ls -A /proc/driver/nvidia/gpus 2>/dev/null)" ]; then
+        echo "cuda"; return
+    fi
+    if command -v rocminfo &> /dev/null || command -v amd-smi &> /dev/null; then
+        echo "rocm"; return
+    fi
+    echo "cpu"
+}
+
+ACCELERATOR="$(detect_accelerator)"
+echo "Detected accelerator: $ACCELERATOR"
+
+# The pytorch-cuda pin, or nothing at all. Kept in one place so the two
+# create-environment branches below cannot disagree.
+TORCH_SPEC="pytorch=2.6.0"
+TORCH_CHANNELS="-c pytorch"
+case "$ACCELERATOR" in
+    cuda)
+        TORCH_SPEC="pytorch=2.6.0 pytorch-cuda=12.4"
+        TORCH_CHANNELS="-c pytorch -c nvidia"
+        ;;
+    rocm)
+        echo "WARNING: an AMD GPU was detected. This installer only knows the CUDA"
+        echo "         and CPU builds, so it will install the CPU one. Follow"
+        echo "         https://pytorch.org/get-started/locally/ for a ROCm build,"
+        echo "         then re-run this script."
+        ;;
+    cpu)
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            echo "WARNING: no GPU detected. Fine-tuning needs one -- praisonai-train"
+            echo "         llm refuses to run on CPU. The environment will still be"
+            echo "         usable for dataset work and exports."
+        fi
+        ;;
+esac
+
 # Check if conda is installed
 if ! command -v conda &> /dev/null; then
     echo "Conda is not installed. Installing Miniconda..."
@@ -69,18 +116,10 @@ ENV_NAME="praison_env"
 if conda info --envs | grep -q "$ENV_NAME"; then
     echo "Environment $ENV_NAME already exists. Recreating..."
     conda env remove -y -n "$ENV_NAME"
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        conda create --name "$ENV_NAME" python=3.11 pytorch=2.6.0 -c pytorch -y
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        conda create --name "$ENV_NAME" python=3.11 pytorch=2.6.0 pytorch-cuda=12.4 -c pytorch -c nvidia -y
-    fi
+    conda create --name "$ENV_NAME" python=3.11 $TORCH_SPEC $TORCH_CHANNELS -y
 else
     echo "Creating new environment $ENV_NAME..."
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        conda create --name "$ENV_NAME" python=3.11 pytorch=2.6.0 -c pytorch -y
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        conda create --name "$ENV_NAME" python=3.11 pytorch=2.6.0 pytorch-cuda=12.4 -c pytorch -c nvidia -y
-    fi
+    conda create --name "$ENV_NAME" python=3.11 $TORCH_SPEC $TORCH_CHANNELS -y
 fi
 
 # Activate the environment

--- a/src/praisonai-train/praisonai_train/train/llm/trainer.py
+++ b/src/praisonai-train/praisonai_train/train/llm/trainer.py
@@ -193,6 +193,16 @@ VALID_QUANTIZATION_METHODS = frozenset({
 
 def _lazy_import_training_deps():
     """Import heavy training dependencies only when needed."""
+    # Check the floors first. They were pip metadata only, and pip is routinely
+    # bypassed -- --no-deps, a hand-built conda env, setup_conda_env.sh pinning
+    # its own torch. Without this the failure arrives as whatever traceback the
+    # mismatched package happens to raise, several imports deep.
+    from praisonai_train.preflight import check, describe
+    problems = check()
+    if problems:
+        raise ImportError(
+            "Training dependencies are missing or too old.\n" + describe(problems))
+
     try:
         import torch
         from transformers import TextStreamer, TrainingArguments

--- a/src/praisonai-train/tests/unit/train/test_preflight.py
+++ b/src/praisonai-train/tests/unit/train/test_preflight.py
@@ -1,0 +1,168 @@
+"""The version floors were pip metadata only, and the CUDA pin ignored hardware.
+
+**Floors.** `pyproject.toml` declares `torch>=2.6.0`, `transformers>=4.51.3`
+and so on, but nothing checked them at runtime — and pip is routinely bypassed:
+`--no-deps`, a hand-built conda env, `setup_conda_env.sh` pinning its own
+torch. The failure then arrives as whatever traceback the mismatched package
+happens to raise, several imports deep, long after the CLI accepted the run.
+
+**The pin.** Every Linux host got `pytorch-cuda=12.4` regardless of what was in
+it. On an AMD box or a Blackwell card that produces a working-*looking*
+environment that fails at the first kernel; on a CPU-only host it installs a
+CUDA build that can never run.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from praisonai_train import preflight as pf
+
+ROOT = Path(__file__).resolve().parents[3]
+SETUP_SH = ROOT / "praisonai_train" / "setup" / "setup_conda_env.sh"
+
+
+def _code():
+    """The script with comments stripped.
+
+    The comment explaining the old behaviour quotes `pytorch-cuda=12.4`, so a
+    structural assertion over the raw text matches the explanation rather than
+    the code — and passes whatever the code does.
+    """
+    lines = []
+    for line in SETUP_SH.read_text().splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        lines.append(line.split(" #", 1)[0])
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# The floors match the packaging metadata
+# --------------------------------------------------------------------------- #
+def test_the_floors_match_pyproject():
+    """Otherwise the runtime check and pip disagree about what is required.
+
+    A floor that is lower here than in pyproject lets a broken environment
+    through; higher, and it refuses one pip would have built.
+    """
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    declared = {}
+    for group in data["project"].get("optional-dependencies", {}).values():
+        for spec in group:
+            m = re.match(r"^([A-Za-z0-9_.-]+)\s*>=\s*([0-9][0-9A-Za-z.]*)", spec)
+            if m:
+                declared[m.group(1).lower()] = m.group(2)
+    for package, floor in pf.FLOORS.items():
+        assert package in declared, f"{package} is checked but not declared"
+        assert declared[package] == floor, (
+            f"{package}: preflight wants {floor}, pyproject declares "
+            f"{declared[package]}")
+
+
+# --------------------------------------------------------------------------- #
+# Comparison
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("installed,floor,ok", [
+    ("2.6.0", "2.6.0", True),
+    ("2.7.1", "2.6.0", True),
+    ("2.5.1", "2.6.0", False),
+    ("2.10.0", "2.9.0", True),      # not a string comparison
+    ("2.9.0", "2.10.0", False),
+    ("2025.9.1", "2025.9.1", True),
+    ("2025.8.9", "2025.9.1", False),
+])
+def test_versions_compare_numerically(installed, floor, ok):
+    assert pf.satisfies(installed, floor) is ok
+
+
+def test_a_prerelease_of_the_required_version_counts():
+    # Refusing 2.6.0rc1 against a 2.6.0 floor blocks people testing upstream,
+    # and unsloth's own checks are release-level too.
+    assert pf.satisfies("2.6.0rc1", "2.6.0") is True
+    assert pf.satisfies("2.6.0.dev20250101", "2.6.0") is True
+
+
+def test_a_missing_version_never_satisfies():
+    assert pf.satisfies(None, "2.6.0") is False
+    assert pf.satisfies("", "2.6.0") is False
+
+
+# --------------------------------------------------------------------------- #
+# The report
+# --------------------------------------------------------------------------- #
+def test_absent_and_stale_are_reported_differently(monkeypatch):
+    # They need different remedies: install versus upgrade.
+    monkeypatch.setattr(pf, "installed_version",
+                        lambda p: None if p == "torch" else "0.0.1")
+    problems = pf.check({"torch": "2.6.0", "trl": "0.18.2"})
+    assert ("torch", None, "2.6.0") in problems
+    assert ("trl", "0.0.1", "0.18.2") in problems
+    text = pf.describe(problems)
+    assert "Missing: torch" in text
+    assert "trl 0.0.1 is older than the required 0.18.2" in text
+
+
+def test_the_report_names_a_command_that_installs_everything(monkeypatch):
+    monkeypatch.setattr(pf, "installed_version", lambda p: None)
+    text = pf.describe(pf.check({"torch": "2.6.0", "trl": "0.18.2"}))
+    assert 'pip install -U "torch>=2.6.0" "trl>=0.18.2"' in text
+
+
+def test_a_healthy_environment_reports_nothing(monkeypatch):
+    monkeypatch.setattr(pf, "installed_version", lambda p: "9999.0.0")
+    assert pf.check() == []
+
+
+def test_the_lazy_import_checks_before_importing(monkeypatch):
+    import inspect
+
+    from praisonai_train.train.llm import trainer
+
+    src = inspect.getsource(trainer._lazy_import_training_deps)
+    check = src.index("from praisonai_train.preflight import")
+    imports = src.index("import torch")
+    assert check < imports, (
+        "the floors are checked after the imports that would fail on them")
+
+
+# --------------------------------------------------------------------------- #
+# The installer probes before it pins
+# --------------------------------------------------------------------------- #
+def test_the_installer_detects_before_pinning():
+    body = _code()
+    probe = body.index("detect_accelerator()")
+    pin = body.index("pytorch-cuda=12.4")
+    assert probe < pin, "the CUDA pin is chosen before the hardware is looked at"
+
+
+def test_the_cuda_pin_is_conditional():
+    body = _code()
+    # Exactly one occurrence, inside the cuda branch of the case statement.
+    assert body.count("pytorch-cuda=12.4") == 1, (
+        "the pin appears more than once; a branch will diverge")
+    case_start = body.index("case \"$ACCELERATOR\"")
+    assert body.index("pytorch-cuda=12.4") > case_start
+
+
+def test_the_probe_covers_the_three_real_outcomes():
+    body = _code()
+    for signal in ("nvidia-smi", "/proc/driver/nvidia/gpus", "rocminfo"):
+        assert signal in body, f"the probe does not look for {signal}"
+
+
+def test_a_cpu_host_is_warned_that_training_will_refuse():
+    # trainer.py raises on a missing CUDA GPU, so an installer that silently
+    # builds a CPU env hands the user a working-looking dead end.
+    body = _code()
+    cpu_branch = body[body.index("    cpu)"):]
+    assert "no GPU detected" in cpu_branch
+
+
+def test_the_script_still_parses():
+    import subprocess
+
+    assert subprocess.run(["bash", "-n", str(SETUP_SH)]).returncode == 0


### PR DESCRIPTION
Two ways to end up with an environment that looks fine and cannot train.

## Version floors were pip metadata only

`pyproject.toml` declares `torch>=2.6.0`, `transformers>=4.51.3` and the rest — but nothing checked them at runtime, and **pip is routinely bypassed**: `--no-deps`, a hand-built conda env, `setup_conda_env.sh` pinning its own torch. The failure then arrived as whatever traceback the mismatched package happened to raise, several imports deep, long after the CLI had accepted the run.

praisonai-train *does* inherit unsloth's own import-time checks — but only once `from unsloth import FastLanguageModel` runs inside a lazy helper. The floors are now checked **before** that import, and the message names the packages and gives one pip command that fixes all of them.

A test asserts the floors match `pyproject.toml` exactly. Lower here lets a broken environment through; higher refuses one pip would have built.

## The CUDA pin ignored the hardware

Every Linux host got `pytorch-cuda=12.4` regardless of what was in it. On an AMD box or a Blackwell card that produces a **working-looking** environment that fails at the first kernel; on a CPU-only host it installs a CUDA build that can never run.

There's a probe now — `nvidia-smi`, then `/proc/driver/nvidia/gpus` for a host with the driver but not the tool, then `rocminfo`/`amd-smi` — and the pin lives in one place instead of four copies across two branches.

A CPU-only Linux host is told plainly that training will refuse, because `trainer.py` raises on a missing CUDA GPU and an installer that quietly builds a CPU env otherwise hands the user a working-looking dead end. AMD says what to do rather than pretending ROCm is handled.

## One judgement call

A prerelease of the required version counts as satisfying the floor. Refusing `2.6.0rc1` against a `2.6.0` floor blocks people testing upstream, and unsloth's own checks are release-level too.

## Testing

19 tests. **Full suite 350 passing.**

Five mutations, all killed: dropping the CUDA pin, dropping the CPU warning, drifting a floor from pyproject, comparing versions as strings (`"2.9.0" > "2.10.0"`), and treating an absent package as satisfying its floor.

**Two assertions needed fixing first.** They matched the comment explaining the old behaviour — which quotes `pytorch-cuda=12.4` — rather than the code, so they passed regardless of what the script did. The helper now strips comments before any structural check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic checks for required training package versions before training starts.
  - Added clear guidance for installing or upgrading missing and outdated dependencies.
  - Added setup support for CUDA, ROCm, and CPU environments.
  - CUDA installations now receive appropriate PyTorch packages, while CPU environments receive a compatibility warning.

- **Bug Fixes**
  - Prevented training dependencies from loading when required versions are unavailable or outdated.
  - Improved accelerator detection before selecting installation packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->