### PR TITLE
feat(train): GRPO, reward modelling and CPO

### DIFF
--- a/src/praisonai-train/praisonai_train/rewards.py
+++ b/src/praisonai-train/praisonai_train/rewards.py
@@ -1,0 +1,141 @@
+"""Resolving reward functions named in a config.
+
+GRPO scores generated completions with one or more reward functions. They are
+Python callables, and a YAML config can only carry a string — so the string has
+to name the callable.
+
+**The convention here is a dotted import path**, `module:function`, the same
+form `console_scripts` and gunicorn use:
+
+    method: grpo
+    reward_funcs:
+      - myproject.rewards:length_penalty
+      - myproject.rewards:contains_answer
+
+Two alternatives were possible and were not chosen. A registry populated by
+decorator would mean the config can only name functions from a module something
+else already imported, which is a worse failure to debug. Inline Python in YAML
+is a code-execution surface in a file people paste from the internet.
+
+An import path is inspectable before anything runs: `praisonai-train llm
+--dry-run` resolves every one and reports the ones that do not exist, before
+the GPU time. That is the property the other two lack.
+
+TRL calls each with `(prompts, completions, **kwargs)` and expects a list of
+floats, one per completion.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+
+class RewardError(ValueError):
+    """A reward function that cannot be resolved or is the wrong shape."""
+
+
+def resolve(spec):
+    """Import `module:function` and return the callable.
+
+    Raises RewardError naming the part that failed, because "no module named
+    x" and "module x has no attribute y" need different fixes and the bare
+    ImportError does not say which happened.
+    """
+    if callable(spec):
+        return spec
+    if not isinstance(spec, str) or ":" not in spec:
+        raise RewardError(
+            f"reward function {spec!r} is not a 'module:function' path. "
+            "Example: myproject.rewards:length_penalty")
+    module_name, _, attr = spec.partition(":")
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        raise RewardError(
+            f"cannot import '{module_name}' for reward function '{spec}': {exc}. "
+            "Is it on PYTHONPATH?") from exc
+    try:
+        fn = getattr(module, attr)
+    except AttributeError as exc:
+        available = [n for n in dir(module) if not n.startswith("_") and callable(
+            getattr(module, n, None))]
+        raise RewardError(
+            f"'{module_name}' has no '{attr}'. Callables there: "
+            f"{', '.join(sorted(available)[:8]) or 'none'}") from exc
+    if not callable(fn):
+        raise RewardError(f"'{spec}' is a {type(fn).__name__}, not a function")
+    return fn
+
+
+def check_signature(fn, spec=""):
+    """Warn-level check that `fn` looks like a TRL reward function.
+
+    TRL calls (prompts, completions, **kwargs). A function that cannot accept
+    that fails deep inside the training loop, after the model is loaded --
+    catching it here costs nothing.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return None      # builtins and C callables; let TRL decide
+    params = list(sig.parameters.values())
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params):
+        positional = [p for p in params
+                      if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)]
+        if len(positional) >= 2:
+            return None
+    names = [p.name for p in params]
+    if "completions" in names:
+        return None
+    return (f"{spec or getattr(fn, '__name__', 'reward function')} does not take "
+            "'completions'; TRL calls reward functions as "
+            "(prompts, completions, **kwargs)")
+
+
+def resolve_all(specs):
+    """Resolve a list, or a single spec, into callables.
+
+    Every failure is collected rather than raised on the first, so someone with
+    three broken paths fixes all three in one pass instead of three runs.
+    """
+    if specs is None:
+        return []
+    if isinstance(specs, (str,)) or callable(specs):
+        specs = [specs]
+    resolved, problems, warnings = [], [], []
+    for spec in specs:
+        try:
+            fn = resolve(spec)
+        except RewardError as exc:
+            problems.append(str(exc))
+            continue
+        resolved.append(fn)
+        note = check_signature(fn, spec if isinstance(spec, str) else "")
+        if note:
+            warnings.append(note)
+    if problems:
+        raise RewardError("\n".join(problems))
+    for note in warnings:
+        print(f"WARNING: {note}")
+    return resolved
+
+
+MISSING_REWARDS = (
+    "method '{method}' needs reward_funcs: a list of 'module:function' import "
+    "paths that score completions. Example:\n"
+    "  reward_funcs:\n"
+    "    - myproject.rewards:length_penalty"
+)
+
+
+def require(method, resolved):
+    """Raise unless `method` has the reward functions it cannot run without.
+
+    Separate from the trainer so it can be tested by calling it. A test that
+    greps train_model's source for the message passes with the branch disabled,
+    which is how this kind of guard goes missing.
+    """
+    if not resolved:
+        raise RewardError(MISSING_REWARDS.format(method=method))
+    return resolved

--- a/src/praisonai-train/praisonai_train/train/llm/trainer.py
+++ b/src/praisonai-train/praisonai_train/train/llm/trainer.py
@@ -51,6 +51,23 @@ TRAINING_METHODS = {
         "columns": ("prompt", "chosen", "rejected"), "needs_ref_model": False,
         "summary": "odds-ratio preference optimisation, no reference model",
     },
+    "grpo": {
+        "trainer": "GRPOTrainer", "config": "GRPOConfig",
+        # GRPO generates its own completions, so the corpus is prompts only.
+        "columns": ("prompt",), "needs_ref_model": False,
+        "needs_rewards": True,
+        "summary": "group-relative policy optimisation, scored by reward functions",
+    },
+    "reward": {
+        "trainer": "RewardTrainer", "config": "RewardConfig",
+        "columns": ("chosen", "rejected"), "needs_ref_model": False,
+        "summary": "train a reward model on preference pairs",
+    },
+    "cpo": {
+        "trainer": "CPOTrainer", "config": "CPOConfig",
+        "columns": ("prompt", "chosen", "rejected"), "needs_ref_model": False,
+        "summary": "contrastive preference optimisation, no reference model",
+    },
     "kto": {
         "trainer": "KTOTrainer", "config": "KTOConfig",
         "columns": ("prompt", "completion", "label"), "needs_ref_model": True,
@@ -225,7 +242,8 @@ def _lazy_import_training_deps():
         # should still be able to run the others rather than failing at import.
         _pref = {}
         for _name in ("DPOTrainer", "DPOConfig", "ORPOTrainer", "ORPOConfig",
-                      "KTOTrainer", "KTOConfig"):
+                      "KTOTrainer", "KTOConfig", "GRPOTrainer", "GRPOConfig",
+                      "RewardTrainer", "RewardConfig", "CPOTrainer", "CPOConfig"):
             try:
                 _pref[_name] = getattr(__import__("trl", fromlist=[_name]), _name)
             except (ImportError, AttributeError):
@@ -432,6 +450,7 @@ class TrainModel:
         "assistant_only_loss", "train_on_responses_only", "save_steps",
         "train", "huggingface_save", "huggingface_save_gguf", "ollama_save",
         "method", "beta", "max_prompt_length", "desirable_weight", "undesirable_weight",
+        "reward_funcs", "num_generations", "max_completion_length",
         "embedding_learning_rate",
         "hf_private", "save_method", "commit_message", "tags",
         "hf_model_name", "ollama_model", "quantization_method", "remove_unused_columns",
@@ -1159,6 +1178,20 @@ class TrainModel:
                         sft_params[w] = float(self.config[w])
             self._require_columns(raw_dataset, spec["columns"], method)
 
+        reward_fns = []
+        if spec.get("needs_rewards"):
+            # Resolved before the model loads: a bad import path is a typo, and
+            # finding it after a multi-gigabyte load is the difference between
+            # a five-second fix and a lost session.
+            from praisonai_train.rewards import RewardError, require, resolve_all
+            try:
+                reward_fns = require(method, resolve_all(self.config.get("reward_funcs")))
+            except RewardError as exc:
+                raise ValueError(f"method '{method}': {exc}") from exc
+            for key in ("num_generations", "max_completion_length"):
+                if self.config.get(key) is not None:
+                    sft_params[key] = int(self.config[key])
+
         cfg_cls = globals().get(spec["config"])
         trainer_cls = globals().get(spec["trainer"])
         if cfg_cls is None or trainer_cls is None:
@@ -1185,6 +1218,8 @@ class TrainModel:
             "args": training_args,
             "callbacks": callbacks or None,
         }
+        if reward_fns:
+            trainer_kwargs["reward_funcs"] = reward_fns
         if spec["needs_ref_model"]:
             # None means "use the frozen base weights". With a PEFT adapter that
             # is exactly right, and it avoids a second full model in VRAM.

--- a/src/praisonai-train/tests/unit/train/test_grpo.py
+++ b/src/praisonai-train/tests/unit/train/test_grpo.py
@@ -1,0 +1,186 @@
+"""GRPO and the trainers behind it — the last of unsloth's methods.
+
+Unsloth rewrites every `trl.trainer.*_trainer` module generically
+(`rl.py:4235-4248`), so GRPO, reward modelling and CPO all work through it.
+praisonai-train had none of them, and GRPO was the blocker for the rest: it
+needs reward functions, and a YAML config can only carry a string.
+
+**The convention chosen is a dotted import path**, `module:function`, the same
+form `console_scripts` and gunicorn use. A registry populated by decorator
+would mean the config can only name functions from a module something else
+already imported; inline Python in YAML is a code-execution surface in a file
+people paste from the internet. An import path is the only one of the three
+that can be checked before anything runs.
+"""
+
+import pytest
+
+from praisonai_train import rewards
+from praisonai_train.train.llm import trainer as trainer_mod
+
+
+def good_reward(prompts, completions, **kwargs):
+    """A well-shaped reward function, used as a fixture by import path."""
+    return [float(len(c)) for c in completions]
+
+
+def wrong_shape(x):
+    return []
+
+
+not_a_function = 42
+
+
+# --------------------------------------------------------------------------- #
+# Resolution
+# --------------------------------------------------------------------------- #
+def test_a_dotted_path_resolves_to_the_callable():
+    fn = rewards.resolve(f"{__name__}:good_reward")
+    assert fn is good_reward
+
+
+def test_an_already_callable_spec_passes_through():
+    assert rewards.resolve(good_reward) is good_reward
+
+
+def test_a_missing_module_and_a_missing_attribute_are_told_apart():
+    # They need different fixes: one is PYTHONPATH, the other is a typo in the
+    # function name. The bare ImportError does not say which happened.
+    with pytest.raises(rewards.RewardError) as no_module:
+        rewards.resolve("definitely_not_a_module:f")
+    assert "cannot import" in str(no_module.value)
+
+    with pytest.raises(rewards.RewardError) as no_attr:
+        rewards.resolve(f"{__name__}:no_such_function")
+    assert "has no 'no_such_function'" in str(no_attr.value)
+
+
+def test_a_missing_attribute_lists_what_is_there():
+    with pytest.raises(rewards.RewardError) as e:
+        rewards.resolve(f"{__name__}:no_such_function")
+    assert "good_reward" in str(e.value), "the error does not say what is available"
+
+
+def test_a_malformed_spec_says_what_the_form_is():
+    with pytest.raises(rewards.RewardError) as e:
+        rewards.resolve("myproject.rewards.length_penalty")   # dot, not colon
+    assert "module:function" in str(e.value)
+
+
+def test_a_non_callable_is_refused_by_type():
+    with pytest.raises(rewards.RewardError) as e:
+        rewards.resolve(f"{__name__}:not_a_function")
+    assert "int" in str(e.value)
+
+
+def test_every_broken_path_is_reported_at_once():
+    # Three broken paths should be three fixes in one pass, not three runs.
+    with pytest.raises(rewards.RewardError) as e:
+        rewards.resolve_all(["nomodule_a:f", "nomodule_b:g", f"{__name__}:nope"])
+    text = str(e.value)
+    assert text.count("\n") >= 2, f"only reported one of three:\n{text}"
+
+
+def test_a_single_spec_does_not_have_to_be_a_list():
+    assert rewards.resolve_all(f"{__name__}:good_reward") == [good_reward]
+
+
+def test_no_rewards_is_an_empty_list_not_an_error():
+    assert rewards.resolve_all(None) == []
+
+
+# --------------------------------------------------------------------------- #
+# Shape check
+# --------------------------------------------------------------------------- #
+def test_a_well_shaped_function_passes_quietly():
+    assert rewards.check_signature(good_reward) is None
+
+
+def test_a_wrong_shaped_function_is_flagged_with_the_expected_call():
+    note = rewards.check_signature(wrong_shape, "m:wrong_shape")
+    assert note and "completions" in note
+    assert "(prompts, completions, **kwargs)" in note
+
+
+def test_a_callable_with_no_readable_signature_is_left_to_trl(monkeypatch):
+    """Guessing about a callable we cannot inspect would refuse working code.
+
+    The first version of this test used `len` on the assumption that
+    inspect.signature raises for builtins. It does not in modern Python — and
+    flagging `len` is the right answer, since it genuinely is not a reward
+    function. So the except branch is exercised directly.
+    """
+    import inspect as _inspect
+
+    def _raises(*a, **k):
+        raise ValueError("no signature for this")
+
+    monkeypatch.setattr(rewards.inspect, "signature", _raises)
+    assert rewards.check_signature(good_reward) is None
+
+
+def test_something_that_is_plainly_not_a_reward_function_is_flagged():
+    note = rewards.check_signature(len, "builtins:len")
+    assert note and "completions" in note
+
+
+# --------------------------------------------------------------------------- #
+# The methods
+# --------------------------------------------------------------------------- #
+def test_grpo_reward_and_cpo_are_offered():
+    assert {"grpo", "reward", "cpo"} <= set(trainer_mod.TRAINING_METHODS)
+
+
+def test_grpo_takes_prompts_only():
+    # It generates its own completions, so a completions column is not needed
+    # and requiring one would reject a correct corpus.
+    assert trainer_mod.TRAINING_METHODS["grpo"]["columns"] == ("prompt",)
+
+
+def test_grpo_is_the_only_method_needing_rewards():
+    needs = {k for k, v in trainer_mod.TRAINING_METHODS.items()
+             if v.get("needs_rewards")}
+    assert needs == {"grpo"}
+
+
+def test_reward_modelling_takes_preference_pairs():
+    assert set(trainer_mod.TRAINING_METHODS["reward"]["columns"]) == {"chosen", "rejected"}
+
+
+def test_cpo_needs_no_reference_model():
+    # Like ORPO, it folds the reference into its loss.
+    assert trainer_mod.TRAINING_METHODS["cpo"]["needs_ref_model"] is False
+
+
+def test_rewards_are_resolved_before_the_model_loads():
+    """A typo should cost five seconds, not a multi-gigabyte load."""
+    import inspect
+
+    src = inspect.getsource(trainer_mod.TrainModel.train_model)
+    resolve = src.index("resolve_all(")
+    build = src.index("trainer = trainer_cls(")
+    assert resolve < build
+
+
+def test_grpo_without_reward_funcs_is_refused():
+    """Tested by calling the guard, not by grepping train_model.
+
+    A source-text assertion passes with the branch disabled — the message is
+    still in the file. That is how a guard like this quietly stops guarding.
+    """
+    with pytest.raises(rewards.RewardError) as e:
+        rewards.require("grpo", [])
+    text = str(e.value)
+    assert "module:function" in text
+    assert "reward_funcs:" in text, "the error does not show the config shape"
+
+
+def test_a_method_with_rewards_passes_the_guard():
+    assert rewards.require("grpo", [good_reward]) == [good_reward]
+
+
+def test_the_trainer_routes_through_the_shared_guard():
+    import inspect
+
+    src = inspect.getsource(trainer_mod.TrainModel.train_model)
+    assert "require(method," in src, "train_model reimplements the check"

--- a/src/praisonai-train/tests/unit/train/test_training_methods.py
+++ b/src/praisonai-train/tests/unit/train/test_training_methods.py
@@ -41,7 +41,8 @@ class _Cols:
 # --------------------------------------------------------------------------- #
 def test_the_methods_unsloth_patches_are_all_offered():
     # If unsloth grows one and this does not, the gap reopens silently.
-    assert set(trainer_mod.TRAINING_METHODS) == {"sft", "cpt", "dpo", "orpo", "kto"}
+    assert set(trainer_mod.TRAINING_METHODS) == {
+        "sft", "cpt", "dpo", "orpo", "kto", "grpo", "reward", "cpo"}
 
 
 def test_every_method_declares_what_it_needs():


### PR DESCRIPTION
The last of unsloth's training methods. It rewrites every `trl.trainer.*_trainer` module generically (`rl.py:4235-4248`), so all three work through it — praisonai-train had none.

GRPO was the blocker for the rest: it needs reward functions, and a YAML config can only carry a string.

## The decision I had to make

**Reward functions are named by dotted import path**, `module:function` — the same form `console_scripts` and gunicorn use.

```yaml
method: grpo
reward_funcs:
  - myproject.rewards:length_penalty
  - myproject.rewards:contains_answer
num_generations: 8
```

Two alternatives rejected:

- **A registry populated by decorator** means the config can only name functions from a module something else already imported — a worse failure to debug.
- **Inline Python in YAML** is a code-execution surface in a file people paste from the internet.

An import path is the only one of the three that can be resolved *before anything runs*, which is why reward functions resolve before the model loads: a typo costs five seconds, not a multi-gigabyte load.

**If you'd rather have a registry, the change is contained to `rewards.py`.** Everything else in this PR is independent of that choice.

## Details worth review

- **A missing module and a missing attribute are told apart** — one is a PYTHONPATH problem, the other a typo, and the bare `ImportError` doesn't say which. The attribute error lists the callables that *are* in the module.
- **Every broken path is reported at once**, so three typos are three fixes in one pass instead of three runs.
- **GRPO takes prompts only.** It generates its own completions; requiring a completions column would reject a correct corpus.
- **The signature check warns rather than refuses**, and stays quiet for callables whose signature can't be read — guessing there would refuse working code.

## Testing

22 tests. **Full suite 372 passing.**

Five mutations, all killed: reporting only the first error, accepting a non-callable, demanding a completions column for GRPO, dropping the did-you-mean list, and letting GRPO run with no reward functions.

**That last one survived at first.** The test grepped `train_model`'s source for the message — which is still there with the branch disabled. The guard is now a function the test calls. Third time this pattern has come up in this sweep, so it's called out in the test docstring.

One more: a test asserting `inspect.signature` raises for builtins was simply wrong — it doesn't in modern Python, and flagging `len` is the right answer. The except branch is now exercised directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GRPO, reward-modeling, and CPO training methods.
  * Added configurable reward functions using callable values or import paths.
  * Added GRPO generation settings, including completion length and generation count.
  * Added validation for reward functions, required datasets, reference models, and training configurations.

* **Bug Fixes**
  * Improved training setup errors with clearer messages and aggregated configuration feedback.
  * Prevented training from starting when required rewards or configuration values are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->