### PR TITLE
ci(desktop): build the Mac app on release and attach it

### DIFF
--- a/.github/workflows/desktop-macos-release.yml
+++ b/.github/workflows/desktop-macos-release.yml
@@ -1,0 +1,74 @@
+# Build the Mac desktop app and attach it to the release.
+#
+# Releases carried no assets at all -- v4.7.1 shipped zero -- so there was
+# nothing for a Mac user to download. This builds a .dmg on tag and uploads it,
+# for both Apple silicon and Intel, because Tauri does not produce a universal
+# binary and a wrong-arch download fails at launch rather than at install.
+#
+# Unsigned, deliberately: signing needs a Developer ID in secrets, and shipping
+# an unsigned build people can right-click-open is better than shipping none.
+# The release notes say so rather than letting Gatekeeper say it for us.
+name: Desktop macOS release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to attach the build to'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14        # Apple silicon
+            target: aarch64-apple-darwin
+            arch: apple-silicon
+          - runner: macos-13        # Intel
+            target: x86_64-apple-darwin
+            arch: intel
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src/praisonai-desktop/src-tauri -> target
+
+      - name: Build the bundle
+        working-directory: src/praisonai-desktop/src-tauri
+        run: |
+          cargo install tauri-cli --version '^2' --locked || true
+          cargo tauri build --target ${{ matrix.target }} --bundles dmg
+
+      - name: Name the artifact for the arch it runs on
+        id: artifact
+        working-directory: src/praisonai-desktop/src-tauri
+        run: |
+          set -euo pipefail
+          dmg="$(find "target/${{ matrix.target }}/release/bundle/dmg" -name '*.dmg' -print -quit)"
+          # Fail loudly rather than uploading nothing: an empty release asset
+          # list is exactly the state this workflow exists to fix.
+          test -n "$dmg" || { echo "no .dmg was produced"; exit 1; }
+          out="PraisonAI-${{ github.event.release.tag_name || inputs.tag }}-macos-${{ matrix.arch }}.dmg"
+          mv "$dmg" "../$out"
+          echo "path=src/praisonai-desktop/$out" >> "$GITHUB_OUTPUT"
+
+      - name: Attach it to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload \
+            "${{ github.event.release.tag_name || inputs.tag }}" \
+            "${{ steps.artifact.outputs.path }}" --clobber

--- a/src/praisonai-desktop/INSTALL-macOS.md
+++ b/src/praisonai-desktop/INSTALL-macOS.md
@@ -1,0 +1,54 @@
+# Installing the PraisonAI Mac app
+
+Every release attaches two disk images. Pick the one for your Mac:
+
+| Your Mac | Download |
+|---|---|
+| Apple silicon (M1–M4) | `PraisonAI-<version>-macos-apple-silicon.dmg` |
+| Intel | `PraisonAI-<version>-macos-intel.dmg` |
+
+Not sure which you have:  → About This Mac. "Chip" means Apple silicon,
+"Processor" means Intel.
+
+There is no universal build. Tauri produces one binary per architecture, and a
+wrong-arch download fails when you launch it rather than when you install it —
+which is a worse place to find out.
+
+## First launch
+
+The build is **not signed with an Apple Developer ID**, so Gatekeeper will
+refuse it on a double-click with *"PraisonAI is damaged and can't be opened"* —
+which is misleading. Nothing is damaged; the app simply has no signature.
+
+1. Drag **PraisonAI** to Applications.
+2. **Right-click** it → **Open** → **Open**.
+
+That once is enough; afterwards it launches normally.
+
+If macOS still refuses, clear the quarantine attribute it added when your
+browser downloaded the file:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/PraisonAI.app
+```
+
+## What happens the first time you open it
+
+The app needs a Python environment to run its engine and will offer to build
+one: it fetches `uv`, installs a pinned CPython, creates a virtual environment
+under `~/Library/Application Support/PraisonAI/venv`, and installs
+`praisonaiagents` into it. Roughly 500 MB, once.
+
+Nothing is installed system-wide, and nothing is written inside the app bundle.
+To remove it completely, delete `/Applications/PraisonAI.app` and
+`~/Library/Application Support/PraisonAI`.
+
+## If it will not start
+
+The window shows the reason and the engine log. The two common ones:
+
+- **"No usable Python"** — the setup screen offers to build the environment.
+  If it fails, the step that failed is named along with what it printed.
+- **"Engine did not report ready in time"** — the first import of the ML stack
+  is slow on a cold machine. Give it a minute; if it persists, the Engine log
+  in the sidebar has the traceback.

--- a/src/praisonai-train/praisonai_train/train/llm/trainer.py
+++ b/src/praisonai-train/praisonai_train/train/llm/trainer.py
@@ -185,6 +185,16 @@ def _accepted_config_fields(cfg_cls):
     return fields or None
 
 
+# LoRA options forwarded verbatim to get_peft_model. A module constant rather
+# than a literal in the loop, so a test can read the list instead of grepping
+# the method for each name -- the shape that let eight mutations survive.
+PEFT_PASSTHROUGH = (
+    "modules_to_save", "rank_pattern", "alpha_pattern", "use_dora",
+    "finetune_last_n_layers", "layers_to_transform", "layers_pattern",
+    "target_parameters", "init_lora_weights",
+)
+
+
 def model_access_kwargs(config, flag):
     """Everything that decides WHICH weights load, and how they are reached.
 
@@ -209,6 +219,22 @@ def model_access_kwargs(config, flag):
             if config.get(key) is not None:
                 kwargs[key] = config[key]
     return kwargs
+
+
+def resolve_mask_setting(mask_setting, supports_mask, markers, flag):
+    """Turn the configured value into "should we mask at all".
+
+    Extracted so a test can CALL it. Its test used to hold a copy of this
+    expression, which meant reverting the real line to the pre-fix
+    `supports_mask` alone changed nothing the suite could see -- the one defect
+    that whole PR existed to fix was undetectable by its own test file.
+
+    `auto` enables masking when EITHER route is usable; decide_masking then
+    picks which.
+    """
+    if isinstance(mask_setting, str) and mask_setting.strip().lower() == "auto":
+        return supports_mask or bool(markers)
+    return flag(mask_setting)
 
 
 def decide_masking(use_mask, supports_mask, markers):
@@ -847,9 +873,7 @@ class TrainModel:
             loftq_config=self.config.get("loftq_config", None),
         )
         # Optional advanced LoRA knobs (only passed when set).
-        for opt in ("modules_to_save", "rank_pattern", "alpha_pattern", "use_dora",
-                    "finetune_last_n_layers", "layers_to_transform",
-                    "layers_pattern", "target_parameters", "init_lora_weights"):
+        for opt in PEFT_PASSTHROUGH:
             if self.config.get(opt) is not None:
                 peft_kwargs[opt] = self.config[opt]
         self.model = FastLanguageModel.get_peft_model(self.model, **peft_kwargs)
@@ -1151,10 +1175,8 @@ class TrainModel:
             # path even when valid turn markers were available -- defeating the whole
             # fallback. Enable it when EITHER route is usable, and let decide_masking
             # pick which one.
-            if isinstance(mask_setting, str) and mask_setting.strip().lower() == "auto":
-                use_mask = supports_mask or bool(markers)
-            else:
-                use_mask = self._flag(mask_setting)
+            use_mask = resolve_mask_setting(
+                mask_setting, supports_mask, markers, self._flag)
             route = decide_masking(use_mask, supports_mask, markers)
             if route == "assistant_only_loss":
                 sft_params["assistant_only_loss"] = True

--- a/src/praisonai-train/tests/unit/train/test_audit_fixes.py
+++ b/src/praisonai-train/tests/unit/train/test_audit_fixes.py
@@ -77,9 +77,17 @@ def test_the_remote_launch_puts_the_config_behind_its_flag():
     before the GPU was touched -- or, with no dataset, config.yaml rewritten to
     name itself as the corpus.
     """
-    src = inspect.getsource(rr.RemoteRunner._launch_script)
-    assert "--config config.yaml" in src, "the config is not passed as an option"
-    assert "llm config.yaml" not in src, "the config is still a positional"
+    runner = rr.RemoteRunner.__new__(rr.RemoteRunner)
+    runner.host = rr.RemoteHost(alias="h", python="python3", workdir="~/w")
+    run = rr.RemoteRun(host="h", run_id="run-1",
+                       remote_dir="/w/run-1", log_path="/w/run-1/train.log")
+
+    script = runner._launch_script(run, " ds.jsonl", None)
+
+    assert "--config config.yaml" in script, "the config is not passed as an option"
+    assert "llm config.yaml" not in script, "the config is still a positional"
+    # And the dataset stays where `llm` expects it: positional, before the flag.
+    assert script.index("ds.jsonl") < script.index("--config")
 
 
 # --------------------------------------------------------------------------- #

--- a/src/praisonai-train/tests/unit/train/test_no_source_text_assertions.py
+++ b/src/praisonai-train/tests/unit/train/test_no_source_text_assertions.py
@@ -1,0 +1,114 @@
+"""A cap on tests that read source text instead of running it.
+
+An adversarial audit ran 16 mutations against this suite. **Eight survived all
+408 tests**, and every survivor was covered only by an assertion of this shape:
+
+    src = inspect.getsource(some_function)
+    assert "the_thing_i_want" in src
+
+That passes whether or not the code does anything, because the string is still
+in the file when the branch around it is disabled. Three separate times in this
+package a test matched an explanatory *comment* rather than the code it
+described — in Python, in CSS, and in a YAML workflow.
+
+The rule this file enforces is not "never inspect source". Ordering constraints
+("X must happen before Y") are legitimately structural and there is no other
+way to state them. The rule is that the count must not grow: a new one needs a
+deliberate bump here, which is the moment to ask whether the thing could be
+extracted and called instead — as `resolve_mask_setting`,
+`decide_masking`, `_accepted_config_fields` and `rewards.require` all were,
+each after a mutation proved its source-text test worthless.
+"""
+
+import re
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+
+# Measured at the time of writing. Lower this as tests are converted; raising it
+# is a decision, not an accident.
+# Raised deliberately from 14 when the audit-fixes PR landed. One of its four
+# was convertible and was converted (_launch_script returns the command, so
+# there was no reason to read its source); the rest are ordering constraints,
+# which is the case this cap exists to allow.
+MAX_SOURCE_TEXT_ASSERTIONS = 18
+
+
+def _code_only(source):
+    """Source with comments and string literals removed."""
+    import io
+    import tokenize
+
+    kept = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type in (tokenize.COMMENT, tokenize.STRING):
+                continue
+            kept.append(tok.string)
+    except (tokenize.TokenError, IndentationError):
+        return source
+    return " ".join(kept)
+
+
+def _counts():
+    found = {}
+    for path in sorted(TESTS.glob("test_*.py")):
+        if path.name == Path(__file__).name:
+            continue
+        n = len(re.findall(r"inspect\s*\.\s*getsource", _code_only(path.read_text())))
+        if n:
+            found[path.name] = n
+    return found
+
+
+def test_source_text_assertions_do_not_grow():
+    counts = _counts()
+    total = sum(counts.values())
+    assert total <= MAX_SOURCE_TEXT_ASSERTIONS, (
+        f"{total} source-text assertions, cap is {MAX_SOURCE_TEXT_ASSERTIONS}.\n"
+        f"{counts}\n"
+        "Extract the logic and call it instead, or raise the cap deliberately."
+    )
+
+
+def test_no_test_reimplements_the_logic_it_tests():
+    """A test holding a copy of the code cannot detect that code changing.
+
+    `test_response_masking.py` defined `_auto_use_mask()` as a mirror of
+    train_model's expression. Reverting the real line to the pre-fix behaviour
+    left the whole suite green — the one defect that PR existed to fix was
+    undetectable by its own test file.
+    """
+    for path in sorted(TESTS.glob("test_*.py")):
+        if path.name == Path(__file__).name:
+            continue      # this file names the pattern in order to ban it
+        # Comments and docstrings stripped. Without this the guard matched the
+        # comment in test_response_masking.py that EXPLAINS the removed copy --
+        # the fourth time in this session an assertion read prose instead of
+        # code, which is the whole reason this file exists.
+        text = _code_only(path.read_text())
+        assert "_auto_use_mask" not in text, (
+            f"{path.name} reimplements masking logic instead of calling "
+            "trainer.resolve_mask_setting")
+
+
+def test_the_extracted_helpers_are_importable_and_callable():
+    """Each of these exists because a source-text test failed to catch a bug.
+
+    If one is inlined again, its test silently goes back to proving nothing.
+    """
+    from praisonai_train import rewards
+    from praisonai_train.train.llm import trainer
+
+    for module, name in (
+        (trainer, "resolve_mask_setting"),
+        (trainer, "decide_masking"),
+        (trainer, "resolve_response_markers"),
+        (trainer, "is_out_of_memory"),
+        (rewards, "require"),
+        (rewards, "resolve_all"),
+    ):
+        fn = getattr(module, name, None)
+        assert callable(fn), (
+            f"{module.__name__}.{name} is gone; whatever tested it is now "
+            "asserting on source text again")

--- a/src/praisonai-train/tests/unit/train/test_response_masking.py
+++ b/src/praisonai-train/tests/unit/train/test_response_masking.py
@@ -154,23 +154,18 @@ def test_the_trainer_uses_the_shared_decision():
 # --------------------------------------------------------------------------- #
 # `auto` normalization feeding the router
 # --------------------------------------------------------------------------- #
-def _auto_use_mask(supports_mask, markers):
-    """The `auto` normalization exactly as train_model computes it.
-
-    decide_masking was tested in isolation, but the bug lived one line up: in
-    `auto`, use_mask was keyed off `supports_mask` alone, so a template with no
-    {% generation %} but valid turn markers still resolved to False -- and the
-    router never saw the markers. This mirrors that normalization so the two
-    pieces are tested together, which is where the defect actually was.
-    """
-    return supports_mask or bool(markers)
+# No local copy of the logic. The previous version of this file defined
+# _auto_use_mask() as a mirror of train_model's expression -- so reverting the
+# real line to the pre-fix behaviour left every test green. A test that
+# reimplements what it tests can only ever confirm itself.
+_flag = lambda v, default=False: default if v is None else bool(v)
 
 
 def test_auto_reaches_the_marker_fallback_when_trl_mask_is_unsupported():
     # Every unsloth template: no {% generation %} (supports_mask False) but valid
     # turn markers. `auto` must still mask -- via the marker route.
     markers = trainer_mod.RESPONSE_MARKERS["llama-3"]
-    use_mask = _auto_use_mask(supports_mask=False, markers=markers)
+    use_mask = trainer_mod.resolve_mask_setting("auto", False, markers, _flag)
     assert use_mask is True, "auto must enable masking when markers exist"
     assert trainer_mod.decide_masking(use_mask, False, markers) == \
         "train_on_responses_only"
@@ -178,7 +173,7 @@ def test_auto_reaches_the_marker_fallback_when_trl_mask_is_unsupported():
 
 def test_auto_prefers_trl_mask_when_the_template_supports_it():
     markers = trainer_mod.RESPONSE_MARKERS["llama-3"]
-    use_mask = _auto_use_mask(supports_mask=True, markers=markers)
+    use_mask = trainer_mod.resolve_mask_setting("auto", True, markers, _flag)
     assert trainer_mod.decide_masking(use_mask, True, markers) == \
         "assistant_only_loss"
 
@@ -186,6 +181,6 @@ def test_auto_prefers_trl_mask_when_the_template_supports_it():
 def test_auto_stays_unmasked_for_an_unknown_template_without_crashing():
     # No TRL support and no known markers: auto degrades to full-sequence loss
     # rather than raising. (The raise is reserved for an EXPLICIT request.)
-    use_mask = _auto_use_mask(supports_mask=False, markers=None)
+    use_mask = trainer_mod.resolve_mask_setting("auto", False, None, _flag)
     assert use_mask is False
     assert trainer_mod.decide_masking(use_mask, False, None) is False

--- a/src/praisonai-train/tests/unit/train/test_unsloth_surface.py
+++ b/src/praisonai-train/tests/unit/train/test_unsloth_surface.py
@@ -108,16 +108,8 @@ def test_nothing_is_passed_when_nothing_is_configured():
 
 
 def test_peft_selectors_reach_the_adapter():
-    """Checked by running the passthrough loop, not by reading it.
-
-    The list of forwarded options is data, so the test can exercise it the same
-    way prepare_model does rather than grepping the method.
-    """
-    import inspect
-
-    src = inspect.getsource(trainer_mod.TrainModel.prepare_model)
-    start = src.index("for opt in (")
-    names = set(re.findall(r'"(\w+)"', src[start:src.index(")", start)]))
+    """Reads the forwarding list, which is data, rather than the method."""
+    names = set(trainer_mod.PEFT_PASSTHROUGH)
     for opt in ("finetune_last_n_layers", "layers_to_transform", "layers_pattern",
                 "target_parameters", "init_lora_weights"):
         assert opt in names, f"{opt} is never forwarded to get_peft_model"


### PR DESCRIPTION
## The gap

**Releases carry no assets.** `v4.7.1` shipped zero — so a Mac user has nothing to download, and no path to the app that exists in this repo. No workflow builds it.

## What this adds

On a published release — or by hand against an existing tag via `workflow_dispatch` — builds a `.dmg` on `macos-14` and `macos-13` and uploads both:

```
PraisonAI-<version>-macos-apple-silicon.dmg
PraisonAI-<version>-macos-intel.dmg
```

**Two per release, not one universal binary.** Tauri doesn't produce a universal build, and a wrong-arch download fails at *launch* rather than at install — a worse place to find out. The filename says which is which.

**It fails loudly when no `.dmg` is produced** rather than uploading nothing. An empty asset list is precisely the state this workflow exists to fix; a silent no-op would recreate it while the run stayed green.

## Unsigned, and saying so

Signing needs a Developer ID in repository secrets. Shipping an unsigned build people can right-click-open beats shipping none — but Gatekeeper's message for an unsigned app is **"PraisonAI is damaged and can't be opened"**, which is alarming and untrue.

So `INSTALL-macOS.md` says it first: which architecture to pick and how to tell, the right-click → Open path, the `xattr -dr com.apple.quarantine` fallback, what first-run provisioning downloads and where it puts it (~500 MB into `~/Library/Application Support/PraisonAI`, nothing system-wide, nothing inside the bundle), and how to remove it completely.

## To sign it later

Add `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD` and `APPLE_TEAM_ID` as secrets, and Tauri's action picks them up — the build step needs no change. Worth doing: notarised, the right-click dance disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)