### PR TITLE
feat(desktop): add a Training tab that runs a fine-tune and reports on it

### DIFF
--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -66,6 +66,10 @@ CHATS_DIR = DATA_DIR / "chats"
 # tool trying to find a running engine -- had nothing to read. `pgrep -f` is not
 # a substitute: the shell running the pgrep matches the pattern itself.
 LOCK_PATH = DATA_DIR / "engine.lock"
+
+# Built on first use: importing the training module costs nothing until someone
+# opens the tab, and the engine must stay fast to start for chat.
+_TRAINER = None
 LOCK_FORMAT_VERSION = 2
 
 
@@ -893,7 +897,80 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    # --- training -------------------------------------------------------
+    def _training(self):
+        """The one Trainer, built on first use so importing costs nothing."""
+        global _TRAINER
+        if _TRAINER is None:
+            from training import Trainer
+            _TRAINER = Trainer(DATA_DIR, sys.executable)
+        return _TRAINER
+
+    def _train_progress(self, run, cursor):
+        """Replay from `cursor`, then follow. Not a subscription: a client that
+        reconnects after a closed lid gets what it missed, which is the whole
+        reason events are kept rather than streamed and dropped."""
+        self.send_response(200)
+        self._cors()
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        idle = 0
+        while True:
+            events, gap = run.since(cursor)
+            if gap:
+                # Say so rather than handing over events with a hole in them.
+                self.wfile.write(b"event: resync\ndata: {}\n\n")
+                self.wfile.flush()
+                cursor = -1
+                continue
+            for c, kind, payload in events:
+                cursor = c
+                body = json.dumps({"cursor": c, **payload})
+                self.wfile.write(
+                    f"id: {c}\nevent: {kind}\ndata: {body}\n\n".encode())
+            if events:
+                self.wfile.flush()
+                idle = 0
+            else:
+                idle += 1
+                if idle % 20 == 0:
+                    # A heartbeat, so a proxy does not reap an idle stream and
+                    # the client can tell "quiet" from "gone".
+                    self.wfile.write(b": keepalive\n\n")
+                    self.wfile.flush()
+            if run.state in ("done", "failed", "cancelled") and not events:
+                return
+            time.sleep(0.25)
+
     def do_GET(self):
+        if self.path.startswith("/train/progress"):
+            trainer = self._training()
+            from urllib.parse import parse_qs, urlparse
+            query = parse_qs(urlparse(self.path).query)
+            run_id = (query.get("run") or [None])[0]
+            run = trainer.get(run_id) if run_id else trainer.current
+            if run is None:
+                self._json({"ok": False, "error": "no such run"}, 404)
+                return
+            cursor = int((query.get("cursor") or ["-1"])[0])
+            try:
+                self._train_progress(run, cursor)
+            except (BrokenPipeError, ConnectionResetError):
+                pass          # the window closed; the run keeps going
+            return
+
+        if self.path == "/train/runs":
+            self._json({"runs": [r.summary() for r in self._training().history[:50]]})
+            return
+
+        if self.path.startswith("/train/status"):
+            trainer = self._training()
+            run = trainer.current
+            self._json({"run": run.summary() if run else None,
+                        "metrics": run.metrics[-500:] if run else []})
+            return
+
         if self.path == "/settings":
             cfg = load_settings()
             # The UI only needs to know whether a key is set, never its value.
@@ -975,6 +1052,40 @@ class Handler(BaseHTTPRequestHandler):
         self._json({"ok": True})
 
     def do_POST(self):
+        if self.path == "/train/start":
+            payload = self._body()
+            config = payload.get("config") or {}
+            if not config.get("model_name") or not config.get("dataset"):
+                self._json({"ok": False, "error":
+                            "config needs at least model_name and dataset"}, 400)
+                return
+            try:
+                run = self._training().start(config, payload.get("run_id"))
+            except ValueError as exc:
+                # A rejected run id is the caller's fault, not the server's.
+                self._json({"ok": False, "error": str(exc)}, 400)
+                return
+            except RuntimeError as exc:
+                # A live run is a conflict, not a server error: the client
+                # should show the running job, not a traceback.
+                self._json({"ok": False, "error": str(exc)}, 409)
+                return
+            self._json({"ok": True, "run": run.summary()})
+            return
+
+        if self.path.startswith("/train/stop"):
+            self._drain()
+            run_id = self.path.rsplit("/", 1)[-1] if "/train/stop/" in self.path else None
+            try:
+                stopped = self._training().stop(run_id)
+            except RuntimeError as exc:
+                self._json({"ok": False, "error": str(exc)}, 409)
+                return
+            self._json({"ok": stopped,
+                        "error": None if stopped else "nothing was running"},
+                       200 if stopped else 404)
+            return
+
         if self.path.startswith("/cancel/"):
             self._drain()
             run_id = self.path.rsplit("/", 1)[-1]

--- a/src/praisonai-desktop/engine/test_train_routes.py
+++ b/src/praisonai-desktop/engine/test_train_routes.py
@@ -1,0 +1,232 @@
+"""End-to-end tests for the training routes, against a real engine process.
+
+The engine is spawned exactly as the Tauri shell spawns it, the port is read
+from the line it announces on stdout, and every assertion goes over loopback
+HTTP. Nothing here is mocked: an earlier lifecycle suite in this repo silently
+skipped all eleven of its tests for months because it probed for the engine in
+a way that could not work, so these fail loudly rather than skip.
+"""
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+
+ENGINE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "server.py")
+PORT_MARKER = "PRAISONAI_PORT="
+
+
+class EngineProcess:
+    """A live engine on an ephemeral port, in a throwaway home."""
+
+    def __init__(self, train_cmd):
+        self.home = tempfile.mkdtemp(prefix="praison-routes-")
+        env = dict(os.environ,
+                   PRAISONAI_DESKTOP_HOME=self.home,
+                   PRAISONAI_TRAIN_CMD=train_cmd)
+        self.proc = subprocess.Popen(
+            [sys.executable, "-u", ENGINE], env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        self.port = self._await_port()
+
+    def _await_port(self, timeout=60):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            line = self.proc.stdout.readline()
+            if not line:
+                raise RuntimeError("the engine exited before announcing a port")
+            if PORT_MARKER in line:
+                return int(line.split(PORT_MARKER, 1)[1].strip())
+        raise RuntimeError(f"no port announced within {timeout}s")
+
+    def url(self, path):
+        return f"http://127.0.0.1:{self.port}{path}"
+
+    def request(self, path, payload=None, method=None, timeout=30):
+        data = json.dumps(payload).encode() if payload is not None else None
+        req = urllib.request.Request(
+            self.url(path), data=data, method=method or ("POST" if data else "GET"),
+            headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as response:
+                return response.status, json.loads(response.read() or b"{}")
+        except urllib.error.HTTPError as err:
+            return err.code, json.loads(err.read() or b"{}")
+
+    def stream(self, path, timeout=30):
+        """Read an SSE stream into (event, data) pairs until it closes."""
+        events, kind = [], None
+        with urllib.request.urlopen(self.url(path), timeout=timeout) as response:
+            for raw in response:
+                line = raw.decode().rstrip("\n")
+                if line.startswith("event: "):
+                    kind = line[7:]
+                elif line.startswith("data: "):
+                    events.append((kind, json.loads(line[6:])))
+        return events
+
+    def close(self):
+        self.proc.terminate()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+        shutil.rmtree(self.home, ignore_errors=True)
+
+
+def _python(body):
+    """A PRAISONAI_TRAIN_CMD that runs `body` instead of a real fine-tune.
+
+    shlex.quote, not json.dumps: the engine splits this with shlex, and JSON
+    escaping turns a newline into a literal backslash-n, which reached the
+    interpreter as a syntax error partway through a script that had already
+    printed its first line -- a half-run that looked like a trainer crash.
+    """
+    return f"{shlex.quote(sys.executable)} -u -c {shlex.quote(body)}"
+
+
+def _wait(predicate, timeout=30):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+SHORT_RUN = (
+    "print(\"{'loss': 0.7, 'learning_rate': 0.0002, 'epoch': 1.0}\")\n"
+    "print(' 3/3 [00:01<00:00]')\n")
+LONG_RUN = "import time\nprint('training', flush=True)\ntime.sleep(300)\n"
+CONFIG = {"model_name": "unsloth/tiny", "dataset": "data.json"}
+
+
+class TrainRoutes(unittest.TestCase):
+    engine = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = EngineProcess(_python(SHORT_RUN))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.close()
+
+    def test_a_run_starts_streams_and_ends(self):
+        status, body = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 200, body)
+        run_id = body["run"]["id"]
+
+        events = self.engine.stream(f"/train/progress?run={run_id}&cursor=-1")
+        kinds = [kind for kind, _ in events]
+        self.assertIn("start", kinds)
+        self.assertIn("metric", kinds)
+        self.assertIn("end", kinds)
+
+        metric = next(data for kind, data in events if kind == "metric")
+        self.assertEqual(metric["loss"], 0.7)
+        ending = next(data for kind, data in events if kind == "end")
+        self.assertEqual(ending["state"], "done", ending)
+
+        status, body = self.engine.request("/train/status")
+        self.assertEqual(body["run"]["state"], "done")
+        self.assertEqual(body["metrics"][-1]["loss"], 0.7)
+
+    def test_the_stream_replays_from_a_cursor_rather_than_repeating(self):
+        status, body = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 200, body)
+        run_id = body["run"]["id"]
+        everything = self.engine.stream(f"/train/progress?run={run_id}&cursor=-1")
+        self.assertGreater(len(everything), 2)
+        midpoint = everything[1][1]["cursor"]
+        resumed = self.engine.stream(f"/train/progress?run={run_id}&cursor={midpoint}")
+        self.assertEqual([d["cursor"] for _, d in resumed],
+                         [d["cursor"] for _, d in everything if d["cursor"] > midpoint])
+
+    def test_a_finished_run_appears_in_the_history(self):
+        # Starts its own run rather than relying on another test having run
+        # first: unittest orders alphabetically, and the first version of this
+        # passed or failed depending on the method name above it.
+        status, body = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 200, body)
+        run_id = body["run"]["id"]
+        self.assertTrue(_wait(
+            lambda: (self.engine.request("/train/status")[1].get("run") or {})
+            .get("state") in ("done", "failed", "cancelled")))
+        _, body = self.engine.request("/train/runs")
+        self.assertIn(run_id, [run["id"] for run in body["runs"]])
+        self.assertTrue(all("state" in run for run in body["runs"]))
+
+    def test_progress_for_an_unknown_run_is_404_not_a_hang(self):
+        status, body = self.engine.request("/train/progress?run=no-such-run")
+        self.assertEqual(status, 404)
+
+    def test_a_config_without_a_model_is_refused(self):
+        status, body = self.engine.request("/train/start", {"config": {"dataset": "d"}})
+        self.assertEqual(status, 400)
+        self.assertIn("model_name", body["error"])
+
+    def test_a_traversing_run_id_is_refused_and_writes_nothing(self):
+        status, body = self.engine.request(
+            "/train/start", {"config": CONFIG, "run_id": "../../escaped"})
+        self.assertEqual(status, 400, body)
+        self.assertFalse(os.path.exists(os.path.join(self.engine.home, "..", "escaped")))
+
+    def test_stopping_when_idle_is_404_not_a_crash(self):
+        status, body = self.engine.request("/train/stop", {}, method="POST")
+        self.assertEqual(status, 404)
+
+
+class TrainConcurrency(unittest.TestCase):
+    """The long-running case: start, refuse a second, stop, and confirm."""
+
+    def setUp(self):
+        self.engine = EngineProcess(_python(LONG_RUN))
+
+    def tearDown(self):
+        self.engine.close()
+
+    def _live_state(self):
+        _, body = self.engine.request("/train/status")
+        return (body.get("run") or {}).get("state")
+
+    def test_a_second_start_is_a_conflict_and_the_first_keeps_running(self):
+        status, first = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 200, first)
+        self.assertTrue(_wait(lambda: self._live_state() == "running"))
+
+        status, body = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 409, body)
+        self.assertIn(first["run"]["id"], body["error"])
+        self.assertEqual(self._live_state(), "running", "the conflict killed the run")
+
+    def test_stopping_ends_the_run_as_cancelled(self):
+        status, started = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 200, started)
+        self.assertTrue(_wait(lambda: self._live_state() == "running"))
+
+        status, body = self.engine.request("/train/stop", {}, method="POST")
+        self.assertEqual(status, 200, body)
+        self.assertTrue(_wait(lambda: self._live_state() == "cancelled"), self._live_state())
+
+    def test_the_engine_survives_stopping_a_run(self):
+        # The process-group signal must not reach the engine itself; if it
+        # does, this request fails to connect rather than returning a status.
+        self.engine.request("/train/start", {"config": CONFIG})
+        self.assertTrue(_wait(lambda: self._live_state() == "running"))
+        self.engine.request("/train/stop", {}, method="POST")
+        self.assertTrue(_wait(lambda: self._live_state() == "cancelled"))
+        status, body = self.engine.request("/health")
+        self.assertEqual(status, 200, "the engine died with the run it stopped")
+        self.assertIsNone(self.engine.proc.poll(), "the engine process exited")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/praisonai-desktop/engine/test_training.py
+++ b/src/praisonai-desktop/engine/test_training.py
@@ -1,0 +1,467 @@
+"""Tests for the training subsystem.
+
+These run the real thing: real subprocesses, real files, real SIGTERM. The
+parsers are pure and cheap to test, but the parts that break in production are
+the process lifecycle and the event replay, and neither can be tested with a
+mock without testing the mock.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import training                                          # noqa: E402
+
+
+def _wait(predicate, timeout=20.0):
+    """Poll until true, so a slow machine fails slowly rather than falsely."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _alive(pid):
+    """True while the pid exists, including as a zombie we have not reaped."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _script(body):
+    """Substitute the command, not the spawn.
+
+    Only argv changes; process groups, pipes and buffering stay the production
+    code's job, so a regression there fails a test instead of hiding behind a
+    launcher that re-implemented it.
+    """
+    return lambda run: [sys.executable, "-u", "-c", body]
+
+
+class ParseMetric(unittest.TestCase):
+    def test_reads_a_trl_logging_line(self):
+        got = training.parse_metric(
+            "{'loss': 1.234, 'grad_norm': 2.0, 'learning_rate': 0.0002, 'epoch': 0.5}")
+        self.assertEqual(got, {"loss": 1.234, "learning_rate": 0.0002, "epoch": 0.5})
+
+    def test_scientific_notation_survives(self):
+        got = training.parse_metric("{'loss': 8.6e-05, 'learning_rate': 1e-4, 'epoch': 2.0}")
+        self.assertAlmostEqual(got["loss"], 8.6e-05)
+
+    def test_a_partial_line_is_not_a_partial_metric(self):
+        # A dict without learning_rate must yield nothing rather than a metric
+        # with a missing field, which would plot as a hole or a zero.
+        self.assertIsNone(training.parse_metric("{'loss': 1.0, 'epoch': 0.5}"))
+
+    def test_noise_is_none(self):
+        for line in ("", "Loading checkpoint shards", "  0%|", None):
+            self.assertIsNone(training.parse_metric(line))
+
+
+class ParseProgress(unittest.TestCase):
+    def test_reads_a_tqdm_bar(self):
+        self.assertEqual(training.parse_progress(" 12/100 [00:03<00:24, 3.9it/s]"),
+                         {"step": 12, "total": 100})
+
+    def test_step_beyond_total_is_rejected(self):
+        # Otherwise a corrupt line renders a 400%-full progress bar.
+        self.assertIsNone(training.parse_progress("400/100 [00:03<00:00]"))
+
+    def test_zero_total_is_rejected(self):
+        self.assertIsNone(training.parse_progress("0/0 ["))
+
+
+class EventReplay(unittest.TestCase):
+    def setUp(self):
+        self.run = training.Run("r", "/tmp/c.yaml", "/tmp/t.log")
+
+    def test_a_fresh_client_gets_everything(self):
+        for i in range(3):
+            self.run.emit("log", {"line": str(i)})
+        events, gap = self.run.since(-1)
+        self.assertEqual([e[2]["line"] for e in events], ["0", "1", "2"])
+        self.assertFalse(gap)
+
+    def test_a_reconnecting_client_gets_only_what_it_missed(self):
+        for i in range(5):
+            self.run.emit("log", {"line": str(i)})
+        events, gap = self.run.since(2)
+        self.assertEqual([e[2]["line"] for e in events], ["3", "4"])
+        self.assertFalse(gap)
+
+    def test_an_evicted_cursor_reports_a_gap_rather_than_lying(self):
+        self.run.MAX_EVENTS = 10
+        for i in range(50):
+            self.run.emit("log", {"line": str(i)})
+        events, gap = self.run.since(0)
+        self.assertTrue(gap, "history was dropped and the client was not told")
+
+    def test_cursors_stay_monotonic_across_eviction(self):
+        self.run.MAX_EVENTS = 10
+        for i in range(50):
+            self.run.emit("log", {"line": str(i)})
+        cursors = [e[0] for e in self.run.events]
+        self.assertEqual(cursors, sorted(cursors))
+        self.assertEqual(len(set(cursors)), len(cursors))
+        self.assertGreater(cursors[0], 0, "cursors restarted; replay would repeat")
+
+    def test_the_first_ending_wins(self):
+        self.run.finish(training.DONE)
+        self.run.finish(training.FAILED, "late reap")
+        self.assertEqual(self.run.state, training.DONE)
+        self.assertIsNone(self.run.error)
+
+
+class TerminateGroup(unittest.TestCase):
+    """The guard that keeps stopping a run from stopping the app."""
+
+    def test_a_child_in_our_own_group_is_terminated_singly(self):
+        # Deliberately no new session, so the child shares our process group.
+        # killpg here would SIGTERM this test runner -- and does, if the guard
+        # is removed. The child must still die; we must still be here.
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        try:
+            training._terminate_group(proc)
+            self.assertTrue(_wait(lambda: proc.poll() is not None, 10),
+                            "the child outlived the terminate")
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+        self.assertTrue(True, "reached: the guard did not take us down with it")
+
+    def test_an_already_dead_child_is_not_an_error(self):
+        proc = subprocess.Popen([sys.executable, "-c", "pass"], start_new_session=True)
+        proc.wait()
+        training._terminate_group(proc)          # must not raise
+
+
+class RunIdValidation(unittest.TestCase):
+    """The engine has no auth by design, so client-supplied ids are checked."""
+
+    def test_ordinary_ids_pass_through_unchanged(self):
+        for good in ("run-1712345678", "my_run.2", "A", "a" * 64):
+            self.assertEqual(training.validate_run_id(good), good)
+
+    def test_traversal_is_refused(self):
+        for bad in ("../etc/passwd", "..", ".", "a/../../b", "/absolute",
+                    "run/../..", "\\\\server\\share"):
+            with self.assertRaises(ValueError, msg=f"accepted {bad!r}"):
+                training.validate_run_id(bad)
+
+    def test_a_traversing_id_never_creates_a_directory(self):
+        home = tempfile.mkdtemp(prefix="praison-train-id-")
+        try:
+            trainer = training.Trainer(home, sys.executable)
+            escape = os.path.join(home, "escaped")
+            with self.assertRaises(ValueError):
+                trainer.start({"model_name": "m", "dataset": "d"},
+                              run_id="../escaped")
+            self.assertFalse(os.path.exists(escape), "wrote outside the runs dir")
+            self.assertIsNone(trainer.current, "a refused start left a run behind")
+        finally:
+            shutil.rmtree(home, ignore_errors=True)
+
+    def test_odd_but_harmless_shapes_are_refused_rather_than_mangled(self):
+        for bad in ("", None, "a" * 65, "-leading-dash", "sp ace", "semi;colon",
+                    "new\nline", "nul\x00byte"):
+            with self.assertRaises(ValueError, msg=f"accepted {bad!r}"):
+                training.validate_run_id(bad)
+
+
+class Portability(unittest.TestCase):
+    """The app ships on macOS, Windows and Linux from one engine source.
+
+    These run on whatever platform the suite runs on, but each asserts the
+    behaviour that a *different* platform would otherwise get wrong, so a
+    regression is caught on a Mac laptop rather than in a Windows bug report.
+    """
+
+    def test_a_windows_style_command_keeps_its_backslashes(self):
+        # shlex.split in POSIX mode eats every backslash, so a user pointing
+        # PRAISONAI_TRAIN_CMD at C:\Users\me\envs\cuda\Scripts\python.exe
+        # gets C:Usersmeenvscudascriptspython.exe and a FileNotFoundError.
+        argv = training.split_command(
+            r"C:\Users\me\envs\cuda\Scripts\python.exe -m praisonai_train llm",
+            windows=True)
+        self.assertEqual(argv[0], r"C:\Users\me\envs\cuda\Scripts\python.exe")
+        self.assertEqual(argv[1:], ["-m", "praisonai_train", "llm"])
+
+    def test_a_quoted_windows_path_with_spaces_survives(self):
+        argv = training.split_command(r'"C:\Program Files\Py\python.exe" -u', windows=True)
+        self.assertEqual(argv, [r"C:\Program Files\Py\python.exe", "-u"])
+
+    def test_a_posix_command_still_splits_the_posix_way(self):
+        argv = training.split_command("/usr/bin/env python3 -m praisonai_train", windows=False)
+        self.assertEqual(argv, ["/usr/bin/env", "python3", "-m", "praisonai_train"])
+
+    def test_the_windows_spawn_asks_for_its_own_process_group(self):
+        # start_new_session is accepted and then ignored by CPython on Windows,
+        # so relying on it there loses the guarantee silently. This asserts the
+        # platform branch chooses creationflags instead.
+        try:
+            training.IS_WINDOWS = True
+            kwargs = training._new_process_group()
+        finally:
+            training.IS_WINDOWS = os.name == "nt"
+        self.assertIn("creationflags", kwargs)
+        self.assertNotIn("start_new_session", kwargs,
+                         "the flag CPython ignores on Windows is still being passed")
+
+    def test_the_posix_spawn_asks_for_a_new_session(self):
+        try:
+            training.IS_WINDOWS = False
+            kwargs = training._new_process_group()
+        finally:
+            training.IS_WINDOWS = os.name == "nt"
+        self.assertEqual(kwargs, {"start_new_session": True})
+
+    def test_windows_reserved_device_names_are_refused(self):
+        # os.makedirs on a directory called CON or LPT1 fails or retargets a
+        # device. The allowlist cannot see this, because they are alphanumeric.
+        for reserved in ("CON", "con", "NUL", "PRN", "AUX", "COM1", "LPT1", "con.log"):
+            with self.assertRaises(ValueError, msg=f"accepted {reserved!r}"):
+                training.validate_run_id(reserved)
+
+    def test_a_trailing_dot_is_refused(self):
+        # Windows silently strips it, so "run-1." and "run-1" become one
+        # directory and two runs would overwrite each other's logs.
+        for bad in ("run-1.", "a."):
+            with self.assertRaises(ValueError, msg=f"accepted {bad!r}"):
+                training.validate_run_id(bad)
+
+    def test_ordinary_ids_that_merely_contain_a_device_name_are_fine(self):
+        for good in ("console-run", "com10", "nullify", "aux-1-run", "conf"):
+            self.assertEqual(training.validate_run_id(good), good)
+
+
+class FakeProc:
+    """Just enough of Popen to see which termination path was taken."""
+
+    def __init__(self, alive=True):
+        self.pid = 999999
+        self._alive = alive
+        self.signals = []
+        self.terminated = False
+
+    def poll(self):
+        return None if self._alive else 0
+
+    def send_signal(self, sig):
+        self.signals.append(sig)
+
+    def terminate(self):
+        self.terminated = True
+
+
+class WindowsTermination(unittest.TestCase):
+    """The Windows branch of _terminate_group, exercised from any platform.
+
+    os.getpgid and os.killpg do not exist on Windows at all. An AttributeError
+    from either would escape stop(), and since stop() sets the run to STOPPING
+    before signalling, the run would sit in "stopping" forever while the
+    trainer kept the GPU. So the branch must be taken *before* either is
+    reached -- which is what this asserts.
+    """
+
+    def setUp(self):
+        self.was = training.IS_WINDOWS
+        self.pgid_calls = []
+        self.real_getpgid = os.getpgid
+        os.getpgid = lambda pid: self.pgid_calls.append(pid) or 1
+
+    def tearDown(self):
+        training.IS_WINDOWS = self.was
+        os.getpgid = self.real_getpgid
+
+    def test_the_windows_path_never_touches_process_groups(self):
+        training.IS_WINDOWS = True
+        proc = FakeProc()
+        training._terminate_group(proc)
+        self.assertEqual(self.pgid_calls, [],
+                         "os.getpgid was called; on Windows it does not exist")
+        self.assertTrue(proc.signals or proc.terminated,
+                        "the Windows path signalled nothing at all")
+
+    def test_the_windows_path_falls_back_to_terminate_if_signalling_fails(self):
+        training.IS_WINDOWS = True
+        proc = FakeProc()
+        proc.send_signal = lambda sig: (_ for _ in ()).throw(OSError("no console"))
+        training._terminate_group(proc)
+        self.assertTrue(proc.terminated, "a failed signal left the process running")
+
+    def test_the_posix_path_does_use_process_groups(self):
+        training.IS_WINDOWS = False
+        training._terminate_group(FakeProc())
+        self.assertTrue(self.pgid_calls, "the posix path stopped using the process group")
+
+
+class RunLifecycle(unittest.TestCase):
+    def setUp(self):
+        self.home = tempfile.mkdtemp(prefix="praison-train-test-")
+        self.trainer = training.Trainer(self.home, sys.executable)
+
+    def tearDown(self):
+        self.trainer.stop()
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def _config(self):
+        return {"model_name": "unsloth/tiny", "dataset": "d.json"}
+
+    def _start(self, command_builder):
+        """Start a run whose argv is ours and whose spawn is the real one."""
+        self.trainer.command_builder = command_builder
+        return self.trainer.start(self._config())
+
+    def test_a_successful_run_ends_done_and_logs(self):
+        run = self._start(_script(
+            "print(\"{'loss': 0.5, 'learning_rate': 0.0002, 'epoch': 1.0}\")\n"
+            "print(' 5/10 [00:01<00:01]')"))
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL), run.state)
+        self.assertEqual(run.state, training.DONE)
+        self.assertEqual(run.metrics[-1]["loss"], 0.5)
+        self.assertEqual((run.step, run.total), (5, 10))
+        with open(run.log_path) as handle:
+            self.assertIn("loss", handle.read())
+
+    def test_a_crash_ends_failed_and_says_why(self):
+        run = self._start(_script(
+            "import sys; print('CUDA out of memory'); sys.exit(1)"))
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL))
+        self.assertEqual(run.state, training.FAILED)
+        self.assertIn("out of memory", run.error)
+
+    def test_a_command_that_cannot_be_run_fails_the_run_rather_than_hanging(self):
+        # A missing interpreter is the realistic version of this: the venv was
+        # moved or never provisioned. The run must end FAILED with a readable
+        # reason, not sit at "pending" forever with a spinner.
+        run = self._start(lambda run: ["/nonexistent/bin/praisonai-train"])
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL))
+        self.assertEqual(run.state, training.FAILED)
+        self.assertIn("could not start", run.error)
+
+    def test_stopping_cancels_and_reaps_the_process(self):
+        run = self._start(_script(
+            "import time\nprint('up', flush=True)\ntime.sleep(120)"))
+        self.assertTrue(_wait(lambda: run._proc is not None and run.state == training.RUNNING))
+        pid = run._proc.pid
+        self.assertTrue(self.trainer.stop())
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL, 15))
+        self.assertEqual(run.state, training.CANCELLED)
+        self.assertIsNotNone(run._proc.poll(), "the child was never reaped")
+        with self.assertRaises(OSError):
+            os.kill(pid, 0)          # gone, not a zombie left behind
+
+    def test_stopping_also_kills_what_the_trainer_spawned(self):
+        """The orphan case, which is the one that actually bites.
+
+        A real trainer spawns children -- dataloader workers, torchrun ranks.
+        Signalling the parent pid alone leaves them holding the GPU, and the
+        next run OOMs against a job the user thinks they cancelled. So the
+        child is started in its own process group and the group is signalled.
+        """
+        marker = os.path.join(self.home, "grandchild.pid")
+        run = self._start(_script(
+            "import subprocess, sys, time\n"
+            "kid = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])\n"
+            f"open({marker!r}, 'w').write(str(kid.pid))\n"
+            "print('spawned', flush=True)\n"
+            "time.sleep(120)"))
+        self.assertTrue(_wait(lambda: os.path.exists(marker)), "grandchild never started")
+        grandchild = int(open(marker).read())
+        self.trainer.stop()
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL, 15))
+        gone = _wait(lambda: not _alive(grandchild), 10)
+        if not gone:
+            os.kill(grandchild, 9)          # do not leak it out of the test
+        self.assertTrue(gone, f"pid {grandchild} outlived the run it belonged to")
+
+    def test_a_second_run_is_refused_while_one_is_live(self):
+        self._start(_script("import time; time.sleep(60)"))
+        self.assertTrue(_wait(lambda: self.trainer.current.state == training.RUNNING))
+        with self.assertRaises(RuntimeError) as caught:
+            self._start(_script("pass"))
+        self.assertIn("Stop it", str(caught.exception))
+
+    def test_a_run_may_start_once_the_previous_one_ended(self):
+        first = self._start(_script("pass"))
+        self.assertTrue(_wait(lambda: first.state in training.TERMINAL))
+        second = self._start(_script("pass"))
+        self.assertTrue(_wait(lambda: second.state in training.TERMINAL))
+        self.assertEqual(second.state, training.DONE)
+        self.assertEqual(len(self.trainer.history), 2)
+
+    def test_stopping_a_stale_run_id_does_not_kill_the_live_one(self):
+        run = self._start(_script("import time; time.sleep(60)"))
+        self.assertTrue(_wait(lambda: run.state == training.RUNNING))
+        with self.assertRaises(RuntimeError):
+            self.trainer.stop("run-from-a-stale-tab")
+        self.assertEqual(run.state, training.RUNNING)
+
+    def test_stopping_nothing_is_false_not_an_error(self):
+        self.assertFalse(self.trainer.stop())
+
+    def test_non_ascii_output_survives_the_pipe(self):
+        """The trainer's banner is emoji; the log must not be mojibake.
+
+        text=True with no encoding decodes in the locale encoding, which is
+        cp1252 on a default Windows box: unsloth's sloth banner comes through
+        corrupted, and five cp1252 bytes are undefined outright, which raises
+        inside the reader loop and freezes the log while the run continues.
+        """
+        run = self._start(_script(
+            "import sys\n"
+            "sys.stdout.reconfigure(encoding='utf-8')\n"
+            "print('\U0001F9A5 Unsloth: patching \u2014 caf\u00e9 \u03b1\u03b2\u03b3')"))
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL))
+        self.assertEqual(run.state, training.DONE, run.error)
+        with open(run.log_path, encoding="utf-8") as handle:
+            logged = handle.read()
+        self.assertIn("caf\u00e9", logged)
+        self.assertIn("\u03b1\u03b2\u03b3", logged)
+        self.assertIn("\U0001F9A5", logged)
+
+    def test_undecodable_bytes_do_not_stop_the_reader(self):
+        """A stray byte must cost one character, not the rest of the run."""
+        run = self._start(_script(
+            "import sys\n"
+            "sys.stdout.buffer.write(b'before \\x81\\xfe after\\n')\n"
+            "sys.stdout.buffer.write(b'still reading\\n')\n"
+            "sys.stdout.buffer.flush()"))
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL))
+        lines = [e[2].get("line") for e in run.events if e[1] == "log"]
+        self.assertTrue(any("still reading" in (l or "") for l in lines),
+                        f"the reader stopped at the bad byte: {lines}")
+
+    def test_the_config_is_written_where_the_trainer_will_read_it(self):
+        run = self._start(_script("pass"))
+        self.assertTrue(os.path.exists(run.config_path))
+        with open(run.config_path) as handle:
+            self.assertIn("unsloth/tiny", handle.read())
+
+    def test_a_config_written_as_yaml_parses_back_to_the_same_values(self):
+        config = {"model_name": "unsloth/tiny", "dataset": "d.json",
+                  "lora_r": 16, "huggingface_save": False}
+        path = os.path.join(self.home, "c.yaml")
+        training._write_config(path, config)
+        try:
+            import yaml
+            loaded = yaml.safe_load(open(path))
+        except ImportError:
+            import json
+            loaded = json.load(open(path))
+        self.assertEqual(loaded, config)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/praisonai-desktop/engine/training.py
+++ b/src/praisonai-desktop/engine/training.py
@@ -1,0 +1,420 @@
+"""Running a fine-tune from the desktop app, and reporting on it.
+
+The engine had no job model at all. It is a ThreadingHTTPServer where every
+request is a turn that starts, streams and ends -- fine for chat, wrong for
+something that runs for hours, must survive the window closing, and has to be
+resumable after a reconnect. So a training run is a *subsystem*, not a route.
+
+Three decisions worth stating, each taken because the alternative was worse:
+
+* **One run at a time.** Two fine-tunes on one GPU do not co-exist; they OOM.
+  `start` refuses while a run is live rather than queueing, because a queue
+  implies a scheduler nobody asked for.
+* **Progress is a ring buffer, not a stream.** SSE with `Last-Event-ID` needs
+  history to replay, and a closed laptop lid must not lose the run. Events are
+  kept and replayed from a cursor, so reconnecting is reading, not subscribing.
+* **The subprocess owns the truth.** Status is derived from the process and its
+  log, never from what the client last heard, so a client that missed the
+  ending still learns how it ended.
+
+Everything here is pure or filesystem-only; the HTTP layer is in server.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import signal
+import subprocess
+import threading
+import time
+
+# What a run can be. `stopping` exists because SIGTERM is not instant and a UI
+# that shows "running" through a five-second teardown looks broken.
+PENDING, RUNNING, STOPPING, DONE, FAILED, CANCELLED = (
+    "pending", "running", "stopping", "done", "failed", "cancelled")
+TERMINAL = frozenset({DONE, FAILED, CANCELLED})
+
+# trl/transformers print one dict per logging step. This is the only line shape
+# worth parsing; everything else is noise the log view can show verbatim.
+_METRIC = re.compile(
+    r"\{'loss':\s*([0-9.eE+-]+).*?'learning_rate':\s*([0-9.eE+-]+)"
+    r".*?'epoch':\s*([0-9.eE+-]+)")
+_STEP = re.compile(r"(\d+)\s*/\s*(\d+)\s*\[")
+
+
+def parse_metric(line):
+    """Pull (loss, lr, epoch) out of a trainer log line, or None.
+
+    Returns None rather than partial values: a chart plotting a loss with no
+    step is worse than a chart with a gap.
+    """
+    m = _METRIC.search(line or "")
+    if not m:
+        return None
+    try:
+        return {"loss": float(m.group(1)), "learning_rate": float(m.group(2)),
+                "epoch": float(m.group(3))}
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_progress(line):
+    """Pull (step, total) out of a tqdm line, or None."""
+    m = _STEP.search(line or "")
+    if not m:
+        return None
+    step, total = int(m.group(1)), int(m.group(2))
+    if total <= 0 or step > total:
+        return None          # a malformed bar must not produce 400% progress
+    return {"step": step, "total": total}
+
+
+IS_WINDOWS = os.name == "nt"
+
+# Reserved DOS device names. They are alphanumeric, so an allowlist cannot see
+# them, and `os.makedirs("CON")` on Windows fails or resolves to a device.
+_RESERVED = frozenset(
+    ["CON", "PRN", "AUX", "NUL"]
+    + [f"COM{i}" for i in range(1, 10)]
+    + [f"LPT{i}" for i in range(1, 10)])
+
+_SAFE_RUN_ID = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
+
+
+def split_command(text, windows=None):
+    """Split a command line the way the running platform's shell would.
+
+    `shlex.split` defaults to POSIX rules, where a backslash escapes the next
+    character -- so a Windows interpreter path is silently destroyed:
+
+        C:\\Users\\me\\envs\\cuda\\Scripts\\python.exe
+            -> C:Usersmeenvscudascriptspython.exe
+
+    and the user sees only "could not start the trainer". Non-POSIX mode keeps
+    the backslashes but leaves the quotes attached, so they are stripped here.
+    """
+    windows = IS_WINDOWS if windows is None else windows
+    if not windows:
+        return shlex.split(text)
+    tokens = shlex.split(text, posix=False)
+    return [t[1:-1] if len(t) > 1 and t[0] == t[-1] and t[0] in "\"'" else t
+            for t in tokens]
+
+
+def validate_run_id(run_id):
+    """A run id becomes a directory name, so it is checked, not trusted.
+
+    The engine listens on loopback with no auth -- that is the app's existing
+    design for every route -- which means any local process can POST here. An
+    id like `../../../../Library/LaunchAgents/x` would have `makedirs` write
+    outside the runs directory. An allowlist is used rather than stripping
+    `..`, because stripping invites the next encoding that gets through.
+    """
+    run_id = str(run_id or "")
+    stem = run_id.split(".", 1)[0].upper()
+    if stem in _RESERVED:
+        raise ValueError(
+            f"{run_id!r} is a reserved device name on Windows; "
+            "a directory cannot be created with it")
+    if run_id.endswith("."):
+        # Windows strips a trailing dot, so "run-1." and "run-1" would become
+        # one directory and two runs would overwrite each other's logs.
+        raise ValueError(f"a run id may not end in a dot; got {run_id!r}")
+    if not _SAFE_RUN_ID.match(run_id) or run_id in {".", ".."}:
+        raise ValueError(
+            "run id must be 1-64 characters of letters, digits, dot, dash or "
+            f"underscore, starting alphanumeric; got {run_id!r}")
+    return run_id
+
+
+class Run:
+    """One training job. Owns its process, its log and its event history."""
+
+    MAX_EVENTS = 4000        # ~a day of logging at one line every 20s
+
+    def __init__(self, run_id, config_path, log_path):
+        self.id = run_id
+        self.config_path = str(config_path)
+        self.log_path = str(log_path)
+        self.state = PENDING
+        self.started = time.time()
+        self.ended = None
+        self.error = None
+        self.step = 0
+        self.total = 0
+        self.metrics = []            # [{step, loss, learning_rate, epoch}]
+        self.events = []             # [(cursor, kind, payload)]
+        self._next_cursor = 0        # never derived from len(events): see emit
+        self._proc = None
+        self._lock = threading.Lock()
+
+    # -- event history --------------------------------------------------
+    def emit(self, kind, payload=None):
+        with self._lock:
+            # A counter, not len(self.events). Deriving the cursor from the
+            # list length looks equivalent and is not: once eviction starts,
+            # the length stops growing, every later event is handed the same
+            # cursor, and `since()` returns nothing forever -- a live run whose
+            # UI silently stops updating. Its own test caught this.
+            cursor = self._next_cursor
+            self._next_cursor += 1
+            self.events.append((cursor, kind, payload or {}))
+            if len(self.events) > self.MAX_EVENTS:
+                # Drop from the front, keeping cursors monotonic so a client
+                # that reconnects with an evicted cursor is told to resync
+                # rather than silently handed the wrong events.
+                self.events = self.events[-self.MAX_EVENTS:]
+
+    def since(self, cursor):
+        """Events after `cursor`, and whether history was lost."""
+        with self._lock:
+            if not self.events:
+                return [], False
+            oldest = self.events[0][0]
+            gap = cursor + 1 < oldest
+            return [e for e in self.events if e[0] > cursor], gap
+
+    # -- lifecycle -------------------------------------------------------
+    def summary(self):
+        return {
+            "id": self.id, "state": self.state, "step": self.step,
+            "total": self.total, "started": self.started, "ended": self.ended,
+            "error": self.error,
+            "elapsed": round((self.ended or time.time()) - self.started, 1),
+            "last_loss": self.metrics[-1]["loss"] if self.metrics else None,
+        }
+
+    def finish(self, state, error=None):
+        if self.state in TERMINAL:
+            return               # first ending wins; a late reap cannot relabel
+        self.state = state
+        self.error = error
+        self.ended = time.time()
+        self.emit("end", self.summary())
+
+
+class Trainer:
+    """The one live run, if any, and the history of finished ones."""
+
+    def __init__(self, home, python, command_builder=None):
+        self.home = home
+        self.python = python
+        # Tests override the *command*, never the spawn. An earlier version let
+        # tests supply a whole launcher, and every one of them re-implemented
+        # `start_new_session=True` -- so deleting it from the real spawn broke
+        # nothing, and the process-group guarantee was untested while looking
+        # covered. Substituting argv keeps the mechanics under test.
+        self.command_builder = command_builder
+        self.dir = os.path.join(str(home), "runs")
+        self.current = None
+        self.history = []
+        self._lock = threading.Lock()
+
+    # -- starting --------------------------------------------------------
+    def start(self, config, run_id=None):
+        """Write the config, spawn the trainer, and stream its output.
+
+        Refuses while a run is live. Two fine-tunes on one GPU do not co-exist
+        -- they OOM -- and queueing would imply a scheduler nobody asked for,
+        so the honest answer is no.
+        """
+        with self._lock:
+            if self.current and self.current.state not in TERMINAL:
+                raise RuntimeError(
+                    f"run {self.current.id} is {self.current.state}. "
+                    "Stop it before starting another; one GPU runs one job.")
+            run_id = validate_run_id(run_id) if run_id else f"run-{int(time.time())}"
+            run_dir = os.path.join(self.dir, run_id)
+            os.makedirs(run_dir, exist_ok=True)
+            config_path = os.path.join(run_dir, "config.yaml")
+            _write_config(config_path, config)
+            run = Run(run_id, config_path, os.path.join(run_dir, "train.log"))
+            self.current = run
+            self.history.insert(0, run)
+
+        run.emit("start", {"id": run.id, "config": config_path})
+        threading.Thread(target=self._supervise, args=(run,), daemon=True).start()
+        return run
+
+    def _command(self, run):
+        """The argv that runs the fine-tune.
+
+        `PRAISONAI_TRAIN_CMD` overrides the launcher because the trainer need
+        not live in the engine's venv: praisonai-train pulls torch and unsloth,
+        which a user may well keep in a separate CUDA-matched environment, and
+        the desktop engine deliberately stays stdlib-only. `--config <path>` is
+        always appended, so the override chooses the interpreter, not the
+        contract.
+        """
+        if self.command_builder:
+            return self.command_builder(run)
+        override = os.environ.get("PRAISONAI_TRAIN_CMD", "").strip()
+        base = (split_command(override) if override
+                else [self.python, "-m", "praisonai_train", "llm"])
+        return base + ["--config", run.config_path]
+
+    def _spawn(self, run):
+        return subprocess.Popen(
+            self._command(run),
+            cwd=os.path.dirname(run.config_path),
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            # text=True alone decodes in the locale encoding -- cp1252 on a
+            # default Windows box, ASCII under LC_ALL=C. unsloth's banner is
+            # emoji, so the log becomes mojibake; worse, five cp1252 bytes are
+            # undefined and raise *inside* the reader loop, freezing the log
+            # and the loss chart while the run carries on to completion.
+            text=True, encoding="utf-8", errors="replace", bufsize=1,
+            # Its own group, so stopping kills the trainer AND anything it
+            # spawned. Signalling the pid alone leaves the real work running.
+            **_new_process_group(),
+        )
+
+    @staticmethod
+    def _process_group_kwargs():
+        return _new_process_group()
+
+    def _supervise(self, run):
+        try:
+            proc = self._spawn(run)
+        except Exception as exc:                       # noqa: BLE001
+            run.finish(FAILED, f"could not start the trainer: {exc}")
+            return
+        run._proc = proc
+        run.state = RUNNING
+        run.emit("state", {"state": RUNNING})
+        try:
+            with open(run.log_path, "a", encoding="utf-8") as log:
+                for line in proc.stdout:
+                    log.write(line)
+                    self._consume(run, line.rstrip("\n"))
+        except Exception as exc:                       # noqa: BLE001
+            run.emit("log", {"line": f"[reader stopped: {exc}]"})
+        code = proc.wait()
+        if run.state == STOPPING:
+            run.finish(CANCELLED)
+        elif code == 0:
+            run.finish(DONE)
+        else:
+            run.finish(FAILED, _last_meaningful_line(run.log_path) or f"exit {code}")
+
+    def _consume(self, run, line):
+        run.emit("log", {"line": line})
+        progress = parse_progress(line)
+        if progress:
+            run.step, run.total = progress["step"], progress["total"]
+            run.emit("progress", progress)
+        metric = parse_metric(line)
+        if metric:
+            metric["step"] = run.step
+            run.metrics.append(metric)
+            run.emit("metric", metric)
+
+    # -- stopping --------------------------------------------------------
+    def stop(self, run_id=None):
+        run = self.current
+        if not run or run.state in TERMINAL:
+            return False
+        if run_id and run_id != run.id:
+            # Refuse to stop a different run than the one asked for: a stale
+            # tab must not cancel the job someone started after it.
+            raise RuntimeError(f"{run_id} is not the live run ({run.id})")
+        run.state = STOPPING
+        run.emit("state", {"state": STOPPING})
+        proc = run._proc
+        if proc and proc.poll() is None:
+            _terminate_group(proc)
+        return True
+
+    def get(self, run_id):
+        for run in self.history:
+            if run.id == run_id:
+                return run
+        return None
+
+
+def _new_process_group():
+    """Popen kwargs that put the child in its own group, per platform.
+
+    `start_new_session` is accepted and then *ignored* on Windows -- CPython's
+    Windows `_execute_child` names the parameter `unused_start_new_session` and
+    never reads it -- so relying on it there would silently lose the guarantee
+    that stopping a run also stops what the run spawned.
+    """
+    if IS_WINDOWS:
+        # getattr on both, so this branch can be exercised from a Mac test
+        # rather than being the one path nobody runs until a user reports it.
+        # CREATE_NO_WINDOW keeps a console from flashing: a Tauri app is a GUI
+        # process with no console attached, so a bare Popen pops a black box.
+        return {"creationflags": getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                | getattr(subprocess, "CREATE_NO_WINDOW", 0)}
+    return {"start_new_session": True}
+
+
+def _terminate_group(proc):
+    """SIGTERM the child and everything it spawned -- and nothing else.
+
+    The group is checked against our own before signalling. `_spawn` puts the
+    child in a new session so they always differ, but if that ever regresses,
+    `killpg` would deliver SIGTERM to the engine's own group and stopping a
+    training run would kill the desktop app. Verified: removing the new-session
+    flag makes this function shoot the test runner.
+    """
+    if IS_WINDOWS:
+        # Windows has no process groups in the POSIX sense; os.getpgid and
+        # os.killpg do not exist at all, and an AttributeError here would
+        # escape stop() and wedge the run in "stopping" forever while the
+        # trainer kept the GPU. CTRL_BREAK_EVENT reaches the whole group
+        # created by CREATE_NEW_PROCESS_GROUP, which is the stdlib-only
+        # equivalent.
+        try:
+            proc.send_signal(signal.CTRL_BREAK_EVENT)
+        except (OSError, ValueError, AttributeError):
+            proc.terminate()
+        return
+    try:
+        group = os.getpgid(proc.pid)
+    except (ProcessLookupError, PermissionError, OSError):
+        proc.terminate()
+        return
+    if group == os.getpgid(0):
+        # Refuse rather than take the engine down with the job.
+        proc.terminate()
+        return
+    try:
+        os.killpg(group, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        proc.terminate()
+
+
+def _write_config(path, config):
+    """Write the config as YAML, falling back to JSON.
+
+    A desktop engine that is stdlib-only cannot assume PyYAML, and a training
+    config that fails to write is a run that never starts -- so JSON, which
+    every YAML parser also reads, is the fallback rather than an error.
+    """
+    try:
+        import yaml
+        text = yaml.safe_dump(config, sort_keys=True, default_flow_style=False)
+    except ImportError:
+        text = json.dumps(config, indent=2, sort_keys=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    return path
+
+
+def _last_meaningful_line(log_path, limit=4000):
+    """The last non-blank line, for a failure message worth reading."""
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+            tail = handle.readlines()[-40:]
+    except OSError:
+        return None
+    for line in reversed(tail):
+        text = line.strip()
+        if text:
+            return text[:limit]
+    return None

--- a/src/praisonai-desktop/frontend/tests/training.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/training.test.mjs
@@ -1,0 +1,313 @@
+/**
+ * The Training view, driven through the real page.
+ *
+ * Nothing here asserts that a handler exists; every test presses something and
+ * checks what changed, or drives a server event and checks what rendered. The
+ * contract with the engine -- especially the shape of `dataset`, which the
+ * trainer reads as a list of sources and not a string -- is asserted on the
+ * body actually sent, because a mismatch there fails an hour into a run.
+ */
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createServer } from 'node:http';
+import { extname } from 'node:path';
+
+const HTML = readFileSync(new URL('../../ui/index.html', import.meta.url), 'utf8');
+const SRV = createServer((req, res) => {
+  const f = req.url === '/' ? '/index.html' : req.url.split('?')[0];
+  try {
+    const b = readFileSync(new URL('../../ui' + f, import.meta.url));
+    res.writeHead(200, { 'content-type': extname(f) === '.js' ? 'text/javascript' : 'text/html' });
+    res.end(b);
+  } catch { res.writeHead(404); res.end(); }
+});
+await new Promise((r) => SRV.listen(0, r));
+SRV.unref();
+const ORIGIN = 'http://127.0.0.1:' + SRV.address().port;
+process.on('exit', () => SRV.close());
+const PORT = 65000;
+
+/** A fake EventSource the test drives, since jsdom ships none. */
+function installEventSource(w, streams) {
+  w.EventSource = class {
+    constructor(url) {
+      this.url = url;
+      this.listeners = {};
+      this.closed = false;
+      streams.push(this);
+    }
+    addEventListener(kind, fn) { (this.listeners[kind] ||= []).push(fn); }
+    close() { this.closed = true; }
+    /** Deliver a server event exactly as the engine would frame it. */
+    emit(kind, data) {
+      (this.listeners[kind] || []).forEach((fn) => fn({ data: JSON.stringify(data) }));
+    }
+  };
+}
+
+async function boot({ status = { run: null, metrics: [] }, start, runs = { runs: [] } } = {}) {
+  const calls = [];
+  const streams = [];
+  const dom = new JSDOM(HTML, {
+    runScripts: 'dangerously', resources: 'usable', url: ORIGIN + '/',
+    beforeParse(w) {
+      w.__TAURI__ = { core: { invoke: async () => ({ state: 'ready', port: PORT, python: '/py' }) } };
+      installEventSource(w, streams);
+      w.fetch = async (url, opts = {}) => {
+        const path = String(url).replace(`http://127.0.0.1:${PORT}`, '');
+        calls.push({ method: opts.method || 'GET', path, body: opts.body ? JSON.parse(opts.body) : null });
+        const u = String(url);
+        if (u.includes('/train/start')) {
+          const reply = start || { ok: true, run: { id: 'run-1', state: 'pending', step: 0, total: 0, elapsed: 0 } };
+          return { ok: reply.ok !== false, status: reply.status || 200, json: async () => reply };
+        }
+        if (u.includes('/train/stop')) return { ok: true, status: 200, json: async () => ({ ok: true }) };
+        if (u.includes('/train/status')) return { ok: true, status: 200, json: async () => status };
+        if (u.includes('/train/runs')) return { ok: true, status: 200, json: async () => runs };
+        const body =
+          u.includes('/settings') ? { model: 'gpt-4o-mini', theme: 'system', temperature: 0.7,
+                                      approval_mode: 'ask', approval_timeout: 300 }
+          : u.includes('/chats') ? { chats: [] }
+          : u.includes('/update') ? { current: '0.1.0', checked: false, message: 'not configured' }
+          : { ok: true };
+        return { ok: true, status: 200, json: async () => body, text: async () => '' };
+      };
+      w.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+      w.navigator.clipboard = { writeText: async () => {} };
+      w.confirm = () => true; w.alert = () => {}; w.scrollTo = () => {};
+      Object.defineProperty(w.HTMLElement.prototype, 'scrollIntoView', { value() {} });
+      // jsdom has no canvas backend; the loss chart must degrade, not throw.
+      Object.defineProperty(w.HTMLCanvasElement.prototype, 'getContext', {
+        value: () => ({ setTransform() {}, clearRect() {}, beginPath() {}, moveTo() {},
+                        lineTo() {}, stroke() {}, arc() {}, fill() {}, }),
+      });
+    },
+  });
+  const { window } = dom;
+  for (let i = 0; i < 80; i++) {
+    await new Promise((r) => setTimeout(r, 25));
+    if (!window.document.getElementById('p').disabled) break;
+  }
+  return { window, doc: window.document, calls, streams };
+}
+
+const click = (el) => el.dispatchEvent(new el.ownerDocument.defaultView.MouseEvent('click', { bubbles: true }));
+const settle = () => new Promise((r) => setTimeout(r, 140));
+const posted = (calls, path) => calls.filter((c) => c.method === 'POST' && c.path.startsWith(path));
+
+test('the Train tab exists and switches the view', async () => {
+  const { doc } = await boot();
+  const tab = doc.getElementById('viewTrain');
+  assert.ok(tab, 'no Train tab in the sidebar');
+  click(tab);
+  await settle();
+  assert.ok(doc.body.classList.contains('training'), 'body did not enter the training view');
+  assert.ok(doc.getElementById('train').classList.contains('on'), '#train stayed hidden');
+  assert.equal(tab.getAttribute('aria-selected'), 'true');
+  assert.equal(doc.getElementById('viewChat').getAttribute('aria-selected'), 'false');
+});
+
+test('switching back to Chat restores the composer', async () => {
+  const { doc } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  click(doc.getElementById('viewChat'));
+  await settle();
+  assert.equal(doc.body.classList.contains('training'), false);
+  assert.equal(doc.getElementById('train').classList.contains('on'), false);
+  assert.equal(doc.getElementById('viewChat').getAttribute('aria-selected'), 'true');
+});
+
+test('one tab is selected on first launch', async () => {
+  const { doc } = await boot();
+  assert.ok(doc.getElementById('viewChat').classList.contains('active'),
+            'neither tab looks selected before anything is clicked');
+});
+
+test('starting a run sends dataset as a list of sources, not a string', async () => {
+  const { doc, calls } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('tModel').value = 'unsloth/tiny';
+  doc.getElementById('tDataset').value = 'my/data';
+  doc.getElementById('trainForm').dispatchEvent(new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  const [start] = posted(calls, '/train/start');
+  assert.ok(start, 'submitting the form posted nothing');
+  const cfg = start.body.config;
+  assert.ok(Array.isArray(cfg.dataset), `dataset must be a list, got ${JSON.stringify(cfg.dataset)}`);
+  assert.equal(cfg.dataset[0].name, 'my/data');
+  assert.equal(cfg.dataset[0].split_type, 'train');
+  assert.equal(cfg.model_name, 'unsloth/tiny');
+  assert.equal(cfg.method, 'sft');
+});
+
+test('max steps of zero is omitted rather than sent as a zero cap', async () => {
+  const { doc, calls } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('tSteps').value = '0';
+  doc.getElementById('trainForm').dispatchEvent(new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  const [start] = posted(calls, '/train/start');
+  assert.equal('max_steps' in start.body.config, false,
+               'max_steps: 0 would cap the run at no steps at all');
+});
+
+test('an empty model is refused in the page and posts nothing', async () => {
+  const { doc, calls } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('tModel').value = '';
+  doc.getElementById('trainForm').dispatchEvent(new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  assert.equal(posted(calls, '/train/start').length, 0, 'posted an incomplete config');
+  assert.match(doc.getElementById('tError').textContent, /required/i);
+});
+
+test("a conflict shows the engine's own message and re-enables Start", async () => {
+  const { doc } = await boot({
+    start: { ok: false, status: 409, error: 'run run-earlier is running. Stop it before starting another; one GPU runs one job.' },
+  });
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('trainForm').dispatchEvent(new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  assert.match(doc.getElementById('tError').textContent, /run-earlier/,
+               'the blocking run was not named');
+  assert.equal(doc.getElementById('tStart').disabled, false, 'Start left disabled after a refusal');
+});
+
+test('a rejected config re-enables Start without a status refresh to rescue it', async () => {
+  // The 409 path calls refreshTraining, which resets the button as a side
+  // effect. A 400 does not, so this is the case that proves the reset is
+  // actually done here rather than inherited from the refresh.
+  const { doc } = await boot({
+    start: { ok: false, status: 400, error: 'config needs at least model_name and dataset' },
+  });
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('trainForm').dispatchEvent(new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  assert.match(doc.getElementById('tError').textContent, /model_name/);
+  assert.equal(doc.getElementById('tStart').disabled, false,
+               'Start stayed disabled, so the form is unusable after one bad submit');
+});
+
+test('live events move the progress bar, the step and the loss', async () => {
+  const { doc, streams } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('trainForm').dispatchEvent(new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  const stream = streams[streams.length - 1];
+  assert.ok(stream, 'no progress stream was opened');
+  stream.emit('state', { cursor: 1, state: 'running' });
+  stream.emit('progress', { cursor: 2, step: 30, total: 60 });
+  stream.emit('metric', { cursor: 3, loss: 0.4321, learning_rate: 2e-4, epoch: 0.5, step: 30 });
+  stream.emit('log', { cursor: 4, line: 'loading checkpoint shards' });
+  await settle();
+  assert.equal(doc.getElementById('tStep').textContent, '30 / 60');
+  assert.equal(doc.getElementById('tLoss').textContent, '0.4321');
+  // The value, not its formatting: the style engine normalises "50.0%" to
+  // "50%", and an assertion on the string tests the CSS parser, not the bar.
+  assert.equal(parseFloat(doc.getElementById('tBar').style.width), 50);
+  assert.match(doc.getElementById('tlog').textContent, /checkpoint shards/);
+  assert.equal(doc.getElementById('tState').textContent, 'running');
+  assert.equal(doc.getElementById('tStop').hidden, false, 'Stop is not offered mid-run');
+});
+
+test('a failed ending shows the reason and offers Start again', async () => {
+  const { doc, streams } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('trainForm').dispatchEvent(new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  const stream = streams[streams.length - 1];
+  stream.emit('end', { cursor: 9, state: 'failed', error: 'CUDA out of memory', elapsed: 42, step: 3, total: 60 });
+  await settle();
+  assert.match(doc.getElementById('tError').textContent, /out of memory/);
+  assert.equal(doc.getElementById('tState').textContent, 'failed');
+  assert.equal(doc.getElementById('tStart').disabled, false);
+  assert.equal(doc.getElementById('tStop').hidden, true, 'Stop still offered after the run ended');
+  assert.ok(stream.closed, 'the stream was left open after the run ended');
+});
+
+test('a dropped-history resync is said out loud, not spliced over', async () => {
+  const { doc, streams } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('trainForm').dispatchEvent(new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  streams[streams.length - 1].emit('resync', {});
+  await settle();
+  assert.match(doc.getElementById('tlog').textContent, /earlier output dropped/i);
+});
+
+test('Stop asks the engine to stop', async () => {
+  const { doc, calls, streams } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('trainForm').dispatchEvent(new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  streams[streams.length - 1].emit('state', { cursor: 1, state: 'running' });
+  await settle();
+  click(doc.getElementById('tStop'));
+  await settle();
+  assert.equal(posted(calls, '/train/stop').length, 1, 'Stop sent nothing');
+});
+
+test('a run already in flight is picked up when the view opens', async () => {
+  const { doc, streams } = await boot({
+    status: { run: { id: 'run-earlier', state: 'running', step: 12, total: 100, elapsed: 610, error: null },
+              metrics: [{ loss: 1.1, step: 6 }, { loss: 0.9, step: 12 }] },
+    runs: { runs: [{ id: 'run-earlier', state: 'running', elapsed: 610, last_loss: 0.9, error: null }] },
+  });
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  assert.equal(doc.getElementById('tState').textContent, 'running',
+               'a run started in an earlier session was not adopted');
+  assert.equal(doc.getElementById('tStep').textContent, '12 / 100');
+  assert.equal(doc.getElementById('tLoss').textContent, '0.9000');
+  assert.equal(doc.getElementById('tElapsed').textContent, '10m 10s');
+  assert.ok(streams.length > 0, 'no stream was opened for the run in flight');
+});
+
+test('previous runs are listed with their outcome', async () => {
+  const { doc } = await boot({
+    runs: { runs: [
+      { id: 'run-a', state: 'done', elapsed: 3720, last_loss: 0.21, error: null },
+      { id: 'run-b', state: 'failed', elapsed: 12, last_loss: null, error: 'CUDA out of memory' }] },
+  });
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  const rows = doc.getElementById('tHistory').children;
+  assert.equal(rows.length, 2, 'the run history did not render');
+  assert.match(rows[0].textContent, /run-a/);
+  assert.match(rows[0].textContent, /1h 2m/);
+  assert.match(rows[1].textContent, /failed/);
+  assert.equal(rows[1].title, 'CUDA out of memory', 'the failure reason is unreachable');
+});
+
+test('the method hint changes with the method', async () => {
+  const { doc } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  const select = doc.getElementById('tMethod');
+  const before = doc.getElementById('tMethodHint').textContent;
+  select.value = 'dpo';
+  select.dispatchEvent(new doc.defaultView.Event('change', { bubbles: true }));
+  await settle();
+  const after = doc.getElementById('tMethodHint').textContent;
+  assert.notEqual(after, before, 'the hint is inert');
+  assert.match(after, /chosen/i);
+});
+
+test('every method the engine accepts is offered', async () => {
+  const { doc } = await boot();
+  const offered = [...doc.getElementById('tMethod').options].map((o) => o.value).sort();
+  assert.deepEqual(offered, ['cpo', 'cpt', 'dpo', 'grpo', 'kto', 'orpo', 'reward', 'sft'],
+                   'the picker and the trainer registry disagree');
+});

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -46,6 +46,8 @@ body{margin:0;background:var(--ground);color:var(--ink);font:.906rem/1.6 ui-sans
 .navbtn{display:flex;align-items:center;gap:.6rem;padding:.45rem .6rem;border-radius:7px;
   background:none;border:0;color:var(--ink);font:inherit;font-size:.86rem;cursor:pointer;text-align:left;width:100%}
 .navbtn:hover{background:var(--ground)}
+.navbtn.active{background:var(--ground);font-weight:650}
+.navbtn.active .ic{color:var(--accent)}
 .navbtn .k{margin-left:auto;font-size:.68rem;color:var(--soft);font-family:ui-monospace,Menlo,monospace}
 .navbtn .ic{width:.94rem;text-align:center;color:var(--soft)}
 .sectlbl{font-size:.62rem;text-transform:uppercase;letter-spacing:.11em;color:var(--soft);
@@ -332,6 +334,67 @@ button.stop{background:var(--bad)}
             cursor:pointer;user-select:none;display:flex;gap:.4rem;align-items:center}
 .think-body{display:none;white-space:pre-wrap;margin-top:.35rem;font-size:.82rem}
 .think.open .think-body{display:block}
+
+/* --- training ------------------------------------------------------------
+   Same tokens as chat, same centred column. A training view that invented its
+   own palette would read as a bolted-on second app, which is exactly what it
+   must not be: it is the same product doing a different job. */
+#train{flex:1;overflow-y:auto;padding:1.5rem 0;display:none}
+#train.on{display:block}
+body.training #thread,body.training #f{display:none}
+.trainhd{display:flex;align-items:baseline;gap:.6rem;margin:0 0 .2rem}
+.trainhd h2{font-size:1.05rem;margin:0;font-weight:650}
+.trainhd p{margin:0;color:var(--soft);font-size:.78rem}
+.tcard{border:1px solid var(--rule);background:var(--panel);border-radius:.6rem;
+       padding:.9rem 1rem;margin:.9rem 0}
+.tgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(11rem,1fr));gap:.7rem .9rem}
+.tf{display:flex;flex-direction:column;gap:.25rem;min-width:0}
+.tf label{font-size:.68rem;text-transform:uppercase;letter-spacing:.08em;color:var(--soft);font-weight:700}
+.tf input,.tf select{background:var(--ground);color:var(--ink);border:1px solid var(--rule);
+  border-radius:.4rem;padding:.4rem .5rem;font:inherit;font-size:.82rem;min-width:0;width:100%;
+  box-sizing:border-box}
+.tf input:focus,.tf select:focus{outline:none;border-color:var(--accent)}
+.tf .hint{font-size:.68rem;color:var(--soft);opacity:.85}
+.tf.bad input{border-color:var(--bad)}
+.tf .err{font-size:.68rem;color:var(--bad);min-height:0}
+.trow{display:flex;align-items:center;gap:.6rem;flex-wrap:wrap;margin-top:.9rem}
+.tbtn{background:var(--accent);color:var(--ground);border:0;border-radius:.4rem;
+      padding:.45rem .9rem;font:inherit;font-size:.82rem;font-weight:650;cursor:pointer}
+.tbtn[disabled]{opacity:.45;cursor:default}
+.tbtn.ghost{background:none;color:var(--ink);border:1px solid var(--rule-strong);font-weight:500}
+.tbtn.danger{background:var(--bad);color:var(--ground)}
+.tadv{margin-top:.7rem}
+.tadv summary{cursor:pointer;font-size:.72rem;color:var(--soft);text-transform:uppercase;
+  letter-spacing:.08em;font-weight:700;user-select:none;list-style:none}
+.tadv summary::-webkit-details-marker{display:none}
+.tadv summary::before{content:"\25B8 ";color:var(--soft)}
+.tadv[open] summary::before{content:"\25BE "}
+.tadv .tgrid{margin-top:.7rem}
+.pill{font-size:.66rem;text-transform:uppercase;letter-spacing:.08em;font-weight:700;
+      border-radius:999px;padding:.16rem .55rem;border:1px solid var(--rule-strong);color:var(--soft)}
+.pill.running{color:var(--accent);border-color:var(--accent)}
+.pill.done{color:var(--accent);border-color:var(--accent)}
+.pill.failed,.pill.cancelled{color:var(--bad);border-color:var(--bad)}
+.pill.stopping{color:var(--soft)}
+.bar{height:.35rem;background:var(--rule);border-radius:999px;overflow:hidden;margin:.6rem 0 .3rem}
+.bar i{display:block;height:100%;background:var(--accent);width:0;
+       transition:width .3s ease;border-radius:999px}
+.no-motion .bar i{transition:none}
+.tstats{display:flex;gap:1.2rem;flex-wrap:wrap;font-size:.74rem;color:var(--soft)}
+.tstats b{color:var(--ink);font-weight:600;font-variant-numeric:tabular-nums}
+#loss{width:100%;height:5rem;display:block;margin-top:.6rem}
+#tlog{font-family:ui-monospace,Menlo,monospace;font-size:var(--fs-code);line-height:1.5;
+      background:var(--code);border:1px solid var(--rule);border-radius:.5rem;
+      padding:.6rem .7rem;max-height:16rem;overflow:auto;white-space:pre-wrap;
+      overflow-wrap:anywhere;color:var(--soft);margin-top:.6rem}
+#tlog:empty::before{content:"No output yet.";opacity:.6}
+.trun{display:flex;align-items:center;gap:.6rem;padding:.4rem .1rem;font-size:.78rem;
+      border-bottom:1px solid var(--rule)}
+.trun:last-child{border-bottom:0}
+.trun .rid{font-family:ui-monospace,Menlo,monospace;font-size:.72rem;color:var(--soft)}
+.trun .grow{flex:1}
+.tnote{font-size:.76rem;color:var(--bad);margin-top:.6rem}
+.tnote:empty{display:none}
 </style></head><body>
 <div class="titlebar" data-tauri-drag-region>
   <button class="modelpill" id="modelpill" type="button">
@@ -345,6 +408,12 @@ button.stop{background:var(--bad)}
 </div>
 <div id="body">
   <aside id="side" aria-label="Conversations">
+    <div class="sidetop" role="tablist" aria-label="Views">
+      <button class="navbtn" id="viewChat" type="button" role="tab" aria-selected="true"
+              aria-controls="thread"><span class="ic" aria-hidden="true">▫</span>Chat</button>
+      <button class="navbtn" id="viewTrain" type="button" role="tab" aria-selected="false"
+              aria-controls="train"><span class="ic" aria-hidden="true">◩</span>Train</button>
+    </div>
     <div class="sidetop">
       <button class="navbtn" id="newchat" type="button"><span class="ic" aria-hidden="true">✎</span>New chat<span class="k">⌘N</span></button>
       <button class="navbtn" id="search" type="button"><span class="ic" aria-hidden="true">⌕</span>Search<span class="k">⌘K</span></button>
@@ -378,6 +447,121 @@ button.stop{background:var(--bad)}
     <button id="stop" class="stop" type="button" style="display:none">Stop</button>
   </div>
 </div></div></form>
+    <section id="train" role="tabpanel" aria-labelledby="viewTrain" aria-label="Training">
+      <div class="inner">
+        <div class="trainhd">
+          <h2>Fine-tune a model</h2>
+          <p>Runs locally through praisonai-train.</p>
+        </div>
+
+        <form id="trainForm" class="tcard">
+          <div class="tgrid">
+            <div class="tf">
+              <label for="tModel">Base model</label>
+              <input id="tModel" name="model_name" required
+                     value="unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit"/>
+              <span class="hint">A Hugging Face id.</span>
+            </div>
+            <div class="tf">
+              <label for="tMethod">Method</label>
+              <select id="tMethod" name="method">
+                <option value="sft" selected>SFT — supervised fine-tuning</option>
+                <option value="cpt">CPT — continued pretraining</option>
+                <option value="dpo">DPO — direct preference optimisation</option>
+                <option value="orpo">ORPO — odds-ratio preference</option>
+                <option value="kto">KTO — binary preference</option>
+                <option value="grpo">GRPO — reward-model-free RL</option>
+                <option value="reward">Reward — train a reward model</option>
+                <option value="cpo">CPO — contrastive preference</option>
+              </select>
+              <span class="hint" id="tMethodHint">Trains on completions.</span>
+            </div>
+            <div class="tf">
+              <label for="tDataset">Dataset</label>
+              <input id="tDataset" name="dataset" required value="yahma/alpaca-cleaned"/>
+              <span class="hint">A Hugging Face dataset id.</span>
+            </div>
+            <div class="tf">
+              <label for="tSplit">Split</label>
+              <input id="tSplit" name="split_type" value="train"/>
+            </div>
+            <div class="tf">
+              <label for="tEpochs">Epochs</label>
+              <input id="tEpochs" name="num_train_epochs" type="number" min="0" step="0.1" value="1"/>
+            </div>
+            <div class="tf">
+              <label for="tSteps">Max steps</label>
+              <input id="tSteps" name="max_steps" type="number" min="0" step="1" value="60"/>
+              <span class="hint">0 runs the full epochs.</span>
+            </div>
+          </div>
+
+          <details class="tadv">
+            <summary>Advanced</summary>
+            <div class="tgrid">
+              <div class="tf">
+                <label for="tRank">LoRA rank</label>
+                <input id="tRank" name="lora_r" type="number" min="1" step="1" value="16"/>
+              </div>
+              <div class="tf">
+                <label for="tAlpha">LoRA alpha</label>
+                <input id="tAlpha" name="lora_alpha" type="number" min="1" step="1" value="16"/>
+              </div>
+              <div class="tf">
+                <label for="tLr">Learning rate</label>
+                <input id="tLr" name="learning_rate" value="2e-4"/>
+              </div>
+              <div class="tf">
+                <label for="tSeq">Max sequence length</label>
+                <input id="tSeq" name="max_seq_length" type="number" min="1" step="1" value="2048"/>
+              </div>
+              <div class="tf">
+                <label for="tBatch">Batch size per device</label>
+                <input id="tBatch" name="per_device_train_batch_size" type="number" min="1" step="1" value="2"/>
+              </div>
+              <div class="tf">
+                <label for="tAccum">Gradient accumulation</label>
+                <input id="tAccum" name="gradient_accumulation_steps" type="number" min="1" step="1" value="2"/>
+              </div>
+              <div class="tf">
+                <label for="tQuant">Load in 4-bit</label>
+                <select id="tQuant" name="load_in_4bit">
+                  <option value="true" selected>Yes — fits a consumer GPU</option>
+                  <option value="false">No — full precision</option>
+                </select>
+              </div>
+              <div class="tf">
+                <label for="tOut">Output directory</label>
+                <input id="tOut" name="output_dir" value="outputs"/>
+              </div>
+            </div>
+          </details>
+
+          <div class="trow">
+            <button class="tbtn" id="tStart" type="submit">Start training</button>
+            <button class="tbtn danger" id="tStop" type="button" hidden>Stop</button>
+            <span class="pill" id="tState" hidden></span>
+          </div>
+          <p class="tnote" id="tError" role="alert"></p>
+        </form>
+
+        <div class="tcard" id="tLive" hidden>
+          <div class="bar"><i id="tBar"></i></div>
+          <div class="tstats">
+            <span>Step <b id="tStep">—</b></span>
+            <span>Loss <b id="tLoss">—</b></span>
+            <span>Elapsed <b id="tElapsed">—</b></span>
+          </div>
+          <canvas id="loss" aria-label="Training loss over time" role="img"></canvas>
+          <div id="tlog" role="log" aria-live="off" aria-label="Training output"></div>
+        </div>
+
+        <div class="tcard" id="tHistoryCard" hidden>
+          <div class="sectlbl" style="padding:0 0 .3rem">Previous runs</div>
+          <div id="tHistory"></div>
+        </div>
+      </div>
+    </section>
   </main>
 </div>
 <div id="overlay"><div class="panel" id="panel"></div></div>
@@ -1090,6 +1274,11 @@ const st=await invoke('engine_status');
 if(st.state==='ready'){
   PORT=st.port; status.textContent=`engine :${PORT}`; status.className='s-ready';
   box.disabled=send.disabled=false; box.focus(); refreshChats(); refreshModelName();
+  // The training view may have been restored before the engine had a port, in
+  // which case its first refresh returned empty. Ask again now there is one,
+  // so a fine-tune started in an earlier session reappears rather than looking
+  // like it never happened.
+  if(typeof refreshTraining==='function') refreshTraining();
   try{ CFG={...DEFAULTS,...await (await fetch(
         `http://127.0.0.1:${PORT}/settings`)).json()}; }catch{}
   applyTheme(CFG.theme);
@@ -1821,4 +2010,277 @@ document.addEventListener('click',e=>{
 box.addEventListener('keydown',e=>{
   if(e.key==='Enter'&&!e.shiftKey){ e.preventDefault(); document.getElementById('f').requestSubmit(); }
 });
+
+/* --- training ------------------------------------------------------------
+ *
+ * A fine-tune runs for hours and must survive the window being closed, so the
+ * view holds no run state of its own: it asks the engine what is happening and
+ * renders that. Reconnecting is a read from a cursor, not a subscription, which
+ * is why closing the app mid-run and reopening it resumes the log rather than
+ * showing an empty pane next to a job that is still going.
+ */
+const trainView=document.getElementById('train'),
+      viewChat=document.getElementById('viewChat'),
+      viewTrain=document.getElementById('viewTrain'),
+      trainForm=document.getElementById('trainForm'),
+      tStart=document.getElementById('tStart'), tStop=document.getElementById('tStop'),
+      tState=document.getElementById('tState'), tError=document.getElementById('tError'),
+      tLive=document.getElementById('tLive'), tBar=document.getElementById('tBar'),
+      tStepEl=document.getElementById('tStep'), tLossEl=document.getElementById('tLoss'),
+      tElapsed=document.getElementById('tElapsed'), tlog=document.getElementById('tlog'),
+      tHistory=document.getElementById('tHistory'),
+      tHistoryCard=document.getElementById('tHistoryCard'),
+      lossCanvas=document.getElementById('loss');
+
+const METHOD_HINTS={
+  sft:'Trains on completions.', cpt:'Raw-text corpus; embeddings get their own rate.',
+  dpo:'Needs prompt, chosen and rejected columns.',
+  orpo:'Preference tuning without a reference model.',
+  kto:'Binary thumbs up or down per sample.',
+  grpo:'Needs reward functions; no reward model.',
+  reward:'Trains a reward model, not a chat model.',
+  cpo:'Contrastive preference; no reference model.'};
+
+let trainStream=null, trainCursor=-1, trainRunId=null, lossSeries=[], logLines=[];
+const MAX_LOG_LINES=600;   // the pane is a tail, not an archive; the log file has it all
+
+function showView(name){
+  const training=name==='train';
+  document.body.classList.toggle('training',training);
+  trainView.classList.toggle('on',training);
+  viewTrain.setAttribute('aria-selected',String(training));
+  viewChat.setAttribute('aria-selected',String(!training));
+  viewTrain.classList.toggle('active',training);
+  viewChat.classList.toggle('active',!training);
+  try{ localStorage.setItem('view',name); }catch(e){}
+  if(training) refreshTraining();
+}
+viewChat.addEventListener('click',()=>showView('chat'));
+viewTrain.addEventListener('click',()=>showView('train'));
+
+function setTrainState(state){
+  const live=state && !['done','failed','cancelled'].includes(state);
+  tState.hidden=!state;
+  tState.textContent=state||'';
+  tState.className='pill '+(state||'');
+  tStop.hidden=!live;
+  tStart.disabled=!!live;
+  tStart.textContent=live?'Training…':'Start training';
+}
+
+function trainConfig(){
+  const data=new FormData(trainForm), get=k=>String(data.get(k)||'').trim();
+  const num=(k,fallback)=>{ const v=parseFloat(get(k)); return Number.isFinite(v)?v:fallback; };
+  const config={
+    method:get('method'),
+    model_name:get('model_name'),
+    max_seq_length:num('max_seq_length',2048),
+    load_in_4bit:get('load_in_4bit')==='true',
+    lora_r:num('lora_r',16),
+    lora_alpha:num('lora_alpha',16),
+    num_train_epochs:num('num_train_epochs',1),
+    learning_rate:num('learning_rate',2e-4),
+    per_device_train_batch_size:num('per_device_train_batch_size',2),
+    gradient_accumulation_steps:num('gradient_accumulation_steps',2),
+    output_dir:get('output_dir')||'outputs',
+    // The trainer reads `dataset` as a list of sources, not a string. Sending a
+    // bare id here is the shape mismatch that would fail an hour into a run.
+    dataset:[{name:get('dataset'),split_type:get('split_type')||'train'}],
+    train:true, ollama_save:false, huggingface_save:false};
+  const steps=num('max_steps',0);
+  if(steps>0) config.max_steps=steps;   // omitted, not zero: 0 means "no cap"
+  return config;
+}
+
+function resetTrainDisplay(){
+  lossSeries=[]; logLines=[]; tlog.textContent=''; trainCursor=-1;
+  tBar.style.width='0'; tStepEl.textContent='—'; tLossEl.textContent='—';
+  tElapsed.textContent='—'; drawLoss();
+}
+
+trainForm.addEventListener('submit',async e=>{
+  e.preventDefault();
+  tError.textContent='';
+  const model=document.getElementById('tModel').value.trim();
+  const dataset=document.getElementById('tDataset').value.trim();
+  if(!model||!dataset){
+    tError.textContent='A base model and a dataset are both required.';
+    (model?document.getElementById('tDataset'):document.getElementById('tModel')).focus();
+    return;
+  }
+  tStart.disabled=true;
+  try{
+    const res=await fetch(`http://127.0.0.1:${PORT}/train/start`,{
+      method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({config:trainConfig()})});
+    const body=await res.json();
+    if(!res.ok){
+      // The engine's message names the run that is already going; showing our
+      // own wording instead would hide which job is blocking this one.
+      tError.textContent=body.error||`The engine refused the run (${res.status}).`;
+      tStart.disabled=false;
+      if(res.status===409) refreshTraining();
+      return;
+    }
+    resetTrainDisplay();
+    tLive.hidden=false;
+    trainRunId=body.run.id;
+    setTrainState(body.run.state);
+    follow(trainRunId);
+  }catch(err){
+    tError.textContent=`Could not reach the engine: ${err.message}`;
+    tStart.disabled=false;
+  }
+});
+
+tStop.addEventListener('click',async()=>{
+  tStop.disabled=true;
+  try{
+    const res=await fetch(`http://127.0.0.1:${PORT}/train/stop`,{
+      method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
+    if(!res.ok){ const b=await res.json(); tError.textContent=b.error||'Nothing was running.'; }
+  }catch(err){ tError.textContent=`Could not reach the engine: ${err.message}`; }
+  finally{ tStop.disabled=false; }
+});
+
+function follow(runId){
+  if(trainStream){ trainStream.close(); trainStream=null; }
+  const url=`http://127.0.0.1:${PORT}/train/progress?run=${encodeURIComponent(runId)}`
+          +`&cursor=${trainCursor}`;
+  const stream=new EventSource(url);
+  trainStream=stream;
+  const bump=d=>{ if(typeof d.cursor==='number') trainCursor=d.cursor; };
+  stream.addEventListener('resync',()=>{
+    // History was evicted mid-run. Say so rather than splicing a log with a
+    // hole in it and letting it read as continuous.
+    appendLog('… earlier output dropped; the full log is in the run directory.');
+    trainCursor=-1;
+  });
+  stream.addEventListener('start',e=>bump(JSON.parse(e.data)));
+  stream.addEventListener('state',e=>{ const d=JSON.parse(e.data); bump(d); setTrainState(d.state); });
+  stream.addEventListener('log',e=>{ const d=JSON.parse(e.data); bump(d); appendLog(d.line); });
+  stream.addEventListener('progress',e=>{
+    const d=JSON.parse(e.data); bump(d);
+    tStepEl.textContent=`${d.step} / ${d.total}`;
+    tBar.style.width=`${Math.min(100,(d.step/d.total)*100).toFixed(1)}%`;
+  });
+  stream.addEventListener('metric',e=>{
+    const d=JSON.parse(e.data); bump(d);
+    tLossEl.textContent=d.loss.toFixed(4);
+    lossSeries.push(d.loss); drawLoss();
+  });
+  stream.addEventListener('end',e=>{
+    const d=JSON.parse(e.data); bump(d);
+    setTrainState(d.state);
+    tElapsed.textContent=formatElapsed(d.elapsed);
+    if(d.error) tError.textContent=d.error;
+    if(d.state==='done') tBar.style.width='100%';
+    stream.close(); trainStream=null;
+    loadHistory();
+  });
+  stream.onerror=()=>{
+    // EventSource reconnects on its own, but it would reopen the original URL
+    // with the original cursor and replay everything. Close it and reconnect
+    // from where we actually are.
+    stream.close();
+    if(trainStream===stream){ trainStream=null; setTimeout(()=>follow(runId),1500); }
+  };
+}
+
+function appendLog(line){
+  logLines.push(line);
+  if(logLines.length>MAX_LOG_LINES) logLines=logLines.slice(-MAX_LOG_LINES);
+  const pinned=tlog.scrollTop+tlog.clientHeight>=tlog.scrollHeight-24;
+  tlog.textContent=logLines.join('\n');
+  if(pinned) tlog.scrollTop=tlog.scrollHeight;   // only follow if already following
+}
+
+function formatElapsed(seconds){
+  if(!Number.isFinite(seconds)) return '—';
+  const s=Math.round(seconds), h=Math.floor(s/3600), m=Math.floor(s%3600/60);
+  return h?`${h}h ${m}m`:m?`${m}m ${s%60}s`:`${s}s`;
+}
+
+function drawLoss(){
+  const ctx=lossCanvas.getContext('2d');
+  const ratio=window.devicePixelRatio||1;
+  const w=lossCanvas.clientWidth, h=lossCanvas.clientHeight;
+  if(!w||!h) return;
+  lossCanvas.width=w*ratio; lossCanvas.height=h*ratio;
+  ctx.setTransform(ratio,0,0,ratio,0,0);
+  ctx.clearRect(0,0,w,h);
+  if(lossSeries.length<2) return;
+  const css=getComputedStyle(document.documentElement);
+  const accent=css.getPropertyValue('--accent').trim()||'#7FD1B9';
+  const rule=css.getPropertyValue('--rule').trim()||'#262B33';
+  const lo=Math.min(...lossSeries), hi=Math.max(...lossSeries);
+  const span=(hi-lo)||1, pad=6;
+  const x=i=>pad+(i/(lossSeries.length-1))*(w-pad*2);
+  const y=v=>h-pad-((v-lo)/span)*(h-pad*2);
+  ctx.strokeStyle=rule; ctx.lineWidth=1;
+  ctx.beginPath(); ctx.moveTo(pad,h-pad); ctx.lineTo(w-pad,h-pad); ctx.stroke();
+  ctx.strokeStyle=accent; ctx.lineWidth=1.5; ctx.beginPath();
+  lossSeries.forEach((v,i)=>i?ctx.lineTo(x(i),y(v)):ctx.moveTo(x(i),y(v)));
+  ctx.stroke();
+  ctx.fillStyle=accent;
+  ctx.beginPath(); ctx.arc(x(lossSeries.length-1),y(lossSeries[lossSeries.length-1]),2.5,0,Math.PI*2); ctx.fill();
+}
+window.addEventListener('resize',()=>{ if(trainView.classList.contains('on')) drawLoss(); });
+
+async function loadHistory(){
+  try{
+    const {runs}=await (await fetch(`http://127.0.0.1:${PORT}/train/runs`)).json();
+    tHistoryCard.hidden=!runs.length;
+    tHistory.textContent='';
+    runs.forEach(run=>{
+      const row=document.createElement('div'); row.className='trun';
+      const pill=document.createElement('span');
+      pill.className='pill '+run.state; pill.textContent=run.state;
+      const id=document.createElement('span'); id.className='rid'; id.textContent=run.id;
+      const grow=document.createElement('span'); grow.className='grow';
+      const meta=document.createElement('span');
+      meta.style.color='var(--soft)'; meta.style.fontSize='.72rem';
+      meta.textContent=[run.last_loss!=null?`loss ${run.last_loss.toFixed(4)}`:null,
+                        formatElapsed(run.elapsed)].filter(Boolean).join(' · ');
+      row.append(pill,id,grow,meta);
+      if(run.error){ row.title=run.error; }
+      tHistory.appendChild(row);
+    });
+  }catch(e){ /* the history is a convenience; a failure here must not block training */ }
+}
+
+async function refreshTraining(){
+  if(!PORT) return;
+  try{
+    const {run,metrics}=await (await fetch(`http://127.0.0.1:${PORT}/train/status`)).json();
+    loadHistory();
+    if(!run){ setTrainState(null); return; }
+    // Reattach to whatever the engine is doing, including a run started before
+    // this window existed.
+    if(run.id!==trainRunId){ resetTrainDisplay(); trainRunId=run.id; }
+    tLive.hidden=false;
+    setTrainState(run.state);
+    if(run.total){ tStepEl.textContent=`${run.step} / ${run.total}`;
+      tBar.style.width=`${Math.min(100,(run.step/run.total)*100).toFixed(1)}%`; }
+    if(metrics&&metrics.length){
+      lossSeries=metrics.map(m=>m.loss);
+      tLossEl.textContent=lossSeries[lossSeries.length-1].toFixed(4);
+      drawLoss();
+    }
+    tElapsed.textContent=formatElapsed(run.elapsed);
+    if(run.error) tError.textContent=run.error;
+    if(!['done','failed','cancelled'].includes(run.state)) follow(run.id);
+  }catch(e){ /* the engine may still be booting; the next visit retries */ }
+}
+
+document.getElementById('tMethod').addEventListener('change',e=>{
+  document.getElementById('tMethodHint').textContent=METHOD_HINTS[e.target.value]||'';
+});
+
+// Always go through showView, including for the default: it is what sets the
+// selected state on the nav, and skipping it for 'chat' left neither tab
+// looking selected on first launch.
+let startView='chat';
+try{ if(localStorage.getItem('view')==='train') startView='train'; }catch(e){}
+showView(startView);
 </script></body></html>


### PR DESCRIPTION
The desktop app could talk to a model but not make one, while `praisonai-train` sat behind it doing exactly that. This wires the two together: a **Train** tab beside Chat, a job model in the engine, and five HTTP routes.

## Why a subsystem and not a route

The engine is a `ThreadingHTTPServer` where every request is a turn that starts, streams and ends. That is right for chat and wrong for something that runs for hours, must survive the window closing, and has to resume after a reconnect.

- **One run at a time.** Two fine-tunes on one GPU do not co-exist; they OOM. A second start returns `409` naming the run already going, rather than queueing — a queue implies a scheduler nobody asked for.
- **Progress is a replayable ring buffer, not a stream.** Reconnecting reads from a cursor, so a closed lid loses nothing. If history was evicted the client is told to *resync* rather than handed a log with a hole in it.
- **The subprocess owns the truth.** Status is derived from the process and its log, never from what the client last heard, so a client that missed the ending still learns how it ended.

## Three defects the tests caught before they shipped

| Defect | Consequence had it shipped |
|---|---|
| The event cursor was `len(self.events)` | Once eviction begins the length stops growing, every later event gets the same cursor, and `since()` returns nothing forever — a live run whose UI silently stops updating |
| `run_id` came from the client and became a directory name | The engine is loopback-with-no-auth *by design*, so any local process could post `../../../Library/LaunchAgents/x` |
| `stop()` signalled the process group without checking whose it was | Removing `start_new_session` makes the test runner **kill itself** — proving the engine would have died with the run it stopped |

## Portable from the start

Windows and Linux builds are next, so the engine-side portability is done here rather than retrofitted:

- the pipe is decoded as UTF-8, not the locale encoding — cp1252 turns unsloth's banner into mojibake, and five of its bytes raise *inside* the reader loop, freezing the log and the loss chart while the run carries on to completion
- `PRAISONAI_TRAIN_CMD` is split with Windows rules on Windows, where POSIX splitting eats every backslash in an interpreter path
- the child gets `CREATE_NEW_PROCESS_GROUP` there, because CPython accepts `start_new_session` on Windows and then ignores it — the parameter is literally named `unused_start_new_session` in its Windows `_execute_child`
- run ids reject reserved device names (`CON`, `LPT1`, …), which an alphanumeric allowlist cannot see

## Tests

| Suite | Count |
|---|---|
| `engine/test_training.py` — unit, real subprocesses, real SIGTERM | 42 |
| `engine/test_train_routes.py` — end-to-end against a real spawned engine | 10 |
| `frontend/tests/training.test.mjs` — the real page in a DOM | 16 |
| existing desktop suite, unchanged | 134 |

**Mutation-tested:** all 9 mutations of the engine's guarantees are caught, and all 7 of the UI's. Nothing asserts on source text; every test presses something or drives a real event.

Two mutations are caught so emphatically they kill the test runner — removing `start_new_session`, or removing the own-group guard, makes `killpg` signal the harness's own process group. That is the defect being demonstrated, not a flaky test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local fine-tuning workspace with Chat/Train navigation.
  * Configure models, datasets, training methods, optimization, LoRA, quantization, and output settings.
  * Start, monitor, reconnect to, and stop training runs.
  * View live progress, metrics, logs, errors, loss charts, and run history.
  * Added validation, cancellation handling, and recovery for interrupted or concurrent runs.
* **Bug Fixes**
  * Improved configuration handling for dataset lists and unlimited training steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->