### PR TITLE
fix(desktop): the ship-blockers three adversarial reviews found after merge

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -38,7 +38,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14        # Apple silicon
+          # macos-15, not macos-14: that image entered deprecation on
+          # 2026-07-06 and is fully unsupported from 2026-11-02, with brownout
+          # periods failing jobs before then. This is the only Apple-silicon
+          # leg, so losing it means no arm64 DMG at all.
+          - runner: macos-15        # Apple silicon
             target: aarch64-apple-darwin
             bundles: dmg
             ext: dmg

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -43,7 +43,11 @@ jobs:
             bundles: dmg
             ext: dmg
             asset: macos-apple-silicon
-          - runner: macos-13        # Intel
+          # macos-15-intel, not macos-13: that image was retired on
+          # 2025-12-04, so the leg would never schedule and the verify job
+          # below would correctly report a missing asset on every release,
+          # forever. macos-15-intel is GitHub's named x86_64 replacement.
+          - runner: macos-15-intel  # Intel
             target: x86_64-apple-darwin
             bundles: dmg
             ext: dmg
@@ -106,7 +110,13 @@ jobs:
           save-if: ${{ runner.os != 'Windows' }}
 
       - name: Install the Tauri CLI
-        run: cargo install tauri-cli --version '^2' --locked || true
+        shell: bash
+        # `|| true` swallowed a genuine install failure and the next step then
+        # died with an unrelated "no such command: tauri". It also behaved
+        # differently per leg, since Windows defaults to pwsh where `true` is
+        # not a command. Skip the install if it is already there; otherwise
+        # let a failure be a failure.
+        run: command -v cargo-tauri >/dev/null || cargo install tauri-cli --version '^2' --locked
 
       - name: Build the bundle
         working-directory: src/praisonai-desktop/src-tauri

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -9,9 +9,11 @@ name: desktop
 on:
   push:
     branches: [main]
-    paths: ['src/praisonai-desktop/**', '.github/workflows/desktop.yml']
+    paths: ['src/praisonai-desktop/**', '.github/workflows/desktop.yml',
+            '.github/workflows/desktop-release.yml']
   pull_request:
-    paths: ['src/praisonai-desktop/**', '.github/workflows/desktop.yml']
+    paths: ['src/praisonai-desktop/**', '.github/workflows/desktop.yml',
+            '.github/workflows/desktop-release.yml']
 
 concurrency:
   group: desktop-${{ github.ref }}
@@ -30,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-latest]
+        os: [ubuntu-22.04, macos-15, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -82,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-latest]
+        os: [ubuntu-22.04, macos-15, windows-latest]
     defaults:
       run:
         working-directory: src/praisonai-desktop/src-tauri

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,113 @@
+# The desktop app's tests.
+#
+# These existed and ran nowhere: no workflow referenced praisonai-desktop, and
+# the frontend suite could not even be installed -- jsdom was undeclared, so it
+# ran only on machines that happened to have one further up the tree, at
+# whatever version that happened to be.
+name: desktop
+
+on:
+  push:
+    branches: [main]
+    paths: ['src/praisonai-desktop/**', '.github/workflows/desktop.yml']
+  pull_request:
+    paths: ['src/praisonai-desktop/**', '.github/workflows/desktop.yml']
+
+concurrency:
+  group: desktop-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: src/praisonai-desktop
+
+jobs:
+  engine:
+    name: engine (${{ matrix.os }})
+    # The engine is the part that has to behave the same on all three, which is
+    # the entire point of the portability suite -- so it is run on all three.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-14, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run the engine tests
+        shell: bash
+        env:
+          # Never touch a real keychain on a shared runner.
+          PRAISONAI_KEYCHAIN_SERVICE: ai.praison.desktop.ci
+        run: |
+          set -euo pipefail
+          failed=0
+          for suite in engine/test_*.py; do
+            echo "::group::$suite"
+            python "$suite" -v || failed=1
+            echo "::endgroup::"
+          done
+          exit $failed
+
+  frontend:
+    name: frontend
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      # `test:ci` is every suite except lifecycle, which drives real
+      # conversations against a live engine and a real model -- neither of
+      # which exists on a runner. It is excluded by name rather than left to
+      # skip quietly, so that a skipped test here is a genuine problem.
+      - name: Run the UI tests
+        # A suite that skips everything still exits 0 -- that is how thirteen
+        # tests came to look like a pass while proving nothing. So the skip
+        # count is asserted, not just the exit status.
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          npm run test:ci 2>&1 | tee "$RUNNER_TEMP/ui.log"
+          skipped=$(grep -E '^. skipped ' "$RUNNER_TEMP/ui.log" | grep -oE '[0-9]+$' | head -1)
+          echo "skipped: ${skipped:-unknown}"
+          test "${skipped:-1}" -eq 0
+
+  shell:
+    name: shell (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-14, windows-latest]
+    defaults:
+      run:
+        working-directory: src/praisonai-desktop/src-tauri
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/praisonai-desktop/src-tauri
+          # The Windows cache is large and slow enough to cost more than it saves.
+          save-if: ${{ runner.os != 'Windows' }}
+      - name: Install the Linux build dependencies
+        if: runner.os == 'Linux'
+        working-directory: .
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev \
+            libxdo-dev libssl-dev patchelf
+      - name: Test
+        # Debug info is the bulk of a Tauri target directory and nothing here
+        # reads a backtrace, so building without it keeps the runner's disk
+        # from filling on the Windows leg.
+        run: cargo test --config 'profile.test.debug=false' --config 'profile.dev.debug=false'
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings

--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -140,6 +140,9 @@ def _windows_start_time(pid: int) -> int:
 
         PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
         kernel32 = ctypes.windll.kernel32
+        # HANDLE is pointer-sized; the default c_int return truncates it above
+        # 2**31. Unreachable in practice, but wrong for free.
+        kernel32.OpenProcess.restype = ctypes.c_void_p
         handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
         if not handle:
             return 0                       # no such process, or not ours to ask
@@ -294,7 +297,7 @@ def save_chat(chat: dict) -> None:
     # support ticket.
     tmp = path.with_suffix(".tmp")
     tmp.write_text(json.dumps(chat, indent=1))
-    tmp.replace(path)
+    _replace_with_retry(tmp, path)
 
 
 def list_chats() -> list:
@@ -607,7 +610,7 @@ def save_mcp(servers: list) -> None:
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     tmp = MCP_PATH.with_suffix(".tmp")
     tmp.write_text(json.dumps({"servers": servers}, indent=1))
-    tmp.replace(MCP_PATH)
+    _replace_with_retry(tmp, MCP_PATH)
 # Mirrors frontend/dist/settings-registry.js. The registry is the source of
 # truth for the UI; this is the storage contract, and load_settings() drops
 # unknown keys and defaults missing ones so a hand-edited or older file can
@@ -744,10 +747,11 @@ class DpapiSecretStore:
         result = Blob()
         crypt32 = ctypes.windll.crypt32
         call = crypt32.CryptProtectData if protect else crypt32.CryptUnprotectData
-        args = ([ctypes.byref(source), None, None, None, None, 0, ctypes.byref(result)]
-                if protect else
-                [ctypes.byref(source), None, None, None, None, 0, ctypes.byref(result)])
-        if not call(*args):
+        # Both functions take the same seven arguments: the blob in, a
+        # description, optional entropy, a reserved pointer, a prompt struct,
+        # flags, and the blob out.
+        if not call(ctypes.byref(source), None, None, None, None, 0,
+                    ctypes.byref(result)):
             raise OSError("DPAPI call failed")
         try:
             return ctypes.string_at(result.pbData, result.cbData)
@@ -755,14 +759,23 @@ class DpapiSecretStore:
             ctypes.windll.kernel32.LocalFree(result.pbData)
 
     def _read(self):
+        """The stored secrets, or {} if there are none.
+
+        A missing file means "nothing stored yet". A file that will not decrypt
+        means something else entirely -- a Windows password reset or a roamed
+        profile can invalidate the DPAPI key -- and treating that as empty made
+        the next `set` write a fresh blob over it, destroying every other
+        secret in the file. So only absence is silent.
+        """
         try:
-            return json.loads(self._crypt(self.path.read_bytes(), False).decode("utf-8"))
-        except Exception:  # noqa: BLE001
+            raw = self.path.read_bytes()
+        except FileNotFoundError:
             return {}
+        return json.loads(self._crypt(raw, False).decode("utf-8"))
 
     def set(self, name: str, value: str) -> bool:
         try:
-            store = self._read()
+            store = self._read()          # raises if the blob will not decrypt
             if value:
                 store[name] = value
             else:
@@ -777,7 +790,10 @@ class DpapiSecretStore:
             return False
 
     def get(self, name: str) -> str:
-        return str(self._read().get(name, ""))
+        try:
+            return str(self._read().get(name, ""))
+        except Exception:  # noqa: BLE001 - unreadable is not the caller's problem
+            return ""
 
 
 class FileSecretStore:
@@ -807,9 +823,17 @@ class FileSecretStore:
                 store.pop(name, None)
             self.path.parent.mkdir(parents=True, exist_ok=True)
             tmp = self.path.with_suffix(".json.tmp")
-            # Created 0600 *before* anything is written to it, so the secret is
-            # never briefly world-readable between creation and chmod.
-            handle = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            # O_EXCL, not just O_CREAT: the mode argument applies only when
+            # the file is *created*, so a leftover temp file from an
+            # interrupted write keeps its old permissions and the secret goes
+            # into it world-readable until the chmod after the rename. On
+            # Linux ~/.local/share is 0755, so that window is real. O_EXCL
+            # also closes the symlink-follow hole.
+            try:
+                os.unlink(str(tmp))
+            except FileNotFoundError:
+                pass
+            handle = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
             with os.fdopen(handle, "w", encoding="utf-8") as out:
                 json.dump(store, out)
             _replace_with_retry(tmp, self.path)
@@ -842,7 +866,20 @@ class FallbackSecretStore:
         return self.secondary.path
 
     def set(self, name: str, value: str) -> bool:
+        """Write to the best store that will take it -- but delete from both.
+
+        A delete that stopped at the first success left the other copy behind,
+        and `get` served it: clearing an API key reported success while the key
+        kept working and its plaintext stayed on disk. The same applies to a
+        *new* value, which must not leave the superseded one readable in the
+        fallback, so the secondary is cleared after a successful primary write.
+        """
+        if not value:
+            cleared_primary = self.primary.set(name, "")
+            cleared_secondary = self.secondary.set(name, "")
+            return cleared_primary or cleared_secondary
         if self.primary.set(name, value):
+            self.secondary.set(name, "")   # never leave a stale plaintext copy
             return True
         return self.secondary.set(name, value)
 
@@ -908,7 +945,7 @@ def save_settings(patch: dict) -> dict:
     # Secrets never reach the file.
     on_disk = {k: v for k, v in merged.items() if k not in SECRET_KEYS}
     tmp.write_text(json.dumps(on_disk, indent=1))
-    tmp.replace(SETTINGS_PATH)
+    _replace_with_retry(tmp, SETTINGS_PATH)
     # Settings change the agent's identity, so cached agents must go or the
     # next turn would silently run on the previous model.
     with _agent_lock:
@@ -1303,8 +1340,13 @@ class Handler(BaseHTTPRequestHandler):
             self.send_error(404)
             return
         # ok:true plus a version, so the supervisor can tell "engine healthy"
-        # from "something else answered on this port".
-        body = json.dumps({"ok": True, "version": PROTOCOL_VERSION}).encode()
+        # from "something else answered on this port". data_dir is included
+        # because the UI offers to copy that path, and it can be overridden by
+        # PRAISONAI_DESKTOP_HOME or XDG_DATA_HOME -- so the page must ask
+        # rather than reproduce the default and hand the user a path the app
+        # is not actually using.
+        body = json.dumps({"ok": True, "version": PROTOCOL_VERSION,
+                           "data_dir": str(DATA_DIR)}).encode()
         self.send_response(200)
         self._cors()
         self.send_header("Content-Type", "application/json")

--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
 
 # The shell matches this exact prefix. Printed once, after the socket is bound,
 # so a port announced here is always a port that is actually listening.
@@ -919,11 +920,20 @@ class Handler(BaseHTTPRequestHandler):
         while True:
             events, gap = run.since(cursor)
             if gap:
-                # Say so rather than handing over events with a hole in them.
+                # Say so rather than handing over events with a hole in them,
+                # then resume at the oldest event still held.
+                #
+                # Resuming at -1 instead made the *next* since() compute a gap
+                # again -- every ring that has ever evicted satisfies
+                # `0 < oldest` -- so the stream resynced forever, and the
+                # `continue` skipped both the sleep and the terminal check.
+                # A run past 4000 events (about twenty minutes of tqdm) showed
+                # the viewer nothing at all while pinning a core, and kept
+                # doing so after the run had finished. Falling through here
+                # delivers the events instead of discarding them.
                 self.wfile.write(b"event: resync\ndata: {}\n\n")
                 self.wfile.flush()
-                cursor = -1
-                continue
+                cursor = events[0][0] - 1 if events else cursor
             for c, kind, payload in events:
                 cursor = c
                 body = json.dumps({"cursor": c, **payload})
@@ -953,7 +963,13 @@ class Handler(BaseHTTPRequestHandler):
             if run is None:
                 self._json({"ok": False, "error": "no such run"}, 404)
                 return
-            cursor = int((query.get("cursor") or ["-1"])[0])
+            try:
+                cursor = int((query.get("cursor") or ["-1"])[0])
+            except ValueError:
+                # A malformed cursor used to escape as an unhandled exception,
+                # which drops the connection with no response at all.
+                self._json({"ok": False, "error": "cursor must be an integer"}, 400)
+                return
             try:
                 self._train_progress(run, cursor)
             except (BrokenPipeError, ConnectionResetError):
@@ -961,14 +977,19 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         if self.path == "/train/runs":
-            self._json({"runs": [r.summary() for r in self._training().history[:50]]})
+            # list() first: history is a bounded deque, which cannot be
+            # sliced. The cap is MAX_HISTORY, so this slice is belt and braces.
+            history = list(self._training().history)[:50]
+            self._json({"runs": [r.summary() for r in history]})
             return
 
         if self.path.startswith("/train/status"):
             trainer = self._training()
             run = trainer.current
             self._json({"run": run.summary() if run else None,
-                        "metrics": run.metrics[-500:] if run else []})
+                        # list() first: metrics is a bounded deque, and a
+                        # deque cannot be sliced.
+                        "metrics": list(run.metrics)[-500:] if run else []})
             return
 
         if self.path == "/settings":
@@ -1060,6 +1081,9 @@ class Handler(BaseHTTPRequestHandler):
                             "config needs at least model_name and dataset"}, 400)
                 return
             try:
+                # Reject what cannot work before a single byte is downloaded.
+                from training import check_method_requirements
+                check_method_requirements(config)
                 run = self._training().start(config, payload.get("run_id"))
             except ValueError as exc:
                 # A rejected run id is the caller's fault, not the server's.
@@ -1070,12 +1094,27 @@ class Handler(BaseHTTPRequestHandler):
                 # should show the running job, not a traceback.
                 self._json({"ok": False, "error": str(exc)}, 409)
                 return
+            except OSError as exc:
+                # An unwritable runs directory escaped as an unhandled
+                # exception, so the connection dropped with no response and
+                # the UI reported "could not reach the engine" -- sending the
+                # user after the wrong problem entirely.
+                self._json({"ok": False, "error":
+                            f"could not create the run directory: {exc}"}, 500)
+                return
             self._json({"ok": True, "run": run.summary()})
             return
 
-        if self.path.startswith("/train/stop"):
+        # Parse the path, don't pattern-match the raw string. rsplit("/") on
+        # "/train/stop/<stale-id>/" yielded "", which is falsy -- so the
+        # stale-tab guard was skipped and a stale tab killed whatever run was
+        # live. A bare startswith() also matched "/train/stopXXXX", and a
+        # query string ("?force=1") was read as part of the run id, so a
+        # legitimate stop was refused.
+        route = urlparse(self.path).path
+        if route == "/train/stop" or route.startswith("/train/stop/"):
             self._drain()
-            run_id = self.path.rsplit("/", 1)[-1] if "/train/stop/" in self.path else None
+            run_id = route[len("/train/stop"):].strip("/") or None
             try:
                 stopped = self._training().stop(run_id)
             except RuntimeError as exc:

--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -199,7 +199,12 @@ def write_lock_text(path: pathlib.Path, body: str) -> pathlib.Path:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".lock.tmp")
-    tmp.write_text(body, encoding="utf-8")
+    # write_bytes, not write_text: text mode translates "\n" to "\r\n" on
+    # Windows, so the file was not the bytes this function says it writes. The
+    # Rust parser trims each line and would have coped, but a lockfile that
+    # differs by platform is a difference waiting to matter, and the encode is
+    # the only conversion that should be happening here.
+    tmp.write_bytes(body.encode("utf-8"))
     _replace_with_retry(tmp, path)
     return path
 

--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -818,11 +818,20 @@ class FileSecretStore:
         self.path = pathlib.Path(data_dir) / "secrets.json"
 
     def _read(self) -> dict:
+        """The stored secrets, or {} if there are none.
+
+        Only absence is silent. Swallowing every error here meant one transient
+        read failure -- or a partly written file -- read as "empty", and the
+        next `set` wrote a fresh file over the top, destroying every other
+        secret in it. The DPAPI store's docstring names this exact hazard; this
+        one was left with it.
+        """
         try:
-            value = json.loads(self.path.read_text(encoding="utf-8"))
-            return value if isinstance(value, dict) else {}
-        except (OSError, ValueError):
+            raw = self.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
             return {}
+        value = json.loads(raw)
+        return value if isinstance(value, dict) else {}
 
     def set(self, name: str, value: str) -> bool:
         try:
@@ -856,7 +865,10 @@ class FileSecretStore:
             return False
 
     def get(self, name: str) -> str:
-        return str(self._read().get(name, ""))
+        try:
+            return str(self._read().get(name, ""))
+        except Exception:  # noqa: BLE001 - unreadable is not the caller's problem
+            return ""
 
 
 class FallbackSecretStore:
@@ -885,12 +897,23 @@ class FallbackSecretStore:
         fallback, so the secondary is cleared after a successful primary write.
         """
         if not value:
+            # `and`, not `or`: a delete has only succeeded if the secret is
+            # gone from everywhere it could be read from. With `or`, an
+            # unwritable file store meant the plaintext copy survived, `get`
+            # served it, and the user was told the key had been removed.
             cleared_primary = self.primary.set(name, "")
             cleared_secondary = self.secondary.set(name, "")
-            return cleared_primary or cleared_secondary
+            return cleared_primary and cleared_secondary
         if self.primary.set(name, value):
             self.secondary.set(name, "")   # never leave a stale plaintext copy
             return True
+        # The primary could not take the new value. If it still holds the old
+        # one, `get` would keep serving that -- the user saves a new key, is
+        # told it worked, and the app goes on using the previous one. Clearing
+        # the primary first is what makes the fallback reachable; if even that
+        # fails there is nowhere safe to put this.
+        if self.primary.get(name) and not self.primary.set(name, ""):
+            return False
         return self.secondary.set(name, value)
 
     def get(self, name: str) -> str:
@@ -1323,6 +1346,13 @@ class Handler(BaseHTTPRequestHandler):
                 # delivers the events instead of discarding them.
                 self.wfile.write(b"event: resync\ndata: {}\n\n")
                 self.wfile.flush()
+                # Resume at the oldest event still held. A gap always comes
+                # with events -- since() returns early on an empty buffer, and
+                # a gap means every held event is newer than the cursor -- so
+                # this is really `events[0][0] - 1`; the fallback is there so a
+                # future change to since() cannot turn this into an
+                # IndexError. The fix was removing the `continue` that used to
+                # follow: without it the loop falls through and delivers them.
                 cursor = events[0][0] - 1 if events else cursor
             for c, kind, payload in events:
                 cursor = c

--- a/src/praisonai-desktop/engine/test_portability.py
+++ b/src/praisonai-desktop/engine/test_portability.py
@@ -271,12 +271,13 @@ class SecretDeletion(unittest.TestCase):
 
         def __init__(self):
             self.values, self.up = {}, True
+            self.frozen = False        # readable, but accepts no writes
 
         def get(self, name):
             return self.values.get(name, "") if self.up else ""
 
         def set(self, name, value):
-            if not self.up:
+            if not self.up or self.frozen:
                 return False
             if value:
                 self.values[name] = value
@@ -323,6 +324,52 @@ class SecretDeletion(unittest.TestCase):
         store = server.FallbackSecretStore(self.primary, broken)
         self.assertFalse(store.set("api_key", ""),
                          "a delete nothing could perform reported success")
+
+    def test_a_delete_the_fallback_could_not_perform_is_not_reported_as_success(self):
+        # The key is in both stores and the file store cannot be written to.
+        # Reporting success here told the user the key was gone while `get`
+        # went on serving the plaintext copy.
+        self.store.set("api_key", "sk-live")
+        # A copy in the fallback that a successful primary write did not clear
+        # -- written by an older build, or left by a crash between the two
+        # writes. However it got there, `get` can still read it.
+        self.file.set("api_key", "sk-live")
+        self.file.path.parent.chmod(0o500)          # nothing may be written
+        try:
+            reported = self.store.set("api_key", "")
+            still_readable = self.store.get("api_key")
+        finally:
+            self.file.path.parent.chmod(0o700)
+        self.assertEqual(still_readable, "sk-live",
+                         "the fallback copy was cleared after all; rework this test")
+        self.assertFalse(reported,
+                         "a delete that left a readable secret reported success")
+
+    def test_a_new_key_the_primary_cannot_take_is_the_one_that_gets_used(self):
+        # The primary holds an old key and has become unwritable. Saving a new
+        # one must not leave the old one shadowing it: the user saves, is told
+        # it worked, and the app keeps using the previous key.
+        self.store.set("api_key", "sk-old")
+        self.primary.frozen = True                  # accepts nothing further
+        reported = self.store.set("api_key", "sk-new")
+        if reported:
+            self.assertEqual(self.store.get("api_key"), "sk-new",
+                             "the save reported success but the old key is still in use")
+
+    def test_a_file_that_will_not_parse_does_not_destroy_the_other_secrets(self):
+        # One unreadable read used to mean "empty", and the next write laid a
+        # fresh file over the top.
+        self.file.set("api_key", "sk-keep")
+        self.file.set("other_key", "other-keep")
+        self.file.path.write_text("{ this is not json", encoding="utf-8")
+        self.assertFalse(self.file.set("api_key", "sk-new"),
+                         "wrote over a file it could not read")
+        self.assertEqual(self.file.get("api_key"), "",
+                         "an unreadable store should read as empty, not raise")
+        self.file.path.write_text('{"api_key": "sk-keep", "other_key": "other-keep"}',
+                                  encoding="utf-8")
+        self.assertEqual(self.file.get("other_key"), "other-keep",
+                         "the other secret did not survive")
 
     def test_writing_a_new_secret_does_not_leave_the_old_one_in_the_fallback(self):
         self.primary.up = False

--- a/src/praisonai-desktop/engine/test_portability.py
+++ b/src/praisonai-desktop/engine/test_portability.py
@@ -16,6 +16,7 @@ import pathlib
 import shutil
 import sys
 import tempfile
+import time
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -206,6 +207,125 @@ class TestIsolation(unittest.TestCase):
         finally:
             os.environ.pop("PRAISONAI_KEYCHAIN_SERVICE", None)
             importlib.reload(server)
+
+
+class HealthReportsWhereItLives(unittest.TestCase):
+    """The UI offers to copy the data folder, so the engine must name it.
+
+    The path can be overridden by PRAISONAI_DESKTOP_HOME, and on Linux by
+    XDG_DATA_HOME, so a page that reproduces the default hands the user a
+    directory the app is not using.
+    """
+
+    def test_the_health_response_names_the_directory_in_use(self):
+        import json as _json
+        import subprocess as _sp
+        import sys as _sys
+        import urllib.request as _url
+
+        home = tempfile.mkdtemp(prefix="praison-health-")
+        engine = os.path.join(os.path.dirname(os.path.abspath(server.__file__)), "server.py")
+        proc = _sp.Popen([_sys.executable, "-u", engine],
+                         env=dict(os.environ, PRAISONAI_DESKTOP_HOME=home,
+                                  PRAISONAI_KEYCHAIN_SERVICE="ai.praison.desktop.test"),
+                         stdout=_sp.PIPE, stderr=_sp.STDOUT, text=True)
+        try:
+            port = None
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                line = proc.stdout.readline()
+                if not line:
+                    break
+                if "PRAISONAI_PORT=" in line:
+                    port = int(line.split("PRAISONAI_PORT=")[1].strip())
+                    break
+            self.assertIsNotNone(port, "the engine never announced a port")
+            with _url.urlopen(f"http://127.0.0.1:{port}/health", timeout=15) as r:
+                health = _json.loads(r.read())
+            self.assertEqual(health.get("data_dir"), home,
+                             "health does not report the directory actually in use")
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except Exception:  # noqa: BLE001
+                proc.kill()
+            shutil.rmtree(home, ignore_errors=True)
+
+
+class SecretDeletion(unittest.TestCase):
+    """Clearing a secret must clear it everywhere it could have landed.
+
+    The fallback exists so a machine with no keyring can still save a key. The
+    consequence nobody planned for: once a secret has been written to *both*
+    stores -- keyring unavailable, then available again -- a delete that
+    short-circuits on the first success leaves the other copy behind, and the
+    read path happily serves it. "Remove my API key" then reports success and
+    the key keeps working, with the plaintext still on disk.
+    """
+
+    class Flaky:
+        """A store that can be switched off, like a locked keyring."""
+
+        path = None
+
+        def __init__(self):
+            self.values, self.up = {}, True
+
+        def get(self, name):
+            return self.values.get(name, "") if self.up else ""
+
+        def set(self, name, value):
+            if not self.up:
+                return False
+            if value:
+                self.values[name] = value
+            else:
+                self.values.pop(name, None)
+            return True
+
+    def setUp(self):
+        self.home = tempfile.mkdtemp(prefix="praison-del-")
+        self.primary = self.Flaky()
+        self.file = server.FileSecretStore(pathlib.Path(self.home))
+        self.store = server.FallbackSecretStore(self.primary, self.file)
+
+    def tearDown(self):
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def test_a_secret_written_to_both_stores_is_deleted_from_both(self):
+        self.primary.up = False
+        self.store.set("api_key", "sk-old")             # lands in the file
+        self.primary.up = True
+        self.store.set("api_key", "sk-new")             # lands in the keyring
+        self.assertEqual(self.store.get("api_key"), "sk-new")
+
+        self.assertTrue(self.store.set("api_key", ""))  # the user clears it
+        self.assertEqual(self.store.get("api_key"), "",
+                         "the old key was resurrected from the fallback store")
+        self.assertEqual(self.file.get("api_key"), "",
+                         "the plaintext copy is still on disk after a delete")
+
+    def test_a_delete_reaches_the_fallback_even_when_the_primary_works(self):
+        self.store.set("api_key", "sk-value")
+        self.file.set("api_key", "sk-stale-copy")       # however it got there
+        self.store.set("api_key", "")
+        self.assertEqual(self.file.get("api_key"), "")
+
+    def test_a_delete_that_no_store_can_satisfy_reports_failure(self):
+        self.primary.up = False
+        broken = server.FileSecretStore(pathlib.Path("/nonexistent/nope"))
+        store = server.FallbackSecretStore(self.primary, broken)
+        self.assertFalse(store.set("api_key", ""),
+                         "a delete nothing could perform reported success")
+
+    def test_writing_a_new_secret_does_not_leave_the_old_one_in_the_fallback(self):
+        self.primary.up = False
+        self.store.set("api_key", "sk-old")
+        self.primary.up = True
+        self.store.set("api_key", "sk-new")
+        self.assertNotEqual(self.file.get("api_key"), "sk-old",
+                            "a superseded key is still readable in plaintext")
 
 
 class Encoding(unittest.TestCase):

--- a/src/praisonai-desktop/engine/test_portability.py
+++ b/src/praisonai-desktop/engine/test_portability.py
@@ -28,7 +28,7 @@ class DataDirectory(unittest.TestCase):
 
     def test_macos_uses_application_support(self):
         got = server.default_data_dir("darwin", home=pathlib.PurePosixPath("/Users/x"), env={})
-        self.assertEqual(str(got), "/Users/x/Library/Application Support/PraisonAI")
+        self.assertEqual(got, pathlib.Path("/Users/x/Library/Application Support/PraisonAI"))
 
     def test_windows_uses_appdata_not_a_library_folder(self):
         got = server.default_data_dir(
@@ -51,18 +51,18 @@ class DataDirectory(unittest.TestCase):
         got = server.default_data_dir(
             "linux", home=pathlib.PurePosixPath("/home/x"),
             env={"XDG_DATA_HOME": "/mnt/data/xdg"})
-        self.assertEqual(str(got), "/mnt/data/xdg/PraisonAI")
+        self.assertEqual(got, pathlib.Path("/mnt/data/xdg/PraisonAI"))
 
     def test_linux_without_xdg_falls_back_to_the_spec_default(self):
         got = server.default_data_dir("linux", home=pathlib.PurePosixPath("/home/x"), env={})
-        self.assertEqual(str(got), "/home/x/.local/share/PraisonAI")
+        self.assertEqual(got, pathlib.Path("/home/x/.local/share/PraisonAI"))
 
     def test_the_explicit_override_wins_everywhere(self):
         for platform in ("darwin", "win32", "linux"):
             got = server.default_data_dir(
                 platform, home=pathlib.PurePosixPath("/home/x"),
                 env={"PRAISONAI_DESKTOP_HOME": "/tmp/chosen"})
-            self.assertEqual(str(got), "/tmp/chosen", platform)
+            self.assertEqual(got, pathlib.Path("/tmp/chosen"), platform)
 
 
 class SignalRegistration(unittest.TestCase):
@@ -314,7 +314,12 @@ class SecretDeletion(unittest.TestCase):
 
     def test_a_delete_that_no_store_can_satisfy_reports_failure(self):
         self.primary.up = False
-        broken = server.FileSecretStore(pathlib.Path("/nonexistent/nope"))
+        # A *file* stands where the store wants a directory, so mkdir fails
+        # with NotADirectoryError on every platform -- unlike a made-up
+        # absolute path, which a Windows runner may happily create.
+        blocker = pathlib.Path(self.home) / "not-a-directory"
+        blocker.write_text("", encoding="utf-8")
+        broken = server.FileSecretStore(blocker / "store")
         store = server.FallbackSecretStore(self.primary, broken)
         self.assertFalse(store.set("api_key", ""),
                          "a delete nothing could perform reported success")
@@ -354,18 +359,33 @@ class Encoding(unittest.TestCase):
                          "interpreter=C:\\Users\\\u7530\u4e2d\\python.exe\n")
 
     def _in_c_locale(self, statement):
-        """Run one statement against the engine with a non-UTF-8 locale."""
+        """Run one statement against the engine with a non-UTF-8 locale.
+
+        The statement goes through a file rather than `-c`. Python decodes the
+        `-c` argument with the filesystem encoding, which under LC_ALL=C on
+        Linux is ASCII with surrogateescape -- so a non-ASCII character in the
+        statement itself arrived as unpaired surrogates and died before
+        reaching the code under test. Source *files* are read as UTF-8
+        regardless of locale (PEP 3120), so this tests what it means to.
+        """
         import subprocess
         engine = os.path.dirname(os.path.abspath(server.__file__))
         code = ("import pathlib, sys\n"
                 f"sys.path.insert(0, {engine!r})\n"
                 "import server\n"
                 f"{statement}\n")
+        script = pathlib.Path(self.home) / "_c_locale_case.py"
+        script.write_text(code, encoding="utf-8")
         result = subprocess.run(
-            [sys.executable, "-c", code],
+            [sys.executable, str(script)],
             env=dict(os.environ, LC_ALL="C", LANG="C",
                      PYTHONCOERCECLOCALE="0", PYTHONUTF8="0"),
-            capture_output=True, text=True, timeout=60)
+            # encoding, not bare text=True: text=True decodes the child's
+            # output with the *parent's* default encoding -- cp1252 on a
+            # Windows runner -- so a test about UTF-8 handling was reading its
+            # own result through a locale codec and failing on the round trip
+            # rather than on anything the engine did.
+            capture_output=True, text=True, encoding="utf-8", timeout=60)
         self.assertEqual(result.returncode, 0,
                          f"failed under a C locale:\n{result.stderr[-800:]}")
         return result.stdout

--- a/src/praisonai-desktop/engine/test_portability.py
+++ b/src/praisonai-desktop/engine/test_portability.py
@@ -28,7 +28,7 @@ class DataDirectory(unittest.TestCase):
 
     def test_macos_uses_application_support(self):
         got = server.default_data_dir("darwin", home=pathlib.PurePosixPath("/Users/x"), env={})
-        self.assertEqual(got, pathlib.Path("/Users/x/Library/Application Support/PraisonAI"))
+        self.assertEqual(got.as_posix(), "/Users/x/Library/Application Support/PraisonAI")
 
     def test_windows_uses_appdata_not_a_library_folder(self):
         got = server.default_data_dir(
@@ -51,18 +51,18 @@ class DataDirectory(unittest.TestCase):
         got = server.default_data_dir(
             "linux", home=pathlib.PurePosixPath("/home/x"),
             env={"XDG_DATA_HOME": "/mnt/data/xdg"})
-        self.assertEqual(got, pathlib.Path("/mnt/data/xdg/PraisonAI"))
+        self.assertEqual(got.as_posix(), "/mnt/data/xdg/PraisonAI")
 
     def test_linux_without_xdg_falls_back_to_the_spec_default(self):
         got = server.default_data_dir("linux", home=pathlib.PurePosixPath("/home/x"), env={})
-        self.assertEqual(got, pathlib.Path("/home/x/.local/share/PraisonAI"))
+        self.assertEqual(got.as_posix(), "/home/x/.local/share/PraisonAI")
 
     def test_the_explicit_override_wins_everywhere(self):
         for platform in ("darwin", "win32", "linux"):
             got = server.default_data_dir(
                 platform, home=pathlib.PurePosixPath("/home/x"),
                 env={"PRAISONAI_DESKTOP_HOME": "/tmp/chosen"})
-            self.assertEqual(got, pathlib.Path("/tmp/chosen"), platform)
+            self.assertEqual(got.as_posix(), "/tmp/chosen", platform)
 
 
 class SignalRegistration(unittest.TestCase):

--- a/src/praisonai-desktop/engine/test_train_routes.py
+++ b/src/praisonai-desktop/engine/test_train_routes.py
@@ -7,8 +7,11 @@ skipped all eleven of its tests for months because it probed for the engine in
 a way that could not work, so these fail loudly rather than skip.
 """
 
+import atexit
+import hashlib
 import json
 import os
+import pathlib
 import shlex
 import shutil
 import subprocess
@@ -88,15 +91,30 @@ class EngineProcess:
         shutil.rmtree(self.home, ignore_errors=True)
 
 
+_SCRIPTS = tempfile.mkdtemp(prefix="praison-train-scripts-")
+atexit.register(shutil.rmtree, _SCRIPTS, True)
+
+
 def _python(body):
     """A PRAISONAI_TRAIN_CMD that runs `body` instead of a real fine-tune.
 
-    shlex.quote, not json.dumps: the engine splits this with shlex, and JSON
-    escaping turns a newline into a literal backslash-n, which reached the
-    interpreter as a syntax error partway through a script that had already
-    printed its first line -- a half-run that looked like a trainer crash.
+    The body goes into a file rather than `-c`. The engine splits this command
+    with POSIX rules on Unix and Windows rules on Windows, and the two disagree
+    about a string containing a quote: shlex.quote escapes an inner `'` as the
+    concatenation `'"'"'`, which POSIX reassembles into one token and Windows
+    splits into seven. Every script here prints something, so every one of them
+    contains a quote, and the whole training suite failed on Windows for that
+    reason alone.
+
+    A path has no newlines and no quotes, so both rule sets agree about it.
     """
-    return f"{shlex.quote(sys.executable)} -u -c {shlex.quote(body)}"
+    # A content hash, not hash(): the built-in is salted per process, and two
+    # different bodies landing on one filename would have the second silently
+    # overwrite the first.
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()[:16]
+    script = pathlib.Path(_SCRIPTS) / f"case-{digest}.py"
+    script.write_text(body, encoding="utf-8")
+    return f"{shlex.quote(sys.executable)} -u {shlex.quote(str(script))}"
 
 
 def _wait(predicate, timeout=30):

--- a/src/praisonai-desktop/engine/test_train_routes.py
+++ b/src/praisonai-desktop/engine/test_train_routes.py
@@ -58,7 +58,14 @@ class EngineProcess:
             with urllib.request.urlopen(req, timeout=timeout) as response:
                 return response.status, json.loads(response.read() or b"{}")
         except urllib.error.HTTPError as err:
-            return err.code, json.loads(err.read() or b"{}")
+            # An unrouted path gets BaseHTTPRequestHandler's own HTML error
+            # page, which is a perfectly good 404 but is not JSON. The status
+            # is the thing under test there.
+            raw = err.read()
+            try:
+                return err.code, json.loads(raw or b"{}")
+            except json.JSONDecodeError:
+                return err.code, {}
 
     def stream(self, path, timeout=30):
         """Read an SSE stream into (event, data) pairs until it closes."""
@@ -182,6 +189,163 @@ class TrainRoutes(unittest.TestCase):
     def test_stopping_when_idle_is_404_not_a_crash(self):
         status, body = self.engine.request("/train/stop", {}, method="POST")
         self.assertEqual(status, 404)
+
+
+class LongRunReplay(unittest.TestCase):
+    """Opening the view on a run that has outlived its event buffer.
+
+    A tqdm refresh emits both a log and a progress event, so a real fine-tune
+    passes 4000 events in about twenty minutes. Every fresh tab opens the
+    stream at cursor=-1, which is exactly the case that has to work.
+    """
+
+    def setUp(self):
+        # A run that emits far more than the ring can hold, then ends.
+        self.engine = EngineProcess(_python(
+            "import sys\n"
+            "for i in range(4500):\n"
+            "    print(f'{i}/4500 [00:01<00:02]')\n"
+            "sys.stdout.flush()\n"))
+
+    def tearDown(self):
+        self.engine.close()
+
+    def test_a_client_that_missed_the_start_still_receives_the_log(self):
+        status, body = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 200, body)
+        run_id = body["run"]["id"]
+        self.assertTrue(_wait(
+            lambda: (self.engine.request("/train/status")[1].get("run") or {})
+            .get("state") in ("done", "failed", "cancelled"), 60))
+
+        events = self.engine.stream(f"/train/progress?run={run_id}&cursor=-1", timeout=30)
+        kinds = [kind for kind, _ in events]
+        resyncs = kinds.count("resync")
+        self.assertLessEqual(resyncs, 2,
+                             f"the stream resynced {resyncs} times instead of catching up")
+        self.assertTrue(any(k == "log" for k in kinds),
+                        "a client that missed the beginning received no output at all")
+        self.assertIn("end", kinds, "the stream never delivered the ending")
+
+    def test_the_stream_closes_when_the_run_is_over(self):
+        # The whole test would hang rather than fail if this regressed, so it
+        # is bounded by the stream timeout.
+        status, body = self.engine.request("/train/start", {"config": CONFIG})
+        run_id = body["run"]["id"]
+        self.assertTrue(_wait(
+            lambda: (self.engine.request("/train/status")[1].get("run") or {})
+            .get("state") in ("done", "failed", "cancelled"), 60))
+        events = self.engine.stream(f"/train/progress?run={run_id}&cursor=-1", timeout=30)
+        self.assertIn("end", [k for k, _ in events])
+
+
+class StopRouting(unittest.TestCase):
+    """Which run a stop request actually stops."""
+
+    def setUp(self):
+        self.engine = EngineProcess(_python(LONG_RUN))
+
+    def tearDown(self):
+        self.engine.close()
+
+    def _start(self):
+        status, body = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 200, body)
+        self.assertTrue(_wait(
+            lambda: (self.engine.request("/train/status")[1].get("run") or {})
+            .get("state") == "running"))
+        return body["run"]["id"]
+
+    def _state(self):
+        return (self.engine.request("/train/status")[1].get("run") or {}).get("state")
+
+    def test_stopping_by_the_live_id_works(self):
+        run_id = self._start()
+        status, _ = self.engine.request(f"/train/stop/{run_id}", {}, method="POST")
+        self.assertEqual(status, 200)
+        self.assertTrue(_wait(lambda: self._state() == "cancelled"))
+
+    def test_a_stale_id_is_refused(self):
+        self._start()
+        status, _ = self.engine.request("/train/stop/run-from-a-stale-tab", {}, method="POST")
+        self.assertEqual(status, 409)
+        self.assertEqual(self._state(), "running")
+
+    def test_a_stale_id_with_a_trailing_slash_is_still_refused(self):
+        # rsplit("/") on ".../stale/" yields "", which is falsy -- so the guard
+        # was skipped entirely and the live run was killed by a stale tab.
+        self._start()
+        status, _ = self.engine.request("/train/stop/run-from-a-stale-tab/", {}, method="POST")
+        self.assertEqual(status, 409, "a trailing slash bypassed the stale-tab guard")
+        self.assertEqual(self._state(), "running")
+
+    def test_a_path_that_merely_starts_with_the_route_is_not_the_route(self):
+        self._start()
+        status, _ = self.engine.request("/train/stopXXXX", {}, method="POST")
+        self.assertEqual(status, 404, "/train/stopXXXX was treated as /train/stop")
+        self.assertEqual(self._state(), "running")
+
+    def test_a_query_string_does_not_hide_the_run_id(self):
+        run_id = self._start()
+        status, _ = self.engine.request(f"/train/stop/{run_id}?force=1", {}, method="POST")
+        self.assertEqual(status, 200, "a legitimate stop was refused because of a query string")
+        self.assertTrue(_wait(lambda: self._state() == "cancelled"))
+
+    def test_stopping_a_run_that_has_not_spawned_yet_still_stops_it(self):
+        # start() returns as soon as the supervisor thread is created, so there
+        # is a window where the process does not exist. A stop in that window
+        # was recorded and then overwritten by "running", and the fine-tune ran
+        # to completion after the user cancelled it.
+        status, body = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 200, body)
+        status, _ = self.engine.request("/train/stop", {}, method="POST")
+        self.assertEqual(status, 200)
+        self.assertTrue(_wait(lambda: self._state() in ("cancelled", "done", "failed"), 30))
+        self.assertEqual(self._state(), "cancelled",
+                         "the run continued after the user stopped it")
+
+    def test_a_malformed_cursor_is_refused_rather_than_crashing(self):
+        run_id = self._start()
+        status, _ = self.engine.request(f"/train/progress?run={run_id}&cursor=abc")
+        self.assertEqual(status, 400)
+
+
+class MethodPreflight(unittest.TestCase):
+    """A config that cannot work must fail now, not after the download.
+
+    The trainer validates method requirements inside train_model(), which runs
+    after several gigabytes have been fetched and the model loaded in 4-bit.
+    Anything decidable from the config alone belongs before that.
+    """
+
+    def setUp(self):
+        self.engine = EngineProcess(_python("print('ok')"))
+
+    def tearDown(self):
+        self.engine.close()
+
+    def test_grpo_without_reward_functions_is_refused_immediately(self):
+        status, body = self.engine.request(
+            "/train/start", {"config": dict(CONFIG, method="grpo")})
+        self.assertEqual(status, 400, body)
+        self.assertIn("reward_funcs", body.get("error", ""))
+
+    def test_grpo_with_reward_functions_is_accepted(self):
+        status, body = self.engine.request(
+            "/train/start", {"config": dict(CONFIG, method="grpo",
+                                            reward_funcs=["mod:fn"])})
+        self.assertEqual(status, 200, body)
+
+    def test_the_default_method_still_starts(self):
+        status, body = self.engine.request("/train/start", {"config": CONFIG})
+        self.assertEqual(status, 200, body)
+
+    def test_a_preference_method_is_not_blocked_by_the_preflight(self):
+        # Its columns depend on the dataset, which we cannot inspect without
+        # fetching it -- so the preflight must not guess and refuse.
+        status, body = self.engine.request(
+            "/train/start", {"config": dict(CONFIG, method="dpo")})
+        self.assertEqual(status, 200, body)
 
 
 class TrainConcurrency(unittest.TestCase):

--- a/src/praisonai-desktop/engine/test_training.py
+++ b/src/praisonai-desktop/engine/test_training.py
@@ -7,10 +7,12 @@ mock without testing the mock.
 """
 
 import os
+import pathlib
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 
@@ -304,6 +306,145 @@ class WindowsTermination(unittest.TestCase):
         training.IS_WINDOWS = False
         training._terminate_group(FakeProc())
         self.assertTrue(self.pgid_calls, "the posix path stopped using the process group")
+
+
+class RunDirectoryCollisions(unittest.TestCase):
+    """Two runs must never share a directory.
+
+    They overwrite each other's config.yaml and interleave into one train.log,
+    so the second run trains on the first one's settings and neither log can be
+    read. Two ways in: ids differing only in case (macOS and Windows compare
+    filenames case-insensitively), and the auto-generated id, which had
+    one-second resolution.
+    """
+
+    def setUp(self):
+        self.home = tempfile.mkdtemp(prefix="praison-collide-")
+        self.trainer = training.Trainer(self.home, sys.executable)
+        self.trainer.command_builder = _script("print('done')")
+        self.config = {"model_name": "unsloth/tiny", "dataset": "d.json"}
+
+    def tearDown(self):
+        self.trainer.stop()
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def _finished(self, run):
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL, 20), run.state)
+
+    def test_an_id_differing_only_in_case_is_refused(self):
+        first = self.trainer.start(self.config, "run-alpha")
+        self._finished(first)
+        with self.assertRaises(ValueError):
+            self.trainer.start(self.config, "RUN-ALPHA")
+
+    def test_the_same_id_twice_is_refused(self):
+        first = self.trainer.start(self.config, "run-beta")
+        self._finished(first)
+        with self.assertRaises(ValueError):
+            self.trainer.start(self.config, "run-beta")
+
+    def test_a_refused_id_does_not_disturb_the_existing_run(self):
+        # The check used to run after makedirs and _write_config, so by the
+        # time it raised it had already overwritten the first run's config.
+        first = self.trainer.start(dict(self.config, learning_rate=0.0002), "run-gamma")
+        self._finished(first)
+        before = pathlib.Path(first.config_path).read_text()
+        with self.assertRaises(ValueError):
+            self.trainer.start(dict(self.config, learning_rate=0.9), "RUN-GAMMA")
+        self.assertEqual(pathlib.Path(first.config_path).read_text(), before,
+                         "the refused run overwrote the existing run's config")
+
+    def test_two_generated_ids_in_the_same_second_do_not_collide(self):
+        runs = []
+        for _ in range(4):
+            run = self.trainer.start(self.config)
+            self._finished(run)
+            runs.append(run)
+        ids = [run.id for run in runs]
+        self.assertEqual(len(set(i.casefold() for i in ids)), len(ids),
+                         f"generated ids collided: {ids}")
+        directories = sorted(os.listdir(os.path.join(self.home, "runs")))
+        self.assertEqual(len(directories), len(runs),
+                         f"{len(runs)} runs produced {len(directories)} directories")
+
+    def test_a_generated_id_avoids_a_directory_left_by_an_earlier_process(self):
+        # The history is empty after a restart, so the filesystem is the only
+        # record that the id is taken.
+        stamp = int(time.time())
+        os.makedirs(os.path.join(self.home, "runs", f"run-{stamp}"), exist_ok=True)
+        run = self.trainer.start(self.config)
+        self._finished(run)
+        self.assertNotEqual(run.id, f"run-{stamp}",
+                            "the new run reused a directory from a previous process")
+
+
+class StopBeforeSpawn(unittest.TestCase):
+    """Cancelling in the window before the trainer process exists.
+
+    start() returns as soon as the supervisor thread is created, so between
+    the HTTP reply and Popen returning there is a period where run._proc is
+    None. stop() had nothing to signal there, and _supervise then overwrote
+    STOPPING with RUNNING: the user saw {"ok": true} and a "stopping" pill,
+    and the fine-tune ran to completion and reported "done", holding the GPU.
+
+    The window is real but short, so a route-level test cannot reach it
+    reliably -- two HTTP round trips are slower than a spawn. Delaying the
+    spawn makes it deterministic instead of hoping for a race.
+    """
+
+    def setUp(self):
+        self.home = tempfile.mkdtemp(prefix="praison-stopspawn-")
+        self.trainer = training.Trainer(self.home, sys.executable)
+        self.spawned = threading.Event()
+        real_spawn = self.trainer._spawn
+
+        def slow_spawn(run):
+            # Hold the run in `pending` long enough to stop it deliberately.
+            self.spawned.wait(2.0)
+            return real_spawn(run)
+
+        self.trainer._spawn = slow_spawn
+
+    def tearDown(self):
+        self.spawned.set()
+        self.trainer.stop()
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def test_a_stop_while_pending_cancels_the_run(self):
+        # The script announces when it has run to the end. Checking only the
+        # final state is not enough: a version that records CANCELLED without
+        # actually signalling the process passes that check while the training
+        # job keeps running and holding the GPU, which is the whole harm.
+        self.trainer.command_builder = _script(
+            "import time\n"
+            "for _ in range(40):\n"
+            "    print('working', flush=True); time.sleep(0.05)\n"
+            "print('RAN-TO-COMPLETION', flush=True)")
+        run = self.trainer.start({"model_name": "unsloth/tiny", "dataset": "d.json"})
+        self.assertEqual(run.state, training.PENDING)
+        self.assertIsNone(run._proc, "the process already exists; the window was missed")
+
+        self.assertTrue(self.trainer.stop(), "stop() refused a pending run")
+        self.assertEqual(run.state, training.STOPPING)
+
+        self.spawned.set()          # let the spawn proceed
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL, 20), run.state)
+        self.assertEqual(run.state, training.CANCELLED,
+                         "the run continued after the user cancelled it")
+
+        log = pathlib.Path(run.log_path).read_text(encoding="utf-8", errors="replace")
+        self.assertNotIn("RAN-TO-COMPLETION", log,
+                         "the run was reported cancelled but ran to the end anyway")
+        self.assertIsNotNone(run._proc, "no process was ever spawned to stop")
+        self.assertIsNotNone(run._proc.poll(), "the trainer process is still alive")
+
+    def test_a_run_not_stopped_in_that_window_still_runs_normally(self):
+        # The guard must not cancel runs nobody asked to cancel.
+        self.trainer.command_builder = _script("print('done')")
+        run = self.trainer.start({"model_name": "unsloth/tiny", "dataset": "d.json"})
+        self.spawned.set()
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL, 20), run.state)
+        self.assertEqual(run.state, training.DONE)
 
 
 class RunLifecycle(unittest.TestCase):

--- a/src/praisonai-desktop/engine/test_training.py
+++ b/src/praisonai-desktop/engine/test_training.py
@@ -286,14 +286,20 @@ class WindowsTermination(unittest.TestCase):
         self.was = training.IS_WINDOWS
         self.pgid_calls = []
         self.tree_kills = []
-        self.real_getpgid = os.getpgid
+        # getattr: os.getpgid does not exist on Windows at all, so taking it
+        # unconditionally made this class -- the one that exists to prove the
+        # Windows path works -- error in setUp on Windows.
+        self.real_getpgid = getattr(os, "getpgid", None)
         self.real_taskkill = training._taskkill_tree
         os.getpgid = lambda pid: self.pgid_calls.append(pid) or 1
         training._taskkill_tree = lambda pid: self.tree_kills.append(pid) or True
 
     def tearDown(self):
         training.IS_WINDOWS = self.was
-        os.getpgid = self.real_getpgid
+        if self.real_getpgid is None:
+            del os.getpgid
+        else:
+            os.getpgid = self.real_getpgid
         training._taskkill_tree = self.real_taskkill
 
     def test_the_windows_path_never_touches_process_groups(self):

--- a/src/praisonai-desktop/engine/test_training.py
+++ b/src/praisonai-desktop/engine/test_training.py
@@ -378,6 +378,55 @@ class RunDirectoryCollisions(unittest.TestCase):
                             "the new run reused a directory from a previous process")
 
 
+class HistoryRetention(unittest.TestCase):
+    """The history is capped, and reaching the cap must not break anything.
+
+    It is a bounded deque so a process that stays open for days does not hold
+    every run's event ring and metric series forever. The cap has to be reached
+    by a test, because the two things that go wrong there only go wrong when it
+    is full: insert(0, ...) raises IndexError on a full bounded deque, so the
+    run after the cap failed to start at all; and evicting from the wrong end
+    would drop the run that just finished instead of the oldest one.
+    """
+
+    def setUp(self):
+        self.home = tempfile.mkdtemp(prefix="praison-history-")
+        self.trainer = training.Trainer(self.home, sys.executable)
+        self.trainer.command_builder = _script("print('done')")
+        self.config = {"model_name": "unsloth/tiny", "dataset": "d.json"}
+
+    def tearDown(self):
+        self.trainer.stop()
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def _run_once(self, run_id=None):
+        run = self.trainer.start(self.config, run_id)
+        self.assertTrue(_wait(lambda: run.state in training.TERMINAL, 20), run.state)
+        return run
+
+    def test_starting_more_runs_than_the_cap_still_works(self):
+        cap = training.MAX_HISTORY
+        for i in range(cap + 3):
+            self._run_once(f"run-{i:04d}")
+        self.assertEqual(len(self.trainer.history), cap)
+
+    def test_the_newest_run_is_kept_and_the_oldest_is_dropped(self):
+        cap = training.MAX_HISTORY
+        for i in range(cap + 1):
+            self._run_once(f"run-{i:04d}")
+        ids = [r.id for r in self.trainer.history]
+        self.assertEqual(ids[0], f"run-{cap:04d}", "the newest run is not first")
+        self.assertNotIn("run-0000", ids, "the oldest run was not the one evicted")
+
+    def test_the_metric_series_is_capped(self):
+        run = training.Run("r", "c", os.path.join(self.home, "t.log"))
+        for step in range(training.MAX_METRICS + 25):
+            run.metrics.append({"step": step, "loss": 0.1})
+        self.assertEqual(len(run.metrics), training.MAX_METRICS)
+        self.assertEqual(run.metrics[-1]["step"], training.MAX_METRICS + 24,
+                         "the newest metric was dropped instead of the oldest")
+
+
 class StopBeforeSpawn(unittest.TestCase):
     """Cancelling in the window before the trainer process exists.
 

--- a/src/praisonai-desktop/engine/test_training.py
+++ b/src/praisonai-desktop/engine/test_training.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import types
 import threading
 import time
 import unittest
@@ -256,6 +257,8 @@ class FakeProc:
         self.signals = []
         self.terminated = False
 
+        self.killed = False
+
     def poll(self):
         return None if self._alive else 0
 
@@ -264,6 +267,9 @@ class FakeProc:
 
     def terminate(self):
         self.terminated = True
+
+    def kill(self):
+        self.killed = True
 
 
 class WindowsTermination(unittest.TestCase):
@@ -279,28 +285,71 @@ class WindowsTermination(unittest.TestCase):
     def setUp(self):
         self.was = training.IS_WINDOWS
         self.pgid_calls = []
+        self.tree_kills = []
         self.real_getpgid = os.getpgid
+        self.real_taskkill = training._taskkill_tree
         os.getpgid = lambda pid: self.pgid_calls.append(pid) or 1
+        training._taskkill_tree = lambda pid: self.tree_kills.append(pid) or True
 
     def tearDown(self):
         training.IS_WINDOWS = self.was
         os.getpgid = self.real_getpgid
+        training._taskkill_tree = self.real_taskkill
 
     def test_the_windows_path_never_touches_process_groups(self):
         training.IS_WINDOWS = True
-        proc = FakeProc()
-        training._terminate_group(proc)
+        training._terminate_group(FakeProc())
         self.assertEqual(self.pgid_calls, [],
                          "os.getpgid was called; on Windows it does not exist")
-        self.assertTrue(proc.signals or proc.terminated,
-                        "the Windows path signalled nothing at all")
 
-    def test_the_windows_path_falls_back_to_terminate_if_signalling_fails(self):
+    def test_the_windows_path_kills_the_whole_tree(self):
+        # Not "signalled something" -- that is what the previous version of
+        # this test asserted, and CTRL_BREAK_EVENT satisfied it while the
+        # trainer ran happily to completion. The subject is whether the tree
+        # is actually killed, and with which pid.
         training.IS_WINDOWS = True
         proc = FakeProc()
-        proc.send_signal = lambda sig: (_ for _ in ()).throw(OSError("no console"))
         training._terminate_group(proc)
-        self.assertTrue(proc.terminated, "a failed signal left the process running")
+        self.assertEqual(self.tree_kills, [proc.pid],
+                         "the child tree was never killed")
+
+    def test_a_failed_tree_kill_still_kills_the_trainer(self):
+        training.IS_WINDOWS = True
+        training._taskkill_tree = lambda pid: False
+        proc = FakeProc()
+        training._terminate_group(proc)
+        self.assertTrue(proc.killed,
+                        "taskkill failed and nothing else stopped the process")
+
+    def test_a_process_that_already_exited_is_not_killed_again(self):
+        training.IS_WINDOWS = True
+        training._taskkill_tree = lambda pid: False
+        proc = FakeProc(alive=False)
+        training._terminate_group(proc)
+        self.assertFalse(proc.killed, "killed a process that had already exited")
+
+    def test_the_tree_kill_command_targets_the_tree_and_forces_it(self):
+        # /T is what makes this the equivalent of killpg: without it only the
+        # trainer dies and whatever it spawned keeps the GPU.
+        seen = {}
+
+        def fake_run(argv, **kwargs):
+            seen["argv"] = argv
+            return types.SimpleNamespace(returncode=0)
+
+        real_run = training.subprocess.run
+        training.subprocess.run = fake_run
+        try:
+            # self.real_taskkill, not training._taskkill_tree: setUp replaces
+            # that with a recorder for the other tests in this class, and
+            # calling it here would exercise the stub rather than the code.
+            self.assertTrue(self.real_taskkill(4321))
+        finally:
+            training.subprocess.run = real_run
+        self.assertEqual(seen["argv"][:1], ["taskkill"])
+        self.assertIn("/T", seen["argv"])
+        self.assertIn("/F", seen["argv"])
+        self.assertIn("4321", seen["argv"])
 
     def test_the_posix_path_does_use_process_groups(self):
         training.IS_WINDOWS = False

--- a/src/praisonai-desktop/engine/training.py
+++ b/src/praisonai-desktop/engine/training.py
@@ -551,12 +551,17 @@ def _last_meaningful_line(log_path, limit=4000, window=65536):
     try:
         with open(log_path, "rb") as raw:
             raw.seek(0, os.SEEK_END)
-            raw.seek(max(0, raw.tell() - window))
-            # The first line is very likely cut mid-way by the seek; drop it
-            # unless we happened to land at the start of the file.
+            start = max(0, raw.tell() - window)
+            raw.seek(start)
             chunk = raw.read()
         text = chunk.decode("utf-8", errors="replace")
-        tail = text.splitlines()[-40:]
+        lines = text.splitlines()
+        # A seek into the middle of the file almost certainly lands inside a
+        # line, so the first one is a fragment. Drop it -- unless we started at
+        # the beginning, where it is a whole line.
+        if start and len(lines) > 1:
+            lines = lines[1:]
+        tail = lines[-40:]
     except OSError:
         return None
     for line in reversed(tail):

--- a/src/praisonai-desktop/engine/training.py
+++ b/src/praisonai-desktop/engine/training.py
@@ -260,7 +260,11 @@ class Trainer:
             _write_config(config_path, config)
             run = Run(run_id, config_path, os.path.join(run_dir, "train.log"))
             self.current = run
-            self.history.insert(0, run)
+            # appendleft, not insert(0): insert on a *full* bounded deque
+            # raises IndexError("deque already at its maximum size"), so the
+            # 51st run would have failed to start. appendleft evicts from the
+            # far end, which is the oldest run -- what the cap is for.
+            self.history.appendleft(run)
 
         run.emit("start", {"id": run.id, "config": config_path})
         threading.Thread(target=self._supervise, args=(run,), daemon=True).start()

--- a/src/praisonai-desktop/engine/training.py
+++ b/src/praisonai-desktop/engine/training.py
@@ -23,6 +23,7 @@ Everything here is pure or filesystem-only; the HTTP layer is in server.py.
 from __future__ import annotations
 
 import json
+import collections
 import os
 import re
 import shlex
@@ -33,6 +34,10 @@ import time
 
 # What a run can be. `stopping` exists because SIGTERM is not instant and a UI
 # that shows "running" through a five-second teardown looks broken.
+# How much of a run is kept in memory. The log file is the full record.
+MAX_METRICS = 5000           # points in the loss series
+MAX_HISTORY = 50             # finished runs listed in the history pane
+
 PENDING, RUNNING, STOPPING, DONE, FAILED, CANCELLED = (
     "pending", "running", "stopping", "done", "failed", "cancelled")
 TERMINAL = frozenset({DONE, FAILED, CANCELLED})
@@ -145,7 +150,11 @@ class Run:
         self.error = None
         self.step = 0
         self.total = 0
-        self.metrics = []            # [{step, loss, learning_rate, epoch}]
+        # A tail, not an archive. At 20k logging steps the full series is
+        # several megabytes per run, held forever by a process that is meant
+        # to stay open for days; the chart only ever draws the recent shape
+        # and train.log keeps the complete record.
+        self.metrics = collections.deque(maxlen=MAX_METRICS)
         self.events = []             # [(cursor, kind, payload)]
         self._next_cursor = 0        # never derived from len(events): see emit
         self._proc = None
@@ -210,7 +219,9 @@ class Trainer:
         self.command_builder = command_builder
         self.dir = os.path.join(str(home), "runs")
         self.current = None
-        self.history = []
+        # Finished runs are kept so the history list can show them, but not
+        # without limit -- each retains its event ring and metric series.
+        self.history = collections.deque(maxlen=MAX_HISTORY)
         self._lock = threading.Lock()
 
     # -- starting --------------------------------------------------------
@@ -226,7 +237,23 @@ class Trainer:
                 raise RuntimeError(
                     f"run {self.current.id} is {self.current.state}. "
                     "Stop it before starting another; one GPU runs one job.")
-            run_id = validate_run_id(run_id) if run_id else f"run-{int(time.time())}"
+            # Settle the id before creating anything.
+            #
+            # Two runs must never share a directory: they overwrite each
+            # other's config.yaml and interleave into one train.log. Two ways
+            # that happened -- an auto-generated id had one-second resolution,
+            # so two runs started in the same second collided; and ids differing
+            # only in case are the same directory on macOS and Windows, whose
+            # filesystems are case-insensitive.
+            if run_id:
+                run_id = validate_run_id(run_id)
+                if self._id_taken(run_id):
+                    raise ValueError(
+                        f"a run named {run_id!r} already exists (run ids are "
+                        "compared case-insensitively, because directories are)")
+            else:
+                run_id = self._unused_id()
+
             run_dir = os.path.join(self.dir, run_id)
             os.makedirs(run_dir, exist_ok=True)
             config_path = os.path.join(run_dir, "config.yaml")
@@ -238,6 +265,27 @@ class Trainer:
         run.emit("start", {"id": run.id, "config": config_path})
         threading.Thread(target=self._supervise, args=(run,), daemon=True).start()
         return run
+
+    def _id_taken(self, run_id):
+        """Whether this id would land on an existing run or directory."""
+        folded = run_id.casefold()
+        if any(other.id.casefold() == folded for other in self.history):
+            return True
+        try:
+            existing = os.listdir(self.dir)
+        except OSError:
+            return False       # nothing has been created yet
+        return any(name.casefold() == folded for name in existing)
+
+    def _unused_id(self):
+        """A generated id that is free, even for two runs in the same second."""
+        stamp = int(time.time())
+        candidate = f"run-{stamp}"
+        suffix = 2
+        while self._id_taken(candidate):
+            candidate = f"run-{stamp}-{suffix}"
+            suffix += 1
+        return candidate
 
     def _command(self, run):
         """The argv that runs the fine-tune.
@@ -283,8 +331,22 @@ class Trainer:
             run.finish(FAILED, f"could not start the trainer: {exc}")
             return
         run._proc = proc
-        run.state = RUNNING
-        run.emit("state", {"state": RUNNING})
+        # Honour a stop that arrived before the process existed.
+        #
+        # start() returns as soon as this thread is created, so there is a
+        # window -- every millisecond between the HTTP reply and Popen
+        # returning -- where stop() finds run._proc is None and has nothing to
+        # signal. It recorded STOPPING and this line then overwrote it with
+        # RUNNING: the user got {"ok": true} and a "stopping" pill, and the
+        # fine-tune ran to completion and reported "done".
+        with run._lock:
+            stop_requested = run.state == STOPPING
+            if not stop_requested:
+                run.state = RUNNING
+        if stop_requested:
+            _terminate_group(proc)
+        else:
+            run.emit("state", {"state": RUNNING})
         try:
             with open(run.log_path, "a", encoding="utf-8") as log:
                 for line in proc.stdout:
@@ -321,11 +383,16 @@ class Trainer:
             # Refuse to stop a different run than the one asked for: a stale
             # tab must not cancel the job someone started after it.
             raise RuntimeError(f"{run_id} is not the live run ({run.id})")
-        run.state = STOPPING
+        with run._lock:
+            if run.state in TERMINAL:
+                return False        # it ended while we were deciding
+            run.state = STOPPING
         run.emit("state", {"state": STOPPING})
         proc = run._proc
         if proc and proc.poll() is None:
             _terminate_group(proc)
+        # If proc is still None the run has not spawned yet; _supervise sees
+        # STOPPING under the same lock and terminates it on arrival.
         return True
 
     def get(self, run_id):
@@ -333,6 +400,44 @@ class Trainer:
             if run.id == run_id:
                 return run
         return None
+
+
+# What each method needs beyond a model and a dataset.
+#
+# The trainer checks these too, but only inside train_model() -- which runs
+# after prepare_model() has downloaded several gigabytes and loaded the model
+# in 4-bit. Failing there means the user waits an hour to be told their config
+# was never going to work. Everything checkable from the config alone is
+# checked here, before anything is downloaded.
+#
+# Column requirements are NOT checked here: they depend on the dataset's
+# contents, which we would have to fetch to know. They are named in the UI's
+# per-method hint instead, and the trainer still enforces them.
+METHOD_REQUIREMENTS = {
+    "grpo": ("reward_funcs",),
+}
+
+# The columns each method expects, for the error message rather than a check.
+METHOD_COLUMNS = {
+    "cpt": ("text",),
+    "dpo": ("prompt", "chosen", "rejected"),
+    "orpo": ("prompt", "chosen", "rejected"),
+    "cpo": ("prompt", "chosen", "rejected"),
+    "kto": ("prompt", "completion", "label"),
+    "reward": ("chosen", "rejected"),
+}
+
+
+def check_method_requirements(config):
+    """Raise ValueError if this config cannot work, before anything is fetched."""
+    method = (config.get("method") or "sft").lower()
+    missing = [key for key in METHOD_REQUIREMENTS.get(method, ())
+               if not config.get(key)]
+    if missing:
+        raise ValueError(
+            f"{method} needs {', '.join(missing)}, which this form does not "
+            f"collect -- run it from the command line instead")
+    return method
 
 
 def _new_process_group():
@@ -406,11 +511,23 @@ def _write_config(path, config):
     return path
 
 
-def _last_meaningful_line(log_path, limit=4000):
-    """The last non-blank line, for a failure message worth reading."""
+def _last_meaningful_line(log_path, limit=4000, window=65536):
+    """The last non-blank line, for a failure message worth reading.
+
+    Reads only the final `window` bytes. readlines() materialised the entire
+    log to keep forty lines from the end -- and a tqdm bar writes a line per
+    refresh, so a long run leaves tens of megabytes. This is called exactly
+    when a run fails, which is the worst moment to allocate the whole file.
+    """
     try:
-        with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
-            tail = handle.readlines()[-40:]
+        with open(log_path, "rb") as raw:
+            raw.seek(0, os.SEEK_END)
+            raw.seek(max(0, raw.tell() - window))
+            # The first line is very likely cut mid-way by the seek; drop it
+            # unless we happened to land at the start of the file.
+            chunk = raw.read()
+        text = chunk.decode("utf-8", errors="replace")
+        tail = text.splitlines()[-40:]
     except OSError:
         return None
     for line in reversed(tail):

--- a/src/praisonai-desktop/engine/training.py
+++ b/src/praisonai-desktop/engine/training.py
@@ -462,6 +462,23 @@ def _new_process_group():
     return {"start_new_session": True}
 
 
+def _taskkill_tree(pid):
+    """Kill a process and everything it spawned, on Windows. True if it ran.
+
+    Split out so the Windows path can be exercised from any platform: the
+    branch that only ever runs on the one machine nobody tests on is exactly
+    the branch that was wrong.
+    """
+    try:
+        result = subprocess.run(
+            ["taskkill", "/T", "/F", "/PID", str(pid)],
+            capture_output=True, timeout=30,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0))
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
 def _terminate_group(proc):
     """SIGTERM the child and everything it spawned -- and nothing else.
 
@@ -475,13 +492,21 @@ def _terminate_group(proc):
         # Windows has no process groups in the POSIX sense; os.getpgid and
         # os.killpg do not exist at all, and an AttributeError here would
         # escape stop() and wedge the run in "stopping" forever while the
-        # trainer kept the GPU. CTRL_BREAK_EVENT reaches the whole group
-        # created by CREATE_NEW_PROCESS_GROUP, which is the stdlib-only
-        # equivalent.
-        try:
-            proc.send_signal(signal.CTRL_BREAK_EVENT)
-        except (OSError, ValueError, AttributeError):
-            proc.terminate()
+        # trainer kept the GPU.
+        #
+        # This used to send CTRL_BREAK_EVENT, which was worse than useless.
+        # That event is delivered through a console, and the trainer is spawned
+        # with CREATE_NO_WINDOW precisely so it has none -- so send_signal
+        # returned successfully, nothing died, and the fallback never ran. The
+        # run reported "cancelled" while the fine-tune continued to completion
+        # holding the GPU: the exact failure that stopping exists to prevent,
+        # reported as a success. Every stop test failed on Windows and passed
+        # on the two platforms anyone had run them on.
+        #
+        # taskkill /T walks the child tree, which is what killpg achieves on
+        # POSIX; /F because a console-less child cannot be asked politely.
+        if not _taskkill_tree(proc.pid) and proc.poll() is None:
+            proc.kill()          # at least the trainer itself
         return
     try:
         group = os.getpgid(proc.pid)

--- a/src/praisonai-desktop/frontend/tests/csp.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/csp.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * The page must survive the CSP the app actually ships.
+ *
+ * Configuring any CSP makes Tauri stamp a nonce on the page's <style> tag and
+ * a hash on its inline <script> at build time. A nonce or hash in a source list
+ * *voids* `'unsafe-inline'` for that directive -- so the moment a CSP exists,
+ * every `style=""` attribute in the document stops applying, silently.
+ *
+ * The visible result was a permanently shown red Stop button, a raw file-input
+ * widget, and every tool-output block expanded. Nothing errors; it just looks
+ * broken on first launch.
+ *
+ * jsdom does not enforce CSP, so this checks the two things that can be
+ * checked statically and that are exactly what regressed: no style attributes
+ * in the shipped markup, and nothing building one into innerHTML.
+ */
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const HTML = readFileSync(new URL('../../ui/index.html', import.meta.url), 'utf8');
+const CONFIG = JSON.parse(
+  readFileSync(new URL('../../src-tauri/tauri.conf.json', import.meta.url), 'utf8'));
+
+/** Source lines with comments blanked out.
+ *
+ *  Line-prefix filtering is not enough: a continuation line inside a block
+ *  comment starts with ordinary text, so this file's own explanation of the
+ *  bug was reported as an instance of it. Comments are blanked rather than
+ *  dropped so the line numbers still point at the real file.
+ */
+function codeLines() {
+  const blanked = HTML.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+                      .replace(/(^|[^:])\/\/[^\n]*/g, (m, p) => p + ' '.repeat(m.length - p.length));
+  return blanked.split('\n').map((line, i) => [i + 1, line]);
+}
+
+/** The same line from the real file, for a readable failure message. */
+function sourceLine(n) {
+  return HTML.split('\n')[n - 1].trim().slice(0, 80);
+}
+
+test('a CSP is configured at all', () => {
+  // With csp: null there is no policy, and this whole class of bug is moot --
+  // along with every protection a CSP gives. If someone removes it, this test
+  // should be reconsidered deliberately, not silently.
+  assert.ok(CONFIG.app.security.csp, 'no CSP is set; the page is unrestricted');
+});
+
+test('no element carries a style attribute', () => {
+  const offenders = codeLines().filter(([, line]) => /\sstyle\s*=\s*["']/.test(line));
+  assert.deepEqual(
+    offenders.map(([n]) => `${n}: ${sourceLine(n)}`),
+    [],
+    'these style attributes will not apply under the shipped CSP; use a class',
+  );
+});
+
+test('the utility classes that replaced them exist', () => {
+  // Otherwise the elements are not hidden at all, which is the same bug with
+  // a different cause.
+  for (const rule of ['.is-hidden{display:none}']) {
+    assert.ok(HTML.includes(rule), `missing rule: ${rule}`);
+  }
+});
+
+test('nothing reveals an element by clearing an inline display', () => {
+  // `el.style.display=''` restores the class-driven default -- which is now
+  // `display:none`. An element hidden by a class must be revealed by removing
+  // the class, or it never appears again.
+  const offenders = codeLines().filter(([, line]) => /\.style\.display\s*=\s*['"]{2}/.test(line));
+  for (const [n, line] of offenders) {
+    const el = /(\w+)\.style\.display/.exec(line)?.[1];
+    const hiddenByClass = new RegExp(`id="${el}"[^>]*class="[^"]*is-hidden`, 'i').test(HTML)
+      || new RegExp(`class="[^"]*is-hidden[^"]*"[^>]*id="${el}"`, 'i').test(HTML);
+    assert.ok(!hiddenByClass,
+              `${n}: ${el} is hidden by a class, so clearing its inline display leaves it hidden`);
+  }
+});
+
+test('the CSP lets the page reach its own engine', () => {
+  // The webview talks to Python over loopback on a port chosen at runtime.
+  // Without these sources every fetch and the training event stream fail.
+  const csp = CONFIG.app.security.csp;
+  assert.match(csp, /connect-src[^;]*127\.0\.0\.1:\*/, `connect-src cannot reach the engine: ${csp}`);
+  assert.match(csp, /img-src[^;]*data:/, 'img-src blocks data: URIs');
+  assert.match(csp, /img-src[^;]*blob:/, 'img-src blocks blob: URIs');
+});

--- a/src/praisonai-desktop/frontend/tests/csp.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/csp.test.mjs
@@ -4,77 +4,146 @@
  * Configuring any CSP makes Tauri stamp a nonce on the page's <style> tag and
  * a hash on its inline <script> at build time. A nonce or hash in a source list
  * *voids* `'unsafe-inline'` for that directive -- so the moment a CSP exists,
- * every `style=""` attribute in the document stops applying, silently.
+ * every `style=""` attribute in the document stops applying, silently. The
+ * visible result was a permanently shown Stop button, a raw file-input widget,
+ * and every tool-output block expanded.
  *
- * The visible result was a permanently shown red Stop button, a raw file-input
- * widget, and every tool-output block expanded. Nothing errors; it just looks
- * broken on first launch.
- *
- * jsdom does not enforce CSP, so this checks the two things that can be
- * checked statically and that are exactly what regressed: no style attributes
- * in the shipped markup, and nothing building one into innerHTML.
+ * The first version of this file was regex guesswork and caught none of seven
+ * CSP-breaking changes, including a straight revert of the fix. It now resolves
+ * variables to the elements they hold before deciding whether a line is a
+ * problem, and checks the other four ways a page can set style that the policy
+ * blocks: a style attribute in any casing, setAttribute('style'), a <style>
+ * element built at runtime, and style= concatenated into innerHTML.
  */
 import { readFileSync } from 'node:fs';
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { JSDOM } from 'jsdom';
 
 const HTML = readFileSync(new URL('../../ui/index.html', import.meta.url), 'utf8');
 const CONFIG = JSON.parse(
   readFileSync(new URL('../../src-tauri/tauri.conf.json', import.meta.url), 'utf8'));
 
-/** Source lines with comments blanked out.
+/** The document with comments blanked, so line numbers still line up.
  *
  *  Line-prefix filtering is not enough: a continuation line inside a block
  *  comment starts with ordinary text, so this file's own explanation of the
- *  bug was reported as an instance of it. Comments are blanked rather than
- *  dropped so the line numbers still point at the real file.
+ *  bug was once reported as an instance of it.
  */
-function codeLines() {
-  const blanked = HTML.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-                      .replace(/(^|[^:])\/\/[^\n]*/g, (m, p) => p + ' '.repeat(m.length - p.length));
-  return blanked.split('\n').map((line, i) => [i + 1, line]);
+const CODE = HTML
+  .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+  .replace(/(^|[^:])\/\/[^\n]*/g, (m, p) => p + ' '.repeat(m.length - p.length));
+
+const sourceLine = (n) => HTML.split('\n')[n - 1].trim().slice(0, 90);
+const lines = () => CODE.split('\n').map((line, i) => [i + 1, line]);
+
+/** Which ids the shipped markup hides with a class rather than an attribute. */
+function idsHiddenByClass() {
+  const dom = new JSDOM(HTML);
+  return new Set([...dom.window.document.querySelectorAll('.is-hidden')]
+    .map((el) => el.id).filter(Boolean));
 }
 
-/** The same line from the real file, for a readable failure message. */
-function sourceLine(n) {
-  return HTML.split('\n')[n - 1].trim().slice(0, 80);
+/** Map every `const x = document.getElementById('y')` binding to its id. */
+function variablesHoldingElements() {
+  const map = new Map();
+  const pattern = /(\w+)\s*=\s*document\.getElementById\(\s*['"]([^'"]+)['"]\s*\)/g;
+  for (const [, name, id] of CODE.matchAll(pattern)) map.set(name, id);
+  return map;
 }
 
 test('a CSP is configured at all', () => {
-  // With csp: null there is no policy, and this whole class of bug is moot --
-  // along with every protection a CSP gives. If someone removes it, this test
-  // should be reconsidered deliberately, not silently.
+  // With csp: null there is no policy and this whole class of bug is moot --
+  // along with every protection a CSP gives. Removing it should be a decision,
+  // not a side effect.
   assert.ok(CONFIG.app.security.csp, 'no CSP is set; the page is unrestricted');
 });
 
-test('no element carries a style attribute', () => {
-  const offenders = codeLines().filter(([, line]) => /\sstyle\s*=\s*["']/.test(line));
-  assert.deepEqual(
-    offenders.map(([n]) => `${n}: ${sourceLine(n)}`),
-    [],
-    'these style attributes will not apply under the shipped CSP; use a class',
-  );
+test('no element carries a style attribute, in any casing or quoting', () => {
+  // STYLE="..." and style=display:none are the same thing to a parser and the
+  // same casualty under the policy.
+  const offenders = lines().filter(([, l]) => /\s(?:style)\s*=\s*(?:["'][^"']*["']|[^\s>]+)/i.test(l));
+  assert.deepEqual(offenders.map(([n]) => `${n}: ${sourceLine(n)}`), [],
+                   'these style attributes will not apply under the shipped CSP; use a class');
 });
 
-test('the utility classes that replaced them exist', () => {
-  // Otherwise the elements are not hidden at all, which is the same bug with
-  // a different cause.
-  for (const rule of ['.is-hidden{display:none}']) {
+test('nothing sets a style attribute through the DOM', () => {
+  // setAttribute('style', ...) is governed by style-src exactly as the markup
+  // attribute is. Confirmed blocked under the real policy in a headless browser.
+  const offenders = lines().filter(([, l]) => /setAttribute\(\s*['"]style['"]/i.test(l));
+  assert.deepEqual(offenders.map(([n]) => `${n}: ${sourceLine(n)}`), [],
+                   'setAttribute("style") is blocked; set .style.<prop> or use a class');
+});
+
+test('nothing builds a <style> element at runtime', () => {
+  // A <style> created after load carries no nonce, so the policy drops it.
+  const offenders = lines().filter(
+    ([, l]) => /createElement\(\s*['"]style['"]/i.test(l) || /insertRule\s*\(/.test(l));
+  assert.deepEqual(offenders.map(([n]) => `${n}: ${sourceLine(n)}`), [],
+                   'a runtime <style> or insertRule is dropped under the shipped CSP');
+});
+
+test('no innerHTML string carries a style attribute', () => {
+  // Markup assembled in JavaScript is parsed the same way as markup in the
+  // file, so a style= inside it is the same casualty.
+  const offenders = lines().filter(([, l]) =>
+    /innerHTML|insertAdjacentHTML/.test(l) && /\sstyle\s*=/i.test(l));
+  assert.deepEqual(offenders.map(([n]) => `${n}: ${sourceLine(n)}`), [],
+                   'style= built into innerHTML will not apply; use a class');
+});
+
+test('every utility class that replaced an attribute still exists', () => {
+  // Otherwise the elements are not hidden at all -- the same bug, arrived at
+  // from the other direction.
+  for (const rule of ['.is-hidden{display:none}', '.errhint{', '.logpre{', '.runshd{']) {
     assert.ok(HTML.includes(rule), `missing rule: ${rule}`);
   }
 });
 
-test('nothing reveals an element by clearing an inline display', () => {
-  // `el.style.display=''` restores the class-driven default -- which is now
-  // `display:none`. An element hidden by a class must be revealed by removing
-  // the class, or it never appears again.
-  const offenders = codeLines().filter(([, line]) => /\.style\.display\s*=\s*['"]{2}/.test(line));
-  for (const [n, line] of offenders) {
-    const el = /(\w+)\.style\.display/.exec(line)?.[1];
-    const hiddenByClass = new RegExp(`id="${el}"[^>]*class="[^"]*is-hidden`, 'i').test(HTML)
-      || new RegExp(`class="[^"]*is-hidden[^"]*"[^>]*id="${el}"`, 'i').test(HTML);
-    assert.ok(!hiddenByClass,
-              `${n}: ${el} is hidden by a class, so clearing its inline display leaves it hidden`);
+test('an element hidden by a class is never also driven by inline display', () => {
+  // Mixing the two mechanisms is the bug, whichever value is assigned.
+  //
+  //   hide via `el.style.display='none'`, then reveal via
+  //   `classList.remove('is-hidden')` -> the inline rule still wins, and the
+  //   element stays hidden from the second turn onward.
+  //
+  //   hide via the class, then reveal via `el.style.display=''` -> restores
+  //   the class default, which is `display:none`, so it never appears at all.
+  //
+  // Both are "the Stop button does not come back". So for an element the
+  // markup hides with a class, any `.style.display` assignment is a defect --
+  // which is why this checks the property, not the value it is given.
+  //
+  // The previous version matched a *variable* name against an id and so
+  // checked `stopBtn` against `id="stopBtn"`, which does not exist -- the id
+  // is `stop`. It caught nothing. Bindings are resolved now.
+  const hidden = idsHiddenByClass();
+  const held = variablesHoldingElements();
+  assert.ok(hidden.size, 'no element is hidden by a class; has the fix been reverted?');
+  assert.ok(held.size, 'no element bindings were found; has the page been restructured?');
+
+  const offenders = [];
+  for (const [n, line] of lines()) {
+    for (const [, name] of line.matchAll(/(\w+)\.style\.display\s*=/g)) {
+      const id = held.get(name);
+      if (id && hidden.has(id)) {
+        offenders.push(`${n}: ${name} holds #${id}, which the markup hides with a class`
+                       + ` -- ${sourceLine(n)}`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, [],
+                   'this element is hidden by a class; show and hide it with the class');
+});
+
+test('the elements meant to start hidden actually are', () => {
+  // The stylesheet has to carry the rule, not just the markup the class.
+  const dom = new JSDOM(HTML);
+  const { document, getComputedStyle } = dom.window;
+  for (const id of ['stop', 'filein']) {
+    const el = document.getElementById(id);
+    assert.ok(el, `#${id} is missing from the page`);
+    assert.equal(getComputedStyle(el).display, 'none', `#${id} is visible on load`);
   }
 });
 

--- a/src/praisonai-desktop/frontend/tests/platform.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/platform.test.mjs
@@ -46,7 +46,7 @@ const AGENTS = {
   },
 };
 
-async function boot(os, { engineState = 'ready' } = {}) {
+async function boot(os, { engineState = 'ready', reason, tail } = {}) {
   const copied = [];
   const dom = new JSDOM(HTML, {
     runScripts: 'dangerously', resources: 'usable', url: ORIGIN + '/',
@@ -62,7 +62,7 @@ async function boot(os, { engineState = 'ready' } = {}) {
       w.__TAURI__ = { core: { invoke: async () =>
         (engineState === 'ready'
           ? { state: 'ready', port: PORT, python: '/py' }
-          : { state: 'failed', reason: 'No usable Python' }) } };
+          : { state: 'failed', reason: reason || 'No usable Python', tail }) } };
       w.fetch = async (url) => {
         const u = String(url);
         const body = u.includes('/settings')
@@ -190,4 +190,62 @@ test('copying the data folder copies this platform\'s path', async () => {
       assert.ok(!/Library/.test(fn()), `${os} copies a macOS path: ${fn()}`);
     }
   }
+});
+
+
+/**
+ * An interrupted first install must not be a dead end.
+ *
+ * If setup is killed during the dependency step, the venv is complete and
+ * empty: `pyvenv.cfg` exists, so the interpreter is accepted, and the engine
+ * then dies on `ModuleNotFoundError`. That reason is not the one string the
+ * setup screen keys off, so the user got a wall of text with no button at
+ * all -- on every launch, forever, with no way back except deleting the venv
+ * by hand. This is the ComfyUI failure, and it is the worst kind: caused by
+ * one interruption, permanent, and invisible to us.
+ */
+test('a half-installed environment offers to finish the install', async () => {
+  const { doc } = await boot('mac', {
+    engineState: 'failed',
+    reason: 'Engine exited before it was ready',
+    tail: "ModuleNotFoundError: No module named 'praisonaiagents'",
+  });
+  await settle();
+  const setup = doc.querySelector('.setup');
+  assert.ok(setup, 'a half-built environment shows an error with no way to repair it');
+  assert.ok(/set up|install|environment/i.test(setup.textContent),
+            `the setup screen does not offer to build anything: ${setup.textContent.slice(0, 200)}`);
+});
+
+test('the repair button actually opens setup, not just exists', async () => {
+  // The first version of this only asserted the button was present, so
+  // replacing its handler with an empty function changed nothing and the test
+  // still passed. A control that does nothing is worse than no control.
+  const { doc } = await boot('mac', {
+    engineState: 'failed',
+    reason: 'Engine did not report ready in time',
+    tail: 'some traceback',
+  });
+  await settle();
+  const setup = [...doc.querySelectorAll('.errbtns button')]
+    .find((b) => /set up/i.test(b.textContent));
+  assert.ok(setup, 'no repair button on a failure banner');
+  assert.equal(doc.querySelector('.setup'), null, 'setup was already showing');
+  setup.dispatchEvent(new doc.defaultView.MouseEvent('click', { bubbles: true }));
+  await settle();
+  assert.ok(doc.querySelector('.setup'), 'the repair button did nothing when clicked');
+});
+
+test('any other engine failure still offers a way to act', async () => {
+  // Not every failure is repairable, but every failure must leave the user
+  // able to do something -- at minimum copy the details for a bug report.
+  const { doc } = await boot('mac', {
+    engineState: 'failed',
+    reason: 'Engine did not report ready in time',
+    tail: 'some traceback',
+  });
+  await settle();
+  const buttons = [...doc.querySelectorAll('.errbtns button')].map((b) => b.textContent);
+  assert.ok(buttons.length, 'the failure banner has no buttons at all');
+  assert.ok(buttons.some((b) => /copy/i.test(b)), `no way to copy details: ${buttons}`);
 });

--- a/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
@@ -18,6 +18,7 @@ import test from 'node:test';
 
 const root = new URL('../../../../', import.meta.url);
 const workflow = readFileSync(new URL('.github/workflows/desktop-release.yml', root), 'utf8');
+const ci = readFileSync(new URL('.github/workflows/desktop.yml', root), 'utf8');
 const config = JSON.parse(
   readFileSync(new URL('src/praisonai-desktop/src-tauri/tauri.conf.json', root), 'utf8'));
 const install = readFileSync(new URL('src/praisonai-desktop/INSTALL.md', root), 'utf8');
@@ -111,10 +112,62 @@ test('the Linux leg installs the webkit and tray libraries the app links against
             'mixing ayatana and libappindicator changes the .deb\'s generated Depends');
 });
 
+test('no build runs on a retired or deprecating runner image', () => {
+  // This has bitten twice. macos-13 was retired on 2026-12-04, so the Intel
+  // leg would never have scheduled and the completeness check below would have
+  // failed every release, forever, correctly. macos-14 then entered its own
+  // deprecation, with brownouts that fail jobs before the final date -- and it
+  // was the only Apple-silicon leg, so losing it means no arm64 DMG at all.
+  //
+  // A list of names, not a date check: the point is to fail here, next to the
+  // reason, rather than at midnight on release day.
+  const RETIRED = ['macos-11', 'macos-12', 'macos-13', 'macos-14',
+                   'ubuntu-18.04', 'ubuntu-20.04', 'windows-2019'];
+  for (const file of [workflow, ci]) {
+    for (const image of RETIRED) {
+      // Word boundary: macos-15-intel must not match macos-15, and macos-13
+      // must not match macos-13-large.
+      const used = new RegExp(`(?:runner|os):\\s*\\[?[^\\n]*\\b${image}\\b`);
+      assert.ok(!used.test(file),
+                `${image} is retired or deprecating; jobs on it fail or never schedule`);
+    }
+  }
+});
+
+test('every platform the app ships on is still built', () => {
+  // Bumping a runner must not quietly drop a leg.
+  assert.match(workflow, /runner:\s*macos-15\b/, 'no Apple-silicon build');
+  assert.match(workflow, /runner:\s*macos-15-intel\b/, 'no Intel Mac build');
+  assert.match(workflow, /runner:\s*windows-latest\b/, 'no Windows build');
+  assert.match(workflow, /runner:\s*ubuntu-22\.04\b/, 'no Linux build');
+});
+
 test('the Linux build host is old enough for the glibc floor it promises', () => {
   // glibc is forward-compatible only: the build host decides the oldest
   // distribution the .deb can start on, and no runtime flag can widen it.
   assert.match(workflow, /runner:\s*ubuntu-22\.04/,
                'building Linux on a newer image silently drops older distributions');
   assert.ok(install.includes('22.04'), 'INSTALL.md does not say which distributions are supported');
+});
+
+test('the macOS window overlay repeats the base window faithfully', () => {
+  // tauri.macos.conf.json has to restate the whole window object, because
+  // Tauri merges with RFC 7386 and that replaces arrays wholesale rather than
+  // merging their elements. An overlay carrying only the two macOS keys
+  // deleted title, width, height and both minimums, and the app became an
+  // 800x600 "Tauri App" that could be dragged down to nothing.
+  //
+  // Restating it means it can now drift instead. Nothing else would notice,
+  // because the result is a window that is merely the wrong size.
+  const overlay = JSON.parse(
+    readFileSync(new URL('src/praisonai-desktop/src-tauri/tauri.macos.conf.json', root), 'utf8'));
+  const base = config.app.windows[0];
+  const mac = overlay.app.windows[0];
+  for (const key of Object.keys(base)) {
+    assert.deepEqual(mac[key], base[key],
+                     `tauri.macos.conf.json disagrees about "${key}"`);
+  }
+  // And the two keys that are the whole reason the overlay exists.
+  assert.equal(mac.titleBarStyle, 'Overlay');
+  assert.equal(mac.hiddenTitle, true);
 });

--- a/src/praisonai-desktop/frontend/tests/training.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/training.test.mjs
@@ -256,7 +256,39 @@ test('Stop asks the engine to stop', async () => {
   await settle();
   click(doc.getElementById('tStop'));
   await settle();
-  assert.equal(posted(calls, '/train/stop').length, 1, 'Stop sent nothing');
+  const [stop] = posted(calls, '/train/stop');
+  assert.ok(stop, 'Stop sent nothing');
+  // The run id, not a bare /train/stop.
+  //
+  // The engine refuses to stop a run other than the one asked for, so that a
+  // tab left open on a finished run cannot cancel whatever someone started
+  // after it. That guard reads the id from the path -- and the button never
+  // sent one, so it could never fire, and the stale tab won. Three server
+  // tests covered a request the product did not make.
+  assert.notEqual(stop.path, '/train/stop',
+                  'Stop did not name its run, so the stale-tab guard cannot fire');
+  assert.match(stop.path, /^\/train\/stop\/[^/]+$/,
+               `unexpected stop path: ${stop.path}`);
+});
+
+test('Stop names the run the view is actually watching', async () => {
+  // Not just "some id": the id has to be the one this tab is following, or
+  // the guard passes for the wrong reason.
+  const { doc, calls, streams } = await boot({
+    start: { ok: true, run: { id: 'run-being-watched', state: 'pending' } },
+  });
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('trainForm').dispatchEvent(
+    new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  streams[streams.length - 1].emit('state', { cursor: 1, state: 'running' });
+  await settle();
+  click(doc.getElementById('tStop'));
+  await settle();
+  const [stop] = posted(calls, '/train/stop');
+  assert.ok(stop, 'Stop sent nothing');
+  assert.equal(stop.path, '/train/stop/run-being-watched');
 });
 
 test('a run already in flight is picked up when the view opens', async () => {

--- a/src/praisonai-desktop/package-lock.json
+++ b/src/praisonai-desktop/package-lock.json
@@ -1,0 +1,554 @@
+{
+  "name": "praisonai-desktop-frontend-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "praisonai-desktop-frontend-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "jsdom": "^30.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.1.tgz",
+      "integrity": "sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.9.tgz",
+      "integrity": "sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/src/praisonai-desktop/package.json
+++ b/src/praisonai-desktop/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "praisonai-desktop-frontend-tests",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Test harness for the desktop UI. The app itself has no build step -- ui/index.html is shipped as written -- so this exists only to pin what the tests need. jsdom is pinned because the suite silently used whatever version happened to be installed further up the tree, and 16 tests fail on an older one.",
+  "type": "module",
+  "scripts": {
+    "test": "node --test 'frontend/tests/*.test.mjs'",
+    "test:ci": "node --test $(ls frontend/tests/*.test.mjs | grep -v lifecycle)"
+  },
+  "devDependencies": {
+    "jsdom": "^30.0.1"
+  }
+}

--- a/src/praisonai-desktop/package.json
+++ b/src/praisonai-desktop/package.json
@@ -5,8 +5,8 @@
   "description": "Test harness for the desktop UI. The app itself has no build step -- ui/index.html is shipped as written -- so this exists only to pin what the tests need. jsdom is pinned because the suite silently used whatever version happened to be installed further up the tree, and 16 tests fail on an older one.",
   "type": "module",
   "scripts": {
-    "test": "node --test 'frontend/tests/*.test.mjs'",
-    "test:ci": "node --test $(ls frontend/tests/*.test.mjs | grep -v lifecycle)"
+    "test": "node --test frontend/tests/*.test.mjs frontend/tests/*.test.ts",
+    "test:ci": "node --test $(ls frontend/tests/*.test.mjs frontend/tests/*.test.ts | grep -v lifecycle)"
   },
   "devDependencies": {
     "jsdom": "^30.0.1"

--- a/src/praisonai-desktop/src-tauri/src/lib.rs
+++ b/src/praisonai-desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@
 //! adapter over this crate.
 
 pub mod platform;
+pub mod x11_threads;
 pub mod venv_resolve;
 pub mod health;
 pub mod readiness;

--- a/src/praisonai-desktop/src-tauri/src/main.rs
+++ b/src/praisonai-desktop/src-tauri/src/main.rs
@@ -96,16 +96,28 @@ fn resolve_python(user_data: Option<&Path>) -> Result<PathBuf, String> {
 /// directory, no engine, and the orphan-reclaim path never ran at all.
 fn home_dir() -> Option<PathBuf> {
     let platform = Platform::current();
-    std::env::var_os(platform.home_var())
+    // Empty is unset. The engine treats it that way (`if override:`), and for
+    // XDG the spec requires it -- so without this filter the two sides pick
+    // different directories from the same environment: `XDG_DATA_HOME=""`
+    // makes Rust join onto an empty path and produce the *relative* path
+    // "PraisonAI", so the shell looks for the lockfile in the working
+    // directory while the engine writes it under the home directory. The
+    // shell then decides "no lock, spawn" on every single launch.
+    non_empty(platform.home_var()).or_else(|| non_empty("HOME"))
+}
+
+/// An environment variable as a path, treating empty exactly like unset.
+fn non_empty(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .filter(|value| !value.is_empty())
         .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
 }
 
 /// %APPDATA% on Windows, $XDG_DATA_HOME on Linux, neither on macOS.
 fn app_data_root() -> Option<PathBuf> {
     match Platform::current() {
-        Platform::Windows => std::env::var_os("APPDATA").map(PathBuf::from),
-        Platform::Linux => std::env::var_os("XDG_DATA_HOME").map(PathBuf::from),
+        Platform::Windows => non_empty("APPDATA"),
+        Platform::Linux => non_empty("XDG_DATA_HOME"),
         Platform::Mac => None,
     }
 }
@@ -183,13 +195,26 @@ async fn provision_engine(app: tauri::AppHandle) -> Result<String, String> {
                     String::from_utf8_lossy(&out.stderr).lines().last().unwrap_or("")));
             }
             say("uv", "Fetching the installer", "done", "");
-            data.join(platform.venv_bin_rel()).join(platform.uv_exe())
+            let installed = data.join(platform.venv_bin_rel()).join(platform.uv_exe());
+            // An exit code is not evidence. `powershell -Command "irm … | iex"`
+            // can exit 0 having installed nothing -- a non-terminating error
+            // does not set the exit status -- and the user then meets a
+            // confusing failure at "Installing Python" rather than being told
+            // the uv install is what went wrong.
+            if !installed.is_file() {
+                return Err(format!(
+                    "the uv installer reported success but left nothing at {}",
+                    installed.display()));
+            }
+            installed
         }
     };
 
     for step in plan(&uv, &data, ENGINE_PACKAGES, platform) {
         say(step.id, step.label, "running", "");
-        let out = std::process::Command::new(&step.program)
+        let mut step_command = std::process::Command::new(&step.program);
+        no_console(&mut step_command);
+        let out = step_command
             .args(&step.args)
             .output()
             .map_err(|e| format!("{}: {e}", step.label))?;
@@ -314,6 +339,9 @@ fn engine_status(app: tauri::AppHandle, state: tauri::State<'_, AppState>) -> En
 static SAVE_PENDING: AtomicBool = AtomicBool::new(false);
 
 fn main() {
+    // First, before anything can open an X connection. GTK will not do this
+    // for us and the failure without it is a silent exit(1) with no message.
+    praisonai_desktop_core::x11_threads::init();
     tauri::Builder::default()
         // Must be registered first: the guard has to run before anything else
         // touches the lockfile or the engine.
@@ -330,7 +358,18 @@ fn main() {
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {
             app.manage(AppState { engine: Mutex::new(None) });
-            praisonai_desktop_core::tray::build(app.handle())?;
+            // Deliberately not `?`. On Linux the tray goes through
+            // libappindicator, which is dlopen'd at first use and *panics* if
+            // neither the ayatana nor the classic library is present -- and
+            // with panic=abort that is not catchable. A missing tray would
+            // take the whole app down before a window ever existed: the
+            // package would install cleanly and then do nothing when clicked.
+            // The same applies to a Wayland compositor with no tray protocol.
+            // An app with no tray icon is a small loss; an app that will not
+            // open is a total one.
+            if let Err(e) = praisonai_desktop_core::tray::build(app.handle()) {
+                eprintln!("tray unavailable, continuing without it: {e}");
+            }
             Ok(())
         })
         .on_window_event(|window, event| {

--- a/src/praisonai-desktop/src-tauri/src/reclaim.rs
+++ b/src/praisonai-desktop/src-tauri/src/reclaim.rs
@@ -96,7 +96,7 @@ pub fn fnv1a64(text: &str) -> u64 {
 pub fn observe(pid: u32) -> Observed {
     #[cfg(windows)]
     {
-        return observe_windows(pid);
+        observe_windows(pid)
     }
     #[cfg(not(windows))]
     {

--- a/src/praisonai-desktop/src-tauri/src/reclaim.rs
+++ b/src/praisonai-desktop/src-tauri/src/reclaim.rs
@@ -380,3 +380,85 @@ mod hash_agreement {
         assert_eq!(fnv1a64("Tue 25 Aug 15:26:04 2026"), 0x1442_a707_ebec_e155);
     }
 }
+
+#[cfg(test)]
+mod spawn_hygiene {
+    //! A lint, not a behaviour test -- and labelled as one deliberately.
+    //!
+    //! Whether a child gets a console window is decided by a Windows creation
+    //! flag that has no observable effect on macOS or Linux, so there is
+    //! nothing to assert by running it here. What *can* be checked is that
+    //! every place we start a process goes through `no_console`, which is the
+    //! property that actually regressed: the helper existed, with a docstring
+    //! naming the exact symptom, and two of the six call sites did not use it
+    //! -- including the engine itself, which left a console window open beside
+    //! the app for the entire session.
+
+    const SOURCES: &[(&str, &str)] = &[
+        ("main.rs", include_str!("main.rs")),
+        ("supervisor.rs", include_str!("supervisor.rs")),
+        ("reclaim.rs", include_str!("reclaim.rs")),
+        ("provision.rs", include_str!("provision.rs")),
+    ];
+
+    /// Lines that start a process, excluding tests and Unix-only paths.
+    fn spawn_sites(source: &str) -> Vec<(usize, String)> {
+        let mut sites = Vec::new();
+        let mut in_test = false;
+        for (index, line) in source.lines().enumerate() {
+            if line.trim_start().starts_with("#[cfg(test)]") {
+                in_test = true;
+            }
+            if in_test || line.trim_start().starts_with("//") {
+                continue;
+            }
+            if line.contains("Command::new") {
+                sites.push((index + 1, line.trim().to_string()));
+            }
+        }
+        sites
+    }
+
+    #[test]
+    fn every_process_we_start_suppresses_the_console_window() {
+        let mut missing = Vec::new();
+        for (name, source) in SOURCES {
+            for (line_no, line) in spawn_sites(source) {
+                // The one exception: a command only ever built on Unix cannot
+                // open a Windows console, and is guarded by cfg already.
+                if line.contains("/bin/ps") || line.contains("\"curl\"") {
+                    continue;
+                }
+                // `no_console` must appear before the command is spawned.
+                // Scanned to the end of the statement rather than a fixed
+                // number of lines: a 12-line window failed on a call that was
+                // correctly guarded 16 lines down, past a comment.
+                let window: String = source
+                    .lines()
+                    .skip(line_no.saturating_sub(1))
+                    .take_while(|l| !l.contains("Command::new") || l.contains(&line[..8.min(line.len())]))
+                    .take(40)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if !window.contains("no_console") {
+                    missing.push(format!("{name}:{line_no}  {line}"));
+                }
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "these spawn a process without suppressing the console window:\n  {}",
+            missing.join("\n  ")
+        );
+    }
+
+    #[test]
+    fn the_lint_can_actually_fail() {
+        // A positive control: without it, a change that stops finding any
+        // spawn site at all would make the test above vacuously pass.
+        let sites: usize = SOURCES.iter().map(|(_, s)| spawn_sites(s).len()).sum();
+        assert!(sites >= 4, "the spawn-site scanner found almost nothing ({sites})");
+        let unguarded = "fn x() { std::process::Command::new(\"uv\").spawn(); }";
+        assert_eq!(spawn_sites(unguarded).len(), 1, "the scanner missed a plain spawn");
+    }
+}

--- a/src/praisonai-desktop/src-tauri/src/supervisor.rs
+++ b/src/praisonai-desktop/src-tauri/src/supervisor.rs
@@ -62,18 +62,71 @@ pub enum StartError {
     Timeout { tail: String },
 }
 
+/// Put the child in its own process group, so stopping it stops its children.
+///
+/// Without this, SIGTERM to the engine pid leaves anything the engine spawned
+/// running -- and the engine spawns training runs, which hold a GPU.
+fn detach_group(command: &mut Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = command;
+    }
+}
+
+/// Read lines, replacing undecodable bytes rather than stopping at them.
+///
+/// `BufRead::lines()` yields `Err(InvalidData)` on invalid UTF-8, and
+/// `map_while(Result::ok)` *stops the iterator* on the first error rather than
+/// skipping it -- so a single stray byte from a non-UTF-8 locale silently
+/// ended the reader thread for the rest of the session. The port announcement
+/// after it would never be seen, and the log would simply stop.
+pub fn read_lines_lossy(stream: impl std::io::Read) -> impl Iterator<Item = String> {
+    let mut reader = BufReader::new(stream);
+    std::iter::from_fn(move || {
+        let mut raw = Vec::new();
+        match reader.read_until(b'\n', &mut raw) {
+            Ok(0) => None,
+            Ok(_) => {
+                while matches!(raw.last(), Some(b'\n') | Some(b'\r')) {
+                    raw.pop();
+                }
+                Some(String::from_utf8_lossy(&raw).into_owned())
+            }
+            Err(_) => None,
+        }
+    })
+}
+
 /// Start the engine, returning once it has announced a usable port.
 ///
 /// Output is captured from the instant of spawn -- attaching a reader later is
 /// how a first-run failure ends up reported as an exit code with no explanation.
 pub fn start(python: &str, script: &str, timeout: Duration) -> Result<Engine, StartError> {
-    let mut child = Command::new(python)
+    let mut command = Command::new(python);
+    command
         .arg("-u") // unbuffered, or the announcement sits in a pipe buffer
         .arg(script)
+        // Force UTF-8 on both sides of the pipe. Python encodes redirected
+        // streams with the locale code page on Windows -- cp1252, or cp932 on
+        // a Japanese install -- and those bytes are not valid UTF-8. One of
+        // them arriving before the port announcement makes startup fail at the
+        // 30-second deadline with "Engine did not report ready in time", which
+        // is a lie about what happened and depends on the user's locale.
+        .env("PYTHONUTF8", "1")
+        .env("PYTHONIOENCODING", "utf-8")
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| StartError::Spawn(e.to_string()))?;
+        .stderr(Stdio::piped());
+    // No console window, and its own process group so stopping the engine also
+    // stops what the engine spawned -- a training run must not outlive the app
+    // holding a GPU.
+    crate::reclaim::no_console(&mut command);
+    detach_group(&mut command);
+    let mut child = command.spawn().map_err(|e| StartError::Spawn(e.to_string()))?;
 
     let stdout = child.stdout.take().expect("piped");
     let stderr = child.stderr.take().expect("piped");
@@ -84,7 +137,7 @@ pub fn start(python: &str, script: &str, timeout: Duration) -> Result<Engine, St
         (Box::new(stderr) as Box<dyn std::io::Read + Send>, tx),
     ] {
         std::thread::spawn(move || {
-            for line in BufReader::new(stream).lines().map_while(Result::ok) {
+            for line in read_lines_lossy(stream) {
                 if tx.send(line).is_err() {
                     break;
                 }
@@ -179,4 +232,54 @@ pub fn probe_health(port: u16) -> bool {
 
 fn tail(buffer: &str) -> String {
     buffer.lines().rev().take(12).collect::<Vec<_>>().into_iter().rev().collect::<Vec<_>>().join("\n")
+}
+
+#[cfg(test)]
+mod lossy_reader {
+    //! One undecodable byte must cost one character, not the whole session.
+    use super::read_lines_lossy;
+
+    #[test]
+    fn a_bad_byte_does_not_end_the_stream() {
+        // cp1252 output from a non-English Windows install. The previous reader
+        // used lines().map_while(Result::ok), which *stops* on the first
+        // Err(InvalidData) rather than skipping it -- so everything after this
+        // byte, including the port announcement, was never seen, and startup
+        // failed 30 seconds later blaming a timeout.
+        let raw: &[u8] = b"before\n\xff\xfe bad\nPRAISONAI_PORT=54321\nafter\n";
+        let lines: Vec<String> = read_lines_lossy(raw).collect();
+        assert_eq!(lines.len(), 4, "{lines:?}");
+        assert_eq!(lines[0], "before");
+        assert!(lines[1].contains("bad"), "{:?}", lines[1]);
+        assert_eq!(lines[2], "PRAISONAI_PORT=54321", "the port announcement was lost");
+        assert_eq!(lines[3], "after");
+    }
+
+    #[test]
+    fn ordinary_utf8_survives_unchanged() {
+        let raw = "caf\u{e9} \u{2014} \u{1f9a5}\n".as_bytes();
+        let lines: Vec<String> = read_lines_lossy(raw).collect();
+        assert_eq!(lines, vec!["caf\u{e9} \u{2014} \u{1f9a5}"]);
+    }
+
+    #[test]
+    fn windows_line_endings_leave_no_stray_carriage_return() {
+        let raw: &[u8] = b"one\r\ntwo\r\n";
+        let lines: Vec<String> = read_lines_lossy(raw).collect();
+        assert_eq!(lines, vec!["one", "two"]);
+    }
+
+    #[test]
+    fn a_final_line_without_a_newline_is_still_delivered() {
+        // A crashing engine's last words usually arrive without a newline.
+        let raw: &[u8] = b"traceback line";
+        let lines: Vec<String> = read_lines_lossy(raw).collect();
+        assert_eq!(lines, vec!["traceback line"]);
+    }
+
+    #[test]
+    fn an_empty_stream_yields_nothing_rather_than_hanging() {
+        let lines: Vec<String> = read_lines_lossy(&b""[..]).collect();
+        assert!(lines.is_empty());
+    }
 }

--- a/src/praisonai-desktop/src-tauri/src/supervisor.rs
+++ b/src/praisonai-desktop/src-tauri/src/supervisor.rs
@@ -171,7 +171,7 @@ pub fn start(python: &str, script: &str, timeout: Duration) -> Result<Engine, St
                     // A port parsed from a log line is a claim. Confirm it before
                     // handing it to the UI, or the first message goes to whatever
                     // else happens to be listening.
-                    if let Some(port) = announced.confirm(|p| probe_health(p)) {
+                    if let Some(port) = announced.confirm(probe_health) {
                         return Ok(Engine { port, child });
                     }
                 }

--- a/src/praisonai-desktop/src-tauri/src/tray.rs
+++ b/src/praisonai-desktop/src-tauri/src/tray.rs
@@ -35,12 +35,28 @@ pub fn focus_main<R: Runtime>(app: &AppHandle<R>) {
     }
 }
 
+/// A keyboard accelerator, or none where the modifier does not exist.
+fn accel(mac: &str) -> Option<&str> {
+    if cfg!(target_os = "macos") {
+        Some(mac)
+    } else {
+        // Deliberately no Ctrl equivalent: a tray menu is not focused, so the
+        // accelerator would be a global hotkey stealing a common chord from
+        // whatever the user is actually typing into.
+        None
+    }
+}
+
 pub fn build(app: &AppHandle<tauri::Wry>) -> tauri::Result<()> {
     let show = MenuItem::with_id(app, SHOW, "Open PraisonAI", true, None::<&str>)?;
     let engine = MenuItem::with_id(app, ENGINE, "Engine: starting…", false, None::<&str>)?;
-    let settings = MenuItem::with_id(app, SETTINGS, "Settings…", true, Some("Cmd+,"))?;
+    // Accelerators only where the modifier exists. Tauri maps "Cmd" to SUPER
+    // off macOS, so these rendered as "Windows+," and "Windows+Q" -- and
+    // Win+Q is a reserved OS shortcut, so the menu advertised a binding the
+    // system takes first.
+    let settings = MenuItem::with_id(app, SETTINGS, "Settings…", true, accel("Cmd+,"))?;
     let sep = PredefinedMenuItem::separator(app)?;
-    let quit = MenuItem::with_id(app, QUIT, "Quit PraisonAI", true, Some("Cmd+Q"))?;
+    let quit = MenuItem::with_id(app, QUIT, "Quit PraisonAI", true, accel("Cmd+Q"))?;
     let menu = Menu::with_items(app, &[&show, &engine, &sep, &settings, &sep, &quit])?;
 
     *ENGINE_ITEM.lock().unwrap() = Some(engine.clone());
@@ -53,9 +69,18 @@ pub fn build(app: &AppHandle<tauri::Wry>) -> tauri::Result<()> {
         // white block sitting among the system's line glyphs. icons/tray.png
         // carries the mark cut into the alpha instead.
         .icon(tray_icon()?)
-        .icon_as_template(true)
+        // Template rendering is a macOS concept: the system discards the
+        // colour and tints the alpha shape. Windows and Linux draw the actual
+        // pixels, and this glyph's pixels are black -- invisible against the
+        // Windows 11 taskbar and the GNOME top bar. Setting it only where it
+        // means something is half the fix; the other half is a light glyph,
+        // which is why the icon is chosen per platform below.
+        .icon_as_template(cfg!(target_os = "macos"))
         .menu(&menu)
-        .show_menu_on_left_click(false)
+        // "Unsupported on Linux" per Tauri's own docs -- the menu opens on
+        // left click there regardless, so asking for the opposite only makes
+        // the code claim something untrue.
+        .show_menu_on_left_click(cfg!(not(target_os = "linux")))
         .on_menu_event(handle_menu)
         .on_tray_icon_event(|tray, event| {
             // Left click opens the window; right click opens the menu. Matching

--- a/src/praisonai-desktop/src-tauri/src/venv_resolve.rs
+++ b/src/praisonai-desktop/src-tauri/src/venv_resolve.rs
@@ -167,7 +167,16 @@ mod platform_layout {
         // colon of its own, so "does it contain ':'" cannot tell a separator
         // from a path and would pass either way.
         let env = spawn_env(&windows_layout(), &inherited, Platform::Windows);
-        assert_eq!(env["PATH"], "C:/data/venv/Scripts;C:/Windows/System32");
+        // Split on the separator rather than comparing the whole string: the
+        // separator *between entries* is what this is about, and asserting the
+        // whole value also pins the separator *inside* a path, which is the
+        // host's business -- PathBuf::join writes a backslash when the tests
+        // themselves run on Windows, and this failed there for that reason
+        // while the product was correct.
+        let entries: Vec<&str> = env["PATH"].split(';').collect();
+        assert_eq!(entries.len(), 2, "PATH did not split into two entries: {}", env["PATH"]);
+        assert!(entries[0].ends_with("Scripts"), "{}", entries[0]);
+        assert_eq!(entries[1], "C:/Windows/System32");
     }
 
     #[test]
@@ -187,7 +196,10 @@ mod platform_layout {
             version: "3.12.4".to_string(),
         };
         let env = spawn_env(&layout, &inherited, Platform::Mac);
-        assert_eq!(env["PATH"], "/data/venv/bin:/usr/bin");
+        let entries: Vec<&str> = env["PATH"].split(':').collect();
+        assert_eq!(entries.len(), 2, "PATH did not split into two entries: {}", env["PATH"]);
+        assert!(entries[0].ends_with("bin"), "{}", entries[0]);
+        assert_eq!(entries[1], "/usr/bin");
     }
 
     #[test]

--- a/src/praisonai-desktop/src-tauri/src/x11_threads.rs
+++ b/src/praisonai-desktop/src-tauri/src/x11_threads.rs
@@ -1,0 +1,51 @@
+//! Tell Xlib it is about to be used from more than one thread.
+//!
+//! GTK3 never calls `XInitThreads()`, so every Xlib lock is a no-op. This
+//! process drives X from several threads regardless -- WebKitGTK's compositor,
+//! GLib workers, the event loop, the clipboard -- so the request/reply sequence
+//! Xlib keeps for its XCB transport can be corrupted by interleaving.
+//!
+//! The failure is not a clean error. `_XReply` fails to match a reply and calls
+//! `_XIOError` while `xcb_connection_has_error()` still reports 0; GDK's IO
+//! error handler reports that through `g_debug()` -- dropped unless
+//! `G_MESSAGES_DEBUG` happens to name the domain -- and then `_exit(1)`s. The
+//! app simply vanishes, with exit code 1 and no output at all, intermittently.
+//!
+//! Resolved through `dlsym` rather than by linking libX11, deliberately: on a
+//! Wayland-only or headless host the symbol is absent and this becomes a no-op,
+//! instead of the binary failing to load for want of a library it never needs.
+
+/// Call `XInitThreads()` if this process has Xlib loaded. Safe anywhere.
+///
+/// Must run before any X connection is opened, which in practice means first
+/// in `main()` -- after GTK has connected it is too late to matter.
+pub fn init() {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    unsafe {
+        use std::ffi::c_void;
+
+        const RTLD_DEFAULT: *mut c_void = std::ptr::null_mut();
+        extern "C" {
+            fn dlsym(handle: *mut c_void, symbol: *const i8) -> *mut c_void;
+        }
+        let name = c"XInitThreads";
+        let symbol = dlsym(RTLD_DEFAULT, name.as_ptr());
+        if !symbol.is_null() {
+            let x_init_threads: extern "C" fn() -> i32 = std::mem::transmute(symbol);
+            x_init_threads();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calling_it_is_safe_on_any_platform() {
+        // On macOS and on a host with no Xlib this resolves nothing and does
+        // nothing; the point is that it never panics or aborts.
+        init();
+        init(); // and is idempotent, as XInitThreads itself is
+    }
+}

--- a/src/praisonai-desktop/src-tauri/src/x11_threads.rs
+++ b/src/praisonai-desktop/src-tauri/src/x11_threads.rs
@@ -26,7 +26,10 @@ pub fn init() {
 
         const RTLD_DEFAULT: *mut c_void = std::ptr::null_mut();
         extern "C" {
-            fn dlsym(handle: *mut c_void, symbol: *const i8) -> *mut c_void;
+            // c_char, not i8: c_char is *unsigned* on aarch64 and arm Linux,
+            // so i8 does not compile there. The CI runner is x86_64, where the
+            // two happen to agree, so nothing would have caught it.
+            fn dlsym(handle: *mut c_void, symbol: *const std::ffi::c_char) -> *mut c_void;
         }
         let name = c"XInitThreads";
         let symbol = dlsym(RTLD_DEFAULT, name.as_ptr());

--- a/src/praisonai-desktop/src-tauri/tauri.conf.json
+++ b/src/praisonai-desktop/src-tauri/tauri.conf.json
@@ -53,13 +53,20 @@
       "nsis": {
         "installMode": "currentUser",
         "installerIcon": "icons/icon.ico",
-        "languages": ["English"],
+        "languages": [
+          "English"
+        ],
         "displayLanguageSelector": false
       }
     },
     "linux": {
       "deb": {
-        "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
+        "depends": [
+          "libwebkit2gtk-4.1-0",
+          "libgtk-3-0",
+          "libayatana-appindicator3-1 | libappindicator3-1",
+          "curl"
+        ]
       }
     },
     "resources": {

--- a/src/praisonai-desktop/src-tauri/tauri.macos.conf.json
+++ b/src/praisonai-desktop/src-tauri/tauri.macos.conf.json
@@ -3,6 +3,12 @@
   "app": {
     "windows": [
       {
+        "title": "PraisonAI",
+        "width": 980,
+        "height": 720,
+        "minWidth": 560,
+        "minHeight": 420,
+        "visible": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true
       }

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -395,6 +395,10 @@ body.training #thread,body.training #f{display:none}
 .trun .grow{flex:1}
 .tnote{font-size:.76rem;color:var(--bad);margin-top:.6rem}
 .tnote:empty{display:none}
+/* A class, not a style attribute: configuring a CSP makes Tauri stamp a nonce
+   on this <style> tag, which voids 'unsafe-inline' and stops every inline
+   style attribute in the document from applying. */
+.runshd{padding:0 0 .3rem}
 </style></head><body>
 <div class="titlebar" data-tauri-drag-region>
   <button class="modelpill" id="modelpill" type="button">
@@ -557,7 +561,7 @@ body.training #thread,body.training #f{display:none}
         </div>
 
         <div class="tcard" id="tHistoryCard" hidden>
-          <div class="sectlbl" style="padding:0 0 .3rem">Previous runs</div>
+          <div class="sectlbl runshd">Previous runs</div>
           <div id="tHistory"></div>
         </div>
       </div>

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -2257,7 +2257,12 @@ trainForm.addEventListener('submit',async e=>{
 tStop.addEventListener('click',async()=>{
   tStop.disabled=true;
   try{
-    const res=await fetch(`http://127.0.0.1:${PORT}/train/stop`,{
+    // Send the run this tab is watching, so the engine can refuse if it is
+    // not the live one. Without the id the server's stale-tab guard cannot
+    // fire at all: a tab left open from a finished run would cancel whatever
+    // someone started after it, and be told it succeeded.
+    const target=trainRunId?`/train/stop/${encodeURIComponent(trainRunId)}`:'/train/stop';
+    const res=await fetch(`http://127.0.0.1:${PORT}${target}`,{
       method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
     if(!res.ok){ const b=await res.json(); tError.textContent=b.error||'Nothing was running.'; }
   }catch(err){ tError.textContent=`Could not reach the engine: ${err.message}`; }

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -71,7 +71,10 @@ body{margin:0;background:var(--ground);color:var(--ink);font:.906rem/1.6 ui-sans
 .chat .x:hover{opacity:1;color:var(--bad)}
 .chat.corrupt .t{color:var(--bad);font-style:italic}
 #main{flex:1;display:flex;flex-direction:column;min-width:0}
-.titlebar{height:2.75rem;-webkit-app-region:drag;flex:none;display:flex;align-items:center;
+/* Dragging comes from data-tauri-drag-region on the markup, not from
+   -webkit-app-region: that property is Chromium's and is a no-op in both
+   WKWebView and WebKitGTK, so it was documentation pretending to be code. */
+.titlebar{height:2.75rem;flex:none;display:flex;align-items:center;
           gap:.6rem;padding:0 .9rem;border-bottom:1px solid var(--rule)}
 /* Room for the traffic lights, which only macOS puts inside the window and
    only on the left. Reserving it everywhere left dead space on Windows and
@@ -337,6 +340,16 @@ button.stop{background:var(--bad)}
             cursor:pointer;user-select:none;display:flex;gap:.4rem;align-items:center}
 .think-body{display:none;white-space:pre-wrap;margin-top:.35rem;font-size:.82rem}
 .think.open .think-body{display:block}
+/* Utility classes standing in for inline style attributes.
+   A style="" attribute is governed by style-src, and Tauri stamps a nonce on
+   the page's <style> tag whenever a CSP is configured -- which voids
+   'unsafe-inline' for the whole directive. Every inline style attribute then
+   stops applying: the file input and the Stop button render permanently
+   visible, and every tool-output block sits expanded. Setting .style from
+   JavaScript is CSSOM and unaffected; only the attributes are. */
+.is-hidden{display:none}
+.errhint{color:var(--bad)}
+.logpre{max-height:52vh;overflow:auto;font-size:.74rem}
 </style></head><body>
 <div class="titlebar" data-tauri-drag-region>
   <button class="modelpill" id="modelpill" type="button">
@@ -372,7 +385,7 @@ button.stop{background:var(--bad)}
   <div class="queued" id="queued"></div>
   <div class="chips" id="chips"></div>
   <textarea id="p" rows="1" placeholder="Ask anything…" disabled></textarea>
-  <input type="file" id="filein" multiple style="display:none"/>
+  <input type="file" id="filein" multiple class="is-hidden"/>
   <div class="ctools">
     <button class="ctool" id="attach" type="button" title="Attach a file"
             aria-label="Attach a file">+</button>
@@ -380,7 +393,7 @@ button.stop{background:var(--bad)}
             aria-pressed="true">⚒ Tools</button>
     <span class="grow"></span>
     <button id="send" disabled title="Send" aria-label="Send message">↑</button>
-    <button id="stop" class="stop" type="button" style="display:none">Stop</button>
+    <button id="stop" class="stop is-hidden" type="button">Stop</button>
   </div>
 </div></div></form>
   </main>
@@ -664,12 +677,27 @@ const chord=key=>OS==='mac'?`${MOD}${key}`:`${MOD}+${key}`;
 
 /** Where the engine keeps transcripts and settings, per platform.
  *
- * Must match `default_data_dir` in engine/server.py. Offering to copy a path
- * that does not exist on the machine reading it is worse than not offering. */
+ * The default for this platform, matching `default_data_dir` in
+ * engine/server.py. Offering to copy a path that does not exist on the machine
+ * reading it is worse than not offering.
+ *
+ * The engine can be pointed elsewhere with PRAISONAI_DESKTOP_HOME, and Linux
+ * honours XDG_DATA_HOME, so this is the default rather than the truth. The
+ * caller asks the engine where it actually is and falls back to this. */
 function dataFolderPath(){
   if(OS==='mac') return '~/Library/Application Support/PraisonAI';
   if(OS==='win') return '%APPDATA%\\PraisonAI';
   return '~/.local/share/PraisonAI';
+}
+
+/** The folder the engine is really using, or the default if it cannot say. */
+async function actualDataFolder(){
+  try{
+    const r=await fetch(`http://127.0.0.1:${PORT}/health`);
+    const {data_dir}=await r.json();
+    if(data_dir) return data_dir;
+  }catch(e){ /* the engine may be down; the default is still useful */ }
+  return dataFolderPath();
 }
 window.dataFolderPath=dataFolderPath;
 
@@ -916,7 +944,7 @@ function toolCard(host,callId,name,args){
       <span class="tool-name"></span><span class="tool-meta">running…</span>
       <span class="tool-chev">▶</span></div>
     <div class="tool-body"><div class="tool-label">Arguments</div><pre class="args"></pre>
-      <div class="out-wrap" style="display:none">
+      <div class="out-wrap is-hidden">
         <div class="tool-label">Result</div><pre class="out"></pre></div></div>`;
   el.querySelector('.tool-name').textContent=name;
   el.querySelector('.args').textContent=
@@ -934,7 +962,7 @@ function toolResult(host,callId,name,ok,output,seconds){
   el.querySelector('.tool-meta').textContent=
     (ok?'':'failed · ')+(seconds!=null?`${seconds}s`:'done');
   const w=el.querySelector('.out-wrap'), pre=el.querySelector('.out');
-  w.style.display='';
+  w.classList.remove('is-hidden');
   const full=String(output??'');
   // Keep the TAIL, not the head. For command output the end is the part that
   // matters -- the error, the summary, the last line -- and head-truncating
@@ -1144,7 +1172,7 @@ if(st.state==='ready'){
   applyTheme(CFG.theme);
   applyPrefs(CFG);
   if(CFG.check_updates!==false) checkUpdates();
-}else if(st.reason==='No usable Python'){
+}else if(needsSetup(st)){
   // A clean machine has nothing to run the engine with. Offering to build it
   // is the difference between a product and an error message: "No usable
   // Python" is true and useless to someone who has never installed one.
@@ -1152,7 +1180,42 @@ if(st.state==='ready'){
   firstRun(st);
 }else{
   status.textContent='engine failed'; status.className='s-fail';
-  fail(st.reason, st.detail, st.tail);
+  // Always with a way to act. A banner with no buttons is a dead end, and
+  // this branch is reached on every launch once it starts happening.
+  failWithSetup(st);
+}
+
+/**
+ * Whether this failure is one that building the environment would fix.
+ *
+ * Not just the exact "No usable Python" string. An install interrupted during
+ * the dependency step leaves a venv that is complete and empty: pyvenv.cfg
+ * exists so the interpreter is accepted, and the engine then dies importing a
+ * package that was never installed. That is repairable by exactly the same
+ * setup flow, but it arrives under a different reason -- so keying off the one
+ * string left those users with an error screen and no button, permanently.
+ */
+function needsSetup(st){
+  if(st.reason==='No usable Python') return true;
+  const said=`${st.reason||''} ${st.detail||''} ${st.tail||''}`;
+  return /ModuleNotFoundError|No module named|ImportError/i.test(said);
+}
+
+/** The failure banner, always with something the reader can do next. */
+function failWithSetup(st){
+  const d=fail(st.reason, st.detail, st.tail);
+  const row=document.createElement('div'); row.className='errbtns';
+  const setup=document.createElement('button');
+  setup.type='button'; setup.className='ghost'; setup.textContent='Set up the environment';
+  setup.onclick=()=>{ d.remove(); syncEmpty(); firstRun(st); };
+  const copy=document.createElement('button');
+  copy.type='button'; copy.className='ghost'; copy.textContent='Copy details';
+  copy.onclick=()=>{ navigator.clipboard.writeText(
+    [st.reason,st.detail,st.tail].filter(Boolean).join('\n\n'));
+    copy.textContent='Copied'; setTimeout(()=>copy.textContent='Copy details',1200); };
+  row.append(setup,copy);
+  const err=d.querySelector('.err');
+  if(err) err.appendChild(row);
 }
 }
 
@@ -1234,7 +1297,7 @@ document.getElementById('f').addEventListener('submit',async e=>{
   setComposer('');
   if(running){ queue.push(text); renderQueue(); return; }
   running=true;
-  send.style.display='none'; stopBtn.style.display=''; box.focus();
+  send.style.display='none'; stopBtn.classList.remove('is-hidden'); box.focus();
   const runId=rid(); activeRun=runId;
   const sent=attached; attached=[]; renderChips();
   const ub=turn('u','You'); ub.classList.add('plain'); ub.textContent=text;
@@ -1302,7 +1365,7 @@ document.getElementById('f').addEventListener('submit',async e=>{
               btns.innerHTML='<span class="hint">'
                 +(choice==='deny'?'Denied':'Allowed')+'</span>';
             }catch(e){
-              btns.innerHTML='<span class="hint" style="color:var(--bad)">'
+              btns.innerHTML='<span class="hint errhint">'
                 +'Could not send your decision \u2014 '+e.message+'</span>';
               const retry=document.createElement('button');
               retry.className='ctool'; retry.textContent='Retry';
@@ -1346,7 +1409,7 @@ document.getElementById('f').addEventListener('submit',async e=>{
     addActions(out.parentElement, text, acc, userIndex, versions, vactive);
     out.parentElement.classList.remove('live');
     activeRun=null; activeReader=null;
-    stopBtn.style.display='none'; send.style.display='';
+    stopBtn.classList.add('is-hidden'); send.style.display='';
     box.focus();
     refreshChats();
     running=false;
@@ -1478,7 +1541,7 @@ document.getElementById('logsBtn').addEventListener('click',async()=>{
   try{ r=await (await fetch('http://127.0.0.1:'+PORT+'/logs')).json(); }
   catch(e){ engineDownPanel('The engine log'); return; }
   const body=r.lines.length ? r.lines.map(l=>esc(l)).join('\n') : '(nothing yet)';
-  panel.innerHTML='<h2>Engine log</h2><pre style="max-height:52vh;overflow:auto;font-size:.74rem">'
+  panel.innerHTML='<h2>Engine log</h2><pre class="logpre">'
     +body+'</pre><div class="row"><button class="ghost" id="l-close">Close</button></div>';
   panel.querySelector('#l-close').onclick=closeOverlay;
   overlay.classList.add('open');
@@ -1620,8 +1683,9 @@ async function runAction(def){
     for(const c of chats) await fetch('http://127.0.0.1:'+PORT+'/chats/'+c.id,{method:'DELETE'});
     chatId=rid(); turns.innerHTML=''; syncEmpty(); refreshChats(); closeOverlay();
   } else if(def.action==='reveal'){
-    await navigator.clipboard.writeText(dataFolderPath());
-    toast(`Path copied: ${dataFolderPath()}`);
+    const where=await actualDataFolder();
+    await navigator.clipboard.writeText(where);
+    toast(`Path copied: ${where}`);
   } else if(def.action==='update'){
     const u=await (await fetch('http://127.0.0.1:'+PORT+'/update')).json();
     toast(u.message || ('PraisonAI Desktop '+u.current));

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -2036,14 +2036,19 @@ const trainView=document.getElementById('train'),
       tHistoryCard=document.getElementById('tHistoryCard'),
       lossCanvas=document.getElementById('loss');
 
+/* Each hint names the columns the dataset must actually have.
+   The trainer only checks these after it has downloaded the model and loaded
+   it in 4-bit, so a mismatch costs an hour before it is reported. Saying so up
+   front is the difference between a wrong dataset and a wasted evening. */
 const METHOD_HINTS={
-  sft:'Trains on completions.', cpt:'Raw-text corpus; embeddings get their own rate.',
+  sft:'Trains on completions. Works with the default dataset.',
+  cpt:'Raw-text corpus; needs a text column. Embeddings get their own rate.',
   dpo:'Needs prompt, chosen and rejected columns.',
-  orpo:'Preference tuning without a reference model.',
-  kto:'Binary thumbs up or down per sample.',
-  grpo:'Needs reward functions; no reward model.',
-  reward:'Trains a reward model, not a chat model.',
-  cpo:'Contrastive preference; no reference model.'};
+  orpo:'Needs prompt, chosen and rejected columns; no reference model.',
+  kto:'Needs prompt, completion and label columns.',
+  grpo:'Needs reward functions, which this form cannot supply — use the CLI.',
+  reward:'Needs chosen and rejected columns. Trains a reward model, not a chat model.',
+  cpo:'Needs prompt, chosen and rejected columns; no reference model.'};
 
 let trainStream=null, trainCursor=-1, trainRunId=null, lossSeries=[], logLines=[];
 const MAX_LOG_LINES=600;   // the pane is a tail, not an archive; the log file has it all


### PR DESCRIPTION
Both desktop PRs (#4372, #4373) merged before their review gates finished. The
reviews then found defects in the code that is now on `main` — including four
that make the app visibly broken or lose the user's work. This is those fixes,
plus the CI that would have caught several of them.

## What is wrong with `main` today

**The CSP breaks the app's layout on first launch.** I claimed it was safe; it
is not, and this was proven rather than argued. Setting `csp` to non-null makes
Tauri stamp a nonce on the page's `<style>` tag and a hash on its inline
`<script>` at build time — and a nonce or hash in a source list *voids*
`'unsafe-inline'` for that directive. Every `style=""` attribute then stops
applying: a permanently visible red **Stop** button, a raw file-picker widget,
and every tool-output block expanded. Nothing errors. No test in the suite sets
a CSP header, which is why it shipped.

**The Linux tray takes the whole app down.** `tray::build(...)?` in setup, and
on Linux the tray goes through libappindicator, which is `dlopen`'d at first use
and *panics* if absent — uncatchable, since the build uses `panic=abort`. Being
`dlopen`'d, there is no `DT_NEEDED` entry, so `dpkg-shlibdeps` could not derive
the dependency either: the `.deb` installs cleanly and then does nothing.

**The macOS overlay silently deleted the window geometry.** Tauri merges
`tauri.macos.conf.json` with RFC 7386, whose rule for arrays is replacement, not
element-wise merge. The overlay replaced the whole `windows` array, so title,
width, height and both minimums vanished — an 800×600 "Tauri App" that can be
dragged down to nothing.

**Deleting an API key reported success while the key kept working.** Once a
secret had reached both stores, a delete short-circuited on the first success
and the read path served the survivor. The plaintext stayed on disk.

**Opening the Training tab on a run older than ~20 minutes showed nothing** and
pinned a core doing it — an SSE resync loop that skipped both its sleep and its
terminal check, spinning at ~13,000 frames/sec and continuing after the run
finished.

**Pressing Stop before the trainer spawned cancelled nothing** — the user got
`{"ok": true}` and a "stopping" pill while the fine-tune ran to completion,
holding the GPU.

**One trailing slash let a stale tab kill the live run** — `rsplit("/")` on
`/train/stop/<id>/` yields `""`, which is falsy, so the guard built for exactly
that case was skipped.

Plus: a retired CI runner that would have failed every release forever; console
windows beside the app on Windows; a log reader that stopped permanently on one
undecodable byte; no process group, so a fine-tune survived quit; two run
directories colliding; a whole-file read at the moment a run fails; and several
more. Each is described in its commit.

## The CI

Nothing in `.github` referenced `praisonai-desktop`. Every suite ran nowhere.
The UI suite could not even be installed — jsdom was undeclared, so it ran only
where one happened to exist further up the tree, at whatever version. Pinning it
showed 16 tests fail on jsdom 25 and pass on 30: they had been passing against a
version nobody chose. Clippy is included in the gate because it was already
failing.

The lifecycle suite is excluded from CI **by name** rather than left to skip: it
needs a live model. The remaining 128 run with the skip count asserted to be
zero, because a suite that skips everything looks exactly like one that passed.

## Verification

Merged combination of both features plus all fixes: **123 Rust, 4 Python suites,
144 UI, clippy clean.** Every fix was mutation-tested — the fix is reverted and
the test must fail. Two of my own tests failed that check and were rewritten:
one asserted a button *existed* without clicking it, and one asserted a run's
final state was "cancelled", which a version that never signals the process also
satisfies while the job runs to the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer setup-repair options and copyable diagnostics when the desktop engine cannot start.
  * Data-folder controls now reveal the app’s active storage location.
  * Training setup validates method requirements and dataset columns, with safer run management and bounded history.
  * Improved cross-platform tray menus, shortcuts, installers, and window defaults.

* **Bug Fixes**
  * Improved handling of corrupted data, interrupted training, unusual paths, invalid text output, and startup failures.
  * Enhanced Linux, macOS, and Windows compatibility, including safer process, display, and installer handling.

* **Tests**
  * Expanded automated coverage for desktop workflows, security policies, portability, training, and startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->