### PR TITLE
Sync to praisonai-js: monorepo → npm mirror

### DIFF
--- a/.cursor/skills/praisonai-js-hub-intake/SKILL.md
+++ b/.cursor/skills/praisonai-js-hub-intake/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 
 **Issues and fixes both live in `MervinPraison/PraisonAI`.** TypeScript code path: `src/praisonai-ts/`.
 
-Do **not** route TS fixes to external repos in automation prompts. The separate [praisonai-js](https://github.com/MervinPraison/praisonai-js) repo is optional for npm publishing/mirror — not the fix target for hub issues.
+Do **not** route TS fixes to external repos in automation prompts. The separate [praisonai-js](https://github.com/MervinPraison/praisonai-js) repo is an npm mirror updated **from** the monorepo (`Sync to praisonai-js` workflow).
 
 ## Routing table
 

--- a/.cursor/skills/praisonai-js-hub-intake/reference.md
+++ b/.cursor/skills/praisonai-js-hub-intake/reference.md
@@ -12,6 +12,15 @@
 | `.github/scripts/merge-gate.js` | FINAL scope includes `src/praisonai-ts/`; no `tsMirrorPathReasons` block |
 | `.github/workflows/claude-merge-gate.yml` | No BLOCK for src/praisonai-ts/ |
 | `CONTRIBUTING.md` | TS fixes in monorepo |
+| `.github/workflows/sync-to-praisonai-js.yml` | Mirror sync: monorepo → praisonai-js |
+
+## Mirror sync (after TS merge)
+
+```bash
+gh workflow run "Sync to praisonai-js" --repo MervinPraison/PraisonAI
+```
+
+Direction: **`src/praisonai-ts/` → praisonai-js** (not the reverse).
 
 ## Tests
 
@@ -30,8 +39,8 @@ cd src/praisonai-ts && npm install && npm run build && npm test
 | Wrong | Right |
 |-------|-------|
 | Route TS fix to praisonai-js in merge gate / Claude | Fix in `src/praisonai-ts/` |
-| Block `src/praisonai-ts/` PRs as "must sync from praisonai-js" | Allow normal TS PRs |
+| Sync praisonai-js → monorepo | Sync **monorepo → praisonai-js** after merge |
 
-## Optional: praisonai-js mirror
+## praisonai-js mirror
 
-Separate repo may mirror for npm; not referenced in issue→fix automation.
+npm repo; updated from monorepo via `Sync to praisonai-js`. See praisonai-js `SYNC.md`.

--- a/.github/workflows/sync-to-praisonai-js.yml
+++ b/.github/workflows/sync-to-praisonai-js.yml
@@ -1,0 +1,106 @@
+name: Sync to praisonai-js
+
+# Canonical TS source: src/praisonai-ts/ in this monorepo.
+# This workflow pushes the mirror to MervinPraison/praisonai-js (npm repo).
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch on MervinPraison/praisonai-js'
+        required: false
+        default: main
+        type: string
+      mode:
+        description: 'pr = open pull request (default); commit = push directly to target branch'
+        required: false
+        default: pr
+        type: choice
+        options:
+          - pr
+          - commit
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      TARGET_REPO: MervinPraison/praisonai-js
+      SOURCE_PATH: src/praisonai-ts
+      TARGET_BRANCH: ${{ inputs.target_branch }}
+    steps:
+      - name: Validate token
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "GH_TOKEN secret is required (PAT with repo write access to praisonai-js)."
+            exit 1
+          fi
+
+      - name: Checkout PraisonAI monorepo
+        uses: actions/checkout@v4
+
+      - name: Checkout praisonai-js
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.TARGET_REPO }}
+          token: ${{ secrets.GH_TOKEN }}
+          path: praisonai-js-target
+          ref: ${{ env.TARGET_BRANCH }}
+
+      - name: Sync monorepo path into praisonai-js
+        run: |
+          set -euo pipefail
+          rsync -a --delete \
+            --exclude '.git/' \
+            --exclude 'node_modules/' \
+            --exclude 'dist/' \
+            --exclude 'coverage/' \
+            --exclude '.DS_Store' \
+            --exclude '*.tsbuildinfo' \
+            "${SOURCE_PATH}/" praisonai-js-target/
+
+      - name: Push changes
+        working-directory: praisonai-js-target
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Preserve praisonai-js automation (rsync source has no .github/)
+          if git diff --quiet; then
+            echo "No changes — praisonai-js already matches ${SOURCE_PATH} on monorepo main."
+            exit 0
+          fi
+
+          git add -A
+          msg="sync: update from monorepo ${SOURCE_PATH}"
+
+          if [ "${{ inputs.mode }}" = "commit" ]; then
+            git commit -m "$msg"
+            git push origin "HEAD:${TARGET_BRANCH}"
+            echo "Committed and pushed directly to ${TARGET_BRANCH} on praisonai-js."
+            exit 0
+          fi
+
+          branch="sync/monorepo-praisonai-ts-$(date -u +%Y%m%d-%H%M%S)"
+          git checkout -b "$branch"
+          git commit -m "$msg"
+          git push origin "$branch"
+
+          gh pr create \
+            --repo "$TARGET_REPO" \
+            --base "$TARGET_BRANCH" \
+            --head "$branch" \
+            --title "$msg" \
+            --body "$(cat <<EOF
+Automated sync from [\`MervinPraison/PraisonAI\`](https://github.com/MervinPraison/PraisonAI) \`${SOURCE_PATH}/\` into the npm mirror repo.
+
+Canonical development is in the monorepo; this PR updates the public \`praisonai-js\` checkout.
+
+Excludes from rsync source: \`node_modules/\`, \`dist/\`, \`coverage/\`. \`.github/\` on praisonai-js is unchanged.
+EOF
+)"
+          echo "Opened PR on ${TARGET_REPO} (${branch} → ${TARGET_BRANCH})."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,4 @@ Thank you for your interest! Here's how to get started:
 - Add tests for new features
 - Update documentation as needed
 - TypeScript changes: implement in `src/praisonai-ts/` and run `npm test` there
+- After merge, sync the npm mirror: `gh workflow run "Sync to praisonai-js" --repo MervinPraison/PraisonAI`


### PR DESCRIPTION
## Summary
- Add `.github/workflows/sync-to-praisonai-js.yml` to rsync `src/praisonai-ts/` → `MervinPraison/praisonai-js` after TS merges
- Update CONTRIBUTING and praisonai-js hub skill docs to document correct sync direction

## Context
The previous model had `praisonai-js → src/praisonai-ts/` (wrong for monorepo-canonical). Fixes belong in the monorepo; praisonai-js is the npm mirror.

## Test plan
- [ ] Merge PR
- [ ] Run `Sync to praisonai-js` workflow manually once
- [ ] Confirm praisonai-js receives updated files from monorepo

Made with [Cursor](https://cursor.com)