### PR TITLE
fix(desktop): the macOS build shipped an invalid signature, so every Mac refused it

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -126,6 +126,39 @@ jobs:
         working-directory: src/praisonai-desktop/src-tauri
         run: cargo tauri build --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
 
+      - name: The macOS bundle must carry a valid signature
+        if: runner.os == 'macOS'
+        working-directory: src/praisonai-desktop/src-tauri
+        run: |
+          set -euo pipefail
+          app="$(find "target/${{ matrix.target }}/release/bundle" -name '*.app' -print -quit)"
+          [ -n "$app" ] || { echo "no .app was produced"; exit 1; }
+
+          # v4.7.2 shipped a DMG that macOS called "damaged and can't be
+          # opened" on every Mac. The cause was not the missing Developer ID:
+          # the only signature present was the one rustc's linker puts on the
+          # bare executable (adhoc, linker-signed), and its CodeDirectory
+          # declares a resource seal that an unsigned bundle does not have --
+          #
+          #   Sealed Resources=none
+          #   code has no resources but signature indicates they must be present
+          #
+          # That is an *invalid* signature, not an unsigned one, and macOS
+          # reports invalid as "damaged". Right-click -> Open cannot bypass it,
+          # so the instructions shipped alongside it could not work either.
+          #
+          # `codesign --verify` is therefore a release gate. An ad-hoc identity
+          # is still not a Developer ID and Gatekeeper will still refuse the
+          # app on a double-click -- but it refuses it as "unidentified
+          # developer", which right-click -> Open does bypass.
+          echo "verifying $app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          # Printed, not asserted: --verify already fails on the exact bundle
+          # that shipped ("code has no resources but signature indicates they
+          # must be present"), so a second check for the same thing would only
+          # be a second way to say it. This is here to make the log readable.
+          codesign -dv --verbose=2 "$app" 2>&1 | grep -E 'Sealed Resources|flags='  || true
+
       - name: Name the artifact for the platform it runs on
         id: artifact
         shell: bash

--- a/src/praisonai-desktop/INSTALL.md
+++ b/src/praisonai-desktop/INSTALL.md
@@ -26,9 +26,10 @@ wording and the exact click are below.
 Not sure which Mac you have:  → About This Mac. "Chip" means Apple silicon,
 "Processor" means Intel.
 
-Gatekeeper refuses an unsigned app on a double-click with *"PraisonAI is
-damaged and can't be opened"* — which is misleading. Nothing is damaged; the
-app simply has no signature.
+Gatekeeper refuses an app it cannot verify. The app carries an ad-hoc
+signature, which makes the signature *valid* but not *trusted* — so macOS says
+it cannot check for malicious software, or that the developer is
+unidentified.
 
 1. Drag **PraisonAI** to Applications.
 2. **Right-click** it → **Open** → **Open**.
@@ -41,6 +42,18 @@ it downloaded the file:
 ```sh
 xattr -dr com.apple.quarantine /Applications/PraisonAI.app
 ```
+
+### If you see *"PraisonAI is damaged and can't be opened"*
+
+That message means something different, and right-click → Open will **not**
+get past it: macOS says "damaged" when a signature is present but *invalid*,
+not when one is merely untrusted.
+
+**v4.7.2 shipped in exactly that state.** The bundle was never signed, so the
+only signature on it was the one the Rust linker leaves on the executable, and
+that signature declares a resource seal an unsigned bundle does not have. Every
+Mac rejected it. Use v4.7.3 or later; the release build now refuses to attach a
+macOS bundle whose signature does not verify.
 
 ## Windows
 

--- a/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
@@ -185,8 +185,12 @@ test('the macOS bundle is configured to be signed', () => {
   // between "damaged" and a warning the user can click past.
   const mac = config.bundle.macOS;
   assert.ok(mac, 'no macOS bundle config at all');
-  assert.ok(mac.signingIdentity,
-            'no signingIdentity: the bundle will ship with an invalid signature');
+  // Pinned to "-", not merely truthy: any other value is either a Developer ID
+  // we do not have (the build has no keychain to satisfy it, so codesign
+  // fails) or a typo Tauri passes straight to codesign. Only "-" is the ad-hoc
+  // identity that turns the shipped "damaged" bundle into a valid signature.
+  assert.equal(mac.signingIdentity, '-',
+               'the macOS bundle must use the ad-hoc signing identity "-"');
 });
 
 test('the release build verifies the signature before uploading', () => {
@@ -204,6 +208,18 @@ test('the release build verifies the signature before uploading', () => {
                'nothing checks the signature before the bundle is attached');
   assert.ok(runnable.indexOf('codesign --verify') < runnable.indexOf('gh release upload'),
             'the signature is verified after upload, which is too late');
+
+  // The gate is worthless if it never runs. Its step is the only place the
+  // codesign command lives, so pin that step to macOS: flipping the `if` to
+  // skip macOS -- or dropping the condition so it runs on Linux where codesign
+  // does not exist and the step is silently skipped -- would otherwise still
+  // pass every assertion above.
+  const stepStart = runnable.lastIndexOf('- name:',
+                                         runnable.indexOf('codesign --verify'));
+  const nextStep = runnable.indexOf('\n      - name:', stepStart + 1);
+  const gate = runnable.slice(stepStart, nextStep === -1 ? undefined : nextStep);
+  assert.match(gate, /if:\s*runner\.os\s*==\s*'macOS'/,
+               'the signature-verification step is not scoped to macOS runners');
 });
 
 test('the macOS overlay does not drop the bundle configuration', () => {

--- a/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
@@ -171,3 +171,49 @@ test('the macOS window overlay repeats the base window faithfully', () => {
   assert.equal(mac.titleBarStyle, 'Overlay');
   assert.equal(mac.hiddenTitle, true);
 });
+
+test('the macOS bundle is configured to be signed', () => {
+  // Without an identity Tauri never runs codesign on the bundle, and the only
+  // signature left is the one rustc's linker applies to the bare executable.
+  // That signature's CodeDirectory declares a resource seal the unsigned
+  // bundle does not have, so macOS calls the app "damaged and can't be
+  // opened" -- not "unidentified developer" -- and right-click -> Open cannot
+  // bypass it. v4.7.2 shipped exactly that.
+  //
+  // "-" is the ad-hoc identity. It is not a Developer ID and does not make the
+  // app trusted; it makes the signature *valid*, which is the difference
+  // between "damaged" and a warning the user can click past.
+  const mac = config.bundle.macOS;
+  assert.ok(mac, 'no macOS bundle config at all');
+  assert.ok(mac.signingIdentity,
+            'no signingIdentity: the bundle will ship with an invalid signature');
+});
+
+test('the release build verifies the signature before uploading', () => {
+  // The config alone is not enough -- if Tauri ever stops honouring it, the
+  // build must fail rather than attach another unopenable DMG.
+  //
+  // Comments are stripped first. The first version of this matched the phrase
+  // "codesign --verify" inside the comment that explains the gate, so deleting
+  // the actual command changed nothing and the test still passed.
+  const runnable = workflow
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+  assert.match(runnable, /codesign\s+--verify\s+--deep\s+--strict/,
+               'nothing checks the signature before the bundle is attached');
+  assert.ok(runnable.indexOf('codesign --verify') < runnable.indexOf('gh release upload'),
+            'the signature is verified after upload, which is too late');
+});
+
+test('the macOS overlay does not drop the bundle configuration', () => {
+  // Tauri merges the overlay with RFC 7386, which replaces rather than merges.
+  // An overlay that grew a "bundle" key would silently discard the signing
+  // identity along with everything else under it.
+  const overlay = JSON.parse(
+    readFileSync(new URL('src/praisonai-desktop/src-tauri/tauri.macos.conf.json', root), 'utf8'));
+  if (overlay.bundle) {
+    assert.ok(overlay.bundle.macOS?.signingIdentity,
+              'the overlay defines bundle but omits signingIdentity, which replaces it away');
+  }
+});

--- a/src/praisonai-desktop/src-tauri/tauri.conf.json
+++ b/src/praisonai-desktop/src-tauri/tauri.conf.json
@@ -43,7 +43,8 @@
     "shortDescription": "Local AI agents on your desktop",
     "longDescription": "PraisonAI runs AI agents locally. Chat with a model, give it tools and files, and fine-tune your own.",
     "macOS": {
-      "minimumSystemVersion": "10.15"
+      "minimumSystemVersion": "10.15",
+      "signingIdentity": "-"
     },
     "windows": {
       "webviewInstallMode": {


### PR DESCRIPTION
v4.7.2's macOS DMG cannot be opened on any Mac. It fails with **"PraisonAI is
damaged and can't be opened"** — which is not the ordinary unsigned-app warning,
and the instructions shipped alongside it could not have worked.

## What's actually wrong

Nothing signs the bundle. The only signature present is the one rustc's linker
applies to the bare executable, and it declares a resource seal that an unsigned
bundle does not have. Inspecting the artifact people are downloading:

```
$ codesign -dv PraisonAI.app
CodeDirectory flags=0x20002(adhoc,linker-signed)
Sealed Resources=none

$ codesign --verify --deep --strict PraisonAI.app
PraisonAI.app: code has no resources but signature indicates they must be present
```

macOS reports an **invalid** signature as *"damaged"* and an **untrusted** one as
*"unidentified developer"*. Only the second can be bypassed with right-click →
Open — so INSTALL.md was telling people to do something that cannot work.

## The fix, verified against the shipped artifact

`signingIdentity: "-"` makes Tauri codesign the bundle with an ad-hoc identity.
Applying that to the DMG people have already downloaded turns

```
code has no resources but signature indicates they must be present
```

into

```
valid on disk
satisfies its Designated Requirement
```

An ad-hoc identity is **not** a Developer ID. Gatekeeper still refuses the app on
a double-click — but it refuses it as untrusted rather than broken, which is a
door with a handle on it.

## Why it can't ship again

The release build now runs `codesign --verify --deep --strict` on the `.app`
**before** the artifact is attached. Tests pin the identity, the gate, and the
ordering, and mutation-testing confirms each fails when reverted.

INSTALL.md now separates the two messages instead of conflating them, and says
plainly that v4.7.2 is affected.

## Notes on the tests

One assertion matched the phrase `codesign --verify` inside the *comment* that
explains the gate, so deleting the command changed nothing — comments are
stripped before matching now. That is the same mistake as an earlier round, in a
new place.

A second check for unsealed resources was **removed** rather than pinned:
`--verify` already fails on the exact bundle that shipped, so it was only a
second way of saying the same thing — which is precisely why deleting it broke
no test.

## Verification

163 UI tests, 4 Python suites, 123 Rust — all green. The signature behaviour was
confirmed by downloading the published v4.7.2 DMG, mounting it, and inspecting
and re-signing the real bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS app signature validation during release packaging.
  * Prevented distribution of desktop builds with invalid signatures.
  * Clarified installation guidance for untrusted versus invalidly signed apps.
  * Added troubleshooting guidance for the v4.7.2 signature issue and recommended upgrading to v4.7.3 or later.

* **Documentation**
  * Updated macOS installation instructions to explain ad-hoc signing and related warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->