### PR TITLE
Auto-trigger Claude for all triaged bug reports

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -105,13 +105,14 @@ jobs:
               });
             }
 
-            // --- Auto-trigger Claude for owner issues and actionable external bug/enhancement reports ---
+            // --- Auto-trigger Claude for bug/enhancement reports ---
             const titleLower = (issue.title || '').toLowerCase();
+            const bodyRaw = issue.body || '';
+            const hasBugMarker = /#?\s*\[bug\]/i.test(issue.title || '') || /#?\s*\[bug\]/i.test(bodyRaw);
             const hasActionableTitle = /^(\[[^\]]+\]|bug:|fix[:(]|feat:|ux:|enhancement:)/i.test(titleLower);
-            const autoClaude = isOwner || (hasActionableTitle && (
-              labels.includes('bug') ||
-              (labels.includes('enhancement') && !labels.includes('question'))
-            ));
+            const isBugReport = labels.includes('bug') || hasBugMarker;
+            const isEnhancement = labels.includes('enhancement') && !labels.includes('question');
+            const autoClaude = isOwner || isBugReport || (hasActionableTitle && isEnhancement);
             if (autoClaude) {
               await github.rest.issues.addLabels({
                 issue_number: issue.number,


### PR DESCRIPTION
## Summary
- Broaden `claude.yml` issue-triage autoClaude: any `bug` label or `# [BUG]` / `[BUG]` in title/body triggers Claude
- Fixes missed automation for CONTRIBUTOR reports like #4374–#4376 (bug in body, plain title)
- Enhancement auto-trigger unchanged: still requires actionable title prefix unless author is OWNER/MEMBER/COLLABORATOR

## Test plan
- [x] Logic review against #4374 reproduction (CONTRIBUTOR + bug label + `# [BUG]` body)
- [ ] Merge and verify next external bug issue gets `claude` label on open

Made with [Cursor](https://cursor.com)