### PR TITLE
fix(desktop): the signature gate looked for a bundle Tauri had already deleted

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -131,14 +131,22 @@ jobs:
         working-directory: src/praisonai-desktop/src-tauri
         run: |
           set -euo pipefail
-          app="$(find "target/${{ matrix.target }}/release/bundle" -name '*.app' -print -quit)"
-          [ -n "$app" ] || { echo "no .app was produced"; exit 1; }
+          dmg="$(find "target/${{ matrix.target }}/release/bundle" -name '*.dmg' -print -quit)"
+          [ -n "$dmg" ] || { echo "no .dmg was produced"; exit 1; }
 
+          # Verify inside the DMG, not the .app beside it.
+          #
+          # Tauri deletes the app bundle once the DMG is built -- the build log
+          # says so plainly ("Cleaning .../bundle/macos/PraisonAI.app") -- so a
+          # gate that looked for the .app found nothing and failed every macOS
+          # leg. Reading the DMG is also the better check: it is the artifact
+          # people download, and the one that was broken.
+          #
           # v4.7.2 shipped a DMG that macOS called "damaged and can't be
           # opened" on every Mac. The cause was not the missing Developer ID:
-          # the only signature present was the one rustc's linker puts on the
-          # bare executable (adhoc, linker-signed), and its CodeDirectory
-          # declares a resource seal that an unsigned bundle does not have --
+          # the only signature was the one rustc's linker puts on the bare
+          # executable, whose CodeDirectory declares a resource seal that an
+          # unsigned bundle does not have --
           #
           #   Sealed Resources=none
           #   code has no resources but signature indicates they must be present
@@ -146,18 +154,19 @@ jobs:
           # That is an *invalid* signature, not an unsigned one, and macOS
           # reports invalid as "damaged". Right-click -> Open cannot bypass it,
           # so the instructions shipped alongside it could not work either.
-          #
-          # `codesign --verify` is therefore a release gate. An ad-hoc identity
-          # is still not a Developer ID and Gatekeeper will still refuse the
-          # app on a double-click -- but it refuses it as "unidentified
-          # developer", which right-click -> Open does bypass.
+          mnt="$(mktemp -d)"
+          hdiutil attach -nobrowse -readonly -quiet -mountpoint "$mnt" "$dmg"
+          trap 'hdiutil detach "$mnt" -quiet || true' EXIT
+
+          app="$(find "$mnt" -maxdepth 1 -name '*.app' -print -quit)"
+          [ -n "$app" ] || { echo "the DMG contains no .app"; ls -la "$mnt"; exit 1; }
+
           echo "verifying $app"
           codesign --verify --deep --strict --verbose=2 "$app"
           # Printed, not asserted: --verify already fails on the exact bundle
-          # that shipped ("code has no resources but signature indicates they
-          # must be present"), so a second check for the same thing would only
-          # be a second way to say it. This is here to make the log readable.
-          codesign -dv --verbose=2 "$app" 2>&1 | grep -E 'Sealed Resources|flags='  || true
+          # that shipped, so a second check for the same thing would only be a
+          # second way to say it. This is here to make the log readable.
+          codesign -dv --verbose=2 "$app" 2>&1 | grep -E 'Sealed Resources|flags=' || true
 
       - name: Name the artifact for the platform it runs on
         id: artifact

--- a/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
@@ -222,6 +222,29 @@ test('the release build verifies the signature before uploading', () => {
                'the signature-verification step is not scoped to macOS runners');
 });
 
+test('the signature gate reads the DMG, not the app beside it', () => {
+  // Tauri deletes the app bundle once the DMG is built -- the build log says
+  // so: "Cleaning .../bundle/macos/PraisonAI.app". A gate that looked for the
+  // .app therefore found nothing and failed every macOS leg of v4.7.3, which
+  // is why that release shipped with no Mac downloads at all.
+  //
+  // Reading the DMG is also the better check: it is the artifact people
+  // download, and the one that was broken.
+  const runnable = workflow
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+  const gate = runnable.slice(runnable.indexOf('must carry a valid signature'),
+                              runnable.indexOf('Name the artifact'));
+  assert.ok(gate, 'the signature gate is gone');
+  assert.match(gate, /hdiutil attach/, 'the gate does not open the DMG');
+  assert.match(gate, /-name '\*\.dmg'/, 'the gate does not look for a .dmg');
+  assert.ok(!/-name '\*\.app' -print -quit"?\s*\)?\s*$/m.test(
+              gate.split('hdiutil attach')[0]),
+            'the gate looks for a .app before mounting; Tauri has deleted it by then');
+  assert.match(gate, /hdiutil detach/, 'the gate never unmounts the DMG');
+});
+
 test('the macOS overlay does not drop the bundle configuration', () => {
   // Tauri merges the overlay with RFC 7386, which replaces rather than merges.
   // An overlay that grew a "bundle" key would silently discard the signing


### PR DESCRIPTION
**v4.7.3 shipped with no macOS downloads.** Both Mac legs failed, and the gate
added one commit earlier is the reason.

## What the build log shows

```
Bundling PraisonAI.app (.../bundle/macos/PraisonAI.app)
 Signing with identity "-"
Signing .../PraisonAI.app: replacing existing signature
Bundling PraisonAI_0.1.0_aarch64.dmg
Cleaning .../bundle/macos/PraisonAI.app        ← deleted here
```

The same run proves two things at once:

1. **The signing fix works.** Tauri signed the executable *and* the bundle with
   the ad-hoc identity, exactly as intended.
2. **The check written to guard it could never pass.** It looked for the `.app`,
   and Tauri removes the `.app` once the DMG exists. Every macOS leg died on
   `no .app was produced` — my own error message.

## The fix

Mount the DMG and verify the bundle inside it. That is also the better check:
the DMG is what people download, and the DMG is what was broken.

## Both directions verified against real disk images

Not argued — run:

| Disk image | Result |
|---|---|
| The published **v4.7.2** DMG | **fails** — `code has no resources but signature indicates they must be present`, `Sealed Resources=none` |
| A properly ad-hoc signed DMG | **passes** — `valid on disk`, `satisfies its Designated Requirement`, `Sealed Resources version=2 rules=13 files=7` |

A gate that only ever rejects is not a gate. It needed the positive control as
much as the negative one — without it, this fix could have blocked every future
release just as effectively as the last one did.

Four mutations, four caught, including reverting the gate to look for the `.app`.

## One near miss worth recording

While testing, my own harness reported the **broken** DMG as passing. It piped
`codesign` to `head` and read `${PIPESTATUS[0]}`, which zsh spells differently,
so the exit status was silently discarded.

The workflow does not pipe that command and was never affected. But a test
harness that swallows the status under test is the same defect as the one being
fixed, one level up — and it would have let me "confirm" a broken gate.

## Verification

164 UI tests green.

After merge, the macOS builds for v4.7.3 can be produced by dispatching the
release workflow against the existing tag — no new version needed, since only
the workflow changed and the app code at the tag is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS release verification by validating the application directly from the generated DMG.
  - Added a clear failure when no DMG is produced, improving release reliability and diagnostics.

- **Tests**
  - Added automated coverage to ensure the macOS verification process mounts, validates, and detaches the generated DMG correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->