### PR TITLE
fix: safe process.env access and accurate ESM CJS banner detection

### DIFF
--- a/src/praisonai-ts/scripts/esm-shim.js
+++ b/src/praisonai-ts/scripts/esm-shim.js
@@ -112,14 +112,19 @@ const CJS_BANNER = [
   'const module = { exports: {} };',
 ].join('\n');
 
+function stripStrings(code) {
+  return code.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`/g, '""');
+}
+
 function needsCjsBanner(code) {
+  const stripped = stripStrings(code);
   return (
-    /\brequire\b/.test(code) ||
-    /\b__dirname\b/.test(code) ||
-    /\b__filename\b/.test(code) ||
-    /\bmodule\.exports\b/.test(code) ||
-    /===\s*module\b/.test(code) ||
-    /\bmodule\s*===/.test(code)
+    /\brequire\b/.test(stripped) ||
+    /\b__dirname\b/.test(stripped) ||
+    /\b__filename\b/.test(stripped) ||
+    /\bmodule\.exports\b/.test(stripped) ||
+    /===\s*module\b/.test(stripped) ||
+    /\bmodule\s*===/.test(stripped)
   );
 }
 

--- a/src/praisonai-ts/src/agent/simple.ts
+++ b/src/praisonai-ts/src/agent/simple.ts
@@ -7,6 +7,15 @@ import type { LLMProvider } from '../llm/providers/types';
 import type { BackendResolutionResult } from '../llm/backend-resolver';
 import { ApprovalManager, createCLIApprovalPrompt } from '../ai/tool-approval';
 
+/** Safe accessor for process.env that works in non-Node runtimes. */
+function safeEnv(key: string): string | undefined {
+  try {
+    return typeof process !== 'undefined' && process.env ? process.env[key] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Agent Configuration
  * 
@@ -233,9 +242,9 @@ export class Agent {
     }
     
     this.name = config.name || `Agent_${Math.random().toString(36).substr(2, 9)}`;
-    this.verbose = config.verbose ?? process.env.PRAISON_VERBOSE !== 'false';
-    this.pretty = config.pretty ?? process.env.PRAISON_PRETTY === 'true';
-    this.llm = config.llm || process.env.OPENAI_MODEL_NAME || process.env.PRAISONAI_MODEL || 'gpt-4o-mini';
+    this.verbose = config.verbose ?? safeEnv('PRAISON_VERBOSE') !== 'false';
+    this.pretty = config.pretty ?? safeEnv('PRAISON_PRETTY') === 'true';
+    this.llm = config.llm || safeEnv('OPENAI_MODEL_NAME') || safeEnv('PRAISONAI_MODEL') || 'gpt-4o-mini';
     this.markdown = config.markdown ?? true;
     this.streamEnabled = config.stream ?? true;
     // NOTE: this.tools is rebuilt below from a snapshot of config.tools —
@@ -1338,8 +1347,8 @@ export class AgentTeam {
       : configOrAgents;
     
     this.agents = config.agents;
-    this.verbose = config.verbose ?? process.env.PRAISON_VERBOSE !== 'false';
-    this.pretty = config.pretty ?? process.env.PRAISON_PRETTY === 'true';
+    this.verbose = config.verbose ?? safeEnv('PRAISON_VERBOSE') !== 'false';
+    this.pretty = config.pretty ?? safeEnv('PRAISON_PRETTY') === 'true';
     this.process = config.process || 'sequential';
 
     // Auto-generate tasks if not provided


### PR DESCRIPTION
## Summary

### #4425 - process.env dereference in Agent constructor

The Agent constructor reads process.env directly, throwing ReferenceError in non-Node runtimes (webview, React Native, browser).

Added a safeEnv() helper that returns undefined when process is unavailable, replacing all direct process.env reads in both Agent and AgentTeam constructors.

### #4427 - esm-shim false positive CJS banner

needsCjsBanner tests for require anywhere in the file including inside string literals. A file containing an error message like 'Zod schemas require zod-to-json-schema' gets the CJS banner with three Node built-in imports it never needed.

Added stripStrings() to remove string literal content before testing regex patterns.

Fixes #4425
Fixes #4427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility in non-Node environments by safely handling configuration defaults.
  * Prevented code conversion checks from misidentifying CommonJS usage inside quoted strings.
  * Preserved support for detecting genuine `require`, filename, directory, and module references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->