### PR TITLE
fix(desktop): tool turns reported "no output", and reopened chats lost their history

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -5182,6 +5182,17 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             self._append_to_chat_history(
                                 {"role": "assistant", "content": followup_text}
                             )
+                        else:
+                            # Tools ran and the model then said nothing. Simply
+                            # returning here is indistinguishable from a model
+                            # that had nothing to say, and that is exactly how
+                            # this reached users: the generator ended having
+                            # yielded not one character, and the caller could
+                            # only report "no output" for a turn whose tools
+                            # had all succeeded. Fail loudly instead.
+                            raise RuntimeError(
+                                "the model called {} tool(s) and then returned "
+                                "no answer".format(len(tool_calls_data)))
                     else:
                         # Add complete response to chat history (text-only response)
                         if response_text:

--- a/src/praisonai-agents/pyproject.toml
+++ b/src/praisonai-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "praisonaiagents"
-version = "1.7.1"
+version = "1.7.2"
 description = "Praison AI agents for completing complex tasks with Self Reflection Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -30,8 +30,27 @@ from urllib.parse import urlparse
 # the one being edited -- the same source/installed-copy divergence that makes
 # a fix appear to have no effect. Explicit and visible here rather than via
 # PYTHONPATH, which would follow every child process invisibly.
-_SOURCE = pathlib.Path(__file__).resolve().parents[2] / "praisonai-agents"
-if (_SOURCE / "praisonaiagents" / "__init__.py").is_file():
+# Searched upward rather than counted: this file is copied into the bundle at
+# src-tauri/target/<profile>/engine/, where a fixed parents[2] resolves to
+# target/praisonai-agents -- which does not exist. So the branch quietly never
+# taken was the one whose whole purpose is to stop a fix having no effect.
+def _checkout_source():
+    """The praisonai-agents checkout above this file, if there is one."""
+    override = os.environ.get("PRAISONAI_AGENTS_SOURCE", "").strip()
+    if override:
+        candidate = pathlib.Path(override)
+        return candidate if (candidate / "praisonaiagents" / "__init__.py").is_file() else None
+    here = pathlib.Path(__file__).resolve()
+    for parent in here.parents:
+        for candidate in (parent / "praisonai-agents",
+                          parent / "src" / "praisonai-agents"):
+            if (candidate / "praisonaiagents" / "__init__.py").is_file():
+                return candidate
+    return None
+
+
+_SOURCE = _checkout_source()
+if _SOURCE is not None:
     sys.path.insert(0, str(_SOURCE))
 
 
@@ -1127,6 +1146,53 @@ def _get_agent(session_id: str = "default", tools: bool = True):
         return _agents[key]
 
 
+def _seed_history(agent, chat_id: str) -> int:
+    """Give the agent the conversation the user can already see.
+
+    The history existed in two places and only one of them was durable: the
+    transcript on disk, which the sidebar renders, and the agent's
+    chat_history, which is what the model is actually shown. Nothing ever
+    copied the first into the second.
+
+    The agent cache is a plain dict in this process (`_agents`), so it is empty
+    after any restart; `save_settings` clears it outright, because a model
+    change must not run on the previous agent; and the tools toggle keys a
+    *different* agent for the same session. After any of those, reopening a
+    chat showed the user their whole conversation while the model was handed a
+    blank slate -- and it said so: "I don't have access to your previous
+    questions. Each session is treated independently."
+
+    Only when the agent has nothing. An agent mid-session already holds the
+    turns, including tool messages this transcript never stored, and replaying
+    over the top would duplicate them.
+
+    Returns how many messages were replayed, for the log.
+    """
+    try:
+        if agent.chat_history:
+            return 0
+    except Exception:  # noqa: BLE001 - an agent without the attribute is not ours to seed
+        return 0
+    try:
+        stored = load_chat(chat_id).get("messages") or []
+    except Exception:  # noqa: BLE001 - a missing or broken transcript is not fatal
+        return 0
+
+    replayed = 0
+    for message in stored:
+        role, content = message.get("role"), message.get("content")
+        # Only the two roles a transcript holds, and never a blank turn: an
+        # empty assistant message is what a failed turn leaves behind, and
+        # feeding it back teaches the model that silence is an acceptable
+        # answer.
+        if role in ("user", "assistant") and isinstance(content, str) and content.strip():
+            agent._append_to_chat_history({"role": role, "content": content})
+            replayed += 1
+    if replayed:
+        log(f"replayed {replayed} messages into the agent for chat {chat_id}")
+    return replayed
+
+
 # --- stream protocol v2 -------------------------------------------------------
 # v1 carried only start/delta/end/error, which is enough to print text and
 # nothing else. Tool calls, reasoning and usage have to be first-class events or
@@ -1793,16 +1859,23 @@ class Handler(BaseHTTPRequestHandler):
             _tool_queue().clear()
             _apply_env(load_settings())
             agent = _get_agent(session, tools=tools_on)
+            # Before the turn, not at construction: the agent is cached per
+            # session and the transcript is per chat, and a settings change
+            # can drop the agent between one turn and the next.
+            _seed_history(agent, chat_id)
             emit("start", {"run_id": run_id})
             streamed = False
+            tools_shown = 0
             def _emit_drafting(name):
                 emit("tool_drafting", {"name": name})
 
             def _drain_tools():
                 """Emit any tool activity recorded since the last check."""
+                shown = 0
                 q = _tool_queue()
                 while q:
                     ev = q.pop(0)
+                    shown += 1
                     _emit_drafting(ev["name"])
                     emit("tool_call", {"call_id": ev["call_id"], "name": ev["name"],
                                        "args": ev["args"]})
@@ -1810,6 +1883,7 @@ class Handler(BaseHTTPRequestHandler):
                     emit("tool_result", {"call_id": ev["call_id"], "name": ev["name"],
                                          "ok": ev["ok"], "output": ev["output"],
                                          "seconds": ev["seconds"]})
+                return shown
 
             for chunk in agent.start(prompt, stream=True,
                                      **_llm_overrides(load_settings())):
@@ -1844,6 +1918,11 @@ class Handler(BaseHTTPRequestHandler):
                 else:
                     emit(event, frame)
             else:
+                # Tool activity belongs to the user even when the turn failed.
+                # Draining only on the success path meant a turn that ran tools
+                # and then died showed neither the answer nor the tools -- the
+                # work happened and left no trace.
+                tools_shown += _drain_tools()
                 if not streamed:
                     # A stream that yielded nothing is a failure, not an empty
                     # answer -- and the cause is usually in the logs, not here.
@@ -1856,11 +1935,19 @@ class Handler(BaseHTTPRequestHandler):
                     elif captured:
                         emit("error", {"kind": "internal",
                                        "message": captured[-1][:300]})
+                    elif tools_shown:
+                        # Not the same failure as "nothing happened". The tools
+                        # ran and their results are on screen; what is missing
+                        # is the model's answer about them. Saying "no output"
+                        # here described the turn to the user as a dead end
+                        # when most of it had in fact succeeded.
+                        emit("error", {"kind": "no_answer", "message":
+                             f"{tools_shown} tool call(s) ran, but the model "
+                             "sent no answer afterwards. Their results are above."})
                     else:
                         emit("error", {"message": "the engine produced no output",
                                        "kind": "empty"})
                 else:
-                    _drain_tools()
                     elapsed = time.perf_counter() - started
                     user_index = _persist(chat_id, prompt, reply, regenerate_of)
                     if cfg_now.get("show_stats", True):

--- a/src/praisonai-desktop/engine/test_chat_stream.py
+++ b/src/praisonai-desktop/engine/test_chat_stream.py
@@ -1,0 +1,288 @@
+"""What the user sees when a turn calls tools.
+
+The chat path had no test at all, which is why this shipped: a turn whose tools
+all ran and succeeded was reported to the user as "the engine produced no
+output". The published praisonaiagents 1.7.1 ends the stream after running
+tools without ever asking the model for its answer, so the generator yields
+nothing -- and the engine could not tell that apart from a turn where nothing
+happened.
+
+The agent is stubbed. These tests never reach a provider and never need a key:
+the point is what the engine does with a given stream, not what a model says.
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+_HOME = tempfile.mkdtemp(prefix="praison-chat-test-")
+os.environ["PRAISONAI_DESKTOP_HOME"] = _HOME
+os.environ.setdefault("PRAISONAI_KEYCHAIN_SERVICE", "ai.praison.desktop.test")
+
+import server                                            # noqa: E402
+
+
+class StubAgent:
+    """An agent whose stream is whatever the test says it is.
+
+    It records the history it was given, because what the model is shown is the
+    thing under test.
+    """
+
+    def __init__(self, chunks=(), tools=()):
+        self.chunks = list(chunks)
+        self.tools = list(tools)
+        self.started = 0
+        self.chat_history = []
+        self.seen_history = None
+
+    def _append_to_chat_history(self, message):
+        self.chat_history.append(message)
+
+    def start(self, prompt, stream=True, **kwargs):
+        self.started += 1
+        self.seen_history = list(self.chat_history)
+        # Tools "run" before the model's answer would arrive, exactly as the
+        # display callback records them during a real turn.
+        for tool in self.tools:
+            server._tool_queue().append(tool)
+        for chunk in self.chunks:
+            yield chunk
+
+
+def _tool(name="current_time", ok=True, output="2026-08-27 00:13:35"):
+    return {"call_id": f"c-{name}", "name": name, "args": {},
+            "ok": ok, "output": output, "seconds": 0.01}
+
+
+class ChatStream(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        cls.port = cls.server.server_address[1]
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        shutil.rmtree(_HOME, ignore_errors=True)
+
+    def setUp(self):
+        server._agents.clear()
+        server._tool_queue().clear()
+
+    def _install(self, chunks=(), tools=()):
+        agent = StubAgent(chunks, tools)
+        # _get_agent returns from this cache when the key is present, so this
+        # replaces the agent without the real one ever being constructed.
+        server._agents["t"] = agent
+        server._agents["t\x00notools"] = agent
+        return agent
+
+    def _chat(self, prompt="what is the current time"):
+        """POST /chat and return the SSE frames as (event, data) pairs."""
+        body = json.dumps({"prompt": prompt, "chat_id": "t", "session": "t"}).encode()
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}/chat", data=body, method="POST",
+            headers={"Content-Type": "application/json"})
+        frames, kind = [], None
+        with urllib.request.urlopen(req, timeout=30) as response:
+            for raw in response:
+                line = raw.decode("utf-8", "replace").rstrip("\n")
+                if line.startswith("event: "):
+                    kind = line[7:]
+                elif line.startswith("data: ") and kind:
+                    frames.append((kind, json.loads(line[6:] or "{}")))
+                    kind = None
+        return frames
+
+    # -- the reported bug ------------------------------------------------
+
+    def test_a_turn_whose_tools_ran_is_not_reported_as_no_output(self):
+        self._install(chunks=(), tools=[_tool()])
+        frames = self._chat()
+        kinds = [k for k, _ in frames]
+        errors = [d for k, d in frames if k == "error"]
+        self.assertTrue(errors, f"no error was reported at all: {kinds}")
+        self.assertNotEqual(
+            errors[0].get("kind"), "empty",
+            "a turn whose tools all ran was reported as producing nothing")
+        self.assertEqual(errors[0].get("kind"), "no_answer")
+
+    def test_the_tool_results_are_still_shown_when_the_answer_never_comes(self):
+        # The work happened. Losing it is the part the user actually feels.
+        self._install(chunks=(), tools=[_tool(output="2026-08-27 00:13:35")])
+        frames = self._chat()
+        kinds = [k for k, _ in frames]
+        self.assertIn("tool_call", kinds, f"the tool call was never shown: {kinds}")
+        self.assertIn("tool_result", kinds, f"the tool result was never shown: {kinds}")
+        results = [d for k, d in frames if k == "tool_result"]
+        self.assertEqual(results[0]["output"], "2026-08-27 00:13:35")
+
+    def test_the_message_says_how_many_tools_ran(self):
+        self._install(chunks=(), tools=[_tool("a"), _tool("b")])
+        errors = [d for k, d in self._chat() if k == "error"]
+        self.assertIn("2 tool call(s)", errors[0]["message"])
+
+    # -- the failures that must still look like failures -----------------
+
+    def test_a_turn_that_did_nothing_at_all_is_still_empty(self):
+        self._install(chunks=(), tools=())
+        errors = [d for k, d in self._chat() if k == "error"]
+        self.assertEqual(errors[0].get("kind"), "empty",
+                         "a genuinely empty turn must not be excused as no_answer")
+
+    # -- the paths that already worked must keep working -----------------
+
+    def test_a_plain_text_turn_still_streams_and_ends(self):
+        self._install(chunks=["The current time ", "is 00:13:35."])
+        frames = self._chat()
+        kinds = [k for k, _ in frames]
+        self.assertIn("delta", kinds)
+        self.assertIn("end", kinds)
+        self.assertNotIn("error", kinds, f"a good turn reported an error: {kinds}")
+        text = "".join(d.get("text", "") for k, d in frames if k == "delta")
+        self.assertEqual(text, "The current time is 00:13:35.")
+
+    def test_a_tool_turn_that_does_answer_shows_both(self):
+        # The success path drains the tool queue too. This is a regression
+        # guard: the drain used to live only in the success branch, and moving
+        # it must not have lost it.
+        self._install(chunks=["It is 00:13:35."], tools=[_tool()])
+        frames = self._chat()
+        kinds = [k for k, _ in frames]
+        self.assertIn("tool_result", kinds, f"tools vanished on the success path: {kinds}")
+        self.assertIn("delta", kinds)
+        self.assertIn("end", kinds)
+        self.assertNotIn("error", kinds)
+
+
+class HistoryAcrossSessions(unittest.TestCase):
+    """Reopening a chat must not hand the model a blank slate.
+
+    The transcript on disk is what the sidebar renders; the agent's
+    chat_history is what the model is shown. Nothing copied one into the other,
+    and the agent cache does not survive a restart, a settings change, or the
+    tools toggle. So the user saw their whole conversation on screen while the
+    model answered "I don't have access to your previous questions."
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        cls.port = cls.server.server_address[1]
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def setUp(self):
+        server._agents.clear()
+        server._tool_queue().clear()
+        # One transcript per test: these persist to disk, so a shared id let
+        # one test's turns leak into the next one's replay.
+        self.chat = f"revisited-{self._testMethodName}"
+
+    def _say(self, prompt, chunks, tools_on=True):
+        agent = StubAgent(chunks)
+        key = self.chat if tools_on else self.chat + "\x00notools"
+        server._agents[key] = agent
+        body = json.dumps({"prompt": prompt, "chat_id": self.chat,
+                           "session": self.chat, "tools": tools_on}).encode()
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}/chat", data=body, method="POST",
+            headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=30) as response:
+            response.read()
+        return agent
+
+    def _roles_and_text(self, agent):
+        return [(m["role"], m["content"]) for m in (agent.seen_history or [])]
+
+    def test_a_returning_session_is_given_the_earlier_turns(self):
+        self._say("what tools do you have", ["I have current_time."])
+        # Navigating away and back drops the cached agent -- as a restart, a
+        # settings change or the tools toggle all do.
+        server._agents.clear()
+        agent = self._say("what were my previous questions", ["You asked about tools."])
+        seen = self._roles_and_text(agent)
+        self.assertTrue(seen, "the model was given no history at all")
+        self.assertIn(("user", "what tools do you have"), seen)
+        self.assertIn(("assistant", "I have current_time."), seen)
+
+    def test_the_replay_is_in_order(self):
+        self._say("first", ["one"])
+        self._say("second", ["two"])
+        server._agents.clear()
+        agent = self._say("third", ["three"])
+        roles = [r for r, _ in self._roles_and_text(agent)]
+        texts = [t for _, t in self._roles_and_text(agent)]
+        self.assertEqual(roles, ["user", "assistant", "user", "assistant"])
+        self.assertEqual(texts, ["first", "one", "second", "two"])
+
+    def test_an_agent_that_already_has_history_is_not_replayed_over(self):
+        # Mid-session the agent already holds the turns, including tool
+        # messages the transcript never stored. Replaying would duplicate them.
+        self._say("first", ["one"])
+        agent = StubAgent(["two"])
+        agent._append_to_chat_history({"role": "user", "content": "first"})
+        agent._append_to_chat_history({"role": "assistant", "content": "one"})
+        server._agents[self.chat] = agent
+        body = json.dumps({"prompt": "second", "chat_id": self.chat,
+                           "session": self.chat}).encode()
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}/chat", data=body, method="POST",
+            headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=30) as response:
+            response.read()
+        self.assertEqual(len(agent.seen_history), 2,
+                         f"history was duplicated: {agent.seen_history}")
+
+    def test_toggling_tools_does_not_lose_the_conversation(self):
+        # The tools flag keys a different agent for the same session.
+        self._say("what tools do you have", ["I have current_time."], tools_on=True)
+        agent = self._say("and now", ["Sure."], tools_on=False)
+        self.assertIn(("user", "what tools do you have"), self._roles_and_text(agent))
+
+    def test_a_chat_with_no_transcript_starts_clean(self):
+        agent = StubAgent(["hi"])
+        server._agents["brand-new"] = agent
+        body = json.dumps({"prompt": "hello", "chat_id": "brand-new",
+                           "session": "brand-new"}).encode()
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}/chat", data=body, method="POST",
+            headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=30) as response:
+            response.read()
+        self.assertEqual(agent.seen_history, [])
+
+    def test_a_failed_turn_is_not_replayed_as_an_empty_answer(self):
+        # A turn that errored leaves nothing useful; feeding an empty
+        # assistant message back teaches the model that silence is fine.
+        self._say("first", ["one"])
+        path = pathlib.Path(server.DATA_DIR) / "chats" / f"{self.chat}.json"
+        chat = json.loads(path.read_text())
+        chat["messages"].append({"role": "assistant", "content": "   "})
+        path.write_text(json.dumps(chat))
+        server._agents.clear()
+        agent = self._say("second", ["two"])
+        self.assertTrue(all(t.strip() for _, t in self._roles_and_text(agent)),
+                        f"a blank turn was replayed: {agent.seen_history}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/praisonai-desktop/src-tauri/src/provision.rs
+++ b/src/praisonai-desktop/src-tauri/src/provision.rs
@@ -188,7 +188,18 @@ pub fn plan(uv: &Path, data_dir: &Path, packages: &[&str], platform: Platform) -
 
 /// What the engine needs to import. Kept here so the provisioning plan and the
 /// failure message cannot disagree about it.
-pub const ENGINE_PACKAGES: &[&str] = &["praisonaiagents"];
+// Pinned to a floor, not left open.
+//
+// The desktop app installs this once, on first run, and never again -- so an
+// unpinned name resolves to whatever was on PyPI that day and stays there
+// forever. 1.7.1 ends a tool-using turn without ever asking the model for its
+// answer: the stream yields nothing, the engine reports "the engine produced
+// no output", and the user sees a failure for a turn whose tools all ran. The
+// fix is in 1.7.2.
+//
+// A floor rather than an exact pin, so a user who already has something newer
+// is not downgraded.
+pub const ENGINE_PACKAGES: &[&str] = &["praisonaiagents>=1.7.2"];
 
 #[cfg(test)]
 mod tests {

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -1496,7 +1496,7 @@ document.getElementById('f').addEventListener('submit',async e=>{
   const out=turn('a','PraisonAI');
   out.innerHTML='<span class="caret"></span>';
 
-  let acc='', streamed=0, userIndex=null, versions=1, vactive=0;
+  let acc='', streamed=0, userIndex=null, versions=1, vactive=0, banner=false;
   const regen=regenerateOf; regenerateOf=null;   // consumed by this submit only
   const canPublish=gate();
   const host=out.parentElement;
@@ -1582,11 +1582,13 @@ document.getElementById('f').addEventListener('submit',async e=>{
           st.textContent=`${data.chars} chars · ${data.seconds}s`
             +(data.ttft!=null?` · ${data.ttft}s to first token`:'');
           host.appendChild(st); }
-        else if(ev==='error'){ out.innerHTML=md(acc);
+        else if(ev==='error'){ out.innerHTML=md(acc); banner=true;
           const titles={auth:'Authentication failed',rate_limit:'Rate limited',
-                        empty:'No output',internal:'The engine reported an error'};
+                        empty:'No output',
+                        no_answer:'The tools ran, but no answer came back',
+                        internal:'The engine reported an error'};
           fail(titles[data.kind]||titles.internal, data.message,'', text); }
-        else if(ev==='cancelled'){ paint();
+        else if(ev==='cancelled'){ paint(); banner=true;
           const c=document.createElement('div'); c.className='cancelled';
           c.textContent='Stopped'; out.parentElement.appendChild(c); }
         else if(ev==='end'){ paint(); userIndex=data?.user_index ?? null;
@@ -1594,7 +1596,13 @@ document.getElementById('f').addEventListener('submit',async e=>{
       }
     }
     paint();
-    if(!acc) fail('No output','The engine finished without producing any text.','',text);
+    // Only when nothing has already been said about it. The engine reports
+    // its own failures, and this line used to add a second banner underneath
+    // the first -- the screenshot of the bug shows both, which reads as two
+    // separate failures when it was one turn. It also fired after a deliberate
+    // Stop, calling the user's own cancellation an error.
+    if(!acc && !banner)
+      fail('No output','The engine finished without producing any text.','',text);
   }catch(err){ fail('Connection to the engine failed', String(err),'', text); }
   finally{
     clearInterval(thinkTimer); draft?.remove();


### PR DESCRIPTION
Two reported bugs. Both have the same shape: **the app had the information and
did not use it.**

## 1. "No output" on a turn whose tools all ran

The desktop engine does not run the praisonaiagents in this repo — it runs the
one installed in the app's venv, published **1.7.1**. In that version a
tool-using turn ends the stream without ever asking the model for its answer:

```
_start_stream_impl in installed 1.7.1:  1 × chat.completions.create
the same function in this repo's HEAD:  2 × chat.completions.create
```

The generator yields nothing, so `streamed` stays `False`
(`engine/server.py:1797`, set only in the text-delta branch at `:1829`) and the
engine reports *"the engine produced no output"* — for a turn where every tool
succeeded.

**The library fix already existed here** (commit `06dfc8e59`, 25 Aug) and could
never reach anyone: `pyproject.toml` still declared `1.7.1`, the same version
already on PyPI, and the desktop installs an unpinned `praisonaiagents` exactly
once, on first run. Now `1.7.2`, with the desktop asking for `>=1.7.2`.

⚠️ **This needs publishing to PyPI to reach users.** The version bump alone
changes nothing for anyone who already has 1.7.1 installed.

**Why it looked intermittent:** whether the model answers in text or calls a
tool is a per-turn decision, and only the first shape streams.
**Why "Try again" worked:** the failed turn still left the tool result in the
cached agent's history, so the retry answered from it in plain text. The failure
fetched the thing that made the next attempt succeed.

Three defensive changes so it cannot be silent again — tool activity is drained
on the failure path (a turn that ran tools and died showed *neither* answer nor
tools), a tool turn with no answer says so rather than claiming nothing
happened, and the library now raises instead of ending a tool turn in silence.

Also: the dev escape hatch meant to prevent exactly this confusion **did not
work.** `engine/server.py` computed the checkout path with a fixed `parents[2]`,
which from the bundled copy resolves to `target/praisonai-agents` — nonexistent.
Its own comment says it exists so "a fix appear[ing] to have no effect" cannot
happen.

## 2. A reopened chat had no history

```
$ grep -c chat_history engine/server.py
0
```

The conversation lived in two places and only one was durable: the transcript on
disk, which the sidebar renders, and the agent's `chat_history`, which is what
the model is shown. **Nothing ever copied one into the other.**

The agent cache is a plain dict in the engine process — empty after any restart;
`save_settings` clears it outright; and the tools toggle keys a *different* agent
for the same session. After any of those, reopening a chat showed the user their
whole conversation while the model got a blank slate, and said so: *"I don't
have access to your previous questions."*

The transcript is now replayed into an agent that has none — **only** when it
has none, since an agent mid-session already holds those turns including tool
messages the transcript never stored. Blank turns are skipped: an empty
assistant message is what a failed turn leaves behind.

## Tests

`engine/test_chat_stream.py` is new — **the chat path had no test at all**,
which is why both of these shipped. Twelve tests, agent stubbed, no provider and
no API key required.

**Eight mutations, eight caught**, including removing the replay, reversing its
order, replaying over an agent that already has history, and restoring the
original "no output" branch.

All suites green: 5 engine suites, 164 UI tests, 49 library streaming tests.
(`tests/test_runtime_middleware.py` fails to import — verified pre-existing on
clean `main`, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat streaming when tool calls complete without a follow-up response.
  - Tool activity and results now remain visible even when an answer is unavailable.
  - Reopened conversations reliably restore prior chat history without duplicating or replaying failed turns.
  - Error messages now distinguish missing answers from empty responses and internal failures.
  - Cancellations no longer display an incorrect “No output” message.
- **Maintenance**
  - Updated the desktop engine package to a version containing these reliability fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->