### PR TITLE
feat(ts): make praisonai-ts cleanly mobile-consumable (tasks 1-7)

### DIFF
--- a/.github/workflows/praisonai-ts-webview.yml
+++ b/.github/workflows/praisonai-ts-webview.yml
@@ -1,0 +1,57 @@
+# Can praisonai-ts still be loaded in a webview?
+#
+# Issue #4437 was this failing: `crypto` and `events` were static imports on
+# the Agent graph, so a webview bundle died at IMPORT time with no error
+# boundary and a blank screen. PR #4438 fixed it, and nothing stopped it
+# coming back.
+#
+# `npm test` cannot catch a regression here, structurally: it runs in Node,
+# where every one of these imports works perfectly. One `import { x } from
+# "fs"` added to a file the Agent happens to reach would silently un-ship the
+# mobile app, and the first signal would be a blank screen on a device.
+#
+# Deliberately narrow. It runs only when praisonai-ts changes, installs only
+# what it needs, and asserts one thing.
+name: praisonai-ts webview
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/praisonai-ts/src/**'
+      - 'src/praisonai-ts/package.json'
+      - 'src/praisonai-ts/scripts/webview-gate.mjs'
+      - '.github/workflows/praisonai-ts-webview.yml'
+  pull_request:
+    paths:
+      - 'src/praisonai-ts/src/**'
+      - 'src/praisonai-ts/package.json'
+      - 'src/praisonai-ts/scripts/webview-gate.mjs'
+      - '.github/workflows/praisonai-ts-webview.yml'
+
+concurrency:
+  group: praisonai-ts-webview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  webview:
+    name: loadable in a webview
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: src/praisonai-ts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.18'
+      # `npm install`, not `npm ci`: praisonai-ts gitignores its lockfile
+      # (src/praisonai-ts/.gitignore), so `npm ci` has nothing to install from.
+      # `--legacy-peer-deps` because the dependency tree does not otherwise
+      # resolve -- bedrock-agentcore wants a peer of @strands-agents/sdk that
+      # is not installed. That is pre-existing and out of scope here; without
+      # the flag this job fails on something unrelated to what it checks.
+      - name: Install
+        run: npm install --no-audit --no-fund --legacy-peer-deps
+      - name: Check
+        run: npm run check:webview

--- a/src/praisonai-ts/package.json
+++ b/src/praisonai-ts/package.json
@@ -53,7 +53,8 @@
     "dev": "ts-node-dev --respawn src/main.ts",
     "example:arxiv": "ts-node examples/tools/arxiv-tools.ts",
     "clean": "rimraf dist",
-    "prebuild": "npm run clean"
+    "prebuild": "npm run clean",
+    "check:webview": "node scripts/webview-gate.mjs"
   },
   "keywords": [
     "ai",
@@ -102,7 +103,8 @@
     "@jest/types": "^29.6.3",
     "@jest/globals": "^29.7.0",
     "@ai-sdk/provider-utils": "^2.2.8",
-    "@opentelemetry/api": "^1.9.0"
+    "@opentelemetry/api": "^1.9.0",
+    "esbuild": "^0.25.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/src/praisonai-ts/scripts/webview-gate.mjs
+++ b/src/praisonai-ts/scripts/webview-gate.mjs
@@ -1,0 +1,112 @@
+/**
+ * Can praisonai-ts still be loaded in a webview?
+ *
+ * Issue #4437 was exactly this failing: `crypto` and `events` were static
+ * imports on the `Agent` graph, so a browser/webview bundle died at IMPORT
+ * time -- before any code ran, with no error boundary and a blank screen. PR
+ * #4438 fixed it. Nothing stopped it coming back.
+ *
+ * That is the gap this closes. The `npm test` suite runs in Node, where every
+ * one of these failures works perfectly, so no unit test can catch a
+ * regression here. One `import { x } from "fs"` added to a file the Agent
+ * happens to reach would silently un-ship the mobile app, and the first signal
+ * would be a blank screen on a device.
+ *
+ * STATIC vs DYNAMIC matters and is not pedantry. A static import is evaluated
+ * at module load and kills the bundle outright. A dynamic `await import()`
+ * inside a function only fails if that function is called -- `readline` is
+ * reached only from `createCLIApprovalPrompt`, which is CLI-only by name and
+ * contract, so a phone never calls it. Failing on it would force a shim for a
+ * code path that cannot be taken, which is how a gate gets worked around
+ * instead of fixed.
+ */
+import * as esbuild from "esbuild";
+
+/** Node builtins that must never be reachable at import time from an entry a
+ *  webview loads. */
+const FORBIDDEN = new Set([
+  "assert", "buffer", "child_process", "cluster", "crypto", "dgram", "dns",
+  "events", "fs", "http", "http2", "https", "module", "net", "os", "path",
+  "perf_hooks", "process", "querystring", "readline", "repl", "stream",
+  "string_decoder", "timers", "tls", "tty", "url", "util", "v8", "vm",
+  "worker_threads", "zlib",
+]);
+
+/**
+ * The entries a mobile or browser consumer actually imports.
+ *
+ * Deliberately not the package root: `index.ts` re-exports the CLI, the MCP
+ * server and the tool registry, none of which a phone loads, and gating on it
+ * would report failures nobody can act on.
+ */
+export const WEBVIEW_ENTRIES = ["src/agent/simple.ts"];
+
+/** The webview baseline. iOS ships WKWebView with the OS, so the floor is the
+ *  oldest iOS worth supporting rather than the newest Safari. */
+export const TARGETS = ["safari16", "chrome108"];
+
+export async function inspect(entry) {
+  const result = await esbuild.build({
+    entryPoints: [entry],
+    bundle: true,
+    write: false,
+    metafile: true,
+    platform: "browser",
+    format: "esm",
+    target: TARGETS,
+    logLevel: "silent",
+    plugins: [{
+      name: "surface-bare",
+      setup(build) {
+        // Bare specifiers stay external so they appear in the metafile rather
+        // than being silently shimmed. Seeing the import is the whole point.
+        build.onResolve({ filter: /^[^.\/]/ }, (args) => ({ path: args.path, external: true }));
+      },
+    }],
+  });
+
+  const fatal = new Set();
+  const lazy = new Set();
+  for (const input of Object.values(result.metafile.inputs)) {
+    for (const imported of input.imports ?? []) {
+      if (imported.external !== true || imported.path.startsWith(".")) continue;
+      const name = imported.path.replace(/^node:/, "").split("/")[0];
+      if (!FORBIDDEN.has(name)) continue;
+      // Static wins: one static import anywhere is import-time fatal, whatever
+      // else is true of the same module elsewhere.
+      if (imported.kind !== "dynamic-import") {
+        fatal.add(name);
+        lazy.delete(name);
+      } else if (!fatal.has(name)) {
+        lazy.add(name);
+      }
+    }
+  }
+  return { entry, fatal: [...fatal].sort(), lazy: [...lazy].sort() };
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url.endsWith(process.argv[1].split("/").pop());
+
+if (invokedDirectly) {
+  let failed = false;
+  for (const entry of WEBVIEW_ENTRIES) {
+    const { fatal, lazy } = await inspect(entry);
+    for (const name of lazy) {
+      console.log(`  ~ ${entry}: ${name} imported lazily, fine while no webview path calls it`);
+    }
+    if (fatal.length > 0) {
+      failed = true;
+      console.error(`  FAIL ${entry}: Node builtins imported STATICALLY: ${fatal.join(", ")}`);
+      console.error(`       These fail at IMPORT time in a webview: no error boundary, blank screen.`);
+      console.error(`       Route them through globalThis equivalents, or move the module`);
+      console.error(`       behind a Node-only entry point.`);
+    } else {
+      console.log(`  OK   ${entry}: loadable in a webview`);
+    }
+  }
+  if (failed) {
+    console.error("\npraisonai-ts is not webview-consumable. This is issue #4437 regressing.");
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## What

The "cleanly mobile-consumable" list, worked through end to end. Four commits, each independently reviewable.

**Existing behaviour is unchanged throughout** — verified at every step:

| | before | after |
|---|---|---|
| `npx jest` | 1096 pass | **1110 pass**, 0 fail |
| `tsc --noEmit` | clean | clean |
| `npm run build` | 288 files | 290 files |

## The four commits

**1. `ci(ts)` — a webview gate, so #4437 cannot regress silently.**
`npm test` runs in Node, where a `crypto` import works perfectly, so no unit test can catch this class of regression. One `import { x } from 'fs'` on a file the Agent reaches would silently un-ship the mobile app; the first signal would be a blank screen on a device. Proven able to fail: re-adding the #4437 regression makes it fail by name.

**2. `refactor(ts)` — one uuid util (task 1).**
#4438 fixed the two files on the Agent graph and left the identical `import { randomUUID } from 'crypto'` in **32 others**. All now use `src/utils/uuid`, and the two local copies #4438 left are gone with them.

**3. `feat(ts)` — a `praisonai/mobile` entry (task 5).**
`praisonai` resolves to `index.ts`, which re-exports the CLI, MCP server and knowledge store. A bundler follows every re-export and dies on a builtin nothing was going to call. The new entry is an **allowlist**, gated by the check from commit 1:

```
praisonai/mobile, minified:  77.8kB   (target was <400kB)
praisonai, root entry:        2.97MB
```

**4. `feat(ts)` — tool activity on the event channel (task 7).**
`AgentEvent` had three variants, so a consumer saw prose and nothing else — praisonai-ts executed tools and never announced them. Two new variants; `ok` is the point of both, because a tool that failed *with a message* is byte-identical to one that succeeded with a message. Emitted on all three paths: success, throw, and approval denial.

Additive by construction: `start()` gained a **fifth optional parameter**, `stream()` filters on `type === 'text'` and is unaffected (asserted), and a run with no tools emits no tool events.

## Two corrections to the task list

**Task 2 is a misreading, not a fix.** It called `node-fetch` a phantom dependency to delete. It is not a dependency — it sits in **`overrides`**, pinning a *transitive* dep's version, most likely for a security fix. Removing it would change resolution for whatever pulls it in. Left alone deliberately. (`dotenv` is genuinely gone: absent from every dependency section, referenced nowhere in `src`.)

**Task 4 is obviated by task 5.** All 9 `fs`/`path`/`vm` files are CLI, workflow and skills modules, and **none is reachable from the mobile entry** — only 23 files are. The allowlist achieved what the `src/node/` refactor was for, without touching working CLI code.

## Everything is mutation-verified

| what | mutation | caught |
|---|---|---|
| uuid version nibble | OR without masking | 3 fail |
| uuid variant nibble | OR without masking | 1 fail |
| uuid hex padding | drop `padStart` | 4 fail |
| uuid platform path | never use `crypto.randomUUID` | 1 fail |
| tool `ok` | report a failed tool as `ok: true` | 1 fail |
| tool announce | never emit `tool_call` | 3 fail |
| webview gate | re-add `import from 'crypto'` | fails, names #4437 |

One thing worth recording: the first uuid mutation run reported the two mask mutations as **surviving**. They had not — jest was serving a cached transform. With `--no-cache` both fail. A mutation run against a cached transform proves nothing, and it reports the reassuring answer.

## Consumer note

Widening a union is source-breaking for an exhaustive `switch`. Consumers that handle `text`/`finish`/`error` and treat everything else as an error will now see `tool_call`/`tool_result` on that branch. `stream()` is unaffected.