### PR TITLE
fix(desktop): sync release version before bundling

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -132,6 +132,23 @@ jobs:
         working-directory: src/praisonai-desktop/src-tauri
         run: cargo tauri build --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
 
+      - name: The Windows binary must carry the release version
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: src/praisonai-desktop/src-tauri
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          $expected = $env:RELEASE_TAG -replace '^v', ''
+          $numeric = ($expected -split '[-+]')[0] + '.0'
+          $version = (Get-Item "target/${{ matrix.target }}/release/praisonai-desktop.exe").VersionInfo
+          if ($version.ProductVersion -ne $expected) {
+            throw "ProductVersion $($version.ProductVersion) does not match $expected"
+          }
+          if ($version.FileVersion -ne $numeric) {
+            throw "FileVersion $($version.FileVersion) does not match $numeric"
+          }
+
       - name: The macOS bundle must carry a valid signature
         if: runner.os == 'macOS'
         working-directory: src/praisonai-desktop/src-tauri

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -122,6 +122,12 @@ jobs:
         # let a failure be a failure.
         run: command -v cargo-tauri >/dev/null || cargo install tauri-cli --version '^2' --locked
 
+      - name: Set the desktop version from the release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: node src/praisonai-desktop/tools/set-release-version.mjs "$RELEASE_TAG"
+
       - name: Build the bundle
         working-directory: src/praisonai-desktop/src-tauri
         run: cargo tauri build --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}

--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -1556,6 +1556,9 @@ class Handler(BaseHTTPRequestHandler):
         # rather than reproduce the default and hand the user a path the app
         # is not actually using.
         body = json.dumps({"ok": True, "version": PROTOCOL_VERSION,
+                           "shell_version": os.environ.get(
+                               "PRAISONAI_DESKTOP_VERSION", "unknown"),
+                           "agents_version": _installed_version(),
                            "data_dir": str(DATA_DIR)}).encode()
         self.send_response(200)
         self._cors()

--- a/src/praisonai-desktop/engine/test_portability.py
+++ b/src/praisonai-desktop/engine/test_portability.py
@@ -228,6 +228,7 @@ class HealthReportsWhereItLives(unittest.TestCase):
         engine = os.path.join(os.path.dirname(os.path.abspath(server.__file__)), "server.py")
         proc = _sp.Popen([_sys.executable, "-u", engine],
                          env=dict(os.environ, PRAISONAI_DESKTOP_HOME=home,
+                                  PRAISONAI_DESKTOP_VERSION="4.7.3",
                                   PRAISONAI_KEYCHAIN_SERVICE="ai.praison.desktop.test"),
                          stdout=_sp.PIPE, stderr=_sp.STDOUT, text=True)
         try:
@@ -245,6 +246,8 @@ class HealthReportsWhereItLives(unittest.TestCase):
                 health = _json.loads(r.read())
             self.assertEqual(health.get("data_dir"), home,
                              "health does not report the directory actually in use")
+            self.assertEqual(health.get("shell_version"), "4.7.3")
+            self.assertIn("agents_version", health)
         finally:
             proc.terminate()
             try:

--- a/src/praisonai-desktop/frontend/src/settings-registry.js
+++ b/src/praisonai-desktop/frontend/src/settings-registry.js
@@ -172,7 +172,12 @@ const SETTINGS = [
 
   // ---- About --------------------------------------------------------------
   { key: "version", section: "about", label: "PraisonAI Desktop",
-    control: { kind: "readout", value: () => "0.1.0" } },
+    control: { kind: "readout", value: () =>
+      globalThis.__PRAISONAI_DESKTOP_VERSION__ || "unknown" } },
+
+  { key: "agents_version", section: "about", label: "PraisonAI Agents",
+    control: { kind: "readout", value: () =>
+      globalThis.__PRAISONAI_AGENTS_VERSION__ || "unknown" } },
 
   { key: "engine_status", section: "about", label: "Engine",
     description: "The Python process this window is talking to.",

--- a/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
@@ -23,6 +23,7 @@ const ci = readFileSync(new URL('.github/workflows/desktop.yml', root), 'utf8');
 const config = JSON.parse(
   readFileSync(new URL('src/praisonai-desktop/src-tauri/tauri.conf.json', root), 'utf8'));
 const install = readFileSync(new URL('src/praisonai-desktop/INSTALL.md', root), 'utf8');
+const ui = readFileSync(new URL('src/praisonai-desktop/ui/index.html', root), 'utf8');
 
 test('the release tag becomes the desktop product version before bundling', () => {
   const runnable = workflow
@@ -36,6 +37,31 @@ test('the release tag becomes the desktop product version before bundling', () =
   assert.equal(releaseVersion('v4.7.3'), '4.7.3');
   assert.equal(releaseVersion('4.8.0-rc.1'), '4.8.0-rc.1');
   assert.throws(() => releaseVersion('latest'), /not a semantic version/);
+  assert.throws(() => releaseVersion('1.2.3-01'), /not a semantic version/);
+});
+
+test('the packaged About view reads the same Tauri version', () => {
+  const start = ui.indexOf('{ key: "version", section: "about"');
+  const end = ui.indexOf('{ key: "engine_status"', start);
+  const desktopVersion = ui.slice(start, end);
+  assert.match(ui, /window\.__TAURI__\.app\.getVersion\(\)/,
+               'the UI never reads the version embedded by Tauri');
+  assert.match(desktopVersion, /__PRAISONAI_DESKTOP_VERSION__/,
+               'About does not use the version returned by Tauri');
+  assert.doesNotMatch(desktopVersion, /0\.1\.0/, 'About still hardcodes the development version');
+  assert.ok(ui.includes('label: "PraisonAI Agents"'),
+            'About does not distinguish the agents package from the desktop shell');
+});
+
+test('the Windows release fails if its embedded version drifts', () => {
+  const start = workflow.indexOf('The Windows binary must carry the release version');
+  const end = workflow.indexOf('The macOS bundle must carry a valid signature', start);
+  const gate = workflow.slice(start, end);
+  assert.match(gate, /VersionInfo/, 'the release never reads the binary version resource');
+  assert.match(gate, /ProductVersion/, 'the release does not verify ProductVersion');
+  assert.match(gate, /FileVersion/, 'the release does not verify FileVersion');
+  assert.ok(start > workflow.indexOf('cargo tauri build'), 'the binary is checked before it exists');
+  assert.ok(start < workflow.indexOf('gh release upload'), 'the binary is checked after upload');
 });
 
 /** The matrix legs, as (bundles, asset, ext) triples. */

--- a/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
@@ -44,8 +44,9 @@ test('the packaged About view reads the same Tauri version', () => {
   const start = ui.indexOf('{ key: "version", section: "about"');
   const end = ui.indexOf('{ key: "engine_status"', start);
   const desktopVersion = ui.slice(start, end);
-  assert.match(ui, /window\.__TAURI__\.app\.getVersion\(\)/,
-               'the UI never reads the version embedded by Tauri');
+  assert.match(ui,
+               /__PRAISONAI_DESKTOP_VERSION__\s*=\s*await\s+window\.__TAURI__\.app\.getVersion\(\)/,
+               'the UI does not assign the version embedded by Tauri to the About value');
   assert.match(desktopVersion, /__PRAISONAI_DESKTOP_VERSION__/,
                'About does not use the version returned by Tauri');
   assert.doesNotMatch(desktopVersion, /0\.1\.0/, 'About still hardcodes the development version');
@@ -60,6 +61,10 @@ test('the Windows release fails if its embedded version drifts', () => {
   assert.match(gate, /VersionInfo/, 'the release never reads the binary version resource');
   assert.match(gate, /ProductVersion/, 'the release does not verify ProductVersion');
   assert.match(gate, /FileVersion/, 'the release does not verify FileVersion');
+  assert.match(gate, /\$version\.ProductVersion\s+-ne\s+\$expected/,
+               'ProductVersion is not compared with the release version');
+  assert.match(gate, /\$version\.FileVersion\s+-ne\s+\$numeric/,
+               'FileVersion is not compared with the numeric release version');
   assert.ok(start > workflow.indexOf('cargo tauri build'), 'the binary is checked before it exists');
   assert.ok(start < workflow.indexOf('gh release upload'), 'the binary is checked after upload');
 });

--- a/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
@@ -15,6 +15,7 @@
 import { readFileSync } from 'node:fs';
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { releaseVersion } from '../../tools/set-release-version.mjs';
 
 const root = new URL('../../../../', import.meta.url);
 const workflow = readFileSync(new URL('.github/workflows/desktop-release.yml', root), 'utf8');
@@ -22,6 +23,20 @@ const ci = readFileSync(new URL('.github/workflows/desktop.yml', root), 'utf8');
 const config = JSON.parse(
   readFileSync(new URL('src/praisonai-desktop/src-tauri/tauri.conf.json', root), 'utf8'));
 const install = readFileSync(new URL('src/praisonai-desktop/INSTALL.md', root), 'utf8');
+
+test('the release tag becomes the desktop product version before bundling', () => {
+  const runnable = workflow
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+  const sync = runnable.indexOf('node src/praisonai-desktop/tools/set-release-version.mjs');
+  const build = runnable.indexOf('cargo tauri build');
+  assert.notEqual(sync, -1, 'the release never writes its tag into tauri.conf.json');
+  assert.ok(sync < build, 'the desktop version is updated after the bundle is built');
+  assert.equal(releaseVersion('v4.7.3'), '4.7.3');
+  assert.equal(releaseVersion('4.8.0-rc.1'), '4.8.0-rc.1');
+  assert.throws(() => releaseVersion('latest'), /not a semantic version/);
+});
 
 /** The matrix legs, as (bundles, asset, ext) triples. */
 function legs() {

--- a/src/praisonai-desktop/src-tauri/src/health.rs
+++ b/src/praisonai-desktop/src-tauri/src/health.rs
@@ -63,6 +63,15 @@ pub fn classify(probe: Probe<'_>, expected_version: u32) -> Result<Ready, NotRea
     Ok(Ready { version })
 }
 
+/// Confirm an engine was launched by the same desktop release as this shell.
+///
+/// Protocol compatibility alone is insufficient when adopting an engine left
+/// behind by a previous shell process: that child retains the old release
+/// version in its environment and would otherwise report stale About data.
+pub fn shell_version_matches(body: &str, expected: &str) -> bool {
+    field(body, "shell_version").as_deref() == Some(expected)
+}
+
 /// Extract a scalar JSON field. Returns `None` rather than a default, so a
 /// missing field can never be mistaken for a present one.
 fn field(body: &str, key: &str) -> Option<String> {
@@ -140,5 +149,14 @@ mod tests {
         // "not_ok" contains "ok"; a substring search would read the wrong field.
         let probe = Probe::Responded { status: 200, body: r#"{"not_ok": true, "ok": false}"# };
         assert!(matches!(classify(probe, V), Err(NotReady::Unhealthy(_))));
+    }
+
+    #[test]
+    fn an_adopted_engine_must_match_the_shell_release() {
+        let current = r#"{"ok": true, "version": 1, "shell_version": "4.7.3"}"#;
+        let stale = r#"{"ok": true, "version": 1, "shell_version": "4.7.2"}"#;
+        assert!(shell_version_matches(current, "4.7.3"));
+        assert!(!shell_version_matches(stale, "4.7.3"));
+        assert!(!shell_version_matches(r#"{"ok": true, "version": 1}"#, "4.7.3"));
     }
 }

--- a/src/praisonai-desktop/src-tauri/src/main.rs
+++ b/src/praisonai-desktop/src-tauri/src/main.rs
@@ -301,11 +301,16 @@ fn engine_status(app: tauri::AppHandle, state: tauri::State<'_, AppState>) -> En
         Some(b) => std::env::set_var("PRAISONAI_APP_BUNDLE", b),
         None => std::env::remove_var("PRAISONAI_APP_BUNDLE"),
     }
+    // The engine exposes this beside its own package version in /health. Read
+    // from Tauri package metadata, which the release workflow derives from the
+    // tag, rather than from Cargo.toml's development-only package version.
+    let shell_version = app.package_info().version.to_string();
 
     match supervisor::start(
         &python.display().to_string(),
         &layout.script.display().to_string(),
         Duration::from_secs(30),
+        &shell_version,
     ) {
         Ok(engine) => {
             let port = engine.port;

--- a/src/praisonai-desktop/src-tauri/src/main.rs
+++ b/src/praisonai-desktop/src-tauri/src/main.rs
@@ -258,6 +258,10 @@ fn engine_status(app: tauri::AppHandle, state: tauri::State<'_, AppState>) -> En
             }
         }
     };
+    // The engine exposes this beside its own package version in /health. Read
+    // from Tauri package metadata, which the release workflow derives from the
+    // tag, rather than from Cargo.toml's development-only package version.
+    let shell_version = app.package_info().version.to_string();
     // Reap or adopt whatever the last run left. Neither `Drop` nor the reap on
     // exit runs when the shell is killed by a signal, and that was observed:
     // `kill -TERM` on the app left the Python child alive with a lockfile still
@@ -266,8 +270,13 @@ fn engine_status(app: tauri::AppHandle, state: tauri::State<'_, AppState>) -> En
         let venv = venv_root_for_python(&python, &RealFs, Platform::current())
             .map(|l| l.root.display().to_string())
             .unwrap_or_default();
-        match reclaim(dir, &python.display().to_string(), &venv,
-                      supervisor::probe_health, kill_pid) {
+        match reclaim(
+            dir,
+            &python.display().to_string(),
+            &venv,
+            |port| supervisor::probe_health(port, &shell_version),
+            kill_pid,
+        ) {
             Decision::Adopt { port } => {
                 log_decision(&Decision::Adopt { port });
                 praisonai_desktop_core::tray::set_engine_label(
@@ -301,11 +310,6 @@ fn engine_status(app: tauri::AppHandle, state: tauri::State<'_, AppState>) -> En
         Some(b) => std::env::set_var("PRAISONAI_APP_BUNDLE", b),
         None => std::env::remove_var("PRAISONAI_APP_BUNDLE"),
     }
-    // The engine exposes this beside its own package version in /health. Read
-    // from Tauri package metadata, which the release workflow derives from the
-    // tag, rather than from Cargo.toml's development-only package version.
-    let shell_version = app.package_info().version.to_string();
-
     match supervisor::start(
         &python.display().to_string(),
         &layout.script.display().to_string(),

--- a/src/praisonai-desktop/src-tauri/src/supervisor.rs
+++ b/src/praisonai-desktop/src-tauri/src/supervisor.rs
@@ -106,7 +106,12 @@ pub fn read_lines_lossy(stream: impl std::io::Read) -> impl Iterator<Item = Stri
 ///
 /// Output is captured from the instant of spawn -- attaching a reader later is
 /// how a first-run failure ends up reported as an exit code with no explanation.
-pub fn start(python: &str, script: &str, timeout: Duration) -> Result<Engine, StartError> {
+pub fn start(
+    python: &str,
+    script: &str,
+    timeout: Duration,
+    shell_version: &str,
+) -> Result<Engine, StartError> {
     let mut command = Command::new(python);
     command
         .arg("-u") // unbuffered, or the announcement sits in a pipe buffer
@@ -119,6 +124,7 @@ pub fn start(python: &str, script: &str, timeout: Duration) -> Result<Engine, St
         // is a lie about what happened and depends on the user's locale.
         .env("PYTHONUTF8", "1")
         .env("PYTHONIOENCODING", "utf-8")
+        .env("PRAISONAI_DESKTOP_VERSION", shell_version)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     // No console window, and its own process group so stopping the engine also

--- a/src/praisonai-desktop/src-tauri/src/supervisor.rs
+++ b/src/praisonai-desktop/src-tauri/src/supervisor.rs
@@ -177,7 +177,7 @@ pub fn start(
                     // A port parsed from a log line is a claim. Confirm it before
                     // handing it to the UI, or the first message goes to whatever
                     // else happens to be listening.
-                    if let Some(port) = announced.confirm(probe_health) {
+                    if let Some(port) = announced.confirm(|port| probe_health(port, shell_version)) {
                         return Ok(Engine { port, child });
                     }
                 }
@@ -203,8 +203,8 @@ pub fn start(
     }
 }
 
-/// Confirm the engine answers on `port` with the shape we expect.
-pub fn probe_health(port: u16) -> bool {
+/// Confirm the engine answers on `port` with the shape and shell version we expect.
+pub fn probe_health(port: u16, expected_shell_version: &str) -> bool {
     use std::io::{Read, Write};
     use std::net::TcpStream;
 
@@ -234,6 +234,7 @@ pub fn probe_health(port: u16) -> bool {
         crate::health::EXPECTED_VERSION,
     )
     .is_ok()
+        && crate::health::shell_version_matches(payload, expected_shell_version)
 }
 
 fn tail(buffer: &str) -> String {

--- a/src/praisonai-desktop/tools/set-release-version.mjs
+++ b/src/praisonai-desktop/tools/set-release-version.mjs
@@ -2,8 +2,13 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const CONFIG = fileURLToPath(new URL('../src-tauri/tauri.conf.json', import.meta.url));
-const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const NUMERIC = '(?:0|[1-9]\\d*)';
+const PRERELEASE = `(?:${NUMERIC}|\\d*[A-Za-z-][0-9A-Za-z-]*)`;
+const SEMVER = new RegExp(
+  `^${NUMERIC}\\.${NUMERIC}\\.${NUMERIC}(?:-${PRERELEASE}(?:\\.${PRERELEASE})*)?` +
+  '(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$');
 
+/** Strip one conventional `v` prefix and validate a strict semantic version. */
 export function releaseVersion(tag) {
   const version = tag?.startsWith('v') ? tag.slice(1) : tag;
   if (!version || !SEMVER.test(version)) {
@@ -12,6 +17,7 @@ export function releaseVersion(tag) {
   return version;
 }
 
+/** Write the release version into the Tauri config consumed by the bundler. */
 export function setReleaseVersion(tag, configPath = CONFIG) {
   const config = JSON.parse(readFileSync(configPath, 'utf8'));
   config.version = releaseVersion(tag);

--- a/src/praisonai-desktop/tools/set-release-version.mjs
+++ b/src/praisonai-desktop/tools/set-release-version.mjs
@@ -1,0 +1,30 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const CONFIG = fileURLToPath(new URL('../src-tauri/tauri.conf.json', import.meta.url));
+const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+export function releaseVersion(tag) {
+  const version = tag?.startsWith('v') ? tag.slice(1) : tag;
+  if (!version || !SEMVER.test(version)) {
+    throw new Error(`release tag "${tag ?? ''}" is not a semantic version`);
+  }
+  return version;
+}
+
+export function setReleaseVersion(tag, configPath = CONFIG) {
+  const config = JSON.parse(readFileSync(configPath, 'utf8'));
+  config.version = releaseVersion(tag);
+  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  return config.version;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const version = setReleaseVersion(process.argv[2]);
+    console.log(`desktop release version: ${version}`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -775,7 +775,12 @@ const SETTINGS = [
 
   // ---- About --------------------------------------------------------------
   { key: "version", section: "about", label: "PraisonAI Desktop",
-    control: { kind: "readout", value: () => "0.1.0" } },
+    control: { kind: "readout", value: () =>
+      globalThis.__PRAISONAI_DESKTOP_VERSION__ || "unknown" } },
+
+  { key: "agents_version", section: "about", label: "PraisonAI Agents",
+    control: { kind: "readout", value: () =>
+      globalThis.__PRAISONAI_AGENTS_VERSION__ || "unknown" } },
 
   { key: "engine_status", section: "about", label: "Engine",
     description: "The Python process this window is talking to.",
@@ -1350,6 +1355,7 @@ function gate(){
 }
 
 async function boot(){
+try{ globalThis.__PRAISONAI_DESKTOP_VERSION__=await window.__TAURI__.app.getVersion(); }catch{}
 const st=await invoke('engine_status');
 if(st.state==='ready'){
   PORT=st.port; status.textContent=`engine :${PORT}`; status.className='s-ready';
@@ -2043,6 +2049,10 @@ document.getElementById('settings').addEventListener('click',async()=>{
   try{
     cfg = await (await fetch('http://127.0.0.1:'+PORT+'/settings')).json();
   }catch(e){ engineDownPanel('Settings'); return; }
+  try{
+    const health=await (await fetch('http://127.0.0.1:'+PORT+'/health')).json();
+    globalThis.__PRAISONAI_AGENTS_VERSION__=health.agents_version||'unknown';
+  }catch(e){}
   settingsQuery=''; renderSettings(); overlay.classList.add('open');
   panel.querySelector('#setq').focus();
 });

--- a/src/praisonai-desktop/ui/settings-registry.js
+++ b/src/praisonai-desktop/ui/settings-registry.js
@@ -172,7 +172,12 @@ const SETTINGS = [
 
   // ---- About --------------------------------------------------------------
   { key: "version", section: "about", label: "PraisonAI Desktop",
-    control: { kind: "readout", value: () => "0.1.0" } },
+    control: { kind: "readout", value: () =>
+      globalThis.__PRAISONAI_DESKTOP_VERSION__ || "unknown" } },
+
+  { key: "agents_version", section: "about", label: "PraisonAI Agents",
+    control: { kind: "readout", value: () =>
+      globalThis.__PRAISONAI_AGENTS_VERSION__ || "unknown" } },
 
   { key: "engine_status", section: "about", label: "Engine",
     description: "The Python process this window is talking to.",


### PR DESCRIPTION
## Summary

- derive the Tauri desktop version from the release tag before every bundle build
- validate strict SemVer, including rejecting numeric prerelease identifiers with leading zeros
- show the Tauri shell version separately from the agents package version in About and `/health`
- fail the Windows release before upload when ProductVersion or FileVersion differs from the tag

## Why

The checked-in desktop config is still version `0.1.0`. The release workflow used the Git tag only for asset naming, so Windows embedded `0.1.0` in the executable metadata even for v4.7.3. The About readout repeated the same hardcoded development version.

## Validation

- release/About workflow tests and settings-effects tests: 38 passed
- desktop portability tests: 42 passed, 3 skipped
- full desktop frontend suite: 166 passed, 13 skipped; one pre-existing registry-drift failure remains on current `main` in files otherwise untouched by this PR
- temporary-config write/read assertion for `v4.7.3` -> `4.7.3`
- desktop release workflow YAML parsed successfully

Fixes #4442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop releases now use the version specified by the release tag.
  * Release tags support standard semantic versions with or without a leading “v”.
  * About settings display separate Desktop and Agents versions.
  * Health information reports both application versions.
  * Invalid release tags are rejected before building.
  * Windows builds verify executable versions match the release tag.

* **Tests**
  * Added coverage for version synchronization, prerelease validation, displayed version information, health reporting, and Windows release validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->