### PR TITLE
fix(desktop): keep first-run setup visible

### DIFF
--- a/src/praisonai-desktop/frontend/tests/first-run.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/first-run.test.mjs
@@ -113,6 +113,15 @@ test('Train stays blocked while initial engine status is still pending', async (
   click(b.doc.getElementById('viewTrain'));
   assert.equal(b.doc.body.classList.contains('training'), false,
     'Train replaced setup before engine readiness was known');
+  assert.equal(b.window.localStorage.getItem('view'), 'train',
+    'clicking Train while readiness was pending discarded the requested view');
+  await new Promise((resolve) => setTimeout(resolve, 700));
+  assert.equal(b.doc.body.classList.contains('training'), false,
+    'the stale startup view replaced setup after readiness resolved');
+  assert.equal(b.window.localStorage.getItem('view'), 'train',
+    'startup completion overwrote the view selected while readiness was pending');
+  assert.ok(b.doc.querySelector('.setup'),
+    'startup completion hid setup after a Train click during readiness detection');
 });
 
 test('the steps are listed before anything starts', async () => {

--- a/src/praisonai-desktop/frontend/tests/first-run.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/first-run.test.mjs
@@ -32,13 +32,14 @@ process.on('exit', () => SRV.close());
  * Boot with no interpreter. `provision` decides what the setup run does:
  * `'ok'` succeeds and the engine comes up, `'fail'` rejects.
  */
-async function boot({ provision = 'ok', steps = [] } = {}) {
+async function boot({ provision = 'ok', steps = [], savedView = null } = {}) {
   const invoked = [];
   let listener = null;
   let readyAfterProvision = provision === 'ok';
   const dom = new JSDOM(HTML, {
     runScripts: 'dangerously', resources: 'usable', url: ORIGIN + '/',
     beforeParse(w) {
+      if (savedView) w.localStorage.setItem('view', savedView);
       w.__TAURI__ = {
         core: {
           invoke: async (cmd) => {
@@ -85,6 +86,18 @@ test('no Python offers setup instead of an error block', async () => {
   assert.equal(b.doc.querySelector('.err'), null,
     'still shown as a failure the user cannot act on');
   assert.match(b.doc.getElementById('status').textContent, /setup/i);
+});
+
+test('a saved or clicked Train view cannot hide first-run setup', async () => {
+  const b = await boot({ savedView: 'train' });
+  assert.equal(b.doc.body.classList.contains('training'), false,
+    'the saved Train view hid the setup screen');
+  assert.ok(b.doc.querySelector('.setup'), 'no setup screen after restoring Train');
+
+  click(b.doc.getElementById('viewTrain'));
+  assert.equal(b.doc.body.classList.contains('training'), false,
+    'Train can replace setup even though it has no engine');
+  assert.ok(b.doc.querySelector('.setup'), 'clicking Train hid the setup screen');
 });
 
 test('the steps are listed before anything starts', async () => {

--- a/src/praisonai-desktop/frontend/tests/first-run.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/first-run.test.mjs
@@ -93,11 +93,15 @@ test('a saved or clicked Train view cannot hide first-run setup', async () => {
   assert.equal(b.doc.body.classList.contains('training'), false,
     'the saved Train view hid the setup screen');
   assert.ok(b.doc.querySelector('.setup'), 'no setup screen after restoring Train');
+  assert.equal(b.window.localStorage.getItem('view'), 'train',
+    'forcing Chat during setup overwrote the saved Train preference');
 
   click(b.doc.getElementById('viewTrain'));
   assert.equal(b.doc.body.classList.contains('training'), false,
     'Train can replace setup even though it has no engine');
   assert.ok(b.doc.querySelector('.setup'), 'clicking Train hid the setup screen');
+  assert.equal(b.window.localStorage.getItem('view'), 'train',
+    'clicking Train during setup discarded the requested view');
 });
 
 test('the steps are listed before anything starts', async () => {

--- a/src/praisonai-desktop/frontend/tests/first-run.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/first-run.test.mjs
@@ -32,7 +32,8 @@ process.on('exit', () => SRV.close());
  * Boot with no interpreter. `provision` decides what the setup run does:
  * `'ok'` succeeds and the engine comes up, `'fail'` rejects.
  */
-async function boot({ provision = 'ok', steps = [], savedView = null } = {}) {
+async function boot({ provision = 'ok', steps = [], savedView = null,
+                      engineStatusDelay = 0 } = {}) {
   const invoked = [];
   let listener = null;
   let readyAfterProvision = provision === 'ok';
@@ -45,6 +46,9 @@ async function boot({ provision = 'ok', steps = [], savedView = null } = {}) {
           invoke: async (cmd) => {
             invoked.push(cmd);
             if (cmd === 'engine_status') {
+              if (engineStatusDelay) {
+                await new Promise((resolve) => setTimeout(resolve, engineStatusDelay));
+              }
               return invoked.filter((c) => c === 'provision_engine').length && readyAfterProvision
                 ? { state: 'ready', port: 65000, python: '/venv/bin/python3' }
                 : { state: 'failed', reason: 'No usable Python',
@@ -102,6 +106,13 @@ test('a saved or clicked Train view cannot hide first-run setup', async () => {
   assert.ok(b.doc.querySelector('.setup'), 'clicking Train hid the setup screen');
   assert.equal(b.window.localStorage.getItem('view'), 'train',
     'clicking Train during setup discarded the requested view');
+});
+
+test('Train stays blocked while initial engine status is still pending', async () => {
+  const b = await boot({ engineStatusDelay: 1000 });
+  click(b.doc.getElementById('viewTrain'));
+  assert.equal(b.doc.body.classList.contains('training'), false,
+    'Train replaced setup before engine readiness was known');
 });
 
 test('the steps are listed before anything starts', async () => {

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -2420,5 +2420,12 @@ document.getElementById('tMethod').addEventListener('change',e=>{
 // looking selected on first launch.
 let startView='chat';
 try{ if(localStorage.getItem('view')==='train') startView='train'; }catch(e){}
-initialBoot.then(()=>showView(startView));
+initialBoot.then(()=>{
+  let nextView=startView;
+  try{
+    const savedView=localStorage.getItem('view');
+    if(savedView==='chat'||savedView==='train') nextView=savedView;
+  }catch(e){}
+  showView(nextView);
+});
 </script></body></html>

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -1483,7 +1483,7 @@ function firstRun(st){
     }finally{ if(un) un(); }
   };
 }
-boot();
+const initialBoot=boot();
 
 document.getElementById('f').addEventListener('submit',async e=>{
   e.preventDefault();
@@ -2419,5 +2419,5 @@ document.getElementById('tMethod').addEventListener('change',e=>{
 // looking selected on first launch.
 let startView='chat';
 try{ if(localStorage.getItem('view')==='train') startView='train'; }catch(e){}
-showView(startView);
+initialBoot.then(()=>showView(startView));
 </script></body></html>

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -827,7 +827,7 @@ window.__REGISTRY__ = { SECTIONS, SETTINGS, DEFAULTS, searchSettings };
 const { invoke } = window.__TAURI__.core;
 const turns=document.getElementById('turns'), thread=document.getElementById('thread');
 const status=document.getElementById('status'), box=document.getElementById('p'), send=document.getElementById('send');
-let PORT=null, atBottom=true, activeRun=null, activeReader=null;
+let PORT=null, engineBlocked=false, atBottom=true, activeRun=null, activeReader=null;
 /** Set by Regenerate for exactly one submit, then cleared. */
 let regenerateOf=null;
 // The renderer honours these directly -- everything in here was previously
@@ -1351,6 +1351,8 @@ function gate(){
 
 async function boot(){
 const st=await invoke('engine_status');
+engineBlocked=st.state!=='ready';
+if(engineBlocked) showView('chat');
 if(st.state==='ready'){
   PORT=st.port; status.textContent=`engine :${PORT}`; status.className='s-ready';
   box.disabled=send.disabled=false; box.focus(); refreshChats(); refreshModelName();
@@ -2174,6 +2176,7 @@ let trainStream=null, trainCursor=-1, trainRunId=null, lossSeries=[], logLines=[
 const MAX_LOG_LINES=600;   // the pane is a tail, not an archive; the log file has it all
 
 function showView(name){
+  if(name==='train' && engineBlocked) name='chat';
   const training=name==='train';
   document.body.classList.toggle('training',training);
   trainView.classList.toggle('on',training);

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -827,7 +827,7 @@ window.__REGISTRY__ = { SECTIONS, SETTINGS, DEFAULTS, searchSettings };
 const { invoke } = window.__TAURI__.core;
 const turns=document.getElementById('turns'), thread=document.getElementById('thread');
 const status=document.getElementById('status'), box=document.getElementById('p'), send=document.getElementById('send');
-let PORT=null, engineBlocked=false, atBottom=true, activeRun=null, activeReader=null;
+let PORT=null, engineBlocked=true, atBottom=true, activeRun=null, activeReader=null;
 /** Set by Regenerate for exactly one submit, then cleared. */
 let regenerateOf=null;
 // The renderer honours these directly -- everything in here was previously

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -1352,7 +1352,7 @@ function gate(){
 async function boot(){
 const st=await invoke('engine_status');
 engineBlocked=st.state!=='ready';
-if(engineBlocked) showView('chat');
+if(engineBlocked) showView('chat',{persist:false});
 if(st.state==='ready'){
   PORT=st.port; status.textContent=`engine :${PORT}`; status.className='s-ready';
   box.disabled=send.disabled=false; box.focus(); refreshChats(); refreshModelName();
@@ -2175,7 +2175,8 @@ const METHOD_HINTS={
 let trainStream=null, trainCursor=-1, trainRunId=null, lossSeries=[], logLines=[];
 const MAX_LOG_LINES=600;   // the pane is a tail, not an archive; the log file has it all
 
-function showView(name){
+function showView(name,{persist=true}={}){
+  const requested=name;
   if(name==='train' && engineBlocked) name='chat';
   const training=name==='train';
   document.body.classList.toggle('training',training);
@@ -2184,7 +2185,7 @@ function showView(name){
   viewChat.setAttribute('aria-selected',String(!training));
   viewTrain.classList.toggle('active',training);
   viewChat.classList.toggle('active',!training);
-  try{ localStorage.setItem('view',name); }catch(e){}
+  if(persist) try{ localStorage.setItem('view',requested); }catch(e){}
   if(training) refreshTraining();
 }
 viewChat.addEventListener('click',()=>showView('chat'));


### PR DESCRIPTION
## Summary

- force the Chat/setup view back to the foreground when `engine_status` reports an unavailable engine
- keep the engine-dependent Train view from replacing setup until the engine is ready
- cover both a restored Train preference and a Train click during first-run setup

## Why

The app restores the saved view while `boot()` awaits the engine status. If the saved view is Train, the later first-run setup is rendered in Chat but remains hidden behind the training form. That produces the reported combination of a highlighted Train tab and `setup needed`, with no visible setup action.

## Validation

- `node --test frontend/tests/first-run.test.mjs frontend/tests/training.test.mjs` (24 passed)
- full desktop suite: 164 passed, 13 skipped; one pre-existing registry-drift failure remains on current `main` in files untouched by this PR

Fixes #4441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the training view from opening while the engine is unavailable or initializing.
  * Ensured the chat view remains visible until the engine is ready.
  * Preserved the first-run setup screen despite saved views or attempts to access training.
  * Preserved saved view preferences during engine initialization.
* **Tests**
  * Added coverage for delayed engine readiness and blocked training access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->