### PR TITLE
feat(train): remote training with CLI, YAML and desktop parity — plus two fixes that did not fix anything

### DIFF
--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -707,10 +707,18 @@ class KeychainSecretStore:
                                check=True, capture_output=True, timeout=10,
                                **_quiet_subprocess_kwargs())
             else:
-                subprocess.run(["security", "delete-generic-password",
-                                "-s", KEYCHAIN_SERVICE, "-a", name],
-                               capture_output=True, timeout=10,
-                               **_quiet_subprocess_kwargs())
+                # The write path above checks its exit status; this one did
+                # not, and returned True regardless. A locked keychain leaves
+                # the item intact, so "your key was removed" was reported
+                # while the credential stayed live and came back on the next
+                # launch. 44 is "no such item", which is a delete that has
+                # already happened.
+                removed = subprocess.run(
+                    ["security", "delete-generic-password",
+                     "-s", KEYCHAIN_SERVICE, "-a", name],
+                    capture_output=True, timeout=10,
+                    **_quiet_subprocess_kwargs())
+                return removed.returncode in (0, 44)
             return True
         except Exception:  # noqa: BLE001 - a keychain failure must not lose the turn
             return False
@@ -740,9 +748,15 @@ class SecretToolSecretStore:
                                input=value.encode(), check=True,
                                capture_output=True, timeout=10)
             else:
-                subprocess.run(["secret-tool", "clear",
-                                "service", KEYCHAIN_SERVICE, "account", name],
-                               capture_output=True, timeout=10)
+                # As above: unchecked, so an unavailable D-Bus session (a
+                # headless or SSH login) reported a delete that never
+                # happened. `secret-tool clear` exits 0 when it matches
+                # nothing, so a non-zero status here is a real failure.
+                cleared = subprocess.run(
+                    ["secret-tool", "clear",
+                     "service", KEYCHAIN_SERVICE, "account", name],
+                    capture_output=True, timeout=10)
+                return cleared.returncode == 0
             return True
         except Exception:  # noqa: BLE001
             return False
@@ -1887,7 +1901,13 @@ class Handler(BaseHTTPRequestHandler):
 
             for chunk in agent.start(prompt, stream=True,
                                      **_llm_overrides(load_settings())):
-                _drain_tools()
+                # Counted here too. This call drains the queue, so discarding
+                # its result meant the tally further down always read zero
+                # unless the loop body never ran at all -- and the tests only
+                # covered that one case, so the count looked right while every
+                # stream that yielded anything before dying still reported
+                # "the engine produced no output" under its own tool cards.
+                tools_shown += _drain_tools()
                 if run_id and _is_cancelled(run_id):
                     # Verified by side effect: emission stops. The client is told
                     # explicitly rather than inferring it from a stream that ends.

--- a/src/praisonai-desktop/engine/test_chat_stream.py
+++ b/src/praisonai-desktop/engine/test_chat_stream.py
@@ -130,6 +130,34 @@ class ChatStream(unittest.TestCase):
         results = [d for k, d in frames if k == "tool_result"]
         self.assertEqual(results[0]["output"], "2026-08-27 00:13:35")
 
+    def test_a_stream_that_yielded_something_first_still_counts_its_tools(self):
+        # Every tool-then-die test above uses chunks=(), which is the one path
+        # where the loop body never runs -- so the drain inside the loop was
+        # never exercised and its discarded return value went unnoticed. One
+        # frame of anything is enough to take the other path.
+        self._install(chunks=[{"type": "reasoning", "text": "thinking"}], tools=[_tool()])
+        frames = self._chat()
+        errors = [d for k, d in frames if k == "error"]
+        self.assertTrue(errors, "no error was reported")
+        self.assertEqual(
+            errors[0].get("kind"), "no_answer",
+            "a stream that yielded a non-text frame lost its tool count")
+        self.assertIn("1 tool call(s)", errors[0]["message"])
+
+    def test_an_empty_text_chunk_does_not_lose_the_tool_count(self):
+        self._install(chunks=[""], tools=[_tool()])
+        errors = [d for k, d in self._chat() if k == "error"]
+        self.assertTrue(errors, "no error was reported")
+        self.assertEqual(errors[0].get("kind"), "no_answer")
+
+    def test_tools_are_counted_once_not_twice(self):
+        # The queue is drained in two places now. Counting the same event in
+        # both would inflate the number the user is shown.
+        self._install(chunks=[{"type": "reasoning", "text": "x"}],
+                      tools=[_tool("a"), _tool("b")])
+        errors = [d for k, d in self._chat() if k == "error"]
+        self.assertIn("2 tool call(s)", errors[0]["message"])
+
     def test_the_message_says_how_many_tools_ran(self):
         self._install(chunks=(), tools=[_tool("a"), _tool("b")])
         errors = [d for k, d in self._chat() if k == "error"]

--- a/src/praisonai-desktop/engine/test_portability.py
+++ b/src/praisonai-desktop/engine/test_portability.py
@@ -254,6 +254,62 @@ class HealthReportsWhereItLives(unittest.TestCase):
             shutil.rmtree(home, ignore_errors=True)
 
 
+class LeafStoreDeletion(unittest.TestCase):
+    """The real stores, not a stand-in.
+
+    FallbackSecretStore was hardened so a delete must succeed everywhere it
+    could be read from -- but it was only ever tested against a fake, and the
+    real leaves underneath it returned True whatever happened. The write path
+    checked its exit status; the delete path did not. A locked keychain, or a
+    Linux session with no D-Bus, left the credential intact and reported that
+    it had been removed. It then came back on the next launch.
+
+    A fake binary on PATH stands in for `security` / `secret-tool`, so this
+    never touches a real keychain.
+    """
+
+    def setUp(self):
+        self.bin = tempfile.mkdtemp(prefix="praison-fakebin-")
+        self.old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = self.bin + os.pathsep + self.old_path
+
+    def tearDown(self):
+        os.environ["PATH"] = self.old_path
+        shutil.rmtree(self.bin, ignore_errors=True)
+
+    def _fake(self, name, script):
+        path = pathlib.Path(self.bin) / name
+        path.write_text("#!/bin/sh\n" + script, encoding="utf-8")
+        path.chmod(0o755)
+
+    def test_a_locked_keychain_does_not_report_a_successful_delete(self):
+        # 51 is what `security` returns when the keychain will not unlock.
+        self._fake("security", 'if [ "$1" = "delete-generic-password" ]; then exit 51; fi\nexit 0\n')
+        self.assertFalse(server.KeychainSecretStore().set("api_key", ""),
+                         "a delete that could not happen reported success")
+
+    def test_deleting_something_already_absent_is_a_success(self):
+        # 44 is "no such item". The key is gone, which is what was asked for.
+        self._fake("security", 'if [ "$1" = "delete-generic-password" ]; then exit 44; fi\nexit 0\n')
+        self.assertTrue(server.KeychainSecretStore().set("api_key", ""),
+                        "an already-absent key was reported as a failed delete")
+
+    def test_a_keychain_delete_that_works_still_reports_success(self):
+        self._fake("security", "exit 0\n")
+        self.assertTrue(server.KeychainSecretStore().set("api_key", ""))
+
+    def test_secret_tool_failure_is_not_reported_as_a_delete(self):
+        # No D-Bus session: `secret-tool` cannot reach the collection.
+        self._fake("secret-tool", 'if [ "$1" = "clear" ]; then exit 1; fi\nexit 0\n')
+        self.assertFalse(server.SecretToolSecretStore().set("api_key", ""),
+                         "a delete that could not happen reported success")
+
+    def test_secret_tool_success_is_reported(self):
+        # `secret-tool clear` exits 0 whether or not it matched anything.
+        self._fake("secret-tool", "exit 0\n")
+        self.assertTrue(server.SecretToolSecretStore().set("api_key", ""))
+
+
 class SecretDeletion(unittest.TestCase):
     """Clearing a secret must clear it everywhere it could have landed.
 

--- a/src/praisonai-desktop/frontend/tests/training.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/training.test.mjs
@@ -337,6 +337,117 @@ test('the method hint changes with the method', async () => {
   assert.match(after, /chosen/i);
 });
 
+test('a local run posts no remote block', async () => {
+  const { doc, calls } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  doc.getElementById('trainForm').dispatchEvent(
+    new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  const [start] = posted(calls, '/train/start');
+  assert.ok(start, 'submitting posted nothing');
+  assert.equal(start.body.config.remote, undefined,
+               'a local run asked for a remote host');
+});
+
+test('choosing a remote server posts the block the CLI and YAML use', async () => {
+  // The same shape as `remote:` in a config file and --remote-host on the
+  // CLI. The engine passes the config through untouched, so this is what
+  // decides where the run happens.
+  const { doc, calls } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  const runOn = doc.getElementById('tRunOn');
+  runOn.value = 'remote';
+  runOn.dispatchEvent(new doc.defaultView.Event('change', { bubbles: true }));
+  await settle();
+  doc.getElementById('tRemoteHost').value = 'gpubox';
+  doc.getElementById('tRemotePython').value = '/opt/conda/bin/python';
+  doc.getElementById('trainForm').dispatchEvent(
+    new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  const [start] = posted(calls, '/train/start');
+  assert.ok(start, 'submitting posted nothing');
+  assert.deepEqual(start.body.config.remote, {
+    host: 'gpubox',
+    python: '/opt/conda/bin/python',
+    workdir: '~/.praisonai-train',
+  });
+});
+
+test('the remote fields are hidden until they apply', async () => {
+  const { doc } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  const host = doc.getElementById('tRemoteHost');
+  assert.equal(doc.defaultView.getComputedStyle(host.closest('.tf')).display, 'none',
+               'the SSH host field is shown for a local run');
+  const runOn = doc.getElementById('tRunOn');
+  runOn.value = 'remote';
+  runOn.dispatchEvent(new doc.defaultView.Event('change', { bubbles: true }));
+  await settle();
+  assert.notEqual(doc.defaultView.getComputedStyle(host.closest('.tf')).display, 'none',
+                  'choosing a remote server did not reveal the host field');
+});
+
+/** Fill the remote fields, then submit, and return what was posted. */
+async function submitRemote(doc, calls, { host, python, workdir, runOn = 'remote' }) {
+  const select = doc.getElementById('tRunOn');
+  select.value = runOn;
+  select.dispatchEvent(new doc.defaultView.Event('change', { bubbles: true }));
+  await settle();
+  if (host !== undefined) doc.getElementById('tRemoteHost').value = host;
+  if (python !== undefined) doc.getElementById('tRemotePython').value = python;
+  if (workdir !== undefined) doc.getElementById('tRemoteWorkdir').value = workdir;
+  // `required` on the host field blocks a real submit, which silently made an
+  // earlier version of these tests assert nothing at all. Drive the handler.
+  doc.getElementById('tRemoteHost').required = false;
+  doc.getElementById('trainForm').dispatchEvent(
+    new doc.defaultView.Event('submit', { bubbles: true, cancelable: true }));
+  await settle();
+  return posted(calls, '/train/start')[0];
+}
+
+test('a whitespace-only host is not a host', async () => {
+  const { doc, calls } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  const start = await submitRemote(doc, calls, { host: '   ' });
+  assert.ok(start, 'nothing was posted, so this test proved nothing');
+  assert.equal(start.body.config.remote, undefined,
+               'posted a remote block whose host is blank');
+});
+
+test('switching back to this computer drops a host already typed', async () => {
+  // The block is built from the choice, not left behind by it.
+  const { doc, calls } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  const start = await submitRemote(doc, calls, { host: 'gpubox', runOn: 'local' });
+  assert.ok(start, 'nothing was posted');
+  assert.equal(start.body.config.remote, undefined,
+               'a local run carried the remote host that had been typed');
+});
+
+test('an emptied remote directory falls back to the default', async () => {
+  const { doc, calls } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  const start = await submitRemote(doc, calls, { host: 'gpubox', workdir: '' });
+  assert.ok(start, 'nothing was posted');
+  assert.equal(start.body.config.remote.workdir, '~/.praisonai-train',
+               'clearing the field sent an empty working directory');
+});
+
+test('an emptied remote python falls back to the default', async () => {
+  const { doc, calls } = await boot();
+  click(doc.getElementById('viewTrain'));
+  await settle();
+  const start = await submitRemote(doc, calls, { host: 'gpubox', python: '' });
+  assert.ok(start, 'nothing was posted');
+  assert.equal(start.body.config.remote.python, 'python3');
+});
+
 test('every method the engine accepts is offered', async () => {
   const { doc } = await boot();
   const offered = [...doc.getElementById('tMethod').options].map((o) => o.value).sort();

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -484,6 +484,14 @@ body.training #thread,body.training #f{display:none}
               <span class="hint">A Hugging Face id.</span>
             </div>
             <div class="tf">
+              <label for="tRunOn">Run on</label>
+              <select id="tRunOn" name="run_on">
+                <option value="local" selected>This computer</option>
+                <option value="remote">A remote server</option>
+              </select>
+              <span class="hint" id="tRunOnHint">Needs an NVIDIA GPU.</span>
+            </div>
+            <div class="tf">
               <label for="tMethod">Method</label>
               <select id="tMethod" name="method">
                 <option value="sft" selected>SFT — supervised fine-tuning</option>
@@ -496,6 +504,21 @@ body.training #thread,body.training #f{display:none}
                 <option value="cpo">CPO — contrastive preference</option>
               </select>
               <span class="hint" id="tMethodHint">Trains on completions.</span>
+            </div>
+            <div class="tf remote-only is-hidden">
+              <label for="tRemoteHost">SSH host</label>
+              <input id="tRemoteHost" name="remote_host" placeholder="gpubox"/>
+              <span class="hint">An alias from your ~/.ssh/config.</span>
+            </div>
+            <div class="tf remote-only is-hidden">
+              <label for="tRemotePython">Remote python</label>
+              <input id="tRemotePython" name="remote_python" value="python3"/>
+              <span class="hint">Interpreter on that machine.</span>
+            </div>
+            <div class="tf remote-only is-hidden">
+              <label for="tRemoteWorkdir">Remote directory</label>
+              <input id="tRemoteWorkdir" name="remote_workdir" value="~/.praisonai-train"/>
+              <span class="hint">Where the run works. Created if absent.</span>
             </div>
             <div class="tf">
               <label for="tDataset">Dataset</label>
@@ -2218,6 +2241,21 @@ function trainConfig(){
     train:true, ollama_save:false, huggingface_save:false};
   const steps=num('max_steps',0);
   if(steps>0) config.max_steps=steps;   // omitted, not zero: 0 means "no cap"
+
+  // Where it runs, expressed the same way the CLI and a hand-written YAML
+  // express it -- a `remote` block, or its absence. There is no separate mode
+  // flag to fall out of step with the block, and the engine passes the config
+  // through untouched, so `praisonai-train llm --config` does the routing.
+  if(get('run_on')==='remote'){
+    // get() already trims; the extra .trim() calls that were here implied
+    // otherwise.
+    const host=get('remote_host');
+    if(host){
+      config.remote={host,
+        python:get('remote_python')||'python3',
+        workdir:get('remote_workdir')||'~/.praisonai-train'};
+    }
+  }
   return config;
 }
 
@@ -2409,6 +2447,19 @@ async function refreshTraining(){
 
 document.getElementById('tMethod').addEventListener('change',e=>{
   document.getElementById('tMethodHint').textContent=METHOD_HINTS[e.target.value]||'';
+});
+
+document.getElementById('tRunOn').addEventListener('change',e=>{
+  const remote=e.target.value==='remote';
+  document.querySelectorAll('.remote-only').forEach(el=>{
+    el.classList.toggle('is-hidden',!remote); });
+  // Said plainly rather than discovered an hour in: fine-tuning needs CUDA,
+  // and a Mac does not have it, so "this computer" is not an option here on
+  // most of the machines this app runs on.
+  document.getElementById('tRunOnHint').textContent=remote
+    ? 'Runs over SSH. Uses your ssh agent — no password is stored.'
+    : 'Needs an NVIDIA GPU on this machine.';
+  document.getElementById('tRemoteHost').required=remote;
 });
 
 // Always go through showView, including for the default: it is what sets the

--- a/src/praisonai-train/.gitignore
+++ b/src/praisonai-train/.gitignore
@@ -1,0 +1,1 @@
+lora_model/

--- a/src/praisonai-train/praisonai_train/cli/commands/train.py
+++ b/src/praisonai-train/praisonai_train/cli/commands/train.py
@@ -56,6 +56,15 @@ def train_llm(
     config: Optional[Path] = typer.Option(
         None, "--config", "-c", exists=True,
         help="Training config YAML. Flags below override it."),
+    remote_host: Optional[str] = typer.Option(
+        None, "--remote-host",
+        help="SSH alias to train on, as in ~/.ssh/config. Omit to train here."),
+    remote_python: Optional[str] = typer.Option(
+        None, "--remote-python", help="Interpreter on the remote host."),
+    remote_workdir: Optional[str] = typer.Option(
+        None, "--remote-workdir", help="Directory to work in on the remote host."),
+    remote_gpus: Optional[int] = typer.Option(
+        None, "--remote-gpus", help="How many GPUs the run expects to find."),
     model: Optional[str] = typer.Option(None, "--model", "-m", help="Base model to fine-tune"),
     method: Optional[str] = typer.Option(None, "--method", help="sft | cpt | dpo | orpo | kto"),
     max_seq_length: Optional[int] = typer.Option(None, "--max-seq-length"),
@@ -88,9 +97,17 @@ def train_llm(
     # importing it. Unfilled parameters then arrive as OptionInfo objects and
     # Path(config) raises. Unwrap them to their declared defaults first.
     def _v(value):
-        return getattr(value, "default", value) if type(value).__name__ == "OptionInfo" \
-            else value
+        # ArgumentInfo as well as OptionInfo. `dataset` is a typer.Argument,
+        # so it produces the former -- and it was the one parameter neither
+        # named below nor recognised here. Called as a plain function it then
+        # arrived as an ArgumentInfo, which is truthy, so it was written into
+        # the resolved config as `dataset: <ArgumentInfo object>` and the YAML
+        # dump raised RepresenterError.
+        return (getattr(value, "default", value)
+                if type(value).__name__ in ("OptionInfo", "ArgumentInfo")
+                else value)
 
+    dataset = _v(dataset)
     config = _v(config)
     model = _v(model)
     method = _v(method)
@@ -104,6 +121,10 @@ def train_llm(
     lora_alpha = _v(lora_alpha)
     output_dir = _v(output_dir)
     chat_template = _v(chat_template)
+    remote_host = _v(remote_host)
+    remote_python = _v(remote_python)
+    remote_workdir = _v(remote_workdir)
+    remote_gpus = _v(remote_gpus)
     dry_run = _v(dry_run) or False
     verbose = _v(verbose) or False
 
@@ -121,6 +142,11 @@ def train_llm(
         overrides["model_name"] = model
     if dataset:
         overrides["dataset"] = dataset
+
+    # Where the run executes, not what it trains. Kept out of `overrides` so it
+    # never lands in the trainer's own settings.
+    remote_overrides = {"host": remote_host, "python": remote_python,
+                        "workdir": remote_workdir, "gpus": remote_gpus}
 
     if dry_run:
         # Answering "what are you about to do?" before an hour of rented GPU is
@@ -147,6 +173,19 @@ def train_llm(
     # IS the one that trains. Pass a bare `train` so the dispatcher takes its
     # "file exists, no model/dataset override" branch and reads our file as-is.
     resolved = _resolve_config(config, overrides)
+
+    # Where before what. Resolved from the same file-then-flags precedence as
+    # everything else, so `remote: {host: gpubox}` in the YAML and
+    # `--remote-host gpubox` are the same instruction -- and the desktop form,
+    # which writes that YAML, is a third way of saying it rather than a
+    # separate mode.
+    #
+    # Checked before the heavy import below on purpose: the whole point of
+    # training elsewhere is that this machine does not have torch or a GPU, so
+    # requiring them here would make the remote option unreachable from exactly
+    # the machines that need it.
+    if _dispatch_remote(resolved, remote_overrides, config, dataset):
+        return
 
     try:
         PraisonAI = import_code_module("praisonai_code.cli.main").PraisonAI
@@ -202,6 +241,110 @@ def train_llm(
             raise typer.Exit(exc.code if isinstance(exc.code, int) else 1) from exc
     finally:
         sys.argv = original_argv
+
+
+def _dispatch_remote(resolved, remote_overrides, config_path, dataset):
+    """Run this job on another machine, if the config says so. True if it ran.
+
+    The local path is untouched: with no host settled this returns False
+    immediately and the caller carries on exactly as before.
+    """
+    from ..output.console import get_output_controller
+    from praisonai_train.remote import settings as remote_settings
+
+    try:
+        block = remote_settings.resolve(resolved, remote_overrides)
+    except remote_settings.RemoteSettingsError as exc:
+        get_output_controller().print_error("Bad remote settings", remediation=str(exc))
+        raise typer.Exit(1) from exc
+
+    if not block:
+        return False
+
+    from praisonai_train.remote.runner import RemoteError, RemoteRunner
+
+    output = get_output_controller()
+    runner = RemoteRunner(host=block["host"], python=block["python"],
+                          workdir=block["workdir"])
+
+    shipped = _write_shipped_config(resolved)
+    try:
+        run = runner.start(config_path=shipped,
+                           dataset_path=Path(dataset) if dataset else None,
+                           expect_gpus=block["gpus"])
+    except RemoteError as exc:
+        output.print_error(f"Could not start the run on {block['host']}",
+                           remediation=str(exc))
+        raise typer.Exit(1) from exc
+
+    output.print_success(f"started {run.run_id} on {block['host']}")
+    typer.echo(f"  tail:  praisonai-train remote tail {block['host']} {run.run_id}")
+    typer.echo(f"  stop:  praisonai-train remote stop {block['host']} {run.run_id}")
+
+    # A stop from the caller has to reach the other machine. Without this the
+    # signal ends the tail and leaves the run holding a rented GPU, reporting
+    # "cancelled" for a job that is still training -- which is how the desktop
+    # Stop button would lie.
+    _stop_remote_on_signal(runner, run, output)
+
+    runner.tail(run, on_line=typer.echo)
+    state = runner.status(run)
+    typer.echo(f"status: {state}")
+    if state == "failed":
+        raise typer.Exit(1)
+    return True
+
+
+def _write_shipped_config(resolved):
+    """The config to send, in a temp file. Returns its path.
+
+    Not _materialize_config: that writes ./config.yaml into the invocation
+    directory (and backs up whatever was there), which is the local
+    dispatcher's contract. Training elsewhere should not rewrite a file in the
+    directory the user happened to be standing in.
+
+    The remote block is stripped. It says where this job goes, and it has
+    already been obeyed -- leaving it in would have the far side read its own
+    config, find a host, and dispatch again.
+    """
+    import tempfile
+
+    import yaml
+
+    to_send = {k: v for k, v in resolved.items() if k != "remote"}
+    dataset = to_send.get("dataset")
+    if isinstance(dataset, str):
+        to_send["dataset"] = [{"name": dataset}]
+
+    handle = tempfile.NamedTemporaryFile(
+        "w", suffix=".yaml", prefix="praisonai-train-", delete=False, encoding="utf-8")
+    with handle:
+        yaml.safe_dump(to_send, handle, sort_keys=False)
+    return Path(handle.name)
+
+
+def _stop_remote_on_signal(runner, run, output):
+    """Make SIGINT and SIGTERM stop the remote run, not just this process."""
+    import signal
+
+    def _stop(signum, _frame):
+        try:
+            runner.stop(run)
+            output.print_success(f"stopped {run.run_id} on {runner.host}")
+        except Exception as exc:  # noqa: BLE001 - never block the exit
+            output.print_error(
+                f"Could not stop {run.run_id} on {runner.host}",
+                remediation=f"praisonai-train remote stop {runner.host} "
+                            f"{run.run_id}  ({exc})")
+        raise SystemExit(130 if signum == signal.SIGINT else 143)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _stop)
+        except (ValueError, OSError):
+            # Not the main thread, or the platform will not take it. The run
+            # still started; only the courtesy stop is unavailable.
+            pass
 
 
 def _resolve_config(config_path, overrides):

--- a/src/praisonai-train/praisonai_train/remote/settings.py
+++ b/src/praisonai-train/praisonai_train/remote/settings.py
@@ -1,0 +1,127 @@
+"""Where a run executes, declared once.
+
+The same four facts have to be expressible three ways -- a YAML block, CLI
+flags, and the desktop form -- and mean the same thing in each. Declaring them
+in one table is what stops the three drifting: the flags are generated from it,
+the YAML is validated against it, and a parity test asserts that every key has
+a flag and every flag has a key.
+
+Nothing here talks to a remote machine. This module is the vocabulary;
+``praisonai_train.remote.runner`` is the transport.
+"""
+
+from __future__ import annotations
+
+# key, CLI flag, default, help. The default is what the trainer uses when the
+# YAML omits the key and the flag is absent.
+REMOTE_KEYS = (
+    ("host", "--remote-host", None,
+     "SSH alias to train on, as in ~/.ssh/config. Omit to train locally."),
+    ("python", "--remote-python", "python3",
+     "Interpreter on the remote host."),
+    ("workdir", "--remote-workdir", "~/.praisonai-train",
+     "Directory on the remote host to work in."),
+    ("gpus", "--remote-gpus", 1,
+     "How many GPUs the run expects to find."),
+)
+
+# Anything the user must never put in a config file, because the file is
+# written into the run directory, shipped to the remote host, and shown in
+# --dry-run. Credentials belong in the ssh agent and the environment.
+FORBIDDEN_KEYS = ("password", "passphrase", "token", "key", "secret",
+                  "identity_file", "private_key")
+
+
+class RemoteSettingsError(ValueError):
+    """A remote block that cannot be used as written."""
+
+
+def defaults() -> dict:
+    """The remote block as it stands with nothing supplied."""
+    return {key: default for key, _flag, default, _help in REMOTE_KEYS}
+
+
+def flag_for(key: str) -> str:
+    for candidate, flag, _default, _help in REMOTE_KEYS:
+        if candidate == key:
+            return flag
+    raise KeyError(key)
+
+
+def resolve(config: dict, overrides: dict) -> dict:
+    """The remote block from the config, with flags on top.
+
+    Same precedence as every other setting: the file is the baseline and a flag
+    wins. Returns {} when no host is settled, which is how "train locally" is
+    expressed -- there is no separate mode switch to get out of step with it.
+    """
+    block = config.get("remote") or {}
+    if not isinstance(block, dict):
+        raise RemoteSettingsError(
+            "remote: must be a mapping of key: value, not "
+            f"{type(block).__name__}")
+
+    merged = defaults()
+    merged.update({k: v for k, v in block.items() if v is not None})
+    merged.update({k: v for k, v in (overrides or {}).items() if v is not None})
+
+    # Credentials first. They are also unknown keys, so checking that first
+    # told the user they had made a typo -- and the remediation for a typo is
+    # to correct the spelling, which here would mean trying harder to put a
+    # password in a file that gets copied to another machine.
+    leaked = sorted(k for k in block if k.lower() in FORBIDDEN_KEYS)
+    if leaked:
+        raise RemoteSettingsError(
+            f"remote: must not carry {', '.join(leaked)}. This file is copied "
+            "to the remote host and printed by --dry-run. Use an ssh agent or "
+            "an entry in ~/.ssh/config instead.")
+
+    unknown = sorted(set(block) - {k for k, _f, _d, _h in REMOTE_KEYS})
+    if unknown:
+        known = ", ".join(k for k, _f, _d, _h in REMOTE_KEYS)
+        raise RemoteSettingsError(
+            f"remote: does not take {', '.join(unknown)}. Known keys: {known}.")
+
+    if not merged.get("host"):
+        return {}
+
+    validate(merged)
+    return merged
+
+
+def validate(block: dict) -> None:
+    """Reject what would fail far away, or fail dangerously."""
+    host = block.get("host")
+    if not isinstance(host, str) or not host.strip():
+        raise RemoteSettingsError("remote.host must be a non-empty SSH alias.")
+    # An alias goes into an ssh command line. Anything outside this set is
+    # either a typo or an attempt to smuggle in shell.
+    if not all(c.isalnum() or c in "._-@" for c in host):
+        raise RemoteSettingsError(
+            f"remote.host {host!r} is not a plain SSH alias. Put connection "
+            "details in ~/.ssh/config and name the alias here.")
+
+    workdir = block.get("workdir") or ""
+    if not isinstance(workdir, str) or not workdir.strip():
+        raise RemoteSettingsError("remote.workdir must be a path.")
+    # Expanded by the remote shell, so it must survive being passed unquoted.
+    if not all(c.isalnum() or c in "._-/~" for c in workdir):
+        raise RemoteSettingsError(
+            f"remote.workdir {workdir!r} may only contain letters, digits and "
+            "._-/~ -- it is expanded by the remote shell.")
+
+    python = block.get("python") or ""
+    if not isinstance(python, str) or not python.strip():
+        raise RemoteSettingsError("remote.python must be an interpreter name or path.")
+    if not all(c.isalnum() or c in "._-/~" for c in python):
+        raise RemoteSettingsError(
+            f"remote.python {python!r} may only contain letters, digits and ._-/~")
+
+    gpus = block.get("gpus", 1)
+    if isinstance(gpus, bool) or not isinstance(gpus, int) or gpus < 1:
+        raise RemoteSettingsError(f"remote.gpus must be a positive integer, got {gpus!r}")
+
+
+def redact(block: dict) -> dict:
+    """The block as it is safe to print."""
+    return {k: v for k, v in (block or {}).items() if k.lower() not in FORBIDDEN_KEYS}

--- a/src/praisonai-train/tests/unit/test_remote_dispatch.py
+++ b/src/praisonai-train/tests/unit/test_remote_dispatch.py
@@ -1,0 +1,191 @@
+"""`praisonai-train llm` sends the job elsewhere when the config says so.
+
+The RemoteRunner is replaced, so nothing here opens an ssh connection. What is
+under test is the decision and what gets handed over -- not the transport.
+"""
+
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from praisonai_train.cli.commands import train as train_cmd  # noqa: E402
+
+
+class FakeRun:
+    run_id = "run-fake"
+
+
+class FakeRunner:
+    """Records what it was asked to do."""
+
+    instances = []
+
+    def __init__(self, host, python, workdir):
+        self.host, self.python, self.workdir = host, python, workdir
+        self.started_with = None
+        self.tailed = False
+        self.state = "done"
+        FakeRunner.instances.append(self)
+
+    def start(self, config_path=None, dataset_path=None, expect_gpus=1, **_):
+        self.started_with = {"config": pathlib.Path(config_path),
+                             "dataset": dataset_path, "gpus": expect_gpus}
+        return FakeRun()
+
+    def tail(self, run, on_line=None):
+        self.tailed = True
+
+    def status(self, run):
+        return self.state
+
+
+@pytest.fixture(autouse=True)
+def _fake_runner(monkeypatch):
+    FakeRunner.instances = []
+    import praisonai_train.remote.runner as runner_mod
+    monkeypatch.setattr(runner_mod, "RemoteRunner", FakeRunner)
+    yield
+
+
+def _config(tmp_path, body):
+    path = tmp_path / "c.yaml"
+    path.write_text(yaml.safe_dump(body), encoding="utf-8")
+    return path
+
+
+def _dispatch(resolved, overrides=None, dataset=None):
+    return train_cmd._dispatch_remote(resolved, overrides or {}, None, dataset)
+
+
+class TestTheDecision:
+    def test_a_local_config_does_not_dispatch(self):
+        assert _dispatch({"model_name": "m"}) is False
+        assert FakeRunner.instances == []
+
+    def test_a_remote_block_dispatches(self):
+        assert _dispatch({"model_name": "m", "remote": {"host": "gpubox"}}) is True
+        assert len(FakeRunner.instances) == 1
+        assert FakeRunner.instances[0].host == "gpubox"
+
+    def test_a_flag_dispatches_without_any_yaml(self):
+        assert _dispatch({"model_name": "m"}, {"host": "gpubox"}) is True
+        assert FakeRunner.instances[0].host == "gpubox"
+
+    def test_the_run_is_followed_and_its_status_reported(self):
+        _dispatch({"remote": {"host": "gpubox"}})
+        assert FakeRunner.instances[0].tailed, "the log was never streamed"
+
+
+class TestWhatIsHandedOver:
+    def test_the_shipped_config_carries_the_resolved_settings(self, tmp_path):
+        _dispatch({"model_name": "unsloth/tiny", "lora_r": 32,
+                   "remote": {"host": "gpubox"}})
+        shipped = FakeRunner.instances[0].started_with["config"]
+        sent = yaml.safe_load(shipped.read_text())
+        assert sent["model_name"] == "unsloth/tiny"
+        assert sent["lora_r"] == 32
+
+    def test_the_remote_block_is_not_shipped(self):
+        # Otherwise the far side reads its own config, finds a host, and
+        # dispatches again.
+        _dispatch({"model_name": "m", "remote": {"host": "gpubox"}})
+        shipped = FakeRunner.instances[0].started_with["config"]
+        sent = yaml.safe_load(shipped.read_text())
+        assert "remote" not in sent, f"the remote block was shipped: {sent}"
+
+    def test_it_does_not_write_config_yaml_into_the_working_directory(
+            self, tmp_path, monkeypatch):
+        # Training elsewhere must not rewrite a file where the user is standing.
+        monkeypatch.chdir(tmp_path)
+        _dispatch({"model_name": "m", "remote": {"host": "gpubox"}})
+        assert not (tmp_path / "config.yaml").exists(), (
+            "a remote run clobbered ./config.yaml")
+
+    def test_the_gpu_expectation_is_passed_through(self):
+        _dispatch({"remote": {"host": "gpubox", "gpus": 4}})
+        assert FakeRunner.instances[0].started_with["gpus"] == 4
+
+    def test_the_interpreter_and_workdir_are_passed_through(self):
+        _dispatch({"remote": {"host": "h", "python": "/opt/py",
+                              "workdir": "~/runs"}})
+        made = FakeRunner.instances[0]
+        assert made.python == "/opt/py"
+        assert made.workdir == "~/runs"
+
+
+class TestFailure:
+    def test_a_run_that_ends_failed_is_reported_as_failure(self, monkeypatch):
+        import typer
+
+        class Failing(FakeRunner):
+            def status(self, run):
+                return "failed"
+
+        import praisonai_train.remote.runner as runner_mod
+        monkeypatch.setattr(runner_mod, "RemoteRunner", Failing)
+        with pytest.raises(typer.Exit):
+            _dispatch({"remote": {"host": "gpubox"}})
+
+    def test_bad_remote_settings_exit_rather_than_training_locally(self):
+        import typer
+        with pytest.raises(typer.Exit):
+            _dispatch({"remote": {"host": "gpu; rm -rf /"}})
+        assert FakeRunner.instances == [], "it tried to connect anyway"
+
+
+class TestTheCommandActuallyDispatches:
+    """Driving `train_llm` itself, not the helper underneath it.
+
+    The tests above call _dispatch_remote directly, so deleting the call site
+    in train_llm left every one of them passing while the remote option did
+    nothing at all. These go through the command.
+    """
+
+    def test_llm_with_a_remote_config_never_reaches_the_local_trainer(
+            self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        config = _config(tmp_path, {"model_name": "unsloth/tiny",
+                                    "dataset": "d.json",
+                                    "remote": {"host": "gpubox"}})
+
+        # If the local path were taken it would import the heavy runner. Make
+        # that unmistakable rather than merely slow.
+        def _boom(*_a, **_k):
+            raise AssertionError("the local trainer was reached for a remote run")
+
+        monkeypatch.setattr(train_cmd, "import_code_module", _boom, raising=False)
+        train_cmd.train_llm(config=config)
+
+        assert len(FakeRunner.instances) == 1, "the run was not sent anywhere"
+        assert FakeRunner.instances[0].host == "gpubox"
+
+    def test_llm_with_the_flag_and_no_yaml_dispatches(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        config = _config(tmp_path, {"model_name": "unsloth/tiny", "dataset": "d.json"})
+        train_cmd.train_llm(config=config, remote_host="gpubox")
+        assert len(FakeRunner.instances) == 1
+        assert FakeRunner.instances[0].host == "gpubox"
+
+    def test_llm_without_remote_settings_does_not_dispatch(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        config = _config(tmp_path, {"model_name": "unsloth/tiny", "dataset": "d.json"})
+        # Stop before the heavy import; the point is only that nothing was sent.
+        monkeypatch.setattr(train_cmd, "import_code_module",
+                            lambda *_a, **_k: (_ for _ in ()).throw(ImportError("no")),
+                            raising=False)
+        try:
+            train_cmd.train_llm(config=config)
+        except Exception:
+            pass
+        assert FakeRunner.instances == [], "a local run was sent to a remote host"
+
+    def test_dry_run_shows_the_remote_block_and_sends_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        config = _config(tmp_path, {"model_name": "unsloth/tiny",
+                                    "remote": {"host": "gpubox"}})
+        train_cmd.train_llm(config=config, dry_run=True)
+        assert FakeRunner.instances == [], "--dry-run started a real run"

--- a/src/praisonai-train/tests/unit/test_remote_parity.py
+++ b/src/praisonai-train/tests/unit/test_remote_parity.py
@@ -1,0 +1,118 @@
+"""The same instruction, three ways.
+
+Where a run executes has to be expressible as a YAML block, as CLI flags, and
+by the desktop form -- and mean the same thing in each. Three surfaces over one
+set of facts is exactly the arrangement that drifts, so the parity is asserted
+rather than described.
+
+Nothing here contacts a remote machine.
+"""
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from praisonai_train.remote import settings  # noqa: E402
+
+
+class TestParity:
+    def test_every_key_has_a_flag_and_every_flag_is_distinct(self):
+        keys = [k for k, _f, _d, _h in settings.REMOTE_KEYS]
+        flags = [f for _k, f, _d, _h in settings.REMOTE_KEYS]
+        assert len(set(keys)) == len(keys), f"duplicate keys: {keys}"
+        assert len(set(flags)) == len(flags), f"duplicate flags: {flags}"
+        for key, flag, _d, _h in settings.REMOTE_KEYS:
+            assert flag == "--remote-" + key.replace("_", "-"), (
+                f"{key} and {flag} do not name the same thing")
+
+    def test_the_cli_declares_exactly_those_flags(self):
+        """The llm command must accept every key, and invent none."""
+        from praisonai_train.cli.commands import train as train_cmd
+
+        import inspect
+        params = inspect.signature(train_cmd.train_llm).parameters
+        for key, flag, _d, _h in settings.REMOTE_KEYS:
+            name = f"remote_{key}"
+            assert name in params, f"{flag} is declared in the table but not on the CLI"
+        declared = {p for p in params if p.startswith("remote_")}
+        expected = {f"remote_{k}" for k, _f, _d, _h in settings.REMOTE_KEYS}
+        assert declared == expected, (
+            f"the CLI and the table disagree: {declared ^ expected}")
+
+    def test_every_key_is_documented(self):
+        for key, _flag, _default, help_text in settings.REMOTE_KEYS:
+            assert help_text and help_text.strip(), f"{key} has no help"
+
+
+class TestResolution:
+    def test_no_remote_block_means_train_here(self):
+        assert settings.resolve({}, {}) == {}
+        assert settings.resolve({"model_name": "x"}, {}) == {}
+
+    def test_a_host_in_yaml_is_enough(self):
+        got = settings.resolve({"remote": {"host": "gpubox"}}, {})
+        assert got["host"] == "gpubox"
+        assert got["python"] == "python3"
+        assert got["workdir"] == "~/.praisonai-train"
+
+    def test_a_flag_beats_the_file(self):
+        got = settings.resolve({"remote": {"host": "from-yaml", "gpus": 1}},
+                               {"host": "from-flag", "gpus": 4})
+        assert got["host"] == "from-flag"
+        assert got["gpus"] == 4
+
+    def test_a_flag_alone_is_enough(self):
+        got = settings.resolve({}, {"host": "gpubox"})
+        assert got["host"] == "gpubox"
+
+    def test_an_absent_flag_does_not_erase_the_file(self):
+        got = settings.resolve({"remote": {"host": "gpubox", "python": "/opt/py"}},
+                               {"host": None, "python": None})
+        assert got["python"] == "/opt/py"
+
+
+class TestRefusals:
+    def test_an_unknown_key_is_named(self):
+        with pytest.raises(settings.RemoteSettingsError) as caught:
+            settings.resolve({"remote": {"host": "h", "hostname": "typo"}}, {})
+        assert "hostname" in str(caught.value)
+
+    def test_a_credential_in_the_config_is_refused(self):
+        # The file is shipped to the remote host and printed by --dry-run.
+        for bad in ("password", "token", "private_key"):
+            with pytest.raises(settings.RemoteSettingsError) as caught:
+                settings.resolve({"remote": {"host": "h", bad: "hunter2"}}, {})
+            message = str(caught.value)
+            assert bad in message
+            # Refused *as a credential*, not as a typo -- these are also
+            # unknown keys, and "you misspelled it" is the wrong advice.
+            assert "must not carry" in message, message
+            assert "ssh agent" in message, message
+            assert "hunter2" not in message, "the value was echoed back"
+
+    def test_shell_metacharacters_in_a_host_are_refused(self):
+        for bad in ("gpu; rm -rf /", "gpu$(whoami)", "gpu`id`", "gpu box", "gpu&x"):
+            with pytest.raises(settings.RemoteSettingsError):
+                settings.resolve({"remote": {"host": bad}}, {})
+
+    def test_shell_metacharacters_in_a_workdir_are_refused(self):
+        for bad in ("~/dir; rm -rf /", "$(pwd)", "a b"):
+            with pytest.raises(settings.RemoteSettingsError):
+                settings.resolve({"remote": {"host": "h", "workdir": bad}}, {})
+
+    def test_a_tilde_workdir_is_allowed(self):
+        # It has to survive being passed unquoted so the remote shell expands it.
+        got = settings.resolve({"remote": {"host": "h", "workdir": "~/runs"}}, {})
+        assert got["workdir"] == "~/runs"
+
+    def test_gpus_must_be_a_positive_integer(self):
+        for bad in (0, -1, "two", 1.5, True):
+            with pytest.raises(settings.RemoteSettingsError):
+                settings.resolve({"remote": {"host": "h", "gpus": bad}}, {})
+
+    def test_a_non_mapping_remote_block_is_refused(self):
+        with pytest.raises(settings.RemoteSettingsError):
+            settings.resolve({"remote": "gpubox"}, {})


### PR DESCRIPTION
…ything

An audit went looking for the pattern this codebase keeps producing -- a check that something was attempted rather than that it worked -- and found two of my own recent fixes were exactly that.

## The "no output" fix only worked when the stream was completely empty

_drain_tools() empties the queue and returns how many events it emitted. It is called in two places: inside the streaming loop, and again on the failure path. The in-loop call discarded its return value, so by the time the tally ran the queue was already empty and tools_shown was zero. The no_answer branch never fired, and the user got "the engine produced no output" printed directly beneath the tool cards it had just been shown.

One frame of anything is enough to take that path -- a reasoning frame, an empty text chunk. The only case that worked was a generator that yielded literally nothing, and that is the only case the tests covered:

    chunks=()                          -> no_answer   (tested)
    chunks=[reasoning frame]           -> empty       (not tested)
    chunks=[""]                        -> empty       (not tested)

The fix is one `tools_shown +=`. The tests now drive the loop body.

## Deleting a key still reported success

FallbackSecretStore was hardened so a delete has to succeed in every store the secret could be read from. That layer is right, and it was only ever tested against a fake -- so nobody looked underneath, where both real stores returned True whatever happened.

Both had the same shape: the write path passes check=True, the delete path did not. A locked keychain leaves the item intact and `security` exits 51; a Linux session with no D-Bus cannot reach the collection at all. In both cases the app said the key was removed, unset it for the running process so it looked gone, and read it back on the next launch.

Exit 44 from `security` means "no such item", which is a delete that has already happened, so it stays a success. `secret-tool clear` exits 0 whether or not it matched, so any non-zero status is a real failure.

The tests put a fake `security` / `secret-tool` on PATH and exercise the real KeychainSecretStore and SecretToolSecretStore. No keychain is touched.

Six mutations, six caught. Both of these fixes were mutation-tested when I first wrote them -- against mutations of the layer I had just edited, which is how a fix passes its own tests while the thing underneath it stays broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote training support via SSH, with options for host, Python interpreter, working directory, and GPU count.
  * Training settings now support local or remote execution with validation and safe configuration handling.

* **Bug Fixes**
  * Secret removal now accurately reports failures.
  * Chat streams correctly count queued tools, including empty or non-text responses, without double-counting.

* **Tests**
  * Added coverage for remote training configuration, dispatch, validation, secure-storage deletion, and tool-count reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->