### PR TITLE
feat(ts): one uuid util, a praisonai/mobile entry, and tool events (tasks 1, 5, 7)

### DIFF
--- a/src/praisonai-ts/package.json
+++ b/src/praisonai-ts/package.json
@@ -12,6 +12,12 @@
       "require": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./mobile": {
+      "types": "./dist/mobile.d.ts",
+      "import": "./dist/esm/mobile.js",
+      "require": "./dist/mobile.js",
+      "default": "./dist/mobile.js"
+    },
     "./*": {
       "types": "./dist/*.d.ts",
       "import": "./dist/esm/*.js",

--- a/src/praisonai-ts/scripts/webview-gate.mjs
+++ b/src/praisonai-ts/scripts/webview-gate.mjs
@@ -39,7 +39,7 @@ const FORBIDDEN = new Set([
  * server and the tool registry, none of which a phone loads, and gating on it
  * would report failures nobody can act on.
  */
-export const WEBVIEW_ENTRIES = ["src/agent/simple.ts"];
+export const WEBVIEW_ENTRIES = ["src/mobile.ts", "src/agent/simple.ts"];
 
 /** The webview baseline. iOS ships WKWebView with the OS, so the floor is the
  *  oldest iOS worth supporting rather than the newest Safari. */

--- a/src/praisonai-ts/src/agent/audio.ts
+++ b/src/praisonai-ts/src/agent/audio.ts
@@ -28,7 +28,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Supported audio providers

--- a/src/praisonai-ts/src/agent/simple.ts
+++ b/src/praisonai-ts/src/agent/simple.ts
@@ -6,6 +6,7 @@ import type { LLMProvider } from '../llm/providers/types';
 import type { BackendResolutionResult } from '../llm/backend-resolver';
 import { ApprovalManager, createCLIApprovalPrompt } from '../ai/tool-approval';
 import { getEnv } from '../llm/openaiClientOptions';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * The default token sink for `start()` when no `onToken` is supplied.
@@ -20,36 +21,6 @@ export function writeTokenToStdout(token: string): void {
   }
 }
 
-/**
- * Generate a RFC-4122 v4 UUID using WebCrypto.
- *
- * Uses `globalThis.crypto.randomUUID` (available in all supported webviews and
- * Node >= 19), falling back to a `getRandomValues`-based implementation so the
- * Agent import graph never pulls in the Node `crypto` builtin. This keeps the
- * module bundleable for browser/webview targets.
- */
-function randomUUID(): string {
-  const c = globalThis.crypto;
-  if (c?.randomUUID) {
-    return c.randomUUID();
-  }
-  const bytes = new Uint8Array(16);
-  if (c?.getRandomValues) {
-    c.getRandomValues(bytes);
-  } else {
-    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
-  }
-  bytes[6] = (bytes[6] & 0x0f) | 0x40;
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
-  return (
-    hex[0] + hex[1] + hex[2] + hex[3] + '-' +
-    hex[4] + hex[5] + '-' +
-    hex[6] + hex[7] + '-' +
-    hex[8] + hex[9] + '-' +
-    hex[10] + hex[11] + hex[12] + hex[13] + hex[14] + hex[15]
-  );
-}
 
 /**
  * Agent Configuration

--- a/src/praisonai-ts/src/agent/simple.ts
+++ b/src/praisonai-ts/src/agent/simple.ts
@@ -182,6 +182,19 @@ export interface SimpleAgentConfig {
  */
 export type AgentEvent =
   | { type: 'text'; delta: string }
+  /**
+   * A tool is about to run. `callId` is the provider's id for this invocation
+   * and is the ONLY key that may pair a result to its call -- matching by
+   * position holds only while exactly one call is ever in flight, and silently
+   * attributes the wrong output the moment that stops being true.
+   */
+  | { type: 'tool_call'; callId: string; name: string; args: Record<string, unknown> }
+  /**
+   * A tool finished. `ok` is the only signal of success: never infer it from a
+   * non-empty `output`, because a tool that failed with a message looks
+   * identical to one that succeeded with one.
+   */
+  | { type: 'tool_result'; callId: string; name: string; ok: boolean; output: string }
   | { type: 'finish'; text: string }
   | { type: 'error'; error: Error };
 
@@ -622,7 +635,7 @@ export class Agent {
    * @param signal Optional AbortSignal; if already aborted, no tool is invoked
    * @returns Array of tool results
    */
-  private async processToolCalls(toolCalls: Array<any>, signal?: AbortSignal): Promise<Array<{role: string, tool_call_id: string, name: string, content: string}>> {
+  private async processToolCalls(toolCalls: Array<any>, signal?: AbortSignal, onEvent?: (event: AgentEvent) => void): Promise<Array<{role: string, tool_call_id: string, name: string, content: string}>> {
     const results = [];
     
     for (const toolCall of toolCalls) {
@@ -658,15 +671,18 @@ export class Agent {
           });
           if (!approved) {
             await Logger.debug(`Tool call denied by approval gate: ${name}`);
-            results.push({
-              role: 'tool',
-              tool_call_id: id,
-              name,
-              content: `Error: Tool call "${name}" was denied by the approval gate.`
-            });
+            const denial = `Error: Tool call "${name}" was denied by the approval gate.`;
+            results.push({ role: 'tool', tool_call_id: id, name, content: denial });
+            // ok:false -- a denied tool did not run, and rendering it as a
+            // success tells the user something happened that did not.
+            onEvent?.({ type: 'tool_result', callId: id, name, ok: false, output: denial });
             continue;
           }
         }
+
+        // Announced BEFORE it runs, so a view can show a call in progress
+        // rather than materialising a finished row out of nowhere.
+        onEvent?.({ type: 'tool_call', callId: id, name, args });
 
         // Call the function - registered wrappers handle positional mapping
         const result = await this.toolFunctions[name](args);
@@ -690,7 +706,8 @@ export class Agent {
           name,
           content
         });
-        
+        onEvent?.({ type: 'tool_result', callId: id, name, ok: true, output: content });
+
         await Logger.debug(`Tool call result for ${name}:`, { result });
       } catch (error: any) {
         // Cancellation is terminal: surface it to the caller instead of
@@ -699,19 +716,30 @@ export class Agent {
           throw (signal as any).reason ?? error;
         }
         await Logger.error(`Error executing tool ${name}:`, error);
-        results.push({
-          role: 'tool',
-          tool_call_id: id,
-          name,
-          content: `Error: ${error.message || 'Unknown error'}`
-        });
+        const failure = `Error: ${error.message || 'Unknown error'}`;
+        results.push({ role: 'tool', tool_call_id: id, name, content: failure });
+        // The case the whole `ok` field exists for: a tool that failed WITH a
+        // message is byte-identical to one that succeeded with a message, so
+        // success can never be inferred from a non-empty output.
+        onEvent?.({ type: 'tool_result', callId: id, name, ok: false, output: failure });
       }
     }
     
     return results;
   }
 
-  async start(prompt: string, previousResult?: string, onToken?: (token: string) => void, signal?: AbortSignal): Promise<string> {
+  async start(
+    prompt: string,
+    previousResult?: string,
+    onToken?: (token: string) => void,
+    signal?: AbortSignal,
+    /**
+     * Structured events, for callers that need to SEE tool activity rather
+     * than infer it from prose. Optional and additive: every existing caller
+     * passes four arguments and gets exactly the behaviour it had before.
+     */
+    onEvent?: (event: AgentEvent) => void,
+  ): Promise<string> {
     await Logger.debug(`Agent ${this.name} starting with prompt: ${prompt}`);
 
     // Token sink: when a caller (e.g. stream()) supplies onToken, tokens go
@@ -786,7 +814,7 @@ export class Agent {
             });
 
             if (result.toolCalls && result.toolCalls.length > 0) {
-              const toolResults = await this.processToolCalls(result.toolCalls, abortSignal);
+              const toolResults = await this.processToolCalls(result.toolCalls, abortSignal, onEvent);
               messages.push(...toolResults);
               continueConversation = true;
             } else {
@@ -919,7 +947,7 @@ export class Agent {
             }
 
             // Process tool calls and add results to messages
-            const toolResults = await this.processToolCalls(perTurn, abortSignal);
+            const toolResults = await this.processToolCalls(perTurn, abortSignal, onEvent);
             messages.push(...toolResults);
 
             // Continue conversation to get final response
@@ -1069,7 +1097,7 @@ export class Agent {
    * ```
    */
   async *streamEvents(prompt: string, opts?: AgentStreamOptions): AsyncIterable<AgentEvent> {
-    const queue: string[] = [];
+    const queue: AgentEvent[] = [];
     let notify: (() => void) | null = null;
     let done = false;
     let cancelled = false;
@@ -1096,11 +1124,21 @@ export class Agent {
     const wake = () => { const n = notify; notify = null; n?.(); };
     const onToken = (token: string) => {
       if (cancelled) return;
-      queue.push(token);
+      queue.push({ type: 'text', delta: token });
+      wake();
+    };
+    // Structured events share the SAME queue as the text, which is what keeps
+    // a tool call in its true position. A separate channel would let it arrive
+    // before the sentence that introduced it, or after the one reporting its
+    // result -- and a reader cannot tell a reordered transcript from a model
+    // that genuinely said things in that order.
+    const onEvent = (event: AgentEvent) => {
+      if (cancelled) return;
+      queue.push(event);
       wake();
     };
 
-    const run = this.start(prompt, opts?.previousResult, onToken, controller.signal)
+    const run = this.start(prompt, opts?.previousResult, onToken, controller.signal, onEvent)
       .then((text) => ({ text } as { text: string }))
       .catch((error) => ({
         error: error instanceof Error ? error : new Error(String(error)),
@@ -1113,7 +1151,7 @@ export class Agent {
           await new Promise<void>((resolve) => { notify = resolve; });
           continue;
         }
-        yield { type: 'text', delta: queue.shift()! };
+        yield queue.shift()!;
       }
 
       const result = await run;

--- a/src/praisonai-ts/src/ai/tool-approval.ts
+++ b/src/praisonai-ts/src/ai/tool-approval.ts
@@ -5,6 +5,8 @@
  * Compatible with AI SDK v6's needsApproval pattern.
  */
 
+import { randomUUID } from '../utils/uuid';
+
 // ============================================================================
 // Internal Event Emitter
 // ============================================================================
@@ -75,36 +77,6 @@ class SimpleEventEmitter {
   }
 }
 
-/**
- * Generate a RFC-4122 v4 UUID using WebCrypto.
- *
- * Uses `globalThis.crypto.randomUUID` (available in all supported webviews and
- * Node >= 19), falling back to a `getRandomValues`-based implementation so this
- * module never depends on the Node `crypto` builtin and stays bundleable for
- * browser/webview targets.
- */
-function randomUUID(): string {
-  const c = globalThis.crypto;
-  if (c?.randomUUID) {
-    return c.randomUUID();
-  }
-  const bytes = new Uint8Array(16);
-  if (c?.getRandomValues) {
-    c.getRandomValues(bytes);
-  } else {
-    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
-  }
-  bytes[6] = (bytes[6] & 0x0f) | 0x40;
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
-  return (
-    hex[0] + hex[1] + hex[2] + hex[3] + '-' +
-    hex[4] + hex[5] + '-' +
-    hex[6] + hex[7] + '-' +
-    hex[8] + hex[9] + '-' +
-    hex[10] + hex[11] + hex[12] + hex[13] + hex[14] + hex[15]
-  );
-}
 
 // ============================================================================
 // Types

--- a/src/praisonai-ts/src/cli/commands/knowledge.ts
+++ b/src/praisonai-ts/src/cli/commands/knowledge.ts
@@ -11,7 +11,7 @@ import { EXIT_CODES } from '../spec/cli-spec';
 import { ERROR_CODES } from '../output/errors';
 import * as fs from 'fs';
 import * as path from 'path';
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../../utils/uuid';
 
 export interface KnowledgeOptions {
   verbose?: boolean;

--- a/src/praisonai-ts/src/context/budgeter.ts
+++ b/src/praisonai-ts/src/context/budgeter.ts
@@ -4,7 +4,7 @@
  * Manages token allocation across context components.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Budget allocation

--- a/src/praisonai-ts/src/context/manager.ts
+++ b/src/praisonai-ts/src/context/manager.ts
@@ -4,7 +4,7 @@
  * Handles context budgeting, windowing, and optimization.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Context item

--- a/src/praisonai-ts/src/context/optimizer.ts
+++ b/src/praisonai-ts/src/context/optimizer.ts
@@ -4,7 +4,7 @@
  * Reduces context size while preserving important information.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Optimization strategy

--- a/src/praisonai-ts/src/eval/base.ts
+++ b/src/praisonai-ts/src/eval/base.ts
@@ -4,7 +4,7 @@
  * Provides base evaluator classes and result types.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Evaluation criteria

--- a/src/praisonai-ts/src/eval/judge.ts
+++ b/src/praisonai-ts/src/eval/judge.ts
@@ -16,7 +16,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 // ============================================================================
 // Types and Interfaces

--- a/src/praisonai-ts/src/eval/results.ts
+++ b/src/praisonai-ts/src/eval/results.ts
@@ -4,7 +4,7 @@
  * Provides structured result types and visualization helpers.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Individual test result

--- a/src/praisonai-ts/src/hooks/manager.ts
+++ b/src/praisonai-ts/src/hooks/manager.ts
@@ -27,7 +27,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Hook event types - matching Python HooksManager + industry standard additions

--- a/src/praisonai-ts/src/knowledge/query-engine.ts
+++ b/src/praisonai-ts/src/knowledge/query-engine.ts
@@ -16,7 +16,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Query result item

--- a/src/praisonai-ts/src/knowledge/rag-pipeline.ts
+++ b/src/praisonai-ts/src/knowledge/rag-pipeline.ts
@@ -20,7 +20,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * RAG Document

--- a/src/praisonai-ts/src/knowledge/readers.ts
+++ b/src/praisonai-ts/src/knowledge/readers.ts
@@ -13,7 +13,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Parsed document result

--- a/src/praisonai-ts/src/mcp/index.ts
+++ b/src/praisonai-ts/src/mcp/index.ts
@@ -29,7 +29,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * MCP Transport types

--- a/src/praisonai-ts/src/mcp/security.ts
+++ b/src/praisonai-ts/src/mcp/security.ts
@@ -4,7 +4,7 @@
  * Provides security policies for MCP servers.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Security policy type

--- a/src/praisonai-ts/src/mcp/server.ts
+++ b/src/praisonai-ts/src/mcp/server.ts
@@ -14,7 +14,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * MCP Tool definition

--- a/src/praisonai-ts/src/mcp/session.ts
+++ b/src/praisonai-ts/src/mcp/session.ts
@@ -12,7 +12,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Session state

--- a/src/praisonai-ts/src/mcp/transports.ts
+++ b/src/praisonai-ts/src/mcp/transports.ts
@@ -4,7 +4,7 @@
  * Provides WebSocket, SSE, and HTTP streaming transports.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Transport message

--- a/src/praisonai-ts/src/memory/docs-manager.ts
+++ b/src/praisonai-ts/src/memory/docs-manager.ts
@@ -14,7 +14,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Document entry

--- a/src/praisonai-ts/src/memory/hooks.ts
+++ b/src/praisonai-ts/src/memory/hooks.ts
@@ -22,7 +22,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Hook function types

--- a/src/praisonai-ts/src/memory/rules-manager.ts
+++ b/src/praisonai-ts/src/memory/rules-manager.ts
@@ -18,7 +18,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Rule action types

--- a/src/praisonai-ts/src/mobile.ts
+++ b/src/praisonai-ts/src/mobile.ts
@@ -1,0 +1,33 @@
+/**
+ * The webview-safe entry point.
+ *
+ * `praisonai` resolves to `src/index.ts`, which re-exports the CLI, the MCP
+ * server, the tool registry and the knowledge store -- modules that read the
+ * filesystem, spawn processes and open sockets. A phone loads none of them,
+ * and a bundler cannot tell that: it follows every re-export, pulls the whole
+ * graph in, and the build dies on a Node builtin that nothing was ever going
+ * to call.
+ *
+ * So this is an allowlist, not a convenience. Everything named here is
+ * verified loadable in a webview by `scripts/webview-gate.mjs`, which fails
+ * the build if any of it gains an import-time Node dependency.
+ *
+ * The rule for adding to this file: if it cannot run in a browser, it does not
+ * belong here -- even if it would be useful. A consumer reaching for something
+ * absent gets a clear resolution error at build time, which is a far better
+ * outcome than a blank screen on a device at import time.
+ */
+
+// The agent loop itself.
+export { Agent } from './agent/simple';
+export type {
+  AgentEvent,
+  AgentStreamOptions,
+  SimpleAgentConfig,
+  StopReason,
+} from './agent/simple';
+
+// Ids, and the env accessor. Both are safe by construction and both are what a
+// caller needs in order to avoid reaching for the Node originals.
+export { randomUUID } from './utils/uuid';
+export { getEnv } from './llm/openaiClientOptions';

--- a/src/praisonai-ts/src/session/hierarchy.ts
+++ b/src/praisonai-ts/src/session/hierarchy.ts
@@ -4,7 +4,7 @@
  * Enables session inheritance and scoping for multi-agent workflows.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Hierarchical session configuration

--- a/src/praisonai-ts/src/session/index.ts
+++ b/src/praisonai-ts/src/session/index.ts
@@ -2,7 +2,7 @@
  * Session Management - Session, Run, and Trace tracking
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 export interface SessionConfig {
   id?: string;

--- a/src/praisonai-ts/src/session/parts.ts
+++ b/src/praisonai-ts/src/session/parts.ts
@@ -4,7 +4,7 @@
  * Manages context, memory, and tools within sessions.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Part type

--- a/src/praisonai-ts/src/session/session.ts
+++ b/src/praisonai-ts/src/session/session.ts
@@ -5,7 +5,7 @@
  * Provides session management with persistent state, memory, and knowledge.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 import type { DbAdapter } from '../db/types';
 
 // ============================================================================

--- a/src/praisonai-ts/src/session/store.ts
+++ b/src/praisonai-ts/src/session/store.ts
@@ -4,7 +4,7 @@
  * Provides in-memory and file-based session storage.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Session data for storage

--- a/src/praisonai-ts/src/telemetry/integration.ts
+++ b/src/praisonai-ts/src/telemetry/integration.ts
@@ -4,7 +4,7 @@
  * Provides hooks for connecting to external observability systems.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Telemetry sink types

--- a/src/praisonai-ts/src/telemetry/performance.ts
+++ b/src/praisonai-ts/src/telemetry/performance.ts
@@ -4,7 +4,7 @@
  * Provides latency, throughput, and error tracking for agents.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Metric types

--- a/src/praisonai-ts/src/tools/subagent.ts
+++ b/src/praisonai-ts/src/tools/subagent.ts
@@ -24,7 +24,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Configuration for subagent tool

--- a/src/praisonai-ts/src/tools/utility-tools.ts
+++ b/src/praisonai-ts/src/tools/utility-tools.ts
@@ -4,7 +4,7 @@
  * Provides file, search, and web scraping tools.
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 /**
  * Tool result

--- a/src/praisonai-ts/src/utils/uuid.ts
+++ b/src/praisonai-ts/src/utils/uuid.ts
@@ -1,0 +1,56 @@
+/**
+ * A UUID that works everywhere praisonai-ts runs.
+ *
+ * `import { randomUUID } from 'crypto'` is a STATIC Node builtin import: in a
+ * browser or webview the bundle dies at module load, before any code runs,
+ * with no error boundary and a blank screen. That was issue #4437, and PR
+ * #4438 fixed it for the two files on the Agent import graph -- leaving the
+ * same import in 32 others, each of which re-breaks the moment anything
+ * reachable from a webview touches it.
+ *
+ * `globalThis.crypto.randomUUID` is a straight substitution rather than a
+ * polyfill: it exists in every supported webview and in Node >= 19. The
+ * fallbacks below exist for older runtimes and are ordered by how much
+ * entropy they can offer.
+ *
+ * The version and variant nibbles are set BY HAND in the fallback, which is
+ * the part worth reading twice: getting the masks wrong yields a string that
+ * looks like a UUID and is not one, and anything validating it rejects the id
+ * far away from here.
+ */
+
+/** RFC 4122 version 4. */
+export function randomUUID(): string {
+  const c = globalThis.crypto;
+  if (c?.randomUUID) {
+    return c.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (c?.getRandomValues) {
+    c.getRandomValues(bytes);
+  } else {
+    // The last resort, for a runtime with no WebCrypto at all. Math.random is
+    // not a CSPRNG and these ids must not be used as secrets -- they are run
+    // and message identifiers, where collision resistance is what matters.
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+
+  // Version 4: clear the high nibble THEN set it. `| 0x40` alone leaves an
+  // all-ones byte reading as version f.
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  // Variant 10xx: same reasoning on the two high bits.
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+
+  // padStart is load-bearing: toString(16) on a byte below 0x10 yields one
+  // character, and the whole string then comes out short with the dashes in
+  // the wrong places.
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+  return (
+    hex[0]! + hex[1]! + hex[2]! + hex[3]! + '-' +
+    hex[4]! + hex[5]! + '-' +
+    hex[6]! + hex[7]! + '-' +
+    hex[8]! + hex[9]! + '-' +
+    hex[10]! + hex[11]! + hex[12]! + hex[13]! + hex[14]! + hex[15]!
+  );
+}

--- a/src/praisonai-ts/src/workflows/index.ts
+++ b/src/praisonai-ts/src/workflows/index.ts
@@ -2,7 +2,7 @@
  * Workflows - Pipeline and orchestration patterns
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 
 // Re-export Loop and Repeat classes (Python-parity workflow patterns)
 export { Loop, loop as loopPattern, type LoopConfig, type LoopResult } from './loop';

--- a/src/praisonai-ts/src/workflows/loop.ts
+++ b/src/praisonai-ts/src/workflows/loop.ts
@@ -25,7 +25,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 import type { WorkflowContext } from './index';
 
 /**

--- a/src/praisonai-ts/src/workflows/repeat.ts
+++ b/src/praisonai-ts/src/workflows/repeat.ts
@@ -30,7 +30,7 @@
  * ```
  */
 
-import { randomUUID } from 'crypto';
+import { randomUUID } from '../utils/uuid';
 import type { WorkflowContext } from './index';
 
 /**

--- a/src/praisonai-ts/tests/unit/agent/tool-events.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/tool-events.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tool activity on the event channel.
+ *
+ * `AgentEvent` carried three variants -- text, finish, error -- so a consumer
+ * could see prose and nothing else. praisonai-ts EXECUTED tools perfectly well
+ * and never announced them, which meant any UI built on `streamEvents` had to
+ * infer tool activity from the model's own description of it. Inference is how
+ * a tool call that silently failed still looks like a normal answer.
+ *
+ * The cases below are mostly about `ok`, because that is the field the whole
+ * widening exists for.
+ */
+import { Agent, type AgentEvent } from '../../../src/agent/simple';
+import { OpenAIService } from '../../../src/llm/openai';
+
+jest.mock('openai');
+
+function streamOf(deltas: any[]): any {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const delta of deltas) yield { choices: [{ delta }] };
+    },
+  };
+}
+
+/** Round 1 calls `probe`; round 2 answers. */
+function twoRounds(args = '{"q":"x"}') {
+  return jest.fn()
+    .mockResolvedValueOnce(streamOf([
+      { content: 'Checking. ' },
+      { tool_calls: [{ index: 0, id: 'call_1', type: 'function', function: { name: 'probe', arguments: '' } }] },
+      { tool_calls: [{ index: 0, function: { arguments: args } }] },
+    ]))
+    .mockResolvedValueOnce(streamOf([{ content: 'Done.' }]));
+}
+
+async function collect(agent: Agent, prompt = 'go'): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of agent.streamEvents(prompt)) events.push(event);
+  return events;
+}
+
+describe('tool activity is announced, not inferred', () => {
+  const origWrite = process.stdout.write;
+  afterEach(() => {
+    process.stdout.write = origWrite;
+    jest.restoreAllMocks();
+  });
+
+  const install = (create: jest.Mock) => {
+    jest.spyOn(OpenAIService.prototype as any, 'getClient').mockResolvedValue({
+      chat: { completions: { create } },
+    });
+    (process.stdout.write as any) = () => true;
+  };
+
+  it('a successful tool produces tool_call then tool_result with ok true', async () => {
+    install(twoRounds());
+    const probe = (q: string) => `found ${q}`;
+    const agent = new Agent({ instructions: 'x', llm: 'gpt-4o-mini', stream: true, verbose: false, tools: [probe] });
+
+    const events = await collect(agent);
+    const call = events.find((e) => e.type === 'tool_call');
+    const result = events.find((e) => e.type === 'tool_result');
+
+    expect(call).toBeDefined();
+    expect(call!.type === 'tool_call' && call!.name).toBe('probe');
+    expect(result).toBeDefined();
+    expect(result!.type === 'tool_result' && result!.ok).toBe(true);
+  });
+
+  it('a THROWING tool reports ok false rather than a plausible-looking result', async () => {
+    // The case the `ok` field exists for. The output is a non-empty string
+    // either way, so a consumer inferring success from content cannot tell a
+    // failure from an answer.
+    install(twoRounds());
+    const probe = (_q: string) => { throw new Error('upstream is down'); };
+    const agent = new Agent({ instructions: 'x', llm: 'gpt-4o-mini', stream: true, verbose: false, tools: [probe] });
+
+    const result = (await collect(agent)).find((e) => e.type === 'tool_result');
+    expect(result!.type === 'tool_result' && result!.ok).toBe(false);
+    expect(result!.type === 'tool_result' && result!.output).toContain('upstream is down');
+    expect(result!.type === 'tool_result' && result!.output.length).toBeGreaterThan(0);
+  });
+
+  it('the call is announced BEFORE the result', async () => {
+    // So a view can show a call in progress rather than materialising a
+    // finished row out of nowhere.
+    install(twoRounds());
+    const probe = (q: string) => `ok ${q}`;
+    const agent = new Agent({
+      instructions: 'x', llm: 'gpt-4o-mini', stream: true, verbose: false,
+      tools: [probe],
+    });
+    const kinds = (await collect(agent)).map((e) => e.type);
+    expect(kinds.indexOf('tool_call')).toBeLessThan(kinds.indexOf('tool_result'));
+  });
+
+  it('a call and its result share a callId', async () => {
+    // The only key that may pair them. Matching by position holds while
+    // exactly one call is in flight and silently mis-attributes after that.
+    install(twoRounds());
+    const probe = (q: string) => `ok ${q}`;
+    const agent = new Agent({
+      instructions: 'x', llm: 'gpt-4o-mini', stream: true, verbose: false,
+      tools: [probe],
+    });
+    const events = await collect(agent);
+    const call = events.find((e) => e.type === 'tool_call')!;
+    const result = events.find((e) => e.type === 'tool_result')!;
+    expect(call.type === 'tool_call' && call.callId).toBe(result.type === 'tool_result' && result.callId);
+    expect(call.type === 'tool_call' && call.callId).toBeTruthy();
+  });
+
+  it('tool events sit in their true position relative to the text', async () => {
+    // They share the text queue precisely so this holds. On a separate channel
+    // a call could arrive before the sentence introducing it, and a reader
+    // cannot tell a reordered transcript from a model that said things in that
+    // order.
+    install(twoRounds());
+    const probe = (q: string) => `ok ${q}`;
+    const agent = new Agent({
+      instructions: 'x', llm: 'gpt-4o-mini', stream: true, verbose: false,
+      tools: [probe],
+    });
+    const kinds = (await collect(agent)).map((e) => e.type);
+    expect(kinds.indexOf('text')).toBeLessThan(kinds.indexOf('tool_call'));
+  });
+
+  it('a run with NO tools emits no tool events at all', async () => {
+    // The pair: an implementation emitting a spurious tool_call would satisfy
+    // every case above and put a phantom row in every plain answer.
+    const create = jest.fn().mockResolvedValueOnce(streamOf([{ content: 'Just an answer.' }]));
+    install(create);
+    const agent = new Agent({ instructions: 'x', llm: 'gpt-4o-mini', stream: true, verbose: false });
+
+    const kinds = (await collect(agent)).map((e) => e.type);
+    expect(kinds).not.toContain('tool_call');
+    expect(kinds).not.toContain('tool_result');
+    expect(kinds).toContain('finish');
+  });
+
+  it('stream() still yields only text, unaffected by the wider union', async () => {
+    // Backward compatibility, asserted rather than assumed: stream() filters on
+    // type === "text", so a new variant must not leak into it as a stray chunk.
+    install(twoRounds());
+    const probe = (q: string) => `ok ${q}`;
+    const agent = new Agent({
+      instructions: 'x', llm: 'gpt-4o-mini', stream: true, verbose: false,
+      tools: [probe],
+    });
+    const chunks: string[] = [];
+    for await (const chunk of agent.stream('go')) chunks.push(chunk);
+    for (const chunk of chunks) expect(typeof chunk).toBe('string');
+    expect(chunks.join('')).toContain('Done.');
+  });
+});

--- a/src/praisonai-ts/tests/unit/utils/uuid.test.ts
+++ b/src/praisonai-ts/tests/unit/utils/uuid.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The shared UUID util.
+ *
+ * `Agent`'s own tests cover the fallback through `getRunId()`, which is the
+ * important end-to-end path. This covers the util directly, because 32 other
+ * modules now depend on it and none of them go through an Agent -- so a break
+ * here would surface as a failure somewhere with no obvious connection to ids.
+ *
+ * The fallback is unreachable in a normal run: `globalThis.crypto.randomUUID`
+ * exists in every environment these tests execute in, so it would stay green
+ * however broken it was. Each case forces it.
+ */
+import { randomUUID } from '../../../src/utils/uuid';
+
+/** RFC 4122: 8-4-4-4-12 hex, version nibble 4, variant nibble 8|9|a|b. */
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('randomUUID', () => {
+  const real = globalThis.crypto;
+  const withCrypto = (value: unknown) => {
+    Object.defineProperty(globalThis, 'crypto', { value, configurable: true, writable: true });
+  };
+  afterEach(() => withCrypto(real));
+
+  it('uses the platform generator when there is one', () => {
+    // The pair for every fallback case below: a util that always fell back
+    // would pass them all while discarding the platform's CSPRNG.
+    let used = false;
+    withCrypto({ randomUUID: () => { used = true; return '11111111-2222-4333-8444-555555555555'; } });
+    expect(randomUUID()).toBe('11111111-2222-4333-8444-555555555555');
+    expect(used).toBe(true);
+  });
+
+  it('falls back to getRandomValues and still produces a valid v4', () => {
+    withCrypto({ getRandomValues: real.getRandomValues.bind(real) });
+    expect(randomUUID()).toMatch(UUID_V4);
+  });
+
+  it('works with no crypto global at all', () => {
+    // The oldest webviews. A weak id beats a ReferenceError at module load.
+    withCrypto(undefined);
+    expect(randomUUID()).toMatch(UUID_V4);
+  });
+
+  it('sets the version nibble when every random byte is 0xff', () => {
+    // Masking, not assignment: `| 0x40` without clearing the high nibble first
+    // leaves an all-ones byte reading as version f. This input exposes it.
+    withCrypto({ getRandomValues: (a: Uint8Array) => a.fill(0xff) });
+    const id = randomUUID();
+    expect(id[14]).toBe('4');
+    expect(['8', '9', 'a', 'b']).toContain(id[19]);
+    expect(id).toMatch(UUID_V4);
+  });
+
+  it('sets the variant nibble when every random byte is 0x00', () => {
+    // The other extreme, which catches a mask that clears too much.
+    withCrypto({ getRandomValues: (a: Uint8Array) => a.fill(0x00) });
+    const id = randomUUID();
+    expect(id[14]).toBe('4');
+    expect(id[19]).toBe('8');
+    expect(id).toMatch(UUID_V4);
+  });
+
+  it('pads a byte below 0x10 to two hex digits', () => {
+    // toString(16) on 0x05 gives "5"; without padStart the string comes out
+    // short and every dash lands in the wrong place.
+    withCrypto({ getRandomValues: (a: Uint8Array) => a.fill(0x05) });
+    expect(randomUUID()).toMatch(UUID_V4);
+  });
+
+  it('does not repeat', () => {
+    withCrypto({ getRandomValues: real.getRandomValues.bind(real) });
+    const ids = new Set(Array.from({ length: 200 }, () => randomUUID()));
+    expect(ids.size).toBe(200);
+  });
+});


### PR DESCRIPTION
## What

The rest of the "cleanly mobile-consumable" list. #4445 landed the CI gate; this is tasks **1, 5 and 7**, which were pushed after that PR was merged.

**Existing behaviour is unchanged** — verified after every commit and again after rebasing onto current `main`:

| | before | after |
|---|---|---|
| `npx jest` | 1096 pass | **1110 pass**, 0 fail |
| `tsc --noEmit` | clean | clean |
| `npm run build` | 288 files | 290 files |

## Task 1 — one uuid util

#4438 replaced the Node `crypto` import in the two files on the `Agent` graph and left the identical import in **32 others**, each of which re-breaks a webview bundle the moment anything reachable touches it. All 32 were byte-identical.

They now import `src/utils/uuid`, and the two local copies #4438 left behind are gone with them — one implementation instead of three drifting ones.

The tests force the fallback, which is otherwise unreachable: `globalThis.crypto.randomUUID` exists in every environment the suite runs in, so that path would stay green however broken it was — and it exists for older webviews, where nobody is watching a console.

## Task 5 — a `praisonai/mobile` entry

`praisonai` resolves to `src/index.ts`, which re-exports the CLI, the MCP server, the tool registry and the knowledge store. A phone loads none of them and a bundler cannot tell: it follows every re-export and dies on a builtin nothing was going to call.

`src/mobile.ts` is an **allowlist**, gated by the check from #4445 (which now covers both entries):

```
praisonai/mobile, minified:  77.8kB   (target was <400kB)
praisonai, root entry:        2.97MB
```

The export is placed before `./*` so it wins the match.

## Task 7 — tool activity on the event channel

`AgentEvent` had three variants — text, finish, error — so a consumer saw prose and nothing else. praisonai-ts executed tools perfectly well and never announced them, which meant any UI built on `streamEvents` had to infer tool activity from the model's own description of it. **Inference is how a tool call that silently failed still looks like a normal answer.**

Two new variants, and `ok` is the point of both: a tool that failed *with a message* is byte-identical to one that succeeded with a message. Emitted on all three paths — success, throw, and approval-gate denial (a denied tool did not run, and rendering it as a success tells the user something happened that did not).

`callId` pairs a result to its call; matching by position holds only while exactly one call is in flight.

Structured events share the **same queue** as the text, which keeps a tool call in its true position. On a separate channel it could arrive before the sentence that introduced it, and a reader cannot tell a reordered transcript from a model that said things in that order.

**Additive by construction.** `start()` gained a fifth *optional* parameter, so every existing caller passes four and behaves exactly as before. `stream()` filters on `type === 'text'` and is unaffected — asserted, not assumed. A run with no tools emits no tool events, which is the pair that stops a spurious emit satisfying every other case.

## Two corrections to the task list

**Task 2 is a misreading, not a fix.** It called `node-fetch` a phantom dependency to delete. It is not a dependency — it sits in **`overrides`**, pinning a *transitive* dep's version, most likely for a security fix. Removing it would change resolution for whatever pulls it in. Left alone deliberately, and recorded so it isn't "fixed" later by someone reading the same list. (`dotenv` is genuinely gone.)

**Task 4 is obviated by task 5.** All 9 `fs`/`path`/`vm` files are CLI, workflow and skills modules, and **none is reachable from the mobile entry** — only 23 files are. The allowlist achieved what the `src/node/` refactor was for, without touching working CLI code.

## Mutation-verified

| what | mutation | caught |
|---|---|---|
| uuid version nibble | OR without masking first | 3 fail |
| uuid variant nibble | OR without masking first | 1 fail |
| uuid hex padding | drop `padStart` | 4 fail |
| uuid platform path | never use `crypto.randomUUID` | 1 fail |
| tool `ok` | report a failed tool as `ok: true` | 1 fail |
| tool announce | never emit `tool_call` | 3 fail |

Worth recording: the first uuid mutation run reported the two mask mutations as **surviving**. They had not — jest was serving a cached transform. With `--no-cache` both fail. A mutation run against a cached transform proves nothing, and it reports the reassuring answer.

## Consumer note

Widening a union is source-breaking for an exhaustive `switch`. A consumer handling `text`/`finish`/`error` and treating everything else as an error will now see `tool_call`/`tool_result` on that branch. `stream()` is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a mobile/browser-compatible entry point for core agent functionality.
  - Added cross-platform UUID generation for broader runtime compatibility.
  - Agent tool activity now emits structured events, including call status, results, errors, and ordering information.
  - Added mobile package exports for ESM, CommonJS, and type definitions.

- **Tests**
  - Added coverage for tool event streaming and cross-platform UUID generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->