### PR TITLE
fix(ci): stop Claude workflow failing on review-chain kick

### DIFF
--- a/.github/scripts/bot-pr-review-chain.js
+++ b/.github/scripts/bot-pr-review-chain.js
@@ -3,7 +3,7 @@
  * @see .github/workflows/auto-pr-comment.yml, claude.yml, bot-pr-recovery.yml
  */
 
-const KICK_AUTHORS = new Set(['MervinPraison', 'github-actions[bot]']);
+const KICK_AUTHORS = new Set(['MervinPraison', 'github-actions[bot]', 'praisonai-triage-agent[bot]']);
 const BOT_PR_AUTHORS = new Set(['praisonai-triage-agent[bot]', 'github-actions[bot]']);
 
 async function listAllComments(github, owner, repo, issueNumber) {

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -376,9 +376,10 @@ jobs:
           steps.check_fork.outputs.is_pr != 'true' &&
           (github.event_name == 'issues' || github.event_name == 'issue_comment') &&
           github.event.issue != null
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const path = require('path');
             const chain = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/bot-pr-review-chain.js'));


### PR DESCRIPTION
## Summary

- Switch the post-issue **Kick review chain** step to the GitHub App token already minted in the job (instead of `GH_TOKEN`).
- Add `continue-on-error: true` so a CodeRabbit/Qodo kick failure does not mark an otherwise successful Claude run as failed.
- Recognise `praisonai-triage-agent[bot]` kick comments in `bot-pr-review-chain.js` for idempotency.

## Root cause

Claude completed and opened PRs, but the workflow failed on the review-chain kick step (often under GitHub API pressure during mass issue re-triggers).

## Test plan

- [x] `node .github/scripts/bot-pr-review-chain-selftest.js`
- [ ] Merge and re-trigger one stuck issue; confirm workflow succeeds even if kick is rate-limited

Made with [Cursor](https://cursor.com)