### PR TITLE
fix(ts): a bare claude- or gemini- model no longer routes to OpenAI

### DIFF
--- a/src/praisonai-ts/src/agent/simple.ts
+++ b/src/praisonai-ts/src/agent/simple.ts
@@ -253,6 +253,12 @@ export class Agent {
   private _backendPromise: Promise<BackendResolutionResult> | null = null;
   private _backendSource: 'ai-sdk' | 'native' | 'custom' | 'legacy' = 'legacy';
   private _useAISDKBackend: boolean = false;
+  // Per-agent credentials. When a bare claude-*/gemini-* name routes to the
+  // AI-SDK backend, this key must reach resolveBackend() too -- otherwise the
+  // caller who passed apiKey (and no provider env var) authenticates on the
+  // OpenAI path but not on the one their model actually takes.
+  private _apiKey?: string;
+  private _baseURL?: string;
 
   constructor(config: SimpleAgentConfig) {
     // Build instructions from either simple or advanced mode
@@ -332,6 +338,8 @@ export class Agent {
     // For OpenAI, use OpenAIService directly for backward compatibility
     // For other providers, we'll use the AI SDK backend via getBackend()
     this._useAISDKBackend = providerId !== 'openai';
+    this._apiKey = config.apiKey;
+    this._baseURL = config.baseURL;
     this.llmService = new OpenAIService(modelId, {
       apiKey: config.apiKey,
       baseURL: config.baseURL,
@@ -1334,7 +1342,17 @@ export class Agent {
     if (!this._backendPromise) {
       this._backendPromise = (async () => {
         const { resolveBackend } = await import('../llm/backend-resolver');
+        // Forward the per-agent apiKey/baseURL so a bare claude-*/gemini-*
+        // that now routes here can authenticate on the same key the caller
+        // gave the constructor -- not only via a provider env var.
+        const config = (this._apiKey || this._baseURL)
+          ? {
+              ...(this._apiKey ? { apiKey: this._apiKey } : {}),
+              ...(this._baseURL ? { baseUrl: this._baseURL } : {}),
+            }
+          : undefined;
         const result = await resolveBackend(this.llm, {
+          config,
           attribution: {
             agentId: this.name,
             runId: this.runId,

--- a/src/praisonai-ts/src/agent/simple.ts
+++ b/src/praisonai-ts/src/agent/simple.ts
@@ -7,6 +7,7 @@ import type { BackendResolutionResult } from '../llm/backend-resolver';
 import { ApprovalManager, createCLIApprovalPrompt } from '../ai/tool-approval';
 import { getEnv } from '../llm/openaiClientOptions';
 import { randomUUID } from '../utils/uuid';
+import { parseModelString } from '../llm/backend-resolver';
 
 /**
  * The default token sink for `start()` when no `onToken` is supplied.
@@ -306,10 +307,27 @@ export class Agent {
     this.telemetryEnabled = config.telemetry ?? false;
     this.signal = config.signal;
     
-    // Parse model string to extract provider and model ID
-    // Format: "provider/model" or just "model"
-    const providerId = this.llm.includes('/') ? this.llm.split('/')[0] : 'openai';
-    const modelId = this.llm.includes('/') ? this.llm.split('/').slice(1).join('/') : this.llm;
+    // Parse model string to extract provider and model ID.
+    //
+    // This was a private copy of the parsing rule that defaulted EVERY
+    // slash-less name to OpenAI -- so `new Agent({ llm:
+    // 'claude-3-5-sonnet-latest' })` sent an OpenAI-format request, with
+    // OpenAI-format tools, to the OpenAI endpoint. Not a dropped tool: the
+    // whole call went to the wrong vendor, surfacing as model-not-found or
+    // as a confusing bill. parseModelString already infers anthropic from a
+    // `claude-` prefix and google from `gemini-`, so there is one rule now
+    // rather than two that disagree.
+    //
+    // A custom baseURL is the exception, deliberately: pointing at an
+    // OpenAI-compatible proxy that serves `claude-*` is a real deployment,
+    // and prefix inference would route it away from the endpoint the caller
+    // explicitly asked for.
+    const hasCustomEndpoint = config.baseURL !== undefined && config.baseURL !== '';
+    const parsed = hasCustomEndpoint && !this.llm.includes('/')
+      ? { providerId: 'openai', modelId: this.llm }
+      : parseModelString(this.llm);
+    const providerId = parsed.providerId;
+    const modelId = parsed.modelId;
     
     // For OpenAI, use OpenAIService directly for backward compatibility
     // For other providers, we'll use the AI SDK backend via getBackend()

--- a/src/praisonai-ts/src/llm/backend-resolver.ts
+++ b/src/praisonai-ts/src/llm/backend-resolver.ts
@@ -140,9 +140,25 @@ export async function resolveBackend(
       try {
         // Lazy import AI SDK backend
         const { createAISDKBackend } = await import('./providers/ai-sdk');
-        
+
+        // The AI-SDK backend keys credentials by provider id
+        // (config.providers[providerId]), while ProviderConfig is flat
+        // (apiKey/baseUrl). Map the flat per-agent key onto the resolved
+        // provider so a programmatic apiKey authenticates here too -- not
+        // only via a provider env var.
+        const providers =
+          options.config?.apiKey || options.config?.baseUrl
+            ? {
+                [providerId]: {
+                  ...(options.config.apiKey ? { apiKey: options.config.apiKey } : {}),
+                  ...(options.config.baseUrl ? { baseURL: options.config.baseUrl } : {}),
+                },
+              }
+            : undefined;
+
         const backend = createAISDKBackend(modelString, {
           ...options.config,
+          providers,
           attribution: options.attribution ? {
             agentId: options.attribution.agentId,
             runId: options.attribution.runId,

--- a/src/praisonai-ts/src/llm/providers/ai-sdk/backend.ts
+++ b/src/praisonai-ts/src/llm/providers/ai-sdk/backend.ts
@@ -96,18 +96,20 @@ export class AISDKBackend implements LLMProvider {
       return;
     }
     
-    // Validate API key
-    if (!validateProviderApiKey(this.providerId)) {
+    // Get provider options from config
+    const providerOptions: AISDKProviderOptions = 
+      this.config.providers?.[this.providerId] || {};
+
+    // Validate API key. A key passed via provider options counts: it is handed
+    // straight to the AI SDK provider below, so requiring the env var too would
+    // reject a perfectly authenticated request.
+    if (!validateProviderApiKey(this.providerId, providerOptions.apiKey)) {
       throw new AISDKError(
         getMissingApiKeyMessage(this.providerId),
         'AUTHENTICATION',
         false
       );
     }
-    
-    // Get provider options from config
-    const providerOptions: AISDKProviderOptions = 
-      this.config.providers?.[this.providerId] || {};
     
     // Create the AI SDK provider
     this.provider = await createAISDKProvider(this.providerId, providerOptions);

--- a/src/praisonai-ts/src/llm/providers/ai-sdk/provider-map.ts
+++ b/src/praisonai-ts/src/llm/providers/ai-sdk/provider-map.ts
@@ -261,7 +261,12 @@ export async function createAISDKProvider(
 /**
  * Validate that a provider has the required API key
  */
-export function validateProviderApiKey(providerId: string): boolean {
+export function validateProviderApiKey(providerId: string, explicitApiKey?: string): boolean {
+  // A key passed programmatically (e.g. new Agent({ apiKey })) is as valid as
+  // one in the environment; the AI SDK provider receives it directly.
+  if (explicitApiKey) {
+    return true;
+  }
   const envKey = getProviderEnvKey(providerId);
   if (!envKey) {
     return true; // Custom providers may not need env keys

--- a/src/praisonai-ts/tests/unit/agent/model-routing.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/model-routing.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Which vendor a model name actually reaches.
+ *
+ * The Agent constructor carried its own copy of the model-parsing rule, and it
+ * defaulted every slash-less name to OpenAI. So `new Agent({ llm:
+ * "claude-3-5-sonnet-latest" })` sent an OpenAI-format request, with
+ * OpenAI-format tools, to the OpenAI endpoint -- a wrong-vendor call that
+ * surfaces as model-not-found, or as a bill nobody can explain.
+ *
+ * `backend-resolver.parseModelString` had always inferred these correctly.
+ * There were simply two rules that disagreed, and the constructor used the
+ * wrong one.
+ */
+import { Agent } from '../../../src/agent/simple';
+
+/** The Agent exposes no getter for this, and it decides the whole request
+ *  shape, so the test reads it directly rather than asserting on a side
+ *  effect two layers away. */
+const usesAISdk = (agent: Agent): boolean => (agent as any)._useAISDKBackend === true;
+const modelOf = (agent: Agent): string => (agent as any).llmService?.model ?? '';
+
+describe('model routing', () => {
+  it('a bare claude- name routes to Anthropic, not OpenAI', () => {
+    expect(usesAISdk(new Agent({ instructions: 'x', llm: 'claude-3-5-sonnet-latest' }))).toBe(true);
+  });
+
+  it('a bare gemini- name routes to Google, not OpenAI', () => {
+    expect(usesAISdk(new Agent({ instructions: 'x', llm: 'gemini-2.0-flash' }))).toBe(true);
+  });
+
+  it('a bare gpt- name still routes to OpenAI', () => {
+    // The pair. Without it, "always use the AI SDK" would satisfy both cases
+    // above and send every OpenAI request down the wrong path instead.
+    expect(usesAISdk(new Agent({ instructions: 'x', llm: 'gpt-4o-mini' }))).toBe(false);
+  });
+
+  it('an explicit provider/model prefix is honoured', () => {
+    expect(usesAISdk(new Agent({ instructions: 'x', llm: 'anthropic/claude-3-5-sonnet-latest' }))).toBe(true);
+    expect(usesAISdk(new Agent({ instructions: 'x', llm: 'openai/gpt-4o' }))).toBe(false);
+  });
+
+  it('the provider prefix is stripped from the model id', () => {
+    // Sending "anthropic/claude-..." as the model NAME is a 404 at whichever
+    // endpoint receives it.
+    expect(modelOf(new Agent({ instructions: 'x', llm: 'openai/gpt-4o' }))).toBe('gpt-4o');
+  });
+
+  it('a custom baseURL keeps a bare name on the OpenAI-compatible path', () => {
+    // The deliberate exception. Pointing at a proxy that serves claude-* over
+    // an OpenAI-shaped API is a real deployment, and prefix inference would
+    // route it away from the endpoint the caller explicitly asked for.
+    const agent = new Agent({
+      instructions: 'x',
+      llm: 'claude-3-5-sonnet-latest',
+      baseURL: 'https://my-gateway.example/v1',
+    });
+    expect(usesAISdk(agent)).toBe(false);
+  });
+
+  it('an EXPLICIT prefix still wins over a custom baseURL', () => {
+    // The pair for the exception: asking for anthropic/... by name is
+    // unambiguous, and a baseURL must not silently override it.
+    const agent = new Agent({
+      instructions: 'x',
+      llm: 'anthropic/claude-3-5-sonnet-latest',
+      baseURL: 'https://my-gateway.example/v1',
+    });
+    expect(usesAISdk(agent)).toBe(true);
+  });
+
+  it('an unknown bare name still defaults to OpenAI', () => {
+    // Unchanged behaviour for anything the prefixes do not recognise.
+    expect(usesAISdk(new Agent({ instructions: 'x', llm: 'some-local-model' }))).toBe(false);
+  });
+});

--- a/src/praisonai-ts/tests/unit/agent/model-routing.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/model-routing.test.ts
@@ -73,3 +73,39 @@ describe('model routing', () => {
     expect(usesAISdk(new Agent({ instructions: 'x', llm: 'some-local-model' }))).toBe(false);
   });
 });
+
+/**
+ * The routing fix exposes a bare claude-/gemini- name to the AI-SDK backend,
+ * whose key gate previously read only the provider env var. A caller who passed
+ * apiKey to the constructor -- and set no env var -- would authenticate on the
+ * OpenAI path but be rejected on the one their model actually takes. These
+ * tests pin the forwarding so that regression cannot return silently.
+ */
+describe('per-agent credential forwarding to the AI-SDK backend', () => {
+  const savedAnthropic = process.env.ANTHROPIC_API_KEY;
+
+  afterEach(() => {
+    if (savedAnthropic === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = savedAnthropic;
+  });
+
+  it('resolveBackend maps a flat apiKey onto the resolved provider', async () => {
+    // With no env var, only a forwarded key can satisfy the backend's gate.
+    delete process.env.ANTHROPIC_API_KEY;
+    const { resolveBackend } = require('../../../src/llm/backend-resolver');
+    const result = await resolveBackend('claude-3-5-sonnet-latest', {
+      config: { apiKey: 'sk-ant-test' },
+    });
+    // The provider constructs at all (ensureInitialized's key gate is lazy, but
+    // the mapping itself must succeed and select the anthropic provider).
+    expect(result.providerId).toBe('anthropic');
+    expect(result.source === 'ai-sdk' || result.source === 'native').toBe(true);
+  });
+
+  it('validateProviderApiKey accepts an explicit key with no env var', () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const { validateProviderApiKey } = require('../../../src/llm/providers/ai-sdk/provider-map');
+    expect(validateProviderApiKey('anthropic')).toBe(false);
+    expect(validateProviderApiKey('anthropic', 'sk-ant-test')).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug

The `Agent` constructor carried its own copy of the model-parsing rule, and it defaulted **every** slash-less name to OpenAI:

```ts
const providerId = this.llm.includes('/') ? this.llm.split('/')[0] : 'openai';
```

So this:

```ts
new Agent({ llm: 'claude-3-5-sonnet-latest', tools: [getWeather] })
```

made **one `OpenAIService.generateChat` call and zero AI-SDK calls**, sending OpenAI-format tools to the OpenAI endpoint with `model = 'claude-3-5-sonnet-latest'`.

The tools were not dropped. **The entire request went to the wrong vendor** — which surfaces as a model-not-found error, or as a bill nobody can explain. Same for `gemini-2.0-flash`.

## Why it existed

`backend-resolver.parseModelString` has always inferred this correctly — `claude-` → anthropic, `gemini-` → google. `provider-map.ts` does too. There were simply **two parsing rules that disagreed**, and the constructor used its own.

Now there is one.

## The deliberate exception

A custom `baseURL` keeps a bare name on the OpenAI-compatible path. Pointing at a proxy that serves `claude-*` over an OpenAI-shaped API is a real deployment, and prefix inference would route it away from the endpoint the caller explicitly asked for.

An **explicit** `anthropic/...` prefix still wins over a `baseURL`, because that is unambiguous.

## Verification

8 new tests, and each "must route away from OpenAI" case is paired with one that keeps OpenAI on the OpenAI path — so "always use the AI SDK" cannot pass.

Positive control — restoring the old parser:

```
✕ a bare claude- name routes to Anthropic, not OpenAI
✕ a bare gemini- name routes to Google, not OpenAI
Tests: 2 failed, 6 passed
```

Exactly the two cases, and nothing else.

Full suite: **1144 passed**, `tsc --noEmit` clean.

## How this was found

Auditing a stale P0 list against `main`. All nine listed gaps turned out to be already fixed — verified by execution rather than grep, with 22 tests written to prove it. This was found on the way, and it is more severe than anything that was on the list.

A second finding from the same audit is **not** in this PR and will follow separately: on non-OpenAI providers, `stream: true` combined with tools silently falls back to `generateText`, so there are no token deltas **and the round-1 assistant text is dropped** — the model says "Let me check." before calling a tool and the consumer never receives it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic routing for Claude and Gemini models.
  * Preserved support for custom endpoints and explicit provider/model prefixes.
  * Ensured GPT and unrecognized models continue using the compatible OpenAI backend.
  * Per-agent API keys and custom endpoints are now honored for supported providers without requiring environment variables.

* **Tests**
  * Added coverage for provider detection, credential handling, explicit prefixes, custom endpoints, and model routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->