### PR TITLE
fix(ts): the shipped praisonai/mobile entry was not browser-loadable

### DIFF
--- a/.github/workflows/praisonai-ts-webview.yml
+++ b/.github/workflows/praisonai-ts-webview.yml
@@ -53,5 +53,10 @@ jobs:
       # the flag this job fails on something unrelated to what it checks.
       - name: Install
         run: npm install --no-audit --no-fund --legacy-peer-deps
+      # Build first: the gate must see what actually SHIPS. The esm-shim adds
+      # a CJS banner that does not exist in the TypeScript sources, and that
+      # banner is what broke the published entry while the sources passed.
+      - name: Build
+        run: npm run build
       - name: Check
         run: npm run check:webview

--- a/src/praisonai-ts/scripts/esm-shim.js
+++ b/src/praisonai-ts/scripts/esm-shim.js
@@ -99,13 +99,29 @@ function rewriteRelativeRequires(code, fileDir) {
   );
 }
 
+// STATIC imports of 'module', 'url' and 'path' were the previous form, and they
+// were import-time fatal for a browser: a bundler must resolve a static import
+// before any code runs, so three files whose `require()` calls were all LAZY
+// turned into three unconditional Node dependencies. dist/esm/mobile.js -- what
+// `praisonai/mobile` actually resolves to -- failed with ten unresolved
+// builtins while the TypeScript source it was built from passed cleanly.
+//
+// A guarded top-level await keeps Node byte-identical in behaviour and lets a
+// browser bundle load. The dynamic import is lazy, so a bundler defers it
+// rather than failing on it; when it does fail at runtime (there is no 'module'
+// in a browser) the catch installs a `require` that throws only if a lazy
+// provider path is actually taken -- which on a phone it is not.
 const CJS_BANNER = [
-  "import { createRequire as __praisonCreateRequire } from 'module';",
-  "import { fileURLToPath as __praisonFileURLToPath } from 'url';",
-  "import { dirname as __praisonDirname } from 'path';",
-  'const require = __praisonCreateRequire(import.meta.url);',
-  'const __filename = __praisonFileURLToPath(import.meta.url);',
-  'const __dirname = __praisonDirname(__filename);',
+  'const [__praisonMod, __praisonUrl, __praisonPath] = await Promise.all([',
+  "  import('module').catch(() => null),",
+  "  import('url').catch(() => null),",
+  "  import('path').catch(() => null),",
+  ']);',
+  'const require = __praisonMod',
+  '  ? __praisonMod.createRequire(import.meta.url)',
+  "  : (id) => { throw new Error('require(' + id + ') is unavailable outside Node'); };",
+  "const __filename = __praisonUrl ? __praisonUrl.fileURLToPath(import.meta.url) : '';",
+  "const __dirname = __praisonPath && __filename ? __praisonPath.dirname(__filename) : '';",
   // In ESM there is no CommonJS module object. Provide a stub so patterns like
   // `require.main === module` compile and evaluate to false (this file is not a
   // CLI entry point when imported), and `module.exports = ...` remains harmless.

--- a/src/praisonai-ts/scripts/webview-gate.mjs
+++ b/src/praisonai-ts/scripts/webview-gate.mjs
@@ -41,6 +41,27 @@ const FORBIDDEN = new Set([
  */
 export const WEBVIEW_ENTRIES = ["src/mobile.ts", "src/agent/simple.ts"];
 
+/**
+ * The BUILT entries, which are what a consumer actually resolves.
+ *
+ * Checking the TypeScript sources alone is not enough, and this gate shipped
+ * with exactly that hole. `scripts/esm-shim.js` prepends a CJS banner --
+ * `import { createRequire } from "module"`, plus `url` and `path` -- to any
+ * emitted file whose source uses a bare synchronous `require()`. Three
+ * first-party files on the mobile graph do.
+ *
+ * That banner does not exist until `build:esm` has run. So the source check
+ * passed while `dist/esm/mobile.js` -- what `package.json` resolves
+ * `praisonai/mobile` to -- failed with ten unresolved builtins, because the
+ * banner had turned three LAZY requires into three STATIC Node imports. That
+ * is precisely the failure this gate was written to prevent, arriving through
+ * the one input it was not looking at.
+ *
+ * Checked only when `dist/` exists, so the gate still runs on a fresh clone;
+ * CI builds first.
+ */
+export const BUILT_ENTRIES = ["dist/esm/mobile.js", "dist/esm/agent/simple.js"];
+
 /** The webview baseline. iOS ships WKWebView with the OS, so the floor is the
  *  oldest iOS worth supporting rather than the newest Safari. */
 export const TARGETS = ["safari16", "chrome108"];
@@ -89,8 +110,15 @@ const invokedDirectly =
   process.argv[1] !== undefined && import.meta.url.endsWith(process.argv[1].split("/").pop());
 
 if (invokedDirectly) {
+  const { existsSync } = await import("node:fs");
+  const built = BUILT_ENTRIES.filter((e) => existsSync(e));
+  if (built.length === 0) {
+    console.log("  note: dist/ is not built, so only sources were checked.");
+    console.log("        Run `npm run build` first to check what actually ships.");
+  }
+
   let failed = false;
-  for (const entry of WEBVIEW_ENTRIES) {
+  for (const entry of [...WEBVIEW_ENTRIES, ...built]) {
     const { fatal, lazy } = await inspect(entry);
     for (const name of lazy) {
       console.log(`  ~ ${entry}: ${name} imported lazily, fine while no webview path calls it`);

--- a/src/praisonai-ts/tests/unit/packaging/esm-shim-banner.test.ts
+++ b/src/praisonai-ts/tests/unit/packaging/esm-shim-banner.test.ts
@@ -19,7 +19,11 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { applyBanner, needsCjsBanner, CJS_BANNER } = require('../../../scripts/esm-shim.js');
 
-const BANNER_MARKER = '__praisonCreateRequire(import.meta.url)';
+// What the banner is FOR, rather than how it happens to be spelled. The old
+// marker was `__praisonCreateRequire(import.meta.url)` -- an internal
+// identifier -- so renaming it broke four tests that were not about naming.
+// A banner that stopped defining `require` would still fail these.
+const BANNER_MARKER = 'const require =';
 
 function hasBanner(code: string): boolean {
   return code.includes(BANNER_MARKER);


### PR DESCRIPTION
## The bug

`src/mobile.ts` passed the webview gate. **`dist/esm/mobile.js` — what `package.json` actually resolves `praisonai/mobile` to — did not.** Bundling it for a browser produced ten unresolved builtins:

```
Could not resolve "module"  @ dist/esm/llm/backend-resolver.js:1
Could not resolve "url"     @ dist/esm/llm/backend-resolver.js:2
Could not resolve "path"    @ dist/esm/llm/backend-resolver.js:3
Could not resolve "module"  @ dist/esm/llm/providers/ai-sdk/index.js:1
... and 6 more
```

## Root cause

`scripts/esm-shim.js` prepends a CJS banner — **static** imports of `module`, `url` and `path` — to any emitted file whose source uses a bare `require()`. Three first-party files on the mobile graph do, and all three requires are **lazy** provider loads.

The banner converted three lazy requires into three **static Node imports**, which is precisely the failure the gate was written to prevent.

## Why the gate missed it

It checked TypeScript **sources** only. The banner does not exist until `build:esm` runs — so the gate passed, confidently and repeatedly, on an input that is not what ships.

**A gate that reports OK about the wrong artifact is worse than no gate, because it is believed.** This one is mine, added in #4445, and it is the more important half of this PR.

## Two fixes, because either alone leaves something wrong

**The banner is browser-safe.** A guarded top-level `await` keeps Node behaviour identical and lets a bundler defer the import rather than fail on it. In a browser the `catch` installs a `require` that throws *only if a lazy provider path is actually taken* — which on a phone it is not.

**The gate checks `dist/esm` too**, and CI builds before gating. Only when `dist/` exists, so `npm run check:webview` still works on a fresh clone.

## Verification

```
OK   src/mobile.ts               loadable in a webview
OK   src/agent/simple.ts         loadable in a webview
OK   dist/esm/mobile.js          loadable in a webview
OK   dist/esm/agent/simple.js    loadable in a webview
```

Node behaviour verified explicitly after the change, since the banner touches all 290 emitted files:

- `dist/esm/mobile.js` loads, exports `Agent`, `getEnv`, `randomUUID`
- `backend-resolver` parses `claude-3-5-sonnet-latest` → `anthropic`
- **the lazy require path still resolves** — `createProvider('openai')` returns an `OpenAIProvider`

Full suite: **1136 passed**.

## One test changed, and why

`esm-shim-banner.test.ts` pinned `BANNER_MARKER` to `'__praisonCreateRequire(import.meta.url)'` — an *internal identifier*, not a behaviour — so renaming it failed four tests that were not about naming.

The marker is now `'const require ='`. A banner that stopped defining `require` would still fail every one of them. This is a test that was over-specified, not a failure being masked.

## How this was found

An agent auditing a stale P0 list against `main`. **All nine listed gaps turned out to be already fixed** — verified by execution, not grep. This was found on the way, and it is more severe than anything that was on the list: it means the entry point published for mobile consumers could not be bundled by any of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webview compatibility across browser and Node.js environments.
  * Webview validation now checks compiled build artifacts when available.
  * Added clearer handling when compiled output has not been generated.

* **Tests**
  * Updated packaging checks to validate the presence and behavior of the `require` shim without relying on implementation-specific naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->