### PR TITLE
fix(ts): non-OpenAI providers dropped the text a model said before a tool

### DIFF
--- a/src/praisonai-ts/src/agent/simple.ts
+++ b/src/praisonai-ts/src/agent/simple.ts
@@ -822,13 +822,47 @@ export class Agent {
               throw (abortSignal as any).reason ?? new Error('The operation was aborted');
             }
 
-            const result = await backend.generateText({
-              messages,
-              temperature: 0.7,
-              tools: toolDefinitions,
-              toolChoice: 'auto',
-              signal: abortSignal,
-            });
+            // Stream the round when streaming is on, instead of always calling
+            // generateText. Two things were wrong with doing it unconditionally:
+            // `stream: true` silently had no effect once tools were configured on
+            // any non-OpenAI provider, and -- worse -- the round's assistant text
+            // was DROPPED. A model that says "Let me check." before calling a
+            // tool had that sentence recorded into `messages` for its own context
+            // and never delivered to the caller, so a user saw a tool run with no
+            // explanation of why.
+            //
+            // StreamChunk carries text AND toolCalls, and StreamTextOptions
+            // extends GenerateTextOptions, so one shape covers both.
+            let result: { text: string; toolCalls?: any[] };
+            if (this.streamEnabled) {
+              const stream = await backend.streamText({
+                messages,
+                temperature: 0.7,
+                tools: toolDefinitions,
+                toolChoice: 'auto',
+                signal: abortSignal,
+              });
+              let streamedText = '';
+              const streamedCalls: any[] = [];
+              for await (const chunk of stream) {
+                if (chunk.text) {
+                  emitToken(chunk.text);
+                  streamedText += chunk.text;
+                }
+                if (chunk.toolCalls && chunk.toolCalls.length > 0) {
+                  streamedCalls.push(...chunk.toolCalls);
+                }
+              }
+              result = { text: streamedText, toolCalls: streamedCalls.length > 0 ? streamedCalls : undefined };
+            } else {
+              result = await backend.generateText({
+                messages,
+                temperature: 0.7,
+                tools: toolDefinitions,
+                toolChoice: 'auto',
+                signal: abortSignal,
+              });
+            }
 
             messages.push({
               role: 'assistant',

--- a/src/praisonai-ts/tests/unit/agent/nonopenai-stream-tools.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/nonopenai-stream-tools.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Streaming with tools on a non-OpenAI provider.
+ *
+ * The AI-SDK tool loop called `generateText` unconditionally, so `stream: true`
+ * silently had no effect once tools were configured -- and the round's
+ * assistant text was DROPPED. A model that says "Let me check." before calling
+ * a tool had that sentence recorded into `messages` for its own context and
+ * never delivered to the caller, so a user watched a tool run with no
+ * explanation of why.
+ *
+ * The text loss is the part that matters. No streaming is a downgrade; losing
+ * a sentence the model actually produced is a wrong transcript.
+ */
+import { Agent } from '../../../src/agent/simple';
+
+const capture: { streamCalls: any[]; generateCalls: any[] } = { streamCalls: [], generateCalls: [] };
+
+jest.mock('../../../src/llm/backend-resolver', () => {
+  const actual = jest.requireActual('../../../src/llm/backend-resolver');
+  return {
+    ...actual,
+    resolveBackend: jest.fn(async () => ({
+      provider: {
+        async streamText(options: any) {
+          capture.streamCalls.push(options);
+          const round = capture.streamCalls.length;
+          return {
+            async *[Symbol.asyncIterator]() {
+              if (round === 1) {
+                yield { text: 'Let me ' };
+                yield { text: 'check. ' };
+                // OpenAI-shaped, which is what processToolCalls destructures:
+                // { id, function: { name, arguments } } with a JSON string.
+                yield { toolCalls: [{ id: 'c1', type: 'function', function: { name: 'getWeather', arguments: '{"city":"Paris"}' } }] };
+              } else {
+                yield { text: 'It is 20C.' };
+              }
+            },
+          };
+        },
+        async generateText(options: any) {
+          capture.generateCalls.push(options);
+          return { text: 'non-streamed answer', toolCalls: undefined };
+        },
+      },
+    })),
+  };
+});
+
+const getWeather = (city: string) => `Weather in ${city}: 20C`;
+
+describe('non-OpenAI streaming with tools', () => {
+  const origWrite = process.stdout.write;
+  beforeEach(() => {
+    capture.streamCalls = [];
+    capture.generateCalls = [];
+  });
+  afterEach(() => {
+    process.stdout.write = origWrite;
+    jest.clearAllMocks();
+  });
+
+  const build = (stream: boolean) =>
+    new Agent({
+      instructions: 'x',
+      llm: 'anthropic/claude-3-5-sonnet-latest',
+      stream,
+      verbose: false,
+      tools: [getWeather],
+    });
+
+  it('the text before a tool call reaches the caller', async () => {
+    // The whole point. This sentence used to exist only inside `messages`.
+    const chunks: string[] = [];
+    for await (const chunk of build(true).stream('weather?')) chunks.push(chunk);
+    expect(chunks.join('')).toContain('Let me check.');
+  });
+
+  it('the answer after the tool also arrives', async () => {
+    const chunks: string[] = [];
+    for await (const chunk of build(true).stream('weather?')) chunks.push(chunk);
+    expect(chunks.join('')).toContain('It is 20C.');
+  });
+
+  it('it actually STREAMS rather than arriving in one lump', async () => {
+    // A finish-only fallback would satisfy both cases above while delivering
+    // the whole answer at the end -- which is the behaviour being fixed.
+    const events: string[] = [];
+    for await (const event of build(true).streamEvents('weather?')) events.push(event.type);
+    const deltas = events.filter((t) => t === 'text').length;
+    expect(deltas).toBeGreaterThan(1);
+  });
+
+  it('the tool still runs, and its events are announced', async () => {
+    const events = [];
+    for await (const event of build(true).streamEvents('weather?')) events.push(event);
+    const kinds = events.map((e) => e.type);
+    expect(kinds).toContain('tool_call');
+    expect(kinds).toContain('tool_result');
+  });
+
+  it('streaming is used when stream is on', async () => {
+    for await (const _ of build(true).stream('weather?')) { /* drain */ }
+    expect(capture.streamCalls.length).toBeGreaterThan(0);
+  });
+
+  it('generateText is still used when streaming is OFF', async () => {
+    // The pair: always streaming would be just as wrong in the other
+    // direction, and would break every non-streaming caller.
+    await build(false).start('weather?');
+    expect(capture.generateCalls.length).toBeGreaterThan(0);
+    expect(capture.streamCalls.length).toBe(0);
+  });
+
+  it('the streamed round still carries the tools', async () => {
+    // Streaming must not quietly drop the tool definitions -- that would trade
+    // one silent failure for another.
+    for await (const _ of build(true).stream('weather?')) { /* drain */ }
+    expect(capture.streamCalls[0]?.tools).toBeDefined();
+  });
+});

--- a/src/praisonai-ts/tests/unit/agent/tools-cross-provider.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/tools-cross-provider.test.ts
@@ -22,7 +22,11 @@ const PROVIDERS = [
 
 describe('tools survive on every non-OpenAI provider', () => {
   for (const llm of PROVIDERS) {
-    it(`passes tools into generateText for ${llm}`, async () => {
+    it(`passes tools into the model call for ${llm}`, async () => {
+      // `stream` defaults to true, so the tool loop streams -- the same thing
+      // the OpenAI path has always done. What this test guards is that the
+      // TOOLS survive to the provider, not which method carries them, so it
+      // asserts on whichever one was actually used.
       const agent = new Agent({ instructions: 'weather', tools: [getWeather], llm, verbose: false });
 
       const generateText = jest.fn().mockResolvedValue({
@@ -31,19 +35,30 @@ describe('tools survive on every non-OpenAI provider', () => {
         usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
         finishReason: 'stop',
       });
+      // A real async iterable, not a bare jest.fn(): the streaming path does
+      // `for await` over it, and an undefined return throws before the
+      // assertion this test is about.
+      const streamText = jest.fn().mockResolvedValue({
+        async *[Symbol.asyncIterator]() {
+          yield { text: 'sunny' };
+        },
+      });
 
       // Stub the resolved AI SDK backend so no network/keys are needed.
       jest.spyOn(agent as any, 'getBackend').mockResolvedValue({
         generateText,
-        streamText: jest.fn(),
+        streamText,
         generateObject: jest.fn(),
       });
 
       const out = await agent.start('weather in Paris?');
       expect(out).toBe('sunny');
 
-      expect(generateText).toHaveBeenCalled();
-      const callArgs = generateText.mock.calls[0][0];
+      // One of the two carried the request. Asserting on the union keeps the
+      // guarantee (tools reached the provider) without pinning the transport.
+      const used = streamText.mock.calls.length > 0 ? streamText : generateText;
+      expect(used).toHaveBeenCalled();
+      const callArgs = used.mock.calls[0][0];
       expect(Array.isArray(callArgs.tools)).toBe(true);
       expect(callArgs.tools.length).toBeGreaterThan(0);
       expect(callArgs.tools[0].name).toBe('getWeather');
@@ -56,6 +71,10 @@ describe('tools survive on every non-OpenAI provider', () => {
       tools: [getWeather],
       llm: 'anthropic/claude-3-5-sonnet-latest',
       verbose: false,
+      // Pinned to the non-streaming path: this case is about the tool LOOP
+      // across rounds, and generateText is the transport it was written for.
+      // The streaming transport is covered by nonopenai-stream-tools.test.ts.
+      stream: false,
     });
 
     const generateText = jest
@@ -107,6 +126,10 @@ describe('tools survive on every non-OpenAI provider', () => {
       outputSchema: schema,
       llm: 'anthropic/claude-3-5-sonnet-latest',
       verbose: false,
+      // Pinned to the non-streaming path: this case is about the tool LOOP
+      // across rounds, and generateText is the transport it was written for.
+      // The streaming transport is covered by nonopenai-stream-tools.test.ts.
+      stream: false,
     });
 
     // Tool loop resolves in one turn (no tool calls), then the final answer


### PR DESCRIPTION
## The bug

The AI-SDK tool loop called `generateText` unconditionally. So on **any non-OpenAI provider**, once tools were configured:

- `stream: true` silently had no effect — no token deltas at all
- **the round's assistant text was dropped**

A model that says *"Let me check."* before calling a tool had that sentence recorded into `messages` for its own context and **never delivered to the caller**. The user watched a tool run with no explanation of why.

Measured on `anthropic/claude-3-5-sonnet-latest`, `stream: true`, one tool:

| | events | AI-SDK calls |
|---|---|---|
| with tools | `tool_call, tool_result, finish` — **0 text deltas** | `generateText, generateText` |
| without tools (control) | deltas `["It ", "is ", "20C."]` | `streamText` |

No streaming is a downgrade. **Losing a sentence the model actually produced is a wrong transcript**, and that is the half that matters.

## The fix

`StreamChunk` already carries `text` **and** `toolCalls`, and `StreamTextOptions` extends `GenerateTextOptions` — so one shape covers both, and the loop streams when streaming is on.

This makes non-OpenAI **consistent with OpenAI rather than inventing behaviour**: the OpenAI path has always streamed pre-tool text through `streamChatWithTools`. And every real provider implements `streamText` — `anthropic.ts`, `google.ts` and the ai-sdk backend all do — so no provider loses a transport it had.

## Tests

7 new, each paired so a trivial implementation fails:

- text before the tool call reaches the caller ↔ the answer after it does too
- it **actually streams** (more than one delta) — a finish-only fallback would satisfy both of the above while delivering one lump, which is the behaviour being fixed
- `generateText` is still used when `stream: false` — always streaming would be just as wrong in the other direction
- the streamed round still carries the tools — streaming must not trade one silent failure for another

## One existing test changed, and why

`tools-cross-provider.test.ts` asserted on `generateText` **specifically**, while its guarantee is in its own name: *"tools survive on every non-OpenAI provider."* Since `stream` defaults to `true`, the call now goes through `streamText`.

It asserts on whichever transport carried the call, which keeps the guarantee without pinning the mechanism. Its two multi-round cases are pinned to `stream: false`, because they are about the tool **loop** across rounds — and that keeps a genuine `generateText` case in the suite.

Worth noting: their mock had `streamText: jest.fn()`, which returns `undefined` and throws on `for await` before reaching any assertion. It is a real async iterable now.

Full suite: **1120 passed**, `tsc --noEmit` clean.

## Context

This is the last open item from an audit of a stale P0 list. All nine listed gaps were verified already-fixed by execution; this was found on the way, alongside the wrong-vendor routing bug (#4483) and the shipped-entry bundling bug (#4484).