### PR TITLE
fix(ci): dedupe merge gate dispatches under CI fan-out

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -287,4 +287,17 @@ assert('fork sync PR link rejected', !mg.isInternalPullRequestLink(
   'PraisonAI'
 ));
 
+assert('dispatch blocked when merge gate active', mg.mergeGateDispatchBlockedReason({
+  labels: ['claude-merge-gate-active'],
+  pendingRuns: 0,
+}) === 'merge gate already active on PR');
+assert('dispatch blocked when queue saturated', mg.mergeGateDispatchBlockedReason({
+  labels: [],
+  pendingRuns: 3,
+})?.includes('already queued or in progress'));
+assert('dispatch allowed when queue below cap', mg.mergeGateDispatchBlockedReason({
+  labels: [],
+  pendingRuns: 2,
+}) == null);
+
 process.exit(failed ? 1 : 0);

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -464,6 +464,55 @@ function hasBlockingClaudeRunForPr(runs, headRef) {
   return (runs || []).some((r) => claudeRunBlocksPr(r, headRef));
 }
 
+const MERGE_GATE_WORKFLOW_FILE = 'claude-merge-gate.yml';
+const MERGE_GATE_ACTIVE_LABEL = 'claude-merge-gate-active';
+const MAX_PENDING_MERGE_GATE_RUNS = 3;
+
+function mergeGateDispatchBlockedReason({ labels, pendingRuns, maxPending = MAX_PENDING_MERGE_GATE_RUNS }) {
+  if ((labels || []).includes(MERGE_GATE_ACTIVE_LABEL)) {
+    return 'merge gate already active on PR';
+  }
+  if (pendingRuns >= maxPending) {
+    return `${pendingRuns} merge gate run(s) already queued or in progress (max ${maxPending})`;
+  }
+  return null;
+}
+
+async function countPendingMergeGateRuns(github, owner, repo) {
+  let pending = 0;
+  for (const status of ['queued', 'in_progress']) {
+    try {
+      const { data } = await github.rest.actions.listWorkflowRuns({
+        owner,
+        repo,
+        workflow_id: MERGE_GATE_WORKFLOW_FILE,
+        status,
+        per_page: 30,
+      });
+      pending += (data.workflow_runs || []).length;
+    } catch {
+      // Best-effort backpressure only.
+    }
+  }
+  return pending;
+}
+
+async function shouldSkipMergeGateDispatch(github, owner, repo, prNumber, core, options = {}) {
+  const maxPending = options.maxPending ?? MAX_PENDING_MERGE_GATE_RUNS;
+  const ctx = await loadPrContext(github, owner, repo, prNumber);
+  const pendingRuns = await countPendingMergeGateRuns(github, owner, repo);
+  const reason = mergeGateDispatchBlockedReason({
+    labels: ctx.labels,
+    pendingRuns,
+    maxPending,
+  });
+  if (reason) {
+    core?.info?.(`Skip merge gate dispatch for PR #${prNumber}: ${reason}`);
+    return true;
+  }
+  return false;
+}
+
 async function hasInProgressClaudeAssistant(github, owner, repo, prNumber = null) {
   try {
     const { data } = await github.rest.actions.listWorkflowRuns({
@@ -1013,4 +1062,10 @@ module.exports = {
   isAutomatedFallbackVerdict,
   AUTOMATED_FALLBACK_MARKER,
   findMergeGateVerdict,
+  MERGE_GATE_WORKFLOW_FILE,
+  MERGE_GATE_ACTIVE_LABEL,
+  MAX_PENDING_MERGE_GATE_RUNS,
+  mergeGateDispatchBlockedReason,
+  countPendingMergeGateRuns,
+  shouldSkipMergeGateDispatch,
 };

--- a/.github/scripts/pipeline-status.js
+++ b/.github/scripts/pipeline-status.js
@@ -181,10 +181,10 @@ async function syncPipelineLabels(github, owner, repo, prNumber, core) {
 
 async function dispatchMergeGateForOldestReady(github, owner, repo, readyCandidates, core) {
   if (!readyCandidates.length) return 0;
+  const mergeGate = require('./merge-gate.js');
   readyCandidates.sort((a, b) => a.createdAt - b.createdAt);
   for (const cand of readyCandidates) {
-    if ((cand.labels || []).includes('claude-merge-gate-active')) {
-      core?.info?.(`Skip dispatch PR #${cand.prNumber}: merge gate already active`);
+    if (await mergeGate.shouldSkipMergeGateDispatch(github, owner, repo, cand.prNumber, core)) {
       continue;
     }
     await github.rest.repos.createDispatchEvent({

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -33,7 +33,8 @@ on:
       - claude-merge-gate
 
 concurrency:
-  group: claude-merge-gate-${{ github.repository }}-${{ github.event.inputs.pr_number || github.event.client_payload.pr_number || github.event.workflow_run.id || 'scan' }}
+  # Serialize workflow_run auto-dispatches (Core Tests / Claude Assistant fan-out).
+  group: claude-merge-gate-${{ github.repository }}-${{ github.event.inputs.pr_number || github.event.client_payload.pr_number || (github.event_name == 'workflow_run' && 'auto-dispatch') || 'scan' }}
   cancel-in-progress: false
 
 env:
@@ -104,6 +105,10 @@ jobs:
             );
             if (!check.ready) {
               core.info(`PR #${prNumber} not ready: ${check.reasons.join(', ')}`);
+              return;
+            }
+
+            if (await mergeGate.shouldSkipMergeGateDispatch(github, owner, repo, prNumber, core)) {
               return;
             }
 


### PR DESCRIPTION
## Summary

Stops merge-gate queue floods when many PRs finish Core Tests / Claude Assistant at once.

- **Serialize `workflow_run` auto-dispatch** — shared concurrency group `auto-dispatch` instead of one group per upstream run id
- **Skip redundant dispatches** — new `shouldSkipMergeGateDispatch()` skips when:
  - PR already has `claude-merge-gate-active`, or
  - ≥3 merge-gate runs are already queued/in progress (backpressure)
- **Reuse guard in pipeline sync** — `dispatchMergeGateForOldestReady()` calls the same helper

## Root cause

Each CI completion triggered a parallel merge-gate `workflow_run` auto-dispatch (unique concurrency per run id), flooding the queue with 40+ runs while eligible PRs waited.

## Test plan

- [x] `node .github/scripts/merge-gate-selftest.js`
- [x] `node .github/scripts/pipeline-status-selftest.js`
- [ ] Merge and confirm queue depth stays ≤3 during multi-PR CI bursts

Made with [Cursor](https://cursor.com)