### PR TITLE
fix(ci): exclude workflow_run probes from merge-gate pending count

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -310,4 +310,20 @@ assert('dispatch allowed when queue below cap', mg.mergeGateDispatchBlockedReaso
   pendingRuns: 2,
 }) == null);
 
+// Pending count excludes workflow_run auto-dispatch probes (PR #4534)
+assert('workflow_run probes excluded from pending count', mg.countSubstantiveMergeGateRuns([
+  { event: 'workflow_dispatch' },
+  { event: 'workflow_run' },
+  { event: 'workflow_run' },
+]) === 1);
+assert('all-probe runs count as zero pending', mg.countSubstantiveMergeGateRuns([
+  { event: 'workflow_run' },
+  { event: 'workflow_run' },
+]) === 0);
+assert('substantive dispatches still counted', mg.countSubstantiveMergeGateRuns([
+  { event: 'workflow_dispatch' },
+  { event: 'schedule' },
+]) === 2);
+assert('countSubstantiveMergeGateRuns null-safe', mg.countSubstantiveMergeGateRuns(null) === 0);
+
 process.exit(failed ? 1 : 0);

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -489,6 +489,12 @@ function mergeGateDispatchBlockedReason({ labels, pendingRuns, maxPending = MAX_
   return null;
 }
 
+// workflow_run probes (auto-dispatch) share concurrency and must not count
+// toward backpressure — they blocked dispatches for merge-ready PRs.
+function countSubstantiveMergeGateRuns(runs) {
+  return (runs || []).filter((r) => r && r.event !== 'workflow_run').length;
+}
+
 async function countPendingMergeGateRuns(github, owner, repo) {
   let pending = 0;
   for (const status of ['queued', 'in_progress']) {
@@ -500,9 +506,7 @@ async function countPendingMergeGateRuns(github, owner, repo) {
         status,
         per_page: 30,
       });
-      // workflow_run probes (auto-dispatch) share concurrency and must not
-      // count toward backpressure — they blocked dispatches for merge-ready PRs.
-      pending += (data.workflow_runs || []).filter((r) => r.event !== 'workflow_run').length;
+      pending += countSubstantiveMergeGateRuns(data.workflow_runs);
     } catch {
       // Best-effort backpressure only.
     }
@@ -1096,6 +1100,7 @@ module.exports = {
   MERGE_GATE_ACTIVE_LABEL,
   MAX_PENDING_MERGE_GATE_RUNS,
   mergeGateDispatchBlockedReason,
+  countSubstantiveMergeGateRuns,
   countPendingMergeGateRuns,
   shouldSkipMergeGateDispatch,
 };

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -500,7 +500,9 @@ async function countPendingMergeGateRuns(github, owner, repo) {
         status,
         per_page: 30,
       });
-      pending += (data.workflow_runs || []).length;
+      // workflow_run probes (auto-dispatch) share concurrency and must not
+      // count toward backpressure — they blocked dispatches for merge-ready PRs.
+      pending += (data.workflow_runs || []).filter((r) => r.event !== 'workflow_run').length;
     } catch {
       // Best-effort backpressure only.
     }


### PR DESCRIPTION
## Summary
- `countPendingMergeGateRuns()` no longer counts `workflow_run` auto-dispatch probe runs toward the max-pending cap (3).
- Fixes merge-ready PRs stuck with `pipeline/merge-ready` but no `MERGE_GATE_VERDICT` because `shouldSkipMergeGateDispatch()` saw phantom pending runs (including a stuck Aug-26 probe).

## Root cause
Pipeline sync logs showed: `Skip merge gate dispatch for PR #4519: 3 merge gate run(s) already queued or in progress (max 3)` while merge-ready desktop PRs had CI green and FINAL complete. Manual `workflow_dispatch` for #4519 assessed and merged immediately.

## Test plan
- [x] `node .github/scripts/merge-gate-selftest.js` — 52/52 pass
- [ ] After merge, confirm scheduled scan dispatches for remaining `pipeline/merge-ready` PRs without manual intervention


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Merge-ready changes are no longer blocked by automated workflow probes counting toward the pending-run limit.
  * Improved merge-gate dispatch reliability when other workflow runs are queued or in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->