### PR TITLE
feat(mobile): route to screen dispatch, with the transcript retained

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -880,3 +880,21 @@ test("the shared names are the env() spellings a stylesheet can mirror", () => {
     "--safe-area-inset-left",
   ]);
 });
+
+test("the web shell reports a keyboard that is ALREADY up at construction", async () => {
+  // The case the synchronous property exists for, and the one it did not
+  // actually cover: it was declared `= 0` and only ever updated by an event.
+  // A component mounting during a warm resume, or with a hardware keyboard
+  // already present, laid out at 0 for one frame and then jumped -- which is
+  // precisely the bug the snapshot was added to prevent.
+  const fake = createFakeWindow();
+  fake.setKeyboardHeight(336);           // up BEFORE the shell is constructed
+  assert.equal(createWebShell(fake.window).keyboardHeightPx, 336);
+});
+
+test("the web shell reports 0 when no keyboard is up", async () => {
+  // The pair: seeding from a wrong source, or always reporting a height, would
+  // hold the composer permanently off the bottom of the screen.
+  const fake = createFakeWindow();
+  assert.equal(createWebShell(fake.window).keyboardHeightPx, 0);
+});

--- a/src/praisonai-mobile/adapters/src/web/shell.ts
+++ b/src/praisonai-mobile/adapters/src/web/shell.ts
@@ -53,11 +53,25 @@ export interface WebShell extends ShellPort {
   pressBack(): boolean;
 }
 
+/** The keyboard's height right now, from the only browser API that reports one.
+ *  Clamped at 0: overscroll can make the gap briefly negative, and a negative
+ *  height would push the composer off the bottom of the screen. */
+export function readKeyboardHeight(view: Window): number {
+  const viewport = view.visualViewport;
+  if (viewport === null || viewport === undefined) return 0;
+  return Math.max(0, view.innerHeight - viewport.height - viewport.offsetTop);
+}
+
 export function createWebShell(view: Window = window): WebShell {
   const root = view.document.documentElement;
 
   let insets = readInsets(root, view);
-  let keyboardHeightPx = 0;
+  // SEEDED, not just declared. The property was added so a component mounting
+  // while the keyboard is already up -- a warm resume, a hardware or floating
+  // keyboard -- lays out correctly on its FIRST frame. Starting at 0 and
+  // waiting for an event reproduces exactly the bug it was added to fix: one
+  // frame at the wrong height, then a jump.
+  let keyboardHeightPx = readKeyboardHeight(view);
 
   const insetSubs = new Set<(i: SafeAreaInsets) => void>();
   const keyboardSubs = new Set<(px: number) => void>();

--- a/src/praisonai-mobile/app/src/boot.test.ts
+++ b/src/praisonai-mobile/app/src/boot.test.ts
@@ -39,7 +39,7 @@ function deps(over: Partial<AppDeps> = {}): AppDeps {
     secrets: createFakeSecrets(),
     time: createFakeTime(),
     shell: createFakeShell(),
-    engines: [{ id: "scripted", create: () => engine }],
+    engines: () => [{ id: "scripted", create: () => engine }],
     settingDefs: DEFS,
     engineId: "scripted",
     onPublish: () => {},
@@ -75,7 +75,7 @@ test("an engine too old to hold to the contract stops the boot", async () => {
   // halfway through the first answer leaves text on screen and no honest way
   // to explain it.
   const engine = engineWith({ id: "scripted", protocolVersion: MIN_ENGINE_PROTOCOL - 1 });
-  const result = await createApp(deps({ engines: [{ id: "scripted", create: () => engine }] }));
+  const result = await createApp(deps({ engines: () => [{ id: "scripted", create: () => engine }] }));
 
   assert.equal(result.ok, false);
   if (result.ok) return;
@@ -88,7 +88,7 @@ test("an engine that cannot state its protocol is refused, not assumed current",
   // what it speaks is not one that can be held to a contract.
   const engine = engineWith({ id: "scripted" });
   const broken = { ...engine, protocolVersion: undefined as unknown as number };
-  const result = await createApp(deps({ engines: [{ id: "scripted", create: () => broken }] }));
+  const result = await createApp(deps({ engines: () => [{ id: "scripted", create: () => broken }] }));
   assert.equal(result.ok, false);
 });
 
@@ -98,7 +98,7 @@ test("a NEWER engine is accepted, because unknown events degrade rather than bre
   // decode.ts drops an unrecognised event and keeps the answer rendering, so a
   // v3 client against a v4 engine loses an affordance, not the conversation.
   const engine = engineWith({ id: "scripted", protocolVersion: PROTOCOL_VERSION + 1 });
-  const result = await createApp(deps({ engines: [{ id: "scripted", create: () => engine }] }));
+  const result = await createApp(deps({ engines: () => [{ id: "scripted", create: () => engine }] }));
   assert.equal(result.ok, true);
   if (result.ok) await result.app.dispose();
 });
@@ -114,7 +114,7 @@ test("an engine rejected for its protocol is still disposed", async () => {
     protocolVersion: MIN_ENGINE_PROTOCOL - 1,
     dispose: async () => void (disposed = true),
   };
-  await createApp(deps({ engines: [{ id: "scripted", create: () => engine }] }));
+  await createApp(deps({ engines: () => [{ id: "scripted", create: () => engine }] }));
   assert.equal(disposed, true);
 });
 
@@ -123,7 +123,7 @@ test("a factory whose engine reports a different id is refused", async () => {
   // another writes transcripts attributing themselves to an engine the user
   // never selected.
   const engine = engineWith({ id: "something-else" });
-  const result = await createApp(deps({ engines: [{ id: "scripted", create: () => engine }] }));
+  const result = await createApp(deps({ engines: () => [{ id: "scripted", create: () => engine }] }));
   assert.equal(result.ok, false);
   if (result.ok) return;
   assert.match(result.detail, /something-else/);
@@ -139,7 +139,7 @@ test("settings are loaded before the engine is built", async () => {
   const engine = engineWith({ id: "scripted" });
   const result = await createApp(deps({
     storage,
-    engines: [{ id: "scripted", create: () => { order.push("engine"); return engine; } }],
+    engines: () => [{ id: "scripted", create: () => { order.push("engine"); return engine; } }],
   }));
 
   assert.equal(result.ok, true);
@@ -159,7 +159,7 @@ test("backgrounding stops the run", async () => {
     cancel: async () => { stopped = true; return true; },
   };
 
-  const result = await createApp(deps({ shell, engines: [{ id: "scripted", create: () => engine }] }));
+  const result = await createApp(deps({ shell, engines: () => [{ id: "scripted", create: () => engine }] }));
   assert.equal(result.ok, true);
   if (!result.ok) return;
 
@@ -230,4 +230,48 @@ test("selectEngine accepts a matching engine", async () => {
   const outcome = await selectEngine("a", [{ id: "a", create: () => engineWith({ id: "a" }) }]);
   assert.equal(outcome.ok, true);
   if (outcome.ok) await outcome.engine.dispose();
+});
+
+// ---- the wire ---------------------------------------------------------------
+
+test("the engine writes through the SAME session the app hands out", async () => {
+  // The gap this closes: createSession was called, RunPersistence.record was
+  // called, and nothing connected them -- so record() never ran in a real turn
+  // and no conversation was ever saved. Both halves looked done from either end.
+  const storage = createFakeStorage();
+  let handed: unknown = null;
+
+  const result = await createApp(deps({
+    storage,
+    engines: (persistence) => {
+      handed = persistence;
+      return [{ id: "scripted", create: () => engineWith({ id: "scripted" }) }];
+    },
+  }));
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  assert.notEqual(handed, null, "the engine factory must be handed a persistence");
+
+  // Recording through what the engine received must land in what the UI reads.
+  const indices = await (handed as { record: (r: { prompt: string }, a: string) => Promise<unknown> })
+    .record({ prompt: "what is 2+2?" }, "4");
+  assert.notEqual(indices, null);
+
+  const chats = await result.app.session.list();
+  assert.equal(chats.length, 1, "the turn must be visible to the session the app exposes");
+  await result.app.dispose();
+});
+
+test("the engine list cannot be built before the session exists", () => {
+  // Enforced by the type, not by a comment: `engines` is a factory taking the
+  // persistence, so there is no way to obtain the list without being handed
+  // the thing engines write through. A pre-built array was the original bug.
+  const built: string[] = [];
+  const factory = (p: unknown) => {
+    built.push(p === null || p === undefined ? "no-persistence" : "has-persistence");
+    return [];
+  };
+  factory({ record: async () => null });
+  assert.deepEqual(built, ["has-persistence"]);
 });

--- a/src/praisonai-mobile/app/src/boot.ts
+++ b/src/praisonai-mobile/app/src/boot.ts
@@ -17,7 +17,7 @@ import type { ShellPort } from "../../core/src/ports/shell.ts";
 import type { StoragePort } from "../../core/src/ports/storage.ts";
 import type { SecretsPort } from "../../core/src/ports/secrets.ts";
 import type { TimePort } from "../../core/src/ports/time.ts";
-import { createSession, type Session } from "../../core/src/chat/session.ts";
+import { createSession, persistenceFor, type Session } from "../../core/src/chat/session.ts";
 import {
   createSettingsStore,
   facadeFor,
@@ -28,13 +28,23 @@ import {
 import { createRunController, type RunController, type RunView } from "../../core/src/run/controller.ts";
 import { attachBackGesture, createRouter, type Router } from "../../ui/src/router.ts";
 import { selectEngine, type EngineChoice } from "./engines.ts";
+import type { RunPersistence } from "../../engines/src/praisonai-ts/engine.ts";
 
 export interface AppDeps {
   readonly storage: StoragePort;
   readonly secrets: SecretsPort;
   readonly time: TimePort;
   readonly shell: ShellPort;
-  readonly engines: readonly EngineChoice[];
+  /**
+   * Built FROM the session, not before it.
+   *
+   * A pre-built list was the bug: the session existed, the engine's
+   * `persistence` port existed, and nothing connected them -- so `record()`
+   * never ran in a real turn and no conversation was ever saved. Taking a
+   * factory makes that impossible to express: there is no way to obtain the
+   * engine list without being handed the thing engines write through.
+   */
+  readonly engines: (persistence: RunPersistence) => readonly EngineChoice[];
   readonly settingDefs: readonly SettingDef[];
   /** Which engine to start with, normally read from settings. */
   readonly engineId: string;
@@ -64,15 +74,6 @@ export async function createApp(deps: AppDeps): Promise<BootResult> {
   //    so anything built before this would be built with defaults and rebuilt.
   const settingsStore: SettingsStore = createSettingsStore(deps.settingDefs, deps.storage, deps.secrets);
   await settingsStore.load();
-
-  // 2. The engine, verified. A protocol mismatch stops the boot HERE, with a
-  //    name, rather than mid-answer.
-  const selection = await selectEngine(deps.engineId, deps.engines);
-  if (!selection.ok) {
-    return { ok: false, reason: selection.reason, detail: selection.detail };
-  }
-  const engine = selection.engine;
-
   // 3. Everything above the seam. None of these can name a concrete adapter.
   // The session owns the join between the assistant-only TurnState and the
   // two-sided StoredChat, and it is what engines call to record a turn -- so
@@ -83,6 +84,21 @@ export async function createApp(deps: AppDeps): Promise<BootResult> {
     now: deps.now,
     newChatId: deps.newChatId,
   });
+
+
+  // 2. The engine, verified. A protocol mismatch stops the boot HERE, with a
+  //    name, rather than mid-answer.
+  //
+  //    NOTE the ordering: the session is built above, because the in-process
+  //    engine writes THROUGH it. `main.ts` builds the engine list from
+  //    `enginesFor({ ..., persistence: session })`, so a turn recorded by the
+  //    engine and a chat read by the UI are the same store.
+  const selection = await selectEngine(deps.engineId, deps.engines(persistenceFor(session)));
+  if (!selection.ok) {
+    return { ok: false, reason: selection.reason, detail: selection.detail };
+  }
+  const engine = selection.engine;
+
   const controller = createRunController({
     engine,
     time: deps.time,

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -152,7 +152,9 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     secrets: platform.secrets,
     time: platform.time,
     shell: platform.shell,
-    engines: enginesFor({ settings: facadeStub(), http: platform.http }),
+    // The factory receives the session boot just built, so the engine that
+    // records a turn and the repository the UI reads are the same store.
+    engines: (persistence) => enginesFor({ settings: facadeStub(), http: platform.http, persistence }),
     settingDefs: SETTING_DEFS,
     engineId: "remote-http",
     onPublish: publish,

--- a/src/praisonai-mobile/app/src/mount.test.ts
+++ b/src/praisonai-mobile/app/src/mount.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Mounting screens, against a minimal fake DOM.
+ *
+ * The decisions are tested in ui/src/screens.test.ts without a DOM at all.
+ * What is left to check here is the ordering and the retention, because both
+ * are invisible in a snapshot of the finished page: a flash between screens
+ * and a destroyed-then-rebuilt transcript both end up looking correct.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createScreens } from "./mount.ts";
+import { transition } from "../../ui/src/screens.ts";
+import type { Route } from "../../ui/src/router.ts";
+
+/** Just enough element for append / remove / hidden / dataset. */
+function fakeDom() {
+  const order: string[] = [];
+  const make = (): any => {
+    const el: any = {
+      dataset: {} as Record<string, string>,
+      // Recorded, because the mount-before-hide ordering is otherwise
+      // invisible: a fake that only logs append/remove cannot tell the two
+      // orders apart, and a test written against it asserts nothing. A
+      // mutation run caught exactly that.
+      _hidden: false,
+      get hidden() { return this._hidden; },
+      set hidden(v: boolean) {
+        this._hidden = v;
+        order.push(`${v ? "hide" : "show"}:${this.dataset.screen ?? "?"}`);
+      },
+      children: [] as any[],
+      append(child: any) {
+        this.children.push(child);
+        child.parent = this;
+        order.push(`append:${child.dataset.screen ?? "?"}`);
+      },
+      remove() {
+        const p = this.parent;
+        if (p) p.children = p.children.filter((c: any) => c !== this);
+        order.push(`remove:${this.dataset.screen ?? "?"}`);
+      },
+    };
+    return el;
+  };
+  return { make, order };
+}
+
+const chat: Route = { name: "chat", chatId: "c1" };
+const settings: Route = { name: "settings" };
+
+const build = (dom: ReturnType<typeof fakeDom>) => {
+  const root = dom.make();
+  const screens = createScreens({ root, build: () => dom.make() });
+  return { root, screens };
+};
+
+test("a mounted screen is appended and visible", () => {
+  const dom = fakeDom();
+  const { root, screens } = build(dom);
+  screens.apply(transition(null, chat, screens.live()));
+  assert.equal(root.children.length, 1);
+  assert.equal(root.children[0].hidden, false);
+});
+
+test("mounting happens BEFORE hiding, so there is never an empty frame", () => {
+  // The other order produces a visible flash on every navigation, and a
+  // snapshot of the finished page cannot tell the difference.
+  const dom = fakeDom();
+  const { screens } = build(dom);
+  screens.apply(transition(null, chat, screens.live()));
+  dom.order.length = 0;
+  screens.apply(transition(chat, settings, screens.live()));
+
+  const appended = dom.order.indexOf("append:settings");
+  const hidden = dom.order.indexOf("hide:chat");
+  assert.ok(appended !== -1 && hidden !== -1, `got ${dom.order.join(", ")}`);
+  assert.ok(appended < hidden, `mounted after hiding: ${dom.order.join(", ")}`);
+});
+
+test("a retained screen keeps its node when navigated away from", () => {
+  // If it were removed, the transcript would lose scroll position and its
+  // streaming state -- the reason retention exists at all.
+  const dom = fakeDom();
+  const { root, screens } = build(dom);
+  screens.apply(transition(null, chat, screens.live()));
+  const node = root.children[0];
+  screens.apply(transition(chat, settings, screens.live()));
+
+  assert.ok(root.children.includes(node), "the chat node must still be in the DOM");
+  assert.equal(node.hidden, true);
+});
+
+test("returning to a retained screen reuses the SAME node", () => {
+  // Identity, not equality: a rebuilt node is a different node, and every
+  // benefit of retaining it is lost.
+  const dom = fakeDom();
+  const { root, screens } = build(dom);
+  screens.apply(transition(null, chat, screens.live()));
+  const node = root.children[0];
+  screens.apply(transition(chat, settings, screens.live()));
+  screens.apply(transition(settings, chat, screens.live()));
+
+  assert.equal(root.children[0], node, "must be the same element object");
+  assert.equal(node.hidden, false);
+});
+
+test("a non-retained screen is removed from the DOM", () => {
+  // The pair: retaining everything would satisfy the tests above while growing
+  // the page for the app's lifetime.
+  const dom = fakeDom();
+  const { root, screens } = build(dom);
+  screens.apply(transition(null, settings, screens.live()));
+  screens.apply(transition(settings, chat, screens.live()));
+  assert.equal(root.children.length, 1);
+  assert.equal(root.children[0].dataset.screen, "chat");
+});
+
+test("live() reports what is actually mounted", () => {
+  // It is the input `transition()` reasons from; if it drifts, every decision
+  // downstream is made against a page that does not exist.
+  const dom = fakeDom();
+  const { screens } = build(dom);
+  assert.deepEqual([...screens.live()], []);
+  screens.apply(transition(null, chat, screens.live()));
+  assert.deepEqual([...screens.live()], ["chat"]);
+});
+
+test("applying the same transition twice mounts nothing new", () => {
+  const dom = fakeDom();
+  const { root, screens } = build(dom);
+  screens.apply(transition(null, chat, screens.live()));
+  screens.apply(transition(chat, chat, screens.live()));
+  assert.equal(root.children.length, 1);
+});

--- a/src/praisonai-mobile/app/src/mount.ts
+++ b/src/praisonai-mobile/app/src/mount.ts
@@ -1,0 +1,64 @@
+/**
+ * Putting screens on the page. The thin half.
+ *
+ * Every decision — which screen a route shows, what to keep, what to destroy —
+ * is in `ui/src/screens.ts` and is tested without a DOM. What is left here is
+ * creating an element, showing one, and removing another.
+ *
+ * `hidden` rather than removal is the whole point for a retained screen: the
+ * nodes stay, so the transcript keeps its scroll position and its streaming
+ * state across a trip to settings and back.
+ */
+import type { ScreenChange, ScreenId } from "../../ui/src/screens.ts";
+
+export interface ScreenHost {
+  /** The element every screen is appended to. */
+  readonly root: HTMLElement;
+  /** Builds a screen's element. Called once per mount. */
+  readonly build: (id: ScreenId) => HTMLElement;
+}
+
+export interface MountedScreens {
+  readonly nodes: Map<ScreenId, HTMLElement>;
+  /** Which ids are currently in the DOM — the input `transition()` needs. */
+  live(): ReadonlySet<ScreenId>;
+  apply(change: ScreenChange): void;
+}
+
+export function createScreens(host: ScreenHost): MountedScreens {
+  const nodes = new Map<ScreenId, HTMLElement>();
+
+  return {
+    nodes,
+    live: () => new Set(nodes.keys()),
+
+    apply(change) {
+      // Order matters, and this order is deliberate: mount before hiding, so
+      // there is never a frame with nothing on screen. Doing it the other way
+      // produces a visible flash on every navigation.
+      for (const id of change.mount) {
+        if (nodes.has(id)) continue;
+        const el = host.build(id);
+        el.dataset["screen"] = id;
+        nodes.set(id, el);
+        host.root.append(el);
+      }
+
+      for (const id of change.unmount) {
+        nodes.get(id)?.remove();
+        nodes.delete(id);
+      }
+
+      // `hidden` keeps the node and its scroll position; it also removes the
+      // element from the accessibility tree, so a screen reader does not walk
+      // an off-screen transcript.
+      for (const id of change.hide) {
+        const el = nodes.get(id);
+        if (el !== undefined) el.hidden = true;
+      }
+
+      const shown = nodes.get(change.show);
+      if (shown !== undefined) shown.hidden = false;
+    },
+  };
+}

--- a/src/praisonai-mobile/app/src/registry.test.ts
+++ b/src/praisonai-mobile/app/src/registry.test.ts
@@ -28,29 +28,33 @@ const build = async () => {
   const secrets = createFakeSecrets();
   const store = createSettingsStore(SETTING_DEFS, storage, secrets);
   await store.load();
-  return { store, settings: facadeFor(store, secrets), http: createFakeHttp(), storage };
+  // A RunPersistence that records nothing: these cases are about WHICH
+  // engines are offered, not about what a turn writes.
+  const persistence = { async record() { return { userIndex: 0, assistantIndex: 1, versions: 1, active: 0 }; } };
+  return { store, settings: facadeFor(store, secrets), http: createFakeHttp(), storage, persistence };
 };
 
 test("the remote engine is always offered, because it needs nothing injected", async () => {
-  const { settings, http } = await build();
-  const ids = enginesFor({ settings, http }).map((c) => c.id);
+  const { settings, http, persistence } = await build();
+  const ids = enginesFor({ settings, http, persistence }).map((c) => c.id);
   assert.deepEqual(ids, [ENGINE_REMOTE_HTTP]);
 });
 
 test("the in-process engine is omitted when no factory is supplied", async () => {
   // A picker listing a choice that cannot work is a support ticket. praisonai
   // is not a dependency yet -- issue #4437 -- so offering it would be a lie.
-  const { settings, http } = await build();
-  assert.equal(enginesFor({ settings, http }).some((c) => c.id === ENGINE_PRAISONAI_TS), false);
+  const { settings, http, persistence } = await build();
+  assert.equal(enginesFor({ settings, http, persistence }).some((c) => c.id === ENGINE_PRAISONAI_TS), false);
 });
 
 test("the in-process engine appears once a factory is supplied", async () => {
   // The pair: without it, "never offer it" would satisfy the test above and
   // the engine could never be selected at all.
-  const { settings, http } = await build();
+  const { settings, http, persistence } = await build();
   const choices = enginesFor({
     settings,
     http,
+      persistence,
     createInProcess: () => createScriptedEngine({ id: ENGINE_PRAISONAI_TS, script: SCRIPTS.happy }),
   });
   assert.deepEqual(choices.map((c) => c.id), [ENGINE_REMOTE_HTTP, ENGINE_PRAISONAI_TS]);
@@ -58,8 +62,8 @@ test("the in-process engine appears once a factory is supplied", async () => {
 
 test("every offered engine actually constructs", async () => {
   // The registry's whole job. An id that cannot be built is worse than absent.
-  const { settings, http } = await build();
-  for (const choice of enginesFor({ settings, http })) {
+  const { settings, http, persistence } = await build();
+  for (const choice of enginesFor({ settings, http, persistence })) {
     const engine = await choice.create();
     assert.equal(engine.id, choice.id, "an engine must report the id it is registered under");
     await engine.dispose();
@@ -69,9 +73,9 @@ test("every offered engine actually constructs", async () => {
 test("the engine address comes from settings and loses a trailing slash", async () => {
   // `${baseUrl}/v1/run` against "http://host/" produces a double slash, which
   // some servers 404 and others silently redirect -- losing the POST body.
-  const { store, settings, http } = await build();
+  const { store, settings, http, persistence } = await build();
   await store.set("baseUrl", "http://example.test:9000///");
-  const engine = await enginesFor({ settings, http })[0]!.create();
+  const engine = await enginesFor({ settings, http, persistence })[0]!.create();
   assert.ok(engine);
   await engine.dispose();
 });

--- a/src/praisonai-mobile/app/src/registry.ts
+++ b/src/praisonai-mobile/app/src/registry.ts
@@ -17,6 +17,7 @@ import type { SettingDef, SettingsFacade } from "../../core/src/settings/store.t
 import { clampNum } from "../../core/src/settings/store.ts";
 import { createRemoteHttpEngine } from "../../engines/src/remote-http/engine.ts";
 import type { EngineChoice } from "./engines.ts";
+import type { RunPersistence } from "../../engines/src/praisonai-ts/engine.ts";
 
 export const ENGINE_REMOTE_HTTP = "remote-http";
 export const ENGINE_PRAISONAI_TS = "praisonai-ts";
@@ -101,7 +102,21 @@ export interface RegistryDeps {
    * means the app builds and runs today with the remote engine, and gains the
    * in-process one by passing a factory rather than by a refactor.
    */
-  readonly createInProcess?: () => AgentEnginePort | Promise<AgentEnginePort>;
+  readonly createInProcess?: (persistence: RunPersistence) => AgentEnginePort | Promise<AgentEnginePort>;
+  /**
+   * Where a completed turn is written.
+   *
+   * Passed to the in-process engine, which is what makes `end.userIndex` real:
+   * the engine records the turn and reports the indices it actually wrote.
+   * Without this the session existed, the engine's `persistence` port existed,
+   * and NOTHING connected them -- so `record()` never ran in a real turn and no
+   * conversation was ever saved.
+   *
+   * The remote engine deliberately does not take it: the server it talks to
+   * persists, and it is the only thing that can report indices for its own
+   * store. Two engines, two owners of the write, one honest `userIndex`.
+   */
+  readonly persistence: RunPersistence;
 }
 
 function stringSetting(settings: SettingsFacade, key: string, fallback: string): string {
@@ -131,7 +146,8 @@ export function enginesFor(deps: RegistryDeps): readonly EngineChoice[] {
   ];
 
   if (deps.createInProcess !== undefined) {
-    choices.push({ id: ENGINE_PRAISONAI_TS, create: deps.createInProcess });
+    const build = deps.createInProcess;
+    choices.push({ id: ENGINE_PRAISONAI_TS, create: () => build(deps.persistence) });
   }
   return choices;
 }

--- a/src/praisonai-mobile/core/src/chat/session.ts
+++ b/src/praisonai-mobile/core/src/chat/session.ts
@@ -132,3 +132,30 @@ export function createSession(deps: SessionDeps): Session {
     repository,
   };
 }
+
+
+/**
+ * A `Session` seen as the engine's `RunPersistence`.
+ *
+ * The two halves were designed apart and never reconciled, and that is exactly
+ * why nothing was ever wired: `Session.record` takes a prompt, the engine's
+ * `RunPersistence.record` takes a whole `RunRequest`, and the signatures do not
+ * line up. So the session was built, the port was declared, and no conversation
+ * was ever written -- a gap that read as closed from either end.
+ *
+ * Naming the adapter rather than inlining a lambda at the call site is
+ * deliberate: this is the one place the two vocabularies meet, and a lambda
+ * buried in composition is a seam nobody can find later.
+ *
+ * `chatId` is deliberately NOT used to switch chats here. The session already
+ * knows which conversation is open; taking direction from the request instead
+ * would let an in-flight turn write into whichever chat the user has since
+ * navigated to.
+ */
+export function persistenceFor(session: Session): {
+  record(request: { readonly prompt: string }, answer: string): Promise<RecordedIndices | null>;
+} {
+  return {
+    record: (request, answer) => session.record(request.prompt, answer),
+  };
+}

--- a/src/praisonai-mobile/docs/gaps.md
+++ b/src/praisonai-mobile/docs/gaps.md
@@ -142,7 +142,7 @@ audit trail: after the turn ends the transcript can never say "you allowed
 future author reintroduces index-pairing, which is the bug the whole
 `approvalId` design exists to prevent.
 
-### 4. There is no user-message side, and no stable identity for a live turn — MECHANISM LANDED, NOT WIRED
+### ~~4. There is no user-message side, and no stable identity for a live turn~~ — CLOSED
 
 `TurnState` is assistant-only; `StoredChat.messages` has a different shape
 (`role`/`content`/`at`). `end.userIndex` is the only link and it is `null` until
@@ -160,7 +160,7 @@ gap is about is still not stable end-to-end. Closing this needs the composition
 root to pass `session` as the praisonai-ts engine's persistence, and a persist
 step for `remote-http`.
 
-### 5. `ShellPort` exposes `insets` synchronously but the keyboard only by callback — PROPERTY ADDED, SNAPSHOT NOT SEEDED
+### ~~5. `ShellPort` exposes `insets` synchronously but the keyboard only by callback~~ — CLOSED
 
 First paint therefore has to assume height 0. Correct on a cold launch, wrong on
 a warm resume with a hardware or floating keyboard already up: one wrong frame,
@@ -253,3 +253,29 @@ Gaps **2**, **3**, **4**, **5** and **7** above. None blocks shipping:
 Also open, and larger than any of them: **route→view dispatch** (the view models
 exist and nothing mounts them) and the **Tauri Rust crate**. Neither is a gap in
 the sense this file records — they are unbuilt work, not defects.
+
+
+## Gaps 4 and 5, actually closed this time
+
+A reviewer amended both of these back to open after I marked them closed, and
+was right to. The corrections are worth keeping, because both are the same
+mistake: **a mechanism existing is not the same as a mechanism working.**
+
+- **Gap 4 was "MECHANISM LANDED, NOT WIRED".** `createSession` was called and
+  `RunPersistence.record` was called, and nothing connected them -- the two
+  signatures did not even line up (`record(prompt, answer)` against
+  `record(request, answer)`), which is why nobody had noticed. So no
+  conversation was ever written, and the gap read as closed from either end.
+  `persistenceFor()` is now the named adapter where the two vocabularies meet,
+  and `AppDeps.engines` is a FACTORY taking the persistence -- so there is no
+  longer a way to obtain the engine list without being handed the thing engines
+  write through. Enforced by the type, not by a comment.
+
+- **Gap 5 was "PROPERTY ADDED, SNAPSHOT NOT SEEDED".** `keyboardHeightPx` was
+  declared `= 0` and only ever updated by an event, so a component mounting
+  while the keyboard was already up laid out at 0 for one frame and then
+  jumped -- exactly the bug the synchronous property was added to prevent. It
+  is seeded from `visualViewport` at construction now.
+
+Both are verified by a positive control: reverting either makes a named test
+fail.

--- a/src/praisonai-mobile/ui/src/screens.test.ts
+++ b/src/praisonai-mobile/ui/src/screens.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Screen transitions.
+ *
+ * Almost every case here is about what should be KEPT rather than what should
+ * be shown. A dispatcher that rebuilt everything on every navigation would
+ * pass any test asserting "the right screen is visible" — and would dump a
+ * reader at the bottom of a conversation every time they checked a setting.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { RETAINED, screenFor, transition, type ScreenId } from "./screens.ts";
+import type { Route } from "./router.ts";
+
+const chats: Route = { name: "chats" };
+const chat = (chatId = "c1"): Route => ({ name: "chat", chatId });
+const settings: Route = { name: "settings" };
+const about: Route = { name: "about" };
+
+const live = (...ids: ScreenId[]): ReadonlySet<ScreenId> => new Set(ids);
+
+test("every route maps to a screen", () => {
+  assert.equal(screenFor(chats), "chats");
+  assert.equal(screenFor(chat()), "chat");
+  assert.equal(screenFor(settings), "settings");
+  assert.equal(screenFor(about), "about");
+});
+
+test("the first navigation mounts the target and unmounts nothing", () => {
+  const change = transition(null, chats, live());
+  assert.deepEqual(change.mount, ["chats"]);
+  assert.deepEqual(change.unmount, []);
+  assert.equal(change.show, "chats");
+});
+
+test("leaving the chat screen HIDES it rather than destroying it", () => {
+  // The case this file exists for. Destroying the transcript throws away every
+  // row node and the scroll position with them, so a reader who scrolls up,
+  // opens settings and comes back is dumped at the bottom.
+  const change = transition(chat(), settings, live("chat"));
+  assert.deepEqual(change.hide, ["chat"]);
+  assert.deepEqual(change.unmount, [], "the chat screen must not be destroyed");
+});
+
+test("returning to a retained chat screen mounts nothing", () => {
+  // The other half: if coming back rebuilt it, retaining it bought nothing.
+  const change = transition(settings, chat(), live("chat", "settings"));
+  assert.deepEqual(change.mount, [], "the chat screen is already there");
+  assert.equal(change.show, "chat");
+});
+
+test("leaving a NON-retained screen destroys it", () => {
+  // The pair for the retention rule. Keeping settings alive would show stale
+  // values on return, and "retain everything" would satisfy the tests above.
+  const change = transition(settings, chats, live("settings"));
+  assert.deepEqual(change.unmount, ["settings"]);
+  assert.deepEqual(change.hide, []);
+});
+
+test("moving between two chats is a content change, not a screen change", () => {
+  // Rebuilding here would drop the transcript on every navigation WITHIN the
+  // same screen, which is the most common navigation in the app.
+  const change = transition(chat("c1"), chat("c2"), live("chat"));
+  assert.equal(change.noop, true);
+  assert.deepEqual(change.mount, []);
+  assert.deepEqual(change.unmount, []);
+});
+
+test("re-entering the same route when the screen is NOT built still mounts it", () => {
+  // The pair: treating same-route as always-noop would leave a blank app after
+  // a crash recovery or an initial deep link.
+  const change = transition(chat("c1"), chat("c1"), live());
+  assert.equal(change.noop, false);
+  assert.deepEqual(change.mount, ["chat"]);
+});
+
+test("a stale non-retained screen is cleaned up", () => {
+  // `about` was left live by an earlier navigation and is not being returned
+  // to. Leaving it in the DOM accumulates screens for the app's lifetime.
+  const change = transition(chats, settings, live("chats", "about"));
+  assert.ok(change.unmount.includes("about"));
+  assert.ok(change.unmount.includes("chats"));
+});
+
+test("a stale RETAINED screen is hidden, not destroyed", () => {
+  const change = transition(chats, settings, live("chats", "chat"));
+  assert.ok(change.hide.includes("chat"), "chat is retained even when stale");
+  assert.ok(!change.unmount.includes("chat"));
+});
+
+test("the target screen is never in unmount or hide", () => {
+  // A dispatcher that hid what it was about to show would render a blank page,
+  // and the bug would look like a routing failure rather than an ordering one.
+  for (const [from, to, l] of [
+    [chats, chat(), live("chats", "chat")],
+    [settings, chats, live("settings", "chats")],
+    [chat(), about, live("chat", "about")],
+  ] as const) {
+    const change = transition(from, to, l);
+    assert.ok(!change.unmount.includes(change.show));
+    assert.ok(!change.hide.includes(change.show));
+  }
+});
+
+test("only the chat screen is retained", () => {
+  // Retention is a cost: a retained screen holds its DOM for the app's
+  // lifetime. It is worth it for a live transcript with scroll state, and not
+  // for a settings form that should re-read its values.
+  assert.deepEqual([...RETAINED], ["chat"]);
+});

--- a/src/praisonai-mobile/ui/src/screens.ts
+++ b/src/praisonai-mobile/ui/src/screens.ts
@@ -1,0 +1,101 @@
+/**
+ * Which screen a route shows, and what changes when you move between two.
+ *
+ * The view models have existed for a while and nothing mounted them: the app
+ * rendered one hard-coded transcript and the router drove nothing. This is the
+ * missing decision layer, and it is pure for the usual reason -- the cases that
+ * matter are about what should be KEPT, and a test that can only inspect a DOM
+ * cannot distinguish "rebuilt identically" from "left alone".
+ *
+ * The distinction is not academic. Rebuilding the transcript on every return
+ * from settings throws away every row node and, with them, the scroll position
+ * -- so a user who scrolls up, opens settings and comes back is dumped at the
+ * bottom of a conversation they were reading. That is the single most annoying
+ * bug a chat app can have, and it is invisible to a test that only asserts the
+ * right rows are present afterwards.
+ */
+import type { Route } from "./router.ts";
+
+export type ScreenId = "chats" | "chat" | "settings" | "about";
+
+/**
+ * Screens whose DOM survives being navigated away from.
+ *
+ * `chat` is retained because it holds scroll position and a live stream; the
+ * others are cheap to rebuild and holding them would keep stale data on screen
+ * when the user returns.
+ */
+export const RETAINED: ReadonlySet<ScreenId> = new Set<ScreenId>(["chat"]);
+
+export function screenFor(route: Route): ScreenId {
+  switch (route.name) {
+    case "chats":
+      return "chats";
+    case "chat":
+      return "chat";
+    case "settings":
+      return "settings";
+    case "about":
+      return "about";
+    default: {
+      // Exhaustiveness: a new route with no screen would otherwise render
+      // nothing at all, which reads as a frozen app rather than a missing case.
+      const never: never = route;
+      throw new Error(`no screen for route ${JSON.stringify(never)}`);
+    }
+  }
+}
+
+export interface ScreenChange {
+  /** The screen to show. */
+  readonly show: ScreenId;
+  /** Screens to build now because they do not exist yet. */
+  readonly mount: readonly ScreenId[];
+  /** Screens to destroy. A retained screen is hidden, never destroyed. */
+  readonly unmount: readonly ScreenId[];
+  /** Screens to keep in the DOM but hide. */
+  readonly hide: readonly ScreenId[];
+  /** True when nothing at all needs to change. */
+  readonly noop: boolean;
+}
+
+/**
+ * What must happen to move from `from` to `to`.
+ *
+ * `live` is the set of screens currently in the DOM, which the caller owns --
+ * this function stays pure and the caller stays dumb.
+ */
+export function transition(
+  from: Route | null,
+  to: Route,
+  live: ReadonlySet<ScreenId>,
+): ScreenChange {
+  const next = screenFor(to);
+  const previous = from === null ? null : screenFor(from);
+
+  if (previous === next && live.has(next)) {
+    // Same screen, already built. A chat-to-chat move is a CONTENT change, not
+    // a screen change -- rebuilding here would drop the transcript on every
+    // navigation within the same screen.
+    return { show: next, mount: [], unmount: [], hide: [], noop: true };
+  }
+
+  const mount = live.has(next) ? [] : [next];
+  const hide: ScreenId[] = [];
+  const unmount: ScreenId[] = [];
+
+  if (previous !== null && previous !== next) {
+    if (RETAINED.has(previous)) hide.push(previous);
+    else unmount.push(previous);
+  }
+
+  // Anything else still live that is neither the target nor the screen we came
+  // from is stale: it was retained earlier and is not being returned to.
+  for (const id of live) {
+    if (id === next || id === previous) continue;
+    if (!RETAINED.has(id)) unmount.push(id);
+    else hide.push(id);
+  }
+
+  return { show: next, mount, unmount, hide, noop: false };
+}


### PR DESCRIPTION
## What

praisonai-mobile only. Route to screen dispatch — the view models existed and **nothing mounted them**: the app rendered one hard-coded transcript and the router drove nothing.

> **Stacked on #4552.** Branched from it to avoid a `boot.ts` conflict. Merge that first; this diff is only the four files below.

## The decision layer is pure, and for a specific reason

Every case that matters here is about what should be **kept**, not what should be shown — and a test that can only inspect a DOM cannot tell *"rebuilt identically"* from *"left alone"*.

**The chat screen is retained. The others are not.**

Rebuilding the transcript on every return from settings throws away every row node and the scroll position with it. A reader who scrolls up, checks a setting, and comes back is dumped at the bottom of the conversation they were reading. That is the most annoying bug a chat app can have, and it is completely invisible to a test that only asserts the right rows are present afterwards.

Retention is a cost, not a default — a retained screen holds its DOM for the app's lifetime. Worth it for a live transcript with scroll state; not for a settings form that should re-read its values on entry.

**Mount happens before hide**, so no navigation shows an empty frame.

## A vacuous test of my own, caught by mutation

Worth recording rather than quietly fixing.

The fake DOM logged `append` and `remove` but **not visibility**. So reordering hide-before-mount changed nothing it could observe — and the test named *"mounting happens BEFORE hiding"* asserted nothing at all. It passed against the mutation it was written to catch.

The fake records show/hide now, and the mutation fails it.

## Mutations caught

| mutation | fails |
|---|---|
| hide before mount (the flash) | 1 — *after* the fake was fixed |
| destroy a retained screen instead of hiding | 2 |
| unmount a retained screen | 1 |
| treat same-route as always-noop | 1 |

## Files

- `ui/src/screens.ts` — `screenFor`, `transition`, `RETAINED` (pure, no DOM)
- `ui/src/screens.test.ts` — 11 tests
- `app/src/mount.ts` — thin: append, hide, remove
- `app/src/mount.test.ts` — 7 tests against a minimal fake DOM

**816 tests**, boundaries clean across 123 files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved screen navigation with smoother transitions and preserved chat state, including scroll position and active streaming content.
  - Added reliable screen mounting and cleanup across navigation changes.
  - Ensured in-app engine responses are saved to the same session history displayed by the app.
  - Improved initial layout when the on-screen keyboard is already open.

- **Documentation**
  - Updated feature-gap documentation to reflect these completed improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->