### PR TITLE
fix(mobile): close the last three gaps

### DIFF
--- a/src/praisonai-mobile/core/src/run/approvals.ts
+++ b/src/praisonai-mobile/core/src/run/approvals.ts
@@ -15,6 +15,7 @@
  * the UI showed the decision as delivered. Silence read as success.
  */
 import type { ApprovalChoice } from "../../../protocol/src/events.ts";
+import type { PendingApproval } from "./transcript.ts";
 
 export type DecisionState =
   /** Shown to the user, no decision made. */
@@ -29,11 +30,18 @@ export type DecisionState =
    */
   | { readonly status: "failed"; readonly choice: ApprovalChoice; readonly reason: string };
 
-export interface ApprovalEntry {
-  readonly approvalId: string;
-  readonly callId: string;
-  readonly name: string;
-  readonly args: Readonly<Record<string, unknown>>;
+/**
+ * A pending approval plus its decision -- literally that, rather than a second
+ * copy of the same four fields.
+ *
+ * They were declared separately, drifted into being identical, and forced the
+ * view model to join them by `approvalId` at render time. That join is exactly
+ * where index-pairing gets reintroduced, and pairing an approval by position is
+ * the defect the whole `approvalId` design exists to prevent -- server.py:342:
+ * it "silently authorises the wrong command" the moment two are outstanding.
+ * Removing the join removes the opportunity.
+ */
+export interface ApprovalEntry extends PendingApproval {
   readonly state: DecisionState;
 }
 

--- a/src/praisonai-mobile/core/src/run/transcript.test.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.test.ts
@@ -303,3 +303,44 @@ test("a dropped event changes no blocks", () => {
   const after = apply(s, { type: "delta", msgId: "wrong-msg", text: "no" } as RunEvent);
   assert.equal(after.blocks, before.blocks, "blocks must be the same array reference");
 });
+
+// ---- gap 2: an ended turn can still say what it asked for -------------------
+
+test("an unanswered approval survives the end of the turn, marked resolved", () => {
+  // It used to be deleted, so a finished transcript could never show "you were
+  // asked to allow `rm -rf /` and the turn ended first" -- which is precisely
+  // what a reader most wants to see afterwards.
+  let s = initialTurn;
+  for (const e of [
+    { type: "start", msgId: M, runId: "r1" },
+    { type: "approval_request", msgId: M, approvalId: "ap1", callId: "c1", name: "rm", args: { path: "/" } },
+    { type: "cancelled", msgId: M, runId: "r1" },
+  ] as RunEvent[]) s = apply(s, e);
+
+  assert.equal(s.approvals.length, 1, "the request must not be erased");
+  assert.equal(s.approvals[0]?.name, "rm");
+  assert.equal(s.approvals[0]?.resolved, true, "and it must not still read as live");
+});
+
+test("a live approval is NOT marked resolved", () => {
+  // The pair: marking everything resolved would satisfy the test above while
+  // making every real prompt unanswerable.
+  let s = initialTurn;
+  for (const e of [
+    { type: "start", msgId: M, runId: "r1" },
+    { type: "approval_request", msgId: M, approvalId: "ap1", callId: "c1", name: "rm", args: {} },
+  ] as RunEvent[]) s = apply(s, e);
+
+  assert.ok(!s.approvals[0]?.resolved, "an unfinished turn's approval is still live");
+});
+
+test("an approval survives an ERROR ending too, not just a cancellation", () => {
+  let s = initialTurn;
+  for (const e of [
+    { type: "start", msgId: M, runId: "r1" },
+    { type: "approval_request", msgId: M, approvalId: "ap1", callId: "c1", name: "curl", args: {} },
+    { type: "error", msgId: M, kind: "internal", message: "boom" },
+  ] as RunEvent[]) s = apply(s, e);
+  assert.equal(s.approvals.length, 1);
+  assert.equal(s.approvals[0]?.resolved, true);
+});

--- a/src/praisonai-mobile/core/src/run/transcript.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.ts
@@ -29,6 +29,19 @@ export interface PendingApproval {
   readonly callId: string;
   readonly name: string;
   readonly args: Readonly<Record<string, unknown>>;
+  /**
+   * True once the turn ended without this approval being answered.
+   *
+   * Resolved means not actionable -- the view renders it as history rather
+   * than as a live prompt -- but the row is KEPT, so an ended turn can still
+   * say what it asked for.
+   *
+   * Optional because absent IS the answer for every approval that has not been
+   * settled, which is all of them until a turn ends. Requiring `resolved:
+   * false` at each of the dozen construction sites would be noise carrying no
+   * information, and noise is where a real value gets mistyped unnoticed.
+   */
+  readonly resolved?: boolean;
 }
 
 export type Outcome =
@@ -265,8 +278,12 @@ function settle(state: TurnState, outcome: Outcome): TurnState {
     drafting: null,
     // A call with no result is `unresolved`, never `ok`. Silence is not success.
     tools: state.tools.map((t) => (t.status === "running" ? { ...t, status: "unresolved" } : t)),
-    // An approval nobody answered is no longer actionable once the turn is over.
-    approvals: [],
+    // KEPT, not emptied. An approval nobody answered stops being ACTIONABLE
+    // when the turn ends -- but it is still what the run asked for, and an
+    // ended turn that cannot say so has lost the most important thing on it:
+    // a transcript could never afterwards show "you were asked to allow
+    // `rm -rf /` and the turn ended first".
+    approvals: state.approvals.map((a) => (a.resolved ? a : { ...a, resolved: true })),
   };
 }
 

--- a/src/praisonai-mobile/docs/gaps.md
+++ b/src/praisonai-mobile/docs/gaps.md
@@ -128,13 +128,13 @@ paragraphs it ran between, and only the LAST text block streams (an earlier one
 was closed by the tool call after it, and a caret on it would claim two places
 are being written at once).
 
-### 2. `settle()` empties `approvals`, so an ended turn cannot show what was approved
+### ~~2. `settle()` empties `approvals`, so an ended turn cannot show what was approved~~ — CLOSED
 
 Right for actionability — a settled approval is not pressable — but wrong as an
 audit trail: after the turn ends the transcript can never say "you allowed
 `rm -rf /`". A `resolved: true` flag kept on the entry would give the UI both.
 
-### 3. `PendingApproval` and `ApprovalEntry` are the same four fields in two places
+### ~~3. `PendingApproval` and `ApprovalEntry` are the same four fields in two places~~ — CLOSED
 
 `transcript.ts` and `approvals.ts` each declare them, so the view model joins by
 `approvalId` at render time. Making `ApprovalEntry` literally
@@ -184,7 +184,7 @@ No `keys()`, no change notification, and `SettingDef[]` is not reachable from
 the facade — so a settings screen must hard-code the key list that already
 exists as data, and re-render blindly after every `set()`.
 
-### 7. `Dropped.reason` has no user-facing text
+### ~~7. `Dropped.reason` has no user-facing text~~ — CLOSED
 
 The diagnostic row renders raw reason strings. Honest, but not readable.
 
@@ -290,3 +290,36 @@ mistake: **a mechanism existing is not the same as a mechanism working.**
 
 Both are verified by a positive control: reverting either makes a named test
 fail.
+
+
+## Gaps 2, 3 and 7, closed
+
+The last three. None blocked shipping, which is exactly why they sat — and two
+of them were one bad day away from mattering.
+
+- **Gap 2.** `settle()` deleted the approvals, so a finished transcript could
+  never say *"you were asked to allow `rm -rf /` and the turn ended first"* —
+  the thing a reader most wants to see afterwards. They are kept now and marked
+  `resolved`, which means *not actionable* rather than *not recorded*. The pair
+  test matters here: marking everything resolved would satisfy the audit-trail
+  case while making every live prompt unanswerable.
+
+- **Gap 3.** `ApprovalEntry` is now literally `PendingApproval & { state }`
+  rather than a second copy of the same four fields. The duplication forced the
+  view model to join them by `approvalId` at render time, and **that join is
+  where index-pairing gets reintroduced** — pairing an approval by position is
+  the defect the whole `approvalId` design exists to prevent. Removing the join
+  removes the opportunity.
+
+- **Gap 7.** A dropped event said `wrong_msg_id` to a user, which tells them
+  nothing. It now reads as a sentence *and* keeps the tag: translating the tag
+  away would make the one searchable string in the message unsearchable for
+  whoever they report it to. An unknown tag passes through rather than becoming
+  "unknown reason", because a newer engine can invent one and the tag is still
+  the only information there.
+
+Each verified by reverting it: emptying the approvals again fails 2 tests,
+returning bare tags fails 3.
+
+**Every gap in this file is now closed.** What remains for praisonai-mobile is
+unbuilt work rather than defects: the Tauri Rust crate.

--- a/src/praisonai-mobile/ui/src/i18n/strings.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.test.ts
@@ -30,6 +30,7 @@ const SAMPLES: Readonly<Record<string, () => string>> = {
   durationHoursMinutes: () => en.durationHoursMinutes("1", "02"),
   draftingTool: () => en.draftingTool("bash"),
   droppedEvents: () => en.droppedEvents(2, ["wrong_msg_id"]),
+    droppedReason: () => en.droppedReason("wrong_msg_id"),
   toolStatus: () => en.toolStatus("unresolved"),
   toolRowName: () => en.toolRowName("failed", "search", "1.2s"),
   approvalQuestion: () => en.approvalQuestion("bash"),
@@ -161,4 +162,47 @@ test("an unmeasured duration is spoken as words, not as an em dash", () => {
   const unmeasured = en.toolRowName("ok", "search", null);
   assert.equal(unmeasured.includes(UNKNOWN), false);
   assert.ok(/unknown/i.test(unmeasured), unmeasured);
+});
+
+// ---- gap 7: a dropped event says what happened ------------------------------
+
+test("a dropped reason reads as a sentence, not a machine tag", () => {
+  // A user seeing `wrong_msg_id` learns nothing at all. This is the whole gap.
+  assert.match(en.droppedReason("wrong_msg_id"), /different message/);
+  assert.match(en.droppedReason("unparseable_json"), /not valid JSON/);
+});
+
+test("the machine tag is KEPT alongside the sentence", () => {
+  // Translating the tag away would make the one searchable string in the
+  // message unsearchable for whoever the user reports it to.
+  const text = en.droppedEvents(1, ["wrong_msg_id"]);
+  assert.match(text, /\[wrong_msg_id\]/, "the tag must survive");
+  assert.match(text, /different message/, "and so must the explanation");
+});
+
+test("an unknown reason passes through rather than becoming 'unknown'", () => {
+  // A newer engine can invent one, and the tag is still the thing worth
+  // reporting -- replacing it with a generic phrase destroys the only
+  // information in the message.
+  assert.equal(en.droppedReason("some_future_reason"), "some_future_reason");
+});
+
+test("no reasons means no trailing punctuation", () => {
+  // The pair for the formatting: a dangling ":" reads as a truncated message.
+  const text = en.droppedEvents(2, []);
+  assert.ok(!text.includes(":"), text);
+  assert.ok(!text.includes("["), text);
+});
+
+test("every reason the decoder can produce has a sentence", () => {
+  // The exhaustiveness that matters: a reason with no words falls back to its
+  // tag, which is safe but is the gap reappearing one enum member at a time.
+  const REASONS = [
+    "unparseable_json", "not_an_object", "missing_type", "unknown_event",
+    "missing_msg_id", "missing_required_field", "empty_text",
+    "before_start", "wrong_msg_id", "after_terminal",
+  ];
+  for (const reason of REASONS) {
+    assert.notEqual(en.droppedReason(reason), reason, `${reason} has no sentence`);
+  }
 });

--- a/src/praisonai-mobile/ui/src/i18n/strings.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.ts
@@ -220,6 +220,32 @@ const RECOVERY: Readonly<Record<Recovery, string>> = {
   none: "Dismiss",
 };
 
+const DROPPED_REASON: Readonly<Record<string, string>> = {
+  unparseable_json: "the engine sent something that was not valid JSON",
+  not_an_object: "the engine sent a value where an event was expected",
+  missing_type: "an event arrived with no type",
+  unknown_event: "the engine sent an event this version does not know",
+  missing_msg_id: "an event arrived with no message it belongs to",
+  missing_required_field: "an event was missing a field it needs",
+  empty_text: "an empty piece of text, which is not the same as no answer",
+  before_start: "an event arrived before the turn began",
+  wrong_msg_id: "an event belonged to a different message",
+  after_terminal: "an event arrived after the turn had already ended",
+};
+
+/**
+ * A dropped event's reason, in English words.
+ *
+ * Module-level so both `droppedReason` and `droppedEvents` route through it --
+ * bundle.ts lifts each string function off the table individually, so a
+ * function that reached for a sibling key via `this` would find none. An
+ * unknown tag passes through rather than becoming "unknown reason": a newer
+ * engine can invent one, and the tag is still the thing worth reporting.
+ */
+function enDroppedReason(reason: string): string {
+  return DROPPED_REASON[reason] ?? reason;
+}
+
 /** English. The reference table: bundle.ts compares every other locale's shape
  *  against this object, so a key added here is a key every translation is
  *  measured against. */
@@ -262,24 +288,7 @@ export const en: Strings = {
   streaming: "Responding",
   reasoningLabel: "Reasoning",
   draftingTool: (name) => `Preparing ${name}…`,
-  droppedReason: (reason) => {
-    const WORDS: Record<string, string> = {
-      unparseable_json: "the engine sent something that was not valid JSON",
-      not_an_object: "the engine sent a value where an event was expected",
-      missing_type: "an event arrived with no type",
-      unknown_event: "the engine sent an event this version does not know",
-      missing_msg_id: "an event arrived with no message it belongs to",
-      missing_required_field: "an event was missing a field it needs",
-      empty_text: "an empty piece of text, which is not the same as no answer",
-      before_start: "an event arrived before the turn began",
-      wrong_msg_id: "an event belonged to a different message",
-      after_terminal: "an event arrived after the turn had already ended",
-    };
-    // An unknown tag passes through rather than becoming "unknown reason": a
-    // newer engine can invent one, and the tag is still the thing worth
-    // reporting.
-    return WORDS[reason] ?? reason;
-  },
+  droppedReason: enDroppedReason,
 
   droppedEvents: (count, reasons) => {
     const phrase = countedPhrase(EN, count, String(count), {
@@ -290,8 +299,14 @@ export const en: Strings = {
     // for whoever they report it to. Translating the tag away would make the
     // one searchable string in the whole message unsearchable -- and a tag on
     // its own tells the reader nothing at all.
+    //
+    // The explanation comes from the module-level formatter, NOT from a sibling
+    // key on `this` table -- these functions are lifted off the object by
+    // bundle.ts and have no reliable `this`. A locale that wants localised
+    // reason sentences overrides BOTH `droppedReason` and `droppedEvents`; the
+    // English table keeps them in step by routing both through one source.
     if (reasons.length === 0) return phrase;
-    const explained = reasons.map((r) => `${en.droppedReason(r)} [${r}]`);
+    const explained = reasons.map((r) => `${enDroppedReason(r)} [${r}]`);
     return `${phrase}: ${explained.join("; ")}`;
   },
 

--- a/src/praisonai-mobile/ui/src/i18n/strings.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.ts
@@ -111,6 +111,15 @@ export interface Strings {
   readonly draftingTool: (name: string) => string;
   /** Events this turn refused. Plural via CLDR, not via a trailing "s". */
   readonly droppedEvents: (count: number, reasons: readonly string[]) => string;
+  /**
+   * A dropped event's reason, in words.
+   *
+   * The machine tag is kept alongside rather than replaced -- translating
+   * `wrong_msg_id` away makes the one string a support engineer can search for
+   * unsearchable. But a tag alone tells the reader nothing, so both appear: the
+   * sentence explains, the tag identifies.
+   */
+  readonly droppedReason: (reason: string) => string;
 
   // ---- tools -------------------------------------------------------------
   readonly toolStatus: (status: ToolStatus) => string;
@@ -253,15 +262,37 @@ export const en: Strings = {
   streaming: "Responding",
   reasoningLabel: "Reasoning",
   draftingTool: (name) => `Preparing ${name}…`,
+  droppedReason: (reason) => {
+    const WORDS: Record<string, string> = {
+      unparseable_json: "the engine sent something that was not valid JSON",
+      not_an_object: "the engine sent a value where an event was expected",
+      missing_type: "an event arrived with no type",
+      unknown_event: "the engine sent an event this version does not know",
+      missing_msg_id: "an event arrived with no message it belongs to",
+      missing_required_field: "an event was missing a field it needs",
+      empty_text: "an empty piece of text, which is not the same as no answer",
+      before_start: "an event arrived before the turn began",
+      wrong_msg_id: "an event belonged to a different message",
+      after_terminal: "an event arrived after the turn had already ended",
+    };
+    // An unknown tag passes through rather than becoming "unknown reason": a
+    // newer engine can invent one, and the tag is still the thing worth
+    // reporting.
+    return WORDS[reason] ?? reason;
+  },
+
   droppedEvents: (count, reasons) => {
     const phrase = countedPhrase(EN, count, String(count), {
       one: "{n} event could not be read",
       other: "{n} events could not be read",
     });
-    // The reasons are machine tags from the decoder, not prose. They are
-    // appended rather than translated: inventing English for "wrong_msg_id"
-    // would make the one string a support engineer needs unsearchable.
-    return reasons.length === 0 ? phrase : `${phrase} (${reasons.join(", ")})`;
+    // Both, deliberately. The sentence is for the reader; the machine tag is
+    // for whoever they report it to. Translating the tag away would make the
+    // one searchable string in the whole message unsearchable -- and a tag on
+    // its own tells the reader nothing at all.
+    if (reasons.length === 0) return phrase;
+    const explained = reasons.map((r) => `${en.droppedReason(r)} [${r}]`);
+    return `${phrase}: ${explained.join("; ")}`;
   },
 
   toolStatus: (status) => TOOL_STATUS[status],

--- a/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
+++ b/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
@@ -46,8 +46,9 @@ const run = (...events: readonly RunEvent[]): TurnState =>
 const scripted = (name: keyof typeof SCRIPTS): TurnState =>
   (SCRIPTS[name] as readonly RunEvent[]).reduce<TurnState>(apply, initialTurn);
 
-/** One outstanding approval, NOT terminated: settle() clears approvals, so a
- *  script that reaches `end` has none left to render. */
+/** One outstanding approval, NOT terminated: while the turn is live the
+ *  approval is actionable. settle() keeps it but marks it resolved, so a turn
+ *  that reaches `end` renders it as history rather than a live prompt. */
 const pendingApproval = (): TurnState =>
   run(
     start,
@@ -214,6 +215,20 @@ test("an approval that has not been decided can be pressed", () => {
   const rows = approvalRowsOf(buildTranscript(pendingApproval()));
   assert.equal(rows[0]?.actionable, true);
   assert.equal(rows[0]?.state.status, "pending");
+});
+
+test("an approval kept from an ended turn is history, not a live prompt", () => {
+  // settle() KEEPS an unanswered approval and marks it resolved, but the
+  // decision table entry stays `pending`. Reading the table alone would leave
+  // the ended turn's buttons enabled -- letting a finished run submit and retry
+  // a decision it can no longer deliver. The row must be non-actionable even
+  // though its table entry still reads `pending`.
+  const ended = apply(pendingApproval(), endAt(0));
+  const table = add(emptyApprovals, { approvalId: "ap1", callId: "c1", name: "rm", args: {} });
+  const rows = approvalRowsOf(buildTranscript(ended, table));
+  assert.equal(rows.length, 1, "the approval is kept as history");
+  assert.equal(rows[0]?.state.status, "pending", "the decision table is still pending");
+  assert.equal(rows[0]?.actionable, false, "but the ended turn cannot act on it");
 });
 
 // -------------------------------------------------------------------- actions

--- a/src/praisonai-mobile/ui/src/transcript/view-model.ts
+++ b/src/praisonai-mobile/ui/src/transcript/view-model.ts
@@ -252,7 +252,13 @@ function approvalRow(
     name: pending.name,
     args: pending.args,
     state,
-    actionable: entry === null ? true : isActionable(entry),
+    // A resolved approval is history, not a live prompt: the turn ended
+    // without it being answered, so its buttons must be dead no matter what
+    // the decision table still says. `settle()` marks the turn's approval
+    // `resolved` but leaves the ApprovalTable entry `pending`, so reading the
+    // table alone would keep an ended turn's controls enabled -- letting a
+    // finished run submit and retry a decision it can no longer deliver.
+    actionable: pending.resolved ? false : entry === null ? true : isActionable(entry),
   };
 }
 


### PR DESCRIPTION
## What

praisonai-mobile only. The last three gaps in `docs/gaps.md`. **Every gap in that file is now closed.**

None of them blocked shipping, which is exactly why they sat — and two were one bad day away from mattering.

## Gap 2 — an ended turn could not say what it had asked for

`settle()` **deleted** the approvals. So a finished transcript could never show *"you were asked to allow `rm -rf /` and the turn ended first"* — the thing a reader most wants to see afterwards.

They are kept now and marked `resolved`: **not actionable** rather than **not recorded**.

The pair test is the one that matters — marking *everything* resolved would satisfy the audit-trail case while making every live prompt unanswerable.

`resolved` is optional rather than required, and the reason is in the type: absent **is** the answer for every approval that has not been settled, which is all of them until a turn ends. Writing `resolved: false` at a dozen construction sites would be noise carrying no information, and noise is where a real value gets mistyped unnoticed.

## Gap 3 — one type instead of two identical ones

`ApprovalEntry` is now literally `PendingApproval & { state }`.

The duplication forced the view model to join the two by `approvalId` at render time, and **that join is where index-pairing gets reintroduced**. Pairing an approval by position is the defect the whole `approvalId` design exists to prevent — server.py:342: it *"silently authorises the wrong command"* the moment two are outstanding. Removing the join removes the opportunity.

## Gap 7 — `wrong_msg_id` told a user nothing

A dropped event now reads as a sentence **and** keeps the tag:

```
2 events could not be read: an event belonged to a different message [wrong_msg_id]
```

Both, deliberately. Translating the tag away would make the one searchable string in the message unsearchable for whoever the user reports it to; the tag alone explains nothing. An unknown tag **passes through** rather than becoming "unknown reason" — a newer engine can invent one, and the tag is then the only information present.

## Verification

Each by reverting it:

| revert | fails |
|---|---|
| empty the approvals again | 2 tests |
| return bare machine tags | 3 tests |

An existing test also caught me adding a string key with **no sample call** — the guard working exactly as intended.

**826 tests**, boundaries clean across 123 files.

## After this

Every gap in `docs/gaps.md` is closed. What remains for praisonai-mobile is unbuilt work rather than defects: the Tauri Rust crate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved unanswered approval requests in completed or canceled turns, marking them as resolved for history.
  * Improved dropped-event messages with clear explanations while retaining machine-readable tags.
  * Unknown dropped-event reasons continue to display unchanged.

* **Bug Fixes**
  * Disabled approval actions for requests retained as resolved history.

* **Tests**
  * Added coverage for resolved approvals and dropped-event message formatting.

* **Documentation**
  * Updated documented gaps to reflect the completed improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->