### PR TITLE
fix(mobile): the Tauri crate does not build on main, and no CI job would say so

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -114,6 +114,11 @@ jobs:
         working-directory: src/praisonai-mobile/src-tauri
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.18'
+          cache: npm
+          cache-dependency-path: src/praisonai-mobile/package-lock.json
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -127,6 +132,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev librsvg2-dev libxdo-dev libssl-dev patchelf
+      # generate_context! expands frontendDist (../dist) at COMPILE time, and
+      # dist/ is gitignored -- absent on a fresh checkout. Without this the
+      # crate cannot compile and neither test nor clippy below ever runs.
+      - name: Build the webview (creates ../dist for generate_context!)
+        working-directory: src/praisonai-mobile
+        run: |
+          npm ci
+          npm run build
       # The pure-logic tests: back-gesture arbitration, the lifecycle mapping,
       # and the event-name contract. None of them needs a phone.
       - name: Test

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -95,3 +95,41 @@ jobs:
         # passing quietly -- a check that silently stops covering anything is
         # worse than no check.
         run: npm run check:upstream
+
+  shell:
+    name: rust shell (${{ matrix.os }})
+    # The Rust crate had 14 tests and no job running them -- the same failure
+    # this workflow's header says it was created to prevent, one language over.
+    #
+    # Both platforms, because the crate is cfg-heavy: the back-gesture fallback
+    # is #[cfg(target_os = "android")] / ios / not(mobile), and a cfg mistake
+    # compiles perfectly on whichever host you happened to try.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15]
+    defaults:
+      run:
+        working-directory: src/praisonai-mobile/src-tauri
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/praisonai-mobile/src-tauri
+      - name: Install the Linux build dependencies
+        if: runner.os == 'Linux'
+        working-directory: .
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev librsvg2-dev libxdo-dev libssl-dev patchelf
+      # The pure-logic tests: back-gesture arbitration, the lifecycle mapping,
+      # and the event-name contract. None of them needs a phone.
+      - name: Test
+        run: cargo test
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings

--- a/src/praisonai-mobile/src-tauri/capabilities/default.json
+++ b/src/praisonai-mobile/src-tauri/capabilities/default.json
@@ -1,10 +1,11 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "The main webview must subscribe to the four shell events and answer the back gesture. Without this, Tauri rejects `plugin:event|listen` and the `back_gesture_result` command silently, and the shell contract stops working with no error anywhere.",
-  "windows": ["main"],
+  "description": "The main webview subscribes to the four shell events through Tauri's event registry, which is what plugin:event|listen needs. The back_gesture_result command is NOT listed: an app command registered via invoke_handler is always reachable and has no ACL entry to grant -- naming one that does not exist fails the build, which is how this file was broken.",
+  "windows": [
+    "main"
+  ],
   "permissions": [
-    "core:event:default",
-    "allow-back-gesture-result"
+    "core:event:default"
   ]
 }

--- a/src/praisonai-mobile/src-tauri/gen/schemas/capabilities.json
+++ b/src/praisonai-mobile/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{}
+{"default":{"identifier":"default","description":"The main webview subscribes to the four shell events through Tauri's event registry, which is what plugin:event|listen needs. The back_gesture_result command is NOT listed: an app command registered via invoke_handler is always reachable and has no ACL entry to grant -- naming one that does not exist fails the build, which is how this file was broken.","local":true,"windows":["main"],"permissions":["core:event:default"]}}

--- a/src/praisonai-mobile/src-tauri/src/shell/back.rs
+++ b/src/praisonai-mobile/src-tauri/src/shell/back.rs
@@ -99,3 +99,9 @@ impl Gate {
 /// leave. Too long leaves a dead back button. Measure the real round trip on a
 /// cold device and set this to several times it.
 pub const ANSWER_TIMEOUT_MS: u64 = 400;
+
+/// Lowering this is a mistake with a specific consequence, so it fails the
+/// BUILD rather than a test: too short a timeout falls back while a slow
+/// handler is still deciding, which sends the app to the background for a back
+/// press the user's own UI was about to handle.
+const _: () = assert!(ANSWER_TIMEOUT_MS >= 250);

--- a/src/praisonai-mobile/src-tauri/tests/back_gesture.rs
+++ b/src/praisonai-mobile/src-tauri/tests/back_gesture.rs
@@ -4,7 +4,7 @@
 //! device, and two of them are the kind a user reports as "the back button is
 //! broken" with no way to say more.
 
-use praisonai_mobile_lib::shell::back::{Action, Gate, ANSWER_TIMEOUT_MS};
+use praisonai_mobile_lib::shell::back::{Action, Gate};
 
 #[test]
 fn a_press_asks_the_webview() {
@@ -90,9 +90,6 @@ fn a_stray_answer_with_no_press_is_ignored() {
     assert_eq!(gate.answered(false), Action::Ignore);
 }
 
-#[test]
-fn the_timeout_is_generous_rather_than_tight() {
-    // Too short falls back while a slow handler is still deciding, which exits
-    // an app the user did not ask to leave. That is the worse direction.
-    assert!(ANSWER_TIMEOUT_MS >= 250, "a tight timeout exits the app under load");
-}
+// The timeout floor is asserted at COMPILE time in shell::back -- clippy
+// correctly points out that asserting on a const inside a test proves nothing
+// at runtime, and a build failure is the stronger guard anyway.


### PR DESCRIPTION
## The Tauri crate does not build on `main`

```
error: failed to run custom build command for `praisonai-mobile`
  Permission allow-back-gesture-result not found
```

`capabilities/default.json` names a permission that does not exist. An app command registered through `invoke_handler` is **always reachable** and has no ACL entry to grant — only *plugin* commands do. Naming a non-existent one fails `tauri-build` before anything compiles.

Removed, with the reason recorded in the file's own `description` so it is not re-added by someone reasoning that a command surely needs a permission.

## Nothing would have caught it, and that is the bigger half

`mobile.yml`'s path filter already triggers on `src-tauri/**` changes. **It has no cargo job at all.** So a crate with 14 tests had none of them run, and a crate that does not compile merged green.

That is precisely the failure this workflow's own header says it was created to prevent — one language over:

> *"praisonai-desktop's suite existed and ran nowhere for months because no workflow referenced it, and a package whose tests never run in CI is a package whose tests are decoration."*

The new `shell` job runs `cargo test` and `cargo clippy -- -D warnings` on **ubuntu-22.04 and macos-15**. Both, deliberately: the crate is cfg-heavy — the back-gesture fallback is `#[cfg(target_os = "android")]` / `ios` / `not(mobile)` — and a cfg mistake compiles perfectly on whichever host you happened to try.

## Clippy caught a test of mine that proved nothing

```
error: this assertion has a constant value
```

`assert!(ANSWER_TIMEOUT_MS >= 250)` inside a test is compile-time-known. It passes regardless of anything that happens at runtime.

The floor is a **const assertion in the source** now, which is the stronger guard anyway: lowering the constant stops the crate compiling rather than failing a test someone could skip. Verified by lowering it to 50 — `E0080`, build refused.

Worth stating why the floor exists at all: too short a timeout falls back *while a slow handler is still deciding*, sending the app to the background for a back press the user's own UI was about to handle.

## Verification

| | |
|---|---|
| `cargo check` | clean |
| `cargo test` | 14 passed |
| `cargo clippy -- -D warnings` | clean |
| compile-time floor | verified by violating it |

## How this was found

An adversarial validation pass — three agents told to attack the package's claims of TDD, protocol-driven design, fail-fast and performance rather than confirm them. This came out of checking whether CI actually covered the crate that had just merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile back-gesture handling to prevent premature fallback while the app processes a response.
  * Corrected mobile capability configuration to avoid build failures caused by invalid permission entries.

* **Tests**
  * Added automated cross-platform validation for mobile components on Linux and macOS.
  * Added safeguards to ensure back-gesture response timing remains reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->