### PR TITLE
fix(mobile): a mutation audit of the wiring nobody tested

### DIFF
--- a/src/praisonai-mobile/adapters/src/web/http.test.ts
+++ b/src/praisonai-mobile/adapters/src/web/http.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The web HttpPort.
+ *
+ * It had no test, and a mutation audit found two survivors that matter:
+ * deleting `signal: request.signal` (Stop reaches the engine and never reaches
+ * `fetch`), and flipping `sendsFromNative` to true — the flag this file's own
+ * header calls "load-bearing rather than informational", because it is the
+ * claim that an API key does not enter the webview heap.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createWebHttp } from "./http.ts";
+
+/** A fetch that records exactly what it was handed. */
+function recordingFetch() {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const impl = (async (url: unknown, init: unknown) => {
+    calls.push({ url: String(url), init: (init ?? {}) as RequestInit });
+    return {
+      status: 200,
+      headers: { forEach: (cb: (v: string, k: string) => void) => cb("application/json", "content-type") },
+      body: null,
+    };
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+test("the caller's abort signal is handed to fetch", () => {
+  // Deleting this line survived the whole suite. Stop would reach the engine
+  // and never reach the network: the provider keeps generating, and keeps
+  // billing, after the user pressed the button.
+  const { impl, calls } = recordingFetch();
+  const controller = new AbortController();
+
+  return createWebHttp(impl)
+    .send({ url: "https://x.test", method: "POST", headers: {}, signal: controller.signal })
+    .then(() => {
+      assert.equal(calls[0]?.init.signal, controller.signal, "the signal must reach fetch");
+    });
+});
+
+test("aborting the caller's signal aborts what fetch was given", () => {
+  // Identity alone could be satisfied by a detached signal that never fires.
+  const { impl, calls } = recordingFetch();
+  const controller = new AbortController();
+
+  return createWebHttp(impl)
+    .send({ url: "https://x.test", method: "GET", headers: {}, signal: controller.signal })
+    .then(() => {
+      controller.abort();
+      assert.equal((calls[0]?.init.signal as AbortSignal).aborted, true);
+    });
+});
+
+test("it never claims to send from native", () => {
+  // The composition root refuses to hand a hardware-backed secret to a
+  // non-native transport. A dishonest flag here makes that check decorative
+  // and puts a keychain-held key into the JS heap.
+  assert.equal(createWebHttp(recordingFetch().impl).sendsFromNative, false);
+});
+
+test("a body is passed through, and omitted when absent", () => {
+  // `...(body === undefined ? {} : { body })` -- sending `body: undefined` on
+  // a GET throws in some runtimes rather than being ignored.
+  const { impl, calls } = recordingFetch();
+  const http = createWebHttp(impl);
+
+  return http.send({ url: "https://x.test", method: "POST", headers: {}, body: "hello", signal: new AbortController().signal })
+    .then(() => http.send({ url: "https://x.test", method: "GET", headers: {}, signal: new AbortController().signal }))
+    .then(() => {
+      assert.equal(calls[0]?.init.body, "hello");
+      assert.equal("body" in (calls[1]?.init ?? {}), false, "a GET must carry no body key at all");
+    });
+});
+
+test("the method and headers reach fetch unchanged", () => {
+  const { impl, calls } = recordingFetch();
+  return createWebHttp(impl)
+    .send({ url: "https://x.test/v1", method: "POST", headers: { authorization: "Bearer t" }, signal: new AbortController().signal })
+    .then(() => {
+      assert.equal(calls[0]?.url, "https://x.test/v1");
+      assert.equal(calls[0]?.init.method, "POST");
+      assert.deepEqual(calls[0]?.init.headers, { authorization: "Bearer t" });
+    });
+});
+
+test("response headers are flattened for the caller", () => {
+  const { impl } = recordingFetch();
+  return createWebHttp(impl)
+    .send({ url: "https://x.test", method: "GET", headers: {}, signal: new AbortController().signal })
+    .then((r) => {
+      assert.equal(r.status, 200);
+      assert.equal(r.headers["content-type"], "application/json");
+    });
+});

--- a/src/praisonai-mobile/app/src/boot.test.ts
+++ b/src/praisonai-mobile/app/src/boot.test.ts
@@ -9,7 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createApp, type AppDeps } from "./boot.ts";
+import { chosenStringOr, createApp, type AppDeps } from "./boot.ts";
 import { selectEngine, type EngineChoice } from "./engines.ts";
 import { createFakeStorage } from "../../testing/src/fake-storage.ts";
 import { createFakeSecrets } from "../../testing/src/fake-secrets.ts";
@@ -324,4 +324,80 @@ test("the engine list cannot be built before the session exists", () => {
   };
   factory({ record: async () => null });
   assert.deepEqual(built, ["has-persistence"]);
+});
+
+// ---- settings the user actually set ----------------------------------------
+
+test("the engine factory is handed the REAL settings, not a stub", async () => {
+  // main.ts used to build the engine list with a stub whose `get` returned
+  // undefined for everything, and the engine closed over it at boot. Nothing
+  // rebuilt it -- the comment claiming it was "replaced by the real one
+  // immediately after" was simply false. So the engine address a user set was
+  // loaded from disk at boot and then thrown away in favour of the hardcoded
+  // default, with no error anywhere.
+  const storage = createFakeStorage();
+  await storage.write(
+    { namespace: "settings", id: "app" },
+    JSON.stringify({ baseUrl: "https://my-engine.example.com" }),
+  );
+
+  let seen: string | undefined;
+  const engine = engineWith({ id: "scripted" });
+  const result = await createApp(deps({
+    storage,
+    settingDefs: [...DEFS, { key: "baseUrl", default: "http://127.0.0.1:8765" }],
+    engines: (_persistence, settings) => {
+      seen = settings.get("baseUrl") as string;
+      return [{ id: "scripted", create: () => engine }];
+    },
+  }));
+
+  assert.equal(result.ok, true);
+  assert.equal(seen, "https://my-engine.example.com", "the engine was built with the stub's undefined");
+  if (result.ok) await result.app.dispose();
+});
+
+test("a persisted engineId is preferred over the caller's default", async () => {
+  // `engineId` is a declared setting with a `choices` list, and selecting one
+  // had no effect whatsoever: main.ts passed the literal "remote-http".
+  const storage = createFakeStorage();
+  await storage.write({ namespace: "settings", id: "app" }, JSON.stringify({ engineId: "second" }));
+
+  const first = engineWith({ id: "scripted" });
+  const second = engineWith({ id: "second" });
+  const result = await createApp(deps({
+    storage,
+    settingDefs: [{ key: "engineId", default: "scripted" }],
+    engineId: "scripted", // the caller's default
+    engines: () => [
+      { id: "scripted", create: () => first },
+      { id: "second", create: () => second },
+    ],
+  }));
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.app.engine.id, "second", "the persisted choice must win");
+  await result.app.dispose();
+});
+
+test("a settings DEFAULT never overrides the caller's explicit engineId", async () => {
+  // The pair, and the one that matters. `get()` returns the def's default for
+  // a key nobody ever set, which reads exactly like a deliberate choice --
+  // so reading it without `isSet` lets a default nobody chose outrank the
+  // engine the composition root actually asked for.
+  const result = await createApp(deps({ engineId: "nope" }));
+  assert.equal(result.ok, false, "an unset default must not rescue an unknown id");
+  if (result.ok) return;
+  assert.equal(result.reason, "unknown_engine");
+});
+
+test("chosenStringOr distinguishes a chosen value from a defaulted one", () => {
+  const facade = {
+    get: (k: string) => (k === "a" ? "chosen" : "defaulted"),
+    isSet: (k: string) => k === "a",
+  } as unknown as Parameters<typeof chosenStringOr>[0];
+
+  assert.equal(chosenStringOr(facade, "a", "fallback"), "chosen");
+  assert.equal(chosenStringOr(facade, "b", "fallback"), "fallback", "a default is not a choice");
 });

--- a/src/praisonai-mobile/app/src/boot.test.ts
+++ b/src/praisonai-mobile/app/src/boot.test.ts
@@ -19,6 +19,7 @@ import { createFakeTime } from "../../testing/src/fake-time.ts";
 import { SCRIPTS } from "../../testing/src/scripts.ts";
 import { MIN_ENGINE_PROTOCOL, PROTOCOL_VERSION } from "../../protocol/src/version.ts";
 import type { AgentEnginePort } from "../../core/src/ports/agent-engine.ts";
+import type { RunEvent } from "../../protocol/src/events.ts";
 import type { SettingDef } from "../../core/src/settings/store.ts";
 
 const DEFS: readonly SettingDef[] = [
@@ -147,25 +148,74 @@ test("settings are loaded before the engine is built", async () => {
   if (result.ok) await result.app.dispose();
 });
 
-test("backgrounding stops the run", async () => {
+test("backgrounding stops a run that is actually in flight", async () => {
   // On iOS the app can be killed while suspended with no further callback, so
   // anything still in flight at this moment is simply lost.
+  //
+  // This test used to assert `stopped || true`, which is true for every value
+  // of `stopped` -- and `stopped` was in fact FALSE, because the test never
+  // started a run: `controller.stop()` returns early when nothing is live, so
+  // `cancel` was never reached. Deleting the whole lifecycle subscription from
+  // boot.ts passed. The run must genuinely be in flight for backgrounding to
+  // have anything to stop.
   const shell = createFakeShell();
-  let stopped = false;
+  let cancelled = false;
+  let releaseRun: () => void = () => {};
+  const held = new Promise<void>((resolve) => { releaseRun = resolve; });
+
   const inner = createScriptedEngine({ script: SCRIPTS.happy });
   const engine: AgentEnginePort = {
     ...inner,
     id: "scripted",
-    cancel: async () => { stopped = true; return true; },
+    async *run(req, signal) {
+      yield { type: "start", msgId: "m1", runId: req.runId } as RunEvent;
+      // Hold the turn open so there is a live run to cancel.
+      await held;
+      if (signal.aborted) return;
+      yield { type: "end", msgId: "m1", userIndex: 0, assistantIndex: 1, versions: 1, active: 0 } as RunEvent;
+    },
+    cancel: async () => { cancelled = true; releaseRun(); return true; },
   };
 
   const result = await createApp(deps({ shell, engines: () => [{ id: "scripted", create: () => engine }] }));
   assert.equal(result.ok, true);
   if (!result.ok) return;
 
+  const sent = result.app.controller.send("hello");
+  // Let the run reach its first yield, so a run is genuinely live.
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+
   shell.setLifecycle("background");
-  await Promise.resolve();
-  assert.equal(stopped || true, true); // stop() is called; cancel is its path
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+
+  assert.equal(cancelled, true, "backgrounding must cancel the in-flight run");
+
+  releaseRun();
+  await sent;
+  await result.app.dispose();
+});
+
+test("a lifecycle phase that is not background does not stop the run", async () => {
+  // The pair. Without it, `if (phase === "background")` widened to `if (true)`
+  // passes -- and every foreground/resume notification would kill the turn the
+  // user is watching.
+  const shell = createFakeShell();
+  let cancelled = false;
+  const inner = createScriptedEngine({ script: SCRIPTS.happy });
+  const engine: AgentEnginePort = {
+    ...inner,
+    id: "scripted",
+    cancel: async () => { cancelled = true; return true; },
+  };
+
+  const result = await createApp(deps({ shell, engines: () => [{ id: "scripted", create: () => engine }] }));
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  shell.setLifecycle("active");
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  assert.equal(cancelled, false, "only backgrounding stops the run");
+
   await result.app.dispose();
 });
 

--- a/src/praisonai-mobile/app/src/boot.ts
+++ b/src/praisonai-mobile/app/src/boot.ts
@@ -44,9 +44,14 @@ export interface AppDeps {
    * factory makes that impossible to express: there is no way to obtain the
    * engine list without being handed the thing engines write through.
    */
-  readonly engines: (persistence: RunPersistence) => readonly EngineChoice[];
+  readonly engines: (
+    persistence: RunPersistence,
+    settings: SettingsFacade,
+  ) => readonly EngineChoice[];
   readonly settingDefs: readonly SettingDef[];
-  /** Which engine to start with, normally read from settings. */
+  /** Which engine to start with when settings name none. The persisted
+   *  `engineId` wins over this -- "normally read from settings" was written
+   *  here from the beginning and nothing read them. */
   readonly engineId: string;
   readonly onPublish: (view: RunView) => void;
   /** Injected so boot is deterministic under test. */
@@ -68,6 +73,28 @@ export interface App {
 export type BootResult =
   | { readonly ok: true; readonly app: App }
   | { readonly ok: false; readonly reason: string; readonly detail: string };
+
+
+/** A string setting, or the fallback when it is absent or not a string.
+ *
+ * Named and exported so a test calls it rather than asserting the expression
+ * appears in the source.
+ */
+export function chosenStringOr(
+  settings: SettingsFacade,
+  key: string,
+  fallback: string,
+): string {
+  // `isSet`, not just `get`. A def's DEFAULT must never outrank the caller's
+  // explicit argument: get() returns the default for a key nobody has ever
+  // touched, which is indistinguishable from a deliberate choice. Reading it
+  // with get() alone made a settings default silently override the engine the
+  // composition root asked for -- caught by an existing boot test, which is
+  // the whole reason that test exists.
+  if (!settings.isSet(key)) return fallback;
+  const value = settings.get(key);
+  return typeof value === "string" && value !== "" ? value : fallback;
+}
 
 export async function createApp(deps: AppDeps): Promise<BootResult> {
   // 1. Settings first: the engine choice and its credentials come from here,
@@ -93,7 +120,24 @@ export async function createApp(deps: AppDeps): Promise<BootResult> {
   //    engine writes THROUGH it. `main.ts` builds the engine list from
   //    `enginesFor({ ..., persistence: session })`, so a turn recorded by the
   //    engine and a chat read by the UI are the same store.
-  const selection = await selectEngine(deps.engineId, deps.engines(persistenceFor(session)));
+  // The facade is built HERE rather than in main.ts, because main.ts has no
+  // settings until this function has loaded them -- which is why it used to
+  // pass a stub whose `get` returned undefined for everything. The engine
+  // closed over that stub at boot and nothing ever rebuilt it, so a user's
+  // engine address, engine choice and credentials were read, stored, and
+  // discarded. The comment on the stub said it was "replaced by the real one
+  // immediately after"; it was not.
+  const settings = facadeFor(settingsStore, deps.secrets);
+
+  // The persisted choice wins over the caller's default. `engineId` is a
+  // declared setting with a `choices` list, and until now selecting one had
+  // no effect whatsoever.
+  const chosenEngineId = chosenStringOr(settings, "engineId", deps.engineId);
+
+  const selection = await selectEngine(
+    chosenEngineId,
+    deps.engines(persistenceFor(session), settings),
+  );
   if (!selection.ok) {
     return { ok: false, reason: selection.reason, detail: selection.detail };
   }
@@ -129,7 +173,7 @@ export async function createApp(deps: AppDeps): Promise<BootResult> {
       engine,
       controller,
       session,
-      settings: facadeFor(settingsStore, deps.secrets),
+      settings,
       router,
       shell: deps.shell,
 

--- a/src/praisonai-mobile/app/src/dom.test.ts
+++ b/src/praisonai-mobile/app/src/dom.test.ts
@@ -17,6 +17,7 @@ import assert from "node:assert/strict";
 
 import { applyOps, emptyNodes } from "./dom.ts";
 import type { Row } from "../../ui/src/transcript/view-model.ts";
+import { UNKNOWN } from "../../ui/src/format.ts";
 
 /** Records how text was set, which is the entire point of these tests. */
 function fakeDoc() {
@@ -134,4 +135,70 @@ test("an approval button carries the approvalId, never the callId", () => {
     assert.equal(b.dataset.approvalId, "ap-1");
     assert.notEqual(b.dataset.approvalId, "call-9");
   }
+});
+
+// ---- the last hop: what actually reaches the element ------------------------
+
+const toolRow = (over: Partial<Row & { kind: "tool" }> = {}): Row => ({
+  kind: "tool",
+  id: "tool:c1",
+  callId: "c1",
+  name: "rm",
+  args: {},
+  status: "failed",
+  tone: "failure",
+  output: "boom",
+  preview: "boom",
+  seconds: null,
+  durationLabel: "—",
+  durationKnown: false,
+  ...over,
+} as Row);
+
+test("a failed tool reaches the element as failed, not as ok", () => {
+  // The `ok`-is-the-only-signal chain is airtight through decode, the reducer
+  // and the view model -- every mutation aimed at those dies. Then dom.ts
+  // writes the attribute the CSS keys off, and hardcoding it to "ok" passed
+  // the whole suite. A failed tool would render with the success styling and
+  // nothing anywhere would fail.
+  const { host, created } = fakeDoc();
+  applyOps(host, emptyNodes(), [
+    { kind: "insert", id: "tool:c1", index: 0, row: toolRow({ status: "failed" }) },
+  ]);
+  const row = created.find((el) => el.dataset.rowId === "tool:c1");
+  assert.ok(row, "the row element was not created");
+  assert.equal(row.dataset.status, "failed");
+});
+
+test("a successful tool reaches the element as ok", () => {
+  // The pair. Without it, hardcoding the attribute to "failed" passes above.
+  const { host, created } = fakeDoc();
+  applyOps(host, emptyNodes(), [
+    { kind: "insert", id: "tool:c1", index: 0, row: toolRow({ status: "ok", tone: "success" }) },
+  ]);
+  assert.equal(created.find((el) => el.dataset.rowId === "tool:c1")?.dataset.status, "ok");
+});
+
+test("an unobserved duration renders as unknown, not as the label", () => {
+  // `seconds: null` means the engine never saw the call begin, which is not
+  // zero. Rendering the label regardless states a duration that was never
+  // measured -- and the invariant is written in a comment two lines above the
+  // code that had nothing checking it.
+  const { host, created } = fakeDoc();
+  applyOps(host, emptyNodes(), [
+    { kind: "insert", id: "tool:c1", index: 0, row: toolRow({ durationKnown: false, durationLabel: "3.2s" }) },
+  ]);
+  const row = created.find((el) => el.dataset.rowId === "tool:c1");
+  const meta = row?.children.find((c: any) => c.className === "tool-meta");
+  assert.equal(meta?._text, UNKNOWN, "an unmeasured duration must not render a number");
+});
+
+test("a measured duration renders its label", () => {
+  const { host, created } = fakeDoc();
+  applyOps(host, emptyNodes(), [
+    { kind: "insert", id: "tool:c1", index: 0, row: toolRow({ durationKnown: true, durationLabel: "3.2s" }) },
+  ]);
+  const row = created.find((el) => el.dataset.rowId === "tool:c1");
+  const meta = row?.children.find((c: any) => c.className === "tool-meta");
+  assert.equal(meta?._text, "3.2s");
 });

--- a/src/praisonai-mobile/app/src/dom.test.ts
+++ b/src/praisonai-mobile/app/src/dom.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The DOM layer, against a fake element.
+ *
+ * This file existed with NO test at all, and a mutation audit found what that
+ * cost: changing `el.textContent = row.text` to `el.innerHTML = row.text` left
+ * all 830 tests passing. Model output, tool results and summarised web pages
+ * all flow through that line, so the file's own header — "makes that
+ * structurally impossible rather than depending on an escaping function nobody
+ * re-reads" — was guaranteed by nothing at all.
+ *
+ * The one thing in the suite that mentioned `applyOps` asserted that the
+ * bundle CONTAINED the symbol. Rename it and that breaks; gut its body and it
+ * passes.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyOps, emptyNodes } from "./dom.ts";
+import type { Row } from "../../ui/src/transcript/view-model.ts";
+
+/** Records how text was set, which is the entire point of these tests. */
+function fakeDoc() {
+  const created: any[] = [];
+  const make = (tag: string): any => {
+    const el: any = {
+      tagName: tag,
+      dataset: {} as Record<string, string>,
+      className: "",
+      hidden: false,
+      disabled: false,
+      children: [] as any[],
+      _text: "",
+      _html: "",
+      get textContent() { return this._text; },
+      set textContent(v: string) { this._text = v; this.children = []; },
+      get innerHTML() { return this._html; },
+      set innerHTML(v: string) { this._html = v; },
+      classList: { toggle() {} },
+      append(...cs: any[]) { this.children.push(...cs); },
+      insertBefore(c: any) { this.children.push(c); },
+      remove() {},
+    };
+    Object.defineProperty(el, "ownerDocument", { get: () => doc, configurable: true });
+    created.push(el);
+    return el;
+  };
+  const doc: any = { createElement: make };
+  const host = make("div");
+  return { host, created };
+}
+
+const textRow = (text: string): Row => ({ kind: "text", id: "t0", text, streaming: false });
+
+test("assistant text is set as TEXT, never as markup", () => {
+  // THE guarantee. A model that summarises a web page returns whatever that
+  // page contained, and a tool result is entirely attacker-shaped in the
+  // ordinary case. innerHTML here executes it in the app's own origin.
+  const { host, created } = fakeDoc();
+  const payload = '<img src=x onerror="alert(1)">';
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: "t0", index: 0, row: textRow(payload) }]);
+
+  const row = created.find((el) => el.dataset.rowId === "t0");
+  assert.ok(row, "the row element was not created");
+  assert.equal(row._text, payload, "the payload must land as text");
+  assert.equal(row._html, "", "innerHTML must never be written");
+});
+
+test("an update also sets text, not markup", () => {
+  // The insert path and the update path are separate call sites; covering only
+  // one leaves the other free to differ.
+  const { host, created } = fakeDoc();
+  const nodes = emptyNodes();
+  applyOps(host, nodes, [{ kind: "insert", id: "t0", index: 0, row: textRow("safe") }]);
+  applyOps(host, nodes, [{ kind: "update", id: "t0", row: textRow("<script>x</script>") }]);
+
+  const row = created.find((el) => el.dataset.rowId === "t0");
+  assert.equal(row._text, "<script>x</script>");
+  assert.equal(row._html, "");
+});
+
+test("a tool result's output is text too", () => {
+  // The most attacker-shaped string in the app: whatever a fetched page or a
+  // shell command produced.
+  const { host, created } = fakeDoc();
+  const row: Row = {
+    kind: "tool", id: "tool:c1", callId: "c1", name: "fetch", status: "ok",
+    args: {}, output: "<b>x</b>", seconds: 1,
+    tone: "neutral", preview: "<b>x</b>", durationLabel: "1s", durationKnown: true,
+  };
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: "tool:c1", index: 0, row }]);
+  for (const el of created) assert.equal(el._html, "", `${el.tagName} got innerHTML`);
+});
+
+test("a settled approval's buttons are disabled", () => {
+  // `b.disabled = !row.actionable` is what stops a double tap sending two
+  // decisions for one approval. Two a11y modules cite this line as the live
+  // behaviour they model -- and modelling it is not executing it.
+  const { host, created } = fakeDoc();
+  const row: Row = {
+    kind: "approval", id: "approval:a1", approvalId: "a1", callId: "c1",
+    name: "rm", args: {}, state: { status: "sending", choice: "allow" }, actionable: false,
+  };
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: "approval:a1", index: 0, row }]);
+
+  const buttons = created.filter((el) => el.tagName === "button");
+  assert.equal(buttons.length, 3, "allow / always / deny");
+  for (const b of buttons) assert.equal(b.disabled, true, "an in-flight decision must not be re-sendable");
+});
+
+test("a live approval's buttons are enabled", () => {
+  // The pair: always-disabled would satisfy the test above and make every
+  // prompt unanswerable.
+  const { host, created } = fakeDoc();
+  const row: Row = {
+    kind: "approval", id: "approval:a1", approvalId: "a1", callId: "c1",
+    name: "rm", args: {}, state: { status: "pending" }, actionable: true,
+  };
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: "approval:a1", index: 0, row }]);
+  for (const b of created.filter((el) => el.tagName === "button")) {
+    assert.equal(b.disabled, false);
+  }
+});
+
+test("an approval button carries the approvalId, never the callId", () => {
+  // The id that goes back on the wire. Sending the callId would answer the
+  // wrong prompt as soon as two are outstanding.
+  const { host, created } = fakeDoc();
+  const row: Row = {
+    kind: "approval", id: "approval:a1", approvalId: "ap-1", callId: "call-9",
+    name: "rm", args: {}, state: { status: "pending" }, actionable: true,
+  };
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: "approval:a1", index: 0, row }]);
+  for (const b of created.filter((el) => el.tagName === "button")) {
+    assert.equal(b.dataset.approvalId, "ap-1");
+    assert.notEqual(b.dataset.approvalId, "call-9");
+  }
+});

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -1,0 +1,30 @@
+/**
+ * The entry point's one decision a test can reach.
+ *
+ * `mount` needs a whole fake SSE transport to drive end to end, so the parts
+ * of it that can be wrong are extracted and called directly instead.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { stopNotice } from "./main.ts";
+import { en } from "../../ui/src/i18n/strings.ts";
+
+test("a stop the engine REFUSED is announced", () => {
+  // Discarding the controller's boolean made a refused Stop indistinguishable
+  // from an accepted one: the button label flips off `turn.phase`, which
+  // settles either way, while the run keeps generating and keeps billing.
+  assert.equal(stopNotice(false, en), en.stopRefused);
+});
+
+test("a stop the engine ACCEPTED says nothing", () => {
+  // The pair. Announcing unconditionally would tell the user every successful
+  // Stop had failed, which is the same defect pointed the other way.
+  assert.equal(stopNotice(true, en), null);
+});
+
+test("the refusal text says the run may still be going", () => {
+  // The point of saying anything at all: the user's next action depends on
+  // whether the work stopped, so "it did not stop" has to be in the sentence.
+  assert.match(en.stopRefused, /still be running/i);
+});

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -45,6 +45,23 @@ function renderFatal(root: HTMLElement, message: string): void {
   root.append(box);
 }
 
+/**
+ * What to announce after a Stop, or null when there is nothing to say.
+ *
+ * Extracted so a test calls it: `mount` needs a whole fake SSE transport to
+ * drive, and the part that can actually be wrong is this decision. The house
+ * rule -- extract the expression rather than assert it appears in the source.
+ *
+ * The controller returns the engine's own answer, and both the scripted engine
+ * and the conformance contract go out of their way to keep that boolean
+ * honest. Discarding it here made a refused Stop look exactly like an accepted
+ * one, because the button label flips off `turn.phase`, which settles either
+ * way -- while the run kept generating and kept billing.
+ */
+export function stopNotice(stopped: boolean, strings: Strings): string | null {
+  return stopped ? null : strings.stopRefused;
+}
+
 export async function mount(deps: MountDeps): Promise<App | null> {
   const strings = deps.strings ?? en;
   const root = deps.root;
@@ -154,8 +171,14 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     shell: platform.shell,
     // The factory receives the session boot just built, so the engine that
     // records a turn and the repository the UI reads are the same store.
-    engines: (persistence) => enginesFor({ settings: facadeStub(), http: platform.http, persistence }),
+    // The REAL settings facade, handed back by createApp once it has loaded
+    // them. This used to be a stub whose `get` returned undefined, captured by
+    // the engine at boot and never replaced -- so the engine address the user
+    // set was read, stored, and thrown away in favour of the hardcoded default.
+    engines: (persistence, settings) => enginesFor({ settings, http: platform.http, persistence }),
     settingDefs: SETTING_DEFS,
+    // The default when settings name none. createApp prefers the persisted
+    // `engineId` over this; passing it as a literal was ignoring the setting.
     engineId: "remote-http",
     onPublish: publish,
     now: deps.now ?? (() => Date.now()),
@@ -202,9 +225,11 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     switch (intent.kind) {
       case "send":
         return submit();
-      case "stop":
-        await app.controller.stop();
+      case "stop": {
+        const notice = stopNotice(await app.controller.stop(), strings);
+        if (notice !== null) assertive.textContent = notice;
         return;
+      }
       case "approve":
         await app.controller.decide(intent.approvalId, intent.choice);
         return;
@@ -243,21 +268,6 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   });
 
   return app;
-}
-
-/** A settings facade before settings exist, used only to build the engine
- *  list at boot. Replaced by the real one immediately after. */
-function facadeStub() {
-  return {
-    get: () => undefined,
-    set: async () => false,
-    defs: () => SETTING_DEFS,
-    subscribe: () => () => {},
-    hasSecret: async () => false,
-    setSecret: async () => {},
-    clearSecret: async () => {},
-    secretsAreHardwareBacked: false,
-  };
 }
 
 // Auto-mount when loaded as a page, never when imported by a test.

--- a/src/praisonai-mobile/app/src/platform.test.ts
+++ b/src/praisonai-mobile/app/src/platform.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Platform detection — the one function that decides which of the two shells
+ * actually ships.
+ *
+ * It had no test. A mutation audit found that making it ALWAYS return the web
+ * shell left the whole suite green: an on-device build would silently fall
+ * back to the browser shell, with no safe-area insets, no OS back gesture and
+ * no lifecycle — and the app would look like it worked.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { detectPlatform } from "./platform.ts";
+import { createFakeWindow } from "../../adapters/src/web/fake-window.ts";
+
+const view = () => createFakeWindow().window;
+
+test("a native host gets the Tauri shell", () => {
+  // The whole point of the file. Falling back here loses every capability the
+  // native shell exists to provide, and nothing errors.
+  const p = detectPlatform({ isNative: () => true, view: view() });
+  assert.equal(p.kind, "tauri");
+  assert.equal(p.shell.kind, "tauri");
+});
+
+test("a browser gets the web shell", () => {
+  // The pair. Always returning Tauri would be just as wrong in the other
+  // direction, and would fail on a host with no __TAURI_INTERNALS__ at all.
+  const p = detectPlatform({ isNative: () => false, view: view() });
+  assert.equal(p.kind, "web");
+  assert.equal(p.shell.kind, "web");
+});
+
+test("`kind` and the shell it built never disagree", () => {
+  // `kind` is what the About screen and the not-hardware-backed warning read.
+  // A kind that says "tauri" over a web shell reports a safety the platform is
+  // not providing.
+  for (const native of [true, false]) {
+    const p = detectPlatform({ isNative: () => native, view: view() });
+    assert.equal(p.kind, p.shell.kind, `kind ${p.kind} but shell ${p.shell.kind}`);
+  }
+});
+
+test("every port is present, whichever platform was chosen", () => {
+  // A missing port is a boot-time crash on a device and nothing here.
+  for (const native of [true, false]) {
+    const p = detectPlatform({ isNative: () => native, view: view() });
+    for (const key of ["shell", "storage", "secrets", "http", "time"] as const) {
+      assert.ok(p[key] !== undefined && p[key] !== null, `${key} missing on ${p.kind}`);
+    }
+  }
+});
+
+test("the probe is synchronous", () => {
+  // `ShellPort.insets` must be readable during the first paint, so the
+  // decision cannot be a promise -- an async answer makes the first frame
+  // guess, paint wrong, and jump.
+  const p = detectPlatform({ isNative: () => true, view: view() });
+  assert.equal(typeof (p as unknown as { then?: unknown }).then, "undefined");
+  assert.equal(typeof p.shell.insets, "object", "insets must be readable immediately");
+});

--- a/src/praisonai-mobile/core/src/chat/session.test.ts
+++ b/src/praisonai-mobile/core/src/chat/session.test.ts
@@ -9,7 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createSession, titleFrom } from "./session.ts";
+import { createSession, persistenceFor, titleFrom } from "./session.ts";
 import { createFakeStorage } from "../../../testing/src/fake-storage.ts";
 
 const build = (over: Partial<Parameters<typeof createSession>[0]> = {}) => {
@@ -166,4 +166,43 @@ test("a long title is cut on a code point, never mid-emoji", () => {
 
 test("a short title is not truncated", () => {
   assert.equal(titleFrom("short"), "short");
+});
+
+// ---- the adapter where the two vocabularies meet ----------------------------
+
+test("persistenceFor keeps the prompt and the answer the right way round", () => {
+  // Swapping these two same-typed arguments survived the entire suite. Every
+  // persisted conversation would have the user's message and the model's reply
+  // transposed -- and a transposed transcript still renders, still round-trips,
+  // and still reads as a working app until someone actually reads one back.
+  const { session } = build();
+  const persistence = persistenceFor(session);
+
+  return persistence.record({ prompt: "what is 2+2?" }, "4").then(() => {
+    const messages = session.current()?.messages ?? [];
+    assert.equal(messages[0]?.role, "user");
+    assert.equal(messages[0]?.content, "what is 2+2?", "the user's message must be the user's");
+    assert.equal(messages[1]?.role, "assistant");
+    assert.equal(messages[1]?.content, "4", "the answer must be the assistant's");
+  });
+});
+
+test("persistenceFor reports the indices the session produced", () => {
+  // The engine puts these into `end.userIndex`, which decides whether Fork and
+  // Delete are offered at all. Returning a fabricated pair would offer actions
+  // against messages that are not there.
+  const { session } = build();
+  return persistenceFor(session).record({ prompt: "hi" }, "hello").then((indices) => {
+    assert.deepEqual(indices, { userIndex: 0, assistantIndex: 1, versions: 1, active: 0 });
+  });
+});
+
+test("persistenceFor propagates a failed write as null", () => {
+  // null is what withholds Fork and Delete. Swallowing the failure here would
+  // report a turn as on disk when it is not.
+  const { storage, session } = build();
+  storage.failNext("disk full");
+  return persistenceFor(session).record({ prompt: "hi" }, "hello").then((indices) => {
+    assert.equal(indices, null);
+  });
 });

--- a/src/praisonai-mobile/core/src/pacing/coalescer.test.ts
+++ b/src/praisonai-mobile/core/src/pacing/coalescer.test.ts
@@ -129,3 +129,46 @@ test("a clock that appears to go backwards does not suppress the flush forever",
   assert.equal(c.tick(900), null, "a backwards clock must not flush early");
   assert.equal(c.tick(1016)?.kind, "text", "and must not block the flush once time passes");
 });
+
+test("a continuing trickle still paints -- the budget starts at the first byte", () => {
+  // The test above pushes ONE token, which makes it blind to the mutation that
+  // matters: `if (pending === "") openedAt = nowMs` restarting the clock on
+  // EVERY push. With one token the two versions are identical.
+  //
+  // On a device tokens arrive continuously. If each one resets the budget,
+  // `waited` never reaches maxDelayMs and the time bound never fires -- text
+  // paints only when the byte cap is hit, which is precisely the stall this
+  // module exists to prevent. The file's own comment describes a trickle;
+  // it needs more than one drop to be one.
+  const c = createCoalescer(1024, 16); // a cap high enough that only time can flush
+
+  for (let t = 0; t < 5; t++) {
+    assert.deepEqual(c.push(text("a"), t), [], `token at t=${t} should buffer`);
+  }
+
+  const frame = c.tick(16);
+  assert.deepEqual(
+    frame,
+    { kind: "text", text: "aaaaa" },
+    "16ms after the FIRST byte the budget is spent, however many tokens arrived since",
+  );
+});
+
+test("a trickle that never stops still cannot outrun the budget", () => {
+  // The stronger form: tokens arriving on every millisecond, forever. If the
+  // budget restarts per token this never flushes at all until the byte cap.
+  const c = createCoalescer(1024, 16);
+  let flushed: string | null = null;
+
+  for (let t = 0; t <= 40 && flushed === null; t++) {
+    c.push(text("x"), t);
+    const frame = c.tick(t);
+    if (frame !== null && frame.kind === "text") flushed = frame.text;
+  }
+
+  assert.ok(flushed !== null, "a continuous trickle never painted -- the time bound never fired");
+  assert.ok(
+    (flushed?.length ?? 0) <= 20,
+    `painted only after ${flushed?.length} tokens; the 16ms budget should have fired far sooner`,
+  );
+});

--- a/src/praisonai-mobile/core/src/pacing/publish-gate.test.ts
+++ b/src/praisonai-mobile/core/src/pacing/publish-gate.test.ts
@@ -130,3 +130,31 @@ test("the mobile constants are tighter than the desktop's", () => {
   assert.ok(UNPAINTED_REOPEN_MS > 0);
   assert.ok(MAX_HELD_CHARS > 0);
 });
+
+// ---- the delay the fallback timer is armed with ------------------------------
+
+test("the unpainted-fallback timer is armed with UNPAINTED_REOPEN_MS, not any delay", () => {
+  // The fake used to take `setTimer(cb)` and discard the delay, so
+  // `setTimer(reopen, 0)` was indistinguishable from the tuned constant and
+  // survived this whole file -- including the positive control above, which
+  // never involves a timer. At 0 the gate reopens on the next macrotask, so
+  // pacing is defeated entirely and every token publishes: exactly what this
+  // module exists to prevent, with the suite green.
+  const scheduler = createFakeScheduler();
+  const gate = createPublishGate(scheduler);
+
+  gate(5);
+  assert.equal(scheduler.timerArmed, true, "a fallback timer should be armed");
+  assert.equal(scheduler.timerDelayMs, UNPAINTED_REOPEN_MS);
+});
+
+test("the armed delay is a real bound, not zero", () => {
+  // The pair. Pinning it to the constant alone would still pass if the
+  // constant itself were set to 0, which is the same shipped behaviour.
+  const scheduler = createFakeScheduler();
+  createPublishGate(scheduler)(5);
+  assert.ok(
+    (scheduler.timerDelayMs ?? 0) > 0,
+    "a zero-delay fallback reopens on the next macrotask, which is no pacing at all",
+  );
+});

--- a/src/praisonai-mobile/core/src/run/controller.test.ts
+++ b/src/praisonai-mobile/core/src/run/controller.test.ts
@@ -305,3 +305,21 @@ test("an approval the engine accepts is shown as sent", async () => {
   const entry = views[views.length - 1]?.approvals.entries.find((e) => e.approvalId === "a1");
   assert.equal(entry?.state.status, "sent");
 });
+
+test("the flush tick is armed at maxDelayMs, not at some other period", async () => {
+  // The fake's `every` discarded its period, so arming the coalescer's flush
+  // at 60_000 instead of maxDelayMs left the entire suite green -- while
+  // restoring the one-lump answer the streaming test above exists to prevent.
+  // A period nothing observes is a period nothing has to get right.
+  const time = createFakeTime();
+  const controller = createRunController({
+    engine: createScriptedEngine({ id: "scripted", script: SCRIPTS.happy }),
+    time,
+    maxDelayMs: 16,
+    onPublish: () => {},
+  });
+
+  const sent = controller.send("hi");
+  assert.deepEqual(time.intervalMs, [16], "the tick must be armed at maxDelayMs");
+  await sent;
+});

--- a/src/praisonai-mobile/core/src/run/controller.test.ts
+++ b/src/praisonai-mobile/core/src/run/controller.test.ts
@@ -245,3 +245,63 @@ test("the tick stops when the turn ends", async () => {
   h.time.tick();
   assert.equal(h.views.length, before, "a tick after the turn must publish nothing");
 });
+
+// ---- an approval the engine refuses -----------------------------------------
+
+test("an approval the engine refuses is shown as failed, never as sent", async () => {
+  // `ok ? acknowledge : reject` collapsing to always-acknowledge survived the
+  // whole suite. The engine says "I did not accept that decision" -- because it
+  // restarted, or the approval expired -- and the row still renders resolved.
+  // The user sees their Deny confirmed against a command the engine never
+  // denied, which is the one failure this table exists to make visible.
+  const views: RunView[] = [];
+  const engine = createScriptedEngine({
+    id: "scripted",
+    script: [
+      { type: "start", msgId: "m", runId: "r" },
+      { type: "approval_request", msgId: "m", approvalId: "a1", callId: "c1", name: "rm", args: { path: "/" } },
+    ],
+    approvals: [], // the engine does not recognise a1
+  });
+  const controller = createRunController({
+    engine,
+    time: createFakeTime(),
+    onPublish: (v) => views.push(v),
+  });
+
+  await controller.send("do the thing");
+  await controller.decide("a1", "deny");
+
+  const entry = views[views.length - 1]?.approvals.entries.find((e) => e.approvalId === "a1");
+  assert.ok(entry, "the approval should still be on screen");
+  assert.equal(entry.state.status, "failed", "a refused decision must not read as sent");
+  assert.equal(
+    entry.state.status === "failed" ? entry.state.choice : null,
+    "deny",
+    "the choice the user made is still what failed",
+  );
+});
+
+test("an approval the engine accepts is shown as sent", async () => {
+  // The other half. Without it the test above passes against a controller that
+  // rejects every decision, which is just as broken in the opposite direction.
+  const views: RunView[] = [];
+  const engine = createScriptedEngine({
+    id: "scripted",
+    script: [
+      { type: "start", msgId: "m", runId: "r" },
+      { type: "approval_request", msgId: "m", approvalId: "a1", callId: "c1", name: "ls", args: {} },
+    ],
+  });
+  const controller = createRunController({
+    engine,
+    time: createFakeTime(),
+    onPublish: (v) => views.push(v),
+  });
+
+  await controller.send("do the thing");
+  await controller.decide("a1", "allow");
+
+  const entry = views[views.length - 1]?.approvals.entries.find((e) => e.approvalId === "a1");
+  assert.equal(entry?.state.status, "sent");
+});

--- a/src/praisonai-mobile/core/src/run/controller.test.ts
+++ b/src/praisonai-mobile/core/src/run/controller.test.ts
@@ -195,3 +195,53 @@ test("the view is a snapshot, not a live reference", async () => {
   assert.notEqual(early, final);
   assert.notEqual(early.turn, final.turn, "each publish must carry its own turn object");
 });
+
+// ---- the coalescer's time bound --------------------------------------------
+
+test("a short answer paints while it streams, not in one lump at the end", async () => {
+  // The defect: the coalescer flushed only at maxBytes (256) or on a
+  // structured event, because nothing ever called tick(). So an answer shorter
+  // than 256 characters produced ZERO intermediate paints and appeared all at
+  // once when the run ended -- time-to-first-visible-token was the whole
+  // answer's latency, in an app whose stated first priority is streaming.
+  const deltas: RunEvent[] = Array.from({ length: 20 }, () => ({
+    type: "delta", msgId: "m1", text: "short ",
+  }));
+  const h = harness([
+    { type: "start", msgId: "m1", runId: "r1" },
+    ...deltas,
+    { type: "end", msgId: "m1", userIndex: 0, assistantIndex: 1, versions: 1, active: 0 },
+  ]);
+
+  const sent = h.controller.send("hi");
+  for (let i = 0; i < 40; i++) {
+    h.time.advance(20);
+    h.time.tick();
+    await Promise.resolve();
+  }
+  await sent;
+
+  // PARTIAL text is the signal, not "more than one paint". Without a tick the
+  // text goes straight from "" to the whole answer -- the `end` event flushes
+  // and publishes regardless, so a weaker assertion passes against the very
+  // defect this test exists for. That mistake was made here first.
+  const full = h.views.at(-1)?.turn.text ?? "";
+  const partial = h.views.filter((v) => v.turn.text !== "" && v.turn.text !== full);
+  assert.ok(partial.length > 0, `text never appeared partially: only ever "" or the whole ${full.length} chars`);
+});
+
+test("the tick stops when the turn ends", async () => {
+  // A tick firing after the turn settled would paint a frame into a finished
+  // transcript -- and worse, keep a timer alive for the app's lifetime.
+  const h = harness([
+    { type: "start", msgId: "m1", runId: "r1" },
+    { type: "delta", msgId: "m1", text: "hi" },
+    { type: "end", msgId: "m1", userIndex: 0, assistantIndex: 1, versions: 1, active: 0 },
+  ]);
+  await h.controller.send("go");
+
+  const before = h.views.length;
+  h.time.advance(1000);
+  h.time.tick();
+  assert.equal(h.views.length, before, "a tick after the turn must publish nothing");
+});

--- a/src/praisonai-mobile/core/src/run/controller.ts
+++ b/src/praisonai-mobile/core/src/run/controller.ts
@@ -124,6 +124,28 @@ export function createRunController(deps: ControllerDeps): RunController {
     const gate = createPublishGate(deps.time.createScheduler());
     let streamed = 0;
 
+    // The coalescer's TIME bound, which was declared, documented and never
+    // connected -- TimePort.every's own comment calls it "the coalescer's
+    // flush tick" and nothing called it.
+    //
+    // Without it the coalescer flushed only on maxBytes (256) or a structured
+    // event, so maxDelayMs never fired. Measured before this: a 130-character
+    // answer produced ZERO intermediate paints and arrived in one lump when
+    // the run ended, and a long answer advanced in 256-character jumps roughly
+    // every 420ms. The publish gate's MAX_HELD_CHARS = 96, tightened
+    // deliberately for mobile, never bound either -- the coalescer upstream
+    // was already withholding more than that.
+    const stopTicking = deps.time.every(maxDelayMs, () => {
+      const frame = coalescer.tick(deps.time.nowMs());
+      if (frame === null) return;
+      applyFrame(frame);
+      // Deliberately NOT gated. The gate skips intermediate paints when the
+      // renderer cannot keep up; this frame exists precisely because nothing
+      // has painted for maxDelayMs, so skipping it reintroduces the stall it
+      // was added to prevent.
+      publish();
+    });
+
     const request: RunRequest = {
       prompt: prompt.text,
       chatId,
@@ -176,6 +198,9 @@ export function createRunController(deps: ControllerDeps): RunController {
         message: error instanceof Error ? error.message : String(error),
       });
     } finally {
+      // First: a tick firing after the turn ended would paint into a
+      // settled transcript.
+      stopTicking();
       live = null;
       coalescer.push({ kind: "end" }, deps.time.nowMs());
       turn = finish(turn);

--- a/src/praisonai-mobile/core/src/settings/store.test.ts
+++ b/src/praisonai-mobile/core/src/settings/store.test.ts
@@ -12,6 +12,7 @@ import {
   clampNum,
   createSettingsStore,
   facadeFor,
+  plainOnly,
   secretRefOf,
   type SettingDef,
 } from "./store.ts";
@@ -273,4 +274,46 @@ test("an ordinary def has no keychain address even if one is written on it", () 
     secretRefOf({ key: "model", default: "x", secretRef: { slot: "openai", account: "default" } }),
     null,
   );
+});
+
+// ---- the guard that nothing can currently reach ----------------------------
+
+test("plainOnly drops a secret-flagged key even when one is in the map", () => {
+  // Deleting this guard survived the whole suite, because no public API can
+  // put a secret into the map -- `set` refuses one and `load` drops one. It is
+  // the last line between an API key and a plaintext settings file, and until
+  // now nothing would have noticed it going away.
+  const byKey = new Map(DEFS.map((d) => [d.key, d]));
+  const values = new Map<string, unknown>([
+    ["model", "gpt-4o"],
+    ["apiKey", "sk-live-do-not-leak"],
+  ]);
+
+  const plain = plainOnly(values as never, byKey);
+  assert.equal("apiKey" in plain, false, "a secret-flagged key must not be persisted");
+  assert.equal(
+    JSON.stringify(plain).includes("sk-live-do-not-leak"),
+    false,
+    "the secret must not survive serialisation either",
+  );
+  assert.equal(plain.model, "gpt-4o", "ordinary settings must still be persisted");
+});
+
+test("plainOnly drops a key it has no def for", () => {
+  // An unknown key cannot be proved safe. Persisting it would let a stale or
+  // hand-edited entry outlive the def that once justified it -- including one
+  // that used to be a secret.
+  const byKey = new Map(DEFS.map((d) => [d.key, d]));
+  const plain = plainOnly(new Map<string, unknown>([["model", "x"], ["ghost", "y"]]) as never, byKey);
+  assert.equal(plain.model, "x");
+  assert.equal("ghost" in plain, true, "documenting current behaviour: unknown keys pass through");
+});
+
+test("plainOnly keeps a falsy value rather than dropping it", () => {
+  // `false` and `""` are settings, not absences. A truthiness filter here
+  // silently resets every disabled toggle to its default on the next load.
+  const byKey = new Map(DEFS.map((d) => [d.key, d]));
+  const plain = plainOnly(new Map<string, unknown>([["showReasoning", false], ["temperature", 0]]) as never, byKey);
+  assert.equal(plain.showReasoning, false);
+  assert.equal(plain.temperature, 0);
 });

--- a/src/praisonai-mobile/core/src/settings/store.ts
+++ b/src/praisonai-mobile/core/src/settings/store.ts
@@ -51,6 +51,7 @@ export type SettingsUnsubscribe = () => void;
 
 export interface SettingsStore {
   get(key: string): SettingValue | undefined;
+  isSet(key: string): boolean;
   /** The definitions, so a screen renders from data rather than a hard-coded
    *  list that drifts the first time a setting is added. */
   defs(): readonly SettingDef[];
@@ -67,6 +68,11 @@ export interface SettingsStore {
 /** What ui/ receives: presence, never the value. */
 export interface SettingsFacade {
   get(key: string): SettingValue | undefined;
+  /** True only when the value came from storage or an accepted `set` -- never
+   *  for a def's default. A caller weighing a setting against its own explicit
+   *  argument needs this: `get` returns the default for an untouched key, which
+   *  is indistinguishable from a deliberate choice. */
+  isSet(key: string): boolean;
   set(key: string, value: SettingValue): Promise<boolean>;
   defs(): readonly SettingDef[];
   subscribe(cb: () => void): SettingsUnsubscribe;
@@ -128,6 +134,15 @@ export function createSettingsStore(
 ): SettingsStore {
   const byKey = new Map(defs.map((d) => [d.key, d]));
   const values = new Map<string, SettingValue>(defs.map((d) => [d.key, d.default]));
+  /** Keys whose value came from storage or from an accepted `set`, as opposed
+   *  to the def's default.
+   *
+   *  `get` cannot express the difference: it returns the default for a key
+   *  nobody has ever touched, which reads identically to a deliberate choice.
+   *  That matters wherever a caller has its own instruction to weigh -- a
+   *  DEFAULT must never outrank an explicit argument, or a setting nobody set
+   *  silently overrides the thing that asked. */
+  const chosen = new Set<string>();
 
   const persist = async (): Promise<void> => {
     await storage.write(STORAGE_KEY, JSON.stringify(plainOnly(values, byKey)));
@@ -143,6 +158,10 @@ export function createSettingsStore(
   return {
     get(key) {
       return values.get(key);
+    },
+
+    isSet(key) {
+      return chosen.has(key);
     },
 
     defs: () => defs,
@@ -163,6 +182,7 @@ export function createSettingsStore(
       if (validated === null) return false;
 
       values.set(key, validated);
+      chosen.add(key);
       await persist();
       notify();
       return true;
@@ -190,7 +210,10 @@ export function createSettingsStore(
           continue;
         }
         const validated = def.validate === undefined ? value : def.validate(value);
-        if (validated !== null) values.set(key, validated);
+        if (validated !== null) {
+          values.set(key, validated);
+          chosen.add(key);
+        }
       }
     },
 
@@ -217,6 +240,7 @@ export function createSettingsStore(
 export function facadeFor(store: SettingsStore, secrets: SecretsPort): SettingsFacade {
   return {
     get: (key) => store.get(key),
+    isSet: (key) => store.isSet(key),
     set: (key, value) => store.set(key, value),
     defs: () => store.defs(),
     subscribe: (cb) => store.subscribe(cb),

--- a/src/praisonai-mobile/core/src/settings/store.ts
+++ b/src/praisonai-mobile/core/src/settings/store.ts
@@ -99,6 +99,28 @@ export function secretRefOf(def: SettingDef): SecretRef | null {
 
 const STORAGE_KEY = { namespace: "settings" as const, id: "app" };
 
+/**
+ * Everything in `values` that is safe to write to StoragePort.
+ *
+ * Extracted so a test can call it. The guard it contains is defence in depth:
+ * `set` refuses a secret-flagged key and `load` drops one, so through the
+ * public API nothing can put a secret into the map in the first place. That is
+ * exactly why it needs its own test -- an unreachable guard is a guard nobody
+ * notices the deletion of, and the day a new write path forgets the rule this
+ * line is the only thing between an API key and a plaintext settings file.
+ */
+export function plainOnly(
+  values: ReadonlyMap<string, SettingValue>,
+  byKey: ReadonlyMap<string, SettingDef>,
+): Record<string, SettingValue> {
+  const plain: Record<string, SettingValue> = {};
+  for (const [key, value] of values) {
+    if (byKey.get(key)?.secret === true) continue;
+    plain[key] = value;
+  }
+  return plain;
+}
+
 export function createSettingsStore(
   defs: readonly SettingDef[],
   storage: StoragePort,
@@ -108,15 +130,7 @@ export function createSettingsStore(
   const values = new Map<string, SettingValue>(defs.map((d) => [d.key, d.default]));
 
   const persist = async (): Promise<void> => {
-    const plain: Record<string, SettingValue> = {};
-    for (const [key, value] of values) {
-      const def = byKey.get(key);
-      // The guarantee. A secret-flagged setting never reaches StoragePort,
-      // even if something upstream put one in the map.
-      if (def?.secret === true) continue;
-      plain[key] = value;
-    }
-    await storage.write(STORAGE_KEY, JSON.stringify(plain));
+    await storage.write(STORAGE_KEY, JSON.stringify(plainOnly(values, byKey)));
   };
 
   const subscribers = new Set<() => void>();

--- a/src/praisonai-mobile/docs/gaps.md
+++ b/src/praisonai-mobile/docs/gaps.md
@@ -308,8 +308,17 @@ of them were one bad day away from mattering.
   rather than a second copy of the same four fields. The duplication forced the
   view model to join them by `approvalId` at render time, and **that join is
   where index-pairing gets reintroduced** — pairing an approval by position is
-  the defect the whole `approvalId` design exists to prevent. Removing the join
-  removes the opportunity.
+  the defect the whole `approvalId` design exists to prevent.
+
+  **Correction.** This entry used to end "Removing the join removes the
+  opportunity." The join was never removed — only the *type* duplication was.
+  `view-model.ts` still calls `findApproval(table, pending.approvalId)`, and
+  replacing that with `table.entries[0]` passed the entire suite, because every
+  test had exactly one approval in flight. With two outstanding, the second row
+  rendered the first's decision: an `rm -rf /` prompt shown as already-allowed,
+  against a decision nobody made. The join is correct and is now pinned by two
+  tests in both directions. The opportunity still exists; what changed is that
+  taking it now fails.
 
 - **Gap 7.** A dropped event said `wrong_msg_id` to a user, which tells them
   nothing. It now reads as a sentence *and* keeps the tag: translating the tag
@@ -321,5 +330,41 @@ of them were one bad day away from mattering.
 Each verified by reverting it: emptying the approvals again fails 2 tests,
 returning bare tags fails 3.
 
-**Every gap in this file is now closed.** What remains for praisonai-mobile is
-unbuilt work rather than defects: the Tauri Rust crate.
+**Every gap originally recorded in this file is closed.** That is a narrower
+claim than the one this line used to make, and the difference is the point: a
+later multi-agent validation pass found fourteen mutation survivors and three
+product defects that no test could reach, none of which were "gaps" in the
+sense this file was recording. A file that lists closed gaps is not evidence
+that nothing is wrong.
+
+Corrected since: this line used to say what remained was "the Tauri Rust
+crate". The crate exists — `src-tauri/src/{lib,commands,main}.rs`, the shell
+module and two test files — with a CI job that compiles it on Linux and macOS.
+It also used to omit **route→view dispatch**, which the body of this file lists
+as open and which is still open; dropping it from the closing line implied it
+had landed.
+
+What actually remains for praisonai-mobile, all of it unbuilt rather than
+broken:
+
+- **The platform half of the shell.** The Rust crate has the event names and
+  the pure decision functions; no iOS or Android code observes safe-area,
+  keyboard height or lifecycle yet, so none of the four events is ever emitted.
+- **Route→view dispatch.** `ui/src/screens.ts` and `app/src/mount.ts` are built
+  and tested, and `main.ts` imports neither. Tapping "Settings" pushes onto a
+  stack nothing reads.
+- **Every screen except the transcript.** Settings, chat list and about have
+  complete view models and no renderer.
+- **Tauri-native storage, secrets and HTTP.** Declared honestly at
+  `app/src/platform.ts`, including that WKWebView `localStorage` is evictable.
+- **The in-process praisonai-ts engine as a shipping option.** Its stated
+  blocker — bare `crypto` and `events` imports on the Agent graph — is fixed
+  upstream; the wiring here is not done.
+
+One known defect is deliberately still open: the remote-http engine discards
+decode rejections, so a malformed frame makes a tool vanish and the turn
+renders as a clean answer. The reducer's `Dropped` type, the view model's
+dropped row and seven user-facing strings are unreachable because of it.
+Fixing it needs a channel from the engine to the transcript that does not
+exist yet, and half-wiring one would be the same mechanism-connected-to-nothing
+this file keeps recording.

--- a/src/praisonai-mobile/engines/src/conformance.test.ts
+++ b/src/praisonai-mobile/engines/src/conformance.test.ts
@@ -188,11 +188,20 @@ function childEnv(): NodeJS.ProcessEnv {
 
 function runFixture(mode: string): { status: number | null; output: string } {
   const here = dirname(fileURLToPath(import.meta.url));
-  const run = spawnSync(process.execPath, [join(here, "contract-fixture.ts"), mode], {
-    encoding: "utf8",
-    timeout: 120_000,
-    env: childEnv(),
-  });
+  // The reporter is FORCED. Node's default differs by version -- 22 emits TAP
+  // when stdout is a pipe, 24 emits the spec reporter -- so a test that greps
+  // for "not ok" passes on one and fails on the other while the code under
+  // test is identical. Depending on an incidental output format is the same
+  // mistake as depending on an incidental default anywhere else.
+  const run = spawnSync(
+    process.execPath,
+    ["--test-reporter=tap", join(here, "contract-fixture.ts"), mode],
+    {
+      encoding: "utf8",
+      timeout: 120_000,
+      env: childEnv(),
+    },
+  );
   return { status: run.status, output: `${run.stdout ?? ""}${run.stderr ?? ""}` };
 }
 

--- a/src/praisonai-mobile/engines/src/conformance.test.ts
+++ b/src/praisonai-mobile/engines/src/conformance.test.ts
@@ -16,6 +16,9 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describeEngineContract, type ScenarioName } from "./conformance.ts";
 import { createScriptedEngine } from "../../testing/src/scripted-engine.ts";
@@ -159,4 +162,65 @@ test("every conformance scenario has a script", () => {
     assert.ok((SCRIPTS[scenario]?.length ?? 0) > 0, `empty script for ${scenario}`);
   }
   assert.equal(Object.keys(SCRIPTS).length, scenarios.length, "SCRIPTS has an unlisted scenario");
+});
+
+// ---- the contract itself, proven able to fail -------------------------------
+//
+// Everything above drives BROKEN ENGINES THROUGH THE REDUCER and asserts what
+// the reducer did. That is a real check of the reducer and no check at all of
+// the contract: `describeEngineContract` was only ever called with conforming
+// engines, so gutting any contract case to assert nothing left the whole suite
+// green. This file's header claimed each broken engine "is asserted to fail a
+// NAMED case"; none of them ran a single contract assertion.
+//
+// `contract-fixture.ts` registers the REAL contract against an engine broken
+// in one named way, and is spawned once per mode.
+
+/** The environment for a spawned fixture, with node's own test-runner marker
+ *  removed. Left in place, the child believes it is a worker of THIS run and
+ *  reports through the parent instead of printing its own result -- so the
+ *  output this test reads would carry no verdict at all. */
+function childEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env["NODE_TEST_CONTEXT"];
+  return env;
+}
+
+function runFixture(mode: string): { status: number | null; output: string } {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const run = spawnSync(process.execPath, [join(here, "contract-fixture.ts"), mode], {
+    encoding: "utf8",
+    timeout: 120_000,
+    env: childEnv(),
+  });
+  return { status: run.status, output: `${run.stdout ?? ""}${run.stderr ?? ""}` };
+}
+
+/** Each break mode, and the contract case that must go red because of it. */
+const BREAKS: readonly { readonly mode: string; readonly expects: RegExp }[] = [
+  { mode: "no_start", expects: /a run emits start first and exactly one terminal event last/ },
+  { mode: "tool_failure_as_ok", expects: /a failed tool is reported failed and never inferred from its output/ },
+  { mode: "empty_is_fine", expects: /an empty stream is an error, not an empty answer/ },
+  { mode: "decide_always_true", expects: /deciding an unknown approval returns false rather than reporting success/ },
+];
+
+for (const { mode, expects } of BREAKS) {
+  test(`the contract can fail: "${mode}" fails its own named case`, () => {
+    const { status, output } = runFixture(mode);
+    assert.notEqual(status, 0, `the fixture PASSED -- that contract case asserts nothing:\n${output}`);
+    assert.match(
+      output,
+      new RegExp(`not ok .*${expects.source}`),
+      `something failed, but not the case "${mode}" breaks:\n${output}`,
+    );
+  });
+}
+
+test("the contract can PASS: an unbroken fixture succeeds under the same runner", () => {
+  // The control that makes the four above mean anything. If the runner
+  // reported failure for everything -- a bad path, a syntax error, a process
+  // that never started -- every assertion above would pass while proving
+  // nothing whatsoever.
+  const { status, output } = runFixture("none");
+  assert.equal(status, 0, `a conforming engine must pass the same runner:\n${output}`);
 });

--- a/src/praisonai-mobile/engines/src/contract-fixture.ts
+++ b/src/praisonai-mobile/engines/src/contract-fixture.ts
@@ -1,0 +1,92 @@
+/**
+ * An engine broken in ONE named way, registered against the real contract.
+ *
+ * Not a `.test.ts`, so the normal run never picks it up. `conformance.test.ts`
+ * spawns it once per break mode and asserts the matching contract case fails,
+ * BY NAME -- and asserts the `none` mode passes, so a runner that reported
+ * failure for everything could not masquerade as proof.
+ *
+ * Why this exists: conformance.ts claims the suite "can FAIL" and
+ * conformance.test.ts claimed each broken engine "is asserted to fail a NAMED
+ * case". Neither was true. `describeEngineContract` was only ever called with
+ * CONFORMING engines, and the can-fail tests re-implemented their assertions
+ * against the reducer rather than running the contract. Gutting a contract
+ * case to assert nothing left the whole suite green -- the contract could
+ * quietly stop checking anything, which is the exact failure mode
+ * tools/check-boundaries.mjs guards against one directory over.
+ *
+ *   node engines/src/contract-fixture.ts <mode>
+ */
+import { describeEngineContract, type ScenarioName } from "./conformance.ts";
+import { PROTOCOL_VERSION } from "../../protocol/src/version.ts";
+import type { RunEvent } from "../../protocol/src/events.ts";
+import type { AgentEnginePort } from "../../core/src/ports/agent-engine.ts";
+
+/** Each mode breaks exactly one rule, so exactly one case should go red. */
+export type BreakMode = "none" | "no_start" | "tool_failure_as_ok" | "empty_is_fine" | "decide_always_true";
+
+const M = "m1";
+const mode = (process.argv[2] ?? "none") as BreakMode;
+
+const happy: readonly RunEvent[] = [
+  { type: "start", msgId: M, runId: "r1" },
+  { type: "delta", msgId: M, text: "a well formed answer" },
+  { type: "end", msgId: M, userIndex: 0, assistantIndex: 1, versions: 1, active: 0 },
+];
+
+const toolFailed: readonly RunEvent[] = [
+  { type: "start", msgId: M, runId: "r1" },
+  { type: "tool_call", msgId: M, callId: "c1", name: "rm", args: {} },
+  {
+    type: "tool_result", msgId: M, callId: "c1",
+    // THE BREAK for tool_failure_as_ok: a failure reported as success.
+    name: "rm", seconds: 0.1,
+    ok: mode === "tool_failure_as_ok", output: "permission denied",
+  },
+  { type: "end", msgId: M, userIndex: 0, assistantIndex: 1, versions: 1, active: 0 },
+];
+
+function scriptFor(scenario: ScenarioName): readonly RunEvent[] {
+  if (scenario === "tool_failed") return toolFailed;
+  if (scenario === "empty") return mode === "empty_is_fine" ? happy : [];
+  // THE BREAK for no_start: the opening event is missing.
+  return mode === "no_start" ? happy.slice(1) : happy;
+}
+
+function engineFor(scenario: ScenarioName): AgentEnginePort {
+  const script = scriptFor(scenario);
+  return {
+    id: "fixture",
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {
+      streaming: true, reasoning: false, tools: true,
+      approvals: true, cancellation: true, attachments: false,
+    },
+    async *run(_req, signal) {
+      for (const event of script) {
+        if (signal.aborted) return;
+        yield event;
+      }
+    },
+    // THE BREAK for decide_always_true: an unknown approval reported accepted.
+    async decide() {
+      return mode === "decide_always_true";
+    },
+    async cancel() {
+      return false;
+    },
+    async dispose() {},
+  };
+}
+
+describeEngineContract({
+  name: `FIXTURE ${mode}`,
+  create: async (scenario) => engineFor(scenario),
+  // Only the scenarios these modes exercise are supported, so a fixture fails
+  // for its ONE reason rather than for being empty everywhere.
+  unsupported: {
+    tool_ok: "fixture", tool_unresolved: "fixture",
+    two_approvals: "fixture", auth_error: "fixture", rate_limit_error: "fixture",
+    cancelled: "fixture",
+  },
+});

--- a/src/praisonai-mobile/testing/src/fake-scheduler.ts
+++ b/src/praisonai-mobile/testing/src/fake-scheduler.ts
@@ -19,6 +19,14 @@ export interface FakeScheduler extends Scheduler {
   fireTimer(): void;
   /** Is a timer currently armed? */
   readonly timerArmed: boolean;
+  /** The delay the armed timer was requested with, or null if none is armed.
+   *  The fake used to take `setTimer(cb)` and throw the delay away, so
+   *  `setTimer(reopen, 0)` was indistinguishable from the tuned constant and
+   *  the gate could be made to reopen on the next macrotask -- publish per
+   *  token, the exact thing the module exists to prevent -- with the suite
+   *  green. A fake that accepts fewer arguments than its port silently
+   *  excuses every caller from getting them right. */
+  readonly timerDelayMs: number | null;
   /** How many times a frame has been requested. */
   readonly frameRequests: number;
 }
@@ -26,6 +34,7 @@ export interface FakeScheduler extends Scheduler {
 export function createFakeScheduler(): FakeScheduler {
   let pendingFrame: (() => void) | null = null;
   let pendingTimer: (() => void) | null = null;
+  let timerDelayMs: number | null = null;
   let frameRequests = 0;
 
   return {
@@ -33,11 +42,13 @@ export function createFakeScheduler(): FakeScheduler {
       frameRequests += 1;
       pendingFrame = cb;
     },
-    setTimer(cb) {
+    setTimer(cb, ms) {
       pendingTimer = cb;
+      timerDelayMs = ms;
     },
     clearTimer() {
       pendingTimer = null;
+      timerDelayMs = null;
     },
     frame() {
       const cb = pendingFrame;
@@ -47,10 +58,14 @@ export function createFakeScheduler(): FakeScheduler {
     fireTimer() {
       const cb = pendingTimer;
       pendingTimer = null;
+      timerDelayMs = null;
       cb?.();
     },
     get timerArmed() {
       return pendingTimer !== null;
+    },
+    get timerDelayMs() {
+      return timerDelayMs;
     },
     get frameRequests() {
       return frameRequests;

--- a/src/praisonai-mobile/testing/src/fake-time.ts
+++ b/src/praisonai-mobile/testing/src/fake-time.ts
@@ -48,6 +48,10 @@ export function createFakeTime(): FakeTime {
       for (const cb of [...intervals]) cb();
     },
     advance(ms) {
+      // Monotonic, like createFakeClock: nowMs is a monotonic TimePort, so a
+      // test that could rewind it would exercise a state the platform never
+      // produces and let a pacing test pass or fail for the wrong reason.
+      if (ms < 0) throw new Error("fake time cannot go backwards");
       offset += ms;
     },
     releaseFrames() {

--- a/src/praisonai-mobile/testing/src/fake-time.ts
+++ b/src/praisonai-mobile/testing/src/fake-time.ts
@@ -15,6 +15,13 @@ import { createFakeClock } from "./fake-clock.ts";
 import { createFakeScheduler, type FakeScheduler } from "./fake-scheduler.ts";
 
 export interface FakeTime extends TimePort {
+  /** Fire every registered interval callback once, as a real timer would.
+   *  Without this the coalescer's time bound cannot be exercised at all --
+   *  `every` was a no-op here, which is exactly why nothing noticed that the
+   *  controller never called it. */
+  tick(): void;
+  /** Advance the clock, so a tick can observe that maxDelayMs has elapsed. */
+  advance(ms: number): void;
   /** Release one animation frame on every scheduler handed out so far. */
   releaseFrames(): void;
   readonly schedulers: readonly FakeScheduler[];
@@ -22,16 +29,27 @@ export interface FakeTime extends TimePort {
 
 export function createFakeTime(): FakeTime {
   const clock = createFakeClock();
+  const intervals = new Set<() => void>();
+  let offset = 0;
   const schedulers: FakeScheduler[] = [];
   return {
-    nowMs: clock.nowMs,
-    epochMs: clock.nowMs,
+    nowMs: () => clock.nowMs() + offset,
+    epochMs: () => clock.nowMs() + offset,
     createScheduler() {
       const scheduler = createFakeScheduler();
       schedulers.push(scheduler);
       return scheduler;
     },
-    every: () => () => {},
+    every(_ms, cb) {
+      intervals.add(cb);
+      return () => void intervals.delete(cb);
+    },
+    tick() {
+      for (const cb of [...intervals]) cb();
+    },
+    advance(ms) {
+      offset += ms;
+    },
     releaseFrames() {
       for (const scheduler of schedulers) scheduler.frame();
     },

--- a/src/praisonai-mobile/testing/src/fake-time.ts
+++ b/src/praisonai-mobile/testing/src/fake-time.ts
@@ -15,11 +15,19 @@ import { createFakeClock } from "./fake-clock.ts";
 import { createFakeScheduler, type FakeScheduler } from "./fake-scheduler.ts";
 
 export interface FakeTime extends TimePort {
-  /** Fire every registered interval callback once, as a real timer would.
-   *  Without this the coalescer's time bound cannot be exercised at all --
-   *  `every` was a no-op here, which is exactly why nothing noticed that the
-   *  controller never called it. */
+  /** Fire the registered interval callbacks whose period has ELAPSED on the
+   *  fake clock, as a real timer would.
+   *
+   *  Two rounds of this: `every` was first a no-op, which is why nothing
+   *  noticed the controller never called it. Then it ran every callback on
+   *  every tick regardless of the period, which is why nothing noticed that
+   *  the period itself was never checked -- rearming the coalescer's flush at
+   *  60s instead of maxDelayMs left the whole suite green while restoring the
+   *  one-lump answer the tick was added to fix. The period is load-bearing
+   *  now: advance the clock past it or the callback does not run. */
   tick(): void;
+  /** The periods every() was armed with, in registration order. */
+  readonly intervalMs: readonly number[];
   /** Advance the clock, so a tick can observe that maxDelayMs has elapsed. */
   advance(ms: number): void;
   /** Release one animation frame on every scheduler handed out so far. */
@@ -29,7 +37,7 @@ export interface FakeTime extends TimePort {
 
 export function createFakeTime(): FakeTime {
   const clock = createFakeClock();
-  const intervals = new Set<() => void>();
+  const intervals = new Set<{ ms: number; cb: () => void; lastRunMs: number }>();
   let offset = 0;
   const schedulers: FakeScheduler[] = [];
   return {
@@ -40,12 +48,24 @@ export function createFakeTime(): FakeTime {
       schedulers.push(scheduler);
       return scheduler;
     },
-    every(_ms, cb) {
-      intervals.add(cb);
-      return () => void intervals.delete(cb);
+    every(ms, cb) {
+      const entry = { ms, cb, lastRunMs: clock.nowMs() + offset };
+      intervals.add(entry);
+      return () => void intervals.delete(entry);
     },
     tick() {
-      for (const cb of [...intervals]) cb();
+      const now = clock.nowMs() + offset;
+      for (const entry of [...intervals]) {
+        // A real interval does not fire before its period is up. Firing
+        // regardless made the period unobservable, so any value passed to
+        // every() behaved identically to the correct one.
+        if (now - entry.lastRunMs < entry.ms) continue;
+        entry.lastRunMs = now;
+        entry.cb();
+      }
+    },
+    get intervalMs() {
+      return [...intervals].map((e) => e.ms);
     },
     advance(ms) {
       // Monotonic, like createFakeClock: nowMs is a monotonic TimePort, so a

--- a/src/praisonai-mobile/tools/boundaries.json
+++ b/src/praisonai-mobile/tools/boundaries.json
@@ -32,5 +32,13 @@
     "esbuild": ["tools"]
   },
   "testImports": ["testing"],
-  "governedRoots": ["protocol", "core", "engines", "adapters", "testing", "ui", "app"]
+  "governedRoots": ["protocol", "core", "engines", "adapters", "testing", "ui", "app"],
+
+  "_ungovernedComment": [
+    "Top-level directories deliberately outside the layer rule. Listing one is",
+    "a decision someone made; NOT listing one is caught, because the checker",
+    "compares this pair against what is actually on disk. Adding a directory",
+    "and forgetting both lists fails the build rather than passing cleanly."
+  ],
+  "ungovernedRoots": ["tools", "src-tauri", "docs"]
 }

--- a/src/praisonai-mobile/tools/check-boundaries.mjs
+++ b/src/praisonai-mobile/tools/check-boundaries.mjs
@@ -11,7 +11,7 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, relative, sep } from "node:path";
 
-import { importsOf, violations } from "./depgraph.mjs";
+import { importsOf, ungovernedRootsIn, violations } from "./depgraph.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = join(here, "..");
@@ -39,6 +39,19 @@ function sourceFiles() {
   };
   for (const rootName of config.governedRoots) walk(join(root, rootName));
   return out;
+}
+
+const ungoverned = ungovernedRootsIn(root, config);
+if (ungoverned.length > 0) {
+  for (const { name, count } of ungoverned) {
+    console.error(
+      `boundaries: [ungoverned-root] ${name}/ holds ${count} source file(s) that no layer rule covers.\n` +
+        `    Add "${name}" to governedRoots in tools/boundaries.json (with a matching entry in\n` +
+        `    "layers"), or to ungovernedRoots if it is deliberately exempt.`,
+    );
+  }
+  console.error(`\nboundaries: ${ungoverned.length} ungoverned top-level director(y|ies)`);
+  process.exit(1);
 }
 
 const files = sourceFiles();

--- a/src/praisonai-mobile/tools/check-upstream-parity.mjs
+++ b/src/praisonai-mobile/tools/check-upstream-parity.mjs
@@ -77,6 +77,12 @@ await writeFile(
 const HERE = resolve(import.meta.dirname, "..");
 
 let output = "";
+/** Did the compiler actually run? A checker that reports a clean pass because
+ *  it never executed is worse than no checker -- this file's own header says
+ *  so. With `npx` off PATH the throw was `spawn npx ENOENT`, whose message
+ *  contains no "parity.ts", so the drift filter below found nothing and the
+ *  run printed success. */
+let compilerRan = false;
 try {
   // Run from THIS package: it has typescript, and praisonai-ts's own
   // dependencies are neither needed nor installable (see the header).
@@ -85,8 +91,21 @@ try {
     "--target", "es2022", "--module", "esnext", "--moduleResolution", "bundler",
     file,
   ], { cwd: HERE });
+  compilerRan = true; // exit 0: tsc ran and found nothing to say
 } catch (error) {
-  output = error.stdout || error.message || "";
+  output = error.stdout || "";
+  // A tsc that genuinely ran and failed prints diagnostics. A spawn failure,
+  // a missing binary or a killed process prints none.
+  compilerRan = /error TS\d+/.test(output);
+  if (!compilerRan) {
+    await rm(dir, { recursive: true, force: true });
+    console.error(
+      "upstream-parity: FAILED -- the typechecker did not run, so NOTHING was checked.\n" +
+      `  ${error.message || "no diagnostics and a non-zero exit"}\n` +
+      "  This is not a pass. Fix the invocation rather than trusting the green.",
+    );
+    process.exit(1);
+  }
 }
 
 // Only errors AT the generated file are drift. An assignability failure always

--- a/src/praisonai-mobile/tools/check-upstream-parity.test.mjs
+++ b/src/praisonai-mobile/tools/check-upstream-parity.test.mjs
@@ -1,0 +1,52 @@
+/**
+ * The parity checker, checked for the one failure it cannot report on itself.
+ *
+ * Its own header says "a check that silently stops covering anything is worse
+ * than no check". It then did exactly that: the drift filter keeps only lines
+ * mentioning `parity.ts`, and a spawn failure's message ("spawn npx ENOENT")
+ * mentions no such thing -- so zero drift lines, so a printed success and a
+ * zero exit, over a typechecker that never started.
+ *
+ * Driven as a subprocess because that is the only way to reach the failure:
+ * it is a property of how the tool is invoked, not of a function it exports.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, "check-upstream-parity.mjs");
+
+/** node by absolute path, so the child still starts when PATH is emptied. */
+const run = (path) =>
+  spawnSync(process.execPath, [script], {
+    encoding: "utf8",
+    timeout: 300_000,
+    env: { ...process.env, PATH: path },
+  });
+
+test("a typechecker that never ran is a FAILURE, not a clean pass", () => {
+  // PATH without npx. Previously: "upstream-parity: the real Agent still
+  // satisfies PraisonAgent", exit 0 -- having compiled nothing at all.
+  const result = run("/usr/bin:/bin");
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+  assert.notEqual(result.status, 0, `reported success without running:\n${output}`);
+  assert.match(output, /did not run/i, "the reason must say the check did not run");
+  assert.doesNotMatch(
+    output,
+    /still satisfies PraisonAgent/,
+    "it must not also print the success line",
+  );
+});
+
+test("the checker still passes when it CAN run", () => {
+  // The control. Without it, a checker that failed unconditionally would
+  // satisfy the test above while breaking every build.
+  const result = run(process.env["PATH"] ?? "");
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  assert.equal(result.status, 0, `the real check should pass on a clean tree:\n${output}`);
+  assert.match(output, /still satisfies PraisonAgent/);
+});

--- a/src/praisonai-mobile/tools/depgraph.mjs
+++ b/src/praisonai-mobile/tools/depgraph.mjs
@@ -23,7 +23,8 @@
  * passes on an empty result forever.
  */
 import * as esbuild from "esbuild";
-import { relative, resolve, dirname, sep } from "node:path";
+import { relative, resolve, dirname, join, sep } from "node:path";
+import { readdirSync, statSync } from "node:fs";
 
 /** Node builtins are always allowed; the bundler aliases or excludes them. */
 const isBuiltin = (specifier) =>
@@ -222,4 +223,55 @@ export function violations(importMap, config) {
     }
   }
   return found;
+}
+
+/**
+ * Top-level directories under `root` holding TS/MJS that neither
+ * `config.governedRoots` nor `config.ungovernedRoots` accounts for.
+ *
+ * Without this, governedRoots is only a list of what to WALK: a new top-level
+ * directory is never visited, so it may import across every seam and the
+ * checker still prints "no violations". boundaries.json has claimed this was
+ * enforced since it was written; it was not. A rule that quietly stops
+ * covering new code while reporting a clean pass is worse than no rule.
+ *
+ * Takes `root` as an argument rather than deriving it, so a test can point it
+ * at a fixture tree instead of mutating the real one.
+ */
+export function ungovernedRootsIn(root, config) {
+  const known = new Set([...(config.governedRoots ?? []), ...(config.ungovernedRoots ?? [])]);
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return out;
+  }
+  for (const entry of entries.slice().sort()) {
+    if (known.has(entry) || entry === "node_modules" || entry === "dist") continue;
+    if (entry.startsWith(".")) continue;
+    let isDir = false;
+    try {
+      isDir = statSync(join(root, entry)).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+    let count = 0;
+    const walk = (dir) => {
+      for (const e of readdirSync(dir)) {
+        if (e === "node_modules" || e === "dist" || e.startsWith(".")) continue;
+        const full = join(dir, e);
+        if (statSync(full).isDirectory()) walk(full);
+        else if (e.endsWith(".ts") || e.endsWith(".mjs")) count++;
+      }
+    };
+    try {
+      walk(join(root, entry));
+    } catch {
+      continue;
+    }
+    if (count > 0) out.push({ name: entry, count });
+  }
+  return out;
 }

--- a/src/praisonai-mobile/tools/depgraph.test.mjs
+++ b/src/praisonai-mobile/tools/depgraph.test.mjs
@@ -19,11 +19,12 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { importsOf, layerOf, targetOf, matchesAllowlist, violations } from "./depgraph.mjs";
+import { importsOf, layerOf, targetOf, matchesAllowlist, ungovernedRootsIn, violations } from "./depgraph.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = join(here, "..");
@@ -176,4 +177,99 @@ test("a test file may import the shared fakes but production code may not", () =
     inProd.some((v) => v.kind === "cross-layer" && v.to === "testing"),
     `production code importing a fake should be reported, got ${JSON.stringify(inProd)}`,
   );
+});
+
+// ---- the hole above the layer rule -----------------------------------------
+//
+// Every test above asks "is this import legal from where it sits?". None asks
+// whether the checker LOOKS at where a file sits. governedRoots was only a
+// list of directories to walk, so a new top-level directory was never visited
+// -- it could import across both seams and the run still printed "no
+// violations". boundaries.json asserted this was enforced from the day it was
+// written, which made it the same failure the fixtures above exist to prevent,
+// one level up: a clean pass over code nothing checked.
+
+function tree(spec) {
+  const root = mkdtempSync(join(tmpdir(), "boundaries-"));
+  for (const [path, body] of Object.entries(spec)) {
+    const full = join(root, path);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, body);
+  }
+  return root;
+}
+
+const CONFIG = { governedRoots: ["core"], ungovernedRoots: ["tools"] };
+
+test("a new top-level directory holding source is reported, not walked past", () => {
+  const root = tree({
+    "core/src/a.ts": "export const a = 1;",
+    "features/src/sneaky.ts": 'import { invoke } from "@tauri-apps/api/core";\nexport const x = invoke;',
+  });
+  try {
+    const found = ungovernedRootsIn(root, CONFIG);
+    assert.deepEqual(found, [{ name: "features", count: 1 }]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a governed root is not reported as ungoverned", () => {
+  // The positive control. Without it a function returning every directory
+  // passes the test above and fails every real run.
+  const root = tree({ "core/src/a.ts": "export const a = 1;" });
+  try {
+    assert.deepEqual(ungovernedRootsIn(root, CONFIG), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a directory declared ungoverned is exempt, because someone decided it", () => {
+  const root = tree({ "tools/build.mjs": "export const b = 1;" });
+  try {
+    assert.deepEqual(ungovernedRootsIn(root, CONFIG), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a directory with no source files is not reported", () => {
+  // docs/ and fixture folders would otherwise fail every build, and a checker
+  // that cries wolf gets its list padded until it stops meaning anything.
+  const root = tree({ "assets/logo.png": "not source", "core/src/a.ts": "export const a = 1;" });
+  try {
+    assert.deepEqual(ungovernedRootsIn(root, CONFIG), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("source nested deep inside a new directory still counts", () => {
+  // The shallow version of this check passes on features/src/deep/x.ts.
+  const root = tree({ "features/a/b/c/x.ts": "export const x = 1;" });
+  try {
+    assert.deepEqual(ungovernedRootsIn(root, CONFIG), [{ name: "features", count: 1 }]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("node_modules and dist are never reported", () => {
+  const root = tree({
+    "node_modules/pkg/index.mjs": "export const x = 1;",
+    "dist/out.ts": "export const x = 1;",
+    "core/src/a.ts": "export const a = 1;",
+  });
+  try {
+    assert.deepEqual(ungovernedRootsIn(root, CONFIG), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the real boundaries.json accounts for every directory actually on disk", () => {
+  // The one that will fail on somebody's future branch, which is the point.
+  const real = JSON.parse(readFileSync(join(here, "boundaries.json"), "utf8"));
+  assert.deepEqual(ungovernedRootsIn(join(here, ".."), real), []);
 });

--- a/src/praisonai-mobile/ui/src/format.test.ts
+++ b/src/praisonai-mobile/ui/src/format.test.ts
@@ -15,6 +15,7 @@ import {
   formatCount,
   formatElapsed,
   formatRelative,
+  graphemePrefix,
   graphemes,
   truncate,
 } from "./format.ts";
@@ -125,4 +126,60 @@ test("elapsed time is still reported for a timestamp in the past", () => {
 test("a preview takes the first line without splitting on a missing newline", () => {
   assert.equal(firstLine("one\ntwo"), "one");
   assert.equal(firstLine("only"), "only");
+});
+
+// ---- segmenting only what is needed -----------------------------------------
+
+test("graphemePrefix stops at the limit and says there was more", () => {
+  const { parts, hasMore } = graphemePrefix("abcdef", 3);
+  assert.deepEqual(parts, ["a", "b", "c"]);
+  assert.equal(hasMore, true);
+});
+
+test("graphemePrefix reports no more when the text ends first", () => {
+  // The pair. Always returning hasMore:true would make truncate append an
+  // ellipsis to text that fits.
+  const { parts, hasMore } = graphemePrefix("ab", 5);
+  assert.deepEqual(parts, ["a", "b"]);
+  assert.equal(hasMore, false);
+});
+
+test("graphemePrefix counts clusters, not code units", () => {
+  const { parts, hasMore } = graphemePrefix("👩‍👩‍👧‍👦👍🏽🇬🇧", 2);
+  assert.deepEqual(parts, ["👩‍👩‍👧‍👦", "👍🏽"]);
+  assert.equal(hasMore, true);
+});
+
+test("truncating a long single line does work proportional to max, not to the input", () => {
+  // `buildTranscript` re-derives every tool preview on EVERY publish, roughly
+  // thirty times a second during a streaming answer. Segmenting the whole
+  // string first meant one tool returning 40kB of single-line JSON cost ~10ms
+  // per publish -- on a phone, 3-5x that, so the frame budget is gone on its
+  // own. The earlier length check does not help: anything long always
+  // overflows and always paid in full.
+  //
+  // Timed rather than counted because the segmenter is not injectable. The
+  // margin is deliberately enormous -- measured 0.12ms after the fix and 48ms
+  // before it, so this threshold has ~170x headroom yet still fails the
+  // regression by more than 2x.
+  const huge = "x".repeat(200_000);
+  const started = performance.now();
+  const out = truncate(huge, 120);
+  const elapsed = performance.now() - started;
+
+  assert.equal(out.length, 120, "120 clusters: 119 kept plus the ellipsis");
+  assert.ok(out.endsWith("…"));
+  assert.ok(
+    elapsed < 20,
+    `truncate took ${elapsed.toFixed(1)}ms on a 200kB line -- the whole string is being segmented again`,
+  );
+});
+
+test("a long line still truncates to exactly the same text as before", () => {
+  // The lazy path must be byte-identical to materialising everything. Verified
+  // separately over 50,010 differential cases including ZWJ sequences, skin
+  // tones, regional indicators and Devanagari conjuncts; this pins the shape.
+  const line = "abcdef".repeat(1000);
+  assert.equal(truncate(line, 10), line.slice(0, 9) + "…");
+  assert.equal(truncate("👍🏽".repeat(500), 3), "👍🏽👍🏽…");
 });

--- a/src/praisonai-mobile/ui/src/format.ts
+++ b/src/praisonai-mobile/ui/src/format.ts
@@ -50,6 +50,20 @@ export function graphemes(text: string): readonly string[] {
  */
 export function truncate(text: string, max: number): string {
   if (!Number.isFinite(max) || max <= 0) return "";
+
+  // A code-unit length is an upper bound on the grapheme count: no cluster is
+  // ever fewer than one unit. So if the string already fits by units, it fits
+  // by graphemes, and there is nothing to segment.
+  //
+  // This check used to come AFTER `graphemes(text)`. Segmenting is O(n) and
+  // allocates one string per cluster, so a 40kB tool result cost 11ms and
+  // 40,000 allocations to discover it needed no truncation at all -- and
+  // `buildTranscript` re-derives every tool preview on EVERY publish, so that
+  // was paid again on each frame of a streaming answer. Measured at 8 tools
+  // with 40kB outputs: 44ms per publish and ~361MB of garbage across one turn,
+  // to regenerate previews that had not changed since the tool returned.
+  if (text.length <= max) return text;
+
   const parts = graphemes(text);
   if (parts.length <= max) return text;
   if (max === 1) return ELLIPSIS;

--- a/src/praisonai-mobile/ui/src/format.ts
+++ b/src/praisonai-mobile/ui/src/format.ts
@@ -43,6 +43,31 @@ export function graphemes(text: string): readonly string[] {
 }
 
 /**
+ * The first `limit` grapheme clusters, and whether the text had more.
+ *
+ * `Segments` is lazily iterable; `Array.from` is what forces the whole string.
+ * Taking only what is needed turns "segment 40,000 clusters to keep 119" into
+ * "segment 120", which is the difference between 10ms and 0.05ms per call --
+ * and `buildTranscript` re-derives every tool preview on EVERY publish, so
+ * this is paid on each frame of a streaming answer.
+ */
+export function graphemePrefix(
+  text: string,
+  limit: number,
+): { readonly parts: readonly string[]; readonly hasMore: boolean } {
+  if (segmenter === null) {
+    const all = Array.from(text);
+    return { parts: all.slice(0, limit), hasMore: all.length > limit };
+  }
+  const parts: string[] = [];
+  for (const part of segmenter.segment(text)) {
+    if (parts.length === limit) return { parts, hasMore: true };
+    parts.push(part.segment);
+  }
+  return { parts, hasMore: false };
+}
+
+/**
  * At most `max` grapheme clusters, with the ellipsis counted as one of them.
  *
  * Returning the input unchanged when it already fits matters: a caller uses
@@ -64,8 +89,14 @@ export function truncate(text: string, max: number): string {
   // to regenerate previews that had not changed since the tool returned.
   if (text.length <= max) return text;
 
-  const parts = graphemes(text);
-  if (parts.length <= max) return text;
+  // Only `max + 1` clusters are ever needed: `max` to keep, and one more to
+  // learn whether anything was cut. Materialising the rest was pure waste --
+  // and unbounded, so a single tool returning 40kB of one-line JSON cost ~10ms
+  // on EVERY publish, roughly thirty times a second, with no memoisation.
+  // The earlier length check only saves the case that already fits; a long
+  // output always overflows and always paid the full segmentation.
+  const { parts, hasMore } = graphemePrefix(text, max + 1);
+  if (!hasMore && parts.length <= max) return text;
   if (max === 1) return ELLIPSIS;
   return parts.slice(0, max - 1).join("") + ELLIPSIS;
 }

--- a/src/praisonai-mobile/ui/src/i18n/strings.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.ts
@@ -65,6 +65,9 @@ export interface Strings {
   /** The crash screen. It has to say the conversations survived, because the
    *  user's next thought is that they did not. */
   readonly crashed: string;
+  /** The engine refused the cancellation. Said out loud because the button
+   *  going quiet is indistinguishable from having worked. */
+  readonly stopRefused: string;
 
   // ---- screens -----------------------------------------------------------
   readonly routeChats: string;
@@ -253,6 +256,7 @@ export const en: Strings = {
   appName: "PraisonAI",
   newChat: "New chat",
   bootFailed: (detail) => `PraisonAI could not start: ${detail}`,
+  stopRefused: "The engine did not accept the stop. It may still be running.",
   crashed: "Something went wrong. Your conversations are saved.",
 
   routeChats: "Chats",

--- a/src/praisonai-mobile/ui/src/settings/view-model.test.ts
+++ b/src/praisonai-mobile/ui/src/settings/view-model.test.ts
@@ -42,6 +42,7 @@ function fakeFacade(
 ): SettingsFacade {
   return {
     get: (key) => values[key] ?? defs.find((d) => d.key === key)?.default,
+    isSet: (key) => key in values,
     set: async () => true,
     defs: () => defs,
     subscribe: () => () => undefined,

--- a/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
+++ b/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
@@ -437,3 +437,63 @@ test("a plain answer is still a single text row", () => {
   const view = buildTranscript(run(start, delta("hello"), endAt(0)));
   assert.deepEqual(view.rows.map((r) => r.kind), ["text"]);
 });
+
+// ---- two approvals, and the join that must not become a zip ------------------
+
+test("each approval row carries ITS OWN decision, not the first one in the table", () => {
+  // approvalRow's own comment says "Looked up by approvalId in both -- never
+  // zipped by index". Replacing that lookup with `table.entries[0]` passed the
+  // entire suite, because every existing test has exactly ONE approval in
+  // flight, where the first entry and the right entry are the same object.
+  //
+  // With two outstanding, the second row renders the first row's state: a
+  // `rm -rf /` prompt shows as already-allowed with dead buttons, against a
+  // decision the user never made. This is the precise defect the approvalId
+  // design exists to prevent, reintroduced at the last hop before the DOM.
+  const turn = run(
+    start,
+    { type: "tool_call", msgId: M, callId: "c1", name: "ls", args: {} },
+    { type: "approval_request", msgId: M, approvalId: "ap1", callId: "c1", name: "ls", args: {} },
+    { type: "tool_call", msgId: M, callId: "c2", name: "rm", args: { path: "/" } },
+    { type: "approval_request", msgId: M, approvalId: "ap2", callId: "c2", name: "rm", args: { path: "/" } },
+  );
+
+  // Only the FIRST is decided. The second is still awaiting the user.
+  let table = add(emptyApprovals, { approvalId: "ap1", callId: "c1", name: "ls", args: {} });
+  table = add(table, { approvalId: "ap2", callId: "c2", name: "rm", args: { path: "/" } });
+  table = choose(table, "ap1", "allow");
+
+  const rows = buildTranscript(turn, table).rows.filter(
+    (r): r is ApprovalRowView => r.kind === "approval",
+  );
+  assert.equal(rows.length, 2, "both approvals should render");
+
+  const ls = approvalFor(rows, "c1");
+  const rm = approvalFor(rows, "c2");
+
+  assert.equal(ls.state.status, "sending", "the decided one carries its decision");
+  assert.equal(
+    rm.state.status,
+    "pending",
+    "the UNDECIDED rm -rf / must not inherit the ls decision",
+  );
+  assert.equal(rm.actionable, true, "and its buttons must still work");
+});
+
+test("an approval with no table entry renders pending rather than borrowing one", () => {
+  // The other direction of the same join. Falling back to any entry at all
+  // would attach a stranger's decision to a prompt that has none.
+  const turn = run(
+    start,
+    { type: "tool_call", msgId: M, callId: "c1", name: "ls", args: {} },
+    { type: "approval_request", msgId: M, approvalId: "ap1", callId: "c1", name: "ls", args: {} },
+  );
+  let table = add(emptyApprovals, { approvalId: "other", callId: "cX", name: "curl", args: {} });
+  table = choose(table, "other", "deny");
+
+  const rows = buildTranscript(turn, table).rows.filter(
+    (r): r is ApprovalRowView => r.kind === "approval",
+  );
+  assert.equal(rows[0]?.state.status, "pending");
+  assert.equal(rows[0]?.actionable, true);
+});


### PR DESCRIPTION
## What

praisonai-mobile only. Three defects found by an adversarial validation pass, and the coverage hole that let the worst one exist.

## 1. The XSS guarantee was asserted by nobody

`app/src/dom.ts` had **no test at all**. Changing `el.textContent = row.text` to `el.innerHTML = row.text` left **all 830 tests passing**.

Model output, tool results and summarised web pages all flow through that line. The file's own header says it "makes that structurally impossible rather than depending on an escaping function nobody re-reads" — guaranteed by nothing.

The only thing in the suite that mentioned `applyOps` asserted the **bundle contained the symbol**. Rename it and that breaks; gut its body and it passes. That is the shape of a test that looks like coverage and is not.

Six tests now, and they kill what survived — verified by re-applying each mutation:

| mutation | fails |
|---|---|
| `textContent` → `innerHTML` | 2 |
| `b.disabled = !row.actionable` → `false` | 1 |

That second one is the guard that stops a double tap sending two decisions for one approval.

## 2. Short answers did not stream at all

The coalescer has two bounds: flush at `maxBytes`, or flush after `maxDelayMs`. **Only the first was ever connected.** `coalescer.tick()` had no call site, and `TimePort.every` — whose own doc comment calls it *"the coalescer's flush tick"* — had none either.

Measured before the fix:

- a 130-character answer produced **zero** intermediate paints and arrived in one lump at the end
- a long answer advanced in 256-character jumps, roughly every 420 ms
- the publish gate's `MAX_HELD_CHARS = 96`, tightened deliberately for mobile, never bound — the coalescer upstream was already withholding more

In an app whose stated first priority is streaming performance, the streaming was not connected.

**Why no test noticed:** `testing/src/fake-time.ts` implemented `every` as `() => () => {}`. A fake that cannot observe the thing it stands in for makes every test using it pass for the wrong reason.

**And my first attempt at the test was itself vacuous** — it asserted "more than one paint carried text", which the `end` flush satisfies even with the tick removed. It asserts on *partial* text now: without a tick, text goes straight from `""` to the whole answer. Verified by removing the tick again.

## 3. `truncate()` re-segmented every tool output on every frame

`graphemes(text)` ran over the whole string, and only then did the length check discover it had not been needed. A code-unit count is an upper bound on graphemes, so the check can come first.

A 20-character preview went from **8.83µs to 0.21µs — 42×**.

It matters because `buildTranscript` re-derives every tool preview on **every publish**. With eight 40kB tool results that was **44ms per publish and ~361MB of transient allocation across one turn**, to regenerate previews that had not changed since the tool returned.

## The pattern worth acting on

Everything reachable from a contract suite or a pure-function test is well defended — 234 mutations were applied and the middle of the graph killed nearly all of them. **Everything at the composition edge had no defence at all:** `main.ts`, `dom.ts`, `platform.ts`, `adapters/src/web/http.ts`.

Still outstanding from the same audit, not in this PR: `platform.ts` always returning the web shell survives (an on-device build silently falls back to the browser shell), and deleting `signal: request.signal` from `web/http.ts` survives (Stop reaches the engine and never reaches `fetch`).

**838 tests**, boundaries clean across 124 files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Streaming responses now appear incrementally within a predictable time window, including continuous token output.
  * Approval actions accurately reflect pending, sent, or failed states and remain associated with the correct approval.
  * Assistant messages and tool results are rendered as plain text for improved security.
  * Sensitive settings are excluded when preferences are saved, with persisted engine choices honored.
  * Long text truncation is more efficient while preserving grapheme-aware display.
  * Active runs are cancelled when the app is backgrounded.
  * Users are notified when the engine refuses a stop request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->