### PR TITLE
fix(train): the pid-ownership test read a file before anything wrote to it

### DIFF
--- a/src/praisonai-train/tests/unit/train/test_audit_fixes.py
+++ b/src/praisonai-train/tests/unit/train/test_audit_fixes.py
@@ -136,13 +136,28 @@ def test_the_recorded_pid_owns_the_trainer_signalable_by_group(tmp_path):
     pid_file = tmp_path / "train.pid"
     trainer_pid_file = tmp_path / "trainer_pid"
     trainer_ppid_file = tmp_path / "trainer_ppid"
+    # Wait for CONTENT, not for existence. `>` creates the target before the
+    # command on its left produces a byte, so `ps ... > trainer_ppid` leaves an
+    # empty file for as long as `ps` takes to run. Breaking on existence read
+    # that empty file and compared '' to the recorded pid -- a real intermittent
+    # failure in CI, not a slow machine: the window is the runtime of `ps`.
+    def _settled(path):
+        try:
+            return path.read_text().strip() != ""
+        except OSError:
+            return False
+
     for _ in range(50):
-        if (pid_file.exists() and trainer_pid_file.exists()
-                and trainer_ppid_file.exists()):
+        if all(_settled(f) for f in (pid_file, trainer_pid_file, trainer_ppid_file)):
             break
         time.sleep(0.1)
     assert pid_file.exists(), "no pid was recorded"
     assert trainer_pid_file.exists(), "the stand-in trainer never ran"
+    # Named separately from the equality below, so a timeout reads as "the
+    # trainer never reported its parent" rather than as the ownership bug this
+    # test exists to catch.
+    assert _settled(trainer_ppid_file), (
+        "the stand-in trainer never recorded its parent pid within 5s")
 
     recorded = pid_file.read_text().strip()
     trainer_pid = trainer_pid_file.read_text().strip()


### PR DESCRIPTION
## The failure

`test_the_recorded_pid_owns_the_trainer_signalable_by_group` fails intermittently in CI:

```
E   AssertionError: recorded pid 2568 does not own the trainer (trainer's parent is )
    assert '' == '2568'
```

It blocked an unrelated mobile PR ([#4558](https://github.com/MervinPraison/PraisonAI/pull/4558)) while that PR touched nothing outside `src/praisonai-mobile/`.

## Why

The stand-in trainer records its parent with

```sh
ps -o ppid= -p $$ | tr -d ' ' > trainer_ppid
```

and the wait loop broke as soon as all three files **existed**. Shell redirection creates its target *before* the command on the left produces a byte — so `trainer_ppid` exists and is empty for as long as `ps` takes to run. The loop saw it, stopped waiting, and compared `''` against the recorded pid.

This is not a slow machine and not too short a timeout. **The window is the runtime of `ps`**, so waiting longer does not help — waiting for *content* does.

Demonstrated on the same shell shape, 300 trials each:

| wait condition | read an empty value |
|---|---|
| existence only (before) | **296 / 300** |
| non-empty content (after) | **0 / 300** |

The real loop polls at 100 ms, which usually outlasts `ps` — which is why this passes most runs and fails under CI load rather than every time.

## The change

One test file. The loop waits for non-empty content, and the emptiness check is asserted **separately** from the ownership comparison, so a genuine timeout reads as *"the trainer never recorded its parent"* rather than masquerading as the ownership bug this test exists to catch.

`36 passed` for the rest of the file.

## Flagged, not fixed

This test is **unsafe to run on a host without `setsid` (macOS)**. The launch script cannot make the wrapper a process-group leader, so the wrapper stays in pytest's own group and the test's `os.killpg(os.getpgid(recorded), SIGTERM)` terminates the test runner — pytest exits `-15` before reporting anything. On Linux CI `setsid` exists and the group is isolated, so the pipeline is unaffected.

I left this alone because fixing it is a design decision about how the test spawns its wrapper, and that belongs to whoever owns this suite. Raising it because it makes the test unrunnable locally on a Mac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training launch reliability by ensuring configuration data is passed correctly to remote runs.
  * Fixed process tracking so the recorded process identifier corresponds to the trainer process group.
  * Corrected handling of private model settings when values cannot be parsed.
  * Improved startup monitoring to wait for valid process information before continuing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->