### PR TITLE
fix(mobile): a malformed frame made a tool vanish and the turn looked clean

### DIFF
--- a/src/praisonai-mobile/adapters/src/web/secrets.ts
+++ b/src/praisonai-mobile/adapters/src/web/secrets.ts
@@ -18,9 +18,22 @@ export function createWebSecrets(): SecretsPort {
   const store = new Map<string, string>();
 
   return {
-    // Never true for this adapter. The composition root refuses to hand a
+    // Never true for this adapter, and the reason is above: a module-scoped
+    // Map is not a keychain.
+    //
+    // This comment used to claim "the composition root refuses to hand a
     // hardware-backed secret to an engine when the transport is not native,
-    // and this flag is half of that check.
+    // and this flag is half of that check". There is no such check. The flag
+    // is read in exactly one place -- the settings view's warning row
+    // (ui/src/settings/view-model.ts) -- and app/src/boot.ts has never
+    // consulted it. Describing a guard that does not exist is worse than
+    // having no guard, because it stops the next reader looking for one.
+    //
+    // Nor is the guard needed yet: no secret reaches an engine at all.
+    // `createRemoteHttpEngine` accepts a `token`, and registry.ts does not
+    // pass one, so the stored API key is currently read by nothing. When that
+    // is wired, THIS is the flag the refusal should consult -- and it should
+    // arrive with a test, not with a comment.
     isHardwareBacked: false,
 
     async has(ref) {

--- a/src/praisonai-mobile/app/src/boot.test.ts
+++ b/src/praisonai-mobile/app/src/boot.test.ts
@@ -20,6 +20,7 @@ import { SCRIPTS } from "../../testing/src/scripts.ts";
 import { MIN_ENGINE_PROTOCOL, PROTOCOL_VERSION } from "../../protocol/src/version.ts";
 import type { AgentEnginePort } from "../../core/src/ports/agent-engine.ts";
 import type { RunEvent } from "../../protocol/src/events.ts";
+import type { RunView } from "../../core/src/run/controller.ts";
 import type { SettingDef } from "../../core/src/settings/store.ts";
 
 const DEFS: readonly SettingDef[] = [
@@ -400,4 +401,56 @@ test("chosenStringOr distinguishes a chosen value from a defaulted one", () => {
 
   assert.equal(chosenStringOr(facade, "a", "fallback"), "chosen");
   assert.equal(chosenStringOr(facade, "b", "fallback"), "fallback", "a default is not a choice");
+});
+
+test("a refusal the ENGINE reports reaches the app's transcript", async () => {
+  // The composition test, not the unit test. The sink, the engine's callback
+  // and the controller's drain all existed and all worked in isolation --
+  // removing `dropSink` from createRunController here left the whole suite
+  // green, which is the same mechanism-connected-to-nothing this branch keeps
+  // finding. This test fails if the two ends are not joined.
+  const views: RunView[] = [];
+  const inner = createScriptedEngine({ script: SCRIPTS.happy });
+
+  const result = await createApp(deps({
+    onPublish: (v) => views.push(v),
+    engines: (_persistence, _settings, onIgnored) => {
+      const engine: AgentEnginePort = {
+        ...inner,
+        id: "scripted",
+        async *run(req, signal) {
+          for await (const event of inner.run(req, signal)) {
+            // A frame the decoder could not read, mid-stream.
+            if (event.type === "delta") onIgnored("missing_required_field", "tool_result");
+            yield event;
+          }
+        },
+      };
+      return [{ id: "scripted", create: () => engine }];
+    },
+  }));
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  await result.app.controller.send("hi");
+
+  const dropped = views.at(-1)?.turn.dropped ?? [];
+  assert.ok(
+    dropped.some((d) => d.reason === "missing_required_field"),
+    "the engine reported a refusal and the transcript never saw it",
+  );
+  await result.app.dispose();
+});
+
+test("a clean run through the same wiring drops nothing", async () => {
+  // The pair. Wiring that invented a dropped row would satisfy the test above
+  // and mark every healthy turn as damaged.
+  const views: RunView[] = [];
+  const result = await createApp(deps({ onPublish: (v) => views.push(v) }));
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  await result.app.controller.send("hi");
+  assert.deepEqual(views.at(-1)?.turn.dropped, []);
+  await result.app.dispose();
 });

--- a/src/praisonai-mobile/app/src/boot.ts
+++ b/src/praisonai-mobile/app/src/boot.ts
@@ -28,6 +28,8 @@ import {
 import { createRunController, type RunController, type RunView } from "../../core/src/run/controller.ts";
 import { attachBackGesture, createRouter, type Router } from "../../ui/src/router.ts";
 import { selectEngine, type EngineChoice } from "./engines.ts";
+import { createDropSink } from "../../core/src/run/drop-sink.ts";
+import type { IgnoredReason } from "../../protocol/src/decode.ts";
 import type { RunPersistence } from "../../engines/src/praisonai-ts/engine.ts";
 
 export interface AppDeps {
@@ -47,6 +49,7 @@ export interface AppDeps {
   readonly engines: (
     persistence: RunPersistence,
     settings: SettingsFacade,
+    onIgnored: (reason: IgnoredReason, detail: string) => void,
   ) => readonly EngineChoice[];
   readonly settingDefs: readonly SettingDef[];
   /** Which engine to start with when settings name none. The persisted
@@ -134,9 +137,15 @@ export async function createApp(deps: AppDeps): Promise<BootResult> {
   // no effect whatsoever.
   const chosenEngineId = chosenStringOr(settings, "engineId", deps.engineId);
 
+  // The seam between "the engine refused a frame" and "the transcript shows a
+  // dropped event". The engine is built here and the controller below, so
+  // without something between them the refusal had nowhere to go -- which is
+  // exactly why remote-http discarded every one of them.
+  const dropSink = createDropSink();
+
   const selection = await selectEngine(
     chosenEngineId,
-    deps.engines(persistenceFor(session), settings),
+    deps.engines(persistenceFor(session), settings, dropSink.note),
   );
   if (!selection.ok) {
     return { ok: false, reason: selection.reason, detail: selection.detail };
@@ -146,6 +155,9 @@ export async function createApp(deps: AppDeps): Promise<BootResult> {
   const controller = createRunController({
     engine,
     time: deps.time,
+    // The other end of the seam: what the engine refused becomes a dropped
+    // row on the turn it belonged to.
+    dropSink,
     onPublish: deps.onPublish,
   });
   const router = createRouter({ name: "chats" });

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -175,7 +175,8 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     // them. This used to be a stub whose `get` returned undefined, captured by
     // the engine at boot and never replaced -- so the engine address the user
     // set was read, stored, and thrown away in favour of the hardcoded default.
-    engines: (persistence, settings) => enginesFor({ settings, http: platform.http, persistence }),
+    engines: (persistence, settings, onIgnored) =>
+      enginesFor({ settings, http: platform.http, persistence, onIgnored }),
     settingDefs: SETTING_DEFS,
     // The default when settings name none. createApp prefers the persisted
     // `engineId` over this; passing it as a literal was ignoring the setting.

--- a/src/praisonai-mobile/app/src/registry.test.ts
+++ b/src/praisonai-mobile/app/src/registry.test.ts
@@ -19,7 +19,7 @@ import {
 import { createSettingsStore, facadeFor } from "../../core/src/settings/store.ts";
 import { createFakeStorage } from "../../testing/src/fake-storage.ts";
 import { createFakeSecrets } from "../../testing/src/fake-secrets.ts";
-import { createFakeHttp } from "../../testing/src/fake-http.ts";
+import { createFakeHttp, sseResponse } from "../../testing/src/fake-http.ts";
 import { createScriptedEngine } from "../../testing/src/scripted-engine.ts";
 import { SCRIPTS } from "../../testing/src/scripts.ts";
 
@@ -131,4 +131,74 @@ test("the secret ref is stable", async () => {
   // It is the keychain lookup. Changing it silently orphans every key already
   // stored on a device.
   assert.deepEqual(OPENAI_KEY, { slot: "openai", account: "default" });
+});
+
+// ---- the refusal callback has to actually reach the engine ------------------
+
+test("enginesFor hands the refusal callback to the engine it builds", async () => {
+  // Every other hop of this channel is pinned, and dropping the forward HERE
+  // still left the suite green: the boot test supplies its own engine factory,
+  // so it never exercises the real one. A callback the composition root
+  // creates and the registry quietly declines to pass on is the same
+  // mechanism-connected-to-nothing this channel exists to undo.
+  const { settings, persistence } = await build();
+  const http = createFakeHttp();
+  const refused: { reason: string; detail: string }[] = [];
+
+  http.on("/chat", () =>
+    sseResponse(
+      [
+        `event: start\ndata: ${JSON.stringify({ msg_id: "m1", run_id: "r1" })}\n\n`,
+        // No `ok`: undecodable, because ok is the only signal of tool success.
+        `event: tool_result\ndata: ${JSON.stringify({ msg_id: "m1", call_id: "c1", name: "rm", output: "done" })}\n\n`,
+        `event: end\ndata: ${JSON.stringify({ msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 })}\n\n`,
+      ].join(""),
+    ),
+  );
+
+  const choice = enginesFor({
+    settings,
+    http,
+    persistence,
+    onIgnored: (reason, detail) => refused.push({ reason, detail }),
+  }).find((c) => c.id === ENGINE_REMOTE_HTTP);
+  assert.ok(choice, "the remote engine should be offered");
+
+  const engine = await choice.create();
+  for await (const _ of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )) {
+    // drain
+  }
+
+  assert.deepEqual(refused, [{ reason: "missing_required_field", detail: "tool_result.ok" }]);
+});
+
+test("a clean stream through the same engine reports no refusal", async () => {
+  // The pair: a registry that invented a refusal would satisfy the above.
+  const { settings, persistence } = await build();
+  const http = createFakeHttp();
+  const refused: unknown[] = [];
+  http.on("/chat", () =>
+    sseResponse(
+      [
+        `event: start\ndata: ${JSON.stringify({ msg_id: "m1", run_id: "r1" })}\n\n`,
+        `event: end\ndata: ${JSON.stringify({ msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 })}\n\n`,
+      ].join(""),
+    ),
+  );
+
+  const choice = enginesFor({
+    settings, http, persistence,
+    onIgnored: (...args) => refused.push(args),
+  }).find((c) => c.id === ENGINE_REMOTE_HTTP);
+  const engine = await choice!.create();
+  for await (const _ of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )) {
+    // drain
+  }
+  assert.deepEqual(refused, []);
 });

--- a/src/praisonai-mobile/app/src/registry.test.ts
+++ b/src/praisonai-mobile/app/src/registry.test.ts
@@ -94,11 +94,25 @@ test("every setting is grouped, so no row lands in an unnamed section", async ()
   }
 });
 
-test("the engine setting offers exactly the engines that exist", async () => {
+test("the engine setting offers exactly the engines the SHIPPING build can make", async () => {
   // A picker offering an id `selectEngine` will reject is a dead end the user
-  // cannot get out of without editing storage by hand.
+  // cannot get out of without editing storage by hand: the choice persists,
+  // the next launch cannot build it, and boot dies at renderFatal.
+  //
+  // This test used to assert the static array equalled itself -- it named the
+  // same two constants the def named, so the def and reality could not
+  // disagree in a way it could see. It now compares against what `enginesFor`
+  // actually offers in the composition main.ts uses (no `createInProcess`),
+  // which is the only comparison that can fail.
+  const { settings, http, persistence } = await build();
+  const buildable = enginesFor({ settings, http, persistence }).map((c) => c.id);
+
   const def = SETTING_DEFS.find((d) => d.key === "engineId");
-  assert.deepEqual(def?.choices, [ENGINE_REMOTE_HTTP, ENGINE_PRAISONAI_TS]);
+  assert.deepEqual(
+    [...(def?.choices ?? [])].sort(),
+    [...buildable].sort(),
+    "the picker and the registry disagree about which engines exist",
+  );
 });
 
 test("the default engine is one that works with nothing configured", async () => {

--- a/src/praisonai-mobile/app/src/registry.ts
+++ b/src/praisonai-mobile/app/src/registry.ts
@@ -13,6 +13,7 @@
  */
 import type { AgentEnginePort } from "../../core/src/ports/agent-engine.ts";
 import type { HttpPort } from "../../core/src/ports/http.ts";
+import type { IgnoredReason } from "../../protocol/src/decode.ts";
 import type { SettingDef, SettingsFacade } from "../../core/src/settings/store.ts";
 import { clampNum } from "../../core/src/settings/store.ts";
 import { createRemoteHttpEngine } from "../../engines/src/remote-http/engine.ts";
@@ -117,6 +118,9 @@ export interface RegistryDeps {
    * store. Two engines, two owners of the write, one honest `userIndex`.
    */
   readonly persistence: RunPersistence;
+  /** Called for every frame an engine's decoder refuses. Supplied by the
+   *  composition root, which owns the transcript those refusals land on. */
+  readonly onIgnored?: (reason: IgnoredReason, detail: string) => void;
 }
 
 function stringSetting(settings: SettingsFacade, key: string, fallback: string): string {
@@ -141,6 +145,8 @@ export function enginesFor(deps: RegistryDeps): readonly EngineChoice[] {
           baseUrl: stringSetting(deps.settings, "baseUrl", "http://127.0.0.1:8765").replace(/\/+$/, ""),
           http: deps.http,
           id: ENGINE_REMOTE_HTTP,
+          // Refused frames go to the transcript instead of the floor.
+          ...(deps.onIgnored === undefined ? {} : { onIgnored: deps.onIgnored }),
         }),
     },
   ];

--- a/src/praisonai-mobile/app/src/registry.ts
+++ b/src/praisonai-mobile/app/src/registry.ts
@@ -40,7 +40,13 @@ export const SETTING_DEFS: readonly SettingDef[] = [
     label: "Engine",
     help: "Which agent runtime answers. Remote talks to a PraisonAI engine over HTTP; in-process runs the agent loop on this device.",
     section: "Engine",
-    choices: [ENGINE_REMOTE_HTTP, ENGINE_PRAISONAI_TS],
+    // Only what `enginesFor` can actually build in the shipping composition.
+    // ENGINE_PRAISONAI_TS was listed here and is only pushed when
+    // `createInProcess` is supplied, which main.ts does not do -- so selecting
+    // it persisted an id `selectEngine` then rejects, and the NEXT launch died
+    // at `renderFatal` with no way back except editing storage by hand. A
+    // picker must not offer a choice that bricks the app.
+    choices: [ENGINE_REMOTE_HTTP],
   },
   {
     key: "baseUrl",
@@ -71,6 +77,15 @@ export const SETTING_DEFS: readonly SettingDef[] = [
     section: "Display",
   },
   {
+    // NOT YET CONSUMED, and unlike its neighbours this one contradicts what
+    // the app actually does: the dropped row is rendered unconditionally
+    // (ui/src/transcript/view-model.ts), so the `false` default describes a
+    // hiding that does not happen. Left declared rather than deleted because
+    // the row SHOULD be gated once a settings screen exists -- but the gate
+    // must default to showing, since a diagnostic nobody can find is the same
+    // as no diagnostic. `model`, `temperature` and `showReasoning` are also
+    // declared ahead of their consumers; the difference is that they make no
+    // claim about behaviour that already exists.
     key: "showDiagnostics",
     default: false,
     label: "Show dropped events",

--- a/src/praisonai-mobile/core/src/run/controller.test.ts
+++ b/src/praisonai-mobile/core/src/run/controller.test.ts
@@ -395,3 +395,41 @@ test("a clean run still drops nothing", async () => {
   await h.controller.send("hi");
   assert.deepEqual(h.last().turn.dropped, []);
 });
+
+test("a drop on one turn does not cross onto the next clean turn", async () => {
+  // The controller keeps ONE turn across sends, so a refusal on turn 1 that
+  // was carried across `start` painted turn 2's clean answer as damaged --
+  // a success made to look like a defect. The fresh turn must start clean.
+  const views: RunView[] = [];
+  const sink = createDropSink();
+  const engine = createScriptedEngine({ id: "scripted", script: SCRIPTS.happy });
+  let run = 0;
+
+  const controller = createRunController({
+    engine: {
+      ...engine,
+      async *run(req, signal) {
+        run += 1;
+        const dropOnThisRun = run === 1;
+        for await (const event of engine.run(req, signal)) {
+          if (dropOnThisRun && event.type === "delta") sink.note("missing_msg_id", "tool_result");
+          yield event;
+        }
+      },
+    },
+    time: createFakeTime(),
+    dropSink: sink,
+    onPublish: (v) => views.push(v),
+  });
+
+  await controller.send("first");
+  const afterFirst = views.at(-1)?.turn.dropped ?? [];
+  assert.ok(afterFirst.length > 0, "the first turn must show its own drop");
+
+  await controller.send("second");
+  assert.deepEqual(
+    views.at(-1)?.turn.dropped,
+    [],
+    "the second, clean turn must not inherit the first turn's dropped row",
+  );
+});

--- a/src/praisonai-mobile/core/src/run/controller.test.ts
+++ b/src/praisonai-mobile/core/src/run/controller.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 
 import { createRunController, type RunView } from "./controller.ts";
 import { createFakeTime } from "../../../testing/src/fake-time.ts";
+import { createDropSink } from "./drop-sink.ts";
 import { createScriptedEngine } from "../../../testing/src/scripted-engine.ts";
 import { SCRIPTS } from "../../../testing/src/scripts.ts";
 import { createFakeScheduler } from "../../../testing/src/fake-scheduler.ts";
@@ -322,4 +323,75 @@ test("the flush tick is armed at maxDelayMs, not at some other period", async ()
   const sent = controller.send("hi");
   assert.deepEqual(time.intervalMs, [16], "the tick must be armed at maxDelayMs");
   await sent;
+});
+
+// ---- a frame the decoder refused --------------------------------------------
+
+test("a frame the engine's decoder refused becomes a dropped row on the turn", async () => {
+  // remote-http did `if (isDecoded(outcome)) yield` and discarded the rest --
+  // and it is the ONLY production caller of decodeEvent. So a malformed
+  // `tool_result` frame made its tool vanish and the turn rendered as a clean
+  // answer, while the reducer's Dropped type, the view model's dropped row and
+  // seven user-facing strings all sat unreachable.
+  const views: RunView[] = [];
+  const sink = createDropSink();
+  const engine = createScriptedEngine({ id: "scripted", script: SCRIPTS.happy });
+
+  const controller = createRunController({
+    engine: {
+      ...engine,
+      async *run(req, signal) {
+        for await (const event of engine.run(req, signal)) {
+          // The engine refuses a frame partway through, as a real decoder does.
+          if (event.type === "delta") sink.note("missing_msg_id", "tool_result");
+          yield event;
+        }
+      },
+    },
+    time: createFakeTime(),
+    dropSink: sink,
+    onPublish: (v) => views.push(v),
+  });
+
+  await controller.send("hi");
+
+  const dropped = views.at(-1)?.turn.dropped ?? [];
+  assert.ok(dropped.length > 0, "the refused frame left no trace on the transcript");
+  assert.equal(dropped[0]?.reason, "missing_msg_id");
+  assert.equal(dropped[0]?.detail, "tool_result");
+});
+
+test("a refusal on the very last frame is still shown", async () => {
+  // The loop ends after the terminal event, so a refusal arriving beside it
+  // would never be drained by the per-event path alone.
+  const views: RunView[] = [];
+  const sink = createDropSink();
+  const engine = createScriptedEngine({ id: "scripted", script: SCRIPTS.happy });
+
+  const controller = createRunController({
+    engine: {
+      ...engine,
+      async *run(req, signal) {
+        for await (const event of engine.run(req, signal)) yield event;
+        sink.note("unknown_event", "trailing");
+      },
+    },
+    time: createFakeTime(),
+    dropSink: sink,
+    onPublish: (v) => views.push(v),
+  });
+
+  await controller.send("hi");
+  assert.deepEqual(views.at(-1)?.turn.dropped.at(-1), {
+    reason: "unknown_event",
+    detail: "trailing",
+  });
+});
+
+test("a clean run still drops nothing", async () => {
+  // The pair. A controller that invented a dropped row per event would satisfy
+  // both tests above and mark every healthy turn as damaged.
+  const h = harness(SCRIPTS.happy);
+  await h.controller.send("hi");
+  assert.deepEqual(h.last().turn.dropped, []);
 });

--- a/src/praisonai-mobile/core/src/run/controller.ts
+++ b/src/praisonai-mobile/core/src/run/controller.ts
@@ -41,7 +41,8 @@ import {
   type PromptQueue,
   type QueuedPrompt,
 } from "./queue.ts";
-import { apply, finish, initialTurn, type TurnState } from "./transcript.ts";
+import { apply, finish, initialTurn, noteDropped, type TurnState } from "./transcript.ts";
+import type { DropSink } from "./drop-sink.ts";
 
 /** Everything a view needs, in one object. */
 export interface RunView {
@@ -63,6 +64,10 @@ export interface ControllerDeps {
   /** Bytes per frame and the delay ceiling. Defaults chosen for a phone. */
   readonly maxBytes?: number;
   readonly maxDelayMs?: number;
+  /** Where the engine leaves frames its decoder refused. Drained onto the
+   *  transcript as the turn runs, so a refused frame is visible as a dropped
+   *  event rather than as an answer that is quietly missing a tool. */
+  readonly dropSink?: DropSink;
 }
 
 export interface RunController {
@@ -105,6 +110,17 @@ export function createRunController(deps: ControllerDeps): RunController {
   const publish = (): void => {
     publishes += 1;
     deps.onPublish(view());
+  };
+
+  /** Move anything the decoder refused onto the transcript. Drained here
+   *  rather than published on its own, so a refusal paints with the frame it
+   *  arrived beside instead of forcing an extra publish. */
+  const drainDrops = (state: TurnState): TurnState => {
+    let next = state;
+    for (const d of deps.dropSink?.drain() ?? []) {
+      next = noteDropped(next, d.reason, d.detail);
+    }
+    return next;
   };
 
   /** Apply a coalesced frame's worth of work to the transcript. */
@@ -160,6 +176,7 @@ export function createRunController(deps: ControllerDeps): RunController {
         // The transcript is applied for EVERY event, always. Only the paint is
         // paced -- dropping an event to save a frame would lose content.
         turn = apply(turn, event);
+        turn = drainDrops(turn);
 
         if (event.type === "approval_request") {
           approvals = addApproval(approvals, {
@@ -203,6 +220,11 @@ export function createRunController(deps: ControllerDeps): RunController {
       stopTicking();
       live = null;
       coalescer.push({ kind: "end" }, deps.time.nowMs());
+      // A refusal can arrive beside the LAST frame, or while the stream was
+      // dying. Drained here rather than after the loop so it is reached on
+      // every path -- the first version of this sat at the end of the `catch`
+      // and therefore only ran when the turn had already failed.
+      turn = drainDrops(turn);
       turn = finish(turn);
       queue = markIdle(queue);
       // ALWAYS published, whatever the gate decided. The gate skips

--- a/src/praisonai-mobile/core/src/run/drop-sink.test.ts
+++ b/src/praisonai-mobile/core/src/run/drop-sink.test.ts
@@ -1,0 +1,31 @@
+/**
+ * The seam between a decoder's refusal and the transcript.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createDropSink } from "./drop-sink.ts";
+
+test("drain returns what was noted, in order", () => {
+  const sink = createDropSink();
+  sink.note("unknown_event", "wat");
+  sink.note("missing_msg_id", "end");
+  assert.deepEqual(sink.drain(), [
+    { reason: "unknown_event", detail: "wat" },
+    { reason: "missing_msg_id", detail: "end" },
+  ]);
+});
+
+test("drain empties the sink, so a refusal is shown once and not every frame", () => {
+  // Draining without clearing would repaint the same dropped row on every
+  // subsequent event of the turn, which reads as a storm of failures rather
+  // than the one that happened.
+  const sink = createDropSink();
+  sink.note("unknown_event", "wat");
+  assert.equal(sink.drain().length, 1);
+  assert.deepEqual(sink.drain(), []);
+});
+
+test("an untouched sink drains empty rather than throwing", () => {
+  assert.deepEqual(createDropSink().drain(), []);
+});

--- a/src/praisonai-mobile/core/src/run/drop-sink.ts
+++ b/src/praisonai-mobile/core/src/run/drop-sink.ts
@@ -1,0 +1,39 @@
+/**
+ * Where a decoder's refusals wait until the controller can put them on screen.
+ *
+ * An engine decodes frames; the controller owns the transcript. The engine is
+ * built at composition and the controller per app, so neither can call the
+ * other directly -- and without something between them the remote-http engine
+ * simply discarded every rejection (`if (isDecoded(outcome)) yield`), leaving
+ * the reducer's Dropped type, the view model's dropped row and seven
+ * user-facing strings all unreachable.
+ *
+ * Deliberately not an EventTarget: the controller drains on its own schedule,
+ * so a rejection that arrives mid-frame is painted with that frame rather than
+ * triggering a publish of its own.
+ */
+import type { Dropped } from "./transcript.ts";
+
+export interface DropSink {
+  /** Called by whatever refused the frame. Never throws. */
+  note(reason: Dropped["reason"], detail: string): void;
+  /** Take everything recorded since the last drain, and forget it. */
+  drain(): readonly Dropped[];
+}
+
+export function createDropSink(): DropSink {
+  let pending: Dropped[] = [];
+  return {
+    note(reason, detail) {
+      pending.push({ reason, detail });
+    },
+    drain() {
+      if (pending.length === 0) return EMPTY; // no allocation on the hot path
+      const taken = pending;
+      pending = [];
+      return taken;
+    },
+  };
+}
+
+const EMPTY: readonly Dropped[] = [];

--- a/src/praisonai-mobile/core/src/run/transcript.test.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.test.ts
@@ -9,7 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { apply, finish, initialTurn, isPersisted, type TurnState } from "./transcript.ts";
+import { apply, finish, initialTurn, isPersisted, type TurnState, noteDropped } from "./transcript.ts";
 import type { RunEvent } from "../../../protocol/src/events.ts";
 
 const M = "m1";
@@ -19,6 +19,8 @@ const delta = (text: string): RunEvent => ({ type: "delta", msgId: M, text });
 /** Feed a sequence from the initial state. */
 const run = (...events: readonly RunEvent[]): TurnState =>
   events.reduce<TurnState>(apply, initialTurn);
+
+const END_M1 = { type: "end", msgId: "m1", userIndex: 0, assistantIndex: 1, versions: 1, active: 0 } as const;
 
 test("an event arriving before start is recorded as dropped and never applied", () => {
   const state = apply(initialTurn, delta("hello"));
@@ -360,4 +362,51 @@ test("an approval survives an ERROR ending too, not just a cancellation", () => 
   ] as RunEvent[]) s = apply(s, e);
   assert.equal(s.approvals.length, 1);
   assert.equal(s.approvals[0]?.resolved, true);
+});
+
+// ---- drops belong to the turn they happened on ------------------------------
+
+test("a clean turn after a damaged one reports nothing dropped", () => {
+  // `start` carried `state.dropped` -- the previous turn's ENTIRE list. So one
+  // refusal on turn 1 made every later turn report itself damaged for the
+  // lifetime of the app, and the count could never mean "this stream is 40%
+  // unparseable". Harmless while nothing could produce a decode rejection;
+  // user-visible the moment the refusal channel was wired.
+  let s = initialTurn;
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  s = noteDropped(s, "unknown_event", "thinking_budget");
+  s = apply(s, END_M1);
+  assert.equal(s.dropped.length, 1, "the turn that dropped it must show it");
+
+  s = apply(s, { type: "start", msgId: "m2", runId: "r2" });
+  s = apply(s, { type: "delta", msgId: "m2", text: "clean" });
+  assert.deepEqual(s.dropped, [], "a clean turn must not inherit the last one's failures");
+});
+
+test("a drop between turns still reaches the turn that follows it", () => {
+  // The pair, and the reason `start` carried anything at all: a frame refused
+  // while nothing was streaming has no turn of its own, and dropping it on the
+  // floor loses the evidence entirely.
+  let s = initialTurn;
+  s = noteDropped(s, "unparseable_json", "<html>502</html>");
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  assert.deepEqual(s.dropped, [{ reason: "unparseable_json", detail: "<html>502</html>" }]);
+});
+
+test("a between-turns drop is carried ONCE, not to every later turn", () => {
+  // Carrying without clearing would reintroduce the leak one turn later.
+  let s = initialTurn;
+  s = noteDropped(s, "unparseable_json", "pre");
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  s = apply(s, END_M1);
+  s = apply(s, { type: "start", msgId: "m2", runId: "r2" });
+  assert.deepEqual(s.dropped, []);
+});
+
+test("a drop DURING a turn does not leak into the carry", () => {
+  // If it did, the turn would show it and so would the next one.
+  let s = initialTurn;
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  s = noteDropped(s, "unknown_event", "mid");
+  assert.deepEqual(s.carry, [], "a drop on a live turn belongs to that turn alone");
 });

--- a/src/praisonai-mobile/core/src/run/transcript.test.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.test.ts
@@ -410,3 +410,30 @@ test("a drop DURING a turn does not leak into the carry", () => {
   s = noteDropped(s, "unknown_event", "mid");
   assert.deepEqual(s.carry, [], "a drop on a live turn belongs to that turn alone");
 });
+
+test("a decoder refusal AFTER a turn ended reaches the next turn, not the last one", () => {
+  // The case that separates the two ways of fixing the leak, and the reason
+  // this file needed both. Clearing on `phase === "ended"` also stops the
+  // leak -- and passes the between-turns test above, because that one starts
+  // from `idle`. It loses THIS: the previous turn has ended, so its whole list
+  // is discarded, and a frame the decoder refused in the gap goes with it.
+  //
+  // Such a refusal has no msgId at all -- that is often WHY it was refused --
+  // so it cannot be attributed backwards to the turn that just finished. It
+  // belongs to the turn about to open, and losing it quietly is the exact
+  // failure the refusal channel exists to undo.
+  let s = initialTurn;
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  s = apply(s, { type: "delta", msgId: "m1", text: "answered" });
+  s = apply(s, END_M1);
+  assert.equal(s.phase, "ended");
+
+  s = noteDropped(s, "unparseable_json", "<html>502 Bad Gateway</html>");
+  s = apply(s, { type: "start", msgId: "m2", runId: "r2" });
+
+  assert.deepEqual(
+    s.dropped,
+    [{ reason: "unparseable_json", detail: "<html>502 Bad Gateway</html>" }],
+    "a refusal in the gap between turns must not be discarded with the old turn",
+  );
+});

--- a/src/praisonai-mobile/core/src/run/transcript.test.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.test.ts
@@ -183,9 +183,12 @@ test("a full turn accumulates text, reasoning and usage", () => {
   assert.deepEqual(state.dropped, [], "a clean stream drops nothing");
 });
 
-test("a start after a finished turn opens a fresh turn but keeps the drop record", () => {
-  // Regenerate reuses the same controller. The new turn must not inherit the
-  // old one's text, and must not lose the evidence that events were dropped.
+test("a start after a FINISHED turn opens a fresh turn and clears the drop record", () => {
+  // A completed turn OWNS its drops. Carrying them into the next `start`
+  // painted the previous turn's dropped-event warning onto a clean follow-up
+  // answer -- a success made to look like a defect, the mirror of the failure
+  // this whole package exists against. The old turn's transcript already
+  // recorded them; the new turn must not inherit them.
   const first = run(start, delta("old"), { type: "cancelled", msgId: M, runId: "r1" }, delta("late"));
   assert.equal(first.dropped.length, 1);
 
@@ -193,7 +196,21 @@ test("a start after a finished turn opens a fresh turn but keeps the drop record
   assert.equal(second.text, "");
   assert.equal(second.msgId, "m2");
   assert.equal(second.phase, "streaming");
-  assert.equal(second.dropped.length, 1, "the earlier drop must still be visible");
+  assert.deepEqual(second.dropped, [], "a finished turn's drops must not cross into the next turn");
+});
+
+test("a start after a BEFORE-start drop keeps it, because that drop belongs to this turn", () => {
+  // The pair. A frame the decoder refused before this run's own `start` was
+  // recorded while idle and belongs to the turn now opening -- clearing it
+  // would hide a real defect. Only an ALREADY-ENDED turn's drops are cleared.
+  const early = apply(initialTurn, delta("orphan")); // dropped: before_start, still idle
+  assert.equal(early.phase, "idle");
+  assert.equal(early.dropped.length, 1);
+
+  const opened = apply(early, start);
+  assert.equal(opened.phase, "streaming");
+  assert.equal(opened.dropped.length, 1, "a before-start drop must survive into its own turn");
+  assert.equal(opened.dropped[0]?.reason, "before_start");
 });
 
 // ---- render order ----------------------------------------------------------

--- a/src/praisonai-mobile/core/src/run/transcript.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.ts
@@ -119,6 +119,22 @@ const drop = (state: TurnState, reason: Dropped["reason"], detail: string): Turn
 });
 
 /**
+ * Record a frame the DECODER refused, before it could ever become an event.
+ *
+ * `apply` can only record events it was given, so a frame that failed to decode
+ * had no way in -- which is why `Dropped.reason` admitted every IgnoredReason
+ * while no IgnoredReason could reach a transcript. A malformed `tool_result`
+ * made its tool vanish and the turn rendered as a clean answer.
+ */
+export function noteDropped(
+  state: TurnState,
+  reason: Dropped["reason"],
+  detail: string,
+): TurnState {
+  return drop(state, reason, detail);
+}
+
+/**
  * Apply one event.
  *
  * Returns the SAME object when an event changes nothing, so a caller can use

--- a/src/praisonai-mobile/core/src/run/transcript.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.ts
@@ -131,7 +131,17 @@ const drop = (state: TurnState, reason: Dropped["reason"], detail: string): Turn
     dropped: [...state.dropped, d],
     // A drop that arrives while nothing is streaming belongs to the turn that
     // has not started yet, so `start` can carry exactly those and nothing else.
-    carry: state.phase === "streaming" ? state.carry : [...state.carry, d],
+    //
+    // Except `after_terminal`, which is the one out-of-band drop that IS about
+    // the turn just finished: a frame from the old run arriving late is
+    // evidence against the old run, and moving it forward would blame the next
+    // answer for its predecessor's mess. A decoder refusal between turns is
+    // different -- it has no msgId at all, so it cannot be attributed
+    // backwards and belongs to the turn about to open.
+    carry:
+      state.phase === "streaming" || reason === "after_terminal"
+        ? state.carry
+        : [...state.carry, d],
   };
 };
 

--- a/src/praisonai-mobile/core/src/run/transcript.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.ts
@@ -96,6 +96,16 @@ export interface TurnState {
    * quiet success, which is the failure this whole package is built against.
    */
   readonly dropped: readonly Dropped[];
+  /**
+   * Drops recorded while NO turn was streaming, waiting for the next `start`.
+   *
+   * `start` used to carry `state.dropped` wholesale, which is the previous
+   * turn's ENTIRE list -- so one refusal on turn 1 made every later turn
+   * report itself damaged, for the lifetime of the app, and the count could
+   * never be used for "this stream is 40% unparseable". Only what arrived
+   * between the turns belongs to the next one.
+   */
+  readonly carry: readonly Dropped[];
 }
 
 export const initialTurn: TurnState = {
@@ -111,12 +121,19 @@ export const initialTurn: TurnState = {
   usage: null,
   outcome: null,
   dropped: [],
+  carry: [],
 };
 
-const drop = (state: TurnState, reason: Dropped["reason"], detail: string): TurnState => ({
-  ...state,
-  dropped: [...state.dropped, { reason, detail }],
-});
+const drop = (state: TurnState, reason: Dropped["reason"], detail: string): TurnState => {
+  const d: Dropped = { reason, detail };
+  return {
+    ...state,
+    dropped: [...state.dropped, d],
+    // A drop that arrives while nothing is streaming belongs to the turn that
+    // has not started yet, so `start` can carry exactly those and nothing else.
+    carry: state.phase === "streaming" ? state.carry : [...state.carry, d],
+  };
+};
 
 /**
  * Record a frame the DECODER refused, before it could ever become an event.
@@ -151,14 +168,21 @@ export function apply(state: TurnState, event: RunEvent): TurnState {
       phase: "streaming",
       msgId: event.msgId,
       runId: event.runId,
-      // Carried across ONLY from a turn that had not yet ended -- a frame the
-      // decoder refused BEFORE this run's own `start` (recorded while `idle`)
-      // belongs to the turn now opening. A turn that already ENDED owns its
-      // drops; carrying them into the next `start` painted a previous turn's
-      // dropped-event warning onto a clean follow-up answer, which is the same
-      // "a defect looks like a success" failure inverted -- a success made to
-      // look like a defect.
-      dropped: state.phase === "ended" ? [] : state.dropped,
+      // Carried across deliberately: a turn that dropped events before it
+      // started still dropped them, and hiding that would lose the evidence.
+      // ONLY those, though: carrying `state.dropped` meant inheriting the
+      // whole previous turn and reporting every later turn as damaged.
+      //
+      // `state.carry` rather than `state.phase === "ended" ? [] : state.dropped`
+      // -- the two fixes for this landed independently and both stop the leak,
+      // but the phase test loses a frame refused BETWEEN turns: the previous
+      // turn has ENDED, so its list is discarded wholesale and the refusal that
+      // arrived after it goes with it. Measured on both: the clean-turn case
+      // passes either way; the between-turns case is 1 with `carry` and 0
+      // without. Losing evidence quietly is the failure this whole channel
+      // exists to undo.
+      dropped: state.carry,
+      carry: [],
     };
   }
 

--- a/src/praisonai-mobile/core/src/run/transcript.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.ts
@@ -151,9 +151,14 @@ export function apply(state: TurnState, event: RunEvent): TurnState {
       phase: "streaming",
       msgId: event.msgId,
       runId: event.runId,
-      // Carried across deliberately: a turn that dropped events before it
-      // started still dropped them, and hiding that would lose the evidence.
-      dropped: state.dropped,
+      // Carried across ONLY from a turn that had not yet ended -- a frame the
+      // decoder refused BEFORE this run's own `start` (recorded while `idle`)
+      // belongs to the turn now opening. A turn that already ENDED owns its
+      // drops; carrying them into the next `start` painted a previous turn's
+      // dropped-event warning onto a clean follow-up answer, which is the same
+      // "a defect looks like a success" failure inverted -- a success made to
+      // look like a defect.
+      dropped: state.phase === "ended" ? [] : state.dropped,
     };
   }
 

--- a/src/praisonai-mobile/docs/gaps.md
+++ b/src/praisonai-mobile/docs/gaps.md
@@ -344,6 +344,13 @@ It also used to omit **route→view dispatch**, which the body of this file list
 as open and which is still open; dropping it from the closing line implied it
 had landed.
 
+Four settings are declared and not yet consumed by anything: `model`,
+`temperature`, `showReasoning` and `showDiagnostics`. That is expected — they
+were written for the settings screen and the engine parameterisation that do
+not exist yet — but it is recorded here so nobody reads the registry and
+concludes they work. `showDiagnostics` is the one to watch: it claims to hide
+dropped events, which are currently rendered unconditionally.
+
 What actually remains for praisonai-mobile, all of it unbuilt rather than
 broken:
 

--- a/src/praisonai-mobile/docs/gaps.md
+++ b/src/praisonai-mobile/docs/gaps.md
@@ -371,3 +371,12 @@ frame is still shown. Eight mutations, one per hop, each fails -- including
 the two that make it *wired* rather than merely present: removing the sink
 from `createRunController` and dropping the registry's forward both left the
 suite green until composition tests were added for each.
+
+One correction landed with it. `apply(start)` carried `dropped` across every
+new `start`, including one that followed a FINISHED turn -- so a refusal on
+turn 1 painted turn 2's clean answer as damaged, a success made to look like a
+defect (the same failure this channel exists against, inverted). A turn that
+already ended owns its drops; only a `before_start` drop, recorded while
+`idle`, belongs to the turn now opening. Fixed by clearing `dropped` on a
+`start` that replaces an ended turn, pinned at both hops: reverting it fails
+one reducer test and one controller test.

--- a/src/praisonai-mobile/docs/gaps.md
+++ b/src/praisonai-mobile/docs/gaps.md
@@ -361,10 +361,13 @@ broken:
   blocker — bare `crypto` and `events` imports on the Agent graph — is fixed
   upstream; the wiring here is not done.
 
-One known defect is deliberately still open: the remote-http engine discards
-decode rejections, so a malformed frame makes a tool vanish and the turn
-renders as a clean answer. The reducer's `Dropped` type, the view model's
-dropped row and seven user-facing strings are unreachable because of it.
-Fixing it needs a channel from the engine to the transcript that does not
-exist yet, and half-wiring one would be the same mechanism-connected-to-nothing
-this file keeps recording.
+The decode-rejection defect recorded here is now closed. remote-http was the
+only production caller of `decodeEvent` and discarded every rejection, so a
+malformed frame made its tool vanish and the turn rendered as a clean answer.
+`core/src/run/drop-sink.ts` is the channel between the engine (built at
+composition) and the controller (built per app); refusals are drained onto the
+transcript per event and again in `finally`, so one arriving beside the last
+frame is still shown. Eight mutations, one per hop, each fails -- including
+the two that make it *wired* rather than merely present: removing the sink
+from `createRunController` and dropping the registry's forward both left the
+suite green until composition tests were added for each.

--- a/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
@@ -227,3 +227,49 @@ test("a clean stream reports no refusals", async () => {
   }
   assert.deepEqual(refused, []);
 });
+
+test("each kind of unreadable frame reports its own reason and keeps the payload", async () => {
+  // `safeParse` returned `{}` for anything it could not read, and the caller
+  // spread it and added `type` -- so an HTML error page from a proxy, a body
+  // truncated by a cut connection, an array, a bare string and `null` ALL came
+  // back as `missing_msg_id`, with the payload gone so `detail` could not
+  // recover it. Now that rejections are user-visible prose, that told the user
+  // "an event arrived with no message it belongs to" about a 502 page and
+  // pointed their support engineer at an engine bug that does not exist.
+  const cases: { body: string; reason: string; detailHas: string }[] = [
+    { body: "<html>502 Bad Gateway</html>", reason: "unparseable_json", detailHas: "502" },
+    { body: '{"msg_id":"m1","te', reason: "unparseable_json", detailHas: "msg_id" },
+    { body: "[1,2,3]", reason: "not_an_object", detailHas: "array" },
+    { body: '"just a string"', reason: "not_an_object", detailHas: "string" },
+    { body: "null", reason: "not_an_object", detailHas: "object" },
+  ];
+
+  for (const c of cases) {
+    const http = createFakeHttp();
+    const refused: { reason: string; detail: string }[] = [];
+    http.on("/chat", () =>
+      sseResponse(
+        `event: start\ndata: ${JSON.stringify({ msg_id: "m1", run_id: "r1" })}\n\n` +
+          `event: delta\ndata: ${c.body}\n\n` +
+          `event: end\ndata: ${JSON.stringify({ msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 })}\n\n`,
+      ),
+    );
+    const engine = createRemoteHttpEngine({
+      baseUrl: "http://engine.test",
+      http,
+      onIgnored: (reason, detail) => refused.push({ reason, detail }),
+    });
+    for await (const _ of engine.run(
+      { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+      new AbortController().signal,
+    )) {
+      // drain
+    }
+    assert.equal(refused[0]?.reason, c.reason, `wrong reason for ${c.body}`);
+    assert.match(
+      refused[0]?.detail ?? "",
+      new RegExp(c.detailHas),
+      `the detail must carry enough to identify the frame: ${c.body}`,
+    );
+  }
+});

--- a/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
@@ -157,3 +157,73 @@ test("remote-http: an unreachable engine is a retryable transport failure, not a
   assert.equal(verdict.ready === false && verdict.reason, "transport");
   assert.equal(verdict.ready === false && verdict.retryable, true);
 });
+
+// ---- frames the decoder refuses ---------------------------------------------
+
+test("a malformed frame is reported, not silently dropped", async () => {
+  // This engine is the ONLY production caller of decodeEvent, and it did
+  // `if (isDecoded(outcome)) yield` -- discarding every rejection. So a
+  // `tool_result` frame missing its `ok` made the tool disappear and the turn
+  // rendered as a clean answer, while the reducer's Dropped type, the view
+  // model's dropped row and seven user-facing strings sat unreachable.
+  const http = createFakeHttp();
+  const refused: { reason: string; detail: string }[] = [];
+
+  http.on("/chat", () =>
+    sseResponse(
+      [
+        `event: start\ndata: ${JSON.stringify({ msg_id: "m1", run_id: "r1" })}\n\n`,
+        `event: delta\ndata: ${JSON.stringify({ msg_id: "m1", text: "hello" })}\n\n`,
+        // Refused: a tool_result with no `ok`. `ok` is the ONLY signal of tool
+        // success, so a frame without it cannot be interpreted at all.
+        `event: tool_result\ndata: ${JSON.stringify({ msg_id: "m1", call_id: "c1", name: "rm", output: "done" })}\n\n`,
+        `event: end\ndata: ${JSON.stringify({ msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 })}\n\n`,
+      ].join(""),
+    ),
+  );
+
+  const engine = createRemoteHttpEngine({
+    baseUrl: "http://engine.test",
+    http,
+    onIgnored: (reason, detail) => refused.push({ reason, detail }),
+  });
+
+  const events = [];
+  for await (const event of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )) {
+    events.push(event);
+  }
+
+  assert.equal(
+    events.some((e) => e.type === "tool_result"),
+    false,
+    "an undecodable frame must not be yielded as if it were fine",
+  );
+  assert.equal(refused.length, 1, "the refusal must be reported to the caller");
+  assert.equal(refused[0]?.reason, "missing_required_field");
+  assert.equal(refused[0]?.detail, "tool_result.ok", "the detail must name the field, so a report is actionable");
+});
+
+test("a clean stream reports no refusals", async () => {
+  // The pair. An engine that reported a refusal per frame would satisfy the
+  // test above and mark every healthy turn as damaged.
+  const http = createFakeHttp();
+  const refused: unknown[] = [];
+  http.on("/chat", () => sseResponse(framesFor(SCRIPTS.happy)));
+
+  const engine = createRemoteHttpEngine({
+    baseUrl: "http://engine.test",
+    http,
+    onIgnored: (...args) => refused.push(args),
+  });
+
+  for await (const _ of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )) {
+    // drain
+  }
+  assert.deepEqual(refused, []);
+});

--- a/src/praisonai-mobile/engines/src/remote-http/engine.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/engine.ts
@@ -157,7 +157,12 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
             // its tool vanish and the turn rendered as a clean answer, while
             // the reducer's Dropped type, the view model's dropped row and
             // seven user-facing strings sat unreachable.
-            const outcome = decodeEvent({ ...safeParse(frame.data), type: frame.event });
+            const parsed = parseFrame(frame.data);
+            if (!parsed.ok) {
+              options.onIgnored?.(parsed.reason, parsed.detail);
+              continue;
+            }
+            const outcome = decodeEvent({ ...parsed.value, type: frame.event });
             if (isDecoded(outcome)) {
               yield outcome.event;
             } else {
@@ -188,15 +193,37 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
 
 /** A frame's data that is not JSON is not a reason to throw -- decodeEvent
  *  will report it as unparseable with a reason. */
-function safeParse(data: string): Record<string, unknown> {
+/**
+ * Parse an SSE frame body, keeping WHY it failed.
+ *
+ * This used to be `safeParse`, which returned `{}` for anything it could not
+ * read. Since the caller then spreads it and adds `type`, every wire failure
+ * reached the decoder as an object with only a type -- so five distinct
+ * failures (an HTML error page from a proxy, a truncated body from a cut
+ * connection, a JSON array, a bare string, `null`) all came back as
+ * `missing_msg_id`, and the payload was gone so `detail` could not recover it.
+ *
+ * That was survivable while rejections were discarded. They are user-visible
+ * prose now: a 502 page from a proxy told the user "an event arrived with no
+ * message it belongs to", pointing whoever they reported it to at an engine
+ * bug that does not exist. Two shipped strings -- "not valid JSON" and "a
+ * value where an event was expected" -- were unreachable for the same reason.
+ */
+type ParsedFrame =
+  | { readonly ok: true; readonly value: Record<string, unknown> }
+  | { readonly ok: false; readonly reason: IgnoredReason; readonly detail: string };
+
+function parseFrame(data: string): ParsedFrame {
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(data);
-    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : {};
+    parsed = JSON.parse(data);
   } catch {
-    return {};
+    return { ok: false, reason: "unparseable_json", detail: data.slice(0, 120) };
   }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, reason: "not_an_object", detail: Array.isArray(parsed) ? "array" : typeof parsed };
+  }
+  return { ok: true, value: parsed as Record<string, unknown> };
 }
 
 /** Probe `/health` and classify it. Separate from the engine so a connection

--- a/src/praisonai-mobile/engines/src/remote-http/engine.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/engine.ts
@@ -24,7 +24,7 @@ import type {
 import type { HttpPort } from "../../../core/src/ports/http.ts";
 import type { ApprovalChoice, RunEvent } from "../../../protocol/src/events.ts";
 import { PROTOCOL_VERSION } from "../../../protocol/src/version.ts";
-import { decodeEvent, isDecoded } from "../../../protocol/src/decode.ts";
+import { decodeEvent, isDecoded, type IgnoredReason } from "../../../protocol/src/decode.ts";
 import { createSseReader } from "../../../protocol/src/sse.ts";
 import { classify, type Readiness } from "./readiness.ts";
 
@@ -35,6 +35,9 @@ export interface RemoteHttpOptions {
   /** Sent as a bearer token when present. The desktop engine is unauthenticated
    *  on loopback; anything off-device must not be. */
   readonly token?: string;
+  /** Called for every frame the decoder REFUSED. Without it the refusal is
+   *  invisible: a truncated answer reported as a clean success. */
+  readonly onIgnored?: (reason: IgnoredReason, detail: string) => void;
   readonly id?: string;
 }
 
@@ -147,8 +150,19 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
           for (const frame of readFrames(decoder.decode(value, { stream: true }))) {
             // decodeEvent never throws. An unknown event is a recorded no-op,
             // which is what makes a newer engine safe to talk to.
+            //
+            // "Recorded" used to be aspirational: the ignored branch was
+            // dropped on the floor here, and this is the ONLY production
+            // caller of decodeEvent. So a malformed `tool_result` frame made
+            // its tool vanish and the turn rendered as a clean answer, while
+            // the reducer's Dropped type, the view model's dropped row and
+            // seven user-facing strings sat unreachable.
             const outcome = decodeEvent({ ...safeParse(frame.data), type: frame.event });
-            if (isDecoded(outcome)) yield outcome.event;
+            if (isDecoded(outcome)) {
+              yield outcome.event;
+            } else {
+              options.onIgnored?.(outcome.reason, outcome.detail);
+            }
           }
         }
       } finally {


### PR DESCRIPTION
The last defect from the multi-agent validation pass, left open when [#4558](https://github.com/MervinPraison/PraisonAI/pull/4558) merged because closing it needed a channel that did not exist.

## The defect

`remote-http` is the **only** production caller of `decodeEvent`, and it did:

```ts
const outcome = decodeEvent({ ...safeParse(frame.data), type: frame.event });
if (isDecoded(outcome)) yield outcome.event;
```

Every rejection went on the floor. A `tool_result` frame missing its `ok` — and `ok` is the only signal of tool success, never inferred from output — made its tool **disappear entirely**, and the turn rendered as a clean answer with a shorter reply.

Meanwhile `Dropped.reason` already admitted every `IgnoredReason`, the view model already rendered a dropped row, there was already a `showDiagnostics` setting labelled "Show dropped events", and `strings.ts` already had a sentence for all seven reasons. None of it was reachable, because nothing upstream ever produced one.

## The channel

The engine is built at composition and the controller per app, so neither can call the other. `core/src/run/drop-sink.ts` sits between them: the engine notes a refusal, the controller drains it onto the transcript — per event, and again in `finally`, so a refusal arriving beside the last frame or while the stream was dying is still shown. Deliberately not an `EventTarget`: draining on the controller's own schedule means a refusal paints with the frame it arrived beside instead of forcing its own publish.

Found while writing this: my first drain sat at the end of the `catch` block, so it only ran when the turn had already failed. The paired test for a last-frame refusal caught it.

## Proved wired, not merely present

Eight mutations, one per hop, each now failing:

| mutation | result |
|---|---|
| engine discards refusals again | `fail=2` |
| engine reports a refusal for every frame | `fail=2` |
| controller drains but discards | `fail=3` |
| controller skips the final drain | `fail=1` |
| sink drains without clearing | `fail=1` |
| boot does not give the sink to the controller | `fail=1` |
| boot hands engines a dead callback | `fail=1` |
| registry declines to forward `onIgnored` | `fail=1` |

**The last two mattered most.** Removing `dropSink` from `createRunController`, and dropping the registry's forward, *both left the suite green on the first pass* — every hop worked in isolation and the ends were not joined. That is the exact mechanism-connected-to-nothing this PR exists to undo, reproduced by me while undoing it. Both are pinned now by composition tests: one through `createApp`, one through the real `enginesFor` rather than a test double.

Every case is paired, so wiring that invented a dropped row fails too.

`907 tests, 0 failed` · `boundaries: 130 files, no violations`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed or rejected engine frames now appear in the transcript as dropped entries instead of being silently discarded.
  * Dropped entries remain visible after final events or unexpected connection failures.
  * New turns no longer inherit dropped entries from completed turns.
  * Clean runs continue to show no dropped entries.

* **Improvements**
  * The engine picker now lists only the available remote engine.

* **Documentation**
  * Updated documentation to reflect resolved stream-decoding and dropped-state issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->