### PR TITLE
fix(mobile): the reconciler's coordinate systems, and decode.ts's 15 surviving mutations

### DIFF
--- a/src/praisonai-mobile/app/src/dom.test.ts
+++ b/src/praisonai-mobile/app/src/dom.test.ts
@@ -16,6 +16,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { applyOps, emptyNodes } from "./dom.ts";
+import { reconcile, emptyRender, type RenderState } from "../../ui/src/render/reconcile.ts";
 import type { Row } from "../../ui/src/transcript/view-model.ts";
 import { UNKNOWN } from "../../ui/src/format.ts";
 
@@ -30,6 +31,7 @@ function fakeDoc() {
       hidden: false,
       disabled: false,
       children: [] as any[],
+      parent: null as any,
       _text: "",
       _html: "",
       get textContent() { return this._text; },
@@ -37,9 +39,31 @@ function fakeDoc() {
       get innerHTML() { return this._html; },
       set innerHTML(v: string) { this._html = v; },
       classList: { toggle() {} },
-      append(...cs: any[]) { this.children.push(...cs); },
-      insertBefore(c: any) { this.children.push(c); },
-      remove() {},
+      append(...cs: any[]) {
+        for (const c of cs) { c.parent = this; this.children.push(c); }
+      },
+      // Real reference-node semantics. A fake that appends unconditionally
+      // cannot fail an ordering test -- it renders every order as append order,
+      // so the reconciler's move ops all look correct. `ref === null` appends;
+      // otherwise the node lands immediately before `ref`. The node is detached
+      // from its current position first, which is what makes a move a move
+      // rather than a duplicate.
+      insertBefore(c: any, ref: any) {
+        const had = this.children.indexOf(c);
+        if (had !== -1) this.children.splice(had, 1);
+        c.parent = this;
+        if (ref === null || ref === undefined) { this.children.push(c); return c; }
+        const at = this.children.indexOf(ref);
+        this.children.splice(at === -1 ? this.children.length : at, 0, c);
+        return c;
+      },
+      remove() {
+        const p = this.parent;
+        if (!p) return;
+        const at = p.children.indexOf(this);
+        if (at !== -1) p.children.splice(at, 1);
+        this.parent = null;
+      },
     };
     Object.defineProperty(el, "ownerDocument", { get: () => doc, configurable: true });
     created.push(el);
@@ -201,4 +225,119 @@ test("a measured duration renders its label", () => {
   const row = created.find((el) => el.dataset.rowId === "tool:c1");
   const meta = row?.children.find((c: any) => c.className === "tool-meta");
   assert.equal(meta?._text, "3.2s");
+});
+
+// ---- reconcile -> applyOps: the ops actually produce the target order -------
+//
+// `reconcile.test.ts` asserts op SHAPES and never applies them: it can say "a
+// move for c at index 0 was emitted" but not whether running the ops yields the
+// intended order. This layer is the only one allowed to import both halves, so
+// the round trip is closed HERE. The reconciler's coordinate-system bug --
+// modelling moves against `surviving` (previous ids minus removals) at the
+// target index (which counts rows inserted this pass) -- rendered [d,e,b,a,c]
+// for [a,b,c] -> [d,e,b,c,a]. Both sweeps below reproduced it before the fix
+// and are 0-wrong after; mutating the fake's insertBefore back to appending
+// makes them fail, so the fake is itself under test.
+
+/** A distinct text row per id, so the sweep only ever exercises ordering. */
+const idRow = (id: string): Row => ({ kind: "text", id, text: id, streaming: false });
+
+/** The DOM's row order, by the id stamped on each element. */
+const domOrder = (host: any): string[] =>
+  host.children.map((c: any) => c.dataset.rowId as string);
+
+/** Drive `previous -> next` through the real reconcile and the real applyOps. */
+function render(host: any, nodes: ReturnType<typeof emptyNodes>, prev: RenderState, ids: readonly string[]) {
+  const { ops, next } = reconcile(prev, ids.map(idRow));
+  applyOps(host, nodes, ops);
+  return next;
+}
+
+test("the smallest failing case renders the target order, not [d,e,b,a,c]", () => {
+  const { host } = fakeDoc();
+  const nodes = emptyNodes();
+  const first = render(host, nodes, emptyRender, ["a", "b", "c"]);
+  render(host, nodes, first, ["d", "e", "b", "c", "a"]);
+  assert.deepEqual(domOrder(host), ["d", "e", "b", "c", "a"]);
+});
+
+test("an insert before a reorder still lands every row where the target says", () => {
+  // The class of case the old model drifted on: an insert this pass shifts the
+  // target indices, and a move computed against a list that lacks the insert
+  // points at the wrong sibling.
+  const { host } = fakeDoc();
+  const nodes = emptyNodes();
+  const first = render(host, nodes, emptyRender, ["b", "c"]);
+  render(host, nodes, first, ["a", "c", "b"]);
+  assert.deepEqual(domOrder(host), ["a", "c", "b"]);
+});
+
+test("exhaustive: every prev/target over a small id set renders the target order", () => {
+  // The sweep the PR measured at 120/960 wrong before the fix. Enumerate every
+  // ordered subset (as `previous`) and every ordered subset (as `target`) over
+  // five ids, apply the REAL ops to the fake DOM, and assert the DOM equals the
+  // target exactly. An id present in target must end up present and in order;
+  // one dropped must be gone.
+  const universe = ["a", "b", "c", "d", "e"];
+  const subsets = (xs: string[]): string[][] => {
+    const out: string[][] = [];
+    const walk = (rest: string[], acc: string[]) => {
+      out.push(acc);
+      for (let i = 0; i < rest.length; i++) walk(rest.slice(i + 1), [...acc, rest[i]!]);
+    };
+    walk(xs, []);
+    return out;
+  };
+  // Orderings: for a set this small, test every permutation of each subset.
+  const permute = (xs: string[]): string[][] => {
+    if (xs.length <= 1) return [xs];
+    const out: string[][] = [];
+    for (let i = 0; i < xs.length; i++) {
+      const rest = [...xs.slice(0, i), ...xs.slice(i + 1)];
+      for (const p of permute(rest)) out.push([xs[i]!, ...p]);
+    }
+    return out;
+  };
+
+  const orderings = subsets(universe).flatMap(permute);
+  let checked = 0;
+  for (const prev of orderings) {
+    for (const target of orderings) {
+      const { host } = fakeDoc();
+      const nodes = emptyNodes();
+      const state = render(host, nodes, emptyRender, prev);
+      render(host, nodes, state, target);
+      assert.deepEqual(domOrder(host), target, `prev=[${prev}] target=[${target}]`);
+      checked++;
+    }
+  }
+  assert.ok(checked > 900, `swept ${checked} pairs`);
+});
+
+test("appending to a long list is one insert, and the row lands last", () => {
+  // The minimal-op guarantee, now proven at the DOM: a rebuilding reconciler
+  // that happened to produce the right order would emit far more than one op.
+  const { host } = fakeDoc();
+  const nodes = emptyNodes();
+  const ids = Array.from({ length: 200 }, (_, i) => `r${i}`);
+  const first = reconcile(emptyRender, ids.map(idRow));
+  applyOps(host, nodes, first.ops);
+
+  const grown = [...ids, "r200"];
+  const second = reconcile(first.next, grown.map(idRow));
+  applyOps(host, nodes, second.ops);
+
+  assert.equal(second.ops.length, 1, "appending is a single insert");
+  assert.equal(second.ops[0]?.kind, "insert");
+  assert.deepEqual(domOrder(host), grown);
+});
+
+test("an unchanged list touches the DOM zero times", () => {
+  const { host } = fakeDoc();
+  const nodes = emptyNodes();
+  const ids = ["a", "b", "c"];
+  const first = render(host, nodes, emptyRender, ids);
+  const second = reconcile(first, ids.map(idRow));
+  assert.deepEqual(second.ops, [], "a settled list must emit no ops");
+  assert.deepEqual(domOrder(host), ids);
 });

--- a/src/praisonai-mobile/app/src/dom.ts
+++ b/src/praisonai-mobile/app/src/dom.ts
@@ -134,6 +134,9 @@ export function applyOps(
       case "move": {
         const el = state.nodes.get(op.id);
         if (el === undefined) break;
+        // `children[op.index]` is read BEFORE insertBefore detaches the node,
+        // so it names a real sibling and the placement is relative to that
+        // node, not to an index that shifts underneath it.
         host.insertBefore(el, host.children[op.index] ?? null);
         break;
       }

--- a/src/praisonai-mobile/protocol/src/decode.test.ts
+++ b/src/praisonai-mobile/protocol/src/decode.test.ts
@@ -21,7 +21,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { decodeEvent, isIgnored, isDecoded } from "./decode.ts";
+import { decodeApprovalChoice, decodeEvent, isIgnored, isDecoded } from "./decode.ts";
 import { encodeEvent } from "./encode.ts";
 import { RUN_EVENT_NAMES, type RunEvent } from "./events.ts";
 
@@ -245,4 +245,175 @@ test("unknown wire fields are ignored so a newer engine can add them freely", ()
   });
   assert.ok(isDecoded(outcome));
   assert.deepEqual(outcome.event, { type: "delta", msgId: "m1", text: "hi" });
+});
+
+// ---- the end event's index arithmetic --------------------------------------
+//
+// A mutation sweep found 15 of 16 mutations in this file surviving. The tests
+// above cover the SHAPE of every event thoroughly; none of them ever passed
+// `versions` other than 1, `active` other than 0, an absent `assistant_index`,
+// or an empty-string id. Those are the fields that decide which message the UI
+// selects and which turn Fork and Delete act on.
+
+const endWith = (extra: Record<string, unknown>) =>
+  decodeEvent({ type: "end", msg_id: "m1", user_index: 4, ...extra });
+
+test("an absent assistant_index is the message AFTER the user's, never the user's own", () => {
+  // `: userIndex + 1` -> `: userIndex` survived. The assistant index would
+  // point at the user's own message, so anything selecting by it renders the
+  // prompt back as the answer.
+  const out = endWith({});
+  assert.ok(isDecoded(out));
+  assert.equal(out.event.type === "end" ? out.event.assistantIndex : null, 5);
+});
+
+test("an explicit assistant_index is used as sent, not recomputed", () => {
+  // The pair: always deriving would discard what the engine actually said.
+  const out = endWith({ assistant_index: 9 });
+  assert.ok(isDecoded(out));
+  assert.equal(out.event.type === "end" ? out.event.assistantIndex : null, 9);
+});
+
+test("a null user_index leaves the assistant index null rather than making one up", () => {
+  // null means "not on disk", which is what withholds Fork and Delete. `null +
+  // 1` would be 1 -- an index into a message list that was never written.
+  const out = decodeEvent({ type: "end", msg_id: "m1", user_index: null });
+  assert.ok(isDecoded(out));
+  assert.equal(out.event.type === "end" ? out.event.assistantIndex : "wrong", null);
+});
+
+test("versions is at least 1, whatever the wire said", () => {
+  // `Math.max(1, versions)` -> `versions` survived. A `versions: 0` reaching
+  // the UI means a message that exists in zero versions.
+  for (const [sent, want] of [[0, 1], [-3, 1], [1, 1], [4, 4]] as const) {
+    const out = endWith({ versions: sent, active: 0 });
+    assert.ok(isDecoded(out));
+    assert.equal(out.event.type === "end" ? out.event.versions : null, want, `versions: ${sent}`);
+  }
+});
+
+test("active is clamped INTO the range of versions that exist", () => {
+  // Both the floor and the ceiling survived, separately, plus an off-by-one on
+  // the ceiling. events.ts says an out-of-range index "selects nothing and the
+  // message renders blank" -- so this clamp is the only thing between a hostile
+  // or buggy engine and an empty answer bubble.
+  const cases = [
+    { versions: 3, active: 9, want: 2 },
+    { versions: 3, active: 2, want: 2 },
+    { versions: 3, active: -1, want: 0 },
+    { versions: 1, active: 5, want: 0 },
+    { versions: 0, active: 5, want: 0 },
+  ];
+  for (const c of cases) {
+    const out = endWith({ versions: c.versions, active: c.active });
+    assert.ok(isDecoded(out));
+    assert.equal(
+      out.event.type === "end" ? out.event.active : null,
+      c.want,
+      `versions=${c.versions} active=${c.active}`,
+    );
+  }
+});
+
+test("absent versions and active default to one version, cursor at zero", () => {
+  const out = endWith({});
+  assert.ok(isDecoded(out));
+  assert.equal(out.event.type === "end" ? out.event.versions : null, 1);
+  assert.equal(out.event.type === "end" ? out.event.active : null, 0);
+});
+
+test("an absent active selects the FIRST version, even when several exist", () => {
+  // With versions absent too, `?? 0` and `?? 1` are indistinguishable: the
+  // clamp pulls both to 0. It takes more than one version for the default to
+  // be observable, and then it decides which answer the user is shown --
+  // defaulting to 1 silently selects the second version of every message the
+  // engine did not give a cursor for.
+  //
+  // (The sibling mutation, `versions ?? 1` -> `?? 0`, IS equivalent: the
+  // Math.max(1, ...) below it maps both to the same output. Recorded here so
+  // nobody hunts it as a live survivor.)
+  const out = endWith({ versions: 3 });
+  assert.ok(isDecoded(out));
+  assert.equal(out.event.type === "end" ? out.event.versions : null, 3);
+  assert.equal(out.event.type === "end" ? out.event.active : null, 0);
+});
+
+// ---- the guards on identity and number-ness ---------------------------------
+
+test("an empty-string id is refused wherever an id is required", () => {
+  // Each `|| x === ""` could be deleted on its own and survive. An empty msgId
+  // is the worst of them: the event is ACCEPTED, and then every later event
+  // mismatches it and is dropped as wrong_msg_id -- a turn that silently
+  // produces nothing, reported as an engine that said nothing.
+  const cases: { raw: Record<string, unknown>; why: string }[] = [
+    { raw: { type: "delta", msg_id: "", text: "hi" }, why: "msg_id" },
+    { raw: { type: "", msg_id: "m1" }, why: "type" },
+    { raw: { type: "tool_call", msg_id: "m1", call_id: "", name: "ls" }, why: "call_id" },
+    {
+      raw: { type: "approval_request", msg_id: "m1", approval_id: "", call_id: "c1", name: "rm" },
+      why: "approval_id",
+    },
+  ];
+  for (const c of cases) {
+    assert.equal(isIgnored(decodeEvent(c.raw)), true, `an empty ${c.why} must be refused`);
+  }
+});
+
+test("NaN and Infinity are not numbers the wire may send", () => {
+  // `typeof v === "number" && Number.isFinite(v)` -> dropping the finite check
+  // survived. JSON cannot carry these, but decodeEvent takes `unknown` and is
+  // called with already-parsed objects, so a buggy engine adapter can.
+  for (const bad of [NaN, Infinity, -Infinity]) {
+    const out = decodeEvent({ type: "end", msg_id: "m1", user_index: 0, versions: bad, active: 0 });
+    assert.ok(isDecoded(out));
+    assert.equal(
+      out.event.type === "end" ? out.event.versions : null,
+      1,
+      `${String(bad)} must fall back to the default, not propagate`,
+    );
+  }
+});
+
+test("a JSON array is not tool arguments", () => {
+  // `&& !Array.isArray(v)` survived. An array reaching `args` gives every
+  // consumer an object whose keys are "0", "1", ... -- and args are rendered
+  // to the user as the command they are approving.
+  const out = decodeEvent({ type: "tool_call", msg_id: "m1", call_id: "c1", name: "sh", args: [1, 2] });
+  assert.ok(isDecoded(out));
+  assert.deepEqual(out.event.type === "tool_call" ? out.event.args : null, {});
+});
+
+test("a key that is absent is not the same as a key set to undefined", () => {
+  // `!(key in o)` -> `o[key] === undefined` survived, collapsing exactly the
+  // distinction this file's own comment says it exists to prevent. Present-but-
+  // undefined is malformed and must be refused; absent means "derive it".
+  const absent = decodeEvent({ type: "end", msg_id: "m1", user_index: 3 });
+  assert.ok(isDecoded(absent));
+  assert.equal(absent.event.type === "end" ? absent.event.assistantIndex : null, 4, "absent derives");
+
+  const present = decodeEvent({
+    type: "end", msg_id: "m1", user_index: 3, assistant_index: undefined,
+  });
+  assert.ok(isDecoded(present));
+  assert.equal(
+    present.event.type === "end" ? present.event.assistantIndex : "wrong",
+    null,
+    "present-but-undefined is malformed, so it resolves to null -- not derived",
+  );
+});
+
+test("every approval choice the protocol defines is accepted", () => {
+  // `|| raw === "always"` survived. "always allow" would decode to null, so
+  // the button exists, is pressed, and nothing happens.
+  for (const choice of ["allow", "always", "deny"] as const) {
+    assert.equal(decodeApprovalChoice(choice), choice, `${choice} must be accepted`);
+  }
+});
+
+test("anything that is not a defined choice decodes to null, never a default", () => {
+  // The pair. Falling back to a value would authorise something the user did
+  // not pick -- and "allow" is the dangerous direction to guess.
+  for (const bad of ["maybe", "", "ALLOW", null, undefined, 1, {}, ["allow"]]) {
+    assert.equal(decodeApprovalChoice(bad), null, `${JSON.stringify(bad)} must not decode`);
+  }
 });

--- a/src/praisonai-mobile/ui/src/render/reconcile.ts
+++ b/src/praisonai-mobile/ui/src/render/reconcile.ts
@@ -89,12 +89,20 @@ export function reconcile(previous: RenderState, rows: readonly Row[]): Diff {
     if (!nextIdSet.has(id)) ops.push({ kind: "remove", id });
   }
 
-  // The surviving rows, in their previous relative order. Anything whose
-  // position within THIS sequence changes genuinely moved; comparing against
-  // raw previous indices instead would report a move for every row after a
-  // single insertion.
-  const surviving = previous.ids.filter((id) => nextIdSet.has(id));
-  let survivorCursor = 0;
+  // The list as the DOM will actually look, updated as each op is emitted.
+  //
+  // This used to be `surviving` -- the previous ids minus removals -- with
+  // moves spliced into it at the TARGET index. Those are two different
+  // coordinate systems: the target index counts rows that were inserted this
+  // pass, and `surviving` contains none of them. Inserted rows were never
+  // added to it either, so the model drifted from the DOM as soon as one
+  // insert preceded a reorder, and the ops then described a list nobody had.
+  //
+  // Measured by applying the real ops through the real `applyOps` to a DOM:
+  // 120 of 960 exhaustive cases over 5 ids rendered the wrong order, and a
+  // fuzz over 8 ids put it at 0.8%. `reconcile.test.ts` asserted op SHAPES and
+  // never applied them, so nothing in the suite could see it.
+  const current = previous.ids.filter((id) => nextIdSet.has(id));
 
   rows.forEach((row, index) => {
     const signature = signatureOf(row);
@@ -102,6 +110,7 @@ export function reconcile(previous: RenderState, rows: readonly Row[]): Diff {
 
     if (!previousIds.has(row.id)) {
       ops.push({ kind: "insert", id: row.id, index, row });
+      current.splice(index, 0, row.id);
       return;
     }
 
@@ -109,13 +118,14 @@ export function reconcile(previous: RenderState, rows: readonly Row[]): Diff {
       ops.push({ kind: "update", id: row.id, row });
     }
 
-    if (surviving[survivorCursor] !== row.id) {
-      ops.push({ kind: "move", id: row.id, index });
-      const at = surviving.indexOf(row.id, survivorCursor);
-      if (at !== -1) surviving.splice(at, 1);
-      surviving.splice(index, 0, row.id);
-    }
-    survivorCursor++;
+    // Already where it belongs: emit nothing. This is what keeps an append
+    // from reporting a move for every row after it.
+    if (current[index] === row.id) return;
+
+    ops.push({ kind: "move", id: row.id, index });
+    const at = current.indexOf(row.id);
+    if (at !== -1) current.splice(at, 1);
+    current.splice(index, 0, row.id);
   });
 
   return { ops, next: { ids: nextIds, signatures: nextSignatures } };


### PR DESCRIPTION
Two findings from a 124-mutation sweep plus a correctness audit, each verified by running code rather than reading it.

## 1. The reconciler modelled its moves in the wrong coordinate system

`reconcile` tracked `surviving` — previous ids minus removals — and spliced each move into it at the **target** index. Those are different coordinate systems: the target index counts rows inserted on this pass, and `surviving` contains none of them. Inserted rows were never added to it either, so the model drifted from the DOM as soon as one insert preceded a reorder.

Measured by applying the **real** ops through the **real** `applyOps` to a DOM:

| sweep | wrong |
|---|---|
| exhaustive, 5 ids, every prev/target pair | **120 / 960** |
| fuzz, 8 ids, 200k pairs | **1546** |
| smallest case `[a,b,c] → [d,e,b,c,a]` | rendered `[d,e,b,a,c]` |

Both sweeps are now **0 wrong**, with the minimal-op guarantees intact (appending to 200 rows is still one insert; an unchanged list still zero ops — both now asserted, so a rebuilding reconciler can't pass by brute force).

### Why nothing caught it — both reasons are worse than the bug

- **`reconcile.test.ts` asserts op *shapes* and never applies them.** It can say "a move was emitted for `c` at index 0"; it cannot say whether running the ops produces the intended order. The pair is now tested in `app/`, the only layer allowed to import both halves.
- **The fake DOM's `insertBefore` ignored its reference node and appended unconditionally.** A fake that cannot represent order cannot fail an ordering test. It now has real semantics, and mutating it back to appending makes the new sweep fail — so the fake is itself under test.

That is the **fourth** fake in this package found lying about the port it stands in for, after `setTimer`'s delay, `every`'s period and `advance`'s amount.

### What I did not keep

I first "fixed" this in `applyOps` by detaching the node before placing it. With the reconciler corrected, that mutation is `fail=0` — no test can tell the difference. So it went back out. Unverified code that claims to fix something is precisely what this session keeps finding; adding more while removing a bug isn't a trade worth making. `dom.ts` keeps only a comment.

**Reachability today is low** — transcript rows are append-only, so the wrong-order path needs an insert before a reorder, which the current view model doesn't produce. Latent defect in a core renderer, fixed before the screens that would reach it exist.

## 2. `decode.ts` had 16 tests and 15 surviving mutations

The weakest file in the package. The existing tests cover every event's *shape* thoroughly — and never pass `versions` other than 1, `active` other than 0, an absent `assistant_index`, or an empty-string id. Those fields decide which message the UI selects and which turn Fork and Delete act on.

Nine mutations now fail:

| mutation | what shipped |
|---|---|
| `: userIndex + 1` → `: userIndex` | the assistant index points at the **user's own message** — the prompt renders back as the answer |
| versions clamp removed | `versions: 0` reaches the UI |
| active floor / ceiling / off-by-one | `events.ts` says an out-of-range index "selects nothing and the message renders blank" |
| `active ?? 0` → `?? 1` | silently selects the **second version** of every message with no cursor — invisible with one version, which is why it survived |
| finite check removed | `NaN`/`Infinity` accepted for versions, active, chars, seconds |
| `!(key in o)` → `=== undefined` | collapses absent vs present-undefined — the exact distinction the file's own comment says it exists to prevent |
| array accepted as tool args | consumers get an object keyed `"0","1",…` — and args are shown to the user as the command being approved |
| `\|\| raw === "always"` | "always allow" decodes to null: the button exists, is pressed, nothing happens |

Two of my first attempts asserted my *guess* rather than the contract and failed — present-but-undefined resolves to `null` (not on disk), and the choice decoder is a standalone export. Both now assert what the code actually guarantees, which is better behaviour in each case. One mutation (`versions ?? 1` → `?? 0`) is genuinely **equivalent** — the clamp maps both to the same output — and is recorded in the test file so nobody hunts it as a live survivor.

`952 tests` on node 22.23 **and** 24.12 · `boundaries: 131 files, no violations`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interface updates when items are moved or inserted together, ensuring the displayed order remains accurate.
  * Prevented incorrect placement of elements during complex list changes.

* **Tests**
  * Expanded approval-choice validation coverage, including defaults, invalid values, numeric constraints, identifiers, arrays, and event indexes.
  * Added checks distinguishing absent fields from explicitly undefined values.
  * Added integration coverage for list ordering, append behavior, no-op updates, and combined reconciliation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->