### PR TITLE
test(mobile): seven mutations could be applied at once and the suite stayed green

### DIFF
--- a/src/praisonai-mobile/core/src/pacing/coalescer.test.ts
+++ b/src/praisonai-mobile/core/src/pacing/coalescer.test.ts
@@ -172,3 +172,16 @@ test("a trickle that never stops still cannot outrun the budget", () => {
     `painted only after ${flushed?.length} tokens; the 16ms budget should have fired far sooner`,
   );
 });
+
+test("the byte cap flushes AT maxBytes, not one character later", () => {
+  // `pending.length >= maxBytes` -> `>` survived. Off by one on the constant
+  // the module's whole contract is written around, and no test ever landed
+  // exactly on the cap.
+  const exact = createCoalescer(8, 10_000);
+  assert.deepEqual(exact.push(text("1234567"), 0), [], "one short of the cap holds");
+  assert.deepEqual(
+    exact.push(text("8"), 0),
+    [{ kind: "text", text: "12345678" }],
+    "reaching the cap exactly must flush",
+  );
+});

--- a/src/praisonai-mobile/ui/src/format.test.ts
+++ b/src/praisonai-mobile/ui/src/format.test.ts
@@ -183,3 +183,18 @@ test("a long line still truncates to exactly the same text as before", () => {
   assert.equal(truncate(line, 10), line.slice(0, 9) + "…");
   assert.equal(truncate("👍🏽".repeat(500), 3), "👍🏽👍🏽…");
 });
+
+// ---- the boundaries between formats ----------------------------------------
+
+test("formatElapsed switches format AT the boundary, not one past it", () => {
+  // `seconds < 10` -> `<= 10` and `minutes < 60` -> `<= 60` both survived. The
+  // whole point of the thresholds is which side of them a value falls on, and
+  // no test placed a value exactly on one.
+  assert.equal(formatElapsed(9.94), "9.9s", "under ten keeps the decimal");
+  assert.equal(formatElapsed(10), "10s", "ten exactly is whole seconds");
+  assert.equal(formatElapsed(59), "59s");
+  assert.equal(formatElapsed(60), "1m 00s", "sixty seconds is a minute, not 60s");
+  assert.equal(formatElapsed(3599), "59m 59s");
+  assert.equal(formatElapsed(3600), "1h 00m", "sixty minutes is an hour, not 60m 00s");
+  assert.equal(formatElapsed(7260), "2h 01m");
+});

--- a/src/praisonai-mobile/ui/src/render/reconcile.test.ts
+++ b/src/praisonai-mobile/ui/src/render/reconcile.test.ts
@@ -136,3 +136,57 @@ test("a long streaming turn costs one update per publish", () => {
   }
   assert.equal(total, 200, "one op per publish -- the first insert plus 199 updates");
 });
+
+// ---- signatures must cover every field the row renders ----------------------
+
+test("an error row repaints when only its recovery changes", () => {
+  // `${row.recovery}` could be dropped from the signature and survive. The
+  // comment two lines above it says exactly why it is there -- "the same
+  // message can offer a different action once the engine reports a different
+  // kind" -- and nothing checked. The row would keep a Retry button after the
+  // engine reclassified the failure as one retrying cannot fix.
+  const base = {
+    kind: "error" as const,
+    id: "err",
+    errorKind: "transport" as const,
+    message: "the connection dropped",
+    tone: "failure" as const,
+  };
+  const first = reconcile(emptyRender, [{ ...base, recovery: "retry" as const }]);
+  const second = reconcile(first.next, [{ ...base, recovery: "settings" as const }]);
+
+  assert.deepEqual(
+    second.ops.map((o) => o.kind),
+    ["update"],
+    "a changed recovery must repaint the row",
+  );
+});
+
+test("a dropped row repaints when the reasons change but the count does not", () => {
+  // `${row.reasons.join(",")}` could be dropped and survive. Two refusals for
+  // different reasons look identical to a count, so the row would keep naming
+  // the wrong failure.
+  const first = reconcile(emptyRender, [
+    { kind: "dropped" as const, id: "dropped", count: 2, reasons: ["unknown_event"] },
+  ]);
+  const second = reconcile(first.next, [
+    { kind: "dropped" as const, id: "dropped", count: 2, reasons: ["unparseable_json"] },
+  ]);
+
+  assert.deepEqual(second.ops.map((o) => o.kind), ["update"]);
+});
+
+test("an unchanged error row still produces nothing", () => {
+  // The pair for both of the above: a signature that changed every time would
+  // pass them and repaint on every frame.
+  const row = {
+    kind: "error" as const,
+    id: "err",
+    errorKind: "transport" as const,
+    message: "same",
+    tone: "failure" as const,
+    recovery: "retry" as const,
+  };
+  const first = reconcile(emptyRender, [row]);
+  assert.deepEqual(reconcile(first.next, [row]).ops, []);
+});

--- a/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
+++ b/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
@@ -23,7 +23,7 @@ import {
   type ToolRowView,
 } from "./view-model.ts";
 import { UNKNOWN, formatElapsed } from "../format.ts";
-import { apply, initialTurn, type TurnState } from "../../../core/src/run/transcript.ts";
+import { apply, initialTurn, noteDropped, type TurnState } from "../../../core/src/run/transcript.ts";
 import { add, choose, emptyApprovals } from "../../../core/src/run/approvals.ts";
 import type { RunEvent } from "../../../protocol/src/events.ts";
 import { SCRIPTS } from "../../../testing/src/scripts.ts";
@@ -496,4 +496,33 @@ test("an approval with no table entry renders pending rather than borrowing one"
   );
   assert.equal(rows[0]?.state.status, "pending");
   assert.equal(rows[0]?.actionable, true);
+});
+
+// ---- the two numbers the dropped row and the actions actually report --------
+
+test("the dropped row reports how many were dropped, not just that some were", () => {
+  // `count: turn.dropped.length` -> `count: 1` survived. `reasons: []` was
+  // caught; the count was not. The whole reason this row carries a number is
+  // to distinguish one malformed frame from a stream that is mostly
+  // unparseable, and it always said "1".
+  let turn = run(start, delta("hi"));
+  turn = noteDropped(turn, "unknown_event", "a");
+  turn = noteDropped(turn, "unparseable_json", "b");
+  turn = noteDropped(turn, "unknown_event", "c");
+
+  const row = buildTranscript(turn).rows.find((r) => r.kind === "dropped");
+  assert.ok(row && row.kind === "dropped");
+  assert.equal(row.count, 3);
+  assert.deepEqual([...row.reasons].sort(), ["unknown_event", "unparseable_json"]);
+});
+
+test("Copy is not offered for a turn with nothing in it", () => {
+  // `copy: turn.text !== ""` -> `copy: true` survived. A Copy button on an
+  // empty answer copies an empty string and reports success -- an action that
+  // says it did something and did not.
+  const empty = run(start);
+  assert.equal(buildTranscript(empty).actions.copy, false);
+
+  const answered = run(start, delta("something"));
+  assert.equal(buildTranscript(answered).actions.copy, true);
 });


### PR DESCRIPTION
The documented tail of round three's 49 survivors.

I set out to confirm each was still live one at a time. A mistake in my restore paths meant they accumulated instead — so **all seven defects were in the tree simultaneously and 957 tests still passed.** That is a sharper demonstration than the one I intended, so I'm recording it rather than tidying it away.

| mutation | what shipped |
|---|---|
| `count: turn.dropped.length` → `count: 1` | the dropped row **always said "1"**. `reasons: []` was caught; the count was not — and the number exists precisely to distinguish one malformed frame from a mostly-unparseable stream |
| `copy: turn.text !== ""` → `copy: true` | a Copy button on an empty answer copies an empty string and reports success |
| `signatureOf` drops `${row.recovery}` | the comment two lines above says why it's there — *"the same message can offer a different action once the engine reports a different kind"* — and nothing checked. The row keeps a **Retry** button after the engine reclassifies the failure as one retrying cannot fix |
| `signatureOf` drops `${row.reasons.join(",")}` | two refusals for different reasons look identical to a count, so the row keeps naming the wrong failure |
| `pending.length >= maxBytes` → `>` | off by one on the constant the coalescer's whole contract is written around; no test ever landed exactly on the cap |
| `formatElapsed` `< 10` → `<= 10`, `< 60` → `<= 60` | the entire point of a threshold is which side a value falls on, and no test placed one exactly on it. 60s rendered `"60s"` instead of `"1m 00s"`; 3600 rendered `"60m 00s"` instead of `"1h 00m"` |

Each is pinned in **both** directions — an unchanged row still produces no ops, so a signature that changed every time cannot pass by repainting always.

`964 tests` on node 22.23 **and** 24.12 · `boundaries: 131 files, no violations` · tests only, no product source changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure buffered text flushes exactly at the configured byte limit.
  * Verified elapsed-time displays switch formats precisely at unit boundaries.
  * Improved coverage for refreshing error and dropped-event rows when their details change.
  * Confirmed dropped-event counts and reasons display accurately.
  * Ensured the Copy action appears only when text is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->