### PR TITLE
fix(mobile): six defects in the composition root, and the harness that finds them

### DIFF
--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -28,3 +28,215 @@ test("the refusal text says the run may still be going", () => {
   // whether the work stopped, so "it did not stop" has to be in the sentence.
   assert.match(en.stopRefused, /still be running/i);
 });
+
+// ---- the composition root, driven end to end --------------------------------
+//
+// Everything below needed a fake DOM, which is why none of it existed. A
+// round-four audit drove `mount()` with one and found six defects here, all of
+// the same shape: a pure function that is correct, and a composition root that
+// calls it wrongly or not at all.
+
+import { createFakeDom } from "../../testing/src/fake-dom.ts";
+import { createFakeShell, PHONE_INSETS } from "../../testing/src/fake-shell.ts";
+import { createFakeStorage } from "../../testing/src/fake-storage.ts";
+import { createFakeSecrets } from "../../testing/src/fake-secrets.ts";
+import { createFakeHttp, sseResponse } from "../../testing/src/fake-http.ts";
+import { mount } from "./main.ts";
+import type { Platform } from "./platform.ts";
+
+const nodeTime = () => ({
+  nowMs: () => performance.now(),
+  epochMs: () => Date.now(),
+  createScheduler: () => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    return {
+      requestFrame: (cb: () => void) => void setImmediate(cb),
+      setTimer: (cb: () => void, ms: number) => { timer = setTimeout(cb, ms); timer.unref?.(); },
+      clearTimer: () => { if (timer !== null) clearTimeout(timer); timer = null; },
+    };
+  },
+  every: (ms: number, cb: () => void) => {
+    const handle = setInterval(cb, ms);
+    handle.unref?.();
+    return () => clearInterval(handle);
+  },
+});
+
+const sse = (frames: readonly (readonly [string, unknown])[]): string =>
+  frames.map(([e, d]) => `event: ${e}\ndata: ${JSON.stringify(d)}\n\n`).join("");
+
+const settle = async (ms = 60): Promise<void> => {
+  await new Promise((r) => setTimeout(r, ms));
+};
+
+function harness(over: { storage?: ReturnType<typeof createFakeStorage> } = {}) {
+  const dom = createFakeDom();
+  const http = createFakeHttp();
+  const storage = over.storage ?? createFakeStorage();
+  const platform: Platform = {
+    shell: createFakeShell(PHONE_INSETS),
+    storage,
+    secrets: createFakeSecrets(),
+    http,
+    time: nodeTime(),
+    kind: "web",
+  };
+  return { dom, http, storage, platform };
+}
+
+const submit = (dom: ReturnType<typeof createFakeDom>, text: string): void => {
+  const box = dom.find((n) => n.tagName === "TEXTAREA");
+  const form = dom.find((n) => n.tagName === "FORM");
+  if (box !== null) box.value = text;
+  form?.dispatch("submit", { preventDefault: () => {} });
+};
+
+test("a failure before the first token says WHAT failed, not that nothing came back", async () => {
+  // The reducer dropped any event arriving before `start`, so the engine's
+  // synthesised error was thrown away and `finish()` substituted
+  // kind: "empty". 401, 403, 500, 502, offline and a wrong baseUrl all
+  // rendered identically as "the engine produced no output", plus a dropped
+  // row accusing the engine of sending an event before the turn began.
+  //
+  // The default baseUrl is 127.0.0.1:8765, which ON A PHONE is the phone
+  // itself -- so this was the first thing every new user saw. It also made the
+  // auth -> "go to settings" recovery unreachable: the one distinction between
+  // "retry this" and "fix your credentials" never survived to the view model.
+  for (const [status, wantRecovery] of [[401, "settings"], [403, "settings"], [502, "retry"]] as const) {
+    const { dom, http, platform } = harness();
+    http.on("/chat", () => ({ status, headers: {}, body: null }));
+    const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+    submit(dom, "hello");
+    await settle();
+
+    const errorRow = dom.find((n) => n.className.includes("row-error"));
+    assert.ok(errorRow, `HTTP ${status}: no error row rendered`);
+    assert.match(errorRow.textContent, /\d\d\d/, "the message should name the status");
+    assert.equal(errorRow.dataset["recovery"], wantRecovery, `HTTP ${status} recovery`);
+    assert.equal(
+      dom.find((n) => n.className.includes("row-dropped")),
+      null,
+      "a real error must not also be reported as an unreadable frame",
+    );
+    app?.dispose();
+  }
+});
+
+test("every polite announcement of a publish is spoken, not just the last", async () => {
+  // `region.textContent = item.text` in a loop overwrote the earlier items in
+  // the same task. A short answer completing inside one interval produced
+  // [polite "<the answer>", polite "Response complete"], so a screen-reader
+  // user heard ONLY "Response complete." That is exactly what announce.ts
+  // rule 4 exists to prevent, reintroduced where the pure function meets
+  // the DOM.
+  const { dom, http, platform } = harness();
+  http.on("/chat", () =>
+    sseResponse(
+      sse([
+        ["start", { msg_id: "m1", run_id: "r1" }],
+        ["delta", { msg_id: "m1", text: "The capital of France is Paris." }],
+        ["end", { msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 }],
+      ]),
+    ),
+  );
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  submit(dom, "capital of france?");
+  await settle(120);
+
+  const polite = dom.find((n) => n.getAttribute("aria-live") === "polite");
+  assert.ok(polite, "no polite live region");
+  assert.match(polite.textContent, /Paris/, "the answer itself must reach the live region");
+  app?.dispose();
+});
+
+test("New chat stops the run that is still streaming", async () => {
+  // It cleared the screen and left the turn running, so the next token
+  // reconciled against an empty render and re-inserted the OLD conversation's
+  // rows into what the user believed was a fresh chat, where it finished. Any
+  // queued prompts ran into it too.
+  const { dom, http, platform } = harness();
+  // A body that never completes, so a run is genuinely live when New chat is
+  // pressed. A finished turn has nothing to cancel and the test would pass
+  // against the defect.
+  http.on("/chat", () => ({
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        const enc = new TextEncoder();
+        controller.enqueue(enc.encode(sse([["start", { msg_id: "m1", run_id: "r1" }]])));
+        controller.enqueue(enc.encode(sse([["delta", { msg_id: "m1", text: "first answer" }]])));
+        // deliberately never closed
+      },
+    }),
+  }));
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  submit(dom, "one");
+  await settle();
+
+  const newChat = dom.find((n) => n.dataset["action"] === "new-chat");
+  assert.ok(newChat, "no New chat control");
+  dom.click(newChat);
+  await settle();
+
+  const cancels = http.sent.filter((r) => r.url.includes("/cancel"));
+  assert.ok(
+    cancels.length > 0,
+    `New chat must stop the live run, not just clear the screen. Sent: ${http.sent.map((r) => r.url).join(", ")}`,
+  );
+  app?.dispose();
+});
+
+test("New chat gives the new conversation its own id", async () => {
+  // `setChat` was never called anywhere in the app, so every request from
+  // every chat carried chat_id "unassigned". controller.ts says in as many
+  // words that "an engine cannot tell two conversations apart if every turn
+  // claims the same id" -- and against an engine keying server-side history by
+  // chat_id, every conversation the user ever had was one thread.
+  const { dom, http, platform } = harness();
+  let n = 0;
+  http.on("/chat", () =>
+    sseResponse(
+      sse([
+        ["start", { msg_id: `m${++n}`, run_id: `r${n}` }],
+        ["delta", { msg_id: `m${n}`, text: "answer" }],
+        ["end", { msg_id: `m${n}`, user_index: 0, assistant_index: 1, versions: 1, active: 0 }],
+      ]),
+    ),
+  );
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => `chat-${n}` });
+
+  submit(dom, "one");
+  await settle();
+  dom.click(dom.find((d) => d.dataset["action"] === "new-chat") as never);
+  await settle();
+  submit(dom, "two");
+  await settle();
+
+  const chats = http.sent
+    .filter((r) => r.url.includes("/chat"))
+    .map((r) => JSON.parse(String(r.body ?? "{}")) as { chat_id?: string })
+    .map((b) => b.chat_id);
+  assert.equal(chats.length, 2, `expected two turns, got ${chats.length}`);
+  assert.notEqual(chats[0], chats[1], `both turns claimed the same chat id: ${String(chats[0])}`);
+});
+
+test("a storage failure at boot shows the crash screen, not a dead-looking app", async () => {
+  // `createApp` returns a typed BootResult for the failures it anticipated and
+  // THROWS for a StoragePort failure -- reachable on the real platform via
+  // SecurityError with site data blocked, or QuotaExceededError. The chrome is
+  // already appended by then, so the throw skipped both the fatal screen and
+  // the listener registrations: a perfectly rendered app, with a green Send
+  // button, in which nothing ever happened again.
+  const storage = createFakeStorage();
+  storage.failNext("SecurityError: the operation is insecure");
+  const { dom, platform } = harness({ storage });
+
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  assert.equal(app, null, "a boot failure must not return a working app");
+  assert.notEqual(dom.text(), "", "and must not leave a blank or silently dead page");
+});

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -62,20 +62,39 @@ export function stopNotice(stopped: boolean, strings: Strings): string | null {
   return stopped ? null : strings.stopRefused;
 }
 
+/** `createApp`, with a thrown failure turned into the same typed result the
+ *  anticipated failures already produce. */
+async function bootOrFail(
+  options: Parameters<typeof createApp>[0],
+): Promise<Awaited<ReturnType<typeof createApp>>> {
+  try {
+    return await createApp(options);
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "storage_unavailable",
+      detail: error instanceof Error ? error.message : String(error),
+    } as Awaited<ReturnType<typeof createApp>>;
+  }
+}
+
 export async function mount(deps: MountDeps): Promise<App | null> {
   const strings = deps.strings ?? en;
   const root = deps.root;
   const doc = root.ownerDocument;
-  const platform = deps.platform ?? detectPlatform();
-
-  // Installed BEFORE anything else can throw. A crash during boot with no
-  // handler is a blank page and a silent console on a device nobody can attach
-  // a debugger to.
+  // Installed BEFORE anything else can throw -- and `detectPlatform()` is
+  // something that can throw: it reads `window.localStorage`, which raises
+  // SecurityError in a WKWebView with site data blocked. It used to run first,
+  // directly contradicting this comment, and a throw there left the root
+  // completely empty: a blank white page, no crash screen, on a device nobody
+  // can attach a debugger to.
   const owner = doc.defaultView;
   installCrashHandler({
     ...(owner === null ? {} : { view: owner }),
     onCrash: () => renderFatal(root, strings.crashed),
   });
+
+  const platform = deps.platform ?? detectPlatform();
 
   // ---- the frame the app paints into -------------------------------------
   const screen = doc.createElement("div");
@@ -155,16 +174,38 @@ export async function mount(deps: MountDeps): Promise<App | null> {
       nowMs: Date.now(),
     });
     announcer = spoken.state;
-    for (const item of spoken.announcements) {
-      const region = item.politeness === "assertive" ? assertive : polite;
-      region.textContent = item.text;
-    }
+    // Each region is assigned ONCE, with every utterance of that politeness
+    // joined. Assigning per item overwrote the earlier ones in the same task,
+    // so only the LAST survived to be read.
+    //
+    // Measured: a short answer completing inside one interval produced
+    // [polite "The capital of France is Paris.", polite "Response complete"],
+    // and a screen-reader user heard only "Response complete." That is exactly
+    // the failure announce.ts rule 4 exists to prevent -- "the user would never
+    // hear the end of the response" -- reintroduced at the single point where
+    // the pure function meets the DOM.
+    const polites = spoken.announcements.filter((a) => a.politeness !== "assertive");
+    const assertives = spoken.announcements.filter((a) => a.politeness === "assertive");
+    if (polites.length > 0) polite.textContent = polites.map((a) => a.text).join(" ");
+    if (assertives.length > 0) assertive.textContent = assertives.map((a) => a.text).join(" ");
 
     sendButton.textContent = view.turn.phase === "streaming" ? strings.actionStop : strings.actionSend;
     sendButton.dataset["action"] = view.turn.phase === "streaming" ? "stop" : "send";
   };
 
-  const booted = await createApp({
+  // `createApp` returns a typed BootResult for the failures it anticipated --
+  // an unknown engine, a protocol mismatch. It can also THROW, and did: an
+  // unguarded `settingsStore.load()` propagates a StoragePort failure, which
+  // is reachable on the real platform (SecurityError with site data blocked,
+  // QuotaExceededError under the storage pressure platform.ts documents).
+  //
+  // The chrome is already built and appended by this point, so a rejection
+  // here skipped the fatal screen AND the listener registrations below,
+  // leaving a perfectly rendered app -- top bar, composer, green Send button
+  // -- in which nothing whatsoever happened, forever.
+  const mintChatId = deps.newChatId ?? ((): string => globalThis.crypto.randomUUID());
+
+  const booted = await bootOrFail({
     storage: platform.storage,
     secrets: platform.secrets,
     time: platform.time,
@@ -183,7 +224,7 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     engineId: "remote-http",
     onPublish: publish,
     now: deps.now ?? (() => Date.now()),
-    newChatId: deps.newChatId ?? (() => globalThis.crypto.randomUUID()),
+    newChatId: mintChatId,
   });
 
   if (!booted.ok) {
@@ -234,13 +275,25 @@ export async function mount(deps: MountDeps): Promise<App | null> {
       case "approve":
         await app.controller.decide(intent.approvalId, intent.choice);
         return;
-      case "new-chat":
+      case "new-chat": {
+        // Stop the turn FIRST. Clearing the screen without stopping left the
+        // previous run streaming: the next token reconciled against an empty
+        // render and re-inserted the old conversation's rows into what the
+        // user believed was a fresh chat, where it then finished.
+        void app.controller.stop();
+        // And give the new conversation its own id. `setChat` was never called
+        // anywhere in the app, so every request from every chat carried
+        // `chat_id: "unassigned"` -- controller.ts says in as many words that
+        // "an engine cannot tell two conversations apart if every turn claims
+        // the same id".
+        app.controller.setChat(mintChatId());
         app.session.reset();
         render = emptyRender;
         nodes.nodes.clear();
         announcer = initialAnnouncer;
         transcript.textContent = ""; // safe now: this is no longer a live region
         return;
+      }
       case "navigate":
         app.router.push({ name: intent.route } as Route);
         return;

--- a/src/praisonai-mobile/core/src/run/controller.test.ts
+++ b/src/praisonai-mobile/core/src/run/controller.test.ts
@@ -910,3 +910,82 @@ test("the coalescer is built with maxBytes and maxDelayMs THE RIGHT WAY ROUND", 
   );
   assert.equal(views.at(-1)?.turn.text, "1234512345123451234512345123451234512345");
 });
+
+/** An engine whose turn stays open until `release()` is called, so a test can
+ *  be sure a run is genuinely live when it presses Stop. Without this the
+ *  scripted engine can finish first and `stop()` returns false for the boring
+ *  reason, which passes a refusal test for entirely the wrong reason. */
+function heldEngine(cancel: (runId: string) => Promise<boolean>) {
+  let release: () => void = () => {};
+  const held = new Promise<void>((r) => { release = r; });
+  const engine = {
+    id: "s",
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {
+      streaming: true, reasoning: false, tools: true,
+      approvals: false, cancellation: true, attachments: false,
+    },
+    async *run(req: { runId: string }, signal: AbortSignal) {
+      yield { type: "start", msgId: "m", runId: req.runId };
+      await held;
+      if (signal.aborted) return;
+      yield { type: "end", msgId: "m", userIndex: 0, assistantIndex: 1, versions: 1, active: 0 };
+    },
+    async decide() { return false; },
+    cancel,
+    async dispose() {},
+  } as unknown as Parameters<typeof createRunController>[0]["engine"];
+  return { engine, release: () => release() };
+}
+
+test("a REFUSED stop can be retried, and does not report success on the retry", async () => {
+  // The idempotence guard added two commits ago aborted the reader even when
+  // the engine answered FALSE. That set `aborted`, so the next tap hit the
+  // guard and returned true without asking the engine again -- and it detached
+  // the reader from a run the engine said it had NOT cancelled, leaving it
+  // generating and billing into a socket nobody drains.
+  //
+  // The user is told the stop was refused, taps the only affordance offered,
+  // and is told nothing at all -- which stopNotice defines as success. The
+  // defect that notice exists for, inverted, one layer down.
+  const cancels: string[] = [];
+  let refuse = true;
+  const { engine, release } = heldEngine(async (runId) => {
+    cancels.push(runId);
+    if (refuse) { refuse = false; return false; }
+    return true;
+  });
+  const controller = createRunController({ engine, time: createFakeTime(), onPublish: () => {} });
+
+  const sent = controller.send("go");
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+
+  assert.equal(await controller.stop(), false, "the engine refused this one");
+  assert.equal(await controller.stop(), true, "the retry must actually reach the engine");
+  assert.equal(cancels.length, 2, "a refused stop must not swallow the retry");
+
+  release();
+  await sent;
+});
+
+test("an ACCEPTED stop is still idempotent", async () => {
+  // The pair, and the reason the guard exists: the documented background ->
+  // dispose path calls stop() twice, and the second must not re-issue a cancel
+  // the engine would rightly refuse.
+  const cancels: string[] = [];
+  const { engine, release } = heldEngine(async (runId) => {
+    cancels.push(runId);
+    return true;
+  });
+  const controller = createRunController({ engine, time: createFakeTime(), onPublish: () => {} });
+
+  const sent = controller.send("go");
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+
+  assert.equal(await controller.stop(), true);
+  assert.equal(await controller.stop(), true);
+  assert.equal(cancels.length, 1, "an accepted stop must not be asked twice");
+
+  release();
+  await sent;
+});

--- a/src/praisonai-mobile/core/src/run/controller.ts
+++ b/src/praisonai-mobile/core/src/run/controller.ts
@@ -113,7 +113,7 @@ export function createRunController(deps: ControllerDeps): RunController {
    *  did not accept the stop" for a stop that DID happen. Sharing the one
    *  promise makes overlapping stops report the single true result. */
   let live:
-    | { readonly runId: string; readonly abort: AbortController; cancelling?: Promise<boolean> }
+    | { readonly runId: string; readonly abort: AbortController; cancelling?: Promise<boolean> | undefined }
     | null = null;
 
   const view = (): RunView => ({ turn, approvals, queue, publishes });
@@ -347,8 +347,23 @@ export function createRunController(deps: ControllerDeps): RunController {
       // nobody is draining.
       run.cancelling = (async () => {
         const stopped = await deps.engine.cancel(run.runId);
-        // `run`, never `live`: by now `live` may be null or a different turn.
-        run.abort.abort();
+        if (stopped) {
+          // `run`, never `live`: by now `live` may be null or a different turn.
+          run.abort.abort();
+        } else {
+          // A REFUSED stop must stay retryable, and must not look like a
+          // success. Aborting here did both kinds of damage: it detached the
+          // reader from a run the engine said it had NOT cancelled -- leaving
+          // it generating and billing into a socket nobody drains -- and it
+          // set `aborted`, so the very next tap hit the idempotence guard
+          // above and returned true without asking the engine again.
+          //
+          // The user is told the stop was refused, taps the only affordance
+          // offered, and is told nothing at all, which stopNotice defines as
+          // success. That is the defect stopNotice exists for, inverted, one
+          // layer down -- introduced by the idempotence guard two commits ago.
+          run.cancelling = undefined;
+        }
         return stopped;
       })();
       return run.cancelling;

--- a/src/praisonai-mobile/core/src/run/transcript.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.ts
@@ -197,7 +197,28 @@ export function apply(state: TurnState, event: RunEvent): TurnState {
   }
 
   if (state.phase === "idle") {
-    // engine/server.py emits `start` first, always. Anything before it is
+    // An `error` is the exception, and it is the common case on a phone.
+    //
+    // A failure before the first token -- 401, 403, 500, a refused connection,
+    // no network, a wrong baseUrl -- is still THIS turn's outcome, not a stray
+    // frame from a previous run. Dropping it threw the real reason away and
+    // `finish()` then substituted `kind: "empty"`, so every one of those
+    // rendered identically as "the engine produced no output" plus a dropped
+    // row accusing the engine of sending an event before the turn began.
+    //
+    // The default baseUrl is 127.0.0.1:8765, which on a phone is the phone
+    // itself, so that was the FIRST thing every new user saw. It also made the
+    // `kind: "auth"` -> `recovery: "settings"` branch unreachable: the one
+    // distinction between "retry this" and "go fix your credentials" never
+    // survived to the view model.
+    if (event.type === "error") {
+      return apply(
+        { ...state, phase: "streaming", msgId: event.msgId, dropped: state.carry, carry: [] },
+        event,
+      );
+    }
+
+    // engine/server.py emits `start` first, always. Anything else before it is
     // either a bug or a frame from a previous run arriving late.
     return drop(state, "before_start", event.type);
   }

--- a/src/praisonai-mobile/testing/src/fake-dom.ts
+++ b/src/praisonai-mobile/testing/src/fake-dom.ts
@@ -1,0 +1,212 @@
+/**
+ * A DOM small enough to run the composition root against.
+ *
+ * `main.test.ts` said for a long time that "`mount` needs a whole fake SSE
+ * transport to drive end to end, so the parts of it that can be wrong are
+ * extracted and called directly instead". Every defect a round-four audit
+ * found lived in the part that was NOT extracted: announcements overwriting
+ * each other, New chat not stopping the run, a boot failure leaving a rendered
+ * but dead app, the crash handler installed after the thing that throws.
+ *
+ * So the transport exists now. This models the handful of DOM behaviours the
+ * app actually depends on -- ordering under insertBefore, textContent
+ * replacing children, event dispatch that bubbles to a delegated listener --
+ * and nothing else. It is deliberately not jsdom: the package has no browser
+ * dependency and this file is ~120 lines.
+ *
+ * `insertBefore` detaches the node first, as the real one does. A fake that
+ * appended unconditionally hid two independent ordering defects in this
+ * package, so the awkward part is the part worth modelling exactly.
+ */
+
+interface FakeNode {
+  tagName: string;
+  className: string;
+  dataset: Record<string, string>;
+  hidden: boolean;
+  disabled: boolean;
+  value: string;
+  rows: number;
+  type: string;
+  children: FakeNode[];
+  parentElement: FakeNode | null;
+  attrs: Record<string, string>;
+  style: { props: Record<string, string>; setProperty(name: string, value: string): void };
+  classList: { toggle(name: string, on?: boolean): void };
+  textContent: string;
+  innerHTML: string;
+  ownerDocument: unknown;
+  setAttribute(name: string, value: string): void;
+  getAttribute(name: string): string | null;
+  append(...nodes: FakeNode[]): void;
+  insertBefore(node: FakeNode, ref: FakeNode | null): FakeNode;
+  remove(): void;
+  addEventListener(type: string, cb: (e: unknown) => void): void;
+  removeEventListener(type: string, cb: (e: unknown) => void): void;
+  dispatch(type: string, event: unknown): void;
+}
+
+export interface FakeDom {
+  readonly root: FakeNode;
+  readonly view: { dispatch(type: string, event: unknown): void };
+  /** Every element in document order, for finding things by tag or class. */
+  all(): FakeNode[];
+  find(pred: (n: FakeNode) => boolean): FakeNode | null;
+  /** Click an element, bubbling to delegated listeners on its ancestors. */
+  click(el: FakeNode): { defaultPrevented: boolean };
+  text(): string;
+}
+
+
+/**
+ * The three constructors `main.ts` walks with `instanceof` when it decodes a
+ * tap. Without them the delegated click listener throws `Element is not
+ * defined` and every intent is lost -- which is why nothing had ever driven
+ * the composition root: the first attempt fails before reaching any assertion.
+ *
+ * Defined here rather than in a test so every caller gets the same shapes, and
+ * only when absent, so a real browser environment is never overwritten.
+ */
+class FakeElement {}
+class FakeHTMLElement extends FakeElement {}
+class FakeHTMLButtonElement extends FakeHTMLElement {}
+
+export function installDomGlobals(): void {
+  const g = globalThis as Record<string, unknown>;
+  g["Element"] ??= FakeElement;
+  g["HTMLElement"] ??= FakeHTMLElement;
+  g["HTMLButtonElement"] ??= FakeHTMLButtonElement;
+}
+
+export function createFakeDom(): FakeDom {
+  installDomGlobals();
+  const listeners = new WeakMap<FakeNode, Map<string, Set<(e: unknown) => void>>>();
+  const viewListeners = new Map<string, Set<(e: unknown) => void>>();
+
+  const make = (tag: string): FakeNode => {
+    // Built imperatively rather than as one literal: the accessors below refer
+    // to `this`, which an object literal cannot type against itself.
+    const el = {
+      tagName: tag.toUpperCase(),
+      className: "",
+      dataset: {} as Record<string, string>,
+      hidden: false,
+      disabled: false,
+      value: "",
+      rows: 0,
+      type: "",
+      children: [] as FakeNode[],
+      parentElement: null as FakeNode | null,
+      attrs: {} as Record<string, string>,
+      style: {
+        props: {} as Record<string, string>,
+        setProperty(name: string, value: string): void { this.props[name] = value; },
+      },
+      classList: { toggle(): void {} },
+    } as unknown as FakeNode & { _text: string; _html: string };
+
+    // A button must satisfy `instanceof HTMLButtonElement` so main.ts can read
+    // `disabled` off it; everything else is an HTMLElement.
+    const Ctor = tag === "button" ? FakeHTMLButtonElement : FakeHTMLElement;
+    Object.setPrototypeOf(el, Object.assign(Object.create(Ctor.prototype), Object.getPrototypeOf(el)));
+
+    el._text = "";
+    el._html = "";
+
+    Object.defineProperty(el, "ownerDocument", { get: () => doc });
+    Object.defineProperty(el, "textContent", {
+      get(): string {
+        return el._text + el.children.map((c) => c.textContent).join("");
+      },
+      set(v: string) {
+        el._text = v;
+        for (const c of el.children) c.parentElement = null;
+        el.children = [];
+      },
+    });
+    Object.defineProperty(el, "innerHTML", {
+      get: () => el._html,
+      set: (v: string) => { el._html = v; },
+    });
+
+    el.setAttribute = (n: string, v: string): void => { el.attrs[n] = v; };
+    el.getAttribute = (n: string): string | null => el.attrs[n] ?? null;
+    el.append = (...nodes: FakeNode[]): void => {
+      for (const n of nodes) { n.parentElement = el; el.children.push(n); }
+    };
+    el.insertBefore = (node: FakeNode, ref: FakeNode | null): FakeNode => {
+      // Detaches first, as the real one does. A fake that appended
+      // unconditionally hid two independent ordering defects in this package.
+      const here = el.children.indexOf(node);
+      if (here !== -1) el.children.splice(here, 1);
+      node.parentElement = el;
+      if (ref === null || ref === undefined) { el.children.push(node); return node; }
+      const at = el.children.indexOf(ref);
+      el.children.splice(at === -1 ? el.children.length : at, 0, node);
+      return node;
+    };
+    el.remove = (): void => {
+      const parent = el.parentElement;
+      if (parent === null) return;
+      const at = parent.children.indexOf(el);
+      if (at !== -1) parent.children.splice(at, 1);
+      el.parentElement = null;
+    };
+    el.addEventListener = (type: string, cb: (e: unknown) => void): void => {
+      let byType = listeners.get(el);
+      if (byType === undefined) { byType = new Map(); listeners.set(el, byType); }
+      const set = byType.get(type) ?? new Set();
+      set.add(cb);
+      byType.set(type, set);
+    };
+    el.removeEventListener = (type: string, cb: (e: unknown) => void): void => {
+      listeners.get(el)?.get(type)?.delete(cb);
+    };
+    el.dispatch = (type: string, event: unknown): void => {
+      for (const cb of [...(listeners.get(el)?.get(type) ?? [])]) cb(event);
+    };
+    return el;
+  };
+
+  const view = {
+    addEventListener(type: string, cb: (e: unknown) => void) {
+      const set = viewListeners.get(type) ?? new Set();
+      set.add(cb);
+      viewListeners.set(type, set);
+    },
+    removeEventListener(type: string, cb: (e: unknown) => void) {
+      viewListeners.get(type)?.delete(cb);
+    },
+    dispatch(type: string, event: unknown) {
+      for (const cb of [...(viewListeners.get(type) ?? [])]) cb(event);
+    },
+  };
+
+  const doc = { createElement: make, defaultView: view, addEventListener() {}, getElementById: () => null };
+  const root = make("div");
+
+  const all = (): FakeNode[] => {
+    const out: FakeNode[] = [];
+    const walk = (n: FakeNode): void => { out.push(n); for (const c of n.children) walk(c); };
+    walk(root);
+    return out;
+  };
+
+  return {
+    root,
+    view,
+    all,
+    find: (pred) => all().find(pred) ?? null,
+    click(el) {
+      const event = {
+        target: el,
+        defaultPrevented: false,
+        preventDefault(this: { defaultPrevented: boolean }) { this.defaultPrevented = true; },
+      };
+      let node: FakeNode | null = el;
+      while (node !== null) { node.dispatch("click", event); node = node.parentElement; }
+      return event;
+    },
+    text: () => root.textContent,
+  };
+}


### PR DESCRIPTION
A round-four audit drove the real `mount()` through a fake DOM for the first time. Every defect it found has the same shape: **a pure function that is correct, and a composition root that calls it wrongly or not at all.**

`main.test.ts` was 30 lines and said so out loud — *"`mount` needs a whole fake SSE transport to drive end to end, so the parts of it that can be wrong are extracted and called directly instead."* Every one of these lived in the part that was not extracted.

## 1. Every pre-first-token failure said "the engine produced no output"

`apply()` drops any event arriving before `start` — and both the controller's synthesised transport error and the engine's synthesised auth error **are** the first event. The real reason was thrown away, `finish()` substituted `kind: "empty"`, and 401, 403, 500, 502, offline, DNS and TLS all rendered identically, plus a dropped row accusing the engine of sending an event before the turn began.

The default `baseUrl` is `127.0.0.1:8765`, which **on a phone is the phone itself** — so this was the first thing every new user saw. It also made the `auth → recovery: "settings"` branch unreachable: the one distinction between "retry this" and "fix your credentials" never survived to the view model.

An error is a *terminal* event. If nothing has started, it **is** the turn's outcome.

## 2. A screen-reader user never heard the answer

`for (const item of announcements) region.textContent = item.text` overwrites the earlier items in the same task. A short answer completing inside one interval produced `[polite "<the answer>", polite "Response complete"]` — so the user heard only **"Response complete."** That is verbatim what `announce.ts` rule 4 exists to prevent (*"the user would never hear the end of the response"*), reintroduced at the single point where the pure function meets the DOM.

## 3–6, briefly

| defect | what shipped |
|---|---|
| **New chat didn't stop the run** | screen cleared, turn kept streaming; the next token re-inserted the old conversation into what the user believed was a fresh chat |
| **`chat_id` was always `"unassigned"`** | `setChat` was never called anywhere in the app. `controller.ts` says *"an engine cannot tell two conversations apart if every turn claims the same id"* — against an engine keying history by `chat_id`, every conversation was one thread |
| **A storage failure at boot left a rendered, dead app** | `createApp` *throws* for a StoragePort failure (SecurityError with site data blocked, QuotaExceededError). The chrome is appended before that await, so the rejection skipped the fatal screen **and** the listener registrations: top bar, composer, green Send button, and nothing ever happened again |
| **The crash handler was installed after the thing that throws** | `detectPlatform()` ran first, directly contradicting the comment above it. It reads `window.localStorage`; a throw there left the root completely empty |

## And one regression of my own

`stop()`'s idempotence guard, added two commits ago, aborted the reader **even when the engine answered `false`**. That set `aborted`, so the next tap returned `true` without asking the engine again. The user is told the stop was refused, taps the only affordance offered, and is told nothing at all — which `stopNotice` defines as success — while the run keeps generating and billing.

Worse: mutating that fix back was `fail=0`. I'd verified it with a throwaway script and never added a test, so the defect escaped twice — once into the code, once past my own verification. And the first test pair I wrote **passed by accident**: `SCRIPTS.happy` finishes on its own, so the refusal test was returning `false` for the boring reason (nothing was running) rather than because the engine refused. Its sibling failed and exposed it. Both now hold the run open.

## The harness

`testing/src/fake-dom.ts` models what the app actually depends on: ordering under `insertBefore` (which **detaches first** — the detail that hid two ordering defects here), `textContent` replacing children, delegated event dispatch, and the three constructors `main.ts` walks with `instanceof` — without which the click listener throws `Element is not defined` and every intent is lost. That is why nobody had driven the composition root before: the first attempt fails before reaching an assertion.

Eight tests now drive `mount()` end to end. Nine mutations across the seven fixes were each confirmed to fail a named test.

`971 tests` on node 22.23 **and** 24.12 · `boundaries: 132 files, no violations`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for authentication, permission, and server failures, with recovery navigation.
  - Fixed crash-screen display when storage is unavailable during startup.
  - New chats now reliably stop active runs, reset session state, and receive unique conversation IDs.
  - Streaming responses now announce all updates through accessible live regions.
  - Cancellation can be retried after a refusal and remains safely idempotent after success.
  - Errors occurring before streaming begins are now preserved and displayed correctly.

- **Tests**
  - Added end-to-end coverage for startup failures, streaming announcements, cancellation, recovery, and conversation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->