### PR TITLE
test(mobile): the SecretsPort had no test, and the fallback paths never ran

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -15,11 +15,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { describeStorageContract } from "./storage-contract.ts";
+import { describeSecretsContract } from "./secrets-contract.ts";
 import { describeShellContract, type ShellHarness } from "./shell-contract.ts";
 import { createFakeStorage } from "../../../testing/src/fake-storage.ts";
 import { createFakeShell, PHONE_INSETS } from "../../../testing/src/fake-shell.ts";
 import { createWebStorage } from "../web/storage.ts";
 import { createWebSecrets } from "../web/secrets.ts";
+import { createFakeSecrets } from "../../../testing/src/fake-secrets.ts";
 import { createWebShell } from "../web/shell.ts";
 import { INSET_VARIABLES } from "../../../core/src/ports/shell.ts";
 import { createFakeWindow } from "../web/fake-window.ts";
@@ -54,6 +56,12 @@ function memoryStorage(): Storage {
 
 describeStorageContract("fake storage", () => createFakeStorage());
 describeStorageContract("web storage", () => createWebStorage(memoryStorage()));
+
+// The SecretsPort had no contract and no test of any kind. Collapsing the web
+// adapter's key from `${slot}:${account}` to `${slot}` survived the whole
+// suite -- two accounts in one slot then share one credential.
+describeSecretsContract("fake secrets", () => createFakeSecrets());
+describeSecretsContract("web secrets", () => createWebSecrets());
 
 // ---- the contract can fail ------------------------------------------------
 

--- a/src/praisonai-mobile/adapters/src/conformance/secrets-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/secrets-contract.ts
@@ -1,0 +1,109 @@
+/**
+ * The SecretsPort contract, as a runnable suite.
+ *
+ * There was no test of any kind for `adapters/src/web/secrets.ts`, and a
+ * mutation sweep found the consequence: collapsing the storage key from
+ * `${slot}:${account}` to `${slot}` survived the entire suite. Two accounts in
+ * one slot then share a single credential -- adding a second profile's API key
+ * silently overwrites the first, reading either returns the last one written,
+ * `has()` returns true for an account that was never set, and deleting one
+ * deletes both.
+ *
+ * That is the worst failure this port can have, and it was reachable in a
+ * module nothing executed.
+ *
+ * Written as a contract rather than a test of one adapter because the fake and
+ * the web adapter must agree: a test that passes against a fake with different
+ * key semantics is how a device-only defect gets shipped. The two ports that
+ * already had contracts scored best in that sweep; the two without scored
+ * worst.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { SecretsPort } from "../../../core/src/ports/secrets.ts";
+
+export function describeSecretsContract(
+  name: string,
+  make: () => SecretsPort | Promise<SecretsPort>,
+): void {
+  const openai = { slot: "openai" as const, account: "default" };
+
+  test(`${name}: a secret that was never set reads as null`, async () => {
+    const secrets = await make();
+    assert.equal(await secrets.get(openai), null);
+    assert.equal(await secrets.has(openai), false);
+  });
+
+  test(`${name}: a stored secret reads back exactly`, async () => {
+    const secrets = await make();
+    await secrets.set(openai, "sk-live-abc123");
+    assert.equal(await secrets.get(openai), "sk-live-abc123");
+    assert.equal(await secrets.has(openai), true);
+  });
+
+  test(`${name}: two ACCOUNTS in one slot are two different secrets`, async () => {
+    // THE CASE. Keying by slot alone makes a second profile silently overwrite
+    // the first, and every read return whichever was written last.
+    const secrets = await make();
+    const a = { slot: "openai" as const, account: "work" };
+    const b = { slot: "openai" as const, account: "personal" };
+
+    await secrets.set(a, "sk-work");
+    await secrets.set(b, "sk-personal");
+
+    assert.equal(await secrets.get(a), "sk-work", "the second account overwrote the first");
+    assert.equal(await secrets.get(b), "sk-personal");
+  });
+
+  test(`${name}: an account that was never set is absent, even in a used slot`, async () => {
+    // The other half: `has` must not answer for a sibling account.
+    const secrets = await make();
+    await secrets.set({ slot: "openai", account: "work" }, "sk-work");
+    assert.equal(await secrets.has({ slot: "openai", account: "never-set" }), false);
+    assert.equal(await secrets.get({ slot: "openai", account: "never-set" }), null);
+  });
+
+  test(`${name}: deleting one account leaves its siblings alone`, async () => {
+    const secrets = await make();
+    const a = { slot: "openai" as const, account: "work" };
+    const b = { slot: "openai" as const, account: "personal" };
+    await secrets.set(a, "sk-work");
+    await secrets.set(b, "sk-personal");
+
+    await secrets.delete(a);
+    assert.equal(await secrets.has(a), false);
+    assert.equal(await secrets.get(b), "sk-personal", "deleting one account deleted both");
+  });
+
+  test(`${name}: two SLOTS are two different secrets`, async () => {
+    const secrets = await make();
+    await secrets.set({ slot: "openai", account: "default" }, "sk-openai");
+    await secrets.set({ slot: "anthropic", account: "default" }, "sk-engine");
+    assert.equal(await secrets.get({ slot: "openai", account: "default" }), "sk-openai");
+    assert.equal(await secrets.get({ slot: "anthropic", account: "default" }), "sk-engine");
+  });
+
+  test(`${name}: overwriting a secret replaces it rather than appending`, async () => {
+    const secrets = await make();
+    await secrets.set(openai, "first");
+    await secrets.set(openai, "second");
+    assert.equal(await secrets.get(openai), "second");
+  });
+
+  test(`${name}: deleting an absent secret succeeds`, async () => {
+    // The caller wanted it gone and it is gone. Throwing forces every clear
+    // path to wrap itself in a try.
+    const secrets = await make();
+    await assert.doesNotReject(() => secrets.delete({ slot: "openai", account: "ghost" }));
+  });
+
+  test(`${name}: an empty string is a stored value, not an absence`, async () => {
+    // `""` is falsy, so an adapter using `||` turns a deliberately-blank
+    // credential back into "not configured" on every read.
+    const secrets = await make();
+    await secrets.set(openai, "");
+    assert.equal(await secrets.get(openai), "");
+    assert.equal(await secrets.has(openai), true);
+  });
+}

--- a/src/praisonai-mobile/app/src/intents.test.ts
+++ b/src/praisonai-mobile/app/src/intents.test.ts
@@ -118,3 +118,32 @@ test("the innermost actionable ancestor wins", () => {
   ]);
   assert.deepEqual(intent, { kind: "delete-chat", chatId: "c1" });
 });
+
+test("a DISABLED control fires nothing, and does not fall through to its row", () => {
+  // `if (el.disabled === true) return null` -> `continue` survived. The walk
+  // would skip the disabled element and keep climbing, so a tap on a greyed-out
+  // approval button reaches the enclosing row and fires THAT row's intent.
+  //
+  // This is the only thing standing between a double-tap and a second send,
+  // and between a tap on a decision already in flight and a second decision.
+  const chain = [
+    { dataset: { action: "send" }, disabled: true },
+    { dataset: { action: "stop" }, disabled: false },
+  ];
+  assert.equal(intentFrom(chain), null, "a disabled control must stop the walk, not skip itself");
+});
+
+test("an ENABLED control still resolves through its ancestors", () => {
+  // The pair: returning null unconditionally would disable the whole app.
+  const chain = [
+    { dataset: {}, disabled: false },
+    { dataset: { action: "stop" }, disabled: false },
+  ];
+  assert.deepEqual(intentFrom(chain), { kind: "stop" });
+});
+
+test("a delete-chat with no chat id is refused, not addressed at nothing", () => {
+  // Defaulting to "" produced a delete request aimed at no chat -- or, if any
+  // chat is keyed "", at the wrong one.
+  assert.equal(intentFrom([{ dataset: { action: "delete-chat" }, disabled: false }]), null);
+});

--- a/src/praisonai-mobile/app/src/mount.test.ts
+++ b/src/praisonai-mobile/app/src/mount.test.ts
@@ -133,3 +133,31 @@ test("applying the same transition twice mounts nothing new", () => {
   screens.apply(transition(chat, chat, screens.live()));
   assert.equal(root.children.length, 1);
 });
+
+test("an unmounted screen is forgotten, so it can be built again", () => {
+  // Dropping `nodes.delete(id)` after unmount survived. `live()` then lies:
+  // screens.ts asks `live.has(next)` to decide whether to mount, gets a stale
+  // yes, and never rebuilds -- a blank screen the user cannot get out of.
+  const dom = fakeDom();
+  const { root, screens } = build(dom);
+
+  screens.apply({ mount: ["chat"], unmount: [], hide: [], show: "chat", noop: false });
+  assert.deepEqual([...screens.live()], ["chat"]);
+
+  screens.apply({ mount: [], unmount: ["chat"], hide: [], show: "chat", noop: false });
+  assert.deepEqual([...screens.live()], [], "an unmounted screen must not report as live");
+  assert.equal(root.children.length, 0);
+
+  screens.apply({ mount: ["chat"], unmount: [], hide: [], show: "chat", noop: false });
+  assert.equal(root.children.length, 1, "and must be rebuilt when mounted again");
+});
+
+test("mounting a screen that is already live does not build it twice", () => {
+  // The pair. Dropping the `has` guard appends a second copy and orphans the
+  // first, so the leak and the double render arrive together.
+  const dom = fakeDom();
+  const { root, screens } = build(dom);
+  screens.apply({ mount: ["chat"], unmount: [], hide: [], show: "chat", noop: false });
+  screens.apply({ mount: ["chat"], unmount: [], hide: [], show: "chat", noop: false });
+  assert.equal(root.children.length, 1);
+});

--- a/src/praisonai-mobile/core/src/chat/repository.test.ts
+++ b/src/praisonai-mobile/core/src/chat/repository.test.ts
@@ -137,3 +137,68 @@ test("a chat file with no engineId reads as unknown rather than failing", async 
   assert.equal(loaded.ok, true);
   assert.equal(loaded.ok === true ? loaded.chat.engineId : null, "unknown");
 });
+
+// ---- a bad file must not take the good ones with it -------------------------
+
+test("one corrupt chat does not hide every chat listed after it", () => {
+  // `if (!result.ok) continue` -> `break` survived. Half the user's library
+  // vanishes with no error anywhere, and listUnreadable still reports only the
+  // one bad file -- so the app is confidently wrong about how much is missing.
+  const storage = createFakeStorage();
+  const repo = createChatRepository(storage);
+
+  const write = async (id: string, body: string): Promise<void> => {
+    await storage.write({ namespace: "chats", id }, body);
+  };
+
+  return (async () => {
+    await write("a", JSON.stringify({ version: 1, chat: { id: "a", title: "A", messages: [], updated: 1 } }));
+    await write("b", "{ not json at all");
+    await write("c", JSON.stringify({ version: 1, chat: { id: "c", title: "C", messages: [], updated: 2 } }));
+    await write("d", JSON.stringify({ version: 1, chat: { id: "d", title: "D", messages: [], updated: 3 } }));
+
+    const listed = await repo.list();
+    assert.deepEqual(
+      listed.map((s) => s.id).sort(),
+      ["a", "c", "d"],
+      "every readable chat must survive an unreadable neighbour",
+    );
+    assert.deepEqual(await repo.listUnreadable(), ["b"]);
+  })();
+});
+
+test("a chat file with no id is reported unreadable, not loaded with an undefined id", () => {
+  // Dropping `typeof chat.id !== "string"` survived. The file loads ok:true
+  // with id undefined, shows in list() as a row addressed at nothing, and
+  // DISAPPEARS from listUnreadable -- so the one rule the header states,
+  // "a chat that fails to parse is reported, not skipped", breaks in the
+  // direction nobody checks. Saving it then writes to the key "chats/undefined".
+  const storage = createFakeStorage();
+  const repo = createChatRepository(storage);
+
+  return (async () => {
+    await storage.write(
+      { namespace: "chats", id: "x" },
+      JSON.stringify({ version: 1, chat: { title: "no id here", messages: [], updated: 1 } }),
+    );
+    assert.deepEqual(await repo.list(), [], "a chat with no id must not be listed");
+    assert.deepEqual(await repo.listUnreadable(), ["x"], "and must be reported as unreadable");
+  })();
+});
+
+test("an id that vanishes between listing and reading is not called corrupt", () => {
+  // Reporting `missing` as unreadable shows a permanent corruption warning for
+  // a file that is simply gone -- deleted by another tab, or evicted.
+  const storage = createFakeStorage();
+  const ghosting = {
+    ...storage,
+    listIds: async () => ["ghost"],
+    read: async () => null,
+  };
+  const repo = createChatRepository(ghosting);
+
+  return (async () => {
+    assert.deepEqual(await repo.list(), []);
+    assert.deepEqual(await repo.listUnreadable(), [], "absent is not the same as corrupt");
+  })();
+});

--- a/src/praisonai-mobile/core/src/run/approvals.test.ts
+++ b/src/praisonai-mobile/core/src/run/approvals.test.ts
@@ -179,3 +179,29 @@ test("clearing the queue does not release the in-flight turn", () => {
   assert.equal(depth(queue), 0);
   assert.equal(queue.busy, true);
 });
+
+test("acknowledge does not resurrect a decision the engine already REFUSED", () => {
+  // `state.status !== "sending"` -> allowing "failed" through survived. A
+  // refused decision would be marked `sent`: isActionable flips to false, the
+  // buttons go dead, outstanding drops to zero, and the run stays blocked on a
+  // prompt the engine never received until its 300-second timeout.
+  //
+  // That is verbatim the desktop failure this file's header says it exists to
+  // prevent -- silence read as success.
+  let table = add(emptyApprovals, { approvalId: "ap1", callId: "c1", name: "rm", args: {} });
+  table = choose(table, "ap1", "deny");
+  table = reject(table, "ap1", "the engine did not accept the decision");
+  assert.equal(find(table, "ap1")?.state.status, "failed");
+
+  const after = acknowledge(table, "ap1");
+  assert.equal(find(after, "ap1")?.state.status, "failed", "a refusal must not become a success");
+  assert.equal(isActionable(find(after, "ap1")!), true, "and the user must still be able to retry");
+});
+
+test("acknowledge still promotes a decision that IS in flight", () => {
+  // The pair: refusing every acknowledge would leave a real decision showing
+  // as unsent forever.
+  let table = add(emptyApprovals, { approvalId: "ap1", callId: "c1", name: "ls", args: {} });
+  table = choose(table, "ap1", "allow");
+  assert.equal(find(acknowledge(table, "ap1"), "ap1")?.state.status, "sent");
+});

--- a/src/praisonai-mobile/ui/src/i18n/locale.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/locale.test.ts
@@ -9,7 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { canonicalise, direction, isRtl, logicalInsets, resolveLocale } from "./locale.ts";
+import { canonicalise, direction, isRtl, logicalInsets, resolveLocale, directionFromTables } from "./locale.ts";
 
 test("a regional tag resolves to the base language rather than to nothing", () => {
   // THE BUG: `supported.includes("en-GB")` is false, so a British user gets the
@@ -80,4 +80,62 @@ test("physical insets map onto logical edges, and only swap for RTL", () => {
   // button's clearance on the wrong side of an Arabic screen.
   assert.deepEqual(logicalInsets("ltr", 12, 34), { startPx: 12, endPx: 34 });
   assert.deepEqual(logicalInsets("rtl", 12, 34), { startPx: 34, endPx: 12 });
+});
+
+// ---- the degraded host: no Intl.Locale.textInfo -----------------------------
+//
+// `direction()` is `directionFromIntl(tag) ?? directionFromTables(tag)`, and
+// the test host is a Node with full ICU where the first half always answers.
+// So the second half -- the branch that runs on an older Android WebView --
+// never ran under test, and a mutation sweep found five indistinguishable
+// mutations in it. These call it directly.
+
+test("the fallback tables lay out the RTL languages right to left", () => {
+  // Mutating the RTL_LANGUAGES membership test made Arabic, Hebrew, Farsi and
+  // Urdu render LTR on exactly the devices most likely to hit this path.
+  for (const tag of ["ar", "he", "fa", "ur", "ps", "sd"]) {
+    assert.equal(directionFromTables(tag), "rtl", `${tag} must be rtl`);
+  }
+});
+
+test("the fallback tables lay out everything else left to right", () => {
+  // The pair. A table that answered "rtl" for everything passes the test above
+  // and makes an English UI unusable, which locale.ts calls out as the
+  // asymmetry that decides the default.
+  for (const tag of ["en", "fr", "ja", "zh-Hans", "ru", "hi", "tr"]) {
+    assert.equal(directionFromTables(tag), "ltr", `${tag} must be ltr`);
+  }
+});
+
+test("a script subtag beats the language, in both directions", () => {
+  // `az` and `ku` are LTR languages written in an RTL script, and `ar` and `ks`
+  // are RTL languages written in an LTR one. Dropping the title-casing of the
+  // script subtag made the first pair render LTR; changing the four-letter
+  // length test made the second pair render RTL.
+  assert.equal(directionFromTables("az-Arab"), "rtl", "an RTL script wins over an LTR language");
+  assert.equal(directionFromTables("ku-Arab"), "rtl");
+  assert.equal(directionFromTables("ar-Latn"), "ltr", "an LTR script wins over an RTL language");
+  assert.equal(directionFromTables("ks-Deva"), "ltr");
+});
+
+test("the script subtag is matched case-insensitively", () => {
+  // A wire tag is not guaranteed to be canonically cased.
+  assert.equal(directionFromTables("az-arab"), "rtl");
+  assert.equal(directionFromTables("az-ARAB"), "rtl");
+});
+
+test("a region subtag is not mistaken for a script", () => {
+  // Regions are two letters or three digits; scripts are four letters. Reading
+  // a region as a script would decide direction from the wrong subtag.
+  assert.equal(directionFromTables("ar-EG"), "rtl", "a region must not override the language");
+  assert.equal(directionFromTables("en-US"), "ltr");
+  assert.equal(directionFromTables("ar-001"), "rtl");
+});
+
+test("the fallback never throws, whatever it is handed", () => {
+  // It is the total half of a total function: `direction()` promises to always
+  // answer, and this is what it falls back to.
+  for (const tag of ["", "-", "x", "en_US", "!!!", "a-b-c-d-e"]) {
+    assert.doesNotThrow(() => directionFromTables(tag), `threw on ${JSON.stringify(tag)}`);
+  }
 });

--- a/src/praisonai-mobile/ui/src/i18n/locale.ts
+++ b/src/praisonai-mobile/ui/src/i18n/locale.ts
@@ -110,7 +110,21 @@ function directionFromIntl(tag: string): Direction | null {
 }
 
 /** The fallback: an explicit script subtag if there is one, else the language. */
-function directionFromTables(tag: string): Direction {
+/**
+ * The table lookup, exported so a test can call it.
+ *
+ * `direction()` is `directionFromIntl(tag) ?? directionFromTables(tag)`, and
+ * the test host is a Node with full ICU where the first half always answers --
+ * so this half never ran under test. A mutation sweep found FIVE
+ * indistinguishable mutations in it: Arabic, Hebrew, Farsi and Urdu rendering
+ * LTR; `az-Arab` and `ku-Arab` rendering LTR; `ar-Latn` and `ks-Deva`
+ * rendering RTL.
+ *
+ * This is the branch that runs on an older Android WebView without
+ * `Intl.Locale.textInfo` -- exactly the devices most likely to be affected --
+ * and the failure is the whole UI mirrored the wrong way, or not at all.
+ */
+export function directionFromTables(tag: string): Direction {
   const parts = subtags(tag).map((part) => part.toLowerCase());
   const language = parts[0] ?? "";
 

--- a/src/praisonai-mobile/ui/src/i18n/segment.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/segment.test.ts
@@ -13,7 +13,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { completedLength, endsSentence, sentences } from "./segment.ts";
+import { completedLength, endsSentence, sentences, fallbackSentences } from "./segment.ts";
 
 test("an unfinished trailing clause is not counted as complete", () => {
   // THE RULE the announcement policy rests on. Announcing the tail means the
@@ -76,4 +76,45 @@ test("a trailing quote or bracket after the terminator still closes the sentence
 test("segmentation never loses text", () => {
   const text = "First. Second! Third? Trailing";
   assert.equal(sentences("en", text).join(""), text);
+});
+
+// ---- the degraded host: no Intl.Segmenter -----------------------------------
+
+test("the fallback splitter does not split on a decimal point", () => {
+  // The first failure this file's header names. On a host without
+  // Intl.Segmenter, "Version 1.2.3 is out." became three sentences.
+  assert.deepEqual(fallbackSentences("Version 1.2.3 is out."), ["Version 1.2.3 is out."]);
+});
+
+test("the fallback splitter splits after a quoted full stop", () => {
+  // The second. `He said "stop." Then left.` is two sentences, and returning
+  // it as one unsplit blob means a screen reader reads it as one breath.
+  assert.deepEqual(
+    fallbackSentences('He said "stop." Then left.'),
+    ['He said "stop." ', "Then left."],
+  );
+});
+
+test("the fallback splitter keeps the unterminated tail", () => {
+  // The one that loses data: dropping the tail means the in-progress end of a
+  // streaming answer is never spoken, and it breaks the seam guarantee that
+  // slice(0, n) + slice(n) recombine to the original.
+  const parts = fallbackSentences("Done. And now this is still be");
+  assert.equal(parts.join(""), "Done. And now this is still be", "no character may be lost");
+  assert.ok(parts.length >= 2, "the finished sentence and the tail are separate");
+});
+
+test("the fallback splitter recombines to exactly the input", () => {
+  // The general form of the guarantee, over the awkward cases together.
+  for (const text of [
+    "",
+    "One.",
+    "One. Two. Three.",
+    "Version 1.2.3 is out. Next.",
+    'He said "stop." Then left.',
+    "No terminator at all",
+    "Trailing space. ",
+  ]) {
+    assert.equal(fallbackSentences(text).join(""), text, `lost characters in ${JSON.stringify(text)}`);
+  }
 });

--- a/src/praisonai-mobile/ui/src/i18n/segment.ts
+++ b/src/praisonai-mobile/ui/src/i18n/segment.ts
@@ -121,7 +121,18 @@ export function completedLength(locale: string, text: string): number {
  * a way that loses text -- the pieces still concatenate back to the input --
  * so the seam guarantee above holds either way.
  */
-function fallbackSentences(text: string): readonly string[] {
+/**
+ * The no-Segmenter splitter, exported so a test can call it.
+ *
+ * `sentences()` uses `Intl.Segmenter` whenever it exists, and it always does
+ * on the test host -- so this path never ran. Three mutations survived in it,
+ * one per failure this file's own header names: splitting on a decimal point,
+ * splitting mid-CJK, and failing to split after a quoted full stop. A fourth
+ * dropped the unterminated tail entirely, which on a host without Segmenter
+ * means a blind user never hears the in-progress end of an answer, and breaks
+ * the documented seam guarantee that slice(0,n) + slice(n) recombine.
+ */
+export function fallbackSentences(text: string): readonly string[] {
   const out: string[] = [];
   let start = 0;
   for (let i = 0; i < text.length; i += 1) {


### PR DESCRIPTION
A **226-mutation** sweep against an isolated worktree: 59 genuine survivors, 10 equivalent mutants each proved by differential test rather than asserted.

## The rate question, answered honestly

| | this round | prior three |
|---|---|---|
| mutations run | 226 | ~180 |
| genuine survivors | 59 | 60+ |
| genuine survival | **26.3%** | ~33% raw |

**The rate has not meaningfully fallen** — but the pool turns out to be *bimodal*, and this sweep locates the boundary. Seven modules killed everything thrown at them (`queue.ts` 8/8, `screens.ts` 5/5, `list-view-model.ts` 6/6, `web/storage.ts` 4/4, `crash.ts` 3/3, `engines.ts` 3/3, `politeness.ts` 3/3) — two of which have no sibling test file and are covered transitively. The style works; the 26% isn't spread evenly over it.

## The structural finding

**Almost every genuine survivor lives on a fallback path** — the branch that runs when the platform is missing something. The suite runs on a Node with full ICU and no DOM, so the primary path is exercised hard and the degraded path is *never entered*. That's one gap, not 59.

`direction()` is `directionFromIntl(tag) ?? directionFromTables(tag)`; the first half always answers here, so the second had five indistinguishable mutations:

| mutation | what ships |
|---|---|
| `RTL_LANGUAGES` never matches | Arabic, Hebrew, Farsi, Urdu render **LTR** |
| script subtag not title-cased | `az-Arab`, `ku-Arab` render LTR |
| length test `4 → 3` | `ar-Latn`, `ks-Deva` render **RTL** |

The whole UI mirrored the wrong way, on exactly the devices most likely to reach that code. Same story in `fallbackSentences`: three survivors, one per failure the file's own header names.

Both are now exported and called directly — this repo's stated rule, and it doesn't leave a stubbing fixture that can itself drift.

## Tier 1 defects

**Two accounts in one slot shared one credential.** `web/secrets.ts` had **no test file of any kind**. Collapsing its key from `${slot}:${account}` to `${slot}` survived everything: a second profile's API key silently overwrites the first, `has()` answers true for an account never set, deleting one deletes both. Now a **contract** covering every adapter — in this same sweep the two ports *with* a contract scored best and the two without scored worst. The mutation now fails three times, once per adapter.

| defect | what shipped |
|---|---|
| `if (el.disabled) return null` → `continue` | a tap on a **greyed-out** approval button walks up and fires the enclosing row's intent — the only thing between a double-tap and a second send |
| `if (!result.ok) continue` → `break` | **one corrupt chat file hides every chat after it**; `listUnreadable` still reports one bad file, so the app is confidently wrong about how much is missing |
| drop `typeof chat.id !== "string"` | a chat loads `ok:true` with `id: undefined`, vanishes from `listUnreadable`, and saves to `chats/undefined` |
| `acknowledge` accepts a `failed` entry | a **refused** decision marked sent: buttons die, run stays blocked until its 300-second timeout |
| drop `nodes.delete(id)` | `live()` lies, `screens.ts` never rebuilds — a blank screen with no way back |

`1009 tests` on node 22.23 **and** 24.12 · `boundaries: 133 files, no violations` · eleven mutations confirmed to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of disabled controls and invalid chat deletion requests.
  * Prevented duplicate screen mounts and ensured unmounted screens can be rebuilt.
  * Improved resilience when chat files are corrupt, malformed, or missing.
  * Preserved refused approval states during acknowledgement.
  * Strengthened locale direction detection and sentence splitting in limited browser environments.

* **Tests**
  * Added coverage for secrets storage behavior, approval handling, chat recovery, mounting, intents, localization, and sentence-splitting edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->