### PR TITLE
test(mobile): the TimePort had no test and no contract, and scored 3 of 3 surviving

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -16,16 +16,18 @@ import assert from "node:assert/strict";
 
 import { describeStorageContract } from "./storage-contract.ts";
 import { describeSecretsContract } from "./secrets-contract.ts";
+import { describeTimeContract } from "./time-contract.ts";
 import { describeShellContract, type ShellHarness } from "./shell-contract.ts";
 import { createFakeStorage } from "../../../testing/src/fake-storage.ts";
 import { createFakeShell, PHONE_INSETS } from "../../../testing/src/fake-shell.ts";
 import { createWebStorage } from "../web/storage.ts";
 import { createWebSecrets } from "../web/secrets.ts";
+import { createWebTime } from "../web/time.ts";
 import { createFakeSecrets } from "../../../testing/src/fake-secrets.ts";
+import { createFakeTime } from "../../../testing/src/fake-time.ts";
 import { createWebShell } from "../web/shell.ts";
 import { INSET_VARIABLES } from "../../../core/src/ports/shell.ts";
 import { createFakeWindow } from "../web/fake-window.ts";
-import { createWebTime } from "../web/time.ts";
 import { createTauriBridge, type TauriBridge } from "../tauri/bridge.ts";
 import {
   createTauriShell,
@@ -62,6 +64,36 @@ describeStorageContract("web storage", () => createWebStorage(memoryStorage()));
 // suite -- two accounts in one slot then share one credential.
 describeSecretsContract("fake secrets", () => createFakeSecrets());
 describeSecretsContract("web secrets", () => createWebSecrets());
+
+// The TimePort had no test file and no contract, and scored 3 of 3 surviving
+// in a mutation sweep -- the worst module in the package. Both implementations
+// run the same cases: the fake driven by its own clock, the web adapter on
+// real timers.
+describeTimeContract("fake time", () => createFakeTime(), async (time, ms) => {
+  const fake = time as ReturnType<typeof createFakeTime>;
+  fake.advance(ms);
+  fake.tick();
+  fake.releaseFrames();
+  // A fake timer fires when the test says so; a real one fires on its own.
+  for (const scheduler of fake.schedulers) {
+    if (scheduler.timerArmed) scheduler.fireTimer();
+  }
+  await Promise.resolve();
+});
+
+// The web adapter targets a browser, so the test supplies the one browser API
+// it needs. Without this `requestFrame` throws ReferenceError in Node and the
+// adapter cannot be contract-tested at all -- which is part of why it never
+// was.
+(globalThis as Record<string, unknown>)["requestAnimationFrame"] ??= (cb: () => void) =>
+  setTimeout(cb, 0);
+
+describeTimeContract(
+  "web time",
+  () => createWebTime(),
+  async (_time, ms) => { await new Promise((r) => setTimeout(r, ms + 10)); },
+  true,
+);
 
 // ---- the contract can fail ------------------------------------------------
 

--- a/src/praisonai-mobile/adapters/src/conformance/time-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/time-contract.ts
@@ -1,0 +1,142 @@
+/**
+ * The TimePort contract, as a runnable suite.
+ *
+ * `adapters/src/web/time.ts` had no test file and no contract, and a mutation
+ * sweep scored it 3 of 3 surviving -- the worst module in the package. What
+ * each survivor shipped:
+ *
+ *   setInterval -> setTimeout   EVERY polling loop stops after one tick.
+ *                               Readiness polling, the coalescer's flush tick,
+ *                               elapsed-time updates: all fire once and stop,
+ *                               and the app looks merely slow.
+ *   clearTimer does nothing     A cancelled timer still fires, so the publish
+ *                               gate reopens after it was deliberately shut.
+ *   performance.now -> Date.now Elapsed measurements jump backwards when the
+ *                               clock is NTP-corrected mid-turn -- which is
+ *                               exactly why the port separates the two.
+ *
+ * Written as a contract because the fake and the real adapter must agree.
+ * `every`'s period was ALREADY found discarded in the fake twice; a test that
+ * only ever drives the fake cannot see it a third time.
+ *
+ * Timing here is real, so every wait is generous and every assertion is about
+ * ORDER or COUNT rather than about a duration. A contract that measures
+ * elapsed milliseconds is a contract that goes red on a loaded CI box.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { TimePort } from "../../../core/src/ports/time.ts";
+
+const after = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export function describeTimeContract(
+  name: string,
+  make: () => TimePort,
+  /** Drives the fake's clock; a real wait for an adapter on real time. */
+  advance: (time: TimePort, ms: number) => Promise<void>,
+  /** True for an adapter on real time, where nowMs and epochMs must differ. */
+  realClock = false,
+): void {
+  test(`${name}: nowMs is monotonic`, async () => {
+    // It is the clock the coalescer measures its delay budget against. A clock
+    // that can go backwards makes the budget either never expire or expire
+    // instantly, and the port says in as many words that this is why nowMs and
+    // epochMs are separate.
+    const time = make();
+    const first = time.nowMs();
+    await advance(time, 20);
+    assert.ok(time.nowMs() >= first, "nowMs went backwards");
+  });
+
+  if (realClock) {
+    test(`${name}: epochMs is wall time and nowMs is not`, async () => {
+      // epochMs may be corrected; nowMs may not. An adapter returning
+      // Date.now() for both compiles, passes every other case here, and
+      // reintroduces the jump the separation exists to prevent.
+      //
+      // Guarded because the FAKE deliberately shares one clock -- its own
+      // header says so, "safe in a fake and wrong in an adapter". A contract
+      // that ignored that would be asserting the fake is broken.
+      const time = make();
+      assert.ok(time.epochMs() > 1_600_000_000_000, "epochMs must be wall-clock milliseconds");
+      assert.ok(time.nowMs() < 1_600_000_000_000, "nowMs must not be wall-clock milliseconds");
+    });
+  }
+
+  test(`${name}: every() repeats, rather than firing once`, async () => {
+    // THE CASE. setInterval -> setTimeout leaves every polling loop in the app
+    // firing exactly once, which reads as "slow" rather than as "broken".
+    const time = make();
+    let fired = 0;
+    const stop = time.every(10, () => void fired++);
+
+    await advance(time, 10);
+    await advance(time, 10);
+    await advance(time, 10);
+    stop();
+
+    assert.ok(fired >= 2, `every() fired ${fired} time(s); it must repeat`);
+  });
+
+  test(`${name}: the unsubscribe actually stops it`, async () => {
+    const time = make();
+    let fired = 0;
+    const stop = time.every(10, () => void fired++);
+    await advance(time, 10);
+    stop();
+    const afterStop = fired;
+    await advance(time, 30);
+    assert.equal(fired, afterStop, "the callback fired after it was unsubscribed");
+  });
+
+  test(`${name}: a cleared timer does not fire`, async () => {
+    // The gate arms a fallback timer and clears it when a frame arrives. A
+    // clearTimer that does nothing reopens a gate that was deliberately shut.
+    const time = make();
+    const scheduler = time.createScheduler();
+    let fired = false;
+    scheduler.setTimer(() => { fired = true; }, 10);
+    scheduler.clearTimer();
+    await advance(time, 40);
+    assert.equal(fired, false, "a cleared timer still fired");
+  });
+
+  test(`${name}: an uncleared timer does fire`, async () => {
+    // The pair. A setTimer that never fires passes the test above and disables
+    // the gate's only escape from a renderer that stopped painting.
+    const time = make();
+    const scheduler = time.createScheduler();
+    let fired = false;
+    scheduler.setTimer(() => { fired = true; }, 5);
+    await advance(time, 40);
+    assert.equal(fired, true, "an armed timer never fired");
+  });
+
+  test(`${name}: requestFrame runs its callback`, async () => {
+    const time = make();
+    const scheduler = time.createScheduler();
+    let ran = false;
+    scheduler.requestFrame(() => { ran = true; });
+    await advance(time, 40);
+    assert.equal(ran, true);
+  });
+
+  test(`${name}: schedulers are independent`, async () => {
+    // "One per run. Reusing a gate across runs carries a closed gate into a new
+    // answer and drops its opening tokens." Clearing one must not clear another.
+    const time = make();
+    const a = time.createScheduler();
+    const b = time.createScheduler();
+    let aFired = false;
+    let bFired = false;
+    a.setTimer(() => { aFired = true; }, 5);
+    b.setTimer(() => { bFired = true; }, 5);
+    a.clearTimer();
+    await advance(time, 40);
+    assert.equal(aFired, false, "the cleared scheduler fired");
+    assert.equal(bFired, true, "clearing one scheduler cleared another");
+  });
+}
+
+export { after };


### PR DESCRIPTION
The worst-scoring module in the 226-mutation sweep, and the last of its three structural recommendations. `adapters/src/web/time.ts` had **no test file and no contract**; every mutation aimed at it survived.

| mutation | what shipped |
|---|---|
| `setInterval` → `setTimeout` | **every polling loop in the app fires once and stops** — readiness polling, the coalescer's flush tick, elapsed-time updates. The app reads as merely *slow* rather than broken |
| `clearTimer` does nothing | a cancelled timer still fires, so the publish gate reopens after it was deliberately shut |
| `performance.now` → `Date.now` | elapsed measurements jump backwards when the clock is NTP-corrected mid-turn — exactly why the port separates the two |
| unsubscribe does nothing | the interval leaks for the app's lifetime |

Written as a **contract** because the fake and the real adapter must agree — and this port has form: `every`'s period and `setTimer`'s delay were *both* found discarded in the fake, in two separate rounds. A test that only ever drives the fake cannot see it a third time.

## Two things the contract had to be honest about

**The fake deliberately uses one clock** for `nowMs` and `epochMs` — its own header says so, *"safe in a fake and wrong in an adapter"*. Asserting they differ would be asserting the fake is broken, so that case is guarded and runs only against a real-time adapter, where it's the case that matters.

**The web adapter targets a browser**, and `requestFrame` throws `ReferenceError` in Node. The contract supplies `requestAnimationFrame` rather than skipping the case. Not having that shim is part of why this adapter had never been contract-tested at all.

## One check worth naming

All four mutations fail by **assertion**, not merely by timing out. I checked, because the unsubscribe mutation *also* hangs the run — the leaked interval keeps the event loop alive, which is precisely the resource leak it ships — and a hang is not the same as a test that says what is wrong.

`1024 tests` on node 22.23 **and** 24.12 · `boundaries: 134 files, no violations` · tests only, no product source changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive conformance coverage for time-related adapter behavior.
  * Verified monotonic clocks, timers, intervals, frame callbacks, cancellation, and scheduler independence.
  * Added support for validating both simulated and real-time adapter implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->