### PR TITLE
test(mobile): nothing asserted what was written, only what was streamed

### DIFF
--- a/src/praisonai-mobile/core/src/chat/session.test.ts
+++ b/src/praisonai-mobile/core/src/chat/session.test.ts
@@ -206,3 +206,30 @@ test("persistenceFor propagates a failed write as null", () => {
     assert.equal(indices, null);
   });
 });
+
+test("every turn advances the chat's updated time", () => {
+  // `updated: at` -> `updated: base.updated` survived: the chat keeps the
+  // timestamp of its FIRST message forever. A list ordered by `updated` then
+  // sinks the conversation you are actively using to the bottom, while one you
+  // have not touched in a month sits at the top.
+  //
+  // Nothing saw it because no test read back what was written across TWO
+  // turns -- the same blind spot that let the persisted answer be duplicated.
+  const { session } = build();
+
+  return (async () => {
+    await session.record("first question", "first answer");
+    const afterOne = session.current();
+    assert.ok(afterOne !== null);
+
+    await session.record("second question", "second answer");
+    const afterTwo = session.current();
+    assert.ok(afterTwo !== null);
+
+    assert.ok(
+      afterTwo.updated > afterOne.updated,
+      `updated did not advance: ${afterOne.updated} -> ${afterTwo.updated}`,
+    );
+    assert.equal(afterTwo.messages.length, 4, "and both turns are still there");
+  })();
+});

--- a/src/praisonai-mobile/engines/src/praisonai-ts/engine.test.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/engine.test.ts
@@ -305,3 +305,86 @@ test("a run before dispose is unaffected", async () => {
   const engine = build(fakeAgent([{ type: "finish", text: "x" }]));
   assert.equal((await collect(engine)).at(-1)!.type, "end");
 });
+
+// ---- what is WRITTEN, not only what is streamed -----------------------------
+//
+// The fake persistence above records `req` and throws the answer away, so no
+// test in this file could see what actually reaches the repository. A mutation
+// sweep found the consequence: `answer = event.text` -> `+=` survived. The
+// screen is built from the streamed deltas and looks right; the PERSISTED
+// transcript contains the answer twice. Reopening the chat shows it doubled.
+
+/** A persistence that keeps the answer, which the one above does not. */
+function capturing() {
+  const writes: { prompt: string; answer: string }[] = [];
+  const port: RunPersistence = {
+    async record(req, answer) {
+      writes.push({ prompt: req.prompt, answer });
+      return { userIndex: 0, assistantIndex: 1, versions: 1, active: 0 };
+    },
+  };
+  return { writes, port };
+}
+
+const runAll = async (engine: ReturnType<typeof build>): Promise<void> => {
+  for await (const _ of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )) {
+    // drain
+  }
+};
+
+test("the finish text REPLACES the streamed accumulation when persisting", async () => {
+  // `finish` carries the full text and the engine trusts it over the
+  // accumulation, because upstream may normalise. Appending instead writes the
+  // answer twice to disk while the screen, built from the deltas, looks
+  // perfectly correct.
+  const p = capturing();
+  await runAll(
+    build(
+      fakeAgent([
+        { type: "text", delta: "Hello" },
+        { type: "text", delta: " world" },
+        { type: "finish", text: "Hello world" },
+      ]),
+      p.port,
+    ),
+  );
+  assert.deepEqual(p.writes.map((w) => w.answer), ["Hello world"]);
+});
+
+test("a normalising finish wins over what was streamed", async () => {
+  // The reason the assignment exists at all: upstream may return a tidied
+  // version. Persisting the concatenation would store text the model did not
+  // finally say.
+  const p = capturing();
+  await runAll(
+    build(
+      fakeAgent([
+        { type: "text", delta: "helo" },
+        { type: "finish", text: "hello" },
+      ]),
+      p.port,
+    ),
+  );
+  assert.deepEqual(p.writes.map((w) => w.answer), ["hello"]);
+});
+
+test("a turn that never streamed still persists the text it finished with", async () => {
+  // The other half of trusting `finish`: a non-streaming provider produces no
+  // deltas at all, and the accumulation would be empty.
+  const p = capturing();
+  await runAll(build(fakeAgent([{ type: "finish", text: "the whole answer" }]), p.port));
+  assert.deepEqual(p.writes.map((w) => w.answer), ["the whole answer"]);
+});
+
+test("with no finish event, the streamed deltas are what gets persisted", async () => {
+  // The pair. Trusting only `finish` would persist nothing for a provider
+  // that streams and then simply stops.
+  const p = capturing();
+  await runAll(
+    build(fakeAgent([{ type: "text", delta: "one " }, { type: "text", delta: "two" }]), p.port),
+  );
+  assert.deepEqual(p.writes.map((w) => w.answer), ["one two"]);
+});


### PR DESCRIPTION
The last of the 226-mutation sweep's three structural recommendations. Its own words: *"items 2, 4 and 41 all hide behind the same blind spot — the tests read the event stream and never read back the file."*

## The blind spot was one line

`engine.test.ts`'s fake persistence:

```ts
async record(req) { recorded.push(req); return indices; }
```

It records the request and **throws the answer away**, so nothing in that file could see what actually reaches the repository.

## What that hid

`answer = event.text` → `+=` **survived**. `finish` carries the full text and the engine trusts it over the streamed accumulation — because upstream may normalise, and a non-streaming provider finishes with content having emitted no deltas at all. Appending instead writes the answer **twice to disk**, while the screen — built from the deltas — looks perfectly correct.

The user sees a normal answer, and finds it doubled when they reopen the chat.

Four tests now assert the persisted side, covering both directions: a normalising `finish` must win over what was streamed, *and* a stream with no `finish` must still persist what it streamed. Deleting the finish handling entirely fails four of them.

## Same blind spot, second instance

`updated: at` → `updated: base.updated` **survived**, because no test read a chat back across *two* turns. The chat keeps the timestamp of its first message forever — so a list ordered by `updated` sinks the conversation you are actively using to the bottom, while one you haven't touched in a month sits at the top.

`1029 tests` · `boundaries: 134 files, no violations` · three mutations confirmed to fail (`fail=2`, `fail=4`, `fail=1`) · tests only, no product source changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat history accuracy so the latest conversation timestamp updates reliably after each turn.
  - Ensured completed responses are saved consistently, including streamed replies, normalized final text, and responses received without streaming.
  - Preserved conversation turns correctly when recording chat activity.

- **Tests**
  - Added coverage for conversation timestamps and response persistence across common completion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->