### PR TITLE
fix(mobile): every failure after the first turn was completely silent

### DIFF
--- a/src/praisonai-mobile/app/src/boot.ts
+++ b/src/praisonai-mobile/app/src/boot.ts
@@ -155,6 +155,17 @@ export async function createApp(deps: AppDeps): Promise<BootResult> {
   const controller = createRunController({
     engine,
     time: deps.time,
+    // The conversation the user starts ON LAUNCH needs an id too. `chatId`
+    // defaults to the literal "unassigned", and `setChat` was only ever called
+    // by the New chat handler -- so the first conversation of every launch, on
+    // every device, went to the engine as "unassigned". controller.ts says in
+    // as many words that "an engine cannot tell two conversations apart if
+    // every turn claims the same id"; against an engine keying server-side
+    // history by chat_id, every user's first chat was one shared thread.
+    //
+    // The existing test asserted only that two chat ids DIFFER, and
+    // "unassigned" !== "chat-2" passes that.
+    chatId: deps.newChatId(),
     // The other end of the seam: what the engine refused becomes a dropped
     // row on the turn it belonged to.
     dropSink,

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -240,3 +240,37 @@ test("a storage failure at boot shows the crash screen, not a dead-looking app",
   assert.equal(app, null, "a boot failure must not return a working app");
   assert.notEqual(dom.text(), "", "and must not leave a blank or silently dead page");
 });
+
+test("the conversation the user starts ON LAUNCH has a real chat id", async () => {
+  // `chatId` defaults to the literal "unassigned", and `setChat` was only ever
+  // called by the New chat handler -- so the first conversation of every
+  // launch, on every device, went to the engine as "unassigned".
+  // controller.ts says in as many words that "an engine cannot tell two
+  // conversations apart if every turn claims the same id"; against an engine
+  // keying server-side history by chat_id, every user's first chat was one
+  // shared thread.
+  //
+  // The existing test asserted only that two chat ids DIFFER, and
+  // "unassigned" !== "chat-2" passes that.
+  const { dom, http, platform } = harness();
+  http.on("/chat", () =>
+    sseResponse(
+      sse([
+        ["start", { msg_id: "m1", run_id: "r1" }],
+        ["delta", { msg_id: "m1", text: "answer" }],
+        ["end", { msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 }],
+      ]),
+    ),
+  );
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "chat-launch" });
+
+  submit(dom, "the very first question");
+  await settle();
+
+  const body = JSON.parse(String(http.sent.find((r) => r.url.includes("/chat"))?.body ?? "{}")) as {
+    chat_id?: string;
+  };
+  assert.notEqual(body.chat_id, "unassigned", "the first chat of a launch must have a real id");
+  assert.equal(body.chat_id, "chat-launch");
+  app?.dispose();
+});

--- a/src/praisonai-mobile/core/src/run/controller.test.ts
+++ b/src/praisonai-mobile/core/src/run/controller.test.ts
@@ -989,3 +989,220 @@ test("an ACCEPTED stop is still idempotent", async () => {
   release();
   await sent;
 });
+
+// ---- the turn belongs to the turn, not to the app ---------------------------
+
+/** An engine whose first run answers and whose later runs fail BEFORE `start`
+ *  -- which is every pre-first-token failure: 401, 403, offline, a refused
+ *  connection, a wrong baseUrl. */
+function answerThenFail(kind: "auth" | "transport", message: string) {
+  let n = 0;
+  return {
+    id: "s",
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {
+      streaming: true, reasoning: false, tools: true,
+      approvals: true, cancellation: true, attachments: false,
+    },
+    async *run(req: { runId: string }) {
+      n += 1;
+      if (n === 1) {
+        yield { type: "start", msgId: "m1", runId: req.runId };
+        yield { type: "delta", msgId: "m1", text: "first answer" };
+        yield { type: "end", msgId: "m1", userIndex: 0, assistantIndex: 1, versions: 1, active: 0 };
+        return;
+      }
+      yield { type: "error", msgId: `m${n}`, kind, message };
+    },
+    async decide() { return false; },
+    async cancel() { return false; },
+    async dispose() {},
+  } as unknown as Parameters<typeof createRunController>[0]["engine"];
+}
+
+test("a failure on the SECOND turn is reported, not silently swallowed", async () => {
+  // `turn` was only ever reset by a `start` event, so a turn producing no
+  // start met a state left `ended` by its predecessor: the error was dropped
+  // as stale and `finish()` returned the PREVIOUS turn untouched.
+  //
+  // The user types a second question, taps Send, the composer clears -- and
+  // nothing happens. The old answer stays on screen. No error, no retry, no
+  // auth prompt, not even a hint a run was attempted. The default baseUrl is
+  // 127.0.0.1:8765, so "engine unreachable" is the common case here.
+  const views: RunView[] = [];
+  const controller = createRunController({
+    engine: answerThenFail("auth", "engine responded 401"),
+    time: createFakeTime(),
+    onPublish: (v) => views.push(v),
+  });
+
+  await controller.send("one");
+  assert.equal(views.at(-1)?.turn.text, "first answer");
+
+  await controller.send("two");
+  const second = views.at(-1);
+  assert.equal(second?.turn.text, "", "the previous answer must not still be on screen");
+  assert.equal(second?.turn.outcome?.type, "error", "the failure must be reported");
+  assert.equal(
+    second?.turn.outcome?.type === "error" ? second.turn.outcome.kind : null,
+    "auth",
+    "and with its real kind, so the UI can offer credentials rather than retry",
+  );
+  assert.deepEqual(second?.turn.dropped, [], "a real failure is not an unreadable frame");
+});
+
+test("a clean turn after a failed one inherits nothing from it", async () => {
+  // The other direction of the same reset, and the amplifier: the dropped
+  // error landed in `carry`, so the next SUCCESSFUL turn rendered a "1 event
+  // could not be read" row blaming itself for its predecessor.
+  const views: RunView[] = [];
+  let n = 0;
+  const engine = {
+    id: "s",
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {
+      streaming: true, reasoning: false, tools: true,
+      approvals: true, cancellation: true, attachments: false,
+    },
+    async *run(req: { runId: string }) {
+      n += 1;
+      if (n === 1) {
+        yield { type: "error", msgId: "m1", kind: "transport", message: "network down" };
+        return;
+      }
+      yield { type: "start", msgId: `m${n}`, runId: req.runId };
+      yield { type: "delta", msgId: `m${n}`, text: "second answer" };
+      yield { type: "end", msgId: `m${n}`, userIndex: 0, assistantIndex: 1, versions: 1, active: 0 };
+    },
+    async decide() { return false; },
+    async cancel() { return false; },
+    async dispose() {},
+  } as unknown as Parameters<typeof createRunController>[0]["engine"];
+
+  const controller = createRunController({ engine, time: createFakeTime(), onPublish: (v) => views.push(v) });
+  await controller.send("one");
+  await controller.send("two");
+
+  const second = views.at(-1);
+  assert.equal(second?.turn.text, "second answer");
+  assert.equal(second?.turn.outcome?.type, "end");
+  assert.deepEqual(second?.turn.dropped, [], "a clean turn must not inherit the last one's failure");
+});
+
+test("switching chats clears the transcript, so nothing resurrects on the next send", async () => {
+  // `send()` publishes before `runTurn` starts, so a stale turn was painted
+  // into what the user believed was a new conversation. With a PENDING
+  // APPROVAL in it, the previous chat's prompt reappeared with live buttons --
+  // `setChat` had already cleared the approvals table, so the row found no
+  // entry and rendered itself actionable, and Allow posted to the engine.
+  //
+  // The scenario is a user abandoning a chat BECAUSE it asked to run something
+  // dangerous, and being asked again under an unrelated question.
+  const views: RunView[] = [];
+  const controller = createRunController({
+    engine: createScriptedEngine({
+      id: "s",
+      script: [
+        { type: "start", msgId: "m1", runId: "r1" },
+        { type: "tool_call", msgId: "m1", callId: "c1", name: "bash", args: { command: "rm -rf /" } },
+        { type: "approval_request", msgId: "m1", approvalId: "a1", callId: "c1", name: "bash", args: { command: "rm -rf /" } },
+      ],
+      approvals: ["a1"],
+    }),
+    time: createFakeTime(),
+    onPublish: (v) => views.push(v),
+  });
+
+  await controller.send("do something");
+  assert.ok((views.at(-1)?.turn.approvals.length ?? 0) > 0, "the approval should be outstanding");
+
+  controller.setChat("a-different-chat");
+  const afterSwitch = controller.view();
+  assert.deepEqual(afterSwitch.turn.approvals, [], "a new chat must not inherit a pending approval");
+  assert.equal(afterSwitch.turn.text, "", "nor the previous conversation's text");
+});
+
+test("a turn the USER stopped reads as cancelled, not as a connection failure", async () => {
+  // The catch mapped every thrown iterator to `transport` without asking
+  // whether the abort was ours. Stop cancels the engine, aborts the reader,
+  // and a real fetch then errors the body stream -- so the deliberately
+  // stopped turn rendered as a red "Connection lost" WITH A RETRY BUTTON, and
+  // announced "Connection lost" to a screen reader.
+  //
+  // The `cancelled` outcome was reachable only if the engine's goodbye frame
+  // won a race against our own abort, which it usually loses.
+  const views: RunView[] = [];
+  let release: () => void = () => {};
+
+  const engine = {
+    id: "s",
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {
+      streaming: true, reasoning: false, tools: true,
+      approvals: false, cancellation: true, attachments: false,
+    },
+    async *run(req: { runId: string }, signal: AbortSignal) {
+      yield { type: "start", msgId: "m1", runId: req.runId };
+      yield { type: "delta", msgId: "m1", text: "the answer so far" };
+      // Wait for OUR abort specifically, so the test is not racing it. A real
+      // fetch behaves this way: the body stream errors when the reader is
+      // aborted mid-response.
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      throw new Error("aborted");
+    },
+    async decide() { return false; },
+    async cancel() { release(); return true; },
+    async dispose() {},
+  } as unknown as Parameters<typeof createRunController>[0]["engine"];
+
+  const controller = createRunController({ engine, time: createFakeTime(), onPublish: (v) => views.push(v) });
+  const sent = controller.send("go");
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await controller.stop();
+  await sent;
+
+  const final = views.at(-1);
+  assert.equal(final?.turn.text, "the answer so far", "the text so far must survive a stop");
+  assert.equal(
+    final?.turn.outcome?.type,
+    "cancelled",
+    "a stop the user asked for must not render as a transport error with Retry",
+  );
+});
+
+test("a stream that dies on its OWN is still a transport error", async () => {
+  // The pair. Treating every throw as cancelled would hide real network
+  // failures behind a calm "Stopped" and remove the retry the user needs.
+  const views: RunView[] = [];
+  const engine = {
+    id: "s",
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {
+      streaming: true, reasoning: false, tools: true,
+      approvals: false, cancellation: true, attachments: false,
+    },
+    async *run(req: { runId: string }) {
+      yield { type: "start", msgId: "m1", runId: req.runId };
+      yield { type: "delta", msgId: "m1", text: "partial" };
+      throw new Error("socket reset by peer");
+    },
+    async decide() { return false; },
+    async cancel() { return false; },
+    async dispose() {},
+  } as unknown as Parameters<typeof createRunController>[0]["engine"];
+
+  const controller = createRunController({ engine, time: createFakeTime(), onPublish: (v) => views.push(v) });
+  await controller.send("go");
+
+  const final = views.at(-1);
+  assert.equal(final?.turn.text, "partial");
+  assert.equal(final?.turn.outcome?.type, "error");
+  assert.equal(
+    final?.turn.outcome?.type === "error" ? final.turn.outcome.kind : null,
+    "transport",
+    "a genuine network failure must still offer retry",
+  );
+});

--- a/src/praisonai-mobile/core/src/run/controller.ts
+++ b/src/praisonai-mobile/core/src/run/controller.ts
@@ -147,6 +147,32 @@ export function createRunController(deps: ControllerDeps): RunController {
     const abort = new AbortController();
     live = { runId, abort };
 
+    // The TURN is per turn, not per app -- and this is the same class of defect
+    // as the approval table below, found the same way one round later.
+    //
+    // `turn` was only ever reset by a `start` event. So a turn that produces
+    // NO start -- which is every pre-first-token failure: 401, 403, offline, a
+    // refused connection, a wrong baseUrl -- met a state left `ended` by the
+    // previous turn. `apply()` dropped the error as `wrong_msg_id` or
+    // `after_terminal`, and `finish()` returned the PREVIOUS turn untouched
+    // because its outcome was already set.
+    //
+    // Measured: turn 1 answers, turn 2 gets a 401, and the screen still shows
+    // turn 1's answer with turn 1's `end` outcome. The user types a second
+    // question, taps Send, the composer clears -- and nothing happens. No
+    // error, no retry, no auth prompt, not even a hint that a run was
+    // attempted. Silent, repeatable, and permanent. The default baseUrl is
+    // 127.0.0.1:8765, so "engine unreachable" is the common case, not an
+    // exotic one.
+    //
+    // Two amplifiers made it worse: the dropped error landed in `carry`, so
+    // the next SUCCESSFUL turn inherited a "1 event could not be read" row
+    // blaming itself for its predecessor; and because `send()` publishes
+    // before `runTurn` begins, a stale turn was painted into what the user
+    // believed was a new conversation.
+    turn = initialTurn;
+    publish();
+
     // The approval table is per TURN, not per app.
     //
     // It was initialised once with the controller and only ever appended to,
@@ -249,15 +275,27 @@ export function createRunController(deps: ControllerDeps): RunController {
         if (frames.length > 0 && gate(streamed)) publish();
       }
     } catch (error) {
-      // A dying stream is normal on a phone. The text already on screen must
-      // survive it, and the failure must be distinguishable from an engine
-      // error so the UI can offer retry for one and not the other.
-      turn = apply(turn, {
-        type: "error",
-        msgId: turn.msgId ?? "unknown",
-        kind: "transport",
-        message: error instanceof Error ? error.message : String(error),
-      });
+      // A stream that dies BECAUSE WE ABORTED IT is not a failure.
+      //
+      // This catch mapped every thrown iterator to `transport`, without asking
+      // whether the abort was ours. Tapping Stop cancels the engine, aborts
+      // the reader, and the real `fetch` then errors the body stream -- so the
+      // throw landed here and the deliberately-stopped turn rendered as a red
+      // "Connection lost" with a Retry button, and announced "Connection lost"
+      // to a screen reader. The `cancelled` outcome and its "Stopped" notice
+      // were reachable only if the engine's goodbye frame won a race against
+      // our own abort, which it usually loses.
+      turn = abort.signal.aborted
+        ? apply(turn, { type: "cancelled", msgId: turn.msgId ?? "unknown", runId })
+        : // A dying stream is normal on a phone. The text already on screen
+          // must survive it, and the failure must be distinguishable from an
+          // engine error so the UI can offer retry for one and not the other.
+          apply(turn, {
+            type: "error",
+            msgId: turn.msgId ?? "unknown",
+            kind: "transport",
+            message: error instanceof Error ? error.message : String(error),
+          });
     } finally {
       // First: a tick firing after the turn ended would paint into a
       // settled transcript.
@@ -291,6 +329,15 @@ export function createRunController(deps: ControllerDeps): RunController {
   return {
     setChat(next: string) {
       chatId = next;
+      // A different conversation cannot inherit the last one's transcript.
+      // Without this, `send()` publishes the stale turn before the new run
+      // starts, so New chat cleared the screen only until the user's next
+      // message -- and the previous chat's PENDING APPROVAL reappeared under
+      // it. Measured: a prompt to run `rm -rf /`, abandoned by starting a new
+      // chat, came back with live buttons, and Allow posted the decision to
+      // the engine. `setChat` had already cleared the approvals table, so the
+      // row found no entry and rendered itself actionable.
+      turn = initialTurn;
       // A different conversation cannot inherit the last one's prompts. The
       // next turn would clear these anyway; this covers the window between
       // switching chats and sending, where the UI renders whatever is here.


### PR DESCRIPTION
Round five, driving realistic **sequences** through the real `mount()` rather than one action at a time. Two critical defects, one root cause.

## The turn outlived the turn

`turn` was a controller-lifetime variable. `runTurn` reset `approvals` — added last round for exactly this reason — and never reset `turn`. The only thing that reset it was a `start` event.

So a turn producing **no start** met a state left `ended` by its predecessor: `apply()` dropped the error as `wrong_msg_id`, and `finish()` returned the *previous* turn untouched because its outcome was already set. And a turn produces no start for **every pre-first-token failure** — 401, 403, 500, offline, a refused connection, a wrong `baseUrl`.

Measured — turn 1 answers, turn 2 gets a 401:

```
turn 2 text   : "first answer"       <- the PREVIOUS answer
turn 2 outcome: {"type":"end", ...}  <- the PREVIOUS outcome
turn 2 dropped: 1
```

The user types a second question, taps Send, the composer clears, and **nothing happens**. The old answer stays on screen. No error, no retry, no auth prompt, not even a hint a run was attempted. Silent, repeatable, permanent. The default `baseUrl` is `127.0.0.1:8765` — the phone itself — so "engine unreachable" is the common case, not an exotic one.

Two amplifiers: the dropped error landed in `carry`, so the next **successful** turn inherited a *"1 event could not be read"* row blaming itself for its predecessor; and `send()` publishes before `runTurn` starts, so a stale turn was painted into what the user believed was a new conversation.

## Same bug, worse payload

New chat clears the screen. It couldn't clear the controller's `turn`, so the wipe held only until the next Send — at which point the **previous chat's pending approval reappeared, with live buttons**. `setChat` had already cleared the approvals table, so the row found no entry, rendered `actionable: true`, and Allow **posted the decision to the engine**.

The scenario is a user abandoning a conversation *because* it asked to run `rm -rf /`, starting a fresh chat, typing something unrelated, and being asked again underneath it.

## Also fixed

**A turn the user stopped rendered as a red "Connection lost" with a Retry button**, and announced "Connection lost" to a screen reader. The catch mapped every thrown iterator to `transport` without asking whether the abort was ours: Stop cancels the engine, aborts the reader, and a real `fetch` then errors the body stream. The `cancelled` outcome and its "Stopped" notice were reachable only if the engine's goodbye frame won a race against our own abort — which it usually loses. Both directions pinned: a stream that dies on its own is still `transport`, because hiding a real network failure behind a calm "Stopped" removes the retry the user needs.

**Every launch's first conversation went to the engine as the literal `"unassigned"`.** `chatId` defaults to it and `setChat` was only ever called by the New chat handler. Against an engine keying history by `chat_id`, every user's first chat on every device was one shared thread. The existing test asserted only that two chat ids *differ* — and `"unassigned" !== "chat-2"` passes that.

## The measure of the gap

The suite passed **1029/1029 before any of this changed**. No test in the package ran a *failing* turn after a *succeeding* one.

`1035 tests` on node 22.23 **and** 24.12 · `boundaries: 134 files, no violations` · five mutations confirmed to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * First conversations now receive a unique chat ID when the app launches.
  * Connection and authentication failures are displayed correctly, including failures before the first response.
  * Stopping a response now shows a clear “Stopped” state instead of a transport error.
  * Switching conversations no longer carries over messages or pending approvals.
  * Stream interruptions continue to display the appropriate transport error.

* **Tests**
  * Added coverage for launch conversations, turn failures, chat switching, cancellation, and interrupted streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->