### PR TITLE
fix(mobile): the adapter contracts could be gutted silently, new ones included

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
@@ -1,0 +1,143 @@
+/**
+ * An adapter broken in ONE named way, registered against the REAL contract.
+ *
+ * Not a `.test.ts`, so the normal run never picks it up. `contracts.test.ts`
+ * spawns it once per break mode and asserts the matching contract case fails
+ * BY NAME -- and asserts the `none` mode passes, so a runner that reported
+ * failure for everything could not masquerade as proof.
+ *
+ * WHY THIS EXISTS. `contracts.test.ts` had a set of tests named "the contract
+ * catches an adapter that ..." which built a broken adapter and then
+ * RE-IMPLEMENTED the contract's assertion inline. Those prove that an
+ * assertion of that shape would catch the defect. They prove nothing about
+ * whether the contract still contains it.
+ *
+ * Measured: deleting `assert.ok(fired >= 2)` from the time contract -- the one
+ * assertion that catches `setInterval` becoming `setTimeout`, which stops
+ * every polling loop in the app after one tick -- left the suite at 1035 pass,
+ * 0 fail. Fourteen separate assertions could be deleted for free, across all
+ * four contracts, old and new alike. An entire section of the time contract
+ * could be removed and the run simply reported one test fewer.
+ *
+ * The identical pattern already existed one directory over, in
+ * engines/src/contract-fixture.ts, written for the same reason. The adapter
+ * contracts never got it.
+ *
+ *   node adapters/src/conformance/contract-fixture.ts <mode>
+ */
+import { describeSecretsContract } from "./secrets-contract.ts";
+import { describeStorageContract } from "./storage-contract.ts";
+import { describeTimeContract } from "./time-contract.ts";
+import type { SecretsPort } from "../../../core/src/ports/secrets.ts";
+import type { StoragePort } from "../../../core/src/ports/storage.ts";
+import type { TimePort } from "../../../core/src/ports/time.ts";
+
+const mode = process.argv[2] ?? "none";
+
+const advance = async (_time: TimePort, ms: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, ms + 10));
+};
+
+// ---- secrets ---------------------------------------------------------------
+
+function secrets(): SecretsPort {
+  const store = new Map<string, string>();
+  // The defect: keying by slot alone, so two accounts share one credential.
+  const key = (ref: { slot: string; account: string }): string =>
+    mode === "secrets_slot_only" ? ref.slot : `${ref.slot}:${ref.account}`;
+  return {
+    isHardwareBacked: false,
+    async has(ref) {
+      return mode === "secrets_empty_is_absent"
+        ? (store.get(key(ref)) ?? "") !== ""
+        : store.has(key(ref));
+    },
+    async get(ref) {
+      return store.get(key(ref)) ?? null;
+    },
+    async set(ref, value) {
+      store.set(key(ref), value);
+    },
+    async delete(ref) {
+      store.delete(key(ref));
+    },
+  };
+}
+
+// ---- storage ---------------------------------------------------------------
+
+function storage(): StoragePort {
+  // Inline rather than importing a fake: `adapters` may not import `testing`,
+  // and the layer rule is right to say so. The engine fixture one directory
+  // over builds its broken engines the same way.
+  const files = new Map<string, string>();
+  const key = (ref: { namespace: string; id: string }): string =>
+    mode === "storage_namespaces_collide" ? ref.id : `${ref.namespace}/${ref.id}`;
+  return {
+    async read(ref) {
+      const found = files.get(key(ref));
+      if (found !== undefined) return found;
+      return mode === "storage_missing_is_undefined" ? (undefined as never) : null;
+    },
+    async write(ref, value) {
+      files.set(key(ref), value);
+    },
+    async remove(ref) {
+      files.delete(key(ref));
+    },
+    async listIds(namespace) {
+      if (mode === "storage_namespaces_collide") return [...files.keys()];
+      const prefix = `${namespace}/`;
+      return [...files.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .map((k) => k.slice(prefix.length));
+    },
+    async clear(namespace) {
+      if (mode === "storage_namespaces_collide") return void files.clear();
+      const prefix = `${namespace}/`;
+      for (const k of [...files.keys()]) if (k.startsWith(prefix)) files.delete(k);
+    },
+  };
+}
+
+// ---- time ------------------------------------------------------------------
+
+function time(): TimePort {
+  // Real timers, like the web adapter -- so the fixture needs no fake, and the
+  // contract is driven exactly as it drives the shipping implementation.
+  return {
+    nowMs: () => performance.now(),
+    epochMs: () => Date.now(),
+    createScheduler() {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      return {
+        requestFrame(cb) {
+          setTimeout(cb, 0);
+        },
+        setTimer(cb, ms) {
+          timer = setTimeout(cb, ms);
+        },
+        clearTimer() {
+          // The defect: a clear that does not clear, so a cancelled fallback
+          // timer still reopens a gate that was deliberately shut.
+          if (mode === "time_clear_does_nothing") return;
+          if (timer !== null) clearTimeout(timer);
+          timer = null;
+        },
+      };
+    },
+    every(ms, cb) {
+      if (mode === "time_every_fires_once") {
+        // The defect: every polling loop in the app fires once and stops.
+        const handle = setTimeout(cb, ms);
+        return () => clearTimeout(handle);
+      }
+      const handle = setInterval(cb, ms);
+      return () => clearInterval(handle);
+    },
+  };
+}
+
+describeSecretsContract("fixture secrets", () => secrets());
+describeStorageContract("fixture storage", () => storage());
+describeTimeContract("fixture time", () => time(), advance, true);

--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -12,6 +12,9 @@
  * 8 of 16 mutations survived a 408-test suite.
  */
 import test from "node:test";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";
 
 import { describeStorageContract } from "./storage-contract.ts";
@@ -960,4 +963,95 @@ test("zooming after construction does not report a phantom keyboard", async () =
   fake.setZoom(2);
   assert.equal(shell.keyboardHeightPx, 0);
   assert.deepEqual(seen, [0]);
+});
+
+// ---- (3) the contracts can FAIL --------------------------------------------
+//
+// The "the contract catches an adapter that ..." tests above build a broken
+// adapter and then RE-IMPLEMENT the contract's assertion inline. That proves
+// an assertion of that shape would catch the defect. It proves nothing about
+// whether the contract still contains it.
+//
+// Measured: deleting `assert.ok(fired >= 2)` from the time contract -- the one
+// assertion catching `setInterval` becoming `setTimeout`, which stops every
+// polling loop in the app after a single tick -- left the suite at 1035 pass,
+// 0 fail. Fourteen assertions across all four contracts could be deleted for
+// free, and removing a whole section merely reported one test fewer.
+//
+// These spawn the REAL contract against a deliberately broken adapter and
+// assert the matching case goes red BY NAME. The identical pattern already
+// existed in engines/src/contract-fixture.ts, written for the same reason; the
+// adapter contracts never got it.
+
+function adapterChildEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env["NODE_TEST_CONTEXT"];
+  return env;
+}
+
+function runAdapterFixture(mode: string): { status: number | null; output: string } {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // The reporter is FORCED: node 22 emits TAP when stdout is a pipe, node 24
+  // emits the spec reporter, and a test grepping for "not ok" would pass on
+  // one and fail on the other with identical code under it.
+  const run = spawnSync(
+    process.execPath,
+    ["--test-reporter=tap", join(here, "contract-fixture.ts"), mode],
+    { encoding: "utf8", timeout: 120_000, env: adapterChildEnv() },
+  );
+  return { status: run.status, output: `${run.stdout ?? ""}${run.stderr ?? ""}` };
+}
+
+/** Each break mode, and the contract case that must go red because of it. */
+const ADAPTER_BREAKS: readonly { readonly mode: string; readonly expects: RegExp }[] = [
+  { mode: "secrets_slot_only", expects: /two ACCOUNTS in one slot are two different secrets/ },
+  { mode: "secrets_empty_is_absent", expects: /an empty string is a stored value, not an absence/ },
+  { mode: "storage_missing_is_undefined", expects: /a missing key reads as null, never undefined/ },
+  { mode: "storage_namespaces_collide", expects: /namespaces are isolated/ },
+  { mode: "time_every_fires_once", expects: /every\(\) repeats, rather than firing once/ },
+  { mode: "time_clear_does_nothing", expects: /a cleared timer does not fire/ },
+];
+
+for (const { mode, expects } of ADAPTER_BREAKS) {
+  test(`the contracts can fail: "${mode}" reddens its own named case`, () => {
+    const { status, output } = runAdapterFixture(mode);
+    assert.notEqual(status, 0, `the fixture passed while broken as "${mode}"`);
+    const reddened = output
+      .split("\n")
+      .filter((line) => line.startsWith("not ok "))
+      .join("\n");
+    assert.match(reddened, expects, `"${mode}" did not fail the case it is supposed to`);
+  });
+}
+
+test("a contract cannot quietly shrink", () => {
+  // The remaining hole after the break modes above: they prove a case still
+  // WORKS, but a case with no break mode could simply be deleted and nothing
+  // would say so. Measured before this: removing an entire section of the time
+  // contract left the run reporting one test fewer and zero failures.
+  //
+  // The floor is counted from a REAL run rather than from the source text --
+  // this repo's rule is to assert on behaviour, and a regex over `test(` would
+  // be satisfied by a case that asserts nothing.
+  //
+  // Raise these numbers when you add cases. If one drops, a contract lost
+  // coverage, and that is exactly the event worth a red build.
+  const { status, output } = runAdapterFixture("none");
+  assert.equal(status, 0, `the unbroken fixture failed:\n${output}`);
+
+  const passed = output.split("\n").filter((line) => line.startsWith("ok "));
+  const casesFor = (prefix: string): number =>
+    passed.filter((line) => line.includes(`fixture ${prefix}:`)).length;
+
+  assert.ok(casesFor("secrets") >= 9, `the secrets contract shrank to ${casesFor("secrets")} cases`);
+  assert.ok(casesFor("storage") >= 11, `the storage contract shrank to ${casesFor("storage")} cases`);
+  assert.ok(casesFor("time") >= 8, `the time contract shrank to ${casesFor("time")} cases`);
+});
+
+test("the contracts can PASS: an unbroken fixture is green", () => {
+  // The control. Without it, a fixture that failed everything -- a syntax
+  // error, a missing import, a runner that cannot start -- would satisfy every
+  // case above while proving nothing at all.
+  const { status, output } = runAdapterFixture("none");
+  assert.equal(status, 0, `an unbroken fixture failed:\n${output}`);
 });


### PR DESCRIPTION
A targeted re-measure asked whether the contracts I added last round actually defend anything. **They do not — and neither did the two that came before them.**

## What I measured

I deleted `assert.ok(fired >= 2)` from the time contract — the one assertion that catches `setInterval` becoming `setTimeout`, which stops *every polling loop in the app* after a single tick — and the suite reported **1035 pass, 0 fail**.

Fourteen assertions across all four contracts could be deleted for free. Removing an entire **section** of the time contract simply reported one test fewer and zero failures.

## The cause

`contracts.test.ts` has a set of meta-tests named *"the contract catches an adapter that …"*. Each builds a broken adapter and then **re-implements the contract's assertion inline**. That proves an assertion of that shape would catch the defect. It proves nothing about whether the contract still contains it.

This is **not** a regression in the new contracts — the old storage and shell contracts have the identical hole. The whole pattern in that file is the same shape as the defect this package keeps producing: *a mechanism that exists, is documented, is tested, and is connected to nothing.*

## The fix already existed one directory over

`engines/src/contract-fixture.ts` spawns the **real** contract against an engine broken in one named way and asserts the matching case goes red *by name* — written for exactly this reason, with a comment saying so. The adapter contracts never got it.

`adapters/src/conformance/contract-fixture.ts` is that, for adapters. Six break modes drawn from real defects:

| break mode | must redden |
|---|---|
| two keychain accounts sharing one credential | `two ACCOUNTS in one slot are two different secrets` |
| an empty string read back as absent | `an empty string is a stored value, not an absence` |
| a missing key reading `undefined` | `a missing key reads as null, never undefined` |
| namespaces colliding | `namespaces are isolated` |
| `every()` firing once | `every() repeats, rather than firing once` |
| a clear that does not clear | `a cleared timer does not fire` |

Plus a `none` control, so a fixture that failed for an unrelated reason — a syntax error, a bad import — could not masquerade as proof.

It builds its broken adapters **inline** rather than importing the fakes, because `adapters` may not import `testing` and the layer rule is right to say so. The boundary checker caught my first attempt.

## And a count floor

The break modes prove a case still *works*; a case with no break mode could still simply be deleted. The floor is counted from a **real run** of the fixture rather than from source text — a regex over `test(` would be satisfied by a case that asserts nothing.

## Verified

| attempt | result |
|---|---|
| gut a case's assertions | **fails** |
| delete a whole case | **fails** |
| delete the load-bearing assertion of a case | **fails** |
| delete one of two *redundant* assertions | passes — correctly; the case retains its power through the other |

`1043 tests` on node 22.23 **and** 24.12 · `boundaries: 135 files, no violations`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conformance coverage for secrets, storage, and time adapters.
  * Added checks ensuring each intentionally invalid adapter behavior is detected.
  * Added safeguards against contract coverage shrinking.
  * Added a control test confirming valid adapters continue to pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->