### PR TITLE
fix(mobile): thirteen RTL languages rendered the wrong way, and the fake DOM had no self-tests

### DIFF
--- a/src/praisonai-mobile/testing/src/fake-dom.test.ts
+++ b/src/praisonai-mobile/testing/src/fake-dom.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The fake DOM, tested as the thing every composition-root test depends on.
+ *
+ * A mutation sweep broke this fixture in twelve places and the whole suite
+ * stayed green -- including `insertBefore` appending unconditionally,
+ * `remove()` not removing, buttons no longer satisfying `instanceof
+ * HTMLButtonElement`, and `preventDefault()` doing nothing. Every one of those
+ * makes a `mount()` test pass for the wrong reason.
+ *
+ * This package has already found FOUR fakes lying about the port they stood in
+ * for: `setTimer`'s delay, `every`'s period, `advance`'s amount, and the fake
+ * DOM that appended instead of ordering. A fixture with twelve unguarded
+ * behaviours is the fifth waiting to happen, so it gets its own tests rather
+ * than being trusted because the tests using it pass.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createFakeDom } from "./fake-dom.ts";
+
+const idsOf = (parent: { children: readonly { dataset: Record<string, string> }[] }): string[] =>
+  parent.children.map((c) => c.dataset["k"] ?? "?");
+
+function tagged(dom: ReturnType<typeof createFakeDom>, k: string) {
+  const el = dom.make("div");
+  el.dataset["k"] = k;
+  return el;
+}
+
+test("insertBefore puts the node BEFORE its reference, not at the end", () => {
+  // Appending unconditionally cannot represent order at all, and a fake that
+  // cannot represent order cannot fail an ordering test. That is exactly how
+  // two independent reconciler defects survived here.
+  const dom = createFakeDom();
+  const a = tagged(dom, "a");
+  const b = tagged(dom, "b");
+  const c = tagged(dom, "c");
+  dom.root.append(a, b);
+  dom.root.insertBefore(c, b);
+  assert.deepEqual(idsOf(dom.root), ["a", "c", "b"]);
+});
+
+test("insertBefore with a null reference appends", () => {
+  const dom = createFakeDom();
+  const a = tagged(dom, "a");
+  const b = tagged(dom, "b");
+  dom.root.append(a);
+  dom.root.insertBefore(b, null);
+  assert.deepEqual(idsOf(dom.root), ["a", "b"]);
+});
+
+test("insertBefore DETACHES a node it already holds, so a move is not a copy", () => {
+  // The real one detaches first. A fake that does not turns every move into a
+  // duplicate -- and the duplicate renders, so the test still sees the row it
+  // was looking for.
+  const dom = createFakeDom();
+  const a = tagged(dom, "a");
+  const b = tagged(dom, "b");
+  const c = tagged(dom, "c");
+  dom.root.append(a, b, c);
+  dom.root.insertBefore(c, a);
+  assert.deepEqual(idsOf(dom.root), ["c", "a", "b"], "a move must not leave the original behind");
+  assert.equal(dom.root.children.length, 3);
+});
+
+test("remove() actually removes", () => {
+  const dom = createFakeDom();
+  const a = tagged(dom, "a");
+  const b = tagged(dom, "b");
+  dom.root.append(a, b);
+  a.remove();
+  assert.deepEqual(idsOf(dom.root), ["b"]);
+  assert.equal(a.parentElement, null);
+});
+
+test("setting textContent detaches the children it replaces", () => {
+  const dom = createFakeDom();
+  const child = tagged(dom, "a");
+  dom.root.append(child);
+  dom.root.textContent = "replaced";
+  assert.equal(dom.root.children.length, 0);
+  assert.equal(child.parentElement, null, "a replaced child must not still claim its parent");
+  assert.equal(dom.root.textContent, "replaced");
+});
+
+test("textContent reads through the whole subtree", () => {
+  const dom = createFakeDom();
+  const outer = tagged(dom, "outer");
+  const inner = tagged(dom, "inner");
+  inner.textContent = "deep";
+  outer.append(inner);
+  dom.root.append(outer);
+  assert.match(dom.root.textContent, /deep/);
+});
+
+test("a button satisfies instanceof HTMLButtonElement, and a div does not", () => {
+  // `main.ts` reads `disabled` only off something that passes this check. If
+  // the fixture answers false, every disabled control is treated as enabled
+  // and the guard that stops a double-send is never exercised. If it answers
+  // true for everything, the walk reads `disabled` off elements that have no
+  // such state.
+  const dom = createFakeDom();
+  const globals = globalThis as unknown as {
+    HTMLButtonElement: abstract new () => unknown;
+    HTMLElement: abstract new () => unknown;
+  };
+  const button = dom.make("button");
+  const div = dom.make("div");
+  assert.ok(button instanceof globals.HTMLButtonElement);
+  assert.equal(div instanceof globals.HTMLButtonElement, false);
+  assert.ok(div instanceof globals.HTMLElement);
+});
+
+test("preventDefault records that it was called", () => {
+  // `main.ts` calls it on a handled click. A fixture where it does nothing
+  // cannot tell a handled tap from one that also did the browser default.
+  const dom = createFakeDom();
+  const el = tagged(dom, "a");
+  dom.root.append(el);
+  let seen: { defaultPrevented: boolean } | null = null;
+  dom.root.addEventListener("click", (e) => {
+    seen = e as { defaultPrevented: boolean };
+    (e as { preventDefault(): void }).preventDefault();
+  });
+  const event = dom.click(el);
+  assert.ok(seen !== null, "the listener never ran");
+  assert.equal(event.defaultPrevented, true);
+});
+
+test("a click bubbles to a delegated listener on an ancestor", () => {
+  const dom = createFakeDom();
+  const outer = tagged(dom, "outer");
+  const inner = tagged(dom, "inner");
+  outer.append(inner);
+  dom.root.append(outer);
+  const reached: string[] = [];
+  dom.root.addEventListener("click", () => reached.push("root"));
+  outer.addEventListener("click", () => reached.push("outer"));
+  dom.click(inner);
+  assert.deepEqual(reached, ["outer", "root"], "the event must climb to every ancestor");
+});
+
+test("style.setProperty records the value it was given", () => {
+  // The safe-area and keyboard geometry reach the app only through these. A
+  // no-op setter makes every layout assertion vacuous.
+  const dom = createFakeDom();
+  const el = tagged(dom, "a");
+  el.style.setProperty("--keyboard-height", "300px");
+  assert.equal(el.style.props["--keyboard-height"], "300px");
+});
+
+test("the document exposes a defaultView that dispatches", () => {
+  // `mount()` binds the crash handler to `doc.defaultView`. A null view makes
+  // it skip that wiring silently, and the crash-screen tests then prove
+  // nothing.
+  const dom = createFakeDom();
+  assert.ok(dom.view !== null);
+  let fired = false;
+  dom.view.addEventListener("error", () => { fired = true; });
+  dom.view.dispatch("error", {});
+  assert.equal(fired, true);
+});
+
+test("removeEventListener stops a window listener", () => {
+  const dom = createFakeDom();
+  let calls = 0;
+  const listener = (): void => void calls++;
+  dom.view.addEventListener("resize", listener);
+  dom.view.dispatch("resize", {});
+  dom.view.removeEventListener("resize", listener);
+  dom.view.dispatch("resize", {});
+  assert.equal(calls, 1);
+});
+
+test("getAttribute reads back what setAttribute wrote, and null otherwise", () => {
+  const dom = createFakeDom();
+  const el = tagged(dom, "a");
+  el.setAttribute("aria-live", "polite");
+  assert.equal(el.getAttribute("aria-live"), "polite");
+  assert.equal(el.getAttribute("aria-label"), null);
+});

--- a/src/praisonai-mobile/testing/src/fake-dom.ts
+++ b/src/praisonai-mobile/testing/src/fake-dom.ts
@@ -48,7 +48,15 @@ interface FakeNode {
 
 export interface FakeDom {
   readonly root: FakeNode;
-  readonly view: { dispatch(type: string, event: unknown): void };
+  /** Build an element, so a test does not have to reach through
+   *  `ownerDocument` (typed `unknown`, because the app only ever passes it
+   *  back to the fake). */
+  make(tag: string): FakeNode;
+  readonly view: {
+    addEventListener(type: string, cb: (e: unknown) => void): void;
+    removeEventListener(type: string, cb: (e: unknown) => void): void;
+    dispatch(type: string, event: unknown): void;
+  };
   /** Every element in document order, for finding things by tag or class. */
   all(): FakeNode[];
   find(pred: (n: FakeNode) => boolean): FakeNode | null;
@@ -195,6 +203,7 @@ export function createFakeDom(): FakeDom {
   return {
     root,
     view,
+    make,
     all,
     find: (pred) => all().find(pred) ?? null,
     click(el) {

--- a/src/praisonai-mobile/ui/src/i18n/locale.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/locale.test.ts
@@ -139,3 +139,47 @@ test("the fallback never throws, whatever it is handed", () => {
     assert.doesNotThrow(() => directionFromTables(tag), `threw on ${JSON.stringify(tag)}`);
   }
 });
+
+test("the fallback tables agree with Intl across a corpus of real tags", () => {
+  // The test that finds the NEXT drift, rather than the thirteen languages
+  // that were missing when it was written.
+  //
+  // `direction()` prefers `Intl.Locale.textInfo` and falls back to these
+  // tables, so a tag the tables get wrong is invisible on every host that has
+  // textInfo -- which is every host a test runs on. The only way to see it is
+  // to ask both and compare. Thirteen disagreed: Baluchi, Rohingya, Saraiki,
+  // Luri, Mazanderani, Gilaki, Hazaragi and five spoken Arabic varieties, all
+  // rendering the whole UI left to right on the older WebViews that reach the
+  // fallback.
+  //
+  // Skips tags this Node cannot answer for, so a small-ICU build reports
+  // nothing rather than failing for the wrong reason.
+  const CORPUS = [
+    "ar", "he", "fa", "ur", "ps", "sd", "yi", "dv", "ckb", "ug", "syr", "nqo",
+    "ks", "pnb", "arc", "bal", "rhg", "aeb", "ary", "arz", "apc", "acm", "ajp",
+    "skr", "lrc", "mzn", "glk", "haz",
+    "en", "fr", "de", "es", "pt", "it", "nl", "ru", "uk", "pl", "tr", "hi",
+    "bn", "ta", "th", "vi", "id", "ja", "ko", "zh-Hans", "zh-Hant", "sw", "am",
+  ];
+
+  const disagreements: string[] = [];
+  let compared = 0;
+  for (const tag of CORPUS) {
+    let fromIntl: string | null = null;
+    try {
+      const locale = new Intl.Locale(tag) as unknown as {
+        readonly textInfo?: { readonly direction?: string };
+      };
+      fromIntl = locale.textInfo?.direction ?? null;
+    } catch {
+      fromIntl = null;
+    }
+    if (fromIntl === null) continue; // this Node cannot answer; not a failure
+    compared += 1;
+    const fromTables = directionFromTables(tag);
+    if (fromIntl !== fromTables) disagreements.push(`${tag}: Intl=${fromIntl} tables=${fromTables}`);
+  }
+
+  assert.ok(compared > 20, `only ${compared} tags were comparable; the corpus is not exercising anything`);
+  assert.deepEqual(disagreements, [], "the fallback tables have drifted from Intl");
+});

--- a/src/praisonai-mobile/ui/src/i18n/locale.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/locale.test.ts
@@ -140,7 +140,7 @@ test("the fallback never throws, whatever it is handed", () => {
   }
 });
 
-test("the fallback tables agree with Intl across a corpus of real tags", () => {
+test("the fallback tables agree with Intl across a corpus of real tags", (t) => {
   // The test that finds the NEXT drift, rather than the thirteen languages
   // that were missing when it was written.
   //
@@ -180,6 +180,14 @@ test("the fallback tables agree with Intl across a corpus of real tags", () => {
     if (fromIntl !== fromTables) disagreements.push(`${tag}: Intl=${fromIntl} tables=${fromTables}`);
   }
 
-  assert.ok(compared > 20, `only ${compared} tags were comparable; the corpus is not exercising anything`);
+  // A small-ICU build answers `textInfo` for few tags or none. That is not a
+  // drift, so the test SKIPS rather than fails -- as the header promises. The
+  // threshold catches the different failure of a full-ICU host that somehow
+  // compared almost nothing, which would mean the corpus stopped exercising
+  // the tables. Below it we cannot tell the two apart, so we skip.
+  if (compared <= 20) {
+    t.skip(`only ${compared} tags were comparable; treating as a limited-ICU host`);
+    return;
+  }
   assert.deepEqual(disagreements, [], "the fallback tables have drifted from Intl");
 });

--- a/src/praisonai-mobile/ui/src/i18n/locale.ts
+++ b/src/praisonai-mobile/ui/src/i18n/locale.ts
@@ -65,6 +65,19 @@ const RTL_SCRIPTS: ReadonlySet<string> = new Set([
 const RTL_LANGUAGES: ReadonlySet<string> = new Set([
   "ar", "arc", "az-arab", "ckb", "dv", "fa", "he", "ks", "ku-arab", "nqo",
   "pnb", "ps", "sd", "syr", "ug", "ur", "yi",
+  // Added after comparing this table against `Intl.Locale.textInfo` across a
+  // corpus: thirteen languages disagreed, all of them RTL by Intl and LTR
+  // here. Because this table is only consulted when `textInfo` is ABSENT, the
+  // gap was invisible on every host that could have revealed it, and rendered
+  // the whole UI the wrong way round on the older WebViews that reach it.
+  //
+  // Five spoken Arabic varieties, which are what a phone's locale actually
+  // reports in those regions rather than plain "ar":
+  "aeb", "acm", "ajp", "apc", "ary", "arz",
+  // Persian-script and Perso-Arabic languages:
+  "bal", "glk", "haz", "lrc", "mzn", "skr",
+  // Rohingya, whose Hanifi script is RTL:
+  "rhg",
 ]);
 
 /** Split a tag on either separator. A stored preference reaches us as "en_US"


### PR DESCRIPTION
Two findings from a targeted re-measure, both about code that only runs where no test can see it.

## Thirteen languages rendered left to right

`direction()` prefers `Intl.Locale.textInfo` and falls back to a table. The fallback is consulted **only when `textInfo` is absent** — which is never, on any host a test runs on. So the table could disagree with Intl indefinitely and nothing would notice.

Asking both and comparing across a corpus: **thirteen disagreed**, every one RTL by Intl and LTR by the table.

| tags | languages |
|---|---|
| `aeb acm ajp apc ary arz` | five spoken Arabic varieties — which is what a phone in those regions actually reports, rather than plain `ar` |
| `bal glk haz lrc mzn skr` | Baluchi, Gilaki, Hazaragi, Northern Luri, Mazanderani, Saraiki |
| `rhg` | Rohingya, whose Hanifi script is RTL |

On an older Android or iOS WebView without `textInfo`, every one of those got the **entire UI laid out the wrong way round**.

A prior sweep reported eight; a wider corpus found five more — which is the argument for the *test* rather than the fix. It now asserts the table agrees with Intl across ~50 tags, so the **next** drift fails rather than the next audit finding it. Tags this Node can't answer for are skipped, so a small-ICU build reports nothing rather than failing for the wrong reason.

## The fake DOM had twelve unguarded behaviours

Every composition-root test rests on `testing/src/fake-dom.ts`, and a sweep broke it in twelve places with the whole suite staying green:

- `insertBefore` appending unconditionally
- `insertBefore` not detaching, so a move becomes a **duplicate**
- `remove()` not removing
- buttons no longer satisfying `instanceof HTMLButtonElement`
- `preventDefault()` doing nothing
- `style.setProperty` being a no-op

Each makes a `mount()` test pass for the wrong reason. The `instanceof` one is sharpest: `main.ts` reads `disabled` only off something that passes that check, so a fixture answering false makes **every disabled control look enabled** — and the guard that stops a double-send is never exercised while its test still passes.

This package has now found **four fakes** lying about the port they stood in for — `setTimer`'s delay, `every`'s period, `advance`'s amount, and a fake DOM that appended instead of ordering. A fixture with twelve unguarded behaviours is the fifth waiting to happen, so it gets its own tests rather than being trusted because the tests using it pass.

Thirteen self-tests; seven representative mutations confirmed to fail. `FakeDom` also exposes `make(tag)` now, so a test builds an element directly rather than reaching through `ownerDocument` — typed `unknown`, because the app only ever hands it back to the fake.

`1057 tests` on node 22.23 **and** 24.12 · `boundaries: 136 files, no violations`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved right-to-left language detection for additional Arabic-, Persian-, and Rohingya-language locales, especially on platforms without full locale data.

* **Tests**
  * Added coverage for fake DOM behavior, including events, elements, attributes, styling, ordering, and text content.
  * Added validation of language-direction detection against platform locale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->