### PR TITLE
test(mobile): the seven no-Intl fallbacks were dead to the suite

### DIFF
--- a/src/praisonai-mobile/ui/src/i18n/format-intl.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/format-intl.test.ts
@@ -161,3 +161,86 @@ test("every entry point answers instead of throwing on a bad tag or a bad number
   assert.equal(formatCountLocalised("en", -1), UNKNOWN);
   assert.equal(formatDate("en", Number.NaN, "UTC"), UNKNOWN);
 });
+
+// ---- the no-Intl fallbacks --------------------------------------------------
+//
+// Seven `fmt === null` branches, every one of them dead to this suite: the
+// test host has full ICU, so `memo(...)` always returns a formatter and the
+// fallback never runs. A mutation sweep put this file at 67% survival for
+// exactly that reason.
+//
+// They are trivially reachable, though, and reachable IN PRODUCTION: every
+// Intl constructor throws RangeError on an underscore tag, and "en_US" is what
+// a stored preference looks like as often as "en-US" -- locale.ts says so in
+// its own header. So these are not hypothetical old-WebView paths; they are
+// one bad settings value away.
+
+/** A tag every Intl constructor refuses, so `memo()` returns null. */
+const NO_INTL = "en_US";
+
+test("formatNumber falls back to the raw number, not to nothing", () => {
+  // `String(value)` -> `""` or a rounded value both survived.
+  assert.equal(formatNumber(NO_INTL, 1234.5), "1234.5");
+  assert.equal(formatNumber(NO_INTL, 0), "0");
+  assert.equal(formatNumber(NO_INTL, -7), "-7");
+  // And the formatted path still differs, so the test is not passing because
+  // BOTH sides went unformatted.
+  assert.notEqual(formatNumber("en", 1234.5), formatNumber(NO_INTL, 1234.5));
+});
+
+test("formatCountLocalised falls back to the whole count", () => {
+  assert.equal(formatCountLocalised(NO_INTL, 1234), "1234");
+  assert.equal(formatCountLocalised(NO_INTL, 0), "0");
+  assert.notEqual(formatCountLocalised("en", 1234), formatCountLocalised(NO_INTL, 1234));
+});
+
+test("formatDate falls back to an ISO date, not to a half-formed one", () => {
+  // `slice(0, 10)` -> `slice(0, 7)` survived: the day disappears and every
+  // date in the chat list reads as a month.
+  assert.equal(formatDate(NO_INTL, 0, null), "1970-01-01");
+  assert.equal(formatDate(NO_INTL, 1_700_000_000_000, null), "2023-11-14");
+  assert.match(formatDate(NO_INTL, 0, null), /^\d{4}-\d{2}-\d{2}$/, "a date needs its day");
+});
+
+test("formatRelativeLocalised falls back to the string table, not to a number", () => {
+  // The fallback delegates to `formatRelativeFromStrings`, which is what makes
+  // "10 minutes ago" possible without Intl. Replacing it with a raw value
+  // survived.
+  const now = 1_700_000_000_000;
+  const tenMinutesAgo = now - 10 * 60 * 1000;
+  const out = formatRelativeLocalised(NO_INTL, en, tenMinutesAgo, now, null);
+  assert.match(out, /10/, "the magnitude must survive");
+  assert.match(out, /minute/i, "and be expressed in words, not left as a number");
+});
+
+test("formatElapsedLocalised falls back with its units intact", () => {
+  // `padStart(2, "0")` dropped survived: "1h 2m" instead of "1h 02m", which
+  // sorts and scans wrongly in a list of durations.
+  assert.equal(formatElapsedLocalised(NO_INTL, en, 3720), "1h 02m");
+  assert.equal(formatElapsedLocalised(NO_INTL, en, 65), "1m 05s");
+  assert.equal(formatElapsedLocalised(NO_INTL, en, 5.25), "5.3s");
+});
+
+test("an unmeasured elapsed is still unknown without Intl", () => {
+  // The guard has to survive the fallback path too, or a null duration renders
+  // as a number the engine never reported.
+  assert.equal(formatElapsedLocalised(NO_INTL, en, null), en.unknownValue);
+  assert.equal(formatElapsedLocalised(NO_INTL, en, -1), en.unknownValue);
+  assert.equal(formatElapsedLocalised(NO_INTL, en, Number.NaN), en.unknownValue);
+});
+
+test("every no-Intl fallback differs from its formatted twin", () => {
+  // The control for the whole block. If a future change made `memo()` succeed
+  // for "en_US" -- or made the formatted path degrade -- these tests would
+  // start passing while testing the wrong branch entirely.
+  const now = 1_700_000_000_000;
+  const pairs: readonly [string, string][] = [
+    [formatNumber("en", 1234.5), formatNumber(NO_INTL, 1234.5)],
+    [formatCountLocalised("en", 1234), formatCountLocalised(NO_INTL, 1234)],
+    [formatDate("en", 0, null), formatDate(NO_INTL, 0, null)],
+  ];
+  for (const [formatted, fallback] of pairs) {
+    assert.notEqual(formatted, fallback, `"${formatted}" -- this test is not reaching the fallback`);
+  }
+  void now;
+});

--- a/src/praisonai-mobile/ui/src/i18n/format-intl.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/format-intl.test.ts
@@ -233,6 +233,10 @@ test("every no-Intl fallback differs from its formatted twin", () => {
   // The control for the whole block. If a future change made `memo()` succeed
   // for "en_US" -- or made the formatted path degrade -- these tests would
   // start passing while testing the wrong branch entirely.
+  //
+  // Number, count and date each have a formatted twin whose English output
+  // already differs from the ASCII fallback (grouping, k/M suffix, "Jan 1,
+  // 1970" vs ISO), so "en" is enough to discriminate the branch for them.
   const now = 1_700_000_000_000;
   const pairs: readonly [string, string][] = [
     [formatNumber("en", 1234.5), formatNumber(NO_INTL, 1234.5)],
@@ -242,5 +246,22 @@ test("every no-Intl fallback differs from its formatted twin", () => {
   for (const [formatted, fallback] of pairs) {
     assert.notEqual(formatted, fallback, `"${formatted}" -- this test is not reaching the fallback`);
   }
-  void now;
+
+  // Elapsed and relative are different: their ENGLISH formatted output is
+  // byte-identical to the ASCII fallback ("1h 02m", "10 minutes ago"), so an
+  // "en" twin cannot tell the fallback branch from a successful `memo()`. The
+  // discriminating twin has to be a locale whose Intl output genuinely differs
+  // -- de-DE writes a comma decimal and its own relative-time phrasing -- while
+  // the "en_US" fallback stays ASCII/English regardless of the requested tag.
+  const tenMinutesAgo = now - 10 * 60 * 1000;
+  const elapsedPairs: readonly [string, string][] = [
+    [formatElapsedLocalised("de-DE", en, 5.25), formatElapsedLocalised(NO_INTL, en, 5.25)],
+    [
+      formatRelativeLocalised("de-DE", en, tenMinutesAgo, now, null),
+      formatRelativeLocalised(NO_INTL, en, tenMinutesAgo, now, null),
+    ],
+  ];
+  for (const [formatted, fallback] of elapsedPairs) {
+    assert.notEqual(formatted, fallback, `"${formatted}" -- this test is not reaching the fallback`);
+  }
 });


### PR DESCRIPTION
The last of the regions the mutation sweep named. `format-intl.ts` measured **67% survival** for one reason: every `fmt === null` branch is unreachable on a host with full ICU — which is every host a test runs on. `memo(...)` always returns a formatter, so seven fallbacks never executed.

**They are not exotic old-WebView paths.** Every `Intl` constructor throws `RangeError` on an underscore tag, and `locale.ts` says in its own header that a stored preference reaches us as `"en_US"` as often as `"en-US"`. These are one bad settings value away, in production, today.

| mutation | what shipped |
|---|---|
| `String(value)` → `""` | a number renders as **nothing** |
| `String(whole)` → `whole + 1` | every count off by one |
| `padStart(2, "0")` dropped | `"1h 2m"` instead of `"1h 02m"` — scans and sorts wrongly in a list of durations |
| `toFixed(1)` dropped | sub-10s durations lose their decimal, and that decimal is the whole reason the branch exists: `"3s"` hides 2.5 from 3.4 |
| `slice(0, 10)` → `slice(0, 7)` | **every date in the chat list loses its day** and reads as a month |
| `formatRelativeFromStrings` → raw value | `"10 minutes ago"` becomes `"10"` |

No export was needed, unlike `segment.ts` and `locale.ts` — these functions are already public and the fallback is reachable through the ordinary API. The gap was never structural; nothing had simply passed a locale that fails.

Each assertion is paired with a check that the **formatted** output differs from the fallback, so the block can't start passing for the wrong reason if `memo()` ever succeeds for `"en_US"` or the formatted path degrades.

One of my expectations was wrong rather than the code: I asserted 5.25 seconds renders `"5.2s"`; `toFixed(1)` rounds it to `"5.3s"`.

`1071 tests` on node 22.23 **and** 24.12 · six mutations confirmed to fail · tests only, no product source changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for locale-independent formatting behavior.
  * Verified reliable number, count, date, relative-time, and elapsed-time display when advanced internationalization support is unavailable.
  * Added checks for padding, invalid or unknown durations, and consistent fallback output across supported formatting scenarios.
  * Confirmed differences between fallback output and localized formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->