### PR TITLE
fix(mobile): the shell contract was the one the fixture never registered

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
@@ -26,8 +26,11 @@
  *   node adapters/src/conformance/contract-fixture.ts <mode>
  */
 import { describeSecretsContract } from "./secrets-contract.ts";
+import { describeShellContract, type ShellHarness } from "./shell-contract.ts";
 import { describeStorageContract } from "./storage-contract.ts";
 import { describeTimeContract } from "./time-contract.ts";
+import { createWebShell } from "../web/shell.ts";
+import { createFakeWindow } from "../web/fake-window.ts";
 import type { SecretsPort } from "../../../core/src/ports/secrets.ts";
 import type { StoragePort } from "../../../core/src/ports/storage.ts";
 import type { TimePort } from "../../../core/src/ports/time.ts";
@@ -138,6 +141,93 @@ function time(): TimePort {
   };
 }
 
+// ---- shell ------------------------------------------------------------------
+//
+// The largest of the four contracts -- 33 cases, including seven `openExternal`
+// refusals -- and it was the ONE this fixture did not register. A re-measure
+// proved the consequence: every assertion in it could be deleted, the whole
+// security section removed, and the entire contract replaced with
+// `assert.ok(shell)`, with the suite green each time.
+//
+// A `javascript:` URL reaching `openExternal` inside a webview is script
+// execution in the app's own origin with the user's session, from a URL that
+// routinely arrives from a model, a tool result, or pasted text. The RULE lives
+// in core/src/ports/shell.ts and both adapters call it; the contract proving
+// each adapter calls it is what was undefended.
+//
+// Built by wrapping a real web shell rather than hand-rolling a ShellPort, so
+// the fixture cannot drift from the interface it is meant to exercise.
+function shellHarness(): ShellHarness {
+  const window = createFakeWindow();
+  const real = createWebShell(window.window);
+
+  const shell = {
+    ...real,
+    get insets() { return real.insets; },
+    get keyboardHeightPx() { return real.keyboardHeightPx; },
+    onInsetsChanged: real.onInsetsChanged.bind(real),
+    onKeyboardHeightChanged: real.onKeyboardHeightChanged.bind(real),
+    onLifecycleChanged: real.onLifecycleChanged.bind(real),
+    haptic: real.haptic.bind(real),
+    share: real.share.bind(real),
+
+    async openExternal(url: string): Promise<void> {
+      // The defect: opening whatever it is handed. `javascript:`, `data:` and
+      // `file:` all reach the OS.
+      if (mode === "shell_opens_anything") {
+        window.window.open(url, "_blank", "noopener,noreferrer");
+        return;
+      }
+      return real.openExternal(url);
+    },
+
+    onBackGesture(cb: () => boolean) {
+      // The defect: the FIRST handler registered answers, rather than the most
+      // recent. A screen pushed on top of another then never gets the back
+      // press -- the bystander bug the contract has a named case for.
+      if (mode === "shell_back_in_registration_order") {
+        backHandlers.push(cb);
+        return () => {
+          const at = backHandlers.indexOf(cb);
+          if (at !== -1) backHandlers.splice(at, 1);
+        };
+      }
+      return real.onBackGesture(cb);
+    },
+
+    pressBack(): boolean {
+      if (mode === "shell_back_in_registration_order") {
+        for (const handler of backHandlers) if (handler()) return true;
+        return false;
+      }
+      return real.pressBack();
+    },
+
+    listenerCount(): number {
+      // The defect: a leak that cannot be seen. An unsubscribed listener still
+      // counts, so "unsubscribing drops the live listener count" cannot fail.
+      if (mode === "shell_listener_count_stuck") return 0;
+      return real.listenerCount();
+    },
+  } as typeof real;
+
+  const backHandlers: (() => boolean)[] = [];
+
+  return {
+    shell,
+    pressBack: () => shell.pressBack(),
+    emitInsets: (insets) => window.setInsets(insets),
+    emitKeyboardHeight: (px) => window.setKeyboardHeight(px),
+    emitLifecycle: (phase) => {
+      if (phase === "background") window.setHidden(true);
+      else if (phase === "inactive") window.setFocused(false);
+      else window.setHidden(false);
+    },
+    listenerCount: () => shell.listenerCount(),
+  };
+}
+
 describeSecretsContract("fixture secrets", () => secrets());
 describeStorageContract("fixture storage", () => storage());
 describeTimeContract("fixture time", () => time(), advance, true);
+describeShellContract("fixture shell", shellHarness);

--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -1023,11 +1023,16 @@ for (const { mode, expects } of ADAPTER_BREAKS) {
   test(`the contracts can fail: "${mode}" reddens its own named case`, () => {
     const { status, output } = runAdapterFixture(mode);
     assert.notEqual(status, 0, `the fixture passed while broken as "${mode}"`);
-    const reddened = output
-      .split("\n")
-      .filter((line) => line.startsWith("not ok "))
-      .join("\n");
-    assert.match(reddened, expects, `"${mode}" did not fail the case it is supposed to`);
+
+    // The `not ok ` prefix is part of the PATTERN, not just of a filter applied
+    // before it. Filtering and then matching separately meant that neutering
+    // the filter let a PASSING line -- "ok 12 - a javascript: URL is refused"
+    // -- satisfy the assertion, so the meta-test went green precisely when the
+    // contract stopped catching anything. Requiring the prefix in the match
+    // itself means the line has to actually be a failure.
+    const failed = new RegExp(`^not ok .*${expects.source}`);
+    const matched = output.split("\n").some((line) => failed.test(line));
+    assert.ok(matched, `"${mode}" did not fail the case it is supposed to:\n${output}`);
   });
 }
 
@@ -1046,14 +1051,19 @@ test("a contract cannot quietly shrink", () => {
   const { status, output } = runAdapterFixture("none");
   assert.equal(status, 0, `the unbroken fixture failed:\n${output}`);
 
-  const passed = output.split("\n").filter((line) => line.startsWith("ok "));
+  // `# SKIP` and `# TODO` are reported as `ok` in TAP, so counting them lets a
+  // case be disabled rather than deleted and the floor never notices. Measured:
+  // changing `test(` to `test.skip(` on a security case kept the run green.
+  const passed = output
+    .split("\n")
+    .filter((line) => line.startsWith("ok ") && !/#\s*(SKIP|TODO)/i.test(line));
   const casesFor = (prefix: string): number =>
     passed.filter((line) => line.includes(`fixture ${prefix}:`)).length;
 
   assert.ok(casesFor("secrets") >= 9, `the secrets contract shrank to ${casesFor("secrets")} cases`);
   assert.ok(casesFor("storage") >= 11, `the storage contract shrank to ${casesFor("storage")} cases`);
   assert.ok(casesFor("time") >= 8, `the time contract shrank to ${casesFor("time")} cases`);
-  assert.ok(casesFor("shell") >= 33, `the shell contract shrank to ${casesFor("shell")} cases`);
+  assert.ok(casesFor("shell") >= 34, `the shell contract shrank to ${casesFor("shell")} cases`);
 
   // The break table needs a floor of its own. Deleting a row from
   // ADAPTER_BREAKS, or lowering a count above, removes a defence and the only

--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -1010,6 +1010,13 @@ const ADAPTER_BREAKS: readonly { readonly mode: string; readonly expects: RegExp
   { mode: "storage_namespaces_collide", expects: /namespaces are isolated/ },
   { mode: "time_every_fires_once", expects: /every\(\) repeats, rather than firing once/ },
   { mode: "time_clear_does_nothing", expects: /a cleared timer does not fire/ },
+  // The shell contract is the largest of the four and was the one this fixture
+  // did not register. A re-measure proved every assertion in it deletable, the
+  // whole security section removable, and the entire contract replaceable with
+  // `assert.ok(shell)` -- green every time.
+  { mode: "shell_opens_anything", expects: /a javascript: URL is refused/ },
+  { mode: "shell_back_in_registration_order", expects: /the most recently registered back handler gets first refusal/ },
+  { mode: "shell_listener_count_stuck", expects: /unsubscribing drops the live listener count/ },
 ];
 
 for (const { mode, expects } of ADAPTER_BREAKS) {
@@ -1046,6 +1053,15 @@ test("a contract cannot quietly shrink", () => {
   assert.ok(casesFor("secrets") >= 9, `the secrets contract shrank to ${casesFor("secrets")} cases`);
   assert.ok(casesFor("storage") >= 11, `the storage contract shrank to ${casesFor("storage")} cases`);
   assert.ok(casesFor("time") >= 8, `the time contract shrank to ${casesFor("time")} cases`);
+  assert.ok(casesFor("shell") >= 33, `the shell contract shrank to ${casesFor("shell")} cases`);
+
+  // The break table needs a floor of its own. Deleting a row from
+  // ADAPTER_BREAKS, or lowering a count above, removes a defence and the only
+  // signal is a smaller number that nothing reads. Guarding the guard.
+  assert.ok(
+    ADAPTER_BREAKS.length >= 9,
+    `the break table shrank to ${ADAPTER_BREAKS.length} modes`,
+  );
 });
 
 test("the contracts can PASS: an unbroken fixture is green", () => {

--- a/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
@@ -234,6 +234,38 @@ export function describeShellContract(
     assert.equal(pressBack(), false);
   });
 
+  test(`${name}: unsubscribing removes the RIGHT registration of a repeated handler`, async () => {
+    // The case above registers two DIFFERENT closures, so `indexOf` and
+    // `lastIndexOf` behave identically and the mutation between them survives.
+    // React StrictMode double-invokes effects, so the same function reference
+    // being registered twice is the ordinary case, not an exotic one.
+    //
+    // Registering A, B, A and then dropping the SECOND A must leave B on top
+    // and the FIRST A beneath it. Removing the first instead leaves the stack
+    // inverted: B is buried and the back press goes to the wrong screen.
+    const { shell, pressBack } = await make();
+    const order: string[] = [];
+    const routeHandler = (): boolean => {
+      order.push("route");
+      return false; // pass it on, so the whole stack is observable
+    };
+
+    shell.onBackGesture(routeHandler);
+    shell.onBackGesture(() => {
+      order.push("modal");
+      return false;
+    });
+    const dropSecond = shell.onBackGesture(routeHandler);
+    dropSecond();
+
+    pressBack();
+    assert.deepEqual(
+      order,
+      ["modal", "route"],
+      "unsubscribing removed the wrong registration, so the stack is inverted",
+    );
+  });
+
   test(`${name}: the most recently registered back handler gets first refusal`, async () => {
     // A modal opened over a route must consume the gesture. In registration
     // order the route pops first and the modal is left floating over the wrong


### PR DESCRIPTION
A re-measurement of the regions a previous sweep named. **The production rates genuinely fell:**

| region | before | now |
|---|---|---|
| `app/src/main.ts` | 74.4% | **28.6%** |
| `adapters/src/{web,tauri}/*` | 44.3% | **24.1%** |
| `ui/src/i18n/*` | 43.8% | **34.8%** |
| `app/src/boot.ts` | 30.8% | **22.2%** |

Those fixes were structural. But the survival **moved into the machinery I added to guard them.**

## The shell contract was completely undefended

`contract-fixture.ts` registered secrets, storage and time. **Not shell** — the largest of the four, 33 cases, including seven `openExternal` refusals. No break mode, no floor.

Measured: every assertion in it deletable, the whole security section removable, the entire contract replaceable with `assert.ok(shell)` — **green each time**. Across all four contracts, 57 of 61 assertions were free; exactly four were load-bearing.

A `javascript:` URL reaching `openExternal` inside a webview is script execution in the app's own origin with the user's session, from a URL that routinely arrives from a model, a tool result, or pasted text. The *rule* lives in `core/src/ports/shell.ts` and both adapters call it. What was undefended is the contract proving they do — and the next shell, React Native, would be written against a contract that cannot fail.

Registered now, with three break modes: a shell that opens anything, a back stack in registration order, and a listener count that can't see a leak. Built by **wrapping a real web shell** rather than hand-rolling a `ShellPort`, so the fixture can't drift from the interface it exercises.

## Two holes the floor had

**`# SKIP` is reported as `ok` in TAP.** Changing `test(` to `test.skip(` on a security case kept the run green — a case could be *disabled* rather than deleted and the count never moved. The floor now excludes skips and todos.

**The meta-test filtered for `not ok` and matched separately**, so neutering the filter let a *passing* line satisfy the assertion — it went green precisely when the contract stopped catching anything. The prefix is part of the pattern now.

## A contract case too weak to catch its own mutation

*"the most recently registered back handler gets first refusal"* registers two **different** closures, so `indexOf` and `lastIndexOf` behave identically — and the mutation between them survived in **both shells**. React StrictMode double-invokes effects, so the same reference registered twice is the ordinary case. The new case registers A, B, A and drops the second A; removing the first instead inverts the stack and the back press goes to the wrong screen.

## Where this stops

Lowering a floor, or rewriting the meta-test's assertion back to its weaker form, is **not** caught by anything — and can't be without another guard above it. The regress has to end somewhere. It ends at code review, and this commit moves the line up: the contracts, the cases, the break table and the skip counting are all defended mechanically now. Only edits to the guard itself are not, and those read as what they are in a diff.

`1077 tests` on node 22.23 **and** 24.12 · `boundaries: 136 files, no violations`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of back-navigation handling when multiple gesture handlers are registered or removed.
  - Added safeguards to prevent unsafe URL schemes from being opened through the app shell.
  - Improved accuracy when tracking active shell event listeners.

- **Tests**
  - Expanded compatibility checks for shell behavior.
  - Strengthened validation to ensure contract coverage remains complete and regressions are detected early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->