### PR TITLE
fix(mobile): five tier-1 survivors, and a shell that could forward what it did not validate

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
@@ -224,6 +224,7 @@ function shellHarness(): ShellHarness {
       else window.setHidden(false);
     },
     listenerCount: () => shell.listenerCount(),
+    forwarded: () => window.opened,
   };
 }
 

--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -312,6 +312,7 @@ function fakeHarness(): ShellHarness {
     emitKeyboardHeight: (px) => fake.setKeyboardHeight(px),
     emitLifecycle: (phase) => fake.setLifecycle(phase),
     listenerCount: () => fake.listenerCount(),
+    forwarded: () => fake.opened,
   };
 }
 
@@ -337,6 +338,7 @@ function tauriHarness(): ShellHarness {
     emitKeyboardHeight: (px) => probe.emit("keyboard-height", px),
     emitLifecycle: (phase) => probe.emit("lifecycle", phase),
     listenerCount: () => shell.listenerCount(),
+    forwarded: () => probe.opened,
   };
 }
 
@@ -357,6 +359,7 @@ function webHarness(): ShellHarness {
       else fake.setHidden(false);
     },
     listenerCount: () => shell.listenerCount(),
+    forwarded: () => fake.opened,
   };
 }
 

--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -263,6 +263,7 @@ interface BridgeProbe {
   readonly bridge: TauriBridge;
   emit(event: string, payload: unknown): void;
   readonly invocations: ReadonlyArray<{ command: string; args: Record<string, unknown> }>;
+  readonly opened: readonly string[];
   /** How many NATIVE listeners exist, as opposed to app subscribers. */
   nativeListenerCount(): number;
 }
@@ -270,6 +271,9 @@ interface BridgeProbe {
 function probeBridge(options: { readonly slowListen?: boolean } = {}): BridgeProbe {
   const listeners = new Map<string, Set<(payload: unknown) => void>>();
   const invocations: Array<{ command: string; args: Record<string, unknown> }> = [];
+  /** What `openExternal` actually handed the OS. Nothing read this before, so
+   *  a shell could validate one string and forward a different one. */
+  const opened: string[] = [];
   return {
     bridge: {
       isPresent: () => true,
@@ -286,7 +290,7 @@ function probeBridge(options: { readonly slowListen?: boolean } = {}): BridgePro
           ? new Promise((resolve) => void queueMicrotask(() => resolve(unsubscribe)))
           : Promise.resolve(unsubscribe);
       },
-      openExternal: () => Promise.resolve(true),
+      openExternal: (url: string) => { opened.push(url); return Promise.resolve(true); },
       haptic: () => Promise.resolve(true),
       share: () => Promise.resolve(true),
     },
@@ -294,6 +298,7 @@ function probeBridge(options: { readonly slowListen?: boolean } = {}): BridgePro
       for (const handler of [...(listeners.get(event) ?? [])]) handler(payload);
     },
     invocations,
+    opened,
     nativeListenerCount: () => [...listeners.values()].reduce((n, set) => n + set.size, 0),
   };
 }
@@ -354,6 +359,24 @@ function webHarness(): ShellHarness {
     listenerCount: () => shell.listenerCount(),
   };
 }
+
+test("the tauri shell forwards the URL it validated, not the one it was given", () => {
+  // `url.trim()` -> `url` survived every contract case, because a contract can
+  // only observe REJECTION and the allowlist tolerates padding either way. What
+  // changes is what reaches the OS: a URL validated in one form and forwarded
+  // in another is the shape of a scheme-confusion bypass, and nothing in the
+  // suite read what the bridge was handed.
+  const probe = probeBridge();
+  const shell = createTauriShell({ bridge: probe.bridge, insetSource: cssSource({}) });
+
+  return shell.openExternal("  https://ok.example/path  ").then(() => {
+    assert.deepEqual(
+      probe.opened,
+      ["https://ok.example/path"],
+      "the OS must receive the trimmed URL the allowlist actually approved",
+    );
+  });
+});
 
 describeShellContract("fake shell", fakeHarness);
 describeShellContract("tauri shell", tauriHarness);
@@ -1063,7 +1086,7 @@ test("a contract cannot quietly shrink", () => {
   assert.ok(casesFor("secrets") >= 9, `the secrets contract shrank to ${casesFor("secrets")} cases`);
   assert.ok(casesFor("storage") >= 11, `the storage contract shrank to ${casesFor("storage")} cases`);
   assert.ok(casesFor("time") >= 8, `the time contract shrank to ${casesFor("time")} cases`);
-  assert.ok(casesFor("shell") >= 34, `the shell contract shrank to ${casesFor("shell")} cases`);
+  assert.ok(casesFor("shell") >= 35, `the shell contract shrank to ${casesFor("shell")} cases`);
 
   // The break table needs a floor of its own. Deleting a row from
   // ADAPTER_BREAKS, or lowering a count above, removes a defence and the only

--- a/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
@@ -49,6 +49,12 @@ export interface ShellHarness {
   emitLifecycle(phase: LifecyclePhase): void;
   /** Live subscriber count, so a leak is provable rather than inferred. */
   listenerCount(): number;
+  /** The URLs `openExternal` actually handed the OS, in order. A shell can
+   *  validate one string and forward another, and `doesNotReject` cannot see
+   *  the difference -- so the harness surfaces the forwarded value and the
+   *  contract reads it. Every real shell can supply this; it is required rather
+   *  than optional so a shell cannot opt out of being checked. */
+  forwarded(): readonly string[];
 }
 
 const PHONE: SafeAreaInsets = { top: 47, right: 0, bottom: 34, left: 0 };
@@ -467,16 +473,30 @@ export function describeShellContract(
   test(`${name}: a padded URL reaches the OS trimmed, or not at all`, async () => {
     // `url.trim()` -> `url` survived: the allowlist still refuses a padded
     // `javascript:`, but a URL that passes validation in one form and is handed
-    // to the OS in another is the shape of a scheme-confusion bypass. Nothing
-    // asserted what the shell actually forwarded.
-    const { shell } = await make();
+    // to the OS in another is the shape of a scheme-confusion bypass. And
+    // `doesNotReject` only proves the call did not throw, never that it did the
+    // right thing -- for a security boundary that gap is the whole question. So
+    // this reads what the shell FORWARDED, not merely whether it settled.
+    const harness = await make();
+    const { shell } = harness;
     await assert.doesNotReject(() => shell.openExternal("  https://ok.example  "));
+    assert.deepEqual(
+      harness.forwarded(),
+      ["https://ok.example"],
+      "the OS must receive the trimmed URL the allowlist actually approved, not the padded input",
+    );
     // And padding must not smuggle a refused scheme past the allowlist.
     await assert.rejects(
       () => shell.openExternal("  javascript:alert(1)  "),
       "whitespace must not launder a refused scheme",
     );
     await assert.rejects(() => shell.openExternal("\tdata:text/html,<script>x</script>"));
+    // A refused scheme must never reach the OS, however it was padded.
+    assert.deepEqual(
+      harness.forwarded(),
+      ["https://ok.example"],
+      "a refused scheme was forwarded to the OS despite the rejection",
+    );
   });
 
 }

--- a/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
@@ -463,4 +463,20 @@ export function describeShellContract(
     assert.equal(seen, 291, "the snapshot must be current inside the callback");
   });
 
+
+  test(`${name}: a padded URL reaches the OS trimmed, or not at all`, async () => {
+    // `url.trim()` -> `url` survived: the allowlist still refuses a padded
+    // `javascript:`, but a URL that passes validation in one form and is handed
+    // to the OS in another is the shape of a scheme-confusion bypass. Nothing
+    // asserted what the shell actually forwarded.
+    const { shell } = await make();
+    await assert.doesNotReject(() => shell.openExternal("  https://ok.example  "));
+    // And padding must not smuggle a refused scheme past the allowlist.
+    await assert.rejects(
+      () => shell.openExternal("  javascript:alert(1)  "),
+      "whitespace must not launder a refused scheme",
+    );
+    await assert.rejects(() => shell.openExternal("\tdata:text/html,<script>x</script>"));
+  });
+
 }

--- a/src/praisonai-mobile/adapters/src/web/http.test.ts
+++ b/src/praisonai-mobile/adapters/src/web/http.test.ts
@@ -94,3 +94,28 @@ test("response headers are flattened for the caller", () => {
       assert.equal(r.headers["content-type"], "application/json");
     });
 });
+
+test("the response status is reported as it was received", async () => {
+  // `status: response.status` -> `status: 200` survived. Every 401, 403, 429
+  // and 502 would be classified as success: the engine reads the status to
+  // decide `auth` vs `transport`, so the whole recovery distinction -- go to
+  // settings, or retry -- is fed a constant.
+  //
+  // The tests that DO cover that distinction drive the fake http, not this
+  // adapter, so the one place the real status is read was unguarded.
+  for (const status of [200, 204, 401, 403, 429, 500, 502]) {
+    const impl = (async () => ({
+      status,
+      headers: { forEach: (cb: (v: string, k: string) => void) => cb("application/json", "content-type") },
+      body: null,
+    })) as unknown as typeof fetch;
+
+    const response = await createWebHttp(impl).send({
+      url: "https://x.test",
+      method: "POST",
+      headers: {},
+      signal: new AbortController().signal,
+    });
+    assert.equal(response.status, status, `HTTP ${status} was reported as ${response.status}`);
+  }
+});

--- a/src/praisonai-mobile/adapters/src/web/shell.ts
+++ b/src/praisonai-mobile/adapters/src/web/shell.ts
@@ -200,7 +200,11 @@ export function createWebShell(view: Window = window): WebShell {
       if (!isOpenableExternally(url)) {
         throw new TypeError(`refusing to open ${url.split(":")[0] ?? ""}: externally`);
       }
-      view.open(url, "_blank", "noopener,noreferrer");
+      // Forward the SAME form the allowlist validated. `isOpenableExternally`
+      // trims before reading the scheme, so handing the OS the padded input
+      // would open a string that was never checked in that form -- the
+      // scheme-confusion seam the contract now reads.
+      view.open(url.trim(), "_blank", "noopener,noreferrer");
     },
   };
 }

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -460,3 +460,76 @@ test("a boot failure names what failed, alone on the screen, as an alert", async
     "the dead chrome must be gone, not merely covered",
   );
 });
+
+test("the composer is emptied after a send, so a second tap is a second question", async () => {
+  // Deleting `input.value = ""` survived. The text stays in the box, and the
+  // next Send tap re-submits the SAME question -- the user double-sends and
+  // pays twice, with no way to tell from the screen that it happened.
+  const { dom, http, platform } = harness();
+  http.on("/chat", () =>
+    sseResponse(
+      sse([
+        ["start", { msg_id: "m1", run_id: "r1" }],
+        ["delta", { msg_id: "m1", text: "answer" }],
+        ["end", { msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 }],
+      ]),
+    ),
+  );
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  submit(dom, "the only question");
+  await settle(120);
+
+  const box = dom.find((n) => n.tagName === "TEXTAREA");
+  assert.equal(box?.value, "", "the sent text must not still be in the composer");
+
+  // And the guard that follows from it: submitting again now sends nothing.
+  dom.find((n) => n.tagName === "FORM")?.dispatch("submit", { preventDefault: () => {} });
+  await settle();
+  assert.equal(
+    http.sent.filter((r) => r.url.includes("/chat")).length,
+    1,
+    "a second tap on an empty composer must not re-send the last question",
+  );
+  app?.dispose();
+});
+
+test("no chat id the app sends is ever the placeholder", async () => {
+  // `setChat(mintChatId())` -> `setChat("unassigned")` survived, because the
+  // existing test only asserts two ids DIFFER and the launch id is real. The
+  // placeholder is what `controller.ts` uses to mean "nobody has said which
+  // conversation this is"; shipping it to an engine that keys history by
+  // chat_id merges conversations.
+  const { dom, http, platform } = harness();
+  let n = 0;
+  http.on("/chat", () =>
+    sseResponse(
+      sse([
+        ["start", { msg_id: `m${++n}`, run_id: `r${n}` }],
+        ["delta", { msg_id: `m${n}`, text: "answer" }],
+        ["end", { msg_id: `m${n}`, user_index: 0, assistant_index: 1, versions: 1, active: 0 }],
+      ]),
+    ),
+  );
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => `chat-${n}` });
+
+  submit(dom, "one");
+  await settle();
+  dom.click(dom.find((d) => d.dataset["action"] === "new-chat") as never);
+  await settle();
+  submit(dom, "two");
+  await settle();
+  dom.click(dom.find((d) => d.dataset["action"] === "new-chat") as never);
+  await settle();
+  submit(dom, "three");
+  await settle();
+
+  const ids = http.sent
+    .filter((r) => r.url.includes("/chat"))
+    .map((r) => (JSON.parse(String(r.body ?? "{}")) as { chat_id?: string }).chat_id);
+
+  assert.equal(ids.length, 3, `expected three turns, got ${ids.length}`);
+  assert.equal(ids.includes("unassigned"), false, `a turn was sent as the placeholder: ${ids.join(", ")}`);
+  assert.equal(new Set(ids).size, 3, `three conversations must have three ids: ${ids.join(", ")}`);
+  app?.dispose();
+});

--- a/src/praisonai-mobile/app/src/platform.test.ts
+++ b/src/praisonai-mobile/app/src/platform.test.ts
@@ -59,3 +59,33 @@ test("the probe is synchronous", () => {
   assert.equal(typeof (p as unknown as { then?: unknown }).then, "undefined");
   assert.equal(typeof p.shell.insets, "object", "insets must be readable immediately");
 });
+
+test("the web platform stores chats in localStorage, not sessionStorage", () => {
+  // `view.localStorage` -> `view.sessionStorage` survived. Every chat would
+  // die with the tab, which on a phone is every time the OS reclaims the
+  // webview. platform.ts's own comment is about localStorage EVICTION being a
+  // risk; nothing asserted which store it actually reached for.
+  const used: string[] = [];
+  const spy = (name: string): Storage =>
+    ({
+      getItem: () => { used.push(name); return null; },
+      setItem: () => void used.push(name),
+      removeItem: () => void used.push(name),
+      key: () => null,
+      clear: () => void used.push(name),
+      length: 0,
+    }) as unknown as Storage;
+
+  // A real fake window, because createWebShell needs getComputedStyle and a
+  // hand-rolled stub cannot keep up with what the adapter reads.
+  const fake = createFakeWindow();
+  const view = fake.window as unknown as { localStorage: Storage; sessionStorage: Storage };
+  view.localStorage = spy("local");
+  view.sessionStorage = spy("session");
+
+  const platform = detectPlatform({ isNative: () => false, view: fake.window as unknown as Window });
+  void platform.storage.read({ namespace: "chats", id: "any" });
+
+  assert.ok(used.includes("local"), `the chat store must be localStorage, got ${used.join(",") || "none"}`);
+  assert.equal(used.includes("session"), false, "sessionStorage dies with the tab");
+});

--- a/src/praisonai-mobile/testing/src/fake-shell.ts
+++ b/src/praisonai-mobile/testing/src/fake-shell.ts
@@ -103,7 +103,10 @@ export function createFakeShell(initial: SafeAreaInsets = NO_INSETS): FakeShell 
       if (!isOpenableExternally(url)) {
         throw new TypeError(`refusing to open ${url.split(":")[0] ?? ""}: externally`);
       }
-      opened.push(url);
+      // Record the trimmed form the allowlist actually validated, matching the
+      // real shells: the fake is the reference the whole suite runs against, so
+      // a fake that forwarded padded input would let the trim regress unseen.
+      opened.push(url.trim());
     },
 
     // ---- test controls ----


### PR DESCRIPTION
The production-side findings from the same re-measure, each verified live against merged `main` before being touched.

| mutation | what shipped |
|---|---|
| `setChat(mintChatId())` → `setChat("unassigned")` | `"unassigned"` is what `controller.ts` uses to mean *nobody has said which conversation this is*. Shipping it to an engine keying history by `chat_id` merges conversations. The existing test only asserted two ids **differ** — and the launch id is real now, so a placeholder on turn two passed it |
| delete `input.value = ""` | the sent text stays in the composer, so the next Send tap **re-submits the same question**. The user double-sends and pays twice, with nothing on screen to say so |
| `view.localStorage` → `view.sessionStorage` | every chat dies with the tab — on a phone, every time the OS reclaims the webview. The file's own comment is about localStorage *eviction* being the risk; nothing asserted which store it reached for |
| `status: response.status` → `status: 200` | every 401, 403, 429 and 502 reported as success. The engine reads the status to choose `auth` vs `transport`, so the whole recovery distinction was fed a constant. The tests that *do* cover that distinction drive the fake http, so the one place the real status is read had nothing on it |

## The interesting one

`url.trim()` → `url` in the Tauri shell survived **every** contract case — including the new padded-URL case I wrote for it. A contract can only observe **rejection**, and the allowlist tolerates padding either way. What changes is *what reaches the OS*.

A URL validated in one form and forwarded in another is the shape of a scheme-confusion bypass, and nothing in the suite read what the bridge was handed. The probe bridge now records it, and the assertion is on the **forwarded string** rather than on whether the promise settled. Mutating the forward to pass the raw `url` instead of `target` also fails now — so the test observes the seam, not just the trim.

That's the general lesson: **`doesNotReject` proves a call did not throw. It does not prove the call did the right thing** — and for a security boundary, that gap is the whole question.

`1085 tests` on node 22.23 **and** 24.12 · six mutations confirmed to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safeguards for external links by trimming approved URLs before opening and rejecting unsafe schemes.
  * Preserved HTTP response status codes across web requests.
  * Prevented empty message submissions and ensured each new conversation receives a unique identifier.
  * Ensured chat history is retained in browser storage across sessions.

* **Tests**
  * Expanded automated coverage for shell security, HTTP responses, message composition, chat creation, and browser storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->