### PR TITLE
fix(mobile): the engines layer was the weakest, and its error paths were unpinned

### DIFF
--- a/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
@@ -14,7 +14,7 @@ import assert from "node:assert/strict";
 
 import { describeEngineContract, type ScenarioName } from "../conformance.ts";
 import { createRemoteHttpEngine, probeHealth } from "./engine.ts";
-import { createFakeHttp, sseResponse, jsonResponse } from "../../../testing/src/fake-http.ts";
+import { createFakeHttp, sseResponse, jsonResponse, streamOf } from "../../../testing/src/fake-http.ts";
 import { SCRIPTS } from "../../../testing/src/scripts.ts";
 import { encodeSseFrame } from "../../../protocol/src/encode.ts";
 import { PROTOCOL_VERSION } from "../../../protocol/src/version.ts";
@@ -295,4 +295,100 @@ test("both 401 and 403 are auth failures, so the UI offers credentials", async (
     const error = events.find((e) => e.type === "error");
     assert.equal(error?.kind, kind, `HTTP ${status} should be ${kind}`);
   }
+});
+
+// ---- the error paths, where a phone spends much of its life -----------------
+//
+// A package-wide sweep put `engines/` at 46.7% genuine mutation survival --
+// more than double the package average, and 4.5x `core/`. Six of its seven
+// survivors were on transport-failure or early-exit paths: the conformance
+// harness covers the happy path thoroughly and nothing covered these.
+
+test("a decision or cancel the engine did NOT accept is reported as refused", async () => {
+  // `response.status !== 200` -> `false` survived. Every non-200 -- 202, 401,
+  // 500 -- would report success, so the UI announces a stop that never
+  // happened and marks an approval sent that the engine never received. Both
+  // callers were written to trust this boolean.
+  for (const status of [202, 400, 401, 403, 500, 502]) {
+    const http = createFakeHttp();
+    http.on("/approve/a1", () => ({ status, headers: {}, body: streamOf(JSON.stringify({ ok: true })) }));
+    http.on("/cancel/r1", () => ({ status, headers: {}, body: streamOf(JSON.stringify({ ok: true })) }));
+    const engine = createRemoteHttpEngine({ baseUrl: "http://engine.test", http });
+
+    assert.equal(await engine.decide("a1", "allow"), false, `HTTP ${status} must not read as accepted`);
+    assert.equal(await engine.cancel("r1"), false, `HTTP ${status} must not read as cancelled`);
+  }
+});
+
+test("a 200 with an ok body is accepted, so the refusal test is not vacuous", async () => {
+  const http = createFakeHttp();
+  http.on("/approve/a1", () => ({ status: 200, headers: {}, body: streamOf(JSON.stringify({ ok: true })) }));
+  http.on("/cancel/r1", () => ({ status: 200, headers: {}, body: streamOf(JSON.stringify({ ok: true })) }));
+  const engine = createRemoteHttpEngine({ baseUrl: "http://engine.test", http });
+  assert.equal(await engine.decide("a1", "allow"), true);
+  assert.equal(await engine.cancel("r1"), true);
+});
+
+test("leaving the stream early releases the socket", async () => {
+  // Dropping `await reader.cancel()` from the `finally` survived. On New chat
+  // or Stop the consumer breaks out of the loop, and without the cancel the
+  // engine keeps generating into a socket nobody drains -- and keeps billing.
+  let cancelled = false;
+  const http = createFakeHttp();
+  http.on("/chat", () => ({
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            `event: start\ndata: ${JSON.stringify({ msg_id: "m1", run_id: "r1" })}\n\n` +
+              `event: delta\ndata: ${JSON.stringify({ msg_id: "m1", text: "one" })}\n\n`,
+          ),
+        );
+        // never closed, so only an explicit cancel releases it
+      },
+      cancel() {
+        cancelled = true;
+      },
+    }),
+  }));
+
+  const engine = createRemoteHttpEngine({ baseUrl: "http://engine.test", http });
+  for await (const event of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )) {
+    if (event.type === "delta") break; // the consumer leaves early
+  }
+
+  assert.equal(cancelled, true, "the response stream must be released when the consumer stops reading");
+});
+
+test("the SSE event name decides the type, not a field inside the payload", async () => {
+  // `{ ...parsed.value, type: frame.event }` transposed survived. A frame whose
+  // data object happens to carry its own `type` would then be decoded as THAT
+  // type -- and a delta arriving as an ill-formed `error` is dropped silently,
+  // so text vanishes from the answer with no diagnostic.
+  const http = createFakeHttp();
+  http.on("/chat", () =>
+    sseResponse(
+      `event: start\ndata: ${JSON.stringify({ msg_id: "m1", run_id: "r1" })}\n\n` +
+        `event: delta\ndata: ${JSON.stringify({ msg_id: "m1", text: "kept", type: "error" })}\n\n` +
+        `event: end\ndata: ${JSON.stringify({ msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 })}\n\n`,
+    ),
+  );
+  const engine = createRemoteHttpEngine({ baseUrl: "http://engine.test", http });
+
+  const events = [];
+  for await (const event of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )) {
+    events.push(event);
+  }
+
+  const delta = events.find((e) => e.type === "delta");
+  assert.ok(delta, `the delta was lost: ${events.map((e) => e.type).join(", ")}`);
+  assert.equal(delta.type === "delta" ? delta.text : null, "kept");
 });

--- a/src/praisonai-mobile/tools/check-boundaries.mjs
+++ b/src/praisonai-mobile/tools/check-boundaries.mjs
@@ -11,7 +11,7 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, relative, sep } from "node:path";
 
-import { importsOf, ungovernedRootsIn, violations } from "./depgraph.mjs";
+import { importsOf, sourceFilesUnder, ungovernedRootsIn, violations } from "./depgraph.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = join(here, "..");
@@ -19,42 +19,7 @@ const config = JSON.parse(readFileSync(join(here, "boundaries.json"), "utf8"));
 
 const norm = (p) => p.split(sep).join("/");
 
-/** Every .ts file under the governed roots. Fixtures are deliberately excluded:
- *  they violate the rule on purpose and are exercised by depgraph.test.mjs. */
-function sourceFiles() {
-  const out = [];
-  const walk = (dir) => {
-    let entries;
-    try {
-      entries = readdirSync(dir);
-    } catch {
-      return; // a governed root that does not exist yet is not an error
-    }
-    for (const entry of entries) {
-      if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
-      const full = join(dir, entry);
-      if (statSync(full).isDirectory()) walk(full);
-      else if (entry.endsWith(".ts") || entry.endsWith(".mjs")) out.push(full);
-    }
-  };
-  for (const rootName of config.governedRoots) walk(join(root, rootName));
-  return out;
-}
-
-const ungoverned = ungovernedRootsIn(root, config);
-if (ungoverned.length > 0) {
-  for (const { name, count } of ungoverned) {
-    console.error(
-      `boundaries: [ungoverned-root] ${name}/ holds ${count} source file(s) that no layer rule covers.\n` +
-        `    Add "${name}" to governedRoots in tools/boundaries.json (with a matching entry in\n` +
-        `    "layers"), or to ungovernedRoots if it is deliberately exempt.`,
-    );
-  }
-  console.error(`\nboundaries: ${ungoverned.length} ungoverned top-level director(y|ies)`);
-  process.exit(1);
-}
-
-const files = sourceFiles();
+const files = sourceFilesUnder(root, config.governedRoots);
 
 if (files.length === 0) {
   // Not a pass. A checker that reports success over an empty set is the exact

--- a/src/praisonai-mobile/tools/depgraph.mjs
+++ b/src/praisonai-mobile/tools/depgraph.mjs
@@ -275,3 +275,36 @@ export function ungovernedRootsIn(root, config) {
   }
   return out;
 }
+
+/**
+ * Every source file under `roots`, relative to `base`.
+ *
+ * Extracted from check-boundaries.mjs so a test can call it. Dropping the
+ * `.mjs` half of the extension test survived the whole suite: the checker
+ * silently stops walking every .mjs in the package and still prints "no
+ * violations". That is verbatim what boundaries.json's own comment warns
+ * about -- "a rule that stops covering new code while still reporting a clean
+ * pass is worse than no rule" -- and tools/ is entirely .mjs.
+ *
+ * `.ts` AND `.mjs`, and nothing else: a .md or a .json under a governed root
+ * is not code and must not be parsed as any.
+ */
+export function sourceFilesUnder(base, roots) {
+  const out = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return; // a governed root that does not exist yet is not an error
+    }
+    for (const entry of entries) {
+      if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry.endsWith(".ts") || entry.endsWith(".mjs")) out.push(full);
+    }
+  };
+  for (const rootName of roots) walk(join(base, rootName));
+  return out;
+}

--- a/src/praisonai-mobile/tools/depgraph.test.mjs
+++ b/src/praisonai-mobile/tools/depgraph.test.mjs
@@ -24,7 +24,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { importsOf, layerOf, targetOf, matchesAllowlist, ungovernedRootsIn, violations } from "./depgraph.mjs";
+import { importsOf, layerOf, targetOf, matchesAllowlist, ungovernedRootsIn, violations, sourceFilesUnder } from "./depgraph.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = join(here, "..");
@@ -272,4 +272,55 @@ test("the real boundaries.json accounts for every directory actually on disk", (
   // The one that will fail on somebody's future branch, which is the point.
   const real = JSON.parse(readFileSync(join(here, "boundaries.json"), "utf8"));
   assert.deepEqual(ungovernedRootsIn(join(here, ".."), real), []);
+});
+
+// ---- the checker must keep checking every kind of file it claims to --------
+
+test("a violation in a .mjs file is reported, not skipped", async () => {
+  // `entry.endsWith(".ts") || entry.endsWith(".mjs")` -> dropping the .mjs half
+  // survived: the checker silently stops walking every .mjs in the package and
+  // still prints "136 files checked, no violations". That is verbatim the
+  // failure boundaries.json's own comment warns about -- "a rule that stops
+  // covering new code while still reporting a clean pass is worse than no
+  // rule" -- and tools/ is entirely .mjs.
+  const root = tree({
+    "core/src/a.ts": "export const a = 1;",
+    "core/src/sneaky.mjs": 'import { invoke } from "@tauri-apps/api/core";\nexport const x = invoke;',
+  });
+  try {
+    const files = await importsOf(
+      [join(root, "core/src/a.ts"), join(root, "core/src/sneaky.mjs")],
+      root,
+    );
+    const found = violations(files, {
+      layers: { core: { path: "core/src", mayImport: [] } },
+      externals: { "@tauri-apps/api": ["adapters/src/tauri"] },
+      governedRoots: ["core"],
+    });
+    assert.ok(
+      found.some((v) => v.file.endsWith(".mjs")),
+      "a .mjs file that crosses a seam must be reported",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the walk collects .mjs files as well as .ts", () => {
+  // The narrower form, so the failure names the cause rather than a symptom.
+  const root = tree({
+    "core/src/a.ts": "export const a = 1;",
+    "core/src/b.mjs": "export const b = 2;",
+    "core/src/notes.md": "not source",
+  });
+  try {
+    const found = sourceFilesUnder(root, ["core"]).map((f) => f.slice(root.length + 1));
+    assert.deepEqual(
+      found.map((f) => f.split("/").pop()).sort(),
+      ["a.ts", "b.mjs"].sort(),
+      "the walk must pick up both extensions, and nothing else",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
A **package-wide** sweep of 154 mutations on current `main` put genuine survival at **23.8%**, against **26.3%** originally — an improvement inside the ±3.4 sampling error, so essentially flat package-wide. The layer split is the actionable result:

| layer | genuine survival |
|---|---|
| **`engines/`** | **46.7%** ← weakest, 4.5× core |
| `adapters/` | 29.2% |
| `ui/` | 20.5% |
| `app/` | 15.4% |
| **`core/`** | **10.3%** ← strongest |

**Six of the seven engine survivors were on transport-failure or early-exit paths.** The conformance harness covers the happy path thoroughly; nothing covered these — and a phone spends a disproportionate amount of its life there.

| mutation | what shipped |
|---|---|
| `postOk`: delete `if (response.status !== 200) return false` | every non-200 — 202, 401, 500, 502 — reports **success**. The UI announces a stop that never happened and marks an approval sent that the engine never received. Both callers were written to trust this boolean |
| delete the reader's `cancel()` in the `finally` | on New chat or Stop the consumer breaks out of the loop; without the cancel the engine keeps generating into a socket nobody drains, and **keeps billing**. Proved with a stream that records its own cancellation |
| `{ ...parsed.value, type: frame.event }` transposed | a frame whose data object carries its own `type` is decoded as *that* type. A delta arriving as an ill-formed `error` is dropped silently, so **text vanishes from the answer** with no diagnostic |

## And the checker stopped checking itself

`tools/check-boundaries.mjs` walked `.ts` and `.mjs`. Dropping the `.mjs` half **survived**: it silently stops walking every `.mjs` in the package — and `tools/` is *entirely* `.mjs` — while still printing `136 files checked, no violations`.

That is verbatim the failure `boundaries.json`'s own comment warns about: *"a rule that stops covering new code while still reporting a clean pass is worse than no rule."* The walk is now `sourceFilesUnder(base, roots)` in `depgraph.mjs` so a test can call it — the same move already made for `ungovernedRootsIn`.

## One test of mine passed for the wrong reason

The refusal test registered `http.on("/approve", …)`, and the fake matches by URL **suffix** — the engine posts to `/approve/{approvalId}`, so nothing matched and every request 404'd. A 404 isn't 200, so the test went green while never exercising the status check it was written for. Its paired *"a 200 with an ok body **is** accepted"* case failed, which is the only reason I noticed.

`1091 tests` on node 22.23 **and** 24.12 · four mutations confirmed to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed remote requests, including non-success responses and interrupted streams.
  * Correctly interprets server-sent event names when decoding streamed responses.

* **Tests**
  * Added coverage for remote request errors, successful responses, stream cleanup, and event decoding.
  * Added dependency-boundary checks for JavaScript module files and improved source file discovery coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->