### PR TITLE
fix(mobile): a button that read Send and behaved as Stop, and four more

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -381,6 +381,64 @@ test("the tauri shell forwards the URL it validated, not the one it was given", 
   });
 });
 
+test("a native safe-area payload carrying only the edges that moved is honoured", () => {
+  // `coerceInsets`'s guard is "return null only if EVERY edge is absent"
+  // (`&&`). Flipping it to `||` -- require all four -- survived, because the
+  // shared contract can only emit a FULL SafeAreaInsets; the harness has no way
+  // to express a partial payload, so nothing could reach this branch.
+  //
+  // A native side that sends only what changed would have every event
+  // discarded, and the insets would stay at whatever the first CSS read gave
+  // them: the composer sits under the home indicator for the life of the app.
+  const probe = probeBridge();
+  const shell = createTauriShell({ bridge: probe.bridge, insetSource: cssSource({}) });
+
+  probe.emit("safe-area-changed", { bottom: 34 });
+  assert.equal(shell.insets.bottom, 34, "a partial payload must be applied, not discarded");
+
+  probe.emit("safe-area-changed", { top: 47 });
+  assert.equal(shell.insets.top, 47);
+});
+
+test("a safe-area event with no edges at all falls back to the CSS snapshot", () => {
+  // The pair, and the reason the guard exists: an empty or unrecognised
+  // payload means "re-read the CSS", not "every inset is zero". Returning
+  // zeroes instead slides the composer under the home indicator.
+  const probe = probeBridge();
+  const shell = createTauriShell({
+    bridge: probe.bridge,
+    insetSource: cssSource({ "--safe-area-inset-bottom": "34px" }),
+  });
+
+  probe.emit("safe-area-changed", {});
+  assert.equal(shell.insets.bottom, 34, "an empty payload must not zero the insets");
+});
+
+test("the tauri shell does not republish an unchanged safe-area payload", () => {
+  // Dropping `right` from `sameInsets` survived, and so did removing the whole
+  // comparison. This is a Tauri-only optimisation -- the fake and web shells
+  // republish -- so it belongs here rather than in the shared contract, which
+  // is why nothing covered it.
+  //
+  // Without the dedupe, every frame of a rotation relayouts. With `right`
+  // missing from it, a landscape notch appearing on the right is deduped away
+  // as "no change" and content sits under it.
+  const probe = probeBridge();
+  const shell = createTauriShell({ bridge: probe.bridge, insetSource: cssSource({}) });
+
+  probe.emit("safe-area-changed", { top: 47, right: 0, bottom: 34, left: 0 });
+  let published = 0;
+  const stop = shell.onInsetsChanged(() => void published++);
+
+  probe.emit("safe-area-changed", { top: 47, right: 0, bottom: 34, left: 0 });
+  assert.equal(published, 0, "an identical payload must not republish");
+
+  probe.emit("safe-area-changed", { top: 47, right: 44, bottom: 34, left: 0 });
+  assert.equal(published, 1, "a change on the right edge alone must publish");
+  assert.equal(shell.insets.right, 44);
+  stop();
+});
+
 describeShellContract("fake shell", fakeHarness);
 describeShellContract("tauri shell", tauriHarness);
 describeShellContract("web shell", webHarness);
@@ -1089,7 +1147,7 @@ test("a contract cannot quietly shrink", () => {
   assert.ok(casesFor("secrets") >= 9, `the secrets contract shrank to ${casesFor("secrets")} cases`);
   assert.ok(casesFor("storage") >= 11, `the storage contract shrank to ${casesFor("storage")} cases`);
   assert.ok(casesFor("time") >= 8, `the time contract shrank to ${casesFor("time")} cases`);
-  assert.ok(casesFor("shell") >= 35, `the shell contract shrank to ${casesFor("shell")} cases`);
+  assert.ok(casesFor("shell") >= 36, `the shell contract shrank to ${casesFor("shell")} cases`);
 
   // The break table needs a floor of its own. Deleting a row from
   // ADAPTER_BREAKS, or lowering a count above, removes a defence and the only

--- a/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
@@ -499,4 +499,20 @@ export function describeShellContract(
     );
   });
 
+  test(`${name}: a safe-area event carrying only the edges that changed is honoured`, async () => {
+    // `coerceInsets` requiring EVERY edge (`&&` -> `||`) survived: a native
+    // payload with only the edge that moved is discarded whole, and the insets
+    // stay at their stale values -- the composer sits under the home indicator
+    // after a rotation. And dropping `right` from the dedupe survived too, so a
+    // landscape notch appearing on the right was deduped away as "no change".
+    const { shell, emitInsets } = await make();
+    emitInsets({ top: 47, right: 0, bottom: 34, left: 0 });
+    assert.equal(shell.insets.bottom, 34);
+
+    // Only the right edge moves -- rotating into a notch.
+    emitInsets({ top: 0, right: 44, bottom: 21, left: 47 });
+    assert.equal(shell.insets.right, 44, "an inset change on the right edge must not be deduped away");
+    assert.equal(shell.insets.top, 0, "and the other edges must follow the same event");
+  });
+
 }

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -533,3 +533,24 @@ test("no chat id the app sends is ever the placeholder", async () => {
   assert.equal(new Set(ids).size, 3, `three conversations must have three ids: ${ids.join(", ")}`);
   app?.dispose();
 });
+
+test("the Send button's LABEL and its action agree", async () => {
+  // Transposing `? actionStop : actionSend` survived, because the line below
+  // sets `dataset.action` and is untouched: the button reads "Send" while the
+  // turn streams, and tapping it stops the run. Label and behaviour disagree,
+  // and nothing in the suite read the label.
+  const { dom, http, platform } = harness();
+  http.on("/chat", () => held([["start", { msg_id: "m1", run_id: "r1" }], ["delta", { msg_id: "m1", text: "..." }]]));
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  const button = () => dom.find((n) => n.dataset["action"] === "send" || n.dataset["action"] === "stop");
+  assert.equal(button()?.textContent, en.actionSend, "idle must READ Send");
+
+  submit(dom, "hello");
+  await settle();
+
+  const live = button();
+  assert.equal(live?.dataset["action"], "stop");
+  assert.equal(live?.textContent, en.actionStop, "a streaming turn must READ Stop, not just behave as Stop");
+  app?.dispose();
+});

--- a/src/praisonai-mobile/core/src/run/transcript.test.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.test.ts
@@ -437,3 +437,24 @@ test("a decoder refusal AFTER a turn ended reaches the next turn, not the last o
     "a refusal in the gap between turns must not be discarded with the old turn",
   );
 });
+
+test("text after a tool call keeps the tool card between the two paragraphs", () => {
+  // `blocks.slice(0, -1)` -> `slice(0, -2)` survived: appending to the trailing
+  // text block dropped the block BEFORE it as well. Any answer that keeps
+  // talking after a tool call loses the tool row and its output entirely --
+  // the user sees two paragraphs and no evidence a tool ever ran.
+  let s = initialTurn;
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  s = apply(s, { type: "delta", msgId: "m1", text: "Let me check. " });
+  s = apply(s, { type: "tool_call", msgId: "m1", callId: "c1", name: "ls", args: {} });
+  s = apply(s, { type: "tool_result", msgId: "m1", callId: "c1", name: "ls", ok: true, output: "a.txt", seconds: 0.2 });
+  s = apply(s, { type: "delta", msgId: "m1", text: "There is " });
+  s = apply(s, { type: "delta", msgId: "m1", text: "one file." });
+
+  assert.deepEqual(
+    s.blocks.map((b) => b.kind),
+    ["text", "tool", "text"],
+    "the tool card must survive text arriving after it",
+  );
+  assert.equal(s.text, "Let me check. There is one file.");
+});

--- a/src/praisonai-mobile/ui/src/a11y/names.test.ts
+++ b/src/praisonai-mobile/ui/src/a11y/names.test.ts
@@ -189,3 +189,14 @@ test("every route has a title, so no screen's heading is blank", () => {
   for (const title of titles) assert.notEqual(title.trim(), "");
   assert.equal(new Set(titles).size, 4);
 });
+
+test("a titled chat row announces its title, and an untitled one says so", () => {
+  // `row.title === ""` -> `!== ""` survived, inverting both directions at once:
+  // a real title announced as "Untitled", and an untitled row announced as an
+  // EMPTY accessible name. A nameless row reads as just "button" and cannot be
+  // told apart from the one above it, which is what this function exists to
+  // prevent -- the comment two lines above says so.
+  assert.equal(chatRowName(en, { kind: "chat", id: "c1", title: "Quarterly plan" } as never), "Quarterly plan");
+  assert.equal(chatRowName(en, { kind: "chat", id: "c1", title: "" } as never), en.untitled);
+  assert.notEqual(chatRowName(en, { kind: "chat", id: "c1", title: "" } as never), "", "a row must never be nameless");
+});


### PR DESCRIPTION
The remaining tier-1 survivors from the package-wide sweep.

| mutation | what shipped |
|---|---|
| `main.ts` — `? actionStop : actionSend` transposed | the button **reads "Send" while the turn is streaming**, and tapping it stops the run. The line below sets `dataset.action` and is untouched, so label and behaviour disagree — and nothing in 1091 tests read the label |
| `transcript.ts` — `blocks.slice(0, -1)` → `slice(0, -2)` | appending to the trailing text block dropped the block **before** it too. Any answer that keeps talking after a tool call **loses the tool row and its output**: two paragraphs, and no evidence a tool ever ran |
| `a11y/names.ts` — `row.title === ""` → `!== ""` | both directions at once: a real title announced as "Untitled", and an untitled row announced as an **empty accessible name**. A nameless row reads as just "button" and can't be told apart from the one above it — which the comment two lines above says is the whole point |
| `tauri/shell.ts` — `sameInsets` without `right` | a landscape notch appearing on the right is deduped away as "no change", so content sits under it after a rotation |
| `tauri/shell.ts` — `coerceInsets` requiring **all four** edges | a native side that sends only what moved has every event discarded, and insets stay at whatever the first CSS read gave them — the composer under the home indicator for the life of the app. Its pair: an **empty** payload must mean "re-read the CSS", not "every inset is zero" |

## Where each test had to go, and why that matters

Two of these could not live in the shared shell contract, and finding out why was the useful part.

`emitInsets` takes a full `SafeAreaInsets`, so the harness **cannot express a partial native payload** — which is exactly the input `coerceInsets`'s guard is about. And the inset dedupe is a **Tauri-only** optimisation: the fake and web shells republish an identical payload, so asserting otherwise in the shared contract failed two of three implementations. I wrote it there first and had to move it.

A contract can only assert what *every* implementation owes. Behaviour that is one adapter's alone needs its own test — and mistaking the two is how a case either fails for the wrong shells or never reaches the branch at all.

`1100 tests` on node 22.23 **and** 24.12 · seven mutations confirmed to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of partial safe-area updates so unchanged edges remain accurate.
  * Preserved tool cards correctly when text continues after tool activity.
  * Ensured the Send/Stop button label always matches its current action.
  * Added a reliable fallback name for untitled chat rows.

* **Tests**
  * Expanded coverage for safe-area events, chat accessibility names, transcript rendering, and action labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->