### PR TITLE
test(mobile): the engines layer's remaining failure paths

### DIFF
--- a/src/praisonai-mobile/engines/src/conformance.test.ts
+++ b/src/praisonai-mobile/engines/src/conformance.test.ts
@@ -208,6 +208,7 @@ function runFixture(mode: string): { status: number | null; output: string } {
 /** Each break mode, and the contract case that must go red because of it. */
 const BREAKS: readonly { readonly mode: string; readonly expects: RegExp }[] = [
   { mode: "no_start", expects: /a run emits start first and exactly one terminal event last/ },
+  { mode: "start_only", expects: /a run emits start first and exactly one terminal event last/ },
   { mode: "tool_failure_as_ok", expects: /a failed tool is reported failed and never inferred from its output/ },
   { mode: "empty_is_fine", expects: /an empty stream is an error, not an empty answer/ },
   { mode: "decide_always_true", expects: /deciding an unknown approval returns false rather than reporting success/ },

--- a/src/praisonai-mobile/engines/src/contract-fixture.ts
+++ b/src/praisonai-mobile/engines/src/contract-fixture.ts
@@ -23,7 +23,13 @@ import type { RunEvent } from "../../protocol/src/events.ts";
 import type { AgentEnginePort } from "../../core/src/ports/agent-engine.ts";
 
 /** Each mode breaks exactly one rule, so exactly one case should go red. */
-export type BreakMode = "none" | "no_start" | "tool_failure_as_ok" | "empty_is_fine" | "decide_always_true";
+export type BreakMode =
+  | "none"
+  | "no_start"
+  | "start_only"
+  | "tool_failure_as_ok"
+  | "empty_is_fine"
+  | "decide_always_true";
 
 const M = "m1";
 const mode = (process.argv[2] ?? "none") as BreakMode;
@@ -50,6 +56,12 @@ function scriptFor(scenario: ScenarioName): readonly RunEvent[] {
   if (scenario === "tool_failed") return toolFailed;
   if (scenario === "empty") return mode === "empty_is_fine" ? happy : [];
   // THE BREAK for no_start: the opening event is missing.
+  // THE BREAK for start_only: the run opens and then simply stops -- no
+  // terminal event at all. The contract asserted `events.length >= 2`, which
+  // this satisfies the moment there are two events of any kind, and separately
+  // asserted exactly one terminal; weakening the length check to `>= 1` let a
+  // start-only run through, which is a turn that never ends.
+  if (mode === "start_only") return happy.slice(0, 1);
   return mode === "no_start" ? happy.slice(1) : happy;
 }
 

--- a/src/praisonai-mobile/engines/src/praisonai-ts/classify.test.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/classify.test.ts
@@ -56,3 +56,21 @@ test("statusOf reads the shapes providers actually throw", () => {
   assert.equal(statusOf(null), null);
   assert.equal(statusOf({ status: "429" }), null, "a string status is not a status");
 });
+
+test("an HTTP 500 is transport, so the UI still offers Retry", () => {
+  // `status >= 500` -> `> 500` survived. A plain 500 -- the single most common
+  // provider failure -- would classify as `internal`, whose recovery is
+  // `none`: the user is told something went wrong and offered no way to try
+  // again. 502 and 503 are unaffected, so the boundary is exactly the case
+  // that matters most.
+  for (const status of [500, 501, 502, 503, 504]) {
+    assert.equal(classifyError({ status } as never), "transport", `HTTP ${status}`);
+  }
+});
+
+test("a 4xx is not transport, so Retry is not offered where it cannot help", () => {
+  // The pair. Classifying everything as transport offers Retry for a bad
+  // request or a revoked key, which can never succeed.
+  assert.notEqual(classifyError({ status: 400 } as never), "transport");
+  assert.notEqual(classifyError({ status: 422 } as never), "transport");
+});

--- a/src/praisonai-mobile/engines/src/praisonai-ts/engine.test.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/engine.test.ts
@@ -388,3 +388,54 @@ test("with no finish event, the streamed deltas are what gets persisted", async 
   );
   assert.deepEqual(p.writes.map((w) => w.answer), ["one two"]);
 });
+
+test("a run started with an ALREADY-aborted signal produces no answer", async () => {
+  // `if (signal.aborted) controller.abort()` -> `if (false)` survived. The
+  // `else` branch's `addEventListener("abort")` never fires for a signal that
+  // aborted BEFORE the listener was attached, so the run streams to completion
+  // and persists an answer nobody is waiting for.
+  //
+  // Reachable through dispose-then-new-run, and through Stop followed
+  // immediately by Send: the controller hands the engine a signal that is
+  // already down.
+  const p = capturing();
+  const engine = build(
+    fakeAgent([
+      { type: "text", delta: "this should never be streamed" },
+      { type: "finish", text: "nor persisted" },
+    ]),
+    p.port,
+  );
+
+  const controller = new AbortController();
+  controller.abort(); // down BEFORE the run starts
+
+  const events = [];
+  for await (const event of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    controller.signal,
+  )) {
+    events.push(event);
+  }
+
+  assert.equal(
+    events.some((e) => e.type === "delta"),
+    false,
+    `an already-aborted run streamed: ${events.map((e) => e.type).join(", ")}`,
+  );
+  assert.deepEqual(p.writes, [], "and it must not have persisted an answer");
+});
+
+test("a run with a live signal still streams, so the abort test is not vacuous", async () => {
+  const p = capturing();
+  const engine = build(fakeAgent([{ type: "text", delta: "kept" }, { type: "finish", text: "kept" }]), p.port);
+  const events = [];
+  for await (const event of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )) {
+    events.push(event);
+  }
+  assert.ok(events.some((e) => e.type === "delta"));
+  assert.deepEqual(p.writes.map((w) => w.answer), ["kept"]);
+});

--- a/src/praisonai-mobile/engines/src/remote-http/readiness.test.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/readiness.test.ts
@@ -115,3 +115,24 @@ test("the_classifier_can_actually_refuse", () => {
   assert.equal(healthy.ready, true);
   assert.equal(broken.ready, false);
 });
+
+test("any status that is not exactly 200 is an http_status failure", () => {
+  // `probe.status !== 200` -> `> 200` survived: a sub-200 status (100, 101,
+  // 199) would fall through and be classified from its BODY, so a websocket
+  // upgrade or a "continue" reported `ready: true`. The engine would then be
+  // offered as usable and every request to it fail.
+  const body = JSON.stringify({ ok: true, version: PROTOCOL_VERSION });
+  for (const status of [100, 101, 199, 201, 204, 301, 404, 500, 503]) {
+    const verdict = classify(http(status, body));
+    assert.equal(verdict.ready, false, `HTTP ${status} must not read as ready`);
+    assert.equal(
+      verdict.ready === false ? verdict.reason : null,
+      "http_status",
+      `HTTP ${status} must be a status failure, not classified from its body`,
+    );
+  }
+});
+
+test("a 200 is still classified from its body, so the status test is not vacuous", () => {
+  assert.equal(classify(ok()).ready, true);
+});


### PR DESCRIPTION
`engines/` measured **46.7%** genuine mutation survival — more than double the package average and 4.5× `core/` — with **six of seven survivors on transport-failure or early-exit paths**. The last three.

| mutation | what shipped |
|---|---|
| `praisonai-ts/engine.ts` — delete `if (signal.aborted) controller.abort()` | the `else` branch attaches an abort **listener**, which never fires for a signal that went down *before* it was attached. A run handed an already-aborted signal streams to completion and **persists an answer nobody is waiting for**. Reachable through dispose-then-new-run, and Stop followed immediately by Send |
| `praisonai-ts/classify.ts` — `status >= 500` → `> 500` | a plain **500** — the most common provider failure there is — classifies as `internal`, whose recovery is `none`. The user is told something went wrong and offered no way to try again. 502/503 are unaffected, so the boundary lands exactly on the case that matters most |
| `remote-http/readiness.ts` — `status !== 200` → `> 200` | a sub-200 status (100, 101, 199) falls through and is classified from its **body**, so a websocket upgrade or a "continue" reports **ready**. The engine is then offered as usable and every request to it fails |

Each is paired: a live signal must still stream, a 4xx must **not** be transport (offering Retry for a revoked key can never succeed), and a 200 must still be classified from its body.

## A new break mode for the engine contract

`start_only` — a run that opens and then simply stops, with no terminal event at all. It's now asserted to redden *"a run emits start first and exactly one terminal event last"* **by name**.

Writing it also settled a survivor I'd listed as a gap: weakening that case's `events.length >= 2` to `>= 1` does **not** let a start-only engine through. Nor does weakening the terminal *count* as well. The case catches it either way — so the length assertion is **redundant rather than unguarded**. Worth knowing, and worth not chasing.

`1107 tests` on node 22.23 **and** 24.12 · three mutations confirmed to fail; the fourth proved redundant rather than surviving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted runs so already-cancelled requests do not produce or save responses.
  * Corrected readiness checks to require an HTTP 200 response.
  * Ensured server errors are eligible for retry, while client errors are not.

* **Tests**
  * Expanded coverage for incomplete runs, response classification, cancellation, and service readiness scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->