### PR TITLE
test(mobile): the tier-2 survivors, and a fifth fake that could lie

### DIFF
--- a/src/praisonai-mobile/core/src/chat/session.test.ts
+++ b/src/praisonai-mobile/core/src/chat/session.test.ts
@@ -233,3 +233,26 @@ test("every turn advances the chat's updated time", () => {
     assert.equal(afterTwo.messages.length, 4, "and both turns are still there");
   })();
 });
+
+test("a title of exactly the maximum length is not truncated", () => {
+  // `points.length <= 60` -> `< 60` survived: a title of exactly 60 graphemes
+  // gets an ellipsis it does not need, and loses its last character to make
+  // room for it.
+  const { session } = build();
+  const exactly60 = "a".repeat(60);
+  return session.record(exactly60, "answer").then(() => {
+    const title = session.current()?.title ?? "";
+    assert.equal(title, exactly60, "a title at the limit must survive whole");
+    assert.equal(title.includes("…"), false);
+  });
+});
+
+test("a title one character over the maximum IS truncated", () => {
+  // The pair, so a function that never truncates cannot pass the test above.
+  const { session } = build();
+  return session.record("b".repeat(61), "answer").then(() => {
+    const title = session.current()?.title ?? "";
+    assert.ok(title.endsWith("…"), `expected an ellipsis, got ${JSON.stringify(title)}`);
+    assert.ok(title.length <= 60);
+  });
+});

--- a/src/praisonai-mobile/protocol/src/decode.test.ts
+++ b/src/praisonai-mobile/protocol/src/decode.test.ts
@@ -417,3 +417,22 @@ test("anything that is not a defined choice decodes to null, never a default", (
     assert.equal(decodeApprovalChoice(bad), null, `${JSON.stringify(bad)} must not decode`);
   }
 });
+
+test("an empty type is missing_type, not unknown_event", () => {
+  // Dropping `|| type === ""` survived my own earlier test, which asserted
+  // only that the frame was REFUSED. It still is -- but as `unknown_event`
+  // with an empty detail, instead of `missing_type` with the key list. The
+  // dropped-events row then blames the engine for sending an event nobody
+  // recognises, when what actually arrived had no type at all. A reason that
+  // names the wrong failure sends whoever reads it to the wrong place.
+  const out = decodeEvent({ type: "", msg_id: "m1" });
+  assert.ok(isIgnored(out));
+  assert.equal(out.reason, "missing_type");
+  assert.match(out.detail, /msg_id/, "the detail must list what the frame DID carry");
+});
+
+test("an unrecognised type really is unknown_event, so the pair is not vacuous", () => {
+  const out = decodeEvent({ type: "thinking_budget", msg_id: "m1" });
+  assert.ok(isIgnored(out));
+  assert.equal(out.reason, "unknown_event");
+});

--- a/src/praisonai-mobile/testing/src/fake-http.test.ts
+++ b/src/praisonai-mobile/testing/src/fake-http.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The fake HTTP transport, tested as the thing engine tests depend on.
+ *
+ * Two of its behaviours are load-bearing for tests written against it, and a
+ * mutation sweep found both unguarded:
+ *
+ *   the route table picks the LONGEST matching suffix, so `/chats` does not
+ *   shadow `/chat` -- inverting it silently mis-routes a test to the wrong
+ *   handler and the test still passes, against the wrong thing;
+ *
+ *   `streamOf` chunks its body deliberately, "because a frame split across
+ *   chunks is the normal case on a real network". Emitting an extra
+ *   zero-length chunk, or the whole body at once, changes what the SSE reader
+ *   is exercised with -- and the reader's pending-CR logic is precisely
+ *   sensitive to chunk boundaries. A fake that stops splitting can mask the
+ *   CRLF defect this package has already shipped once.
+ *
+ * This is the fifth fake in the package to get its own tests after being
+ * caught misrepresenting what it stands in for.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createFakeHttp, streamOf } from "./fake-http.ts";
+
+const send = (http: ReturnType<typeof createFakeHttp>, url: string) =>
+  http.send({ url, method: "POST", headers: {}, signal: new AbortController().signal });
+
+test("the longest matching suffix wins, so a general route does not shadow a specific one", async () => {
+  const http = createFakeHttp();
+  http.on("/chat", () => ({ status: 200, headers: {}, body: null }));
+  http.on("/v1/chat", () => ({ status: 201, headers: {}, body: null }));
+
+  const specific = await send(http, "http://engine.test/v1/chat");
+  assert.equal(specific.status, 201, "the more specific route must win");
+
+  const general = await send(http, "http://engine.test/chat");
+  assert.equal(general.status, 200);
+});
+
+test("an unmatched request is a 404, not a silent success", async () => {
+  const http = createFakeHttp();
+  http.on("/chat", () => ({ status: 200, headers: {}, body: null }));
+  const missed = await send(http, "http://engine.test/nothing-registered");
+  assert.equal(missed.status, 404, "an unregistered path must be visibly unhandled");
+});
+
+test("every request is recorded, in order", async () => {
+  const http = createFakeHttp();
+  http.on("/a", () => ({ status: 200, headers: {}, body: null }));
+  http.on("/b", () => ({ status: 200, headers: {}, body: null }));
+  await send(http, "http://engine.test/a");
+  await send(http, "http://engine.test/b");
+  assert.deepEqual(
+    http.sent.map((r) => r.url),
+    ["http://engine.test/a", "http://engine.test/b"],
+  );
+});
+
+test("streamOf splits the body, and emits no empty chunks", async () => {
+  // The chunking is the point: a frame split across chunks is the normal case
+  // on a real network, and the SSE reader's pending-CR logic is sensitive to
+  // exactly where the boundaries fall. An extra zero-length chunk at the end
+  // is not something a real network produces, and it changes what the reader
+  // is being exercised with.
+  const read = async (text: string, size?: number): Promise<number[]> => {
+    const reader = (size === undefined ? streamOf(text) : streamOf(text, size)).getReader();
+    const sizes: number[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      sizes.push(value.length);
+    }
+    return sizes;
+  };
+
+  assert.deepEqual(await read(""), [], "an empty body is no chunks at all");
+  assert.deepEqual(await read("abcdefg"), [7], "a body shorter than the chunk size is one chunk");
+  assert.deepEqual(await read("abcdefgh"), [7, 1], "and a longer one is split");
+  assert.deepEqual(await read("abcdef", 2), [2, 2, 2], "the chunk size is honoured exactly");
+  assert.equal(
+    (await read("abcdefghij", 3)).includes(0),
+    false,
+    "a zero-length chunk is not something a network produces",
+  );
+});
+
+test("streamOf reassembles to exactly the input", async () => {
+  const text = 'event: delta\r\ndata: {"msg_id":"m","text":"hello"}\r\n\r\n';
+  const reader = streamOf(text, 3).getReader();
+  const parts: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parts.push(value);
+  }
+  const joined = new TextDecoder().decode(
+    Uint8Array.from(parts.flatMap((p) => [...p])),
+  );
+  assert.equal(joined, text, "no byte may be lost or duplicated by the chunking");
+});

--- a/src/praisonai-mobile/ui/src/format.test.ts
+++ b/src/praisonai-mobile/ui/src/format.test.ts
@@ -198,3 +198,13 @@ test("formatElapsed switches format AT the boundary, not one past it", () => {
   assert.equal(formatElapsed(3600), "1h 00m", "sixty minutes is an hour, not 60m 00s");
   assert.equal(formatElapsed(7260), "2h 01m");
 });
+
+test("formatRelative's just-now threshold is 45 seconds exactly", () => {
+  // `seconds < 45` -> `< 44` survived. The threshold is the whole contract of
+  // the function, and no test placed a value on it. `format-intl.ts` has the
+  // same boundary and is pinned separately -- the two must not drift.
+  const now = 1_700_000_000_000;
+  assert.match(formatRelative(now - 44_000, now), /just now/i, "44s is still just now");
+  assert.doesNotMatch(formatRelative(now - 45_000, now), /just now/i, "45s is not");
+  assert.doesNotMatch(formatRelative(now - 46_000, now), /just now/i);
+});

--- a/src/praisonai-mobile/ui/src/i18n/bundle.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/bundle.test.ts
@@ -113,3 +113,13 @@ test("the report reads as a sentence a human can act on", () => {
   assert.ok(describeBundle(createBundle("de", {})).includes("missing"));
   assert.equal(markMissing("Stopped"), "⟦Stopped⟧");
 });
+
+test("a half-bracketed string is not a marked-missing one", () => {
+  // `&&` -> `||` in isMarked survived: "⟦x" and "x⟧" both report as marked.
+  // A translator's literal bracket then reads as a missing key, and the report
+  // names strings that are present.
+  assert.equal(isMarked(`${"⟦"}missing${"⟧"}`), true);
+  assert.equal(isMarked(`${"⟦"}half`), false, "an opening bracket alone is not a mark");
+  assert.equal(isMarked(`half${"⟧"}`), false, "nor is a closing one");
+  assert.equal(isMarked("plain"), false);
+});

--- a/src/praisonai-mobile/ui/src/i18n/segment.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/segment.test.ts
@@ -118,3 +118,21 @@ test("the fallback splitter recombines to exactly the input", () => {
     assert.equal(fallbackSentences(text).join(""), text, `lost characters in ${JSON.stringify(text)}`);
   }
 });
+
+test("a one-character sentence is complete", () => {
+  // `end === 0` -> `end === 1` survived: a chunk whose only character is a
+  // terminator reports incomplete, so `completedLength` returns 0 and the
+  // screen-reader announcement stalls. CJK writes short sentences and "。" is
+  // a whole one; so is "." after a trimmed fragment.
+  for (const one of [".", "!", "?", "。", "！", "？"]) {
+    assert.equal(endsSentence(one), true, `${one} is a complete sentence`);
+  }
+  assert.equal(completedLength("en", "。"), 1, "a single terminator is one complete character");
+});
+
+test("a chunk with no terminator is still incomplete", () => {
+  // The pair. Reporting everything complete announces half-sentences as they
+  // stream, which is the stutter announce.ts exists to prevent.
+  assert.equal(endsSentence("still typing"), false);
+  assert.equal(endsSentence(""), false);
+});

--- a/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
+++ b/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
@@ -526,3 +526,22 @@ test("Copy is not offered for a turn with nothing in it", () => {
   const answered = run(start, delta("something"));
   assert.equal(buildTranscript(answered).actions.copy, true);
 });
+
+test("a multi-line tool output previews as ONE line", () => {
+  // Dropping `firstLine(...)` survived: the preview keeps its newlines and a
+  // one-line row renders as several, breaking the transcript's layout for
+  // every `ls`, every stack trace, every file read.
+  const turn = run(
+    start,
+    { type: "tool_call", msgId: M, callId: "c1", name: "ls", args: {} },
+    {
+      type: "tool_result", msgId: M, callId: "c1", name: "ls", ok: true,
+      output: "total 3\n-rw-r--r-- a.txt\n-rw-r--r-- b.txt", seconds: 0.1,
+    },
+  );
+  const row = buildTranscript(turn).rows.find((r) => r.kind === "tool");
+  assert.ok(row && row.kind === "tool");
+  assert.equal(row.preview.includes("\n"), false, `the preview spans lines: ${JSON.stringify(row.preview)}`);
+  assert.equal(row.preview, "total 3");
+  assert.match(row.output, /b\.txt/, "the full output is still carried for the expanded view");
+});


### PR DESCRIPTION
The remainder of the package-wide sweep's genuine survivors.

| mutation | what shipped |
|---|---|
| `truncate(firstLine(output), …)` → `truncate(output, …)` | the tool preview keeps its newlines, so a one-line row renders as several. Every `ls`, every stack trace, every file read breaks the transcript's layout |
| `decode.ts` — drop `\|\| type === ""` | survived **my own earlier test**, which asserted only that the frame was *refused*. It still is — but as `unknown_event` with an empty detail instead of `missing_type` with the key list. The dropped-events row then blames the engine for sending something unrecognised when what arrived had no type at all |
| `bundle.ts` — `isMarked` `&&` → `\|\|` | `"⟦half"` and `"half⟧"` both report as marked-missing, so a translator's literal bracket reads as a missing key and the report names strings that are present |
| `segment.ts` — `end === 0` → `end === 1` | a chunk whose only character is a terminator reports incomplete, so `completedLength` returns 0 and the screen-reader announcement **stalls**. CJK writes short sentences; a lone `。` is a whole one |
| `format.ts` `< 45` → `< 44`, `session.ts` `<= 60` → `< 60` | threshold and boundary, each the entire contract of its function, and neither had a value placed on it. `format-intl.ts` has the same 45s boundary pinned separately — the two must not drift |

## And the fifth fake

`testing/src/fake-http.ts` had **no test file**. Two of its behaviours are load-bearing for every engine test written against it:

**The route table picks the longest matching suffix**, so `/chats` doesn't shadow `/chat`. Inverting it silently mis-routes a test to the wrong handler and the test still passes — against the wrong thing. I was bitten by this file's suffix matching once already this session, when a handler registered for `/approve` never matched `/approve/{id}` and a test went green without exercising what it was written for.

**`streamOf` chunks its body deliberately**, *"because a frame split across chunks is the normal case on a real network"*. Emitting an extra zero-length chunk changes what the SSE reader is exercised with — and that reader's pending-CR logic is precisely sensitive to where boundaries fall. A fake that stops splitting properly can mask the CRLF defect this package shipped once already.

That's the **fifth** fake here to get its own tests after being caught misrepresenting what it stands in for — after `setTimer`'s delay, `every`'s period, `advance`'s amount, and the fake DOM that appended instead of ordering.

`1121 tests` on node 22.23 **and** 24.12 · eight mutations confirmed to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of chat title truncation at the 60-character boundary.
  * Clarified handling of incomplete and unrecognized message events.
  * Ensured sentence detection correctly handles one-character and unterminated messages.
  * Improved recognition of fully marked translation strings.
  * Multi-line tool output previews now display cleanly on a single line while retaining full details when expanded.

* **Tests**
  * Expanded coverage for networking, streaming, formatting, localization, and transcript display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->