### PR TITLE
fix(mobile): the boundary gate had no test, and I had already broken it

### DIFF
--- a/src/praisonai-mobile/core/src/ports/shell.test.ts
+++ b/src/praisonai-mobile/core/src/ports/shell.test.ts
@@ -1,0 +1,35 @@
+/**
+ * The scheme allowlist, tested where it is defined.
+ *
+ * Both shells delegate to `isOpenableExternally` before handing a URL to the
+ * OS, and the shared shell contract asserts each adapter refuses what it
+ * refuses. Nothing tested the guard itself at its own boundary -- dropping the
+ * `^` from its regex survived, so any string CONTAINING a permitted scheme
+ * anywhere passed.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isOpenableExternally } from "./shell.ts";
+
+test("a scheme is only trusted at the START of the URL", () => {
+  // Dropping the `^` from the scheme regex survived. Any string CONTAINING a
+  // permitted scheme anywhere then passes: `/redirect?to=https://evil.example`
+  // returns true, and so does `./rel?x=mailto:a@b`.
+  //
+  // This is the guard the whole file exists for -- both shells delegate to it
+  // before handing a URL to the OS -- and a relative URL that smuggles an
+  // allowed scheme in its query string is exactly the shape it must refuse.
+  assert.equal(isOpenableExternally("/redirect?to=https://evil.example"), false);
+  assert.equal(isOpenableExternally("./rel?x=mailto:a@b"), false);
+  assert.equal(isOpenableExternally("//evil.example/https:"), false);
+  assert.equal(isOpenableExternally("javascript:alert(1)#https:"), false);
+  assert.equal(isOpenableExternally("  https://ok.example  "), true, "leading space is trimmed, not a bypass");
+});
+
+test("the refusal is about position, not about the word", () => {
+  // The pair: a guard that refused anything containing "https" anywhere would
+  // pass the test above and break every real link.
+  assert.equal(isOpenableExternally("https://ok.example/path?next=https://other"), true);
+  assert.equal(isOpenableExternally("mailto:a@b?subject=https://x"), true);
+});

--- a/src/praisonai-mobile/tools/check-boundaries.mjs
+++ b/src/praisonai-mobile/tools/check-boundaries.mjs
@@ -14,18 +14,49 @@ import { dirname, join, relative, sep } from "node:path";
 import { importsOf, sourceFilesUnder, ungovernedRootsIn, violations } from "./depgraph.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const root = join(here, "..");
+// The package root, or one given on the command line. Injectable so the CLI
+// itself can be tested: it had no test of any kind, and a mutation sweep found
+// two independent ways to turn the whole gate into a no-op with a green build.
+const root = process.argv[2] ?? join(here, "..");
 const config = JSON.parse(readFileSync(join(here, "boundaries.json"), "utf8"));
 
 const norm = (p) => p.split(sep).join("/");
 
+/** Top-level directories holding source that neither `governedRoots` nor
+ *  `ungovernedRoots` accounts for.
+ *
+ *  Restored: this check was silently deleted when `sourceFiles` was extracted
+ *  into depgraph.mjs -- the import survived and the CALL did not, so for six
+ *  commits a new top-level directory could import across every seam and the
+ *  checker said nothing. Precisely the defect it was written to prevent,
+ *  reintroduced by the refactor that was meant to make it testable. Nothing
+ *  noticed, because the CLI had no test; the test below is what found it. */
+const ungoverned = ungovernedRootsIn(root, config);
+if (ungoverned.length > 0) {
+  for (const { name, count } of ungoverned) {
+    console.error(
+      `boundaries: [ungoverned-root] ${name}/ holds ${count} source file(s) that no layer rule covers.\n` +
+        `    Add "${name}" to governedRoots in tools/boundaries.json (with a matching entry in\n` +
+        `    "layers"), or to ungovernedRoots if it is deliberately exempt.`,
+    );
+  }
+  console.error(`\nboundaries: ${ungoverned.length} ungoverned top-level director(y|ies)`);
+  process.exit(1);
+}
+
 const files = sourceFilesUnder(root, config.governedRoots);
 
 if (files.length === 0) {
-  // Not a pass. A checker that reports success over an empty set is the exact
-  // failure this package's tests are written to prevent, so say so out loud.
-  console.log("boundaries: no source files under the governed roots yet — nothing checked");
-  process.exit(0);
+  // NOT a pass, and now the exit code agrees with the sentence.
+  //
+  // This branch used to print "nothing checked" and exit 0. The comment said
+  // "Not a pass" and the exit code said otherwise, which is the same defect
+  // the rest of this file exists to catch -- and it made the whole gate
+  // switchable off by a single character: `files.length === 0` -> `>= 0`
+  // takes this branch every time, so the checker reports success having looked
+  // at nothing at all, and `npm run check` stays green.
+  console.error("boundaries: no source files under the governed roots — nothing was checked");
+  process.exit(1);
 }
 
 const found = violations(await importsOf(files, root), config);

--- a/src/praisonai-mobile/tools/check-boundaries.test.mjs
+++ b/src/praisonai-mobile/tools/check-boundaries.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * The gate itself, run as a process.
+ *
+ * `check-boundaries.mjs` had no test of any kind, and it is the mechanism every
+ * layering claim in this package rests on. A mutation sweep found TWO
+ * independent ways to turn it into a complete no-op with `npm run check` still
+ * green:
+ *
+ *   `files.length === 0` -> `>= 0`   takes the "nothing to check" branch every
+ *                                    time, so it reports success having looked
+ *                                    at nothing;
+ *   `process.exit(1)`    -> `exit(0)` prints every violation it found and then
+ *                                    passes anyway.
+ *
+ * depgraph.test.mjs covers the RULE thoroughly. Nothing covered the CLI that
+ * runs it, decides what to walk, and turns the answer into an exit code -- and
+ * an exit code is the only part CI actually reads.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function tree(spec) {
+  const root = mkdtempSync(join(tmpdir(), "gate-"));
+  for (const [path, body] of Object.entries(spec)) {
+    const full = join(root, path);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, body);
+  }
+  // The checker reads its config from beside itself, so the fixture only needs
+  // the source tree.
+  return root;
+}
+
+function runGate(root) {
+  const run = spawnSync(process.execPath, [join(here, "check-boundaries.mjs"), root], {
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  return { status: run.status, output: `${run.stdout ?? ""}${run.stderr ?? ""}` };
+}
+
+test("a clean tree passes", () => {
+  const root = tree({
+    "core/src/a.ts": 'import { b } from "../../protocol/src/b.ts";\nexport const a = b;',
+    "protocol/src/b.ts": "export const b = 1;",
+  });
+  try {
+    const { status, output } = runGate(root);
+    assert.equal(status, 0, `a clean tree failed:\n${output}`);
+    assert.match(output, /no violations/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a real violation exits NON-ZERO, which is the only part CI reads", () => {
+  // `process.exit(1)` -> `exit(0)` prints the violation and passes anyway. The
+  // message is not the gate; the exit code is.
+  const root = tree({
+    "core/src/leak.ts": 'import { invoke } from "@tauri-apps/api/core";\nexport const x = invoke;',
+  });
+  try {
+    const { status, output } = runGate(root);
+    assert.notEqual(status, 0, `a violation exited 0:\n${output}`);
+    assert.match(output, /violation/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("finding NOTHING to check is a failure, not a pass", () => {
+  // The comment on this branch always said "Not a pass"; the exit code said
+  // otherwise. That disagreement is what made the gate switchable off by one
+  // character -- `files.length === 0` -> `>= 0` takes this branch every time.
+  const root = tree({ "docs/readme.md": "no source here" });
+  try {
+    const { status, output } = runGate(root);
+    assert.notEqual(status, 0, `an empty governed set reported success:\n${output}`);
+    assert.match(output, /nothing was checked/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("an ungoverned top-level directory holding source is a failure", () => {
+  // The other half of the same rule, already covered as a library function --
+  // this asserts the CLI turns it into a non-zero exit.
+  const root = tree({
+    "core/src/a.ts": "export const a = 1;",
+    "features/src/sneaky.ts": "export const x = 1;",
+  });
+  try {
+    const { status, output } = runGate(root);
+    assert.notEqual(status, 0, `an ungoverned directory passed:\n${output}`);
+    assert.match(output, /ungoverned/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a violation inside a .mjs file exits non-zero too", () => {
+  // tools/ is entirely .mjs. Dropping the extension from the walk made the
+  // checker skip all of it and still print a clean pass.
+  const root = tree({
+    "core/src/a.ts": "export const a = 1;",
+    "core/src/leak.mjs": 'import { invoke } from "@tauri-apps/api/core";\nexport const x = invoke;',
+  });
+  try {
+    const { status, output } = runGate(root);
+    assert.notEqual(status, 0, `a .mjs violation passed:\n${output}`);
+    assert.match(output, /leak\.mjs/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
An eighth package-wide sweep put **`tools/` at 46.7%** genuine survival — the weakest layer in the package, and the one holding the gate every layering claim depends on. `check-boundaries.mjs` had **no test of any kind**.

Two independent one-character edits turned the whole gate into a no-op with `npm run check` still green:

| mutation | result |
|---|---|
| `files.length === 0` → `>= 0` | takes the "nothing to check" branch every time — reports success having looked at **nothing at all** |
| `process.exit(1)` → `exit(0)` | prints every violation it found and **passes anyway** |

`depgraph.test.mjs` covers the *rule* thoroughly. Nothing covered the CLI that decides what to walk and turns the answer into an exit code — and the exit code is the only part CI reads.

## And the test immediately found a regression of mine

**The ungoverned-root check was gone.** Not mutated — *gone*, from `main`, since the commit where I extracted `sourceFiles` into `depgraph.mjs` to make it testable. The import survived and the call did not: my slice ran from the function's doc comment to its call site, and the ungoverned block sat between them.

So for six commits, a new top-level directory could import across both seams and the checker said nothing — exactly the defect that check was written to prevent, reintroduced by the refactor meant to make it testable, in a file with no test. It's restored, and the fourth test in the new file is what caught it.

The empty-set branch now **exits 1**. Its comment always said *"Not a pass"*; the exit code said otherwise, and that disagreement is what made the gate switchable off by one character. The root is injectable now (`node check-boundaries.mjs [root]`), which is what lets the CLI be driven against fixture trees at all.

## The scheme guard was only tested through its callers

`isOpenableExternally` had no test at its own boundary. Dropping the `^` from its regex **survived**: any string *containing* a permitted scheme anywhere then passes, so `/redirect?to=https://evil.example` and `./rel?x=mailto:a@b` both return `true`. Both shells delegate to this before handing a URL to the OS.

Pinned in both directions — a guard that refused anything containing `"https"` anywhere would pass the new cases and break every real link, so `https://ok.example/path?next=https://other` must still be allowed.

`1128 tests` on node 22.23 **and** 24.12 · four mutations confirmed to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external-link validation so only properly positioned, permitted URL schemes are accepted.
  * Leading whitespace and misleading scheme placements are handled safely.

* **Chores**
  * Strengthened project boundary checks to detect ungoverned source areas and empty validation targets.
  * Boundary validation now supports checking specified project roots and reports failures consistently.

* **Tests**
  * Added coverage for URL safety and boundary-validation scenarios, including violations in module files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->