### PR TITLE
fix(mobile): a Stop that could never match, and a link that opened nothing

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -1165,3 +1165,64 @@ test("the contracts can PASS: an unbroken fixture is green", () => {
   const { status, output } = runAdapterFixture("none");
   assert.equal(status, 0, `an unbroken fixture failed:\n${output}`);
 });
+
+test("the tauri bridge opens links in a NEW context, with the opener severed", () => {
+  // Three independent survivors in one line of webOpen:
+  //   drop `open(url)` but keep `return true` -- reports success having opened
+  //     nothing, so tapping a link does nothing and the app believes it worked;
+  //   `"_blank"` -> `"_self"` -- the link REPLACES the running app;
+  //   `"noopener,noreferrer"` -> `""` -- the opened page keeps a live
+  //     `window.opener` back into the app, and the referrer leaks.
+  const opened: { url: string; target: string; features: string }[] = [];
+  const scope = {
+    open(url: string, target: string, features: string) {
+      opened.push({ url, target, features });
+      return null;
+    },
+  };
+  const bridge = createTauriBridge({ scope });
+
+  return bridge.openExternal("https://ok.example").then((result) => {
+    assert.equal(opened.length, 1, "openExternal must actually open something");
+    assert.equal(opened[0]?.url, "https://ok.example");
+    assert.equal(opened[0]?.target, "_blank", "a link must not replace the running app");
+    assert.match(opened[0]?.features ?? "", /noopener/, "the opener must be severed");
+    assert.match(opened[0]?.features ?? "", /noreferrer/);
+    assert.equal(result, true);
+  });
+});
+
+test("openExternal reports FAILURE when there is nothing to open with", () => {
+  // The pair. Returning true unconditionally is the defect above; returning
+  // false unconditionally would make every real link look broken.
+  const bridge = createTauriBridge({ scope: {} });
+  return bridge.openExternal("https://ok.example").then((result) => {
+    assert.equal(result, false);
+  });
+});
+
+test("the web storage adapter namespaces its keys", () => {
+  // `PREFIX = "praisonai."` -> `""` survived. Keys become `chats.c1` on the
+  // shared origin: they collide with anything else stored there, and every
+  // existing install's data becomes unreachable at the new key. The port
+  // contract cannot see this -- it only checks read-back through the same
+  // adapter, which is self-consistent either way.
+  const written = new Map<string, string>();
+  const backing = {
+    getItem: (k: string) => written.get(k) ?? null,
+    setItem: (k: string, v: string) => void written.set(k, v),
+    removeItem: (k: string) => void written.delete(k),
+    key: (i: number) => [...written.keys()][i] ?? null,
+    clear: () => written.clear(),
+    get length() { return written.size; },
+  } as unknown as Storage;
+
+  return createWebStorage(backing)
+    .write({ namespace: "chats", id: "c1" }, "body")
+    .then(() => {
+      const keys = [...written.keys()];
+      assert.equal(keys.length, 1);
+      assert.match(keys[0] ?? "", /^praisonai\./, `the key was not namespaced: ${keys[0]}`);
+      assert.match(keys[0] ?? "", /chats/);
+    });
+});

--- a/src/praisonai-mobile/core/src/run/transcript.test.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.test.ts
@@ -458,3 +458,46 @@ test("text after a tool call keeps the tool card between the two paragraphs", ()
   );
   assert.equal(s.text, "Let me check. There is one file.");
 });
+
+test("a tool_result keeps the arguments its tool_call recorded", () => {
+  // `args: existing === -1 ? {} : (state.tools[existing]?.args ?? {})` -> `{}`
+  // survived: the result WIPES the arguments the call recorded. The transcript
+  // can then no longer say what a completed tool actually ran -- and the args
+  // are what an approval row shows the user before they allow it.
+  let s = initialTurn;
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  s = apply(s, {
+    type: "tool_call", msgId: "m1", callId: "c1", name: "sh", args: { command: "rm -rf /tmp/x" },
+  });
+  assert.deepEqual(s.tools[0]?.args, { command: "rm -rf /tmp/x" }, "recorded while running");
+
+  s = apply(s, {
+    type: "tool_result", msgId: "m1", callId: "c1", name: "sh", ok: true, output: "done", seconds: 0.1,
+  });
+  assert.deepEqual(
+    s.tools[0]?.args,
+    { command: "rm -rf /tmp/x" },
+    "a finished tool must still say what it ran",
+  );
+});
+
+test("a tool_result with no matching call records empty args rather than inventing them", () => {
+  // The pair: the `existing === -1` branch is the one that must yield {}.
+  let s = initialTurn;
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  s = apply(s, {
+    type: "tool_result", msgId: "m1", callId: "orphan", name: "sh", ok: true, output: "x", seconds: 0.1,
+  });
+  assert.deepEqual(s.tools[0]?.args, {});
+});
+
+test("reasoning accumulates across chunks", () => {
+  // `reasoning: state.reasoning + event.text` -> `event.text` survived: only
+  // the LAST chunk is ever shown, so a model's visible thinking is truncated
+  // to its final fragment.
+  let s = initialTurn;
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  s = apply(s, { type: "reasoning", msgId: "m1", text: "First I will " });
+  s = apply(s, { type: "reasoning", msgId: "m1", text: "read the file." });
+  assert.equal(s.reasoning, "First I will read the file.");
+});

--- a/src/praisonai-mobile/core/src/settings/store.test.ts
+++ b/src/praisonai-mobile/core/src/settings/store.test.ts
@@ -342,3 +342,22 @@ test("a REFUSED write does not mark the key as chosen", () => {
     assert.equal(store.isSet("temperature"), false);
   });
 });
+
+test("a subscriber that unsubscribes another during notify does not silence it", () => {
+  // `for (const cb of [...subscribers])` -> `for (const cb of subscribers)`
+  // survived: notify iterates the LIVE set, so removing an entry mid-iteration
+  // skips the next one. A settings screen tearing down one row while another
+  // is still mounted silently drops the second row's update.
+  const { store } = build();
+  const fired: string[] = [];
+  let stopB = (): void => {};
+  store.subscribe(() => {
+    fired.push("A");
+    stopB();
+  });
+  stopB = store.subscribe(() => void fired.push("B"));
+
+  return store.set("model", "gpt-4o").then(() => {
+    assert.deepEqual(fired, ["A", "B"], "B was skipped because the set was mutated while iterating");
+  });
+});

--- a/src/praisonai-mobile/engines/src/praisonai-ts/classify.test.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/classify.test.ts
@@ -74,3 +74,13 @@ test("a 4xx is not transport, so Retry is not offered where it cannot help", () 
   assert.notEqual(classifyError({ status: 400 } as never), "transport");
   assert.notEqual(classifyError({ status: 422 } as never), "transport");
 });
+
+test("a 403 is an auth failure even when its message says nothing useful", () => {
+  // Dropping `status === 403` survived because the message-matching branch
+  // catches anything that literally contains "403" or "forbidden". A provider
+  // returning `{status: 403, message: "nope"}` then classifies as `internal`,
+  // and the user gets no route to their credentials -- which is the whole
+  // reason ErrorKind separates auth from everything else.
+  assert.equal(classifyError({ status: 403, message: "nope" } as never), "auth");
+  assert.equal(classifyError({ status: 401, message: "nope" } as never), "auth");
+});

--- a/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
@@ -392,3 +392,70 @@ test("the SSE event name decides the type, not a field inside the payload", asyn
   assert.ok(delta, `the delta was lost: ${events.map((e) => e.type).join(", ")}`);
   assert.equal(delta.type === "delta" ? delta.text : null, "kept");
 });
+
+test("the request carries the RUN id and the CHAT id in their own fields", () => {
+  // `run_id: request.runId` -> `request.chatId` survived. `POST /cancel/{runId}`
+  // could then never match a live run, so Stop is permanently dead against the
+  // remote engine -- which keeps generating and keeps billing -- and the two
+  // ids are the same shape, so nothing about the payload looks wrong.
+  const http = createFakeHttp();
+  http.on("/chat", () => sseResponse(""));
+  const engine = createRemoteHttpEngine({ baseUrl: "http://engine.test", http });
+
+  return (async () => {
+    for await (const _ of engine.run(
+      { prompt: "hi", chatId: "chat-42", runId: "run-7", tools: true, regenerateOf: null, attachments: [] },
+      new AbortController().signal,
+    )) {
+      // drain
+    }
+    const body = JSON.parse(String(http.sent.find((r) => r.url.includes("/chat"))?.body ?? "{}"));
+    assert.equal(body.run_id, "run-7", "the run id must be the run id");
+    assert.equal(body.chat_id, "chat-42", "and the chat id must be the chat id");
+  })();
+});
+
+test("the stream request advertises that it wants SSE", () => {
+  // Dropping `accept: "text/event-stream"` survived. A conforming proxy or
+  // engine is then free to answer with something else entirely, and the
+  // failure surfaces as an unparseable stream rather than as a bad request.
+  const http = createFakeHttp();
+  http.on("/chat", () => sseResponse(""));
+  const engine = createRemoteHttpEngine({ baseUrl: "http://engine.test", http });
+
+  return (async () => {
+    for await (const _ of engine.run(
+      { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+      new AbortController().signal,
+    )) {
+      // drain
+    }
+    const sent = http.sent.find((r) => r.url.includes("/chat"));
+    assert.equal(sent?.headers["accept"], "text/event-stream");
+  })();
+});
+
+test("a base URL with several trailing slashes still builds one clean path", () => {
+  // `/\/+$/` -> `/\/$/` survived: `http://host//` becomes `http://host//chat`,
+  // which 404s. A user pasting an address with a stray slash gets an engine
+  // that cannot be reached, and nothing says why.
+  for (const base of ["http://engine.test", "http://engine.test/", "http://engine.test//", "http://engine.test///"]) {
+    const http = createFakeHttp();
+    http.on("/chat", () => sseResponse(""));
+    const engine = createRemoteHttpEngine({ baseUrl: base, http });
+    void engine;
+    // The URL is built when the run starts; assert on what was sent.
+  }
+  const http = createFakeHttp();
+  http.on("/chat", () => sseResponse(""));
+  const engine = createRemoteHttpEngine({ baseUrl: "http://engine.test///", http });
+  return (async () => {
+    for await (const _ of engine.run(
+      { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+      new AbortController().signal,
+    )) {
+      // drain
+    }
+    assert.equal(http.sent[0]?.url, "http://engine.test/chat");
+  })();
+});


### PR DESCRIPTION
Eleven more survivors from the eighth package-wide sweep, all user-facing.

| mutation | what shipped |
|---|---|
| `remote-http` — `run_id: request.runId` → `request.chatId` | `POST /cancel/{runId}` can never match a live run, so **Stop is permanently dead** against the remote engine — which keeps generating and keeps billing. Both ids are the same shape, so nothing about the payload looks wrong |
| `tauri/bridge` — drop `open(url)`, keep `return true` | **reports success having opened nothing**: a link does nothing and the app believes it worked |
| `tauri/bridge` — `"_blank"` → `"_self"` | the link **replaces the running app** |
| `tauri/bridge` — `"noopener,noreferrer"` → `""` | the opened page keeps a live `window.opener` back into the app, and the referrer leaks |
| `transcript` — `tool_result` wiping its `tool_call`'s args | a finished tool can no longer say **what it ran** — and args are what an approval row shows the user before they allow it |
| `transcript` — reasoning assigned, not accumulated | only the last chunk is ever shown; visible thinking truncates to its final fragment |
| `web/storage` — `PREFIX = "praisonai."` → `""` | keys become `chats.c1` on a shared origin: they collide with anything else there, and **every existing install's data becomes unreachable**. The port contract can't see this — it reads back through the same adapter, self-consistent either way |
| `settings` — notify iterating the **live** subscriber set | a subscriber that unsubscribes another mid-notify makes the second never fire. A settings screen tearing down one row silently drops another's update |
| `classify` — `status === 403` dropped | the message branch only catches text literally containing "403"/"forbidden", so `{status: 403, message: "nope"}` becomes `internal` and the user gets **no route to their credentials** |
| `remote-http` — accept header, and `/\/+$/` → `/\/$/` | the stream stops advertising SSE; an address with two trailing slashes builds `//chat`, which 404s with nothing explaining why |

Each is paired where a one-sided assertion would have been satisfiable by the opposite defect — `openExternal` must report **false** when there's nothing to open with, and an orphan `tool_result` *should* yield `{}`.

`1139 tests` on node 22.23 **and** 24.12 · eleven mutations confirmed to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for external-link handling, including secure window-opening behavior and unavailable browser windows.
  * Verified namespaced web storage keys.
  * Added transcript coverage for preserving tool arguments and accumulating reasoning.
  * Confirmed settings notifications remain reliable during unsubscription.
  * Added authentication error classification and remote HTTP request-handling coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->