### PR TITLE
fix(desktop): the Windows version gate rejected a correctly stamped binary

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -140,13 +140,32 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           $expected = $env:RELEASE_TAG -replace '^v', ''
-          $numeric = ($expected -split '[-+]')[0] + '.0'
-          $version = (Get-Item "target/${{ matrix.target }}/release/praisonai-desktop.exe").VersionInfo
+          $core = ($expected -split '[-+]')[0]
+          $exe = "target/${{ matrix.target }}/release/praisonai-desktop.exe"
+          $version = (Get-Item $exe).VersionInfo
+          Write-Host "ProductVersion=$($version.ProductVersion) FileVersion=$($version.FileVersion)"
+
           if ($version.ProductVersion -ne $expected) {
             throw "ProductVersion $($version.ProductVersion) does not match $expected"
           }
-          if ($version.FileVersion -ne $numeric) {
-            throw "FileVersion $($version.FileVersion) does not match $numeric"
+
+          # Compare the three components that carry meaning, not the string.
+          #
+          # This gate blocked the v4.7.4 Windows build with
+          #   FileVersion 4.7.4 does not match 4.7.4.0
+          # It appended ".0" and compared literally, but Windows reports what
+          # was stamped -- three parts here. The stamping was correct and the
+          # check was not, so the release shipped with no Windows installer at
+          # all: the one platform it was cut to fix.
+          #
+          # [version] normalises a missing fourth component to -1, so both
+          # "4.7.4" and "4.7.4.0" compare equal on major.minor.build.
+          $got = [version]$version.FileVersion
+          $want = [version]$core
+          if ($got.Major -ne $want.Major -or
+              $got.Minor -ne $want.Minor -or
+              $got.Build -ne $want.Build) {
+            throw "FileVersion $($version.FileVersion) does not match $core"
           }
 
       - name: The macOS bundle must carry a valid signature

--- a/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
+++ b/src/praisonai-desktop/frontend/tests/release-workflow.test.mjs
@@ -63,8 +63,17 @@ test('the Windows release fails if its embedded version drifts', () => {
   assert.match(gate, /FileVersion/, 'the release does not verify FileVersion');
   assert.match(gate, /\$version\.ProductVersion\s+-ne\s+\$expected/,
                'ProductVersion is not compared with the release version');
-  assert.match(gate, /\$version\.FileVersion\s+-ne\s+\$numeric/,
-               'FileVersion is not compared with the numeric release version');
+  // FileVersion is compared by component, not as a string.
+  //
+  // This assertion used to require `$version.FileVersion -ne $numeric`, where
+  // $numeric was the tag plus a literal ".0" -- so it pinned the very bug that
+  // blocked the v4.7.4 Windows build: a binary correctly stamped 4.7.4 was
+  // rejected for not reading "4.7.4.0". A test that requires the broken
+  // comparison stops anyone fixing it, which is worse than no test.
+  assert.match(gate, /\[version\]\$version\.FileVersion|\$got\s*=\s*\[version\]/,
+               'FileVersion is not parsed as a version before comparison');
+  assert.ok(!/\+\s*'\.0'/.test(gate),
+            'the gate still appends ".0" and compares the string literally');
   assert.ok(start > workflow.indexOf('cargo tauri build'), 'the binary is checked before it exists');
   assert.ok(start < workflow.indexOf('gh release upload'), 'the binary is checked after upload');
 });
@@ -301,4 +310,26 @@ test('the macOS overlay does not drop the bundle configuration', () => {
     assert.ok(overlay.bundle.macOS?.signingIdentity,
               'the overlay defines bundle but omits signingIdentity, which replaces it away');
   }
+});
+
+test('the Windows version gate compares components, not the literal string', () => {
+  // It appended ".0" and compared literally, so a binary correctly stamped
+  // 4.7.4 was rejected against "4.7.4.0" and the v4.7.4 release shipped with
+  // no Windows installer -- the one platform it was cut to fix. The stamping
+  // was right; the check was not.
+  const runnable = workflow
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+  const gate = runnable.slice(runnable.indexOf('must carry the release version'),
+                              runnable.indexOf('must carry a valid signature'));
+  assert.ok(gate, 'the Windows version gate is gone');
+  assert.ok(!/\+ '\.0'/.test(gate),
+            'the gate still appends ".0" and compares the string literally');
+  assert.match(gate, /\$got\.Major|\[version\]/,
+               'the gate does not compare version components');
+  // The half that was always right must stay: a binary stamped 0.1.0 is the
+  // bug this gate exists for.
+  assert.match(gate, /ProductVersion/,
+               'the gate no longer checks ProductVersion');
 });


### PR DESCRIPTION
**v4.7.4 shipped with no Windows installer.** The release was cut specifically to
deliver the Windows fixes, and the Windows leg is the one that failed:

```
FileVersion 4.7.4 does not match 4.7.4.0
```

## The stamping was right; the check was not

`ProductVersion` read `4.7.4` — that is #4527 fixed and working. The gate then
appended a literal `".0"` to the tag and compared strings, so a binary carrying
exactly the version it was asked to carry was rejected for not spelling it with
a fourth component.

```powershell
$numeric = ($expected -split '[-+]')[0] + '.0'   # "4.7.4.0"
if ($version.FileVersion -ne $numeric) { throw }  # actual: "4.7.4"
```

## The fix

Parse both sides and compare major, minor and build. `[version]` normalises a
missing fourth component to `-1`, so `4.7.4` and `4.7.4.0` agree on the parts
that mean anything.

Six cases checked:

| FileVersion | vs tag | result |
|---|---|---|
| `4.7.4` | 4.7.4 | pass |
| `4.7.4.0` | 4.7.4 | pass |
| `4.7.4.123` | 4.7.4 | pass |
| `4.7.3` | 4.7.4 | **fail** |
| `4.8.4` | 4.7.4 | **fail** |
| `0.1.0` | 4.7.4 | **fail** ← the original defect |

## The test was pinning the bug

The existing test asserted `$version.FileVersion -ne $numeric` **literally**, so
it required the broken comparison. Anyone fixing the gate would have failed the
suite. A test that mandates the wrong behaviour is worse than no test — it turns
a one-line fix into an argument.

It now asserts the comparison parses versions and that the `.0` concatenation is
gone.

## Verification

189 UI tests green. Three mutations, three caught, including restoring the string
comparison.

**Honest limit:** pwsh is not installed on this machine, so the comparison was
checked against a model of .NET `[version]` semantics rather than PowerShell
itself. The Windows CI leg is the real proof.

## After this merges

v4.7.4 has 3 of 4 assets. The Windows installer can be produced by dispatching
**Desktop release** with `tag: v4.7.4` — the app code at the tag and on `main`
is unchanged by this PR, which only touches the workflow, so the binary will
match what the tag describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows release validation to correctly accept three-part file versions, such as `4.7.4`.
  * Release checks now compare version components instead of relying on exact text formatting.
  * Added clearer version information during validation, including product and file versions.

* **Tests**
  * Expanded automated coverage for Windows version validation and prevention of formatting-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->