### PR TITLE
fix(mobile): the wrong tool card, live buttons on a finished run, and gates that could be widened

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -1147,7 +1147,7 @@ test("a contract cannot quietly shrink", () => {
   assert.ok(casesFor("secrets") >= 9, `the secrets contract shrank to ${casesFor("secrets")} cases`);
   assert.ok(casesFor("storage") >= 11, `the storage contract shrank to ${casesFor("storage")} cases`);
   assert.ok(casesFor("time") >= 8, `the time contract shrank to ${casesFor("time")} cases`);
-  assert.ok(casesFor("shell") >= 36, `the shell contract shrank to ${casesFor("shell")} cases`);
+  assert.ok(casesFor("shell") >= 37, `the shell contract shrank to ${casesFor("shell")} cases`);
 
   // The break table needs a floor of its own. Deleting a row from
   // ADAPTER_BREAKS, or lowering a count above, removes a defence and the only
@@ -1164,6 +1164,41 @@ test("the contracts can PASS: an unbroken fixture is green", () => {
   // case above while proving nothing at all.
   const { status, output } = runAdapterFixture("none");
   assert.equal(status, 0, `an unbroken fixture failed:\n${output}`);
+});
+
+test("the tauri bridge subscribes to events for ANY target", () => {
+  // Nothing asserted the arguments handed to `internals.invoke`, so the
+  // `listen` payload's `target: { kind: "Any" }` could be changed to
+  // `{ kind: "Window" }` -- or removed entirely -- and stay green. On a device
+  // that is "the app stops receiving safe-area, keyboard, lifecycle and back
+  // events", with no error anywhere.
+  //
+  // The previous hardening covered `openExternal`'s call site and missed this
+  // one: same file, same commit, a different invoke.
+  const calls: { command: string; args: Record<string, unknown> }[] = [];
+  const internals = {
+    invoke: (command: string, args: Record<string, unknown>) => {
+      calls.push({ command, args });
+      return Promise.resolve(1);
+    },
+    transformCallback: (cb: unknown) => {
+      void cb;
+      return 7;
+    },
+  };
+  const bridge = createTauriBridge({ scope: { __TAURI_INTERNALS__: internals } } as never);
+
+  return bridge.listen("safe-area-changed", () => {}).then(() => {
+    const listen = calls.find((c) => c.command === "plugin:event|listen");
+    assert.ok(listen, "no listen call was made");
+    assert.deepEqual(
+      listen.args["target"],
+      { kind: "Any" },
+      "an event subscription scoped to one window misses the events the app needs",
+    );
+    assert.equal(listen.args["event"], "safe-area-changed");
+    assert.equal(listen.args["handler"], 7, "the transformed callback id must be forwarded");
+  });
 });
 
 test("the tauri bridge opens links in a NEW context, with the opener severed", () => {

--- a/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
@@ -515,4 +515,30 @@ export function describeShellContract(
     assert.equal(shell.insets.top, 0, "and the other edges must follow the same event");
   });
 
+  test(`${name}: unsubscribing TWICE does not remove a bystander`, async () => {
+    // Dropping the `if (at !== -1)` guard before `splice(at, 1)` survived. A
+    // double unsubscribe -- a re-render, React StrictMode double-invoking an
+    // effect -- splices at index -1, which removes the LAST element: another
+    // screen's back handler silently disappears.
+    //
+    // The second call must be a no-op, not a removal of whatever happens to be
+    // at the end of the stack.
+    const { shell, pressBack } = await make();
+    const order: string[] = [];
+    const stopA = shell.onBackGesture(() => {
+      order.push("A");
+      return false;
+    });
+    shell.onBackGesture(() => {
+      order.push("B");
+      return false;
+    });
+
+    stopA();
+    stopA(); // the double unsubscribe
+
+    pressBack();
+    assert.deepEqual(order, ["B"], "the bystander handler was removed by a repeated unsubscribe");
+  });
+
 }

--- a/src/praisonai-mobile/core/src/run/controller.test.ts
+++ b/src/praisonai-mobile/core/src/run/controller.test.ts
@@ -1206,3 +1206,46 @@ test("a stream that dies on its OWN is still a transport error", async () => {
     "a genuine network failure must still offer retry",
   );
 });
+
+test("an accepted stop DETACHES the reader, so nothing more paints", async () => {
+  // `run.abort.abort()` deleted after a successful cancel survived. Stop
+  // reports success, the reader is never detached, and the stream keeps
+  // arriving and painting into a turn the user stopped -- so the answer goes
+  // on growing after the button said it had stopped.
+  const views: RunView[] = [];
+  let releaseNext: () => void = () => {};
+  const engine = {
+    id: "s",
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {
+      streaming: true, reasoning: false, tools: true,
+      approvals: false, cancellation: true, attachments: false,
+    },
+    async *run(req: { runId: string }, signal: AbortSignal) {
+      yield { type: "start", msgId: "m1", runId: req.runId };
+      yield { type: "delta", msgId: "m1", text: "before stop" };
+      await new Promise<void>((resolve) => { releaseNext = resolve; });
+      // A well-behaved engine checks; the point of the abort is that a
+      // less careful one is stopped anyway by the reader detaching.
+      if (signal.aborted) return;
+      yield { type: "delta", msgId: "m1", text: " AFTER STOP" };
+    },
+    async decide() { return false; },
+    async cancel() { return true; },
+    async dispose() {},
+  } as unknown as Parameters<typeof createRunController>[0]["engine"];
+
+  const controller = createRunController({ engine, time: createFakeTime(), onPublish: (v) => views.push(v) });
+  const sent = controller.send("go");
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+
+  assert.equal(await controller.stop(), true);
+  releaseNext();
+  await sent;
+
+  assert.equal(
+    views.at(-1)?.turn.text.includes("AFTER STOP"),
+    false,
+    "text arrived after the user stopped the run",
+  );
+});

--- a/src/praisonai-mobile/core/src/run/transcript.test.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.test.ts
@@ -501,3 +501,29 @@ test("reasoning accumulates across chunks", () => {
   s = apply(s, { type: "reasoning", msgId: "m1", text: "read the file." });
   assert.equal(s.reasoning, "First I will read the file.");
 });
+
+test("a tool_result is matched by callId, never by tool NAME", () => {
+  // `findIndex((t) => t.callId === event.callId)` -> `t.name === event.name`
+  // survived. With two concurrent calls to the same tool -- which is ordinary
+  // for `bash` or `read` -- the result for the second overwrites the FIRST
+  // one's row and appends a duplicate. The wrong card shows the other call's
+  // output, and one call is stuck "running" forever.
+  //
+  // Same class as the index-pairing defect the whole callId design exists to
+  // prevent, one layer down.
+  let s = initialTurn;
+  s = apply(s, { type: "start", msgId: "m1", runId: "r1" });
+  s = apply(s, { type: "tool_call", msgId: "m1", callId: "c1", name: "bash", args: { cmd: "one" } });
+  s = apply(s, { type: "tool_call", msgId: "m1", callId: "c2", name: "bash", args: { cmd: "two" } });
+  s = apply(s, {
+    type: "tool_result", msgId: "m1", callId: "c2", name: "bash", ok: false, output: "boom", seconds: 0.1,
+  });
+
+  assert.equal(s.tools.length, 2, "resolving one call must not add a third row");
+  const first = s.tools.find((t) => t.callId === "c1");
+  const second = s.tools.find((t) => t.callId === "c2");
+  assert.equal(first?.status, "running", "the unresolved call must stay unresolved");
+  assert.deepEqual(first?.args, { cmd: "one" }, "and keep its own arguments");
+  assert.equal(second?.status, "failed", "the resolved call takes the result");
+  assert.equal(second?.output, "boom");
+});

--- a/src/praisonai-mobile/tools/build-webview.mjs
+++ b/src/praisonai-mobile/tools/build-webview.mjs
@@ -7,7 +7,7 @@
  */
 import { mkdir, copyFile, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { bundle } from "./bundle.mjs";
+import { bundle, isShippable } from "./bundle.mjs";
 
 const here = dirname(new URL(import.meta.url).pathname);
 const pkg = resolve(here, "..");
@@ -35,7 +35,7 @@ for (const problem of report.problems) {
 }
 console.log(`bundle: ${(report.bytes / 1024).toFixed(1)}kB of a 400kB budget, ${report.bare.length} external`);
 
-if (report.problems.length > 0) {
+if (!isShippable(report)) {
   console.error("\nThe webview bundle is not shippable. See above.");
   process.exit(1);
 }

--- a/src/praisonai-mobile/tools/bundle.mjs
+++ b/src/praisonai-mobile/tools/bundle.mjs
@@ -187,3 +187,19 @@ if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop()
   console.log(`bundle: ${(report.bytes / 1024).toFixed(1)}kB, ${report.bare.length} external`);
   if (report.problems.length > 0) process.exit(1);
 }
+
+/**
+ * Whether a bundle report may ship.
+ *
+ * Exported so a test calls THIS rather than re-implementing the comparison --
+ * `problems.length > 0` -> `> 1` survived a mutation sweep, and a test that
+ * rewrote the predicate inline would have proved only that a predicate of that
+ * shape works, not that this file still contains it. That distinction is the
+ * one this package keeps being bitten by.
+ *
+ * ONE problem is enough. A bare external, a forbidden builtin, or a top-level
+ * process.env read each make the bundle unshippable on its own.
+ */
+export function isShippable(report) {
+  return report.problems.length === 0;
+}

--- a/src/praisonai-mobile/tools/bundle.test.mjs
+++ b/src/praisonai-mobile/tools/bundle.test.mjs
@@ -20,8 +20,7 @@ import {
   unresolvedBareImports,
   classifyBareImports,
   FORBIDDEN_BUILTINS,
-  SIZE_BUDGET_BYTES,
-} from "./bundle.mjs";
+  SIZE_BUDGET_BYTES, isShippable } from "./bundle.mjs";
 
 /** Write a throwaway package and bundle it. */
 async function fixture(files) {
@@ -227,4 +226,18 @@ test("classifyBareImports labels each kind", () => {
   assert.equal(found.get("crypto"), "static");
   assert.equal(found.get("readline"), "dynamic");
   assert.equal(found.has("./local.js"), false);
+});
+
+test("a single fatal problem makes a bundle unshippable", () => {
+  // `problems.length > 0` -> `> 1` in build-webview.mjs survived: ONE fatal
+  // problem -- a bare external, a forbidden builtin, a top-level process.env
+  // read -- no longer failed the build. It took two to be noticed, and the
+  // whole point of the gate is that one is enough.
+  //
+  // This calls the REAL predicate. Re-implementing the comparison inline would
+  // prove only that a predicate of that shape works, not that the CLI still
+  // contains it -- which is the distinction this package keeps being bitten by.
+  assert.equal(isShippable({ problems: [] }), true, "a clean bundle ships");
+  assert.equal(isShippable({ problems: ["one fatal problem"] }), false, "one problem is enough");
+  assert.equal(isShippable({ problems: ["a", "b"] }), false);
 });

--- a/src/praisonai-mobile/tools/depgraph.test.mjs
+++ b/src/praisonai-mobile/tools/depgraph.test.mjs
@@ -24,6 +24,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
+import { SIZE_BUDGET_BYTES, TARGETS } from "./bundle.mjs";
 import { importsOf, layerOf, targetOf, matchesAllowlist, ungovernedRootsIn, violations, sourceFilesUnder } from "./depgraph.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -323,4 +324,35 @@ test("the walk collects .mjs files as well as .ts", () => {
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("an ungoverned directory holding only .mjs is still reported", () => {
+  // The file-count walk inside `ungovernedRootsIn` had its own `.mjs` test,
+  // separate from the one in `sourceFilesUnder`. Dropping it makes a new
+  // all-.mjs top-level directory report ZERO files, so it is not flagged and
+  // passes ungoverned -- verbatim the failure boundaries.json's comment warns
+  // about, and `tools/` itself is entirely .mjs.
+  const root = tree({
+    "core/src/a.ts": "export const a = 1;",
+    "scripts/build.mjs": "export const b = 1;",
+  });
+  try {
+    assert.deepEqual(
+      ungovernedRootsIn(root, { governedRoots: ["core"], ungovernedRoots: [] }),
+      [{ name: "scripts", count: 1 }],
+      "an all-.mjs directory must be counted, not skipped",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the size budget and the webview targets are the values the gate claims", () => {
+  // `SIZE_BUDGET_BYTES` and `TARGETS` are the entire contract of the bundle
+  // gate, and both could be changed silently -- 400kB to 4MB, or the baseline
+  // moved from safari16/chrome108 to a browser no target device runs. A gate
+  // whose threshold can be edited without a failing test is a gate that can be
+  // turned off.
+  assert.equal(SIZE_BUDGET_BYTES, 400 * 1024, "the budget is what makes a dependency a decision");
+  assert.deepEqual(TARGETS, ["safari16", "chrome108"], "the WebView floor is the OS, not the current Chrome");
 });

--- a/src/praisonai-mobile/ui/src/render/reconcile.test.ts
+++ b/src/praisonai-mobile/ui/src/render/reconcile.test.ts
@@ -190,3 +190,45 @@ test("an unchanged error row still produces nothing", () => {
   const first = reconcile(emptyRender, [row]);
   assert.deepEqual(reconcile(first.next, [row]).ops, []);
 });
+
+test("an approval row repaints when it stops being actionable", () => {
+  // `signatureOf` dropping `row.actionable` survived. When a turn ends with an
+  // unanswered approval, `settle()` marks it resolved: `actionable` flips
+  // true -> false while `state.status` stays "pending". With actionable out of
+  // the signature nothing changes, so NO update op is emitted and the three
+  // buttons stay painted as live on a finished run.
+  //
+  // The user then taps Allow on a run that can no longer deliver it.
+  const base = {
+    kind: "approval" as const,
+    id: "approval:a1",
+    approvalId: "a1",
+    callId: "c1",
+    name: "bash",
+    args: {},
+    state: { status: "pending" as const },
+  };
+  const first = reconcile(emptyRender, [{ ...base, actionable: true }]);
+  const second = reconcile(first.next, [{ ...base, actionable: false }]);
+
+  assert.deepEqual(
+    second.ops.map((o) => o.kind),
+    ["update"],
+    "a row that stopped being actionable must repaint",
+  );
+});
+
+test("an unchanged approval row still produces nothing", () => {
+  const row = {
+    kind: "approval" as const,
+    id: "approval:a1",
+    approvalId: "a1",
+    callId: "c1",
+    name: "bash",
+    args: {},
+    state: { status: "pending" as const },
+    actionable: true,
+  };
+  const first = reconcile(emptyRender, [row]);
+  assert.deepEqual(reconcile(first.next, [row]).ops, []);
+});

--- a/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
+++ b/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
@@ -551,7 +551,11 @@ test("an empty text block never becomes a message bubble", () => {
   // exactly what the file's own comment forbids -- it "makes a failure look
   // like a short answer". A turn whose text block was closed by a tool call
   // before any delta arrived renders one.
+  // `decode` rejects an empty delta, but `apply` is a public reducer and does
+  // not -- so an engine adapter that does not go through decode can produce
+  // exactly this state.
   let turn = run(start);
+  turn = apply(turn, { type: "delta", msgId: M, text: "" });
   turn = apply(turn, { type: "tool_call", msgId: M, callId: "c1", name: "bash", args: {} });
   turn = apply(turn, { type: "delta", msgId: M, text: "after the tool" });
 

--- a/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
+++ b/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
@@ -545,3 +545,20 @@ test("a multi-line tool output previews as ONE line", () => {
   assert.equal(row.preview, "total 3");
   assert.match(row.output, /b\.txt/, "the full output is still carried for the expanded view");
 });
+
+test("an empty text block never becomes a message bubble", () => {
+  // `if (block.text === "") continue;` removed survived. An empty bubble is
+  // exactly what the file's own comment forbids -- it "makes a failure look
+  // like a short answer". A turn whose text block was closed by a tool call
+  // before any delta arrived renders one.
+  let turn = run(start);
+  turn = apply(turn, { type: "tool_call", msgId: M, callId: "c1", name: "bash", args: {} });
+  turn = apply(turn, { type: "delta", msgId: M, text: "after the tool" });
+
+  const textRows = buildTranscript(turn).rows.filter((r) => r.kind === "text");
+  assert.equal(
+    textRows.some((r) => r.kind === "text" && r.text === ""),
+    false,
+    `an empty bubble was rendered: ${JSON.stringify(textRows.map((r) => r.kind === "text" && r.text))}`,
+  );
+});


### PR DESCRIPTION
A fourth package-wide sweep put genuine survival at **17.0%** (48/282), against 26.3% → 23.8% → 18.5% before it.

**Honest reading: the fall has essentially stopped.** Binomial SE is 2.24pp and the previous 18.5% sits inside this run's 95% interval, so 17.0 and 18.5 are indistinguishable. The drop from 26.3 is real; the last step is not. Two caveats push the true figure *worse*, not better — the sample deliberately avoided just-hardened lines, and every ambiguous equivalence call was resolved in the codebase's favour.

**13 of 14 spot-checks of previously-closed items still die**, so those held.

## The new Tier 1

| mutation | what shipped |
|---|---|
| `transcript.ts` — `findIndex(t => t.callId === …)` → `t.name === event.name` | two concurrent calls to the same tool — ordinary for `bash` — and the second's result **overwrites the first's row** and appends a duplicate. The wrong card shows the other call's output; one call is stuck "running" forever. The index-pairing defect the whole `callId` design exists to prevent, one layer down |
| `reconcile.ts` — approval signature dropping `actionable` | when a turn ends with an unanswered approval, `settle()` flips `actionable` true→false while `state.status` stays `"pending"`. Nothing repaints, so the three buttons stay **live on a finished run** |
| `controller.ts` — `run.abort.abort()` deleted after a successful cancel | Stop reports success, the reader is never detached, and the stream **keeps painting into a turn the user stopped** |
| `view-model.ts` — the empty-text-block guard | renders an empty message bubble — what the file's comment forbids, because it "makes a failure look like a short answer" |
| `web/shell.ts` — `if (at !== -1)` before `splice(at, 1)` | a **double unsubscribe** splices at −1 and removes the last element: another screen's back handler silently disappears |
| `tauri/bridge` — the `listen` payload's `target: { kind: "Any" }` | on a device: *the app stops receiving safe-area, keyboard, lifecycle and back events*, silently. **My earlier hardening covered `openExternal`'s call site and missed this one** — same file, same commit, a different invoke |

## The gates

`tools/` is still the weakest layer (33.3%), and it's where a survivor switches off a **gate** rather than breaking a feature: the size budget could go 400kB → 4MB, the WebView baseline could move off the floor, `ungovernedRootsIn` could stop counting `.mjs` (so a new all-`.mjs` directory passes ungoverned), and `build-webview`'s `problems.length > 0` → `> 1` lets **one** fatal problem ship.

The shippability predicate moved into `bundle.mjs` and is now **called** by the test rather than re-implemented in it — re-implementing would prove a predicate of that shape works, not that the CLI still contains it. That's the exact weakness this package found in its own conformance meta-tests.

## And a flaw in my own verification

While checking these I found `npm run check` can report **`fail 0` while three tests did not pass** — node counts them as `cancelled`, not `fail`. I'd been grepping `^ℹ fail`, so two of these nine *looked* like survivors when the run had actually exited 1.

The reliable signal is the **exit code**, and every result above is measured that way. That cuts against me twice: some earlier "survivor" readings this session may have been false, and a harness that reads the wrong counter is the same defect class as everything it was hunting.

`1161 tests` on node 22.23 **and** 24.12 · nine mutations confirmed caught **by exit code**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when stopping runs, handling concurrent tool calls, unsubscribing back-gesture handlers, and subscribing to event targets.
  - Approval controls now update correctly when their actionable state changes.
  - Prevented empty transcript bubbles from appearing after tool calls.

- **Tests**
  - Expanded coverage for event handling, navigation, transcript updates, bundle validation, size limits, and ungoverned files.
  - Added checks to ensure only valid, shippable bundles are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->