### PR TITLE
fix(mobile): a contract case could still exist and assert nothing

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
@@ -79,6 +79,9 @@ function storage(): StoragePort {
   return {
     async read(ref) {
       const found = files.get(key(ref));
+      // The defect: `||` instead of `??`, so a deliberately-blank value reads
+      // back as "not configured" on every read.
+      if (mode === "storage_empty_is_absent" && found === "") return null;
       if (found !== undefined) return found;
       return mode === "storage_missing_is_undefined" ? (undefined as never) : null;
     },
@@ -130,6 +133,12 @@ function time(): TimePort {
       };
     },
     every(ms, cb) {
+      if (mode === "time_unsubscribe_does_nothing") {
+        // The defect: the interval leaks for the app's lifetime, and nothing
+        // the caller does can stop it.
+        const handle = setInterval(cb, ms);
+        return () => {};
+      }
       if (mode === "time_every_fires_once") {
         // The defect: every polling loop in the app fires once and stops.
         const handle = setTimeout(cb, ms);
@@ -163,7 +172,12 @@ function shellHarness(): ShellHarness {
 
   const shell = {
     ...real,
-    get insets() { return real.insets; },
+    get insets() {
+      // The defect: a negative inset reaching the layout, which lifts content
+      // off the wrong edge.
+      if (mode === "shell_negative_insets") return { top: -5, right: 0, bottom: -5, left: 0 };
+      return real.insets;
+    },
     get keyboardHeightPx() { return real.keyboardHeightPx; },
     onInsetsChanged: real.onInsetsChanged.bind(real),
     onKeyboardHeightChanged: real.onKeyboardHeightChanged.bind(real),
@@ -172,6 +186,12 @@ function shellHarness(): ShellHarness {
     share: real.share.bind(real),
 
     async openExternal(url: string): Promise<void> {
+      // The defect: a case-SENSITIVE allowlist. `JAVASCRIPT:` then slips past
+      // a guard that refuses `javascript:`, which is the oldest trick there is.
+      if (mode === "shell_scheme_case_sensitive" && /^[A-Z]/.test(url.trim())) {
+        window.window.open(url, "_blank", "noopener,noreferrer");
+        return;
+      }
       // The defect: opening whatever it is handed. `javascript:`, `data:` and
       // `file:` all reach the OS.
       if (mode === "shell_opens_anything") {

--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -1101,6 +1101,14 @@ const ADAPTER_BREAKS: readonly { readonly mode: string; readonly expects: RegExp
   { mode: "shell_opens_anything", expects: /a javascript: URL is refused/ },
   { mode: "shell_back_in_registration_order", expects: /the most recently registered back handler gets first refusal/ },
   { mode: "shell_listener_count_stuck", expects: /unsubscribing drops the live listener count/ },
+  // The count floor catches a DELETED case; it cannot catch a case that still
+  // exists and asserts nothing. A sweep found seven assertions that could be
+  // hollowed out with a green build. One break mode per hollowable case is
+  // what closes that, because a mode reddens the case BY NAME.
+  { mode: "storage_empty_is_absent", expects: /an empty string is a value, not an absence/ },
+  { mode: "time_unsubscribe_does_nothing", expects: /the unsubscribe actually stops it/ },
+  { mode: "shell_scheme_case_sensitive", expects: /an uppercase JAVASCRIPT: URL is refused/ },
+  { mode: "shell_negative_insets", expects: /no inset is negative/ },
 ];
 
 for (const { mode, expects } of ADAPTER_BREAKS) {
@@ -1153,7 +1161,7 @@ test("a contract cannot quietly shrink", () => {
   // ADAPTER_BREAKS, or lowering a count above, removes a defence and the only
   // signal is a smaller number that nothing reads. Guarding the guard.
   assert.ok(
-    ADAPTER_BREAKS.length >= 9,
+    ADAPTER_BREAKS.length >= 13,
     `the break table shrank to ${ADAPTER_BREAKS.length} modes`,
   );
 });

--- a/src/praisonai-mobile/engines/src/conformance.test.ts
+++ b/src/praisonai-mobile/engines/src/conformance.test.ts
@@ -209,6 +209,7 @@ function runFixture(mode: string): { status: number | null; output: string } {
 const BREAKS: readonly { readonly mode: string; readonly expects: RegExp }[] = [
   { mode: "no_start", expects: /a run emits start first and exactly one terminal event last/ },
   { mode: "start_only", expects: /a run emits start first and exactly one terminal event last/ },
+  { mode: "abort_ignored", expects: /aborting the signal stops the stream/ },
   { mode: "tool_failure_as_ok", expects: /a failed tool is reported failed and never inferred from its output/ },
   { mode: "empty_is_fine", expects: /an empty stream is an error, not an empty answer/ },
   { mode: "decide_always_true", expects: /deciding an unknown approval returns false rather than reporting success/ },

--- a/src/praisonai-mobile/engines/src/conformance.ts
+++ b/src/praisonai-mobile/engines/src/conformance.ts
@@ -296,6 +296,16 @@ export function describeEngineContract(harness: EngineHarness): void {
       seen.push(event);
       if (seen.length === 1) controller.abort();
     }
+    // Asserted against the FULL script rather than an arbitrary ceiling. The
+    // bound here used to be `seen.length < 50`, and every scenario is five
+    // events or fewer -- so an engine that ignored the signal entirely and ran
+    // to completion satisfied it. A cap only larger than any real run cannot
+    // tell stopping from finishing.
+    const whole = await drive(await harness.create("happy"));
+    assert.ok(
+      seen.length < whole.events.length,
+      `aborting after the first event must stop the stream: saw ${seen.length} of ${whole.events.length}`,
+    );
     // The engine must stop rather than run to completion. Exactly how it
     // terminates is its business; that it stops is the contract.
     assert.ok(seen.length < 50, `abort did not stop the stream: ${seen.length} events`);

--- a/src/praisonai-mobile/engines/src/contract-fixture.ts
+++ b/src/praisonai-mobile/engines/src/contract-fixture.ts
@@ -29,7 +29,8 @@ export type BreakMode =
   | "start_only"
   | "tool_failure_as_ok"
   | "empty_is_fine"
-  | "decide_always_true";
+  | "decide_always_true"
+  | "abort_ignored";
 
 const M = "m1";
 const mode = (process.argv[2] ?? "none") as BreakMode;
@@ -76,7 +77,12 @@ function engineFor(scenario: ScenarioName): AgentEnginePort {
     },
     async *run(_req, signal) {
       for (const event of script) {
-        if (signal.aborted) return;
+        // THE BREAK for abort_ignored: the signal is never consulted, so a
+        // cancelled run streams to completion. The contract's own case for
+        // this asserted only `seen.length < 50`, and the happy script is five
+        // events -- so simply ENDING satisfied it. A break mode is what makes
+        // that case mean something.
+        if (mode !== "abort_ignored" && signal.aborted) return;
         yield event;
       }
     },


### PR DESCRIPTION
The structural finding of the fourth sweep, and the one that keeps recurring in this package: **the meta-defence catches a deleted case and not a hollowed one.** Seven assertions inside the conformance suites could be replaced with nothing and the build stayed green.

The count floors added earlier assert how many cases *run*. A case that still runs and asserts nothing passes them, and no break mode covered these seven. That's the same shape as the original defect — a check reporting success over work it didn't do — one level further in.

## Five new break modes, each reddening its case by name

| mode | the defect it plants |
|---|---|
| `storage_empty_is_absent` | an empty string read back as absent — `\|\|` where the code must use `??`. It turns a deliberately-blank setting back into its default on every read |
| `time_unsubscribe_does_nothing` | the interval leaks for the app's lifetime and nothing the caller does can stop it |
| `shell_scheme_case_sensitive` | `JAVASCRIPT:` slips past a guard that refuses `javascript:` — the oldest trick there is |
| `shell_negative_insets` | a negative inset reaching the layout, lifting content off the wrong edge |
| `abort_ignored` | a run that never consults its signal |

## And the abort case could not have caught its own defect

*"aborting the signal stops the stream"* asserted `seen.length < 50`. **Every scenario in the suite is five events or fewer**, so an engine that ignored the signal entirely and ran to completion *satisfied* it — the case could only fail for an engine emitting fifty events, which none does.

It now compares against the length of the full script. A cap larger than any real run cannot tell stopping from finishing, and that's what an arbitrary ceiling always is.

## Verified

By attempting the hollowing that worked before — gutting the empty-string, unsubscribe, uppercase-scheme and negative-inset cases to assert nothing, widening the inset bound to `-100`, and making the abort ceiling vacuous again. **All six now exit non-zero.**

`1166 tests` on node 22.23 **and** 24.12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded adapter and engine conformance coverage for storage, timers, shell behavior, URL scheme validation, and stream cancellation.
  * Improved cancellation verification by comparing aborted streams with a complete run.
  * Added targeted scenarios to ensure contract violations are detected reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->