### PR TITLE
fix(mobile): Deny recorded as allow, and three buttons that all said allow

### DIFF
--- a/src/praisonai-mobile/app/src/dom.test.ts
+++ b/src/praisonai-mobile/app/src/dom.test.ts
@@ -341,3 +341,45 @@ test("an unchanged list touches the DOM zero times", () => {
   assert.deepEqual(second.ops, [], "a settled list must emit no ops");
   assert.deepEqual(domOrder(host), ids);
 });
+
+test("each approval button carries its OWN choice", () => {
+  // `b.dataset["choice"] = choice` -> `= "allow"` survived: all three buttons
+  // send `allow`, so Deny becomes Allow at the DOM. Every layer above this is
+  // careful to route a decision by approvalId; the last hop decides WHAT the
+  // decision is, and nothing read it.
+  const { host } = fakeDoc();
+  applyOps(host, emptyNodes(), [
+    {
+      kind: "insert",
+      id: "approval:a1",
+      index: 0,
+      row: {
+        kind: "approval",
+        id: "approval:a1",
+        approvalId: "a1",
+        callId: "c1",
+        name: "rm",
+        args: { path: "/" },
+        state: { status: "pending" },
+        actionable: true,
+      } as never,
+    },
+  ]);
+
+  const buttons: any[] = [];
+  const walk = (node: any): void => {
+    if (String(node.tagName).toUpperCase() === "BUTTON" && node.dataset.choice !== undefined) buttons.push(node);
+    for (const child of node.children) walk(child);
+  };
+  walk(host);
+
+  assert.equal(buttons.length, 3, `expected three choices, got ${buttons.length}`);
+  assert.deepEqual(
+    buttons.map((b: any) => b.dataset.choice).sort(),
+    ["allow", "always", "deny"],
+    "the three buttons must offer three different decisions",
+  );
+  for (const b of buttons) {
+    assert.equal(b.dataset.approvalId, "a1", "and each must address its own approval");
+  }
+});

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -40,7 +40,7 @@ import { createFakeDom } from "../../testing/src/fake-dom.ts";
 import { createFakeShell, PHONE_INSETS } from "../../testing/src/fake-shell.ts";
 import { createFakeStorage } from "../../testing/src/fake-storage.ts";
 import { createFakeSecrets } from "../../testing/src/fake-secrets.ts";
-import { createFakeHttp, sseResponse } from "../../testing/src/fake-http.ts";
+import { createFakeHttp, sseResponse, streamOf } from "../../testing/src/fake-http.ts";
 import { mount } from "./main.ts";
 import type { Platform } from "./platform.ts";
 
@@ -552,5 +552,41 @@ test("the Send button's LABEL and its action agree", async () => {
   const live = button();
   assert.equal(live?.dataset["action"], "stop");
   assert.equal(live?.textContent, en.actionStop, "a streaming turn must READ Stop, not just behave as Stop");
+  app?.dispose();
+});
+
+test("an approval row shows the decision after the user answers it", async () => {
+  // `buildTranscript(view.turn, view.approvals)` -> dropping the second
+  // argument survived. The approval TABLE is where the decision lifecycle
+  // lives; without it the row is built from the turn alone and stays `pending`
+  // forever, so the user taps Deny and the card never acknowledges it.
+  const { dom, http, platform } = harness();
+  http.on("/approve/a1", () => ({ status: 200, headers: {}, body: streamOf(JSON.stringify({ ok: true })) }));
+  http.on("/chat", () =>
+    held([
+      ["start", { msg_id: "m1", run_id: "r1" }],
+      ["tool_call", { msg_id: "m1", call_id: "c1", name: "rm", args: { path: "/" } }],
+      ["approval_request", { msg_id: "m1", approval_id: "a1", call_id: "c1", name: "rm", args: { path: "/" } }],
+    ]),
+  );
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  submit(dom, "do it");
+  await settle(120);
+
+  const row = () => dom.find((n) => n.className.includes("row-approval"));
+  assert.ok(row(), "the approval row should be on screen");
+  assert.equal(row()?.dataset["state"], "pending");
+
+  const deny = dom.find((n) => n.dataset["choice"] === "deny");
+  assert.ok(deny, "no Deny button");
+  dom.click(deny);
+  await settle(120);
+
+  assert.notEqual(
+    row()?.dataset["state"],
+    "pending",
+    "the row must acknowledge the decision, not stay pending forever",
+  );
   app?.dispose();
 });

--- a/src/praisonai-mobile/app/src/registry.test.ts
+++ b/src/praisonai-mobile/app/src/registry.test.ts
@@ -216,3 +216,26 @@ test("a clean stream through the same engine reports no refusal", async () => {
   }
   assert.deepEqual(refused, []);
 });
+
+test("every setting's default satisfies its own validator", () => {
+  // `default: 0.7` -> `default: 7` survived. `validate` runs on `set` and on
+  // `load` -- never on the shipped default -- so an out-of-range default is
+  // used verbatim on a fresh install and nothing anywhere complains.
+  //
+  // Asserted for every def rather than the one that was broken, because the
+  // next one to drift will be a different key.
+  for (const def of SETTING_DEFS) {
+    if (def.validate === undefined) continue;
+    const validated = def.validate(def.default);
+    assert.notEqual(
+      validated,
+      null,
+      `${def.key}: the shipped default ${JSON.stringify(def.default)} is refused by its own validator`,
+    );
+    assert.deepEqual(
+      validated,
+      def.default,
+      `${def.key}: the shipped default is changed by its own validator, so it is out of range`,
+    );
+  }
+});

--- a/src/praisonai-mobile/core/src/run/approvals.test.ts
+++ b/src/praisonai-mobile/core/src/run/approvals.test.ts
@@ -205,3 +205,23 @@ test("acknowledge still promotes a decision that IS in flight", () => {
   table = choose(table, "ap1", "allow");
   assert.equal(find(acknowledge(table, "ap1"), "ap1")?.state.status, "sent");
 });
+
+test("acknowledging records the choice the user actually made", () => {
+  // `choice: entry.state.choice` -> `choice: "allow"` survived. An
+  // acknowledged DENY is then recorded as an allow: the row the user reads
+  // back says they permitted the thing they refused, and `outstanding` and the
+  // audit trail agree with it.
+  for (const choice of ["allow", "always", "deny"] as const) {
+    let table = add(emptyApprovals, { approvalId: "ap1", callId: "c1", name: "rm", args: {} });
+    table = choose(table, "ap1", choice);
+    table = acknowledge(table, "ap1");
+
+    const state = find(table, "ap1")?.state;
+    assert.equal(state?.status, "sent");
+    assert.equal(
+      state?.status === "sent" ? state.choice : null,
+      choice,
+      `an acknowledged ${choice} must be recorded as ${choice}`,
+    );
+  }
+});

--- a/src/praisonai-mobile/core/src/settings/store.test.ts
+++ b/src/praisonai-mobile/core/src/settings/store.test.ts
@@ -361,3 +361,34 @@ test("a subscriber that unsubscribes another during notify does not silence it",
     assert.deepEqual(fired, ["A", "B"], "B was skipped because the set was mutated while iterating");
   });
 });
+
+test("persist() writes through plainOnly, so no secret can reach storage", () => {
+  // `plainOnly(values, byKey)` -> `Object.fromEntries(values)` survived.
+  // `plainOnly` is the ONLY thing keeping API keys out of localStorage, and
+  // deleting the call was invisible: every existing test either never put a
+  // secret in the map, or checked the guard function directly rather than the
+  // write that uses it.
+  //
+  // This asserts on what the StoragePort actually received, with a secret
+  // forced into the map the way a future write path might.
+  const { storage, secrets, store } = build();
+  return (async () => {
+    await store.setSecret({ slot: "openai", account: "default" }, "sk-live-must-not-leak");
+    await store.set("model", "gpt-4o");
+
+    // And the harder case: a secret sitting in the values map, which `set`
+    // refuses to create but `load` or a future caller could.
+    await storage.write(
+      { namespace: "settings", id: "app" },
+      JSON.stringify({ model: "gpt-4o", apiKey: "sk-also-must-not-leak" }),
+    );
+    const reloaded = createSettingsStore(DEFS, storage, secrets);
+    await reloaded.load();
+    await reloaded.set("model", "gpt-4o-mini");
+
+    const written = (await storage.read({ namespace: "settings", id: "app" })) ?? "";
+    assert.equal(written.includes("sk-live-must-not-leak"), false, "a stored secret reached plain storage");
+    assert.equal(written.includes("sk-also-must-not-leak"), false, "an adopted secret reached plain storage");
+    assert.match(written, /gpt-4o-mini/, "and ordinary settings are still persisted");
+  })();
+});

--- a/src/praisonai-mobile/core/src/settings/store.test.ts
+++ b/src/praisonai-mobile/core/src/settings/store.test.ts
@@ -362,33 +362,35 @@ test("a subscriber that unsubscribes another during notify does not silence it",
   });
 });
 
-test("persist() writes through plainOnly, so no secret can reach storage", () => {
-  // `plainOnly(values, byKey)` -> `Object.fromEntries(values)` survived.
-  // `plainOnly` is the ONLY thing keeping API keys out of localStorage, and
-  // deleting the call was invisible: every existing test either never put a
-  // secret in the map, or checked the guard function directly rather than the
-  // write that uses it.
+test("no public route can put a secret into the persisted file", () => {
+  // A sweep reported `plainOnly(values, byKey)` -> `Object.fromEntries(values)`
+  // as "every secret is written to plain storage". Checked: it is NOT. No
+  // public route can get a secret into the values map -- `set` refuses a
+  // secret-flagged key and `load` drops one -- so the two forms are equivalent
+  // through the public API, and the mutation survives this test too.
   //
-  // This asserts on what the StoragePort actually received, with a secret
-  // forced into the map the way a future write path might.
+  // `plainOnly` is defence in depth for the day a new write path forgets the
+  // rule, which is why it is tested directly rather than through here. This
+  // test asserts the OTHER half: that no route currently exists. If one is
+  // ever added, this fails before the guard has to catch it.
   const { storage, secrets, store } = build();
   return (async () => {
+    assert.equal(await store.set("apiKey", "sk-refused"), false, "set must refuse a secret key");
     await store.setSecret({ slot: "openai", account: "default" }, "sk-live-must-not-leak");
     await store.set("model", "gpt-4o");
 
-    // And the harder case: a secret sitting in the values map, which `set`
-    // refuses to create but `load` or a future caller could.
     await storage.write(
       { namespace: "settings", id: "app" },
-      JSON.stringify({ model: "gpt-4o", apiKey: "sk-also-must-not-leak" }),
+      JSON.stringify({ model: "gpt-4o", apiKey: "sk-from-disk" }),
     );
     const reloaded = createSettingsStore(DEFS, storage, secrets);
     await reloaded.load();
+    assert.notEqual(reloaded.get("apiKey"), "sk-from-disk", "load must not adopt a secret from disk");
     await reloaded.set("model", "gpt-4o-mini");
 
     const written = (await storage.read({ namespace: "settings", id: "app" })) ?? "";
-    assert.equal(written.includes("sk-live-must-not-leak"), false, "a stored secret reached plain storage");
-    assert.equal(written.includes("sk-also-must-not-leak"), false, "an adopted secret reached plain storage");
-    assert.match(written, /gpt-4o-mini/, "and ordinary settings are still persisted");
+    assert.equal(written.includes("sk-live-must-not-leak"), false);
+    assert.equal(written.includes("sk-from-disk"), false);
+    assert.match(written, /gpt-4o-mini/, "ordinary settings are still persisted");
   })();
 });


### PR DESCRIPTION
A fifth package-wide sweep put genuine survival at **36.1%**, against 17.0% before it — and the rise is unambiguous (z = 4.77). **Nothing regressed**: the baseline is byte-identical and 25 of 27 previously-closed items still die.

## The reason is worse than a regression would have been

The sweep reconstructed every prior mutation list — **3,063 records, 1,000 distinct anchors** — and found that **125 of its first 153 mutations landed on lines a prior sweep had already mutated**, 51 of them byte-identical repeats. Four sweeps had touched 835 of 7,542 lines, and those 835 are essentially the whole branchy, killable surface.

So it rebuilt the sample: 0 repeats, 104 mutations on lines never anchored before. That is what moved the number.

> **"The suite was never at 17%; the sample was."**

The declining trend I'd been reporting — 26.3 → 23.8 → 18.5 → 17.0 — was substantially re-measuring ground already hardened. The drop was real *for the ground it covered* and did not generalise, and I reported it as though it did.

## What the fresh ground found

| mutation | what shipped |
|---|---|
| `approvals.ts` — `choice: entry.state.choice` → `"allow"` | an acknowledged **Deny is recorded as an Allow**. The row the user reads back says they permitted the thing they refused |
| `dom.ts` — `b.dataset["choice"] = choice` → `"allow"` | **all three buttons send `allow`**. Every layer above is careful to route a decision by `approvalId`; the last hop decides *what* the decision is, and nothing read it |
| `main.ts` — `buildTranscript(view.turn, view.approvals)` → one argument | the approval **table** carries the decision lifecycle. Without it the row is built from the turn alone and stays `pending` forever — the user taps Deny and the card never acknowledges it |
| `registry.ts` — `default: 0.7` → `default: 7` | `validate` runs on `set` and on `load`, **never on the shipped default**, so an out-of-range value is used verbatim on a fresh install. Now asserted for *every* def |

## And one the sweep overstated — checked rather than accepted

It reported `plainOnly(values, byKey)` → `Object.fromEntries(values)` as *"every secret is written to plain storage"*. **It is not.** No public route can put a secret into the values map: `set` refuses a secret-flagged key and `load` drops one — verified by driving all three routes and reading the persisted file, which contains only `model`. The two forms are equivalent through the public API and the mutation survives the new test too.

`plainOnly` is defence in depth for the day a new write path forgets the rule, which is why it's tested directly. The new test asserts the *other* half: that no such route exists today, so it fails if one is added.

`1179 tests` on node 22.23 **and** 24.12 · four mutations confirmed caught **by exit code**; the fifth proved equivalent rather than fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved approval handling so the selected decision is correctly reflected in the app.
  - Strengthened protection for sensitive settings by preventing secrets from being stored in regular app storage.
  - Added safeguards to ensure default settings load with valid values.

- **Tests**
  - Expanded coverage for approval actions, settings validation, user interactions, and approval status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->