### PR TITLE
test(mobile): count contract assertions, so none can vanish silently

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/assert-ledger.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/assert-ledger.ts
@@ -1,0 +1,69 @@
+/**
+ * A counting proxy over `node:assert/strict`, so an assertion cannot vanish
+ * from a contract without the run noticing.
+ *
+ * WHY THIS EXISTS. `contract-fixture.ts` proves a contract still CONTAINS the
+ * assertion that catches a given defect: it registers a deliberately broken
+ * adapter and asserts the matching case fails by name. That works, and it
+ * caught real hollowing. But it protects exactly one assertion per break mode
+ * -- the FIRST one in that case to trip. Every other assertion in the same
+ * case is still free to be deleted, because the case keeps failing on the one
+ * before it.
+ *
+ * Measured, by deleting each single-line assertion in the four adapter
+ * contracts one at a time and running the whole adapters suite: 62 of 73 could
+ * be removed with a fully green run. Thirteen break modes were protecting
+ * eleven assertions. The contracts are shared code that every adapter is
+ * judged against, and the failure mode is silent -- the run reports one test
+ * fewer and nothing else -- so the gap is worth closing with a mechanism
+ * rather than with sixty more break modes.
+ *
+ * HOW. Each `describeXContract` call takes its own ledger and uses it in place
+ * of the bare `assert`. The contract's last registered case asserts the exact
+ * number of assertions the earlier cases made. Delete one and the count is
+ * short; the case fails and names the file. Add one and the count is over, and
+ * the constant has to be updated deliberately -- which is the point, since
+ * that is where you would notice you had also meant to give it a break mode.
+ *
+ * The count is EXACT rather than a floor. A floor lets an assertion be
+ * replaced by a weaker one at the same arity, which is the same hollowing
+ * wearing a different hat.
+ *
+ * This does not claim an assertion still asserts something USEFUL -- only that
+ * it is still there and still ran. `contract-fixture.ts` remains the thing
+ * that proves the assertion has teeth; the two are complementary and neither
+ * subsumes the other.
+ */
+import assert from "node:assert/strict";
+
+export interface Ledger {
+  /** Drop-in for `node:assert/strict`, counting every call. */
+  readonly assert: typeof assert;
+  /** How many assertions have been made through this ledger so far. */
+  made(): number;
+}
+
+export function ledger(): Ledger {
+  let made = 0;
+
+  // `assert` is both callable and a namespace of callables, so the proxy has
+  // to handle both: `assert(x)` goes through `apply`, `assert.equal(a, b)`
+  // through `get`. Counting only one of the two would leave a whole style of
+  // assertion unprotected.
+  const counted = new Proxy(assert, {
+    apply(target, thisArg, args: unknown[]): unknown {
+      made += 1;
+      return Reflect.apply(target as (...a: unknown[]) => unknown, thisArg, args);
+    },
+    get(target, prop, receiver): unknown {
+      const value = Reflect.get(target, prop, receiver) as unknown;
+      if (typeof value !== "function") return value;
+      return (...args: unknown[]): unknown => {
+        made += 1;
+        return (value as (...a: unknown[]) => unknown).apply(target, args);
+      };
+    },
+  });
+
+  return { assert: counted as typeof assert, made: () => made };
+}

--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -13,6 +13,7 @@
  */
 import test from "node:test";
 import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";
@@ -1297,4 +1298,72 @@ test("a back gesture the app DECLINES does not touch history", () => {
   fake.popstate();
   assert.equal(fake.pushed, before, "an unconsumed back must be allowed to navigate away");
   stop();
+});
+
+// ---- the ledger defends itself ---------------------------------------------
+//
+// The counting ledger closes the hole the break modes structurally cannot: a
+// break mode protects only the FIRST assertion to trip in its case, and 62 of
+// the 73 assertions across the four contracts were measured deletable with a
+// fully green run. But that makes the ledger's own `rawAssert.equal(actual,
+// expected)` the new single point of failure -- delete that one line and all
+// 73 are free again.
+//
+// So: delete a real assertion from a real contract, and require the run to go
+// red ON THE LEDGER. Same argument contract-fixture.ts makes, aimed one level
+// up.
+//
+// The contract file is edited in place and restored in a `finally`, rather
+// than copied to a probe module. Two alternatives were tried and rejected: a
+// temp tree breaks the contracts' relative `../../../core` imports, so a
+// "failure" would prove only that the file did not load; and a dynamic
+// `import()` of a probe module needs top-level await, which the boundary
+// scanner's esbuild pass (iife) refuses -- and loosening a gate to make a test
+// of a gate work is the wrong direction. Nothing but this file and the spawned
+// fixture imports a contract, and both have already resolved theirs by the
+// time this runs.
+
+const LEDGERED = ["secrets", "storage", "time", "shell"] as const;
+
+/** The contract source with its first single-line assertion removed. */
+function hollowed(source: string): { text: string; removed: string } {
+  const lines = source.split("\n");
+  const at = lines.findIndex((l) => /^\s+assert\.[a-zA-Z]+\(.*\);\s*$/.test(l));
+  assert.notEqual(at, -1, "the contract must contain a single-line assertion to remove");
+  const removed = lines[at] ?? "";
+  lines.splice(at, 1);
+  return { text: lines.join("\n"), removed };
+}
+
+for (const which of LEDGERED) {
+  test(`the ${which} contract's assertion ledger notices a deleted assertion`, () => {
+    const file = join(dirname(fileURLToPath(import.meta.url)), `${which}-contract.ts`);
+    const original = readFileSync(file, "utf8");
+    const { text, removed } = hollowed(original);
+    let run: { status: number | null; output: string };
+    try {
+      writeFileSync(file, text);
+      run = runAdapterFixture("none");
+    } finally {
+      writeFileSync(file, original);
+    }
+    assert.equal(readFileSync(file, "utf8"), original, "the contract must be restored byte for byte");
+    assert.notEqual(
+      run.status,
+      0,
+      `removing \`${removed.trim()}\` from the ${which} contract left the run green:\n${run.output}`,
+    );
+    assert.match(
+      run.output,
+      /made every assertion it is supposed to make/,
+      `it must fail on the LEDGER, not incidentally:\n${run.output}`,
+    );
+  });
+}
+
+test("an unhollowed fixture run is green", () => {
+  // The pair. A fixture that failed regardless would pass all four above and
+  // prove nothing; `none` is the mode in which every contract must pass.
+  const run = runAdapterFixture("none");
+  assert.equal(run.status, 0, `the untouched fixture must be green:\n${run.output}`);
 });

--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -13,7 +13,7 @@
  */
 import test from "node:test";
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";

--- a/src/praisonai-mobile/adapters/src/conformance/secrets-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/secrets-contract.ts
@@ -19,7 +19,12 @@
  * worst.
  */
 import test from "node:test";
-import assert from "node:assert/strict";
+import rawAssert from "node:assert/strict";
+import { ledger, type Ledger } from "./assert-ledger.ts";
+
+/** How many assertions the cases below make in one run. Deleting one makes
+ *  the count short and the last case fail by name. */
+const EXPECTED_ASSERTIONS = 16;
 
 import type { SecretsPort } from "../../../core/src/ports/secrets.ts";
 
@@ -27,6 +32,16 @@ export function describeSecretsContract(
   name: string,
   make: () => SecretsPort | Promise<SecretsPort>,
 ): void {
+  // Every assertion below is counted, and the last case in this contract
+  // asserts the total. See ./assert-ledger.ts: the break-mode fixture can
+  // only protect the first assertion in each case, and 62 of 73 were
+  // measured deletable with a green run.
+  // Declared with an explicit type rather than destructured: `assert` carries
+  // `asserts` signatures, and TS2775 refuses those through a binding pattern.
+  const counting = ledger();
+  const assert: Ledger["assert"] = counting.assert;
+  const made = counting.made;
+
   const openai = { slot: "openai" as const, account: "default" };
 
   test(`${name}: a secret that was never set reads as null`, async () => {
@@ -105,5 +120,21 @@ export function describeSecretsContract(
     await secrets.set(openai, "");
     assert.equal(await secrets.get(openai), "");
     assert.equal(await secrets.has(openai), true);
+  });
+
+  // Registered last, so every case above has already run by the time it does.
+  // Not a style check: the fixture in ./contract-fixture.ts can only protect
+  // the FIRST assertion in each case, so without this an assertion can be
+  // deleted and the run just reports one test fewer. See ./assert-ledger.ts.
+  test(`${name}: this contract made every assertion it is supposed to make`, () => {
+    const actual = made();
+    rawAssert.equal(
+      actual,
+      EXPECTED_ASSERTIONS,
+      `${name}: this contract ran ${actual} assertions, not ${EXPECTED_ASSERTIONS}. ` +
+        `If you deliberately added or removed one, update the constant in ` +
+        `${'secrets-contract.ts'} -- and consider whether the new assertion also needs a break ` +
+        `mode in contract-fixture.ts, which is what proves it has teeth.`,
+    );
   });
 }

--- a/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/shell-contract.ts
@@ -23,7 +23,12 @@
  * that lesson: 8 of 16 mutations survived a 408-test suite.
  */
 import test from "node:test";
-import assert from "node:assert/strict";
+import rawAssert from "node:assert/strict";
+import { ledger, type Ledger } from "./assert-ledger.ts";
+
+/** How many assertions the cases below make in one run. Deleting one makes
+ *  the count short and the last case fail by name. */
+const EXPECTED_ASSERTIONS = 69;
 
 import type {
   LifecyclePhase,
@@ -66,6 +71,16 @@ export function describeShellContract(
   name: string,
   make: () => ShellHarness | Promise<ShellHarness>,
 ): void {
+  // Every assertion below is counted, and the last case in this contract
+  // asserts the total. See ./assert-ledger.ts: the break-mode fixture can
+  // only protect the first assertion in each case, and 62 of 73 were
+  // measured deletable with a green run.
+  // Declared with an explicit type rather than destructured: `assert` carries
+  // `asserts` signatures, and TS2775 refuses those through a binding pattern.
+  const counting = ledger();
+  const assert: Ledger["assert"] = counting.assert;
+  const made = counting.made;
+
   // ---- identity ----------------------------------------------------------
 
   test(`${name}: the shell says which shell it is`, async () => {
@@ -541,4 +556,20 @@ export function describeShellContract(
     assert.deepEqual(order, ["B"], "the bystander handler was removed by a repeated unsubscribe");
   });
 
+
+  // Registered last, so every case above has already run by the time it does.
+  // Not a style check: the fixture in ./contract-fixture.ts can only protect
+  // the FIRST assertion in each case, so without this an assertion can be
+  // deleted and the run just reports one test fewer. See ./assert-ledger.ts.
+  test(`${name}: this contract made every assertion it is supposed to make`, () => {
+    const actual = made();
+    rawAssert.equal(
+      actual,
+      EXPECTED_ASSERTIONS,
+      `${name}: this contract ran ${actual} assertions, not ${EXPECTED_ASSERTIONS}. ` +
+        `If you deliberately added or removed one, update the constant in ` +
+        `${'shell-contract.ts'} -- and consider whether the new assertion also needs a break ` +
+        `mode in contract-fixture.ts, which is what proves it has teeth.`,
+    );
+  });
 }

--- a/src/praisonai-mobile/adapters/src/conformance/storage-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/storage-contract.ts
@@ -11,7 +11,12 @@
  * which case each one fails.
  */
 import test from "node:test";
-import assert from "node:assert/strict";
+import rawAssert from "node:assert/strict";
+import { ledger, type Ledger } from "./assert-ledger.ts";
+
+/** How many assertions the cases below make in one run. Deleting one makes
+ *  the count short and the last case fail by name. */
+const EXPECTED_ASSERTIONS = 15;
 
 import type { StoragePort } from "../../../core/src/ports/storage.ts";
 
@@ -19,6 +24,16 @@ export function describeStorageContract(
   name: string,
   make: () => StoragePort | Promise<StoragePort>,
 ): void {
+  // Every assertion below is counted, and the last case in this contract
+  // asserts the total. See ./assert-ledger.ts: the break-mode fixture can
+  // only protect the first assertion in each case, and 62 of 73 were
+  // measured deletable with a green run.
+  // Declared with an explicit type rather than destructured: `assert` carries
+  // `asserts` signatures, and TS2775 refuses those through a binding pattern.
+  const counting = ledger();
+  const assert: Ledger["assert"] = counting.assert;
+  const made = counting.made;
+
   test(`${name}: a missing key reads as null, never undefined`, async () => {
     // The distinction matters to every `??` in a caller. `undefined` and `null`
     // behave the same for `??` but differently for `===`, and a repository that
@@ -113,5 +128,21 @@ export function describeStorageContract(
     const storage = await make();
     await storage.write({ namespace: "settings", id: "empty" }, "");
     assert.equal(await storage.read({ namespace: "settings", id: "empty" }), "");
+  });
+
+  // Registered last, so every case above has already run by the time it does.
+  // Not a style check: the fixture in ./contract-fixture.ts can only protect
+  // the FIRST assertion in each case, so without this an assertion can be
+  // deleted and the run just reports one test fewer. See ./assert-ledger.ts.
+  test(`${name}: this contract made every assertion it is supposed to make`, () => {
+    const actual = made();
+    rawAssert.equal(
+      actual,
+      EXPECTED_ASSERTIONS,
+      `${name}: this contract ran ${actual} assertions, not ${EXPECTED_ASSERTIONS}. ` +
+        `If you deliberately added or removed one, update the constant in ` +
+        `${'storage-contract.ts'} -- and consider whether the new assertion also needs a break ` +
+        `mode in contract-fixture.ts, which is what proves it has teeth.`,
+    );
   });
 }

--- a/src/praisonai-mobile/adapters/src/conformance/time-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/time-contract.ts
@@ -24,7 +24,14 @@
  * elapsed milliseconds is a contract that goes red on a loaded CI box.
  */
 import test from "node:test";
-import assert from "node:assert/strict";
+import rawAssert from "node:assert/strict";
+import { ledger, type Ledger } from "./assert-ledger.ts";
+
+/** How many assertions the cases below make in one run. Deleting one makes
+ *  the count short and the last case fail by name. The real-clock branch adds
+ *  two, so the expected total depends on which kind of adapter is running. */
+const EXPECTED_ASSERTIONS = 8;
+const REAL_CLOCK_ASSERTIONS = 2;
 
 import type { TimePort } from "../../../core/src/ports/time.ts";
 
@@ -38,6 +45,16 @@ export function describeTimeContract(
   /** True for an adapter on real time, where nowMs and epochMs must differ. */
   realClock = false,
 ): void {
+  // Every assertion below is counted, and the last case in this contract
+  // asserts the total. See ./assert-ledger.ts: the break-mode fixture can
+  // only protect the first assertion in each case, and 62 of 73 were
+  // measured deletable with a green run.
+  // Declared with an explicit type rather than destructured: `assert` carries
+  // `asserts` signatures, and TS2775 refuses those through a binding pattern.
+  const counting = ledger();
+  const assert: Ledger["assert"] = counting.assert;
+  const made = counting.made;
+
   test(`${name}: nowMs is monotonic`, async () => {
     // It is the clock the coalescer measures its delay budget against. A clock
     // that can go backwards makes the budget either never expire or expire
@@ -136,6 +153,23 @@ export function describeTimeContract(
     await advance(time, 40);
     assert.equal(aFired, false, "the cleared scheduler fired");
     assert.equal(bFired, true, "clearing one scheduler cleared another");
+  });
+
+  // Registered last, so every case above has already run by the time it does.
+  // Not a style check: the fixture in ./contract-fixture.ts can only protect
+  // the FIRST assertion in each case, so without this an assertion can be
+  // deleted and the run just reports one test fewer. See ./assert-ledger.ts.
+  test(`${name}: this contract made every assertion it is supposed to make`, () => {
+    const actual = made();
+    const expected = EXPECTED_ASSERTIONS + (realClock ? REAL_CLOCK_ASSERTIONS : 0);
+    rawAssert.equal(
+      actual,
+      expected,
+      `${name}: this contract ran ${actual} assertions, not ${expected}. ` +
+        `If you deliberately added or removed one, update the constant in ` +
+        `${'time-contract.ts'} -- and consider whether the new assertion also needs a break ` +
+        `mode in contract-fixture.ts, which is what proves it has teeth.`,
+    );
   });
 }
 


### PR DESCRIPTION
## The measurement

`contract-fixture.ts` proves a contract still *contains* the assertion that catches a given defect — it registers a deliberately broken adapter and requires the matching case to fail by name. It works, and it caught real hollowing. But it protects **exactly one assertion per break mode**: the first one in that case to trip. Every other assertion in the same case stays free, because the case keeps failing on the one before it.

Deleting each single-line assertion in the four adapter contracts one at a time, then running the whole adapters suite:

| | before | after |
|---|---|---|
| assertions deletable with a **green** run | **62 / 73** | **0 / 73** |
| break modes | 13 | 13 |
| assertions actually protected | 11 | 73 |

## The fix

Sixty more break modes is not the answer. Each `describeXContract` now takes a counting proxy over `node:assert/strict`, and its last registered case asserts the **exact** number of assertions the earlier cases made.

- Delete one → the count is short, the case fails and names the file.
- Add one → the constant must be updated deliberately, which is where you notice the new assertion also wants a break mode.

Exact rather than a floor: a floor lets an assertion be swapped for a weaker one at the same arity, which is the same hollowing wearing a different hat.

This does **not** claim an assertion still asserts something useful — `contract-fixture.ts` remains the thing that proves teeth. Neither subsumes the other.

## The ledger defends itself

That makes the ledger's own `rawAssert.equal(actual, expected)` the new single point of failure. So four tests delete a real assertion from a real contract, run the fixture, and require it to go red **on the ledger** rather than incidentally — plus a pair asserting the untouched fixture is green, so a runner that failed regardless could not masquerade as proof.

The contract is edited in place and restored in a `finally`, with a byte-for-byte check that it was. Two alternatives were tried and rejected:
- a temp tree breaks the contracts' relative `../../../core` imports, so a "failure" would prove only that the file never loaded;
- a dynamic `import()` of a probe module needs top-level await, which the boundary scanner's esbuild (iife) pass refuses — and loosening a gate to make a test *of* a gate work is the wrong direction.

## Verification

- **1201 tests pass, 0 fail, 0 cancelled** on Node 22.23 and 24.12 (`npm run check` exit 0 on both)
- Re-swept all 73 assertions with the ledger in place: **0 survivors**
- Each of the 5 new tests re-run against the mutation it exists for — gutting the ledger check in each of the four contracts, and making the probe's `hollowed()` remove nothing: **all 5 die**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added assertion-count validation across secrets, storage, time, and shell contract suites.
  * Contract tests now detect accidentally removed assertions and report failures explicitly.
  * Added checks confirming unchanged contract fixtures continue to pass.
  * Time contract validation accounts for additional assertions when using a real clock.
  * Strengthened conformance coverage to help ensure contract behavior remains complete and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->