### PR TITLE
test(mobile): pin the engine contract's assertion counts, and test the ledger

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/assert-ledger.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/assert-ledger.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The ledger is load-bearing -- every assertion count in the engine contract is
+ * only as trustworthy as this proxy -- and it had no test of its own. Removing
+ * `made += 1` from the `apply` trap survived the whole engines suite, because
+ * no contract happens to use a bare `assert(x)`. That is not a harmless gap:
+ * the day someone writes one it goes uncounted, and the committed constant for
+ * that case is quietly wrong from then on.
+ *
+ * Every ledger's `assert` is bound to an explicitly annotated local. TS2775
+ * refuses an `asserts` signature reached through a property chain, which is
+ * also why the contracts declare theirs rather than destructuring.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ledger, type Ledger } from "./assert-ledger.ts";
+
+test("a namespace call is counted", () => {
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  assert.equal(l.made(), 0, "a fresh ledger has counted nothing");
+  counted.equal(1, 1);
+  counted.ok(true);
+  assert.equal(l.made(), 2);
+});
+
+test("a BARE assert(x) is counted too", () => {
+  // `assert` is both callable and a namespace of callables. Counting only the
+  // namespace leaves a whole style of assertion invisible to the ledger --
+  // measured: dropping the apply trap's counter survived the entire suite.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  counted(true);
+  counted(1 === 1);
+  assert.equal(l.made(), 2, "the apply trap must count");
+});
+
+test("a FAILING assertion still throws, and is still counted", () => {
+  // A proxy that swallowed the throw would turn every contract green.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  assert.throws(() => counted.equal(1, 2), /Expected values to be strictly equal/);
+  assert.throws(() => counted(false));
+  assert.equal(l.made(), 2, "an assertion that fails is an assertion that ran");
+});
+
+test("the message reaches the thrown error", () => {
+  // The proxy forwards every argument, not just the first two.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  assert.throws(
+    () => counted.equal(1, 2, "the message survives the proxy"),
+    /the message survives the proxy/,
+  );
+  // The bare form takes a message too, and truncating the apply trap's
+  // arguments to one survived until this line existed -- a failing
+  // `assert(cond, "why")` would then report nothing about why.
+  assert.throws(() => counted(false, "the bare form keeps its message"), /the bare form keeps its message/);
+});
+
+test("a non-function property is passed through, not wrapped", () => {
+  // Dropping the `typeof value !== "function"` guard survived a first version
+  // of this test, which read `assert.AssertionError` -- a class, so a function
+  // either way. `name` and `length` are the properties that actually
+  // distinguish the two: without the guard they come back as arrow functions,
+  // and anything reading them gets a function where it expected a string.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  assert.equal(counted.name, "strict", "a string property must survive as a string");
+  assert.equal(typeof counted.length, "number");
+  assert.equal(l.made(), 0, "reading a property is not making an assertion");
+});
+
+test("two ledgers count independently", () => {
+  // Each describeXContract call takes its own, and one file runs the same
+  // contract against several adapters. A shared counter would make every count
+  // after the first wrong.
+  const first = ledger();
+  const second = ledger();
+  const a: Ledger["assert"] = first.assert;
+  const b: Ledger["assert"] = second.assert;
+  a.ok(true);
+  a.ok(true);
+  b.ok(true);
+  assert.equal(first.made(), 2);
+  assert.equal(second.made(), 1);
+});
+
+test("made() is a snapshot, not a live binding", () => {
+  // Every case in the engine contract opens with `const made0 = made()` and
+  // closes by differencing it. If that read tracked the counter, the
+  // difference would always be zero and every count would pass.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  const before = l.made();
+  counted.ok(true);
+  assert.equal(before, 0, "the earlier read must not have moved");
+  assert.equal(l.made(), 1);
+});

--- a/src/praisonai-mobile/engines/src/assert-ledger.test.ts
+++ b/src/praisonai-mobile/engines/src/assert-ledger.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The ledger is load-bearing -- every assertion count in the engine contract is
+ * only as trustworthy as this proxy -- and it had no test of its own. Removing
+ * `made += 1` from the `apply` trap survived the whole engines suite, because
+ * no contract happens to use a bare `assert(x)`. That is not a harmless gap:
+ * the day someone writes one it goes uncounted, and the committed constant for
+ * that case is quietly wrong from then on.
+ *
+ * Every ledger's `assert` is bound to an explicitly annotated local. TS2775
+ * refuses an `asserts` signature reached through a property chain, which is
+ * also why the contracts declare theirs rather than destructuring.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ledger, type Ledger } from "./assert-ledger.ts";
+
+test("a namespace call is counted", () => {
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  assert.equal(l.made(), 0, "a fresh ledger has counted nothing");
+  counted.equal(1, 1);
+  counted.ok(true);
+  assert.equal(l.made(), 2);
+});
+
+test("a BARE assert(x) is counted too", () => {
+  // `assert` is both callable and a namespace of callables. Counting only the
+  // namespace leaves a whole style of assertion invisible to the ledger --
+  // measured: dropping the apply trap's counter survived the entire suite.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  counted(true);
+  counted(1 === 1);
+  assert.equal(l.made(), 2, "the apply trap must count");
+});
+
+test("a FAILING assertion still throws, and is still counted", () => {
+  // A proxy that swallowed the throw would turn every contract green.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  assert.throws(() => counted.equal(1, 2), /Expected values to be strictly equal/);
+  assert.throws(() => counted(false));
+  assert.equal(l.made(), 2, "an assertion that fails is an assertion that ran");
+});
+
+test("the message reaches the thrown error", () => {
+  // The proxy forwards every argument, not just the first two.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  assert.throws(
+    () => counted.equal(1, 2, "the message survives the proxy"),
+    /the message survives the proxy/,
+  );
+  // The bare form takes a message too, and truncating the apply trap's
+  // arguments to one survived until this line existed -- a failing
+  // `assert(cond, "why")` would then report nothing about why.
+  assert.throws(() => counted(false, "the bare form keeps its message"), /the bare form keeps its message/);
+});
+
+test("a non-function property is passed through, not wrapped", () => {
+  // Dropping the `typeof value !== "function"` guard survived a first version
+  // of this test, which read `assert.AssertionError` -- a class, so a function
+  // either way. `name` and `length` are the properties that actually
+  // distinguish the two: without the guard they come back as arrow functions,
+  // and anything reading them gets a function where it expected a string.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  assert.equal(counted.name, "strict", "a string property must survive as a string");
+  assert.equal(typeof counted.length, "number");
+  assert.equal(l.made(), 0, "reading a property is not making an assertion");
+});
+
+test("two ledgers count independently", () => {
+  // Each describeXContract call takes its own, and one file runs the same
+  // contract against several adapters. A shared counter would make every count
+  // after the first wrong.
+  const first = ledger();
+  const second = ledger();
+  const a: Ledger["assert"] = first.assert;
+  const b: Ledger["assert"] = second.assert;
+  a.ok(true);
+  a.ok(true);
+  b.ok(true);
+  assert.equal(first.made(), 2);
+  assert.equal(second.made(), 1);
+});
+
+test("made() is a snapshot, not a live binding", () => {
+  // Every case in the engine contract opens with `const made0 = made()` and
+  // closes by differencing it. If that read tracked the counter, the
+  // difference would always be zero and every count would pass.
+  const l = ledger();
+  const counted: Ledger["assert"] = l.assert;
+  const before = l.made();
+  counted.ok(true);
+  assert.equal(before, 0, "the earlier read must not have moved");
+  assert.equal(l.made(), 1);
+});

--- a/src/praisonai-mobile/engines/src/assert-ledger.ts
+++ b/src/praisonai-mobile/engines/src/assert-ledger.ts
@@ -2,6 +2,11 @@
  * A counting proxy over `node:assert/strict`, so an assertion cannot vanish
  * from a contract without the run noticing.
  *
+ * A byte-for-byte twin of `adapters/src/conformance/assert-ledger.ts`. The two
+ * are deliberately separate files: `engines` may not import `adapters` and the
+ * layer rule is right to say so, and neither belongs in `core`, which ships.
+ * The fixture pattern one directory over is duplicated for the same reason.
+ *
  * WHY THIS EXISTS. `contract-fixture.ts` proves a contract still CONTAINS the
  * assertion that catches a given defect: it registers a deliberately broken
  * adapter and asserts the matching case fails by name. That works, and it
@@ -10,20 +15,23 @@
  * case is still free to be deleted, because the case keeps failing on the one
  * before it.
  *
- * Measured, by deleting each single-line assertion in the four adapter
- * contracts one at a time and running the whole adapters suite: 62 of 73 could
- * be removed with a fully green run. Thirteen break modes were protecting
- * eleven assertions. The contracts are shared code that every adapter is
- * judged against, and the failure mode is silent -- the run reports one test
- * fewer and nothing else -- so the gap is worth closing with a mechanism
- * rather than with sixty more break modes.
+ * Measured, by deleting each single-line assertion in this contract one
+ * at a time and running the whole engines suite: 30 of 32 could be removed
+ * with a fully green run. Five break modes were protecting two assertions.
+ * (The four adapter contracts measured 62 of 73 on the same method.) A
+ * contract is shared code that every engine is judged against, and the failure
+ * mode is silent -- the run reports one test fewer and nothing else -- so the
+ * gap is worth closing with a mechanism rather than with thirty more break
+ * modes.
  *
- * HOW. Each `describeXContract` call takes its own ledger and uses it in place
- * of the bare `assert`. The contract's last registered case asserts the exact
- * number of assertions the earlier cases made. Delete one and the count is
- * short; the case fails and names the file. Add one and the count is over, and
- * the constant has to be updated deliberately -- which is the point, since
- * that is where you would notice you had also meant to give it a break mode.
+ * HOW. `describeEngineContract` takes its own ledger and uses it in place of the
+ * bare `assert`, and EACH case ends by asserting the exact number of
+ * assertions it made. Per case rather than one total, because a harness
+ * declares which scenarios it cannot support and skips them, so no single
+ * total is right for every engine. Delete an assertion and its case's count is
+ * short and the case fails by name. Add one and the count is over, and the
+ * constant has to be updated deliberately -- which is the point, since that is
+ * where you would notice the new assertion also wants a break mode.
  *
  * The count is EXACT rather than a floor. A floor lets an assertion be
  * replaced by a weaker one at the same arity, which is the same hollowing
@@ -33,13 +41,7 @@
  * it is still there and still ran. `contract-fixture.ts` remains the thing
  * that proves the assertion has teeth; the two are complementary and neither
  * subsumes the other. `assert-ledger.test.ts` covers this file itself, which
- * is now load-bearing for every count in all four contracts -- removing the
- * `apply` trap's counter survived a full suite run before it existed, because
- * no contract happens to use a bare `assert(x)`.
- *
- * A byte-for-byte twin of `engines/src/assert-ledger.ts` apart from these
- * notes: `adapters` may not import `engines` and the layer rule is right to
- * say so, and neither belongs in `core`, which ships.
+ * is now load-bearing for every count in the contract.
  */
 import assert from "node:assert/strict";
 

--- a/src/praisonai-mobile/engines/src/conformance.test.ts
+++ b/src/praisonai-mobile/engines/src/conformance.test.ts
@@ -17,6 +17,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -234,4 +235,48 @@ test("the contract can PASS: an unbroken fixture succeeds under the same runner"
   // nothing whatsoever.
   const { status, output } = runFixture("none");
   assert.equal(status, 0, `a conforming engine must pass the same runner:\n${output}`);
+});
+
+
+// ---- the ledger defends itself ---------------------------------------------
+//
+// The per-case assertion counts closed a hole the break modes structurally
+// cannot: a break mode protects only the FIRST assertion to trip in its case,
+// and 30 of the 32 assertions in this contract were measured deletable with a
+// fully green run -- five break modes guarding two assertions. That makes each
+// `rawAssert.equal(made() - made0, N, LEDGER)` the new thing worth deleting.
+//
+// So: delete a real assertion from the real contract and require the fixture
+// run to go red ON THE LEDGER. The file is edited in place and restored in a
+// finally, with a byte-for-byte check that it was -- a copy elsewhere would
+// break the contract's relative imports, and a "failure" that is really a
+// module that never loaded proves nothing.
+
+test("the engine contract's assertion ledger notices a deleted assertion", () => {
+  const file = join(dirname(fileURLToPath(import.meta.url)), "conformance.ts");
+  const original = readFileSync(file, "utf8");
+  const lines = original.split("\n");
+  const at = lines.findIndex((l) => /^\s+assert\.[a-zA-Z]+\(.*\);\s*$/.test(l));
+  assert.notEqual(at, -1, "the contract must contain a single-line assertion to remove");
+  const removed = (lines[at] ?? "").trim();
+  lines.splice(at, 1);
+
+  let run: { status: number | null; output: string };
+  try {
+    writeFileSync(file, lines.join("\n"));
+    run = runFixture("none");
+  } finally {
+    writeFileSync(file, original);
+  }
+  assert.equal(readFileSync(file, "utf8"), original, "the contract must be restored byte for byte");
+  assert.notEqual(
+    run.status,
+    0,
+    `removing \`${removed}\` from the engine contract left the run green:\n${run.output}`,
+  );
+  assert.match(
+    run.output,
+    /did not make the assertions it is supposed to make/,
+    `it must fail on the LEDGER, not incidentally:\n${run.output}`,
+  );
 });

--- a/src/praisonai-mobile/engines/src/conformance.ts
+++ b/src/praisonai-mobile/engines/src/conformance.ts
@@ -18,7 +18,8 @@
  * audit ran 16 mutations against a 408-test suite and 8 survived.
  */
 import test from "node:test";
-import assert from "node:assert/strict";
+import rawAssert from "node:assert/strict";
+import { ledger, type Ledger } from "./assert-ledger.ts";
 
 import type { AgentEnginePort, RunRequest } from "../../core/src/ports/agent-engine.ts";
 import { apply, finish, initialTurn, type TurnState } from "../../core/src/run/transcript.ts";
@@ -86,20 +87,30 @@ async function drive(
  */
 export function describeEngineContract(harness: EngineHarness): void {
   const name = harness.name;
+  const counting = ledger();
+  const assert: Ledger["assert"] = counting.assert;
+  const made = counting.made;
+  const LEDGER =
+    `${name}: this case did not make the assertions it is supposed to make. ` +
+    `See engines/src/assert-ledger.ts -- 30 of 32 assertions in this contract ` +
+    `were deletable with a green run before the counts were pinned.`;
   const skip = (scenario: ScenarioName): string | null =>
     harness.unsupported?.[scenario] ?? null;
 
   // ---- handshake ---------------------------------------------------------
 
   test(`${name}: an adapter reports a protocol version before any turn is started`, async () => {
+    const made0 = made();
     const engine = await harness.create("happy");
     assert.equal(typeof engine.protocolVersion, "number");
     assert.equal(engine.protocolVersion, PROTOCOL_VERSION);
     assert.equal(checkProtocol(engine.protocolVersion).ok, true);
     await engine.dispose();
+    rawAssert.equal(made() - made0, 3, LEDGER);
   });
 
   test(`${name}: an engine declares a stable id`, async () => {
+    const made0 = made();
     const a = await harness.create("happy");
     const b = await harness.create("happy");
     assert.equal(typeof a.id, "string");
@@ -107,11 +118,13 @@ export function describeEngineContract(harness: EngineHarness): void {
     assert.equal(a.id, b.id, "the id must not vary between instances");
     await a.dispose();
     await b.dispose();
+    rawAssert.equal(made() - made0, 3, LEDGER);
   });
 
   // ---- lifecycle and ordering -------------------------------------------
 
   test(`${name}: a run emits start first and exactly one terminal event last`, async () => {
+    const made0 = made();
     const engine = await harness.create("happy");
     const { events } = await drive(engine);
     assert.ok(events.length >= 2, "a run must emit at least start and a terminal event");
@@ -121,32 +134,39 @@ export function describeEngineContract(harness: EngineHarness): void {
     assert.equal(terminals.length, 1, `expected one terminal event, got ${terminals.length}`);
     assert.ok(isTerminal(events[events.length - 1] as RunEvent), "the last event must be terminal");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 4, LEDGER);
   });
 
   test(`${name}: every event in a run carries the same msgId`, async () => {
+    const made0 = made();
     const engine = await harness.create("happy");
     const { events } = await drive(engine);
     const ids = new Set(events.map((e) => e.msgId));
     assert.equal(ids.size, 1, `expected one msgId, got ${[...ids].join(", ")}`);
     assert.notEqual([...ids][0], "", "msgId must not be empty");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 2, LEDGER);
   });
 
   test(`${name}: a conforming run drops nothing`, async () => {
+    const made0 = made();
     // The control that stops "emit garbage" from passing the suite: if the
     // reducer refused any event, it would be recorded here.
     const engine = await harness.create("happy");
     const { state } = await drive(engine);
     assert.deepEqual(state.dropped, [], `a clean run dropped: ${JSON.stringify(state.dropped)}`);
     await engine.dispose();
+    rawAssert.equal(made() - made0, 1, LEDGER);
   });
 
   test(`${name}: a happy run produces text and ends persisted`, async () => {
+    const made0 = made();
     const engine = await harness.create("happy");
     const { state } = await drive(engine);
     assert.notEqual(state.text, "", "a happy run must produce text");
     assert.equal(state.outcome?.type, "end");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 2, LEDGER);
   });
 
   // ---- emptiness ---------------------------------------------------------
@@ -154,11 +174,13 @@ export function describeEngineContract(harness: EngineHarness): void {
   test(`${name}: an empty stream is an error, not an empty answer`, async () => {
     const why = skip("empty");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("empty");
     const { state } = await drive(engine);
     assert.equal(state.outcome?.type, "error");
     assert.equal(state.outcome?.type === "error" && state.outcome.kind, "empty");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 2, LEDGER);
   });
 
   // ---- tools -------------------------------------------------------------
@@ -166,16 +188,19 @@ export function describeEngineContract(harness: EngineHarness): void {
   test(`${name}: a successful tool call resolves to ok`, async () => {
     const why = skip("tool_ok");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("tool_ok");
     const { state } = await drive(engine);
     assert.ok(state.tools.length >= 1, "expected at least one tool row");
     assert.equal(state.tools[0]?.status, "ok");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 2, LEDGER);
   });
 
   test(`${name}: a failed tool is reported failed and never inferred from its output`, async () => {
     const why = skip("tool_failed");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("tool_failed");
     const { state } = await drive(engine);
     assert.ok(state.tools.length >= 1, "expected at least one tool row");
@@ -185,18 +210,22 @@ export function describeEngineContract(harness: EngineHarness): void {
       "a tool that failed must not read as successful because its output looks plausible",
     );
     await engine.dispose();
+    rawAssert.equal(made() - made0, 2, LEDGER);
   });
 
   test(`${name}: a tool call with no result is unresolved at the end, not successful`, async () => {
     const why = skip("tool_unresolved");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("tool_unresolved");
     const { state } = await drive(engine);
     assert.equal(state.tools[0]?.status, "unresolved");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 1, LEDGER);
   });
 
   test(`${name}: an engine that declares no tool support never emits a tool event`, async () => {
+    const made0 = made();
     // The negative direction. Without it a capability flag is documentation
     // rather than a contract.
     const engine = await harness.create("happy");
@@ -209,6 +238,10 @@ export function describeEngineContract(harness: EngineHarness): void {
       );
     }
     await engine.dispose();
+    // Nothing to assert when the engine DOES support tools -- the case exists
+    // for the other branch. The count says so rather than leaving a case that
+    // silently checks nothing for most harnesses.
+    rawAssert.equal(made() - made0, engine.capabilities.tools ? 0 : 1, LEDGER);
   });
 
   // ---- approvals ---------------------------------------------------------
@@ -216,6 +249,7 @@ export function describeEngineContract(harness: EngineHarness): void {
   test(`${name}: an approval decision is routed by approvalId, not by the pending row`, async () => {
     const why = skip("two_approvals");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("two_approvals");
     const controller = new AbortController();
 
@@ -236,11 +270,13 @@ export function describeEngineContract(harness: EngineHarness): void {
       "a decision already made must not be reported as made again",
     );
     await engine.dispose();
+    rawAssert.equal(made() - made0, 3, LEDGER);
   });
 
   test(`${name}: deciding an unknown approval returns false rather than reporting success`, async () => {
     const why = skip("approval");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("approval");
     assert.equal(
       await engine.decide("no-such-approval", "allow"),
@@ -248,9 +284,11 @@ export function describeEngineContract(harness: EngineHarness): void {
       "reporting success for an unknown id is a lie the UI cannot detect",
     );
     await engine.dispose();
+    rawAssert.equal(made() - made0, 1, LEDGER);
   });
 
   test(`${name}: an engine that declares no approval support never emits an approval_request`, async () => {
+    const made0 = made();
     const engine = await harness.create("happy");
     if (!engine.capabilities.approvals) {
       const { events } = await drive(engine);
@@ -261,30 +299,37 @@ export function describeEngineContract(harness: EngineHarness): void {
       );
     }
     await engine.dispose();
+    // Same shape as the tools capability case above.
+    rawAssert.equal(made() - made0, engine.capabilities.approvals ? 0 : 1, LEDGER);
   });
 
   // ---- cancellation ------------------------------------------------------
 
   test(`${name}: cancelling a run that is not live returns false`, async () => {
+    const made0 = made();
     // server.py:392 -- "the button would confirm a cancellation that never
     // happened".
     const engine = await harness.create("happy");
     assert.equal(await engine.cancel("no-such-run"), false);
     await engine.dispose();
+    rawAssert.equal(made() - made0, 1, LEDGER);
   });
 
   test(`${name}: a cancelled turn emits no end and no usage`, async () => {
     const why = skip("cancelled");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("cancelled");
     const { events, state } = await drive(engine);
     assert.equal(state.outcome?.type, "cancelled");
     assert.equal(events.some((e) => e.type === "end"), false, "a cancelled turn must not also end");
     assert.equal(events.some((e) => e.type === "usage"), false, "a cancelled turn is not persisted");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 3, LEDGER);
   });
 
   test(`${name}: aborting the signal stops the stream`, async () => {
+    const made0 = made();
     const engine = await harness.create("happy");
     if (!engine.capabilities.cancellation) {
       await engine.dispose();
@@ -310,6 +355,7 @@ export function describeEngineContract(harness: EngineHarness): void {
     // terminates is its business; that it stops is the contract.
     assert.ok(seen.length < 50, `abort did not stop the stream: ${seen.length} events`);
     await engine.dispose();
+    rawAssert.equal(made() - made0, 2, LEDGER);
   });
 
   // ---- error taxonomy ----------------------------------------------------
@@ -317,36 +363,46 @@ export function describeEngineContract(harness: EngineHarness): void {
   test(`${name}: an auth failure is kind auth so the ui can offer settings`, async () => {
     const why = skip("auth_error");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("auth_error");
     const { state } = await drive(engine);
     assert.equal(state.outcome?.type, "error");
     assert.equal(state.outcome?.type === "error" && state.outcome.kind, "auth");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 2, LEDGER);
   });
 
   test(`${name}: a rate limit is distinct from an internal error`, async () => {
     const why = skip("rate_limit_error");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("rate_limit_error");
     const { state } = await drive(engine);
     assert.equal(state.outcome?.type === "error" && state.outcome.kind, "rate_limit");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 1, LEDGER);
   });
 
   test(`${name}: an error carries a message that is never the empty string`, async () => {
     const why = skip("auth_error");
     if (why !== null) return void console.log(`  skipped: ${why}`);
+    const made0 = made();
     const engine = await harness.create("auth_error");
     const { state } = await drive(engine);
     assert.notEqual(state.outcome?.type === "error" && state.outcome.message, "");
     await engine.dispose();
+    rawAssert.equal(made() - made0, 1, LEDGER);
   });
 
   // ---- hygiene -----------------------------------------------------------
 
   test(`${name}: dispose is idempotent`, async () => {
+    const made0 = made();
     const engine = await harness.create("happy");
     await engine.dispose();
     await engine.dispose();
+    // Deliberately zero: this case passes by NOT throwing, so there is nothing
+    // to count. Pinned anyway, so adding an assertion here is a decision.
+    rawAssert.equal(made() - made0, 0, LEDGER);
   });
 }


### PR DESCRIPTION
> Stacked on #4599. Retarget to `main` once that merges.

## The same defect, worse, in the suite I cited as the model

#4599 gave the four adapter contracts a counting ledger, because a break mode protects only the *first* assertion to trip in its case. The engine contract has the same shape and the same fixture — and it measured worse.

Deleting each of its 32 single-line assertions one at a time and running the whole engines suite, judged by exit code:

| | before | after |
|---|---|---|
| deletable with a **green** run | **30 / 32** | **0 / 32** |
| break modes | 5 | 5 |
| assertions actually protected | 2 | 32 |

## Per case, not one total

A harness declares which scenarios it cannot support and skips them, so no single total is right for every engine. Each case opens with `const made0 = made()` and closes by asserting the exact number of assertions it made.

Three counts are not constants, and say so:
- the two **capability-gated** cases assert *nothing* when the engine has the capability — the case exists for the other branch;
- `dispose is idempotent` makes **zero** assertions by design: it passes by not throwing. Pinned anyway, so adding one there is a decision rather than an accident.

## The ledger had no test, and that mattered

Removing `made += 1` from the **`apply` trap** survived the entire engines suite — no contract happens to use a bare `assert(x)`. Seven tests now cover the ledger, and seven mutations against them all die, including two the first draft of those tests missed:

- reading `assert.AssertionError` to check the non-function guard proves nothing — a class is a function either way. `name` and `length` are the properties that actually distinguish a wrapped value from a passed-through one.
- truncating the apply trap's arguments went unnoticed until a bare `assert(false, "why")` was asserted to keep its message.

## Why two copies of the ledger

`engines` may not import `adapters` and the layer rule is right to say so, and neither belongs in `core`, which ships. The fixture pattern is already duplicated for exactly that reason.

## Verification

- **1216 tests pass, 0 fail, 0 cancelled** on Node 22.23 and 24.12 (`npm run check` exit 0 on both)
- Re-swept all 32 contract assertions with the ledger in place: **0 survivors**
- 7 mutations against the ledger's own tests: **all die**
- The contract's self-defence probe (delete a real assertion, require the fixture to go red *on the ledger*) re-verified against gutting a case's ledger check and against a probe that removes nothing: **both die**

🤖 Generated with [Claude Code](https://claude.com/claude-code)