### PR TITLE
fix(mobile): an RTL locale with a Unicode extension was laid out left to right

### DIFF
--- a/src/praisonai-mobile/app/src/dom.test.ts
+++ b/src/praisonai-mobile/app/src/dom.test.ts
@@ -38,7 +38,22 @@ function fakeDoc() {
       set textContent(v: string) { this._text = v; this.children = []; },
       get innerHTML() { return this._html; },
       set innerHTML(v: string) { this._html = v; },
-      classList: { toggle() {} },
+      // A real classList. The previous `toggle() {}` was a fake that lied: it
+      // accepted every call and recorded nothing, so `classList.toggle(
+      // "streaming", row.streaming)` could be deleted outright and no test
+      // could tell. Backed by `className` so the two agree, as they do in a
+      // browser.
+      classList: {
+        toggle(name: string, on?: boolean) {
+          const set = new Set(el.className.split(" ").filter((c: string) => c !== ""));
+          const want = on ?? !set.has(name);
+          if (want) set.add(name); else set.delete(name);
+          el.className = [...set].join(" ");
+        },
+        contains(name: string) {
+          return el.className.split(" ").includes(name);
+        },
+      },
       append(...cs: any[]) {
         for (const c of cs) { c.parent = this; this.children.push(c); }
       },
@@ -382,4 +397,147 @@ test("each approval button carries its OWN choice", () => {
   for (const b of buttons) {
     assert.equal(b.dataset.approvalId, "a1", "and each must address its own approval");
   }
+});
+
+// ---- what a row actually SAYS ----------------------------------------------
+//
+// A mutation audit found nine survivors in this file. Every one of them is the
+// same shape: the tests reached rows by `dataset`, never by what a person
+// reads, so every visible string and every class name could be dropped or
+// swapped with a green suite.
+
+const auditToolRow = (over: Partial<Extract<Row, { kind: "tool" }>> = {}): Row => ({
+  kind: "tool",
+  id: "tool:c1",
+  callId: "c1",
+  name: "bash",
+  args: {},
+  status: "ok",
+  tone: "success",
+  output: "total 4\ndrwxr-xr-x",
+  preview: "total 4",
+  seconds: 1.2,
+  durationLabel: "1.2s",
+  durationKnown: true,
+  ...over,
+});
+
+const approvalRow = (over: Partial<Extract<Row, { kind: "approval" }>> = {}): Row => ({
+  kind: "approval",
+  id: "approval:ap1",
+  approvalId: "ap1",
+  callId: "c1",
+  name: "rm",
+  args: { path: "/" },
+  state: { status: "pending" },
+  actionable: true,
+  ...over,
+});
+
+const paintOne = (row: Row) => {
+  const { host } = fakeDoc();
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: row.id, index: 0, row }]);
+  return host.children[0] as any;
+};
+
+const descend = (node: any, out: any[] = []): any[] => {
+  out.push(node);
+  for (const c of node.children ?? []) descend(c, out);
+  return out;
+};
+
+test("each approval button says what it does", () => {
+  // `b.textContent = strings.approvalChoice(choice)` was removable. All three
+  // buttons then read the same -- blank -- and the user taps the one they
+  // believe is Deny and sends `allow`. Every existing test found its button by
+  // `dataset["choice"]`, which the mutation leaves perfectly intact.
+  const el = paintOne(approvalRow());
+  const buttons = descend(el).filter((n) => String(n.tagName).toLowerCase() === "button");
+
+  assert.equal(buttons.length, 3);
+  assert.deepEqual(
+    buttons.map((b) => b.textContent),
+    ["Allow", "Always allow", "Deny"],
+    "the label a user reads must match the choice the button sends",
+  );
+  // And each label must sit on the button that sends that choice.
+  for (const b of buttons) {
+    assert.equal(
+      b.textContent,
+      { allow: "Allow", always: "Always allow", deny: "Deny" }[b.dataset["choice"] as string],
+      `the "${b.textContent}" button sends "${b.dataset["choice"]}"`,
+    );
+  }
+});
+
+test("an approval names the command it is asking about", () => {
+  // `q.textContent = strings.approvalQuestion(row.name)` was removable: the
+  // user is asked to authorise a command the prompt does not identify.
+  const el = paintOne(approvalRow({ name: "rm" }));
+  const text = descend(el).map((n) => n.textContent).join(" ");
+  assert.ok(text.includes("rm"), `the prompt must name the tool; got: ${text}`);
+});
+
+test("a tool row shows the tool's name and its output preview", () => {
+  // Two survivors: `name.textContent = row.name` (rows showed the call id) and
+  // the whole `if (row.preview !== "")` block (no tool output ever painted).
+  const el = paintOne(auditToolRow());
+  const all = descend(el);
+  const name = all.find((n) => n.className === "tool-name");
+  const out = all.find((n) => n.className === "tool-output");
+
+  assert.equal(name?.textContent, "bash", "the tool's NAME, not its call id");
+  assert.equal(out?.textContent, "total 4", "the preview must be painted");
+});
+
+test("a tool row shows the PREVIEW, not the whole output", () => {
+  // `out.textContent = row.preview` -> `row.output` survived: a 40kB tool
+  // result floods the row instead of the truncated first line.
+  const el = paintOne(auditToolRow({ output: "line one\nline two", preview: "line one" }));
+  const out = descend(el).find((n) => n.className === "tool-output");
+  assert.equal(out?.textContent, "line one");
+});
+
+test("a tool row with no output paints no output element -- the pair", () => {
+  const el = paintOne(auditToolRow({ output: "", preview: "" }));
+  assert.equal(descend(el).find((n) => n.className === "tool-output"), undefined);
+});
+
+test("every row carries the class its stylesheet selects on", () => {
+  // ``el.className = `row row-${row.kind}` `` was removable. Every
+  // `.row-tool` / `.row-approval` / `.row-error` rule in app.css then stops
+  // matching and the transcript renders as undifferentiated grey boxes --
+  // which no assertion about textContent can see.
+  for (const row of [
+    auditToolRow(),
+    approvalRow(),
+    { kind: "text", id: "t0", text: "hi", streaming: false } as Row,
+    { kind: "notice", id: "n0", text: "Stopped", tone: "warning" } as Row,
+  ]) {
+    const el = paintOne(row);
+    assert.ok(
+      String(el.className).split(" ").includes(`row-${row.kind}`),
+      `a ${row.kind} row must carry row-${row.kind}; got "${el.className}"`,
+    );
+    assert.ok(String(el.className).split(" ").includes("row"), "and the base class");
+  }
+});
+
+test("only the streaming row carries the streaming class", () => {
+  // `classList.toggle("streaming", row.streaming)` was removable -- and could
+  // not have been caught before, because this file's fake document had a
+  // `classList.toggle() {}` that accepted every call and recorded nothing.
+  const live = paintOne({ kind: "text", id: "t0", text: "half", streaming: true } as Row);
+  const done = paintOne({ kind: "text", id: "t1", text: "whole", streaming: false } as Row);
+
+  assert.ok(String(live.className).split(" ").includes("streaming"), "the live row has the caret");
+  assert.ok(!String(done.className).split(" ").includes("streaming"), "a finished row does not");
+});
+
+test("a notice shows its text and its tone", () => {
+  // Both lines were removable: the Stopped notice rendered the literal word
+  // "warning", or nothing at all.
+  const el = paintOne({ kind: "notice", id: "n0", text: "Stopped", tone: "warning" } as Row);
+  assert.equal(el.textContent, "Stopped");
+  assert.equal(el.dataset["tone"], "warning");
 });

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -590,3 +590,61 @@ test("an approval row shows the decision after the user answers it", async () =>
   );
   app?.dispose();
 });
+
+// ---- the accessibility wiring, which nothing had asserted -------------------
+//
+// A mutation audit found that `polite`'s aria-live was pinned and `assertive`'s
+// was not, that the transcript's NOT being a live region -- the catastrophe its
+// own comment describes -- was undefended, and that the composer's label could
+// go back to the regression the code comment records as fixed.
+
+test("the two live regions have the politeness each one is for", async () => {
+  // `assertive.setAttribute("aria-live", "assertive")` was removable, and
+  // could also be flipped to "polite". The assertive region carries approval
+  // prompts and errors: an approval BLOCKS the run, so waiting politely for
+  // the queue to drain is waiting for something that will not happen until
+  // the user answers. Only `polite`'s attribute had a test.
+  const { dom, platform } = harness();
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  const regions = dom.all().filter((n) => n.getAttribute("aria-live") !== null);
+  assert.deepEqual(
+    regions.map((n) => n.getAttribute("aria-live")).sort(),
+    ["assertive", "polite"],
+    "exactly one polite region and one assertive one",
+  );
+  for (const region of regions) {
+    assert.ok(region.className.includes("sr-only"), "a live region is not visible");
+  }
+  app?.dispose();
+});
+
+test("the transcript is NOT a live region", async () => {
+  // Nothing asserted this, and the consequence is written out in main.ts: the
+  // transcript is mutated on every publish, so aria-live here makes the reader
+  // restart on each token batch and no sentence is ever finished. A one-line
+  // addition away, and undetectable.
+  const { dom, platform } = harness();
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  const log = dom.find((n) => n.getAttribute("role") === "log");
+  assert.ok(log, "the transcript is a log");
+  assert.equal(log.getAttribute("aria-live"), null, "and must never also be a live region");
+  assert.equal(log.getAttribute("aria-label"), en.appName, "it must still be named");
+  app?.dispose();
+});
+
+test("the message field is labelled as the field, not as the button beside it", async () => {
+  // `input.setAttribute("aria-label", strings.composerLabel)` was removable
+  // and could be given the Send button's name -- which is the exact regression
+  // the line's own comment records: the composer announced as "Send, edit
+  // text".
+  const { dom, platform } = harness();
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  const box = dom.find((n) => n.tagName === "TEXTAREA");
+  assert.ok(box);
+  assert.equal(box.getAttribute("aria-label"), en.composerLabel);
+  assert.notEqual(box.getAttribute("aria-label"), en.actionSend, "not the button's name");
+  app?.dispose();
+});

--- a/src/praisonai-mobile/ui/src/i18n/locale.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/locale.test.ts
@@ -191,3 +191,71 @@ test("the fallback tables agree with Intl across a corpus of real tags", (t) => 
   }
   assert.deepEqual(disagreements, [], "the fallback tables have drifted from Intl");
 });
+
+test("an EXTENSION subtag is not mistaken for a script", () => {
+  // A LIVE BUG, not a mutant. `ar-EG-u-nu-latn` -- an Arabic phone whose
+  // locale carries a Unicode numbering-system extension, which is what a real
+  // device reports -- was read as script "Latn" and laid out LEFT TO RIGHT.
+  // The old loop scanned every subtag for a four-letter one; `latn` inside
+  // `-u-nu-latn` is four letters. Per BCP 47 a script sits immediately after
+  // the language and nowhere else, and everything from the first singleton
+  // subtag onward is an extension.
+  //
+  // Invisible on any host with `Intl.Locale.textInfo`, because `direction()`
+  // answers from ICU first -- and this table is only consulted where ICU is
+  // ABSENT, which is exactly the older WebView it exists for.
+  assert.equal(directionFromTables("ar-EG-u-nu-latn"), "rtl");
+  assert.equal(directionFromTables("fa-IR-u-nu-latn"), "rtl");
+  assert.equal(directionFromTables("ur-PK-u-nu-latn"), "rtl");
+  assert.equal(directionFromTables("ar-u-nu-latn"), "rtl");
+  // Transform and private-use extensions are the same shape.
+  assert.equal(directionFromTables("he-IL-t-en-latn"), "rtl");
+  assert.equal(directionFromTables("ar-x-latn"), "rtl");
+  // And the extension must not flip an LTR locale either way.
+  assert.equal(directionFromTables("en-US-u-nu-arab"), "ltr");
+  // A real script subtag still wins, extension or not.
+  assert.equal(directionFromTables("az-Arab-IR-u-nu-latn"), "rtl");
+  assert.equal(directionFromTables("ar-Latn-EG-u-nu-arab"), "ltr");
+});
+
+test("the fallback tables agree with ICU on every tag ICU can answer", () => {
+  // The drift check, widened to the tags that carry extensions. A previous
+  // comparison over plain tags found thirteen disagreements; this one found
+  // `-u-nu-latn`. Comparing is the durable form -- the table cannot be
+  // enumerated correctly by hand, and this fails the day it drifts again.
+  const bases = [
+    "ar", "ar-EG", "ar-SA", "he", "he-IL", "fa", "fa-IR", "ur", "ur-PK", "ps",
+    "sd", "dv", "ckb", "ug", "yi", "arc", "nqo", "syr", "pnb", "ks",
+    "en", "en-US", "fr", "de", "ja", "zh-Hans", "ru", "hi", "tr", "ta", "ko",
+  ];
+  const suffixes = ["", "-u-nu-latn", "-u-ca-gregory", "-u-nu-arab", "-x-priv"];
+
+  const drift: string[] = [];
+  let compared = 0;
+  for (const base of bases) {
+    for (const suffix of suffixes) {
+      const tag = `${base}${suffix}`;
+      let icu: string | undefined;
+      try {
+        const loc = new Intl.Locale(tag) as {
+          getTextInfo?: () => { direction: string };
+          textInfo?: { direction: string };
+        };
+        icu = loc.getTextInfo?.().direction ?? loc.textInfo?.direction;
+      } catch {
+        icu = undefined;
+      }
+      if (icu === undefined) continue; // ICU cannot answer; nothing to compare
+      compared += 1;
+      const tables = directionFromTables(tag);
+      if (tables !== icu) drift.push(`${tag}: tables=${tables} icu=${icu}`);
+    }
+  }
+  // A drift test on a host where ICU answers NOTHING passes while comparing
+  // nothing, which is the exact false green this file's history is made of.
+  assert.ok(
+    compared >= bases.length,
+    `the comparison was vacuous: ICU answered ${compared} of ${bases.length * suffixes.length}`,
+  );
+  assert.deepEqual(drift, [], `the fallback disagrees with ICU:\n${drift.join("\n")}`);
+});

--- a/src/praisonai-mobile/ui/src/i18n/locale.ts
+++ b/src/praisonai-mobile/ui/src/i18n/locale.ts
@@ -137,22 +137,40 @@ function directionFromIntl(tag: string): Direction | null {
  * `Intl.Locale.textInfo` -- exactly the devices most likely to be affected --
  * and the failure is the whole UI mirrored the wrong way, or not at all.
  */
+/** The script subtag, if this tag has one: four letters at position 1 exactly. */
+function identifier(parts: readonly string[]): string | undefined {
+  const second = parts[1];
+  return second !== undefined && second.length === 4 ? second : undefined;
+}
+
 export function directionFromTables(tag: string): Direction {
   const parts = subtags(tag).map((part) => part.toLowerCase());
   const language = parts[0] ?? "";
 
-  // A script subtag is four letters. Checked before the language table because
+  // A script subtag is four letters and, per BCP 47, sits IMMEDIATELY after
+  // the language and nowhere else. Checked before the language table because
   // "az-Arab" must beat "az".
-  for (const part of parts.slice(1)) {
-    if (part.length !== 4) continue;
-    const script = part.charAt(0).toUpperCase() + part.slice(1);
-    if (RTL_SCRIPTS.has(script)) return "rtl";
-    return "ltr";
+  //
+  // Position matters, and the previous version scanned every subtag for a
+  // four-letter one. `ar-EG-u-nu-latn` -- an Arabic phone reporting a Unicode
+  // numbering-system extension, which is what a real device sends -- then
+  // matched `latn` inside the extension, and the whole UI was laid out left to
+  // right. Invisible on any host with `Intl.Locale.textInfo`, because
+  // `direction()` answers from ICU first and only falls back here where ICU is
+  // ABSENT -- the older WebView this table exists to serve.
+  //
+  // Reading only position 1 is sufficient on its own: an extension begins with
+  // a single-character subtag, which is never four letters, and no subtag
+  // after position 1 can be a script. A separate "stop at the first singleton"
+  // pass was written first and then removed -- it made the two guards mutually
+  // redundant, so neither could be shown to matter by any test.
+  const script = identifier(parts);
+  if (script !== undefined) {
+    const titled = script.charAt(0).toUpperCase() + script.slice(1);
+    return RTL_SCRIPTS.has(titled) ? "rtl" : "ltr";
   }
 
-  if (RTL_LANGUAGES.has(language)) return "rtl";
-  const withScript = parts.length > 1 ? `${language}-${parts[1] ?? ""}` : language;
-  return RTL_LANGUAGES.has(withScript) ? "rtl" : "ltr";
+  return RTL_LANGUAGES.has(language) ? "rtl" : "ltr";
 }
 
 /**


### PR DESCRIPTION
## A live bug, not a mutant

`directionFromTables` scanned **every** subtag for a four-letter one and read it as the script. `ar-EG-u-nu-latn` — an Arabic phone reporting a Unicode numbering-system extension, which is what a real device sends — matched `latn` *inside the extension*:

```
ar-EG-u-nu-latn   tables=ltr   (should be rtl)
fa-IR-u-nu-latn   tables=ltr
ur-PK-u-nu-latn   tables=ltr
```

The entire UI, mirrored the wrong way. Invisible on any host with `Intl.Locale.textInfo`, because `direction()` answers from ICU first and only falls back to this table where ICU is **absent** — the older Android WebView the table exists to serve.

Per BCP 47 a script subtag sits immediately after the language and nowhere else, so the fix reads position 1 only.

**A second guard was written and then removed.** A "stop at the first singleton subtag" pass fixed the same case independently — which made the two guards mutually redundant, and neither could be shown to matter by any test (both mutations survived). One mechanism that can be tested beats two that cannot.

The ICU drift test is widened to tags carrying extensions, with a **non-vacuity floor**: a drift test on a host where ICU answers nothing passes while comparing nothing.

## Ten survivors in `app/src/dom.ts`, all the same shape

The tests reached rows by `dataset`, never by what a person reads.

| Mutation | What the user sees |
|---|---|
| drop the approval button label | **All three buttons blank or identical.** The user taps the one they believe says Deny and sends `allow`. Every existing test found its button by `dataset["choice"]` — untouched by the mutation. |
| drop the approval question | The user authorises a command the prompt does not name. |
| tool name → call id | Tool rows show `c1` instead of `bash`. |
| remove the preview block | **No tool output is ever painted.** |
| preview → full output | A 40 kB tool result floods the row. |
| drop `row row-${kind}` | Every `.row-tool` / `.row-approval` / `.row-error` rule in `app.css` stops matching — the transcript is undifferentiated grey boxes. |
| drop the notice tone | The Stopped notice renders the literal word "warning". |

The **streaming-class toggle could not have been caught before**: this file's fake document had `classList: { toggle() {} }` — a fake that accepted every call and recorded nothing. It's now backed by `className`, as a browser's is.

## Three in `main.ts`'s accessibility wiring

- **`polite`'s `aria-live` was pinned; `assertive`'s was not.** The region carrying approval prompts and errors could silently go polite — and an approval *blocks the run*, so waiting for the queue to drain waits for something that will not happen until the user answers.
- **Nothing asserted the transcript is NOT a live region** — the catastrophe its own comment describes (the reader restarts on every token batch, no sentence ever finishes) was one line away and undetectable.
- **The composer's label could be given the Send button's name** — the exact regression that line's comment records as fixed: "Send, edit text".

## Verification

- **1229 tests pass, 0 fail, 0 cancelled** on Node 22.23 and 24.12 (`npm run check` exit 0 on both)
- The live locale bug reproduced before the fix and re-verified after
- **21 mutations** re-run against the new tests — including reverting the locale fix itself — **all die**
- Every negative case paired with a positive one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved right-to-left and left-to-right language detection for tags containing Unicode extensions.
  - Added broader support for Arabic, Persian-script, and related languages.
  - Corrected accessibility labeling for the message composer and transcript area.
  - Ensured live announcements use the appropriate polite and assertive regions.

- **Tests**
  - Expanded coverage for approval prompts, tool previews, streaming states, notices, accessibility behavior, and text direction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->