### PR TITLE
perf: compile completion patterns once

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -8,6 +8,7 @@ import contextlib
 import threading
 import concurrent.futures
 import random
+import re
 from typing import List, Optional, Any, Dict, Union, Literal, TYPE_CHECKING, Callable, Generator
 from collections import OrderedDict
 import inspect
@@ -32,6 +33,18 @@ from ..goal.loop import GoalLoopMixin
 
 # Module-level logger for thread safety errors and debugging
 logger = get_logger(__name__)
+
+_COMPLETION_NEGATION_RE = re.compile(
+    r'\b(?:not|never|no longer|hardly|barely|isn\'t|aren\'t|wasn\'t|weren\'t|hasn\'t|haven\'t|hadn\'t|won\'t|wouldn\'t|can\'t|couldn\'t|shouldn\'t|don\'t|doesn\'t|didn\'t)\b'
+    r'.{0,20}'
+)
+_COMPLETION_PATTERNS = (
+    (re.compile(r'\btask\s+completed?\b'), False),
+    (re.compile(r'\bcompleted\s+successfully\b'), False),
+    (re.compile(r'\ball\s+done\b'), False),
+    (re.compile(r'\bdone\b'), True),
+    (re.compile(r'\bfinished\b'), True),
+)
 
 # ============================================================================
 # Performance: Lazy imports for heavy dependencies
@@ -4191,21 +4204,7 @@ Summary:"""
         Returns:
             True if a completion signal is detected
         """
-        import re
         response_lower = response_text.lower()
-        # Negation patterns that should NOT be treated as completion
-        _NEGATION_RE = re.compile(
-            r'\b(?:not|never|no longer|hardly|barely|isn\'t|aren\'t|wasn\'t|weren\'t|hasn\'t|haven\'t|hadn\'t|won\'t|wouldn\'t|can\'t|couldn\'t|shouldn\'t|don\'t|doesn\'t|didn\'t)\b'
-            r'.{0,20}'   # up to 20 chars between negation and keyword
-        )
-        # Word-boundary patterns to avoid substring false positives
-        _COMPLETION_PATTERNS = [
-            (re.compile(r'\btask\s+completed?\b'), False),         # no negation check needed
-            (re.compile(r'\bcompleted\s+successfully\b'), False),
-            (re.compile(r'\ball\s+done\b'), False),
-            (re.compile(r'\bdone\b'), True),          # 'done' needs negation check
-            (re.compile(r'\bfinished\b'), True),      # 'finished' needs negation check
-        ]
         for pattern, needs_negation_check in _COMPLETION_PATTERNS:
             match = pattern.search(response_lower)
             if match:
@@ -4213,7 +4212,7 @@ Summary:"""
                     # Check if a negation word precedes the match within 30 chars
                     start = max(0, match.start() - 30)
                     prefix = response_lower[start:match.start()]
-                    if _NEGATION_RE.search(prefix):
+                    if _COMPLETION_NEGATION_RE.search(prefix):
                         continue  # Skip — negated completion
                     # Also check "not X yet" pattern
                     end = min(len(response_lower), match.end() + 10)

--- a/src/praisonai-agents/tests/unit/test_autonomy_gaps.py
+++ b/src/praisonai-agents/tests/unit/test_autonomy_gaps.py
@@ -24,6 +24,25 @@ from unittest.mock import patch, AsyncMock
 class TestCompletionDetection:
     """Tests that completion detection uses word boundaries, not substrings."""
 
+    def test_completion_patterns_are_compiled_once(self, monkeypatch):
+        """Completion checks should reuse patterns compiled at module import."""
+        import re
+        from praisonaiagents.agent.agent import Agent
+
+        compile_calls = 0
+        original_compile = re.compile
+
+        def counting_compile(*args, **kwargs):
+            nonlocal compile_calls
+            compile_calls += 1
+            return original_compile(*args, **kwargs)
+
+        monkeypatch.setattr(re, "compile", counting_compile)
+
+        assert Agent._is_completion_signal("Task completed.") is True
+        assert Agent._is_completion_signal("Still working.") is False
+        assert compile_calls == 0
+
     def _make_agent(self):
         """Create a minimal autonomy-enabled agent."""
         from praisonaiagents import Agent


### PR DESCRIPTION
## Summary

- compile the completion-signal negation and keyword patterns once at module import
- reuse the compiled patterns on every autonomy-loop completion check
- add a regression test proving repeated checks do not call `re.compile`

## Validation

- `test_autonomy_gaps.py`: 50 passed
- focused compile-once regression: 1 passed (and failed with 12 compile calls before the source change)
- `python -m py_compile` on both changed files
- `git diff --check`

The repository's live-agent test was not run because this automation environment has no supported provider API key. The change does not alter completion matching, method signatures, call sites, or public APIs.

Fixes #4609


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved completion detection efficiency by reusing precompiled matching patterns.

* **Bug Fixes**
  * Preserved existing completion-signal behavior while avoiding repeated pattern compilation.

* **Tests**
  * Added coverage confirming completion patterns are not recompiled during runtime checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->