### PR TITLE
test(mobile): the ledger's self-defence protected one case, not twenty-one

### DIFF
--- a/src/praisonai-mobile/engines/src/conformance.ts
+++ b/src/praisonai-mobile/engines/src/conformance.ts
@@ -85,6 +85,10 @@ async function drive(
  * `describeEngineContract(harness)` at the top level of a .test.ts file is all
  * an engine author has to write.
  */
+/** How many cases this contract registers. Each must either count its own
+ *  assertions or declare itself skipped; the last case checks that they did. */
+const CONTRACT_CASES = 21;
+
 export function describeEngineContract(harness: EngineHarness): void {
   const name = harness.name;
   const counting = ledger();
@@ -97,6 +101,36 @@ export function describeEngineContract(harness: EngineHarness): void {
   const skip = (scenario: ScenarioName): string | null =>
     harness.unsupported?.[scenario] ?? null;
 
+  // Every case ends by CLOSING itself -- either it made its assertions, or it
+  // was skipped because the harness declared the scenario unsupported. The
+  // final case asserts that all of them did exactly one of the two.
+  //
+  // Without that, each `rawAssert.equal(made() - made0, N)` was individually
+  // deletable: the self-defence probe in conformance.test.ts removes ONE
+  // assertion and requires the run to redden, so only the case containing that
+  // assertion had its own count defended. Measured against the full suite:
+  // 18 of 21 could be deleted with `npm run check` still exiting 0.
+  //
+  // Which is the same structural hole the ledger was built to close, one level
+  // up -- a check that protects the first thing it happens to reach.
+  let closed = 0;
+  let skippedCases = 0;
+
+  /** This case made exactly the assertions it is supposed to make. */
+  const close = (made0: number, expected: number): void => {
+    closed += 1;
+    rawAssert.equal(made() - made0, expected, LEDGER);
+  };
+
+  /** Declared unsupported by this harness: say so, count it, and stop. */
+  const skipping = (scenario: ScenarioName): boolean => {
+    const why = skip(scenario);
+    if (why === null) return false;
+    skippedCases += 1;
+    console.log(`  skipped: ${why}`);
+    return true;
+  };
+
   // ---- handshake ---------------------------------------------------------
 
   test(`${name}: an adapter reports a protocol version before any turn is started`, async () => {
@@ -106,7 +140,7 @@ export function describeEngineContract(harness: EngineHarness): void {
     assert.equal(engine.protocolVersion, PROTOCOL_VERSION);
     assert.equal(checkProtocol(engine.protocolVersion).ok, true);
     await engine.dispose();
-    rawAssert.equal(made() - made0, 3, LEDGER);
+    close(made0, 3);
   });
 
   test(`${name}: an engine declares a stable id`, async () => {
@@ -118,7 +152,7 @@ export function describeEngineContract(harness: EngineHarness): void {
     assert.equal(a.id, b.id, "the id must not vary between instances");
     await a.dispose();
     await b.dispose();
-    rawAssert.equal(made() - made0, 3, LEDGER);
+    close(made0, 3);
   });
 
   // ---- lifecycle and ordering -------------------------------------------
@@ -134,7 +168,7 @@ export function describeEngineContract(harness: EngineHarness): void {
     assert.equal(terminals.length, 1, `expected one terminal event, got ${terminals.length}`);
     assert.ok(isTerminal(events[events.length - 1] as RunEvent), "the last event must be terminal");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 4, LEDGER);
+    close(made0, 4);
   });
 
   test(`${name}: every event in a run carries the same msgId`, async () => {
@@ -145,7 +179,7 @@ export function describeEngineContract(harness: EngineHarness): void {
     assert.equal(ids.size, 1, `expected one msgId, got ${[...ids].join(", ")}`);
     assert.notEqual([...ids][0], "", "msgId must not be empty");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 2, LEDGER);
+    close(made0, 2);
   });
 
   test(`${name}: a conforming run drops nothing`, async () => {
@@ -156,7 +190,7 @@ export function describeEngineContract(harness: EngineHarness): void {
     const { state } = await drive(engine);
     assert.deepEqual(state.dropped, [], `a clean run dropped: ${JSON.stringify(state.dropped)}`);
     await engine.dispose();
-    rawAssert.equal(made() - made0, 1, LEDGER);
+    close(made0, 1);
   });
 
   test(`${name}: a happy run produces text and ends persisted`, async () => {
@@ -166,40 +200,37 @@ export function describeEngineContract(harness: EngineHarness): void {
     assert.notEqual(state.text, "", "a happy run must produce text");
     assert.equal(state.outcome?.type, "end");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 2, LEDGER);
+    close(made0, 2);
   });
 
   // ---- emptiness ---------------------------------------------------------
 
   test(`${name}: an empty stream is an error, not an empty answer`, async () => {
-    const why = skip("empty");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("empty")) return;
     const made0 = made();
     const engine = await harness.create("empty");
     const { state } = await drive(engine);
     assert.equal(state.outcome?.type, "error");
     assert.equal(state.outcome?.type === "error" && state.outcome.kind, "empty");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 2, LEDGER);
+    close(made0, 2);
   });
 
   // ---- tools -------------------------------------------------------------
 
   test(`${name}: a successful tool call resolves to ok`, async () => {
-    const why = skip("tool_ok");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("tool_ok")) return;
     const made0 = made();
     const engine = await harness.create("tool_ok");
     const { state } = await drive(engine);
     assert.ok(state.tools.length >= 1, "expected at least one tool row");
     assert.equal(state.tools[0]?.status, "ok");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 2, LEDGER);
+    close(made0, 2);
   });
 
   test(`${name}: a failed tool is reported failed and never inferred from its output`, async () => {
-    const why = skip("tool_failed");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("tool_failed")) return;
     const made0 = made();
     const engine = await harness.create("tool_failed");
     const { state } = await drive(engine);
@@ -210,18 +241,17 @@ export function describeEngineContract(harness: EngineHarness): void {
       "a tool that failed must not read as successful because its output looks plausible",
     );
     await engine.dispose();
-    rawAssert.equal(made() - made0, 2, LEDGER);
+    close(made0, 2);
   });
 
   test(`${name}: a tool call with no result is unresolved at the end, not successful`, async () => {
-    const why = skip("tool_unresolved");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("tool_unresolved")) return;
     const made0 = made();
     const engine = await harness.create("tool_unresolved");
     const { state } = await drive(engine);
     assert.equal(state.tools[0]?.status, "unresolved");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 1, LEDGER);
+    close(made0, 1);
   });
 
   test(`${name}: an engine that declares no tool support never emits a tool event`, async () => {
@@ -241,14 +271,13 @@ export function describeEngineContract(harness: EngineHarness): void {
     // Nothing to assert when the engine DOES support tools -- the case exists
     // for the other branch. The count says so rather than leaving a case that
     // silently checks nothing for most harnesses.
-    rawAssert.equal(made() - made0, engine.capabilities.tools ? 0 : 1, LEDGER);
+    close(made0, engine.capabilities.tools ? 0 : 1);
   });
 
   // ---- approvals ---------------------------------------------------------
 
   test(`${name}: an approval decision is routed by approvalId, not by the pending row`, async () => {
-    const why = skip("two_approvals");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("two_approvals")) return;
     const made0 = made();
     const engine = await harness.create("two_approvals");
     const controller = new AbortController();
@@ -270,12 +299,11 @@ export function describeEngineContract(harness: EngineHarness): void {
       "a decision already made must not be reported as made again",
     );
     await engine.dispose();
-    rawAssert.equal(made() - made0, 3, LEDGER);
+    close(made0, 3);
   });
 
   test(`${name}: deciding an unknown approval returns false rather than reporting success`, async () => {
-    const why = skip("approval");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("approval")) return;
     const made0 = made();
     const engine = await harness.create("approval");
     assert.equal(
@@ -284,7 +312,7 @@ export function describeEngineContract(harness: EngineHarness): void {
       "reporting success for an unknown id is a lie the UI cannot detect",
     );
     await engine.dispose();
-    rawAssert.equal(made() - made0, 1, LEDGER);
+    close(made0, 1);
   });
 
   test(`${name}: an engine that declares no approval support never emits an approval_request`, async () => {
@@ -300,7 +328,7 @@ export function describeEngineContract(harness: EngineHarness): void {
     }
     await engine.dispose();
     // Same shape as the tools capability case above.
-    rawAssert.equal(made() - made0, engine.capabilities.approvals ? 0 : 1, LEDGER);
+    close(made0, engine.capabilities.approvals ? 0 : 1);
   });
 
   // ---- cancellation ------------------------------------------------------
@@ -312,12 +340,11 @@ export function describeEngineContract(harness: EngineHarness): void {
     const engine = await harness.create("happy");
     assert.equal(await engine.cancel("no-such-run"), false);
     await engine.dispose();
-    rawAssert.equal(made() - made0, 1, LEDGER);
+    close(made0, 1);
   });
 
   test(`${name}: a cancelled turn emits no end and no usage`, async () => {
-    const why = skip("cancelled");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("cancelled")) return;
     const made0 = made();
     const engine = await harness.create("cancelled");
     const { events, state } = await drive(engine);
@@ -325,7 +352,7 @@ export function describeEngineContract(harness: EngineHarness): void {
     assert.equal(events.some((e) => e.type === "end"), false, "a cancelled turn must not also end");
     assert.equal(events.some((e) => e.type === "usage"), false, "a cancelled turn is not persisted");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 3, LEDGER);
+    close(made0, 3);
   });
 
   test(`${name}: aborting the signal stops the stream`, async () => {
@@ -355,43 +382,40 @@ export function describeEngineContract(harness: EngineHarness): void {
     // terminates is its business; that it stops is the contract.
     assert.ok(seen.length < 50, `abort did not stop the stream: ${seen.length} events`);
     await engine.dispose();
-    rawAssert.equal(made() - made0, 2, LEDGER);
+    close(made0, 2);
   });
 
   // ---- error taxonomy ----------------------------------------------------
 
   test(`${name}: an auth failure is kind auth so the ui can offer settings`, async () => {
-    const why = skip("auth_error");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("auth_error")) return;
     const made0 = made();
     const engine = await harness.create("auth_error");
     const { state } = await drive(engine);
     assert.equal(state.outcome?.type, "error");
     assert.equal(state.outcome?.type === "error" && state.outcome.kind, "auth");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 2, LEDGER);
+    close(made0, 2);
   });
 
   test(`${name}: a rate limit is distinct from an internal error`, async () => {
-    const why = skip("rate_limit_error");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("rate_limit_error")) return;
     const made0 = made();
     const engine = await harness.create("rate_limit_error");
     const { state } = await drive(engine);
     assert.equal(state.outcome?.type === "error" && state.outcome.kind, "rate_limit");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 1, LEDGER);
+    close(made0, 1);
   });
 
   test(`${name}: an error carries a message that is never the empty string`, async () => {
-    const why = skip("auth_error");
-    if (why !== null) return void console.log(`  skipped: ${why}`);
+    if (skipping("auth_error")) return;
     const made0 = made();
     const engine = await harness.create("auth_error");
     const { state } = await drive(engine);
     assert.notEqual(state.outcome?.type === "error" && state.outcome.message, "");
     await engine.dispose();
-    rawAssert.equal(made() - made0, 1, LEDGER);
+    close(made0, 1);
   });
 
   // ---- hygiene -----------------------------------------------------------
@@ -403,6 +427,18 @@ export function describeEngineContract(harness: EngineHarness): void {
     await engine.dispose();
     // Deliberately zero: this case passes by NOT throwing, so there is nothing
     // to count. Pinned anyway, so adding an assertion here is a decision.
-    rawAssert.equal(made() - made0, 0, LEDGER);
+    close(made0, 0);
+  });
+
+  // Registered last, so every case above has already run.
+  test(`${name}: every case in this contract closed itself`, () => {
+    rawAssert.equal(
+      closed + skippedCases,
+      CONTRACT_CASES,
+      `${name}: ${closed} cases counted their assertions and ${skippedCases} were ` +
+        `skipped, which is ${closed + skippedCases} of ${CONTRACT_CASES}. A case that ` +
+        `neither counted nor skipped has lost its ledger check, and every assertion ` +
+        `in it is free again. See engines/src/assert-ledger.ts.`,
+    );
   });
 }

--- a/src/praisonai-mobile/tools/build-webview.test.mjs
+++ b/src/praisonai-mobile/tools/build-webview.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -26,6 +26,32 @@ test("a shippable app builds, and dist carries the page and the stylesheet", () 
   for (const f of ["index.html", "app.css", "app.js"]) {
     assert.ok(existsSync(join(dir, "dist", f)), `dist/${f} must exist`);
   }
+});
+
+test("a stale file from a previous build does not survive into dist", () => {
+  // `await rm(dist, ...)` was removable with a green suite, because every test
+  // built into a fresh temp directory where dist did not exist yet. On a real
+  // machine dist DOES exist -- that is the whole point of a build directory --
+  // so a renamed or deleted asset stays in the shipped output forever, and the
+  // page keeps loading a file nobody can find in the source any more.
+  const dir = fixture("export const hi: string = 'hi';\ndocument.title = hi;\n");
+  mkdirSync(join(dir, "dist"), { recursive: true });
+  writeFileSync(join(dir, "dist/left-over.js"), "// from a build two versions ago\n");
+  writeFileSync(join(dir, "dist/app.css"), "/* a stale stylesheet */\n");
+
+  const r = build(dir);
+  assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+
+  assert.equal(
+    existsSync(join(dir, "dist/left-over.js")),
+    false,
+    "a file the build no longer produces must not be shipped",
+  );
+  assert.match(
+    readFileSync(join(dir, "dist/app.css"), "utf8"),
+    /color: red/,
+    "and a file it DOES produce must be the fresh one, not the stale one",
+  );
 });
 
 test("an unshippable bundle FAILS the build, it does not merely print", () => {

--- a/src/praisonai-mobile/tools/check-upstream-parity.mjs
+++ b/src/praisonai-mobile/tools/check-upstream-parity.mjs
@@ -37,7 +37,15 @@ import { promisify } from "node:util";
 
 const run = promisify(execFile);
 
-const UPSTREAM = resolve(import.meta.dirname, "../../praisonai-ts");
+/** Where the sibling checkout lives.
+ *
+ *  Overridable for the same reason AGENT_API is: the SKIP path -- a standalone
+ *  clone with no praisonai-ts beside it -- had no test, and three mutations
+ *  survived in it. Dropping `process.exit(0)` makes the checker carry on
+ *  without the file it is meant to check; making `exists` answer true for a
+ *  missing path does the same from the other end. Either way a standalone
+ *  clone's CI fails for a reason that has nothing to do with drift. */
+const UPSTREAM = process.env["PARITY_UPSTREAM"] ?? resolve(import.meta.dirname, "../../praisonai-ts");
 const AGENT_SRC = join(UPSTREAM, "src/agent/simple.ts");
 /** The structural interface the real Agent must satisfy.
  *

--- a/src/praisonai-mobile/tools/check-upstream-parity.test.mjs
+++ b/src/praisonai-mobile/tools/check-upstream-parity.test.mjs
@@ -99,3 +99,53 @@ test("the parity typecheck runs in STRICT mode", () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("with no praisonai-ts beside it, the checker SKIPS and exits clean", () => {
+  // A standalone clone has no sibling checkout. Three mutations survived here:
+  // dropping `process.exit(0)` so the run carries on without the file it is
+  // meant to check, and flipping `exists` so a missing path reads as present.
+  // Either way the job fails for a reason that has nothing to do with drift,
+  // and whoever sees it goes looking for an API change that never happened.
+  const empty = mkdtempSync(join(tmpdir(), "parity-absent-"));
+  const result = spawnSync(process.execPath, [script], {
+    encoding: "utf8",
+    env: { ...process.env, PARITY_UPSTREAM: join(empty, "praisonai-ts") },
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+  assert.equal(result.status, 0, `a missing sibling must not fail the build:\n${output}`);
+  assert.match(output, /SKIPPED/, "and it must say it skipped rather than passing silently");
+  assert.doesNotMatch(
+    output,
+    /still satisfies PraisonAgent/,
+    "a skip is not a pass -- it must not claim the check ran",
+  );
+});
+
+test("with praisonai-ts present, it does NOT skip -- the pair", () => {
+  // Without this, an `exists` that always answered false would satisfy the
+  // test above and skip on every machine, including CI, forever.
+  const result = spawnSync(process.execPath, [script], { encoding: "utf8" });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  assert.doesNotMatch(output, /SKIPPED/, `the monorepo has the sibling:\n${output}`);
+  assert.equal(result.status, 0, output);
+});
+
+test("a drift failure NAMES what drifted, not just that something did", () => {
+  // `console.error` of the drift lines was removable with a green suite: the
+  // job goes red and prints nothing about which member changed, so the next
+  // person has a failing gate and no way to act on it. The exit code is the
+  // gate; the message is what makes it fixable.
+  const dir = mkdtempSync(join(tmpdir(), "parity-named-"));
+  const api = join(dir, "agent-api.ts");
+  writeFileSync(api, "export interface PraisonAgent { __aMemberUpstreamDoesNotHave: number; }\n");
+  const result = spawnSync(process.execPath, [script], {
+    encoding: "utf8",
+    env: { ...process.env, PARITY_AGENT_API: api },
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+  assert.notEqual(result.status, 0, `drift must fail:\n${output}`);
+  assert.match(output, /__aMemberUpstreamDoesNotHave/, `it must name the member:\n${output}`);
+  assert.match(output, /parity\.ts/, "and where the mismatch was reported");
+});

--- a/src/praisonai-mobile/ui/src/a11y/announce.test.ts
+++ b/src/praisonai-mobile/ui/src/a11y/announce.test.ts
@@ -222,6 +222,39 @@ test("refused events are announced at the end, and NOT during the stream", () =>
   const ended = apply(midStream, end);
   const second = tick(first.state, ended, 10_000);
   assert.equal(second.announcements.some((a) => a.reason === "dropped"), true);
+
+  // And exactly ONCE. Dropping `spokenDropped = turn.dropped.length` survived
+  // the whole suite: the cursor never advances, so every later publish of the
+  // same finished turn re-announces the same decoder gap. A screen-reader user
+  // hears "1 event could not be read" on a loop, and it is assertive, so it
+  // interrupts whatever else was being read each time.
+  const third = tick(second.state, ended, 20_000);
+  assert.equal(
+    third.announcements.some((a) => a.reason === "dropped"),
+    false,
+    "a gap already announced must not be announced again",
+  );
+  const fourth = tick(third.state, ended, 30_000);
+  assert.equal(fourth.announcements.some((a) => a.reason === "dropped"), false);
+});
+
+test("a SECOND refused event after the first was announced is announced too", () => {
+  // The pair. A cursor that simply latched "already said something" would pass
+  // the test above and then stay silent about every later gap in the same turn
+  // -- so the count is what advances, not a flag.
+  const one = run(start, delta("Working. "), { type: "delta", msgId: "other", text: "stray" });
+  const endedOnce = apply(one, end);
+  const said = tick(initialAnnouncer, endedOnce, 0);
+  assert.equal(said.announcements.some((a) => a.reason === "dropped"), true);
+
+  const endedTwice = apply(endedOnce, { type: "delta", msgId: "other", text: "stray again" });
+  assert.equal(endedTwice.dropped.length, 2, "the reducer recorded a second gap");
+  const again = tick(said.state, endedTwice, 10_000);
+  assert.equal(
+    again.announcements.some((a) => a.reason === "dropped"),
+    true,
+    "a new gap must still be reported",
+  );
 });
 
 test("a new turn starts the cursor over instead of skipping the answer", () => {


### PR DESCRIPTION
A fresh sweep of the code this session changed — **316 mutations over the eight files it touched** — found that the assertion ledger had reproduced, one level up, the exact structural hole it was built to close.

## The finding

The self-defence probe deletes **one** assertion from the engine contract and requires the fixture run to redden on the ledger. So only the case containing that assertion has its own `rawAssert.equal(made() - made0, N)` defended.

Measured against the **full** suite (`npm run check`, judged by exit code):

| | before | after |
|---|---|---|
| ledger checks deletable with a green run | **18 of 21** | **0 of 21** |

Every assertion in those 18 cases was free again. Which is exactly what a break mode does — protect the first thing it happens to reach.

Every case now **closes itself**: it either counts its assertions or declares itself skipped, and a final case asserts all 21 did exactly one of the two.

### Four skip guards still survive, and are not gaps

`empty`, `tool_failed` and `auth_error` are declared unsupported by no harness, so those guards are dead until one does. Removing `approval`'s skip leaves the case passing against praisonai-ts anyway — which says that map entry is documentation rather than a requirement. Reported rather than papered over.

## Three more, each confirmed against the full suite first

- **`spokenDropped = turn.dropped.length` was removable.** The cursor never advances, so every later publish of the same finished turn re-announces the same decoder gap — and it's `assertive`, so it interrupts whatever else the screen reader was saying, on a loop. Paired with a test that a *second* gap is still reported, so a latch can't pass in place of a count.
- **The parity checker's SKIP path had no test at all.** Dropping its `process.exit(0)` makes it carry on without the file it exists to check; making `exists` answer true for a missing path does the same from the other end. Either way a standalone clone's CI fails for a reason unrelated to drift. `UPSTREAM` is now injectable, as `AGENT_API` already was.
- **The drift lines could stop being printed.** The job still goes red, so the gate holds — but with nothing about *which* member changed, which leaves a failing gate nobody can act on. The exit code is the gate; the message is what makes it fixable.
- **`await rm(dist)` was removable**, because every test built into a fresh temp directory where `dist` didn't exist yet. On a real machine it does, so a renamed or deleted asset stays in the shipped output and the page keeps loading a file that's no longer in the source.

## Not gaps — proved, not assumed

- **Five surviving mutations in the rewritten SSE reader are equivalent** across 1,157 (stream, chunking) pairs: `parseBlock` skips empty lines, so a stray leading or trailing newline is invisible.
- **Eight were artefacts of my own sweep**, which ran `node --test` without `tsc` — deleting an `interface` member is a typecheck error, and `npm run check` catches it. Worth stating so the 37% raw survival number isn't read as 37% real.
- **The `locale.ts` survivors are redundancy by design.** `direction()` is `directionFromIntl(tag) ?? directionFromTables(tag)`, and the drift test forces both paths to agree — so swapping which one answers is unobservable on purpose.

## Verification

- **1278 tests pass, 0 fail, 0 cancelled** on Node 22.23 and 24.12 (`npm run check` exit 0 on both)
- 21/21 ledger checks re-swept individually: **0 survive**
- 6 mutations re-run against the new tests: **all die**
- Every negative case paired with a positive one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale files from previous web builds from remaining in the output.
  * Improved accessibility announcements by avoiding duplicate notifications for the same dropped event while announcing later events correctly.

* **Tests**
  * Strengthened conformance checks so every case is counted or explicitly skipped.
  * Added coverage for upstream parity checks, including missing sources and drift diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->