### PR TITLE
fix(mobile): an unreachable engine must not stop the app from starting

### DIFF
--- a/src/praisonai-mobile/app/src/boot.test.ts
+++ b/src/praisonai-mobile/app/src/boot.test.ts
@@ -496,10 +496,39 @@ test("an engine answering 200 with ok:false is refused at BOOT, not mid-turn", a
     engines: () => [probedChoice("remote", () => probeHealth(http, "http://engine.test"))],
   }));
 
-  assert.equal(result.ok, false, "boot must refuse an unhealthy engine");
+  // The probe RUNS -- that is what this file's predecessor was written for, and
+  // it stands. What changed is the verdict: an unhealthy engine may recover, so
+  // it is reported rather than refused. Making it fatal meant a phone with no
+  // desktop engine to reach could not open the app at all, and the user could
+  // not correct the address because Settings is inside the app that would not
+  // start. `main.ts` renders `notReady` as a warning and announces it.
+  assert.equal(result.ok, true, "a recoverable unreadiness must not stop the app");
+  if (!result.ok) return;
+  assert.equal(result.notReady?.reason, "unhealthy", "but the app must be told");
+  assert.match(String(result.notReady?.detail), /false/, "and told what the engine said");
+  await result.app.dispose();
+});
+
+test("a PERMANENT unreadiness is still refused at boot", async () => {
+  // The pair, and the line between the two: a version mismatch does not fix
+  // itself, so booting into it only defers the same failure to the user's
+  // first message. `readiness.ts` marks exactly these `retryable: false`.
+  const http = createFakeHttp();
+  http.on("/health", () => ({
+    status: 200,
+    headers: {},
+    body: streamOf(JSON.stringify({ ok: true, version: 1 })),
+  }));
+
+  const result = await createApp(deps({
+    engineId: "remote",
+    engines: () => [probedChoice("remote", () => probeHealth(http, "http://engine.test"))],
+  }));
+
+  assert.equal(result.ok, false, "a too-old engine must refuse to boot");
   if (result.ok) return;
-  assert.equal(result.reason, "unhealthy");
-  assert.equal(result.retryable, true, "an unhealthy engine may recover, so a caller can poll");
+  assert.equal(result.reason, "version_mismatch");
+  assert.equal(result.retryable, false, "waiting will not fix a version mismatch");
 });
 
 test("an engine that cannot be reached at all is refused at boot, and retryably", async () => {
@@ -512,10 +541,13 @@ test("an engine that cannot be reached at all is refused at boot, and retryably"
     engines: () => [probedChoice("remote", () => probeHealth(http, "http://engine.test"))],
   }));
 
-  assert.equal(result.ok, false);
-  if (result.ok) return;
-  assert.equal(result.reason, "http_status");
-  assert.equal(result.retryable, true);
+  // Retryable, so the app STARTS and reports it. This is the case that made
+  // the hard gate untenable: on a phone there is usually no desktop engine to
+  // reach, so refusing here meant the app never opened.
+  assert.equal(result.ok, true, "an unreachable engine must not stop the app");
+  if (!result.ok) return;
+  assert.equal(result.notReady?.reason, "http_status");
+  await result.app.dispose();
 });
 
 test("a healthy probe lets the boot through -- the pair", async () => {
@@ -548,7 +580,7 @@ test("an engine with no probe boots unchanged -- probing is optional", async () 
   if (result.ok) await result.app.dispose();
 });
 
-test("an engine rejected by its probe is disposed, not left holding a socket", async () => {
+test("an engine PERMANENTLY rejected by its probe is disposed, not left holding a socket", async () => {
   // Same guarantee a protocol mismatch already has: a refused engine that keeps
   // its socket is a leak that only surfaces as a second, unrelated failure.
   let disposed = false;
@@ -561,10 +593,34 @@ test("an engine rejected by its probe is disposed, not left holding a socket", a
   await createApp(deps({
     engineId: "remote",
     engines: () => [
-      { id: "remote", create: () => engine, probe: async () => ({ ready: false, reason: "unhealthy", detail: "false", retryable: true }) },
+      { id: "remote", create: () => engine, probe: async () => ({ ready: false, reason: "version_mismatch", detail: "too old", retryable: false }) },
     ],
   }));
   assert.equal(disposed, true);
+});
+
+test("an engine kept despite a RETRYABLE rejection is NOT disposed", async () => {
+  // The pair, and the reason the two cases differ: a retryable unreadiness
+  // hands the engine over so the app can use it once the remote comes up.
+  // Disposing it here would leave the app holding a dead engine it can never
+  // retry through.
+  let disposed = false;
+  const inner = createScriptedEngine({ script: SCRIPTS.happy });
+  const engine: AgentEnginePort = {
+    ...inner,
+    id: "remote",
+    dispose: async () => void (disposed = true),
+  };
+  const result = await createApp(deps({
+    engineId: "remote",
+    engines: () => [
+      { id: "remote", create: () => engine, probe: async () => ({ ready: false, reason: "unhealthy", detail: "false", retryable: true }) },
+    ],
+  }));
+  assert.equal(disposed, false, "the engine is still the one the app will use");
+  assert.equal(result.ok, true);
+  if (result.ok) await result.app.dispose();
+  assert.equal(disposed, true, "and it is disposed when the app is");
 });
 
 test("selectEngine runs the probe only after the protocol check passes", async () => {

--- a/src/praisonai-mobile/app/src/boot.ts
+++ b/src/praisonai-mobile/app/src/boot.ts
@@ -74,7 +74,14 @@ export interface App {
 }
 
 export type BootResult =
-  | { readonly ok: true; readonly app: App }
+  | {
+      readonly ok: true;
+      readonly app: App;
+      /** The app started, but the engine is not answering yet. A caller must
+       *  SAY so -- silently booting into an engine that cannot reply is how a
+       *  first message fails with no explanation. */
+      readonly notReady?: { readonly reason: string; readonly detail: string };
+    }
   | {
       readonly ok: false;
       readonly reason: string;
@@ -209,6 +216,9 @@ export async function createApp(deps: AppDeps): Promise<BootResult> {
 
   return {
     ok: true,
+    // Attached, not swallowed: `selectEngine` hands back an engine that is not
+    // answering yet rather than refusing to boot, and the caller has to say so.
+    ...(selection.notReady === undefined ? {} : { notReady: selection.notReady }),
     app: {
       engine,
       controller,

--- a/src/praisonai-mobile/app/src/engines.ts
+++ b/src/praisonai-mobile/app/src/engines.ts
@@ -34,7 +34,14 @@ export interface EngineChoice {
 }
 
 export type EngineSelection =
-  | { readonly ok: true; readonly engine: AgentEnginePort }
+  | {
+      readonly ok: true;
+      readonly engine: AgentEnginePort;
+      /** The engine was selected but is not answering yet. Set only for a
+       *  RETRYABLE unreadiness -- see the probe branch below for why that is
+       *  not a refusal. */
+      readonly notReady?: { readonly reason: string; readonly detail: string };
+    }
   | {
       readonly ok: false;
       readonly reason: "unknown_engine" | "protocol_mismatch" | Extract<Readiness, { ready: false }>["reason"];
@@ -99,15 +106,30 @@ export async function selectEngine(
   if (choice.probe !== undefined) {
     const readiness = await choice.probe();
     if (!readiness.ready) {
-      // Dispose for the same reason a protocol mismatch does: an engine left
-      // holding a socket is a leak that only shows up as a second failure.
-      await engine.dispose();
-      return {
-        ok: false,
-        reason: readiness.reason,
-        detail: readiness.detail,
-        retryable: readiness.retryable,
-      };
+      // A PERMANENT unreadiness is a refusal: a version mismatch does not fix
+      // itself, so booting into it only defers the same failure to the user's
+      // first message.
+      if (readiness.retryable === false) {
+        // Dispose for the same reason a protocol mismatch does: an engine left
+        // holding a socket is a leak that only shows up as a second failure.
+        await engine.dispose();
+        return { ok: false, reason: readiness.reason, detail: readiness.detail, retryable: false };
+      }
+
+      // A RETRYABLE one is not. An engine that is still binding its socket, or
+      // a phone that has no desktop engine to reach at all, must not stop the
+      // app from starting: refusing here left the user on an error screen with
+      // no way back -- they cannot open Settings to change the address,
+      // because that is where the address is changed.
+      //
+      // Measured before this branch existed: with no `/health` route the whole
+      // app rendered "PraisonAI could not start: 404" and nothing else, and 17
+      // end-to-end tests went red on main.
+      //
+      // So the engine is handed over WITH its unreadiness attached. The app
+      // starts, says what is wrong, and a retry costs the user one tap instead
+      // of a reinstall.
+      return { ok: true, engine, notReady: { reason: readiness.reason, detail: readiness.detail } };
     }
   }
 

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -41,6 +41,7 @@ import { createFakeShell, PHONE_INSETS } from "../../testing/src/fake-shell.ts";
 import { createFakeStorage } from "../../testing/src/fake-storage.ts";
 import { createFakeSecrets } from "../../testing/src/fake-secrets.ts";
 import { createFakeHttp, sseResponse, streamOf } from "../../testing/src/fake-http.ts";
+import { PROTOCOL_VERSION } from "../../protocol/src/version.ts";
 import { appEngines, mount } from "./main.ts";
 import { ENGINE_PRAISONAI_TS, ENGINE_REMOTE_HTTP, SETTING_DEFS } from "./registry.ts";
 import { createSettingsStore, facadeFor, type SettingsFacade } from "../../core/src/settings/store.ts";
@@ -728,4 +729,72 @@ test("the message field is labelled as the field, not as the button beside it", 
   assert.equal(box.getAttribute("aria-label"), en.composerLabel);
   assert.notEqual(box.getAttribute("aria-label"), en.actionSend, "not the button's name");
   app?.dispose();
+});
+
+// ---- an unreachable engine must not be a dead app ---------------------------
+
+test("the app STARTS when the engine is not answering, and says so", async () => {
+  // PR #4647 made the health probe a hard boot gate, and the whole app
+  // rendered "PraisonAI could not start: 404" -- 17 end-to-end tests went red
+  // on main, and on a phone with no desktop engine to reach the app simply
+  // would not open. The user cannot fix it either: the address is changed in
+  // Settings, and Settings is behind the app that will not start.
+  const { dom, platform } = harness(); // no /health route: the engine is unreachable
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  assert.notEqual(app, null, "an unreachable engine must not stop the app from starting");
+  assert.ok(dom.find((n) => n.tagName === "TEXTAREA"), "the composer must be there");
+  assert.ok(dom.find((n) => String(n.dataset["action"]) === "send"), "and the send control");
+
+  const notice = dom.find((n) => n.className.includes("row-notice"));
+  assert.ok(notice, `the app must SAY the engine is not answering:\n${dom.text()}`);
+  assert.equal(notice.dataset["tone"], "warning");
+
+  // Assertive, because the user is about to type into something that cannot
+  // reply yet -- waiting politely for the queue means they find out by sending.
+  const shouted = dom.all().find((n) => n.getAttribute("aria-live") === "assertive");
+  assert.match(String(shouted?.textContent), /not answering yet/);
+  app?.dispose();
+});
+
+test("a HEALTHY engine boots with no warning -- the pair", async () => {
+  // Without this, an app that always warned would pass the test above and cry
+  // wolf on every launch.
+  const { dom, http, platform } = harness();
+  http.on("/health", () => ({
+    status: 200,
+    headers: {},
+    body: streamOf(JSON.stringify({ ok: true, version: PROTOCOL_VERSION })),
+  }));
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  assert.notEqual(app, null);
+  assert.equal(
+    dom.find((n) => n.className.includes("row-notice")),
+    null,
+    "a healthy engine must not be reported as unhealthy",
+  );
+  app?.dispose();
+});
+
+test("a PERMANENT refusal still stops the app, with a name", async () => {
+  // The other half. A retryable unreadiness boots and warns; a protocol
+  // mismatch never resolves itself, so booting into it only defers the same
+  // failure to the user's first message. It must still be fatal.
+  //
+  // Version 1, not 99: a NEWER engine is deliberately accepted, because
+  // version.ts treats unknown fields as additive and refusing one would strand
+  // every shipped client on the day the engine ships first. Too OLD is the
+  // permanent refusal.
+  const { dom, http, platform } = harness();
+  http.on("/health", () => ({
+    status: 200,
+    headers: {},
+    body: streamOf(JSON.stringify({ ok: true, version: 1 })),
+  }));
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  assert.equal(app, null, "a version mismatch must refuse to boot");
+  assert.match(dom.text(), /could not start/, dom.text());
+  assert.match(dom.text(), /too_old|engine=1|protocol/, "and it must name the reason");
 });

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -328,11 +328,31 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     // A named failure, on screen. `app/src/engines.ts` promises exactly this
     // and nothing rendered it: an unusable engine used to be an unhandled
     // branch that left a blank page.
+    //
+    // Reached now only by a PERMANENT failure -- storage that will not open, a
+    // protocol mismatch. An engine that is merely unreachable boots and warns
+    // instead; see below.
     renderFatal(root, strings.bootFailed(booted.detail));
     return null;
   }
 
   const app = booted.app;
+
+  // The engine is not answering, but the app is usable. Said out loud rather
+  // than left for the first message to discover -- and assertive, because the
+  // user is about to type into something that cannot reply yet.
+  //
+  // This branch exists because refusing to boot on an unreachable engine left
+  // the user on an error screen with no way back: they cannot open Settings to
+  // change the address, because Settings is where the address is changed.
+  if (booted.notReady !== undefined) {
+    const warning = doc.createElement("p");
+    warning.className = "row row-notice";
+    warning.dataset["tone"] = "warning";
+    warning.textContent = strings.engineNotReady(booted.notReady.detail);
+    transcript.append(warning);
+    assertive.textContent = strings.engineNotReady(booted.notReady.detail);
+  }
 
   // ---- the shell drives layout -------------------------------------------
   const applyGeometry = (): void => {

--- a/src/praisonai-mobile/ui/src/i18n/strings.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.test.ts
@@ -20,6 +20,7 @@ import { UNKNOWN } from "../format.ts";
  *  asserted below, so a new function key cannot be added without a sample. */
 const SAMPLES: Readonly<Record<string, () => string>> = {
   bootFailed: () => en.bootFailed("no storage"),
+  engineNotReady: () => en.engineNotReady("ECONNREFUSED"),
   chatUnreadable: () => en.chatUnreadable("chat-7"),
   chatsAllUnreadable: () => en.chatsAllUnreadable(3),
   minutesAgo: () => en.minutesAgo(2, "2"),

--- a/src/praisonai-mobile/ui/src/i18n/strings.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.ts
@@ -62,6 +62,10 @@ export interface Strings {
   /** The app could not start at all. The detail is machine text appended, not
    *  interpolated into the middle of a sentence. */
   readonly bootFailed: (detail: string) => string;
+  /** The app started but the engine is not answering yet. Says the app is
+   *  usable and what is wrong, which is the difference between a warning
+   *  and the fatal screen this used to be. */
+  readonly engineNotReady: (detail: string) => string;
   /** The crash screen. It has to say the conversations survived, because the
    *  user's next thought is that they did not. */
   readonly crashed: string;
@@ -256,6 +260,8 @@ export const en: Strings = {
   appName: "PraisonAI",
   newChat: "New chat",
   bootFailed: (detail) => `PraisonAI could not start: ${detail}`,
+  engineNotReady: (detail) =>
+    `The engine is not answering yet (${detail}). You can still type; sending will retry it.`,
   stopRefused: "The engine did not accept the stop. It may still be running.",
   crashed: "Something went wrong. Your conversations are saved.",
 


### PR DESCRIPTION
> **`main` is currently red.** `npm run check` exits 1 with **17 failures**, all in `app/src/main.test.ts`. This restores it and removes the regression underneath.

## What happened

#4647 (closing #4638) made the health probe a **hard boot gate**. It added tests for `boot.ts`, `registry.ts` and `engine.ts`, and never ran `main.test.ts` — which mounts the whole app against a fake HTTP with no `/health` route.

Driving `mount()` directly:

```
no /health handler   ->  "PraisonAI could not start: 404"
/health says ok      ->  "PraisonAI  New chat  Settings  Send"
```

## It is not only a test problem

On a phone with no desktop engine to reach, the app now **would not open at all** — and the user could not correct the address, because the address is changed in Settings, and Settings is inside the app that will not start.

#4638 asked for a named failure *with* a bounded retry, and warned explicitly that boot must not hang on a dead engine. `retryable` was computed by `readiness.ts`, carried through `engines.ts:109` all the way to `boot.ts:167` — and then read by nothing.

## The line

Drawn where `readiness.ts` already draws it:

| Unreadiness | Verdict | Engine |
|---|---|---|
| **Permanent** (`retryable: false` — version mismatch) | refuses to boot, with a name | disposed |
| **Retryable** (transport, unhealthy, malformed) | **boots**, reports `notReady` | kept — it is the one the app will use |

Waiting does not fix a version mismatch, so booting into one only defers the same failure to the user's first message. Waiting *does* fix a socket that is still binding.

On the retryable path `main.ts` renders a warning notice into the transcript and announces it **assertively** — the user is about to type into something that cannot reply yet, and waiting politely for the queue means they find out by sending.

Everything #4647 was for is kept: the probe still runs at selection, a 200 with `{"ok": false}` is still not readiness, and the reason still has a name. Only the verdict on a *recoverable* failure changed.

## The three tests from #4647 that asserted the hard gate

Rewritten to the new contract rather than deleted — each keeps its original intent and gains the pair that makes the boundary visible:

- an unhealthy engine **boots and reports** · **+** a too-old one still refuses
- an unreachable engine **boots and reports** · (this is the case that made the gate untenable)
- a **permanently** refused engine is disposed · **+** a retained one is not, until the app is

## Verification

- **1295 tests pass, 0 fail, 0 cancelled** on Node 22.23 and 24.12 (`npm run check` exit 0 on both) — from 17 failing
- **7 mutations, all die**, including reinstating the hard gate (`if (readiness.retryable === false)` → `if (true)`) and flipping it the other way (`→ if (false)`), dropping `notReady` at each of the three points it is threaded through, and removing the notice, its tone, and its announcement

Refs #4638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The app now starts even when the engine is temporarily unreachable or unhealthy.
  - Displays an accessible warning explaining that the engine is not responding and that sending will retry.
  - Permanently incompatible engines still prevent startup with a clear failure message.

- **Bug Fixes**
  - Improved engine handling and cleanup based on whether failures are temporary or permanent.

- **Tests**
  - Added coverage for healthy, unavailable, and incompatible engine startup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->