### PR TITLE
fix(bot): bound gateway subprocess calls so a hung command cannot stall the loop

### DIFF
--- a/src/praisonai-bot/praisonai_bot/_guarded_subprocess.py
+++ b/src/praisonai-bot/praisonai_bot/_guarded_subprocess.py
@@ -33,6 +33,7 @@ Callers with legitimately long work should pass an explicit ``timeout``.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import signal
 import subprocess
@@ -104,7 +105,13 @@ def diagnose(captured: str) -> str:
 
 
 def _default_timeout() -> float:
-    """Resolve the global timeout, ignoring an unusable env override."""
+    """Resolve the global timeout, ignoring an unusable env override.
+
+    ``inf`` is rejected alongside zero and negatives: it parses cleanly and is
+    positive, so a bare ``value > 0`` check would accept it and hand back an
+    unbounded wait -- reinstating the exact hang this module prevents. ``nan``
+    fails the comparison on its own, but is covered explicitly for clarity.
+    """
     raw = os.environ.get(_ENV_TIMEOUT)
     if not raw:
         return DEFAULT_TIMEOUT
@@ -112,7 +119,9 @@ def _default_timeout() -> float:
         value = float(raw)
     except (TypeError, ValueError):
         return DEFAULT_TIMEOUT
-    return value if value > 0 else DEFAULT_TIMEOUT
+    if not math.isfinite(value) or value <= 0:
+        return DEFAULT_TIMEOUT
+    return value
 
 
 def _non_interactive_env(env: Optional[Mapping[str, str]]) -> dict:

--- a/src/praisonai-bot/praisonai_bot/_guarded_subprocess.py
+++ b/src/praisonai-bot/praisonai_bot/_guarded_subprocess.py
@@ -5,10 +5,25 @@ them. ``subprocess.run`` without ``timeout=`` blocks forever if the child
 waits on stdin -- a git credential prompt, an ``index.lock`` contention, a
 confirmation prompt -- and the whole gateway stops serving.
 
-This module provides :func:`run_guarded`, a drop-in replacement that always
-bounds the call and, when it does fire, hands the caller a *diagnosis* rather
-than a bare timeout. Knowing that a command died waiting on a confirmation
-prompt is actionable; knowing only that 120 seconds elapsed is not.
+``subprocess.run(timeout=...)`` alone is not enough, because it only kills
+the *direct* child:
+
+* On POSIX its timeout path calls ``kill()`` then ``wait()``. The call
+  returns, but any grandchild the command spawned is orphaned and keeps
+  running.
+* On Windows it calls ``kill()`` then ``communicate()`` with **no timeout**.
+  A surviving grandchild that inherited the captured stdout/stderr pipe holds
+  it open, so that ``communicate()`` blocks until the grandchild exits --
+  reintroducing exactly the indefinite hang this module exists to prevent.
+
+That is not hypothetical for the calls here: ``git`` routinely spawns
+credential helpers and transport processes, and a stuck credential helper is
+the motivating failure.
+
+:func:`run_guarded` therefore runs the command in its own process group (or
+Windows process group), kills the whole group on timeout, and then reaps
+with a *bounded* second wait so a stubborn descendant can never block the
+caller.
 
 Note on semantics: this is a total-runtime cap, not an inactivity timer. A
 command that streams output steadily for longer than the cap is still killed.
@@ -17,11 +32,15 @@ Callers with legitimately long work should pass an explicit ``timeout``.
 
 from __future__ import annotations
 
+import logging
 import os
+import signal
 import subprocess
 from typing import Mapping, Optional, Sequence
 
-__all__ = ["run_guarded", "DEFAULT_TIMEOUT", "diagnose"]
+__all__ = ["run_guarded", "DEFAULT_TIMEOUT", "TIMEOUT_RETURNCODE", "diagnose"]
+
+logger = logging.getLogger(__name__)
 
 #: Total seconds a guarded command may run before it is killed.
 #: Override per call, or globally via ``PRAISONAI_SUBPROCESS_TIMEOUT``.
@@ -30,6 +49,11 @@ DEFAULT_TIMEOUT = 120.0
 #: Returncode reported for a killed command. 124 is the conventional exit
 #: status used by coreutils ``timeout``.
 TIMEOUT_RETURNCODE = 124
+
+#: Seconds allowed for the post-kill reap. Bounded on purpose: if a
+#: descendant somehow survives the group kill and still holds the pipe, we
+#: abandon the output rather than block the caller.
+REAP_TIMEOUT = 5.0
 
 _ENV_TIMEOUT = "PRAISONAI_SUBPROCESS_TIMEOUT"
 
@@ -104,6 +128,65 @@ def _non_interactive_env(env: Optional[Mapping[str, str]]) -> dict:
     return resolved
 
 
+def _kill_process_group(proc: subprocess.Popen) -> None:
+    """Terminate the command *and everything it spawned*.
+
+    Killing only the direct child leaves grandchildren holding the inherited
+    stdout/stderr pipe, which is what turns a bounded call back into a hang.
+    """
+    if os.name == "nt":
+        try:
+            # /T walks the tree, /F forces. Bounded so the cleanup itself
+            # cannot become the new hang.
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                capture_output=True,
+                timeout=REAP_TIMEOUT,
+            )
+        except Exception:  # pragma: no cover - Windows-only path
+            _kill_direct(proc)
+        return
+
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        # Already gone, or we could not resolve the group; fall back.
+        _kill_direct(proc)
+
+
+def _kill_direct(proc: subprocess.Popen) -> None:
+    """Last-resort kill of the direct child only."""
+    try:
+        proc.kill()
+    except Exception:  # pragma: no cover - process already reaped
+        pass
+
+
+def _reap(proc: subprocess.Popen) -> tuple[str, str]:
+    """Collect whatever output is available without blocking indefinitely."""
+    try:
+        return proc.communicate(timeout=REAP_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        # A descendant survived the group kill and still holds the pipe.
+        # Abandon the output rather than block the caller -- returning late
+        # is the failure mode this module exists to prevent.
+        logger.warning(
+            "Guarded command %s left a descendant holding its output pipe; "
+            "abandoning captured output after %.0fs.",
+            proc.args,
+            REAP_TIMEOUT,
+        )
+        for stream in (proc.stdout, proc.stderr):
+            try:
+                if stream is not None:
+                    stream.close()
+            except Exception:  # pragma: no cover - best effort
+                pass
+        return "", ""
+    except Exception:  # pragma: no cover - defensive
+        return "", ""
+
+
 def run_guarded(
     cmd: Sequence[str],
     *,
@@ -111,15 +194,19 @@ def run_guarded(
     cwd: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
     interactive: bool = False,
+    check: bool = False,
+    text: bool = True,
+    capture_output: bool = True,
     **kwargs,
 ) -> subprocess.CompletedProcess:
     """Run ``cmd`` with a bounded runtime, never raising on timeout.
 
     Behaves like ``subprocess.run(..., capture_output=True, text=True)``. On
-    timeout the child is killed and a :class:`subprocess.CompletedProcess` is
-    returned with returncode :data:`TIMEOUT_RETURNCODE` and a diagnosis
-    appended to stderr, so existing ``returncode == 0`` checks keep working
-    instead of having to grow a new exception path.
+    timeout the whole process group is killed and a
+    :class:`subprocess.CompletedProcess` is returned with returncode
+    :data:`TIMEOUT_RETURNCODE` and a diagnosis appended to stderr, so existing
+    ``returncode == 0`` checks keep working instead of having to grow a new
+    exception path.
 
     Args:
         cmd: Command and arguments.
@@ -128,12 +215,19 @@ def run_guarded(
         cwd: Working directory.
         env: Environment; prompt-suppressing defaults are layered underneath.
         interactive: Set True only for a command that must reach a terminal.
-            Skips prompt suppression; the timeout still applies.
-        **kwargs: Forwarded to ``subprocess.run``.
+            Skips prompt suppression and stdin redirection; the timeout and
+            the group kill still apply.
+        check: Raise ``CalledProcessError`` on a non-zero exit, matching
+            ``subprocess.run``. A timeout still returns rather than raising.
+        text: Decode output as text.
+        capture_output: Capture stdout and stderr.
+        **kwargs: Forwarded to ``subprocess.Popen``.
     """
     resolved_timeout = _default_timeout() if timeout is None else timeout
-    kwargs.setdefault("capture_output", True)
-    kwargs.setdefault("text", True)
+
+    if capture_output:
+        kwargs.setdefault("stdout", subprocess.PIPE)
+        kwargs.setdefault("stderr", subprocess.PIPE)
 
     # stdin at /dev/null turns "wait forever for input" into an immediate EOF
     # for tools that honour it, so the timeout is a backstop rather than the
@@ -141,32 +235,66 @@ def run_guarded(
     if not interactive:
         kwargs.setdefault("stdin", subprocess.DEVNULL)
 
-    try:
-        return subprocess.run(
-            list(cmd),
-            timeout=resolved_timeout,
-            cwd=cwd,
-            env=env if interactive else _non_interactive_env(env),
-            **kwargs,
+    # Isolate the command so the whole tree can be killed together.
+    if os.name == "nt":
+        kwargs["creationflags"] = (
+            kwargs.get("creationflags", 0) | subprocess.CREATE_NEW_PROCESS_GROUP
         )
-    except subprocess.TimeoutExpired as exc:
-        partial_out = _as_text(exc.stdout)
-        partial_err = _as_text(exc.stderr)
-        reason = diagnose(f"{partial_out}\n{partial_err}")
+    else:
+        kwargs.setdefault("start_new_session", True)
+
+    argv = list(cmd)
+    proc = subprocess.Popen(
+        argv,
+        cwd=cwd,
+        env=env if interactive else _non_interactive_env(env),
+        text=text,
+        **kwargs,
+    )
+
+    try:
+        stdout, stderr = proc.communicate(timeout=resolved_timeout)
+    except subprocess.TimeoutExpired:
+        _kill_process_group(proc)
+        stdout, stderr = _reap(proc)
+        stdout = _as_text(stdout)
+        stderr = _as_text(stderr)
+        # Built outside the f-string: a backslash inside an f-string
+        # expression is a syntax error before Python 3.12, and this package
+        # supports 3.10+.
+        captured = stdout + "\n" + stderr
         detail = (
-            f"Command killed after {resolved_timeout:g}s: {' '.join(cmd)}\n"
-            f"{reason}"
+            f"Command killed after {resolved_timeout:g}s: {' '.join(argv)}\n"
+            f"{diagnose(captured)}"
         )
         return subprocess.CompletedProcess(
-            args=list(cmd),
+            args=argv,
             returncode=TIMEOUT_RETURNCODE,
-            stdout=partial_out,
-            stderr=(partial_err + "\n" + detail).strip(),
+            stdout=stdout,
+            stderr=(stderr + "\n" + detail).strip(),
         )
+    except BaseException:
+        # Never leave a running child behind on an unexpected error, including
+        # KeyboardInterrupt.
+        _kill_process_group(proc)
+        _reap(proc)
+        raise
+
+    result = subprocess.CompletedProcess(
+        args=argv,
+        returncode=proc.returncode,
+        stdout=_as_text(stdout) if capture_output else stdout,
+        stderr=_as_text(stderr) if capture_output else stderr,
+    )
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, argv, result.stdout, result.stderr
+        )
+    return result
 
 
 def _as_text(value) -> str:
-    """Normalise TimeoutExpired's stdout/stderr, which may be bytes or None."""
+    """Normalise stdout/stderr, which may be bytes, None, or already str."""
     if value is None:
         return ""
     if isinstance(value, bytes):

--- a/src/praisonai-bot/praisonai_bot/_guarded_subprocess.py
+++ b/src/praisonai-bot/praisonai_bot/_guarded_subprocess.py
@@ -1,0 +1,174 @@
+"""Subprocess execution that cannot hang the caller indefinitely.
+
+Several gateway paths shell out while an asyncio event loop is waiting on
+them. ``subprocess.run`` without ``timeout=`` blocks forever if the child
+waits on stdin -- a git credential prompt, an ``index.lock`` contention, a
+confirmation prompt -- and the whole gateway stops serving.
+
+This module provides :func:`run_guarded`, a drop-in replacement that always
+bounds the call and, when it does fire, hands the caller a *diagnosis* rather
+than a bare timeout. Knowing that a command died waiting on a confirmation
+prompt is actionable; knowing only that 120 seconds elapsed is not.
+
+Note on semantics: this is a total-runtime cap, not an inactivity timer. A
+command that streams output steadily for longer than the cap is still killed.
+Callers with legitimately long work should pass an explicit ``timeout``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Mapping, Optional, Sequence
+
+__all__ = ["run_guarded", "DEFAULT_TIMEOUT", "diagnose"]
+
+#: Total seconds a guarded command may run before it is killed.
+#: Override per call, or globally via ``PRAISONAI_SUBPROCESS_TIMEOUT``.
+DEFAULT_TIMEOUT = 120.0
+
+#: Returncode reported for a killed command. 124 is the conventional exit
+#: status used by coreutils ``timeout``.
+TIMEOUT_RETURNCODE = 124
+
+_ENV_TIMEOUT = "PRAISONAI_SUBPROCESS_TIMEOUT"
+
+# Substrings that identify why a child process is sitting idle. Ordered most
+# specific first; the first hit wins.
+_SIGNATURES: tuple[tuple[tuple[str, ...], str], ...] = (
+    (
+        ("username for", "password for", "passphrase", "authentication failed"),
+        "DETECTED: credential prompt. The command is waiting for a login that "
+        "will never arrive. Configure a credential helper, or set "
+        "GIT_TERMINAL_PROMPT=0 so it fails fast instead of blocking.",
+    ),
+    (
+        ("index.lock", "unable to create", "another git process"),
+        "DETECTED: git lock contention. Another git process holds the "
+        "repository lock. Retry once it exits, or remove a stale .git/index.lock.",
+    ),
+    (
+        ("[y/n]", "(yes/no)", "are you sure", "continue?", "overwrite?", "proceed?"),
+        "DETECTED: confirmation prompt. Re-run non-interactively with the "
+        "command's own flag (--yes, -y, --force, --no-confirm).",
+    ),
+    (
+        ("host key", "fingerprint", "known_hosts"),
+        "DETECTED: SSH host-key prompt. Pre-populate known_hosts, or pass "
+        "-o StrictHostKeyChecking=accept-new.",
+    ),
+)
+
+_GENERIC = (
+    "No interactive prompt was detected. The command may be genuinely slow, "
+    "blocked on network I/O, or deadlocked. Raise timeout= if the work is "
+    "expected to take longer."
+)
+
+
+def diagnose(captured: str) -> str:
+    """Return a human- and model-actionable reason a command stalled.
+
+    ``captured`` is whatever the child emitted before it was killed; it may be
+    empty, which is itself common for a process blocked on stdin.
+    """
+    haystack = (captured or "").lower()
+    for needles, message in _SIGNATURES:
+        if any(needle in haystack for needle in needles):
+            return message
+    return _GENERIC
+
+
+def _default_timeout() -> float:
+    """Resolve the global timeout, ignoring an unusable env override."""
+    raw = os.environ.get(_ENV_TIMEOUT)
+    if not raw:
+        return DEFAULT_TIMEOUT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT
+    return value if value > 0 else DEFAULT_TIMEOUT
+
+
+def _non_interactive_env(env: Optional[Mapping[str, str]]) -> dict:
+    """Environment that makes common tools fail rather than prompt.
+
+    Suppressing the prompt at source is better than killing the process after
+    it hangs: the command returns an error the caller can act on immediately.
+    """
+    resolved = dict(env if env is not None else os.environ)
+    resolved.setdefault("GIT_TERMINAL_PROMPT", "0")
+    resolved.setdefault("GCM_INTERACTIVE", "never")
+    resolved.setdefault("DEBIAN_FRONTEND", "noninteractive")
+    return resolved
+
+
+def run_guarded(
+    cmd: Sequence[str],
+    *,
+    timeout: Optional[float] = None,
+    cwd: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    interactive: bool = False,
+    **kwargs,
+) -> subprocess.CompletedProcess:
+    """Run ``cmd`` with a bounded runtime, never raising on timeout.
+
+    Behaves like ``subprocess.run(..., capture_output=True, text=True)``. On
+    timeout the child is killed and a :class:`subprocess.CompletedProcess` is
+    returned with returncode :data:`TIMEOUT_RETURNCODE` and a diagnosis
+    appended to stderr, so existing ``returncode == 0`` checks keep working
+    instead of having to grow a new exception path.
+
+    Args:
+        cmd: Command and arguments.
+        timeout: Total seconds allowed. Defaults to
+            ``PRAISONAI_SUBPROCESS_TIMEOUT`` or :data:`DEFAULT_TIMEOUT`.
+        cwd: Working directory.
+        env: Environment; prompt-suppressing defaults are layered underneath.
+        interactive: Set True only for a command that must reach a terminal.
+            Skips prompt suppression; the timeout still applies.
+        **kwargs: Forwarded to ``subprocess.run``.
+    """
+    resolved_timeout = _default_timeout() if timeout is None else timeout
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+
+    # stdin at /dev/null turns "wait forever for input" into an immediate EOF
+    # for tools that honour it, so the timeout is a backstop rather than the
+    # primary defence.
+    if not interactive:
+        kwargs.setdefault("stdin", subprocess.DEVNULL)
+
+    try:
+        return subprocess.run(
+            list(cmd),
+            timeout=resolved_timeout,
+            cwd=cwd,
+            env=env if interactive else _non_interactive_env(env),
+            **kwargs,
+        )
+    except subprocess.TimeoutExpired as exc:
+        partial_out = _as_text(exc.stdout)
+        partial_err = _as_text(exc.stderr)
+        reason = diagnose(f"{partial_out}\n{partial_err}")
+        detail = (
+            f"Command killed after {resolved_timeout:g}s: {' '.join(cmd)}\n"
+            f"{reason}"
+        )
+        return subprocess.CompletedProcess(
+            args=list(cmd),
+            returncode=TIMEOUT_RETURNCODE,
+            stdout=partial_out,
+            stderr=(partial_err + "\n" + detail).strip(),
+        )
+
+
+def _as_text(value) -> str:
+    """Normalise TimeoutExpired's stdout/stderr, which may be bytes or None."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)

--- a/src/praisonai-bot/praisonai_bot/gateway/kanban_dispatcher.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/kanban_dispatcher.py
@@ -8,6 +8,7 @@ system and follows Hermes patterns for worker management.
 
 import asyncio
 import logging
+import math
 import os
 import re
 import subprocess
@@ -26,7 +27,12 @@ _DEFAULT_GIT_TIMEOUT = 300.0
 
 
 def _git_timeout() -> float:
-    """Resolve the per-git-command ceiling, ignoring an unusable override."""
+    """Resolve the per-git-command ceiling, ignoring an unusable override.
+
+    ``inf`` is rejected as well as zero and negatives: it is positive and
+    parses cleanly, so accepting it would silently restore the unbounded git
+    call this guard exists to remove.
+    """
     raw = os.environ.get("PRAISONAI_KANBAN_GIT_TIMEOUT")
     if not raw:
         return _DEFAULT_GIT_TIMEOUT
@@ -34,7 +40,9 @@ def _git_timeout() -> float:
         value = float(raw)
     except (TypeError, ValueError):
         return _DEFAULT_GIT_TIMEOUT
-    return value if value > 0 else _DEFAULT_GIT_TIMEOUT
+    if not math.isfinite(value) or value <= 0:
+        return _DEFAULT_GIT_TIMEOUT
+    return value
 
 # Global dispatcher state
 _dispatcher_running = False

--- a/src/praisonai-bot/praisonai_bot/gateway/kanban_dispatcher.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/kanban_dispatcher.py
@@ -14,7 +14,27 @@ import subprocess
 import time
 from typing import Dict, Any, List, Optional
 
+from .._guarded_subprocess import run_guarded
+
 logger = logging.getLogger(__name__)
+
+# Ceiling for a single git invocation. Worktree add, merge and commit on a
+# large repository are legitimately slow, so this is set well above the
+# general default: the aim is to bound an indefinite hang, not to fail slow
+# work. Override with PRAISONAI_KANBAN_GIT_TIMEOUT (seconds).
+_DEFAULT_GIT_TIMEOUT = 300.0
+
+
+def _git_timeout() -> float:
+    """Resolve the per-git-command ceiling, ignoring an unusable override."""
+    raw = os.environ.get("PRAISONAI_KANBAN_GIT_TIMEOUT")
+    if not raw:
+        return _DEFAULT_GIT_TIMEOUT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_GIT_TIMEOUT
+    return value if value > 0 else _DEFAULT_GIT_TIMEOUT
 
 # Global dispatcher state
 _dispatcher_running = False
@@ -415,12 +435,22 @@ class KanbanDispatcher:
 
         A thin subprocess wrapper so worktree isolation stays self-contained in
         the wrapper without pulling in a Tier-2 package dependency.
+
+        Bounded via :func:`run_guarded`: the dispatcher calls this from inside
+        the gateway's event loop, so a git command blocked on a credential
+        prompt or an ``index.lock`` would otherwise stall every WebSocket
+        client indefinitely. On timeout the result carries returncode 124 and
+        a diagnosis in stderr, which the existing ``returncode == 0`` checks
+        already treat as failure.
+
+        The ceiling is deliberately generous — worktree creation and merges on
+        a large repository are legitimately slow, and the goal is to bound a
+        hang, not to fail slow-but-healthy work.
         """
-        return subprocess.run(
+        return run_guarded(
             ["git", *args],
-            capture_output=True,
-            text=True,
             cwd=cwd or self._repo_dir(),
+            timeout=_git_timeout(),
         )
 
     def _worktree_root(self) -> str:

--- a/src/praisonai-bot/praisonai_bot/gateway/pairing.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/pairing.py
@@ -111,7 +111,8 @@ def _restrict_windows_acl(secret_path: str) -> bool:
     """
     try:
         import getpass
-        import subprocess
+
+        from .._guarded_subprocess import run_guarded
 
         user = os.environ.get("USERNAME") or getpass.getuser()
         # Resolve icacls from the trusted system directory rather than PATH
@@ -123,7 +124,9 @@ def _restrict_windows_acl(secret_path: str) -> bool:
         )
         # Quote the username so principals containing spaces (e.g. "John Doe")
         # are parsed as a single principal by icacls.
-        result = subprocess.run(
+        # Bounded: this runs while hardening the pairing secret on the gateway
+        # startup path, so a stalled icacls must not block it forever.
+        result = run_guarded(
             [
                 icacls,
                 secret_path,
@@ -131,7 +134,7 @@ def _restrict_windows_acl(secret_path: str) -> bool:
                 "/grant:r",
                 f'"{user}":F',
             ],
-            capture_output=True,
+            timeout=15,
             check=False,
         )
         return result.returncode == 0

--- a/src/praisonai-bot/praisonai_bot/gateway/preflight.py
+++ b/src/praisonai-bot/praisonai_bot/gateway/preflight.py
@@ -879,7 +879,8 @@ def _read_env_file_tokens(path: str) -> Dict[str, str]:
 def _scan_launch_agent(label: str) -> DuplicateService:
     """Inspect a macOS LaunchAgent plist by label."""
     import plistlib
-    import subprocess
+
+    from .._guarded_subprocess import run_guarded
 
     plist_path = os.path.expanduser(f"~/Library/LaunchAgents/{label}.plist")
     service = DuplicateService(label=label, plist_path=plist_path)
@@ -899,11 +900,9 @@ def _scan_launch_agent(label: str) -> DuplicateService:
             pass
 
     try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-        )
+        # Bounded: preflight runs on the gateway's startup path, and a
+        # launchctl that stalls would hold up service discovery indefinitely.
+        result = run_guarded(["launchctl", "list", label], timeout=15)
         service.running = result.returncode == 0
         if service.running and result.stdout:
             parts = result.stdout.strip().split("\t")

--- a/src/praisonai-bot/praisonai_bot/kanban/sqlite_store.py
+++ b/src/praisonai-bot/praisonai_bot/kanban/sqlite_store.py
@@ -223,10 +223,15 @@ class SQLiteKanbanStore:
         if not path or not isinstance(path, str):
             return False
         try:
-            import subprocess
-            result = subprocess.run(
+            from .._guarded_subprocess import run_guarded
+
+            # Bounded: this sits on the create_task path, which the gateway
+            # dispatcher calls from its event loop. A git command that stalls
+            # on a network-mounted or lock-contended path would otherwise
+            # block every card creation.
+            result = run_guarded(
                 ["git", "-C", path, "rev-parse", "--is-inside-work-tree"],
-                capture_output=True, text=True,
+                timeout=15,
             )
             return result.returncode == 0 and result.stdout.strip() == "true"
         except Exception:

--- a/src/praisonai-bot/praisonai_bot/kanban/sqlite_store.py
+++ b/src/praisonai-bot/praisonai_bot/kanban/sqlite_store.py
@@ -1,4 +1,5 @@
 """SQLite kanban store implementation."""
+import logging
 import sqlite3
 import json
 import uuid
@@ -12,6 +13,8 @@ from .models import (
     KanbanStoreProtocol,
 )
 from .paths import get_kanban_db_path
+
+_logger = logging.getLogger(__name__)
 
 # Board-wide default for the per-task retry/circuit-breaker.
 DEFAULT_MAX_RETRIES = 3
@@ -223,7 +226,7 @@ class SQLiteKanbanStore:
         if not path or not isinstance(path, str):
             return False
         try:
-            from .._guarded_subprocess import run_guarded
+            from .._guarded_subprocess import TIMEOUT_RETURNCODE, run_guarded
 
             # Bounded: this sits on the create_task path, which the gateway
             # dispatcher calls from its event loop. A git command that stalls
@@ -233,6 +236,19 @@ class SQLiteKanbanStore:
                 ["git", "-C", path, "rev-parse", "--is-inside-work-tree"],
                 timeout=15,
             )
+            if result.returncode == TIMEOUT_RETURNCODE:
+                # A timeout is "unknown", not "not a repository". We still
+                # answer False so a slow path can never fail the create, but
+                # say so: the caller downgrades the task to the shared
+                # workspace, and silently losing worktree isolation is the
+                # kind of thing an operator needs to see.
+                _logger.warning(
+                    "Timed out probing %s for a git worktree; treating it as "
+                    "not a repository, so this task will run in the shared "
+                    "workspace rather than an isolated worktree. %s",
+                    path,
+                    result.stderr.strip(),
+                )
             return result.returncode == 0 and result.stdout.strip() == "true"
         except Exception:
             return False

--- a/src/praisonai-bot/tests/unit/test_guarded_subprocess.py
+++ b/src/praisonai-bot/tests/unit/test_guarded_subprocess.py
@@ -1,0 +1,214 @@
+"""Tests for the bounded subprocess wrapper.
+
+The behaviour that matters: a command that would block forever returns, the
+caller can still branch on returncode, and the stderr it gets back says *why*
+the command stalled.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from praisonai_bot._guarded_subprocess import (
+    DEFAULT_TIMEOUT,
+    TIMEOUT_RETURNCODE,
+    diagnose,
+    run_guarded,
+)
+
+
+class TestHappyPath:
+    def test_returns_completed_process(self):
+        result = run_guarded([sys.executable, "-c", "print('ok')"])
+        assert result.returncode == 0
+        assert result.stdout.strip() == "ok"
+
+    def test_propagates_nonzero_exit(self):
+        result = run_guarded([sys.executable, "-c", "import sys; sys.exit(3)"])
+        assert result.returncode == 3
+
+    def test_honours_cwd(self, tmp_path):
+        result = run_guarded(
+            [sys.executable, "-c", "import os; print(os.getcwd())"],
+            cwd=str(tmp_path),
+        )
+        assert os.path.realpath(result.stdout.strip()) == os.path.realpath(str(tmp_path))
+
+
+class TestTimeout:
+    def test_hanging_command_returns_instead_of_blocking(self):
+        result = run_guarded(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            timeout=0.5,
+        )
+        assert result.returncode == TIMEOUT_RETURNCODE
+
+    def test_timeout_does_not_raise(self):
+        # The whole point: existing `returncode == 0` call sites keep working
+        # without growing an exception handler.
+        run_guarded([sys.executable, "-c", "import time; time.sleep(30)"], timeout=0.3)
+
+    def test_stderr_names_the_command_and_the_limit(self):
+        result = run_guarded(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            timeout=0.4,
+        )
+        assert "killed after 0.4s" in result.stderr
+        assert "time.sleep(30)" in result.stderr
+
+    def test_reading_stdin_is_not_a_hang(self):
+        # stdin is /dev/null, so a command that reads it gets EOF immediately
+        # rather than waiting for the timeout to save it.
+        result = run_guarded(
+            [sys.executable, "-c", "import sys; sys.stdin.read(); print('done')"],
+            timeout=5,
+        )
+        assert result.returncode == 0
+        assert "done" in result.stdout
+
+
+class TestDiagnosis:
+    def test_credential_prompt(self):
+        assert "credential prompt" in diagnose("Username for 'https://github.com':")
+
+    def test_git_lock(self):
+        msg = diagnose("fatal: Unable to create '/repo/.git/index.lock': File exists")
+        assert "lock contention" in msg
+
+    def test_confirmation_prompt(self):
+        assert "confirmation prompt" in diagnose("Overwrite existing file? [y/N]")
+
+    def test_host_key_prompt(self):
+        assert "host-key" in diagnose("The authenticity of host ... key fingerprint is")
+
+    def test_unknown_output_gets_generic_guidance(self):
+        msg = diagnose("compiling module 41 of 900")
+        assert "No interactive prompt was detected" in msg
+
+    def test_empty_output_is_safe(self):
+        # A process blocked on stdin often emits nothing at all.
+        assert diagnose("") == diagnose(None)
+
+    def test_diagnosis_is_attached_on_timeout(self):
+        script = (
+            "import sys, time; "
+            "sys.stderr.write(\"Username for 'https://github.com':\"); "
+            "sys.stderr.flush(); time.sleep(30)"
+        )
+        result = run_guarded([sys.executable, "-c", script], timeout=1.0)
+        assert result.returncode == TIMEOUT_RETURNCODE
+        assert "credential prompt" in result.stderr
+
+
+class TestEnvironment:
+    def test_suppresses_git_prompting_by_default(self):
+        result = run_guarded(
+            [sys.executable, "-c", "import os; print(os.environ['GIT_TERMINAL_PROMPT'])"]
+        )
+        assert result.stdout.strip() == "0"
+
+    def test_caller_env_wins(self):
+        result = run_guarded(
+            [sys.executable, "-c", "import os; print(os.environ['GIT_TERMINAL_PROMPT'])"],
+            env={"GIT_TERMINAL_PROMPT": "1", "PATH": os.environ.get("PATH", "")},
+        )
+        assert result.stdout.strip() == "1"
+
+    def test_interactive_mode_adds_no_suppression(self, monkeypatch):
+        # Clear the ambient value first -- CI images commonly export
+        # GIT_TERMINAL_PROMPT=0 already, which would mask the behaviour under
+        # test. Interactive mode must not *introduce* the variable itself.
+        monkeypatch.delenv("GIT_TERMINAL_PROMPT", raising=False)
+        result = run_guarded(
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('GIT_TERMINAL_PROMPT', 'unset'))",
+            ],
+            interactive=True,
+        )
+        assert result.stdout.strip() == "unset"
+
+    def test_default_mode_suppresses_even_when_ambient_is_unset(self, monkeypatch):
+        monkeypatch.delenv("GIT_TERMINAL_PROMPT", raising=False)
+        result = run_guarded(
+            [sys.executable, "-c", "import os; print(os.environ['GIT_TERMINAL_PROMPT'])"]
+        )
+        assert result.stdout.strip() == "0"
+
+
+class TestTimeoutResolution:
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("PRAISONAI_SUBPROCESS_TIMEOUT", "0.3")
+        result = run_guarded([sys.executable, "-c", "import time; time.sleep(30)"])
+        assert result.returncode == TIMEOUT_RETURNCODE
+
+    @pytest.mark.parametrize("bad", ["", "abc", "0", "-5"])
+    def test_unusable_override_falls_back_to_default(self, monkeypatch, bad):
+        monkeypatch.setenv("PRAISONAI_SUBPROCESS_TIMEOUT", bad)
+        # Must not raise, and must not adopt a non-positive timeout that would
+        # kill every command instantly.
+        result = run_guarded([sys.executable, "-c", "print('fine')"])
+        assert result.returncode == 0
+        assert DEFAULT_TIMEOUT > 0
+
+    def test_explicit_timeout_beats_env(self, monkeypatch):
+        monkeypatch.setenv("PRAISONAI_SUBPROCESS_TIMEOUT", "30")
+        result = run_guarded(
+            [sys.executable, "-c", "import time; time.sleep(30)"], timeout=0.3
+        )
+        assert result.returncode == TIMEOUT_RETURNCODE
+
+
+class TestCompatibility:
+    def test_result_is_a_real_completed_process(self):
+        result = run_guarded([sys.executable, "-c", "import time; time.sleep(5)"], timeout=0.3)
+        assert isinstance(result, subprocess.CompletedProcess)
+        assert result.args == [sys.executable, "-c", "import time; time.sleep(5)"]
+        # Call sites read .stdout/.stderr unconditionally; both must be str.
+        assert isinstance(result.stdout, str)
+        assert isinstance(result.stderr, str)
+
+
+class TestKanbanGitTimeout:
+    """The dispatcher's git ceiling must bound hangs without failing slow work."""
+
+    def test_default_is_generous(self):
+        from praisonai_bot.gateway.kanban_dispatcher import _git_timeout
+
+        # Worktree add / merge on a large repo can legitimately run for
+        # minutes; the bound exists to stop an indefinite hang, not slow work.
+        assert _git_timeout() >= 300.0
+
+    def test_env_override(self, monkeypatch):
+        from praisonai_bot.gateway.kanban_dispatcher import _git_timeout
+
+        monkeypatch.setenv("PRAISONAI_KANBAN_GIT_TIMEOUT", "42")
+        assert _git_timeout() == 42.0
+
+    @pytest.mark.parametrize("bad", ["", "abc", "0", "-1"])
+    def test_unusable_override_falls_back(self, monkeypatch, bad):
+        from praisonai_bot.gateway.kanban_dispatcher import _git_timeout
+
+        monkeypatch.setenv("PRAISONAI_KANBAN_GIT_TIMEOUT", bad)
+        assert _git_timeout() >= 300.0
+
+    def test_run_git_is_bounded(self, monkeypatch):
+        """_run_git must route through run_guarded, not raw subprocess.run."""
+        from praisonai_bot.gateway import kanban_dispatcher as kd
+
+        seen = {}
+
+        def fake_run_guarded(cmd, **kwargs):
+            seen["cmd"] = cmd
+            seen["timeout"] = kwargs.get("timeout")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(kd, "run_guarded", fake_run_guarded)
+        dispatcher = kd.KanbanDispatcher.__new__(kd.KanbanDispatcher)
+        dispatcher._run_git("status")
+
+        assert seen["cmd"][0] == "git"
+        assert seen["timeout"] is not None and seen["timeout"] > 0

--- a/src/praisonai-bot/tests/unit/test_guarded_subprocess.py
+++ b/src/praisonai-bot/tests/unit/test_guarded_subprocess.py
@@ -212,3 +212,71 @@ class TestKanbanGitTimeout:
 
         assert seen["cmd"][0] == "git"
         assert seen["timeout"] is not None and seen["timeout"] > 0
+
+
+class TestDescendantTermination:
+    """A grandchild must not outlive the kill, nor hold the caller open.
+
+    subprocess.run's own timeout path kills only the direct child: on POSIX it
+    then wait()s (orphaning the grandchild), and on Windows it communicate()s
+    with no timeout, which blocks until the grandchild releases the inherited
+    pipe. Both are why run_guarded kills the whole process group.
+    """
+
+    def test_returns_promptly_despite_a_surviving_descendant(self):
+        import time
+
+        script = (
+            "import subprocess, sys, time; "
+            "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
+            "time.sleep(60)"
+        )
+        started = time.monotonic()
+        result = run_guarded([sys.executable, "-c", script], timeout=1.0)
+        elapsed = time.monotonic() - started
+
+        assert result.returncode == TIMEOUT_RETURNCODE
+        # Generous bound: the point is that it does not wait out the 60s
+        # sleeps, on any platform.
+        assert elapsed < 20, f"took {elapsed:.1f}s; descendant blocked the reap"
+
+    def test_grandchild_is_actually_killed(self, tmp_path):
+        marker = tmp_path / "grandchild-survived.txt"
+        grandchild = (
+            f"import time; time.sleep(4); "
+            f"open({str(marker)!r}, 'w').write('alive')"
+        )
+        script = (
+            "import subprocess, sys, time; "
+            f"subprocess.Popen([sys.executable, '-c', {grandchild!r}]); "
+            "time.sleep(60)"
+        )
+        result = run_guarded([sys.executable, "-c", script], timeout=1.0)
+        assert result.returncode == TIMEOUT_RETURNCODE
+
+        # Outlive the grandchild's sleep. If the group kill worked it never
+        # gets to write; if only the direct child died, the marker appears.
+        import time
+
+        time.sleep(6)
+        assert not marker.exists(), "grandchild survived the group kill"
+
+
+class TestCheck:
+    def test_check_raises_on_nonzero(self):
+        with pytest.raises(subprocess.CalledProcessError):
+            run_guarded([sys.executable, "-c", "import sys; sys.exit(2)"], check=True)
+
+    def test_check_is_off_by_default(self):
+        result = run_guarded([sys.executable, "-c", "import sys; sys.exit(2)"])
+        assert result.returncode == 2
+
+    def test_timeout_returns_even_with_check(self):
+        # A timeout is reported as a value, never an exception, so callers
+        # branching on returncode keep working.
+        result = run_guarded(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            timeout=0.4,
+            check=True,
+        )
+        assert result.returncode == TIMEOUT_RETURNCODE

--- a/src/praisonai-bot/tests/unit/test_guarded_subprocess.py
+++ b/src/praisonai-bot/tests/unit/test_guarded_subprocess.py
@@ -20,6 +20,7 @@ from praisonai_bot._guarded_subprocess import (
 
 
 class TestHappyPath:
+    """A bounded call must stay a faithful subprocess.run replacement."""
     def test_returns_completed_process(self):
         result = run_guarded([sys.executable, "-c", "print('ok')"])
         assert result.returncode == 0
@@ -38,6 +39,7 @@ class TestHappyPath:
 
 
 class TestTimeout:
+    """A stalled command returns a value; it never raises and never blocks."""
     def test_hanging_command_returns_instead_of_blocking(self):
         result = run_guarded(
             [sys.executable, "-c", "import time; time.sleep(30)"],
@@ -70,6 +72,7 @@ class TestTimeout:
 
 
 class TestDiagnosis:
+    """Stall output is turned into guidance a caller can act on."""
     def test_credential_prompt(self):
         assert "credential prompt" in diagnose("Username for 'https://github.com':")
 
@@ -103,6 +106,7 @@ class TestDiagnosis:
 
 
 class TestEnvironment:
+    """Prompt suppression is layered under the caller, never over it."""
     def test_suppresses_git_prompting_by_default(self):
         result = run_guarded(
             [sys.executable, "-c", "import os; print(os.environ['GIT_TERMINAL_PROMPT'])"]
@@ -140,6 +144,7 @@ class TestEnvironment:
 
 
 class TestTimeoutResolution:
+    """Explicit argument beats env var beats default; junk never wins."""
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv("PRAISONAI_SUBPROCESS_TIMEOUT", "0.3")
         result = run_guarded([sys.executable, "-c", "import time; time.sleep(30)"])
@@ -163,6 +168,7 @@ class TestTimeoutResolution:
 
 
 class TestCompatibility:
+    """Call sites read .returncode/.stdout/.stderr unconditionally."""
     def test_result_is_a_real_completed_process(self):
         result = run_guarded([sys.executable, "-c", "import time; time.sleep(5)"], timeout=0.3)
         assert isinstance(result, subprocess.CompletedProcess)
@@ -263,6 +269,7 @@ class TestDescendantTermination:
 
 
 class TestCheck:
+    """check= matches subprocess.run, except a timeout still returns."""
     def test_check_raises_on_nonzero(self):
         with pytest.raises(subprocess.CalledProcessError):
             run_guarded([sys.executable, "-c", "import sys; sys.exit(2)"], check=True)
@@ -280,3 +287,45 @@ class TestCheck:
             check=True,
         )
         assert result.returncode == TIMEOUT_RETURNCODE
+
+
+class TestNonFiniteTimeoutOverrides:
+    """An override that parses as positive can still be unbounded.
+
+    float("inf") passes a bare `value > 0` check, which would hand back an
+    infinite timeout and silently reinstate the hang this module prevents.
+    """
+
+    @pytest.mark.parametrize("bad", ["inf", "Infinity", "+inf", "1e400", "nan"])
+    def test_subprocess_timeout_rejects_non_finite(self, monkeypatch, bad):
+        import math
+
+        from praisonai_bot._guarded_subprocess import DEFAULT_TIMEOUT, _default_timeout
+
+        # Assert on the resolver, not on run_guarded with an explicit
+        # timeout= -- an explicit argument bypasses the env var entirely, so
+        # that spelling would pass even with the bug present.
+        monkeypatch.setenv("PRAISONAI_SUBPROCESS_TIMEOUT", bad)
+        resolved = _default_timeout()
+        assert math.isfinite(resolved)
+        assert resolved == DEFAULT_TIMEOUT
+
+    @pytest.mark.parametrize("bad", ["inf", "Infinity", "+inf", "1e400", "nan"])
+    def test_git_timeout_rejects_non_finite(self, monkeypatch, bad):
+        import math
+
+        from praisonai_bot.gateway.kanban_dispatcher import _git_timeout
+
+        monkeypatch.setenv("PRAISONAI_KANBAN_GIT_TIMEOUT", bad)
+        resolved = _git_timeout()
+        assert math.isfinite(resolved)
+        assert resolved >= 300.0
+
+    def test_default_resolver_stays_finite_without_override(self, monkeypatch):
+        import math
+
+        from praisonai_bot._guarded_subprocess import _default_timeout
+
+        monkeypatch.delenv("PRAISONAI_SUBPROCESS_TIMEOUT", raising=False)
+        assert math.isfinite(_default_timeout())
+


### PR DESCRIPTION
## The defect

Four gateway paths shell out with **no timeout**, and the dispatcher calls them from inside the asyncio event loop. A child blocked on stdin — a git credential prompt, an `index.lock`, a confirmation prompt — stops the whole gateway serving. Indefinitely, and silently.

`gateway/kanban_dispatcher.py::_run_git` is the worst of them: reached from `dispatch_once → _spawn_worker → _prepare_worktree` and from the worktree integration path, so it can hold every WebSocket client, every channel bot and every heartbeat behind one stuck `git`.

This came out of a robustness audit of `praisonai-bot`; it was the highest-severity finding and is unchanged after 119 commits.

## The fix

`praisonai_bot/_guarded_subprocess.run_guarded` — a drop-in wrapper that always bounds the call and, on timeout, returns a `CompletedProcess` with returncode 124 and a **diagnosis** in stderr rather than raising. Existing `returncode == 0` checks keep working without growing an exception path.

Two defences, in order:

1. **Prevent the hang.** stdin is `/dev/null`, and `GIT_TERMINAL_PROMPT=0` / `GCM_INTERACTIVE=never` / `DEBIAN_FRONTEND=noninteractive` are layered *underneath* the caller's env, so the common cases fail fast rather than block. The timeout is a backstop, not the primary defence.
2. **Explain the hang.** Partial output is matched against known stall signatures, so the caller gets something actionable instead of a bare elapsed time:

| Signature | Diagnosis |
|---|---|
| `Username for` / `passphrase` | credential prompt — configure a helper or set `GIT_TERMINAL_PROMPT=0` |
| `index.lock` / `another git process` | git lock contention — retry, or clear a stale lock |
| `[y/N]` / `Are you sure` | confirmation prompt — re-run with `--yes` / `-y` / `--force` |
| `host key` / `known_hosts` | SSH host-key prompt — pre-populate, or `StrictHostKeyChecking=accept-new` |

That structured-feedback idea is borrowed from Headlong's inactivity watchdog. One honest difference: Python's `subprocess.run` gives a *total-runtime* cap, not an inactivity timer, so a command streaming output for longer than the ceiling is still killed. Documented in the module docstring.

## Adopted at

| Site | Why it matters |
|---|---|
| `gateway/kanban_dispatcher.py::_run_git` | blocks the event loop |
| `kanban/sqlite_store.py` | `git rev-parse` on the `create_task` path |
| `gateway/preflight.py` | `launchctl` on the startup path |
| `gateway/pairing.py` | `icacls` while hardening the pairing secret |

## On the timeouts

Git gets a deliberately generous **300s** ceiling (`PRAISONAI_KANBAN_GIT_TIMEOUT`), not the 120s default. Worktree add and merge on a large repository are legitimately slow, and the goal is to bound an indefinite hang — not to convert slow-but-healthy work into a failure. Everything else uses 120s (`PRAISONAI_SUBPROCESS_TIMEOUT`). Both ignore an unusable override rather than adopting a non-positive value that would kill every command instantly.

## Scope

Deliberately narrow. The ~66 remaining `subprocess.run` sites without timeouts are in `daemon/` and CLI paths, where a hang stalls one user command rather than the gateway. Worth a separate pass; not smuggled into this one.

## Testing

32 new tests: timeout-without-raising, stdin EOF, every diagnosis signature, env layering and precedence, interactive mode, unusable env overrides, `CompletedProcess` compatibility, and that `_run_git` actually routes through the guard.

```
tests/unit/kanban + tests/unit/gateway + tests/unit/test_guarded_subprocess.py
625 passed, 22 failed, 21 skipped
```

**The 22 failures are pre-existing.** Confirmed by stashing this branch's changes and re-running the same selection on a clean tree: identical count, identical tests (`test_gateway_watchdog_wiring`, `test_pid_lock_windows`, and others). Two further files fail to *collect* because the optional `websockets` package is absent in this environment. Neither is related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZfTXTzdudKb4oswNSHpHw

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZfTXTzdudKb4oswNSHpHw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded execution for system commands, with configurable time limits and clear timeout diagnostics.
  * Added detection for common credential, confirmation, Git lock, and SSH host-key prompts.
  * Added an interactive mode for commands that require user input.

* **Bug Fixes**
  * Prevented stalled Git, service discovery, and Windows permission commands from blocking gateway operations.
  * Commands exceeding their time limit now fail predictably instead of hanging indefinitely.

* **Tests**
  * Added coverage for timeout handling, environment behavior, diagnostics, and Git command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->