### PR TITLE
fix(agents): stop auto-compaction latching itself off for the rest of a session

### DIFF
--- a/src/praisonai-agents/praisonaiagents/compaction/compactor.py
+++ b/src/praisonai-agents/praisonaiagents/compaction/compactor.py
@@ -139,7 +139,12 @@ class ContextCompactor:
         # Anti-thrashing state tracking
         self._last_savings_pct: float = 100.0  # Start high to allow first compaction
         self._low_savings_streak: int = 0
-        
+        # Token count at the moment the streak reached its cap. The guard is
+        # released once the conversation grows materially past this, so a
+        # compactor that once could not shrink the context is never disabled
+        # for the rest of the session.
+        self._low_savings_tokens: int = 0
+
         # Iterative summary state
         self._previous_summary: Optional[str] = None
         self._previous_summary_global_idx: int = 0
@@ -208,14 +213,56 @@ class ContextCompactor:
         - Token count is below threshold
         - We've had too many consecutive low-savings attempts
         """
-        if self.count_total_tokens(messages) <= self.max_tokens:
+        total_tokens = self.count_total_tokens(messages)
+        if total_tokens <= self.max_tokens:
             return False
-            
-        # Anti-thrashing: skip if we've had too many low-savings attempts
-        if self._low_savings_streak >= self.config.max_consecutive_low_savings:
+
+        # Anti-thrashing: skip if we've had too many low-savings attempts,
+        # unless the conversation has grown enough to be worth re-testing.
+        if self._should_skip_low_savings(total_tokens):
             return False
-            
+
         return True
+
+    #: Growth factor that releases the anti-thrashing guard. A conversation
+    #: 25% larger than the one we gave up on is materially different input,
+    #: so the earlier "not worth compacting" verdict is re-tested.
+    _LOW_SAVINGS_RETRY_GROWTH = 1.25
+
+    def _should_skip_low_savings(self, original_tokens: int) -> bool:
+        """Whether the anti-thrashing guard should skip this pass.
+
+        The guard stops a compactor that cannot shrink a conversation from
+        burning a summarisation call every turn. It must not be permanent:
+        ``_low_savings_streak`` is only cleared *after* a compaction actually
+        runs, so a compactor that trips the cap would otherwise skip forever
+        and let the context grow without bound -- the precise opposite of what
+        the guard is for.
+
+        Growth past the size we gave up on is new evidence, so the verdict is
+        retried and the streak reset.
+        """
+        if self._low_savings_streak < self.config.max_consecutive_low_savings:
+            return False
+        if self._low_savings_tokens and original_tokens >= (
+            self._low_savings_tokens * self._LOW_SAVINGS_RETRY_GROWTH
+        ):
+            self._low_savings_streak = 0
+            self._low_savings_tokens = 0
+            return False
+        return True
+
+    def _record_savings_outcome(self, savings_pct: float, original_tokens: int) -> None:
+        """Update anti-thrashing state after a completed compaction pass."""
+        self._last_savings_pct = savings_pct
+        if savings_pct >= self.config.min_savings_pct:
+            self._low_savings_streak = 0
+            self._low_savings_tokens = 0
+            return
+        self._low_savings_streak += 1
+        if self._low_savings_streak >= self.config.max_consecutive_low_savings:
+            # Remember the size we gave up at, so growth can release the guard.
+            self._low_savings_tokens = original_tokens
     
     def compact(
         self,
@@ -254,7 +301,7 @@ class ContextCompactor:
         # Anti-thrashing: if prior passes yielded too little savings, skip and
         # surface it on the result so callers can detect the skip. Without this
         # the documented ``was_skipped_due_to_low_savings`` flag never fired.
-        if self._low_savings_streak >= self.config.max_consecutive_low_savings:
+        if self._should_skip_low_savings(original_tokens):
             result = CompactionResult(
                 original_tokens=original_tokens,
                 compacted_tokens=original_tokens,
@@ -323,11 +370,7 @@ class ContextCompactor:
         result.calculate_savings_pct()
         
         # Update anti-thrashing tracking based on actual results
-        self._last_savings_pct = result.savings_pct
-        if result.savings_pct >= self.config.min_savings_pct:
-            self._low_savings_streak = 0
-        else:
-            self._low_savings_streak += 1
+        self._record_savings_outcome(result.savings_pct, original_tokens)
         
         return compacted, result
 
@@ -365,7 +408,7 @@ class ContextCompactor:
         # Anti-thrashing: if prior passes yielded too little savings, skip and
         # surface it on the result so callers can detect the skip. Without this
         # the documented ``was_skipped_due_to_low_savings`` flag never fired.
-        if self._low_savings_streak >= self.config.max_consecutive_low_savings:
+        if self._should_skip_low_savings(original_tokens):
             result = CompactionResult(
                 original_tokens=original_tokens,
                 compacted_tokens=original_tokens,
@@ -416,11 +459,7 @@ class ContextCompactor:
         result.calculate_savings_pct()
         
         # Update anti-thrashing tracking based on actual results
-        self._last_savings_pct = result.savings_pct
-        if result.savings_pct >= self.config.min_savings_pct:
-            self._low_savings_streak = 0
-        else:
-            self._low_savings_streak += 1
+        self._record_savings_outcome(result.savings_pct, original_tokens)
         
         return compacted, result
 

--- a/src/praisonai-agents/tests/unit/compaction/test_low_savings_guard.py
+++ b/src/praisonai-agents/tests/unit/compaction/test_low_savings_guard.py
@@ -1,0 +1,166 @@
+"""The anti-thrashing guard must be able to go stale.
+
+``_low_savings_streak`` stops a compactor that cannot shrink a conversation
+from burning a summarisation call every turn. The streak is only cleared
+*after* a compaction actually runs -- but the guard returns before reaching
+that code, so once it latched it could never be released. A long-running
+agent that tripped it stopped compacting for the rest of the session and its
+context grew without bound, which is the precise opposite of what auto
+compaction is for.
+
+These tests pin both halves of the contract: the guard still suppresses
+repeat passes on an unchanged conversation, and it releases once the
+conversation has grown enough to be worth re-testing.
+"""
+
+import pytest
+
+from praisonaiagents.compaction import CompactionConfig, ContextCompactor
+
+
+def _config(**overrides):
+    base = dict(
+        max_tokens=200,
+        target_tokens=150,
+        preserve_recent=2,
+        min_savings_pct=10.0,
+        max_consecutive_low_savings=2,
+    )
+    base.update(overrides)
+    return CompactionConfig(**base)
+
+
+def _conversation(turns):
+    """A highly compactible conversation: repetitive, summarisable turns."""
+    return [{"role": "system", "content": "sys"}] + [
+        {"role": "user", "content": f"Please refactor module_{i}.py and keep the public API stable."}
+        for i in range(turns)
+    ]
+
+
+def _latched(config, at_tokens):
+    """A compactor in the state a long session reaches after two low-yield passes."""
+    compactor = ContextCompactor(config=config, strategy="summarize")
+    compactor._low_savings_streak = config.max_consecutive_low_savings
+    compactor._low_savings_tokens = at_tokens
+    return compactor
+
+
+class TestGuardHolds:
+    """Anti-thrashing behaviour must be preserved."""
+
+    def test_unchanged_conversation_is_still_skipped(self):
+        config = _config()
+        messages = _conversation(200)
+        probe = ContextCompactor(config=config, strategy="summarize")
+        compactor = _latched(config, probe.count_total_tokens(messages))
+
+        _, result = compactor.compact(messages)
+
+        assert result.was_skipped_due_to_low_savings
+        assert result.messages_removed == 0
+
+    def test_marginal_growth_is_still_skipped(self):
+        # Below the retry threshold: not enough new material to justify
+        # re-running a summarisation that just failed to pay for itself.
+        config = _config()
+        probe = ContextCompactor(config=config, strategy="summarize")
+        compactor = _latched(config, probe.count_total_tokens(_conversation(200)))
+
+        _, result = compactor.compact(_conversation(205))
+
+        assert result.was_skipped_due_to_low_savings
+
+
+class TestGuardReleases:
+    """A materially larger conversation is new evidence."""
+
+    def test_growth_releases_the_guard(self):
+        config = _config()
+        probe = ContextCompactor(config=config, strategy="summarize")
+        compactor = _latched(config, probe.count_total_tokens(_conversation(200)))
+
+        _, result = compactor.compact(_conversation(300))
+
+        assert not result.was_skipped_due_to_low_savings
+        assert result.messages_removed > 0
+        # And it must actually shrink -- a released guard that yields nothing
+        # would mean the release is cosmetic.
+        assert result.compacted_tokens < result.original_tokens
+
+    def test_release_matches_a_fresh_compactor(self):
+        # The clearest statement of the bug: a latched compactor used to
+        # return input untouched that an identical fresh one shrinks by ~96%.
+        config = _config()
+        messages = _conversation(300)
+        probe = ContextCompactor(config=config, strategy="summarize")
+        latched = _latched(config, probe.count_total_tokens(_conversation(200)))
+        fresh = ContextCompactor(config=config, strategy="summarize")
+
+        _, latched_result = latched.compact(messages)
+        _, fresh_result = fresh.compact(messages)
+
+        assert latched_result.compacted_tokens == fresh_result.compacted_tokens
+
+    def test_streak_resets_so_the_full_allowance_returns(self):
+        config = _config()
+        probe = ContextCompactor(config=config, strategy="summarize")
+        compactor = _latched(config, probe.count_total_tokens(_conversation(200)))
+
+        compactor.compact(_conversation(300))
+
+        assert compactor._low_savings_streak < config.max_consecutive_low_savings
+
+    def test_needs_compaction_agrees_with_compact(self):
+        # needs_compaction() is the public gate callers consult; if it kept
+        # reporting False the release would never be reached in the agent's
+        # real code path, and compact() alone being fixed would be useless.
+        config = _config()
+        probe = ContextCompactor(config=config, strategy="summarize")
+        compactor = _latched(config, probe.count_total_tokens(_conversation(200)))
+
+        assert compactor.needs_compaction(_conversation(300)) is True
+
+    def test_needs_compaction_still_declines_an_unchanged_conversation(self):
+        config = _config()
+        messages = _conversation(200)
+        probe = ContextCompactor(config=config, strategy="summarize")
+        compactor = _latched(config, probe.count_total_tokens(messages))
+
+        assert compactor.needs_compaction(messages) is False
+
+
+class TestLongSession:
+    """End-to-end: the failure this guard bug actually caused."""
+
+    def test_compaction_keeps_engaging_across_a_long_session(self):
+        config = CompactionConfig(max_tokens=300, target_tokens=200, preserve_recent=2)
+        compactor = ContextCompactor(config=config, strategy="summarize")
+        messages = [{"role": "system", "content": "You are a coding agent."}]
+        events = 0
+
+        for turn in range(1, 41):
+            messages.extend([
+                {"role": "user", "content": f"Step {turn}: refactor module_{turn}.py, keep the API stable."},
+                {"role": "assistant", "content": f"Done: module_{turn}.py refactored, helper_{turn}() extracted."},
+            ])
+            compacted, result = compactor.compact(messages)
+            messages[:] = compacted
+            if result.messages_removed:
+                events += 1
+
+        # Before the fix this latched at 4 events and then never fired again,
+        # letting the context grow unbounded for the rest of the session.
+        assert events > 4, f"compaction stopped engaging after {events} events"
+
+
+@pytest.mark.parametrize("strategy", ["summarize", "truncate", "sliding"])
+def test_guard_release_is_strategy_independent(strategy):
+    """The guard lives above strategy selection, so it must not favour one."""
+    config = _config()
+    probe = ContextCompactor(config=config, strategy=strategy)
+    compactor = _latched(config, probe.count_total_tokens(_conversation(200)))
+
+    _, result = compactor.compact(_conversation(300))
+
+    assert not result.was_skipped_due_to_low_savings

--- a/src/praisonai-agents/tests/unit/compaction/test_low_savings_guard.py
+++ b/src/praisonai-agents/tests/unit/compaction/test_low_savings_guard.py
@@ -19,6 +19,7 @@ from praisonaiagents.compaction import CompactionConfig, ContextCompactor
 
 
 def _config(**overrides):
+    """A tight budget so a handful of turns is enough to trip the guard."""
     base = dict(
         max_tokens=200,
         target_tokens=150,
@@ -50,6 +51,7 @@ class TestGuardHolds:
     """Anti-thrashing behaviour must be preserved."""
 
     def test_unchanged_conversation_is_still_skipped(self):
+        """Re-running on identical input is the thrashing the guard exists to stop."""
         config = _config()
         messages = _conversation(200)
         probe = ContextCompactor(config=config, strategy="summarize")
@@ -61,8 +63,12 @@ class TestGuardHolds:
         assert result.messages_removed == 0
 
     def test_marginal_growth_is_still_skipped(self):
-        # Below the retry threshold: not enough new material to justify
-        # re-running a summarisation that just failed to pay for itself.
+        """Growth below the retry threshold is not new evidence.
+
+        A couple of extra turns does not justify re-running a summarisation
+        that just failed to pay for itself; without this the release would
+        fire on essentially every turn.
+        """
         config = _config()
         probe = ContextCompactor(config=config, strategy="summarize")
         compactor = _latched(config, probe.count_total_tokens(_conversation(200)))
@@ -76,6 +82,7 @@ class TestGuardReleases:
     """A materially larger conversation is new evidence."""
 
     def test_growth_releases_the_guard(self):
+        """Past the threshold the verdict is retried, and the retry pays off."""
         config = _config()
         probe = ContextCompactor(config=config, strategy="summarize")
         compactor = _latched(config, probe.count_total_tokens(_conversation(200)))
@@ -89,8 +96,12 @@ class TestGuardReleases:
         assert result.compacted_tokens < result.original_tokens
 
     def test_release_matches_a_fresh_compactor(self):
-        # The clearest statement of the bug: a latched compactor used to
-        # return input untouched that an identical fresh one shrinks by ~96%.
+        """The clearest statement of the bug.
+
+        A latched compactor used to hand back untouched the very input an
+        otherwise-identical fresh one shrinks by ~96%. Once released the two
+        must be indistinguishable.
+        """
         config = _config()
         messages = _conversation(300)
         probe = ContextCompactor(config=config, strategy="summarize")
@@ -103,6 +114,11 @@ class TestGuardReleases:
         assert latched_result.compacted_tokens == fresh_result.compacted_tokens
 
     def test_streak_resets_so_the_full_allowance_returns(self):
+        """Releasing must clear the streak, not merely skip the check once.
+
+        A release that left the streak at the cap would re-latch on the next
+        call, turning the fix into a one-shot reprieve.
+        """
         config = _config()
         probe = ContextCompactor(config=config, strategy="summarize")
         compactor = _latched(config, probe.count_total_tokens(_conversation(200)))
@@ -112,9 +128,12 @@ class TestGuardReleases:
         assert compactor._low_savings_streak < config.max_consecutive_low_savings
 
     def test_needs_compaction_agrees_with_compact(self):
-        # needs_compaction() is the public gate callers consult; if it kept
-        # reporting False the release would never be reached in the agent's
-        # real code path, and compact() alone being fixed would be useless.
+        """Both gates must release together.
+
+        ``needs_compaction()`` is the public gate callers consult. If it kept
+        reporting False the release would never be reached in the agent's real
+        code path, and fixing ``compact()`` alone would be dead code.
+        """
         config = _config()
         probe = ContextCompactor(config=config, strategy="summarize")
         compactor = _latched(config, probe.count_total_tokens(_conversation(200)))
@@ -122,6 +141,7 @@ class TestGuardReleases:
         assert compactor.needs_compaction(_conversation(300)) is True
 
     def test_needs_compaction_still_declines_an_unchanged_conversation(self):
+        """The other half of that agreement: both gates must also hold together."""
         config = _config()
         messages = _conversation(200)
         probe = ContextCompactor(config=config, strategy="summarize")
@@ -134,6 +154,11 @@ class TestLongSession:
     """End-to-end: the failure this guard bug actually caused."""
 
     def test_compaction_keeps_engaging_across_a_long_session(self):
+        """No white-box setup: drive a real session and watch compaction die.
+
+        This is the failure a user actually hits, reproduced only through the
+        public API, so it stands even if the guard's internals are reworked.
+        """
         config = CompactionConfig(max_tokens=300, target_tokens=200, preserve_recent=2)
         compactor = ContextCompactor(config=config, strategy="summarize")
         messages = [{"role": "system", "content": "You are a coding agent."}]


### PR DESCRIPTION
## How this was found

I set out to add Headlong-style decaying-resolution compaction. Before writing it I measured whether it would actually add value — and it wouldn't: the existing summariser is well-behaved, holding a stable ~430-character summary across repeated compactions rather than growing as I'd assumed.

What the measurements *did* surface is a real defect in the existing feature. So this PR fixes that instead, and the new strategy is not being added.

## The defect

The anti-thrashing guard in `ContextCompactor` can never be released.

Once `_low_savings_streak` reaches `max_consecutive_low_savings` (default 2), both `compact()` and `needs_compaction()` return early. The only line that clears the streak — `self._low_savings_streak = 0` — sits *after* a compaction actually runs, which those early returns skip. The compactor stops compacting permanently, for the life of the instance.

That inverts the guard's purpose. It exists so a compactor that can't shrink a conversation doesn't burn a summarisation call every turn. The effect is that long-running agents — exactly what auto-compaction is for — silently stop compacting and let context grow without bound.

## Evidence

A compactor placed in the latched state, given input it would otherwise shrink **2991 → 125 tokens (96%)**:

```
attempt 1:  2991 ->  2991 tokens  removed=0  skipped=True
attempt 2:  2991 ->  2991 tokens  removed=0  skipped=True
...                                          (indefinitely)

Same input, fresh compactor:  2991 -> 125 tokens, removed=197
```

And end-to-end, a simulated 40-round session against a 300-token limit:

| | compaction events | final context |
|---|---|---|
| before | 4, then never again | 1172 tokens |
| after | 12 | 1052 tokens |

## The fix

The guard can now go stale. `_should_skip_low_savings()` releases it once the conversation has grown 25% beyond the size it gave up at — materially more content is new evidence, so the earlier verdict no longer applies — and resets the streak so the full allowance returns.

Both the sync and async paths plus `needs_compaction()` route through that one helper, and the bookkeeping is consolidated into `_record_savings_outcome()`, so the three sites can't drift apart again.

Anti-thrashing itself is unchanged: an unchanged or marginally-grown conversation is still skipped, and `was_skipped_due_to_low_savings` still reports it.

## What this does not do

Worth being precise rather than overclaiming: this converts *permanently disabled* into *periodically re-tested*. Context can still sit above the ceiling between releases. Pinning it to the limit would mean compacting on nearly every turn — the thrashing the guard exists to prevent. The 25% threshold is the tunable trade-off between the two.

## Testing

11 new tests. I checked they catch the defect rather than merely passing alongside it — **reverting the staleness check turns 8 of them red.**

Coverage: guard holds on an unchanged conversation and on marginal growth; releases on real growth; a released compactor matches a fresh one's output exactly; the streak resets; `needs_compaction()` and `compact()` agree (a fix to only one would be useless, since `needs_compaction()` is the gate callers consult); the end-to-end long session; and all three affected strategies.

```
pytest tests/unit -k compact  →  158 passed, 6 failed
```

The 6 failures are pre-existing — confirmed by stashing this branch and re-running the identical selection on a clean tree: same count, same tests (`test_compactor_llm_summarize_async_*`, `test_compactor_format_messages_for_summary`, `test_context_compaction_policy`).

## On the Headlong feature

Not included, deliberately. `merge_summaries()` concatenates rather than re-compressing, which I expected to grow unboundedly — it doesn't, measurably. A seventh strategy on a module that already has six, with no demonstrated failure it fixes, would be surface area for its own sake. The analysis is in the brief; happy to revisit if a concrete case turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZfTXTzdudKb4oswNSHpHw

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZfTXTzdudKb4oswNSHpHw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compaction can resume after a conversation grows substantially, instead of remaining permanently skipped following repeated low-savings attempts.
  * Low-savings tracking now resets appropriately after successful compaction or guard release.
  * Compaction behavior remains consistent across supported strategies and synchronous or asynchronous operation.
  * Compaction checks and execution now apply the same low-savings guard behavior, improving predictability during long-running conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->