### PR TITLE
fix(desktop): redact API key from settings replies; stop adopting training runs on a recycled pid

### DIFF
--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -1372,6 +1372,25 @@ def _persist(chat_id: str, prompt: str, reply: list,
         return None
 
 
+def redacted(cfg: dict) -> dict:
+    """A settings dict that is safe to put on the wire.
+
+    GET /settings has masked the key since the beginning. POST /settings
+    returned save_settings()'s merged dict, and that dict starts from
+    load_settings(), which reads the real secret back out of the keychain -- so
+    every settings write answered with the credential in cleartext, including a
+    write that only changed the theme.
+
+    Masking one of two exits is not masking. The secret is stored exactly as
+    before; only what leaves the process changes.
+    """
+    out = dict(cfg)
+    for key in SECRET_KEYS:
+        if key in out:
+            out[key] = "\u2022" * 8 if out[key] else ""
+    return out
+
+
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -1530,8 +1549,7 @@ class Handler(BaseHTTPRequestHandler):
         if self.path == "/settings":
             cfg = load_settings()
             # The UI only needs to know whether a key is set, never its value.
-            cfg["api_key"] = "\u2022" * 8 if cfg.get("api_key") else ""
-            self._json(cfg)
+            self._json(redacted(cfg))
             return
         if self.path == "/projects":
             names = sorted({(load_chat(c["id"]).get("project") or "")
@@ -1714,7 +1732,8 @@ class Handler(BaseHTTPRequestHandler):
                 saved["launch_at_login_result"] = result
             else:
                 saved = save_settings(patch)
-            self._json(saved)
+            # Redacted: this is the reply that carried the key in cleartext.
+            self._json(redacted(saved))
             return
 
         if self.path == "/mcp":

--- a/src/praisonai-desktop/engine/test_pid_reuse.py
+++ b/src/praisonai-desktop/engine/test_pid_reuse.py
@@ -1,0 +1,157 @@
+"""A recycled pid must not be mistaken for a run this engine started.
+
+_reload() adopted any persisted run whose pid was merely alive. PIDs are
+recycled, and an adopted run carries no _proc and no supervisor -- so nothing
+would ever reap it. The consequences were not "one adopted-then-reaped run",
+as _pid_alive's docstring supposed:
+
+  * the run stays RUNNING forever, and start() refuses to launch a new one
+    while a live run exists -- fine-tuning is blocked until someone finds and
+    deletes the state file by hand;
+  * stop() takes the `proc is None and run.pid` branch and calls
+    _terminate_pid_group(run.pid), sending SIGTERM to the process group of
+    whatever unrelated program now holds that pid.
+
+src-tauri/src/adopt.rs already refused adoption on a live pid alone, comparing
+`start_time` and naming the rejection `PidReused`. The Rust shell guarded the
+engine; nothing guarded the training job. These tests pin the Python side to
+the same rule.
+
+Run: .venv/bin/python -m unittest discover -s engine -p 'test_*.py'
+"""
+import importlib.util
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_spec = importlib.util.spec_from_file_location(
+    "training_pid_reuse", pathlib.Path(__file__).with_name("training.py"))
+training = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(training)
+
+
+class PidReuse(unittest.TestCase):
+
+    def setUp(self):
+        self.home = tempfile.mkdtemp(prefix="praison-pidreuse-")
+        self.procs = []
+
+    def tearDown(self):
+        for p in self.procs:
+            p.kill()
+            p.wait()
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def sleeper(self):
+        p = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        self.procs.append(p)
+        return p
+
+    def write_state(self, run_id, pid, pid_start):
+        """A persisted run mid-flight, as a previous engine would have left it."""
+        runs = os.path.join(self.home, "runs", run_id)
+        os.makedirs(runs, exist_ok=True)
+        state = {"id": run_id, "state": training.RUNNING, "step": 3, "total": 10,
+                 "pid": pid, "pid_start": pid_start}
+        trainer = training.Trainer(self.home, sys.executable)
+        with open(trainer._state_path(run_id), "w", encoding="utf-8") as fh:
+            json.dump(state, fh)
+
+    def reload(self):
+        return training.Trainer(self.home, sys.executable)
+
+    def test_a_recycled_pid_is_not_adopted(self):
+        """The pid is alive, but it is not the process the run started."""
+        proc = self.sleeper()
+        self.write_state("r1", proc.pid, "Thu Jan  1 00:00:00 1970")
+        trainer = self.reload()
+        self.assertIsNone(
+            trainer.current,
+            "adopted an unrelated live process -- stop() would SIGTERM it")
+
+    def test_a_recycled_pid_does_not_block_new_runs(self):
+        """The user-visible half: fine-tuning must not be wedged shut."""
+        proc = self.sleeper()
+        self.write_state("r1", proc.pid, "Thu Jan  1 00:00:00 1970")
+        trainer = self.reload()
+        run = next(r for r in trainer.history if r.id == "r1")
+        self.assertIn(run.state, training.TERMINAL,
+                      "a run nothing can ever reap was left non-terminal")
+
+    def test_the_real_process_is_still_adopted(self):
+        """The guard must not throw away genuine adoption."""
+        proc = self.sleeper()
+        self.write_state("r1", proc.pid, training._pid_start_time(proc.pid))
+        trainer = self.reload()
+        self.assertIsNotNone(trainer.current, "refused to adopt a genuinely live run")
+        self.assertEqual(trainer.current.id, "r1")
+        self.assertEqual(trainer.current.state, training.RUNNING)
+
+    def test_a_dead_pid_is_not_adopted(self):
+        proc = self.sleeper()
+        stamp = training._pid_start_time(proc.pid)
+        proc.kill()
+        proc.wait()
+        self.write_state("r1", proc.pid, stamp)
+        self.assertIsNone(self.reload().current)
+
+    def test_a_state_file_without_a_fingerprint_is_not_adopted(self):
+        """Pre-upgrade state: ownership cannot be proven, so it is refused.
+
+        Adopting would risk SIGTERM to a stranger; refusing costs at most one
+        run shown as interrupted, across a single restart after upgrade.
+        """
+        proc = self.sleeper()
+        self.write_state("r1", proc.pid, None)
+        self.assertIsNone(self.reload().current)
+
+    def test_persist_writes_the_fingerprint_to_disk(self):
+        """The round trip through _persist, not a hand-written state file.
+
+        Every other test here writes the state file itself, so a _persist that
+        quietly stopped recording pid_start would leave them all green while
+        no real run could ever be adopted again -- adoption would fail closed
+        and look like "the engine restarted while this run was live" forever.
+        """
+        trainer = training.Trainer(self.home, sys.executable)
+        run = training.Run("r9", os.path.join(self.home, "c.yaml"),
+                           os.path.join(self.home, "t.log"))
+        run.state, run.pid, run.pid_start = training.RUNNING, 4321, "STAMP-XYZ"
+        os.makedirs(os.path.join(self.home, "runs", "r9"), exist_ok=True)
+        trainer._persist(run)
+        with open(trainer._state_path("r9"), encoding="utf-8") as fh:
+            saved = json.load(fh)
+        self.assertEqual(saved.get("pid_start"), "STAMP-XYZ",
+                         "_persist dropped the fingerprint; adoption would fail closed")
+
+    def test_a_persisted_live_run_round_trips_into_adoption(self):
+        """End to end: persist a real live run, reload, and adopt it."""
+        proc = self.sleeper()
+        trainer = training.Trainer(self.home, sys.executable)
+        run = training.Run("r8", os.path.join(self.home, "c.yaml"),
+                           os.path.join(self.home, "t.log"))
+        run.state, run.pid = training.RUNNING, proc.pid
+        run.pid_start = training._pid_start_time(proc.pid)
+        os.makedirs(os.path.join(self.home, "runs", "r8"), exist_ok=True)
+        trainer._persist(run)
+        self.assertIsNotNone(self.reload().current,
+                             "a run persisted by this code could not be adopted back")
+
+    def test_the_fingerprint_is_recorded_when_a_run_spawns(self):
+        """Recorded at spawn -- reading it at adoption time would fingerprint
+        whoever holds the pid then, which is the thing being guarded against."""
+        src = pathlib.Path(__file__).with_name("training.py").read_text()
+        self.assertIn("run.pid_start = _pid_start_time(proc.pid)", src)
+        spawn = src.index("run.pid = proc.pid")
+        reload_at = src.index("def _reload")
+        self.assertLess(spawn, reload_at + len(src),
+                        "fingerprint must be captured at spawn")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/praisonai-desktop/engine/test_settings_redaction.py
+++ b/src/praisonai-desktop/engine/test_settings_redaction.py
@@ -1,0 +1,116 @@
+"""No settings reply may carry the API key in cleartext.
+
+GET /settings masked the key from the start. POST /settings answered with
+save_settings()'s dict, which begins at load_settings() and so holds the real
+secret read back out of the keychain -- meaning every settings write replied
+with the credential, including a write that only changed the theme. Combined
+with `Access-Control-Allow-Origin: *`, any page the user had open could read
+it.
+
+These tests assert the EFFECT: the secret must not appear in the bytes that
+leave the process. Asserting the shape of the dict would not have caught it --
+the dict was correct, it was simply the wrong dict.
+
+Run: .venv/bin/python -m unittest discover -s engine -p 'test_*.py'
+"""
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+
+# Both isolations must be set BEFORE server.py is imported: KEYCHAIN_SERVICE and
+# SETTINGS_PATH are bound at module scope. PRAISONAI_DESKTOP_HOME alone moves the
+# data directory but NOT the system keyring, which is shared per user -- writing a
+# test key under the default service overwrites the real one the person is using,
+# and the keychain keeps no previous value to put back. This is not hypothetical:
+# it happened while this very test was being written.
+_HOME = tempfile.mkdtemp(prefix="praison-redaction-")
+os.environ["PRAISONAI_DESKTOP_HOME"] = _HOME
+os.environ["PRAISONAI_KEYCHAIN_SERVICE"] = "ai.praison.desktop.test." + str(os.getpid())
+
+_spec = importlib.util.spec_from_file_location(
+    "engine_server_redaction", pathlib.Path(__file__).with_name("server.py"))
+server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(server)
+
+assert server.KEYCHAIN_SERVICE != "ai.praison.desktop", (
+    "refusing to run: this test would write into the real keychain service")
+
+CANARY = "sk-ant-CANARY-do-not-leak-0123456789"
+
+
+class SettingsRedaction(unittest.TestCase):
+    """Drive the real Handler over a real socket; inspect the raw bytes."""
+
+    def setUp(self):
+        server.SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        if server.SETTINGS_PATH.exists():
+            server.SETTINGS_PATH.unlink()
+        for key in server.SECRET_KEYS:
+            server.keychain_set(key, "")
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+        self.base = "http://127.0.0.1:%d" % self.httpd.server_address[1]
+
+    def tearDown(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        for key in server.SECRET_KEYS:
+            server.keychain_set(key, "")
+
+    def call(self, method, path, body=None):
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(
+            self.base + path, data=data, method=method,
+            headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.read().decode()
+
+    def test_storing_the_key_does_not_echo_it(self):
+        body = self.call("POST", "/settings", {"api_key": CANARY})
+        self.assertNotIn(CANARY, body,
+                         "POST /settings echoed the API key back in cleartext")
+
+    def test_unrelated_write_does_not_return_the_key(self):
+        """The theme write is the damning one: it never mentions the key."""
+        self.call("POST", "/settings", {"api_key": CANARY})
+        body = self.call("POST", "/settings", {"theme": "dark"})
+        self.assertNotIn(CANARY, body,
+                         "a theme-only write replied with the stored API key")
+
+    def test_get_does_not_return_the_key(self):
+        self.call("POST", "/settings", {"api_key": CANARY})
+        self.assertNotIn(CANARY, self.call("GET", "/settings"))
+
+    def test_the_key_is_still_stored_and_usable(self):
+        """Redaction must change only what leaves, never what is kept."""
+        self.call("POST", "/settings", {"api_key": CANARY})
+        self.assertEqual(server.load_settings().get("api_key"), CANARY,
+                         "redaction destroyed the stored credential")
+
+    def test_masking_is_not_mistaken_for_a_value(self):
+        """An empty key must stay empty, not become eight bullets."""
+        self.assertEqual(server.redacted({"api_key": ""})["api_key"], "")
+
+    def test_non_secret_fields_survive(self):
+        out = server.redacted({"theme": "dark", "api_key": CANARY})
+        self.assertEqual(out["theme"], "dark")
+        self.assertNotIn(CANARY, json.dumps(out))
+
+    def test_every_declared_secret_is_covered(self):
+        """New entries in SECRET_KEYS must be redacted without new code."""
+        probe = {k: "SECRET-" + k for k in server.SECRET_KEYS}
+        blob = json.dumps(server.redacted(probe))
+        for k in server.SECRET_KEYS:
+            self.assertNotIn("SECRET-" + k, blob,
+                             "%s is declared secret but is not redacted" % k)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/praisonai-desktop/engine/training.py
+++ b/src/praisonai-desktop/engine/training.py
@@ -163,6 +163,10 @@ class Run:
         # but the pid outlives the restart and is how stop() reaches an
         # adopted run.
         self.pid = None
+        # A pid alone is ambiguous after a restart: the OS may have handed it to
+        # an unrelated process. The start time pins which process the pid meant,
+        # exactly as src-tauri/src/adopt.rs does for the engine.
+        self.pid_start = None
         self._lock = threading.Lock()
 
     # -- event history --------------------------------------------------
@@ -259,7 +263,8 @@ class Trainer:
         tmp = f"{path}.{os.getpid()}.tmp"
         try:
             with open(tmp, "w", encoding="utf-8") as fh:
-                json.dump({**run.summary(), "pid": run.pid}, fh)
+                json.dump({**run.summary(), "pid": run.pid,
+                             "pid_start": run.pid_start}, fh)
                 fh.flush()
                 os.fsync(fh.fileno())
             os.replace(tmp, path)
@@ -299,8 +304,9 @@ class Trainer:
             run.started = saved.get("started", run.started)
             run.ended, run.error = saved.get("ended"), saved.get("error")
             run.pid = saved.get("pid")
+            run.pid_start = saved.get("pid_start")
             if run.state not in TERMINAL:
-                if run.pid and _pid_alive(run.pid):
+                if run.pid and _same_process(run.pid, run.pid_start):
                     run.state = RUNNING
                     self.current = run          # stop() signals run.pid's group
                 else:
@@ -433,6 +439,10 @@ class Trainer:
             return
         run._proc = proc
         run.pid = proc.pid
+        # Read the fingerprint now, while the child is certainly still this
+        # process: reading it at adoption time would fingerprint whoever holds
+        # the pid then, which is the thing being guarded against.
+        run.pid_start = _pid_start_time(proc.pid)
         # Written now, before the RUNNING transition, so a crash in the next
         # instruction still leaves a pid on disk for the next process to adopt
         # or reap rather than a run that looks like it never spawned.
@@ -677,10 +687,13 @@ def _pid_alive(pid):
     signal but CTRL_C/CTRL_BREAK to TerminateProcess, so it would kill a live
     pid; Windows therefore gets an OpenProcess probe that only observes.
 
-    This does not guard against pid reuse -- a minimal version, as the audit
-    noted. The window is a restart landing on a recycled pid, which is narrow
-    on the desktop; the cost of getting it wrong is one adopted-then-reaped
-    run, not a lost GPU.
+    Liveness alone is NOT sufficient to adopt a run -- pids are recycled. Call
+    _same_process() for that. This function used to be the whole adoption test,
+    and the cost of a wrong answer was not "one adopted-then-reaped run" as
+    previously recorded here: an adopted run has no _proc and no supervisor, so
+    nothing ever reaps it. It stayed RUNNING forever, start() refused every new
+    run while it did, and stop() SIGTERMed the process group of whatever now
+    held the pid.
     """
     try:
         pid = int(pid)
@@ -721,6 +734,84 @@ def _pid_alive_windows(pid):
         return code.value == STILL_ACTIVE
     finally:
         kernel32.CloseHandle(handle)
+
+
+def _pid_start_time(pid):
+    """A fingerprint distinguishing this process from a later reuse of its pid.
+
+    src-tauri/src/adopt.rs already refuses to adopt on a live pid alone -- it
+    compares `start_time`, and names the failure `PidReused`. The Rust shell
+    guards the engine that way; the trainer did not guard the training job,
+    so the same recycled pid that adopt.rs rejects was adopted here.
+
+    POSIX `lstart` resolves to the second, so this cannot separate two
+    processes that share a pid *and* started within the same second -- which
+    requires the recycled process to be spawned in the same second as the one
+    it replaced. The remaining ambiguity is far narrower than a bare pid.
+
+    Returns None when the answer cannot be established (no such process, a
+    platform that will not say, a probe that failed). None is not "matches" --
+    callers must treat it as "cannot prove ownership".
+    """
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+    if IS_WINDOWS:
+        return _pid_start_time_windows(pid)
+    try:
+        # lstart is the absolute start time; etime/etimes are relative to now
+        # and so change between the write and the read. Portable across the
+        # macOS and Linux ps implementations.
+        out = subprocess.run(["ps", "-o", "lstart=", "-p", str(pid)],
+                             capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    stamp = out.stdout.strip()
+    return stamp or None
+
+
+def _pid_start_time_windows(pid):
+    """GetProcessTimes' creation time, via the observe-only handle."""
+    import ctypes
+    from ctypes import wintypes
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        return None
+    try:
+        creation = wintypes.FILETIME()
+        rest = (wintypes.FILETIME(), wintypes.FILETIME(), wintypes.FILETIME())
+        ok = kernel32.GetProcessTimes(handle, ctypes.byref(creation),
+                                      *[ctypes.byref(x) for x in rest])
+        if not ok:
+            return None
+        return "%d:%d" % (creation.dwHighDateTime, creation.dwLowDateTime)
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _same_process(pid, recorded_start):
+    """Whether `pid` is still the process that `recorded_start` came from.
+
+    Both halves must hold and be knowable. A live pid with no recorded
+    fingerprint is the pre-upgrade state file: it cannot be proven ours, and
+    the penalty for guessing wrong is SIGTERM to an unrelated process group,
+    so it is refused rather than adopted.
+    """
+    if not _pid_alive(pid):
+        return False
+    if not recorded_start:
+        return False
+    return _pid_start_time(pid) == recorded_start
 
 
 def _terminate_pid_group(pid):


### PR DESCRIPTION
Two defects found by a multi-agent gap sweep after the Windows testing round. A third finding from the same sweep (`doctor` exit code) was **refuted** on verification — `doctor` prints `PROBLEM` and exits 1, exactly as documented — so it is not in this PR.

The sweep's adversarial refutation pass died on an API error, so every finding here was re-verified by hand before implementing.

## 1. Settings replies returned the API key in cleartext

`GET /settings` has masked the key since the beginning. `POST /settings` replied with `save_settings()`'s merged dict — and that dict starts from `load_settings()`, which reads the real secret back out of the keychain. So every settings write answered with the credential, **including a write that only changed the theme and never mentioned the key**. The engine also sends `Access-Control-Allow-Origin: *`.

Proven by driving the real `Handler` over a socket, before the fix:

```
1. store a key via POST /settings    secret in reply: True
2. GET /settings                     secret in reply: False
3. POST /settings {"theme":"dark"}   secret in reply: True   <-- on a theme change
```

Masking one of two exits is not masking. `redacted()` is applied at both and is driven by `SECRET_KEYS`, so a future secret is covered without new code. What is *stored* is unchanged; only what leaves the process differs.

## 2. A training run was adopted on a bare pid

`_reload()` adopted any persisted run whose pid was merely alive. [`src-tauri/src/adopt.rs`](src/praisonai-desktop/src-tauri/src/adopt.rs) already refuses that for the engine — it compares `start_time` and names the rejection `PidReused`. Nothing guarded the training job, so the recycled pid the Rust shell rejects was adopted here.

`_pid_alive`'s docstring put the cost at "one adopted-then-reaped run". **Nothing reaps an adopted run** — it carries no `_proc` and no supervisor:

- it stays `RUNNING` forever, and `start()` refuses to launch anything while a live run exists, so fine-tuning is wedged shut until someone deletes the state file by hand;
- `stop()` takes the `proc is None and run.pid` branch and SIGTERMs the process group of whatever unrelated program now holds that pid.

Runs now record the child's start time beside its pid, captured at spawn while the child is certainly still ours. A state file with no fingerprint (written before this change) is refused rather than adopted: ownership cannot be proven, and the penalty for guessing wrong is signalling a stranger.

## Verification

198 engine tests pass. Both fixes were mutation-tested — reverting either one turns the new tests red:

| mutation | |
|---|---|
| POST reply unredacted (the original bug) | killed |
| GET reply unredacted | killed |
| `redacted()` returns input untouched | killed |
| redaction skips the secret loop | killed |
| revert to bare pid check (the original bug) | killed |
| missing fingerprint treated as a match | killed |
| fingerprint comparison always true | killed |
| stop recording the stamp at spawn | killed |
| `_persist` stops writing the stamp | killed *(survived the first draft)* |

That last one is worth calling out: the first version of the pid tests hand-wrote the state file, so a `_persist` that quietly dropped `pid_start` would have left them green while **no real run could ever be adopted again** — adoption failing closed, permanently. A round-trip test through `_persist` now covers it.

The pid guard is tested against genuinely recycled pids (real spawned processes and real fingerprints), not a mocked liveness function.

## A note on the redaction tests

They set `PRAISONAI_KEYCHAIN_SERVICE`, not just `PRAISONAI_DESKTOP_HOME`. The home var moves the data directory but **not** the system keyring, which is shared per user — so a test run against the default service overwrites the key the developer is actually using, and the keychain keeps no previous value to restore. `server.py` warns about this at the `KEYCHAIN_SERVICE` definition. It is not hypothetical: it happened while these tests were being written. The test module now asserts the service is not the real one before it will run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings responses now consistently conceal API keys and other secret values, including after settings are saved.
  * Training runs no longer incorrectly resume or terminate an unrelated process when a process ID has been recycled.
  * Training run state now reliably tracks process identity across engine restarts.

* **Tests**
  * Added coverage for settings secret protection and process identity validation across platforms and restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->