### PR TITLE
fix(mobile): the unresolvable-import check flagged installed packages too

### DIFF
--- a/src/praisonai-mobile/tools/bundle.mjs
+++ b/src/praisonai-mobile/tools/bundle.mjs
@@ -19,6 +19,8 @@
  */
 import * as esbuild from "esbuild";
 import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
 
 /** Node builtins that must never survive into a webview bundle. */
 /** esbuild's own metafile markers, which are not packages. */
@@ -199,9 +201,32 @@ export async function bundle({ entry, outfile, minify = true, write = true }) {
   // openai, ai, @ai-sdk/cohere, @ai-sdk/google, @ai-sdk/openai,
   // @ai-sdk/provider-utils, chalk, ora, boxen, figlet and cli-table3. That
   // bundle loads on a laptop with node_modules beside it and dies on a phone.
-  const unresolved = bare.filter(
-    (name) => !RUNTIME_MARKERS.has(name) && !NODE_BUILTINS.includes(name.split("/")[0]),
-  );
+  //
+  // CORRECTED. The first version of this asked "did it stay external?", which
+  // is true of EVERY bare import here -- the plugin below externalises them all
+  // on purpose, so builtins surface in the metafile instead of being shimmed.
+  // So it flagged installed, perfectly resolvable packages as unresolvable, and
+  // only passed because the shipped bundle happens to have no bare imports at
+  // all. Confirmed against a real install: `praisonai/mobile` resolves to
+  // node_modules/praisonai/dist/mobile.js and was reported unresolved anyway.
+  //
+  // The question that actually matters is whether the specifier can be
+  // RESOLVED from the entry, so it is asked directly.
+  const resolver = createRequire(resolve(entry));
+  const unresolved = bare.filter((name) => {
+    if (RUNTIME_MARKERS.has(name)) return false;
+    // Redundant in practice and kept for intent: `createRequire` resolves
+    // builtins too, so removing this line changes nothing (verified). A
+    // builtin is already classified as fatal-or-lazy above and must not be
+    // reported twice under a different heading -- that is what this says.
+    if (NODE_BUILTINS.includes(name.split("/")[0])) return false;
+    try {
+      resolver.resolve(name);
+      return false;
+    } catch {
+      return true;
+    }
+  });
   const processReads = topLevelProcessReads(code);
   const bytes = Buffer.byteLength(code, "utf8");
 

--- a/src/praisonai-mobile/tools/bundle.test.mjs
+++ b/src/praisonai-mobile/tools/bundle.test.mjs
@@ -10,7 +10,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -288,6 +288,34 @@ test("an unresolvable import fails the gate, with the package named", async () =
   );
   assert.match(report.problems.join("\n"), /could not resolve/);
   assert.match(report.problems.join("\n"), /a-package-that-is-not-installed/, "and named in the message");
+});
+
+test("a bare import that IS installed is not reported unresolvable", async () => {
+  // The correction. The first version of this check asked "did it stay
+  // external?" -- which is true of every bare import, because the plugin
+  // externalises them all on purpose so builtins surface in the metafile. So
+  // it flagged installed, resolvable packages, and only passed because the
+  // shipped bundle happens to have no bare imports at all.
+  //
+  // `esbuild` is a real dependency of this package, so it is the honest probe:
+  // resolvable from here, and nothing to do with Node builtins.
+  // The probe lives INSIDE the package, because resolution is relative to the
+  // entry: a temp-directory entry has no node_modules above it, so everything
+  // would look missing and the test would pass for the wrong reason. The real
+  // app entry is inside the package too.
+  const entry = join(import.meta.dirname, ".resolvable-probe.ts");
+  writeFileSync(entry, 'import * as e from "esbuild";\nexport const x = e;\n');
+  try {
+    const report = await bundle({
+      entry,
+      outfile: join(mkdtempSync(join(tmpdir(), "installed-")), "o.js"),
+      write: false,
+    });
+    assert.deepEqual(report.unresolved, [], "an installed package resolves");
+    assert.equal(isShippable(report), true, report.problems.join("\n"));
+  } finally {
+    rmSync(entry, { force: true });
+  }
 });
 
 test("a LAZY Node builtin is still allowed -- the pair", async () => {


### PR DESCRIPTION
**A defect I shipped in #4678.** Found while testing `praisonai@1.7.4`, published today with the `./mobile` entry the in-process engine needs.

## What was wrong

The check asked *"did this bare import stay external?"* — which is true of **every** bare import, because the plugin in that same file externalises them all on purpose, so Node builtins surface in the metafile instead of being silently shimmed:

```js
build.onResolve({ filter: /^[^.\/]/ }, (args) => ({ path: args.path, external: true }));
```

So it reported installed, perfectly resolvable packages as unresolvable:

```
gate:          praisonai/mobile -> unresolved, shippable: false
createRequire: praisonai/mobile -> node_modules/praisonai/dist/mobile.js
```

It passed only because the shipped bundle happens to have **no bare imports at all** — and it would have blocked the first real dependency the app ever added, which is exactly the change the in-process engine now needs.

## The fix

It asks the question it claims to ask: can the specifier be **resolved** from the entry.

| | before | after |
|---|---|---|
| `praisonai/mobile` (installed) | ✗ flagged | ✓ passes |
| `definitely-not-installed` | ✗ flagged | ✗ flagged |

## Why it went unnoticed

The original had only the **failing** direction tested. A check that flags everything passes a test that only ever feeds it something bad. Both directions are pinned now.

The probe for the passing direction lives **inside the package**, not a temp directory — resolution is relative to the entry, so a temp-dir entry has no `node_modules` above it and everything looks missing. That was my first draft and it failed for precisely that reason before being corrected.

## Verification

- **1327 tests, 0 failed** on Node 22.23 and 24.12
- 3 mutations: 2 die. The third — dropping the Node-builtin exemption — is **equivalent**, because `createRequire` resolves builtins too (verified for `crypto`, `fs`, `readline`, `node:fs`). It's kept as intent and the source now says so, rather than leaving a line no test can hold.

Refs #4678, #4673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bundle validation to correctly detect unresolved package imports.
  * Prevented valid, installed packages from being incorrectly reported as missing.
  * Ensured shippability results accurately reflect whether required packages can be resolved.

* **Tests**
  * Added coverage confirming that resolvable installed packages pass bundle validation successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->