### PR TITLE
fix(parity): the drift gate was blind, and the tracker could not fail

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -26,9 +26,18 @@ name: mobile
 on:
   push:
     branches: [main]
-    paths: ['src/praisonai-mobile/**', '.github/workflows/mobile.yml']
+    paths: &watched
+      - 'src/praisonai-mobile/**'
+      - '.github/workflows/mobile.yml'
+      # The `upstream parity` job below typechecks the REAL praisonai-ts Agent
+      # against the structural contract in engines/src/praisonai-ts/agent-api.ts.
+      # Watching only praisonai-mobile made that gate fire when the CONSUMER
+      # changed and stay silent when the thing it watches did -- so upstream
+      # drift landed on main unchecked. Verified on 71197fa80, which edited
+      # src/praisonai-ts/src/agent/simple.ts: no parity check ran on it.
+      - 'src/praisonai-ts/src/**'
   pull_request:
-    paths: ['src/praisonai-mobile/**', '.github/workflows/mobile.yml']
+    paths: *watched
 
 concurrency:
   group: mobile-${{ github.ref }}

--- a/.github/workflows/update-docs-parity.yml
+++ b/.github/workflows/update-docs-parity.yml
@@ -6,7 +6,11 @@ on:
     paths:
       - 'src/praisonai-agents/praisonaiagents/**/*.py'
       - 'src/praisonai-ts/src/**/*.ts'
-      - 'src/praisonai-rust/src/**/*.rs'
+      # The crate lives at src/praisonai-rust/praisonai/src -- the old
+      # 'src/praisonai-rust/src/**' path does not exist, so a Rust change
+      # never triggered either tracker and the Rust numbers only ever
+      # refreshed incidentally, on an unrelated push.
+      - 'src/praisonai-rust/praisonai/src/**/*.rs'
       - 'src/praisonai/praisonai/_dev/parity/**/*.py'
       - '.github/workflows/update-docs-parity.yml'
   workflow_dispatch:  # Allow manual trigger

--- a/.github/workflows/update-parity-tracker.yml
+++ b/.github/workflows/update-parity-tracker.yml
@@ -1,12 +1,28 @@
 name: Update Feature Parity Tracker
 
 on:
+  pull_request:
+    paths: &watched
+      - 'src/praisonai-agents/praisonaiagents/**/*.py'
+      - 'src/praisonai-ts/src/**/*.ts'
+      - 'src/praisonai-rust/praisonai/src/**/*.rs'
+      - 'src/praisonai/praisonai/_dev/parity/**/*.py'
+      - 'src/praisonai/praisonai/cli/features/**/*.py'
+      - '.github/workflows/update-parity-tracker.yml'
   push:
     branches: [ "main" ]
     paths:
       - 'src/praisonai-agents/praisonaiagents/**/*.py'
       - 'src/praisonai-ts/src/**/*.ts'
-      - 'src/praisonai-rust/src/**/*.rs'
+      # The crate lives at src/praisonai-rust/praisonai/src -- the old
+      # 'src/praisonai-rust/src/**' path does not exist, so a Rust change
+      # never triggered either tracker and the Rust numbers only ever
+      # refreshed incidentally, on an unrelated push.
+      - 'src/praisonai-rust/praisonai/src/**/*.rs'
+      # The generator's own code and the wrapper features it counts. Change
+      # either and nothing regenerated until an unrelated push landed.
+      - 'src/praisonai/praisonai/_dev/parity/**/*.py'
+      - 'src/praisonai/praisonai/cli/features/**/*.py'
       - '.github/workflows/update-parity-tracker.yml'
 
 permissions:
@@ -14,6 +30,10 @@ permissions:
 
 jobs:
   update-parity-tracker:
+    # Push only. On a PR the job below CHECKS instead -- committing a
+    # regenerated tracker onto a contributor's branch is not this
+    # workflow's business, and would fail on a fork besides.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     
     steps:
@@ -59,3 +79,27 @@ jobs:
         commit_user_email: "454862+MervinPraison@users.noreply.github.com"
         commit_author: "MervinPraison <454862+MervinPraison@users.noreply.github.com>"
 
+  # ------------------------------------------------------------------
+  # On a PR: CHECK, do not commit.
+  #
+  # `--check` has existed since the script was written and exits 1 on a stale
+  # tracker -- and was invoked by nothing, so the tracker could only ever be
+  # corrected after the fact by the push job below. It was also unusable as a
+  # gate until the absolute `path` field was removed from the output, because
+  # it failed on every machine that was not the GitHub runner.
+  #
+  # This does NOT check parity. It checks that the committed artifact matches
+  # what today's source produces -- staleness only. What the number means is a
+  # separate problem, recorded in the tracker's own disclaimer.
+  # ------------------------------------------------------------------
+  check-parity-tracker:
+    name: parity tracker is current
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Is the committed tracker what the source produces?
+        run: python3 src/praisonai/scripts/generate_parity_tracker.py --check

--- a/.github/workflows/update-parity-tracker.yml
+++ b/.github/workflows/update-parity-tracker.yml
@@ -101,5 +101,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      # The generator imports pyyaml. The first run of this job failed in 8s
+      # with `No module named 'yaml'` -- the push job above installs it and
+      # this one did not.
+      - run: pip install pyyaml
       - name: Is the committed tracker what the source produces?
         run: python3 src/praisonai/scripts/generate_parity_tracker.py --check

--- a/src/praisonai-rust/FEATURE_PARITY_TRACKER.json
+++ b/src/praisonai-rust/FEATURE_PARITY_TRACKER.json
@@ -3,12 +3,12 @@
   "lastUpdated": "2026-09-02",
   "generatedBy": "praisonai._dev.parity.generator",
   "sourceOfTruth": "Python SDK (praisonaiagents)",
-  "status": "PARITY_ACHIEVED",
+  "status": "NEAR_PARITY",
   "summary": {
     "pythonCoreFeatures": 411,
     "rustFeatures": 667,
     "gapCount": 129,
-    "parityPercentage": 162.3
+    "parityPercentage": 68.6
   },
   "pythonCoreSDK": {
     "exports": [
@@ -426,7 +426,7 @@
     ]
   },
   "rustSDK": {
-    "path": "/home/runner/work/PraisonAI/PraisonAI/src/praisonai-rust",
+    "path": "src/praisonai-rust",
     "exports": [
       "A2A",
       "A2AAgentCapabilities",
@@ -1181,6 +1181,7 @@
         "WebSearchProvider"
       ],
       "config_loader": [
+        "AutoRagConfig",
         "SessionConfig"
       ],
       "context": [
@@ -1802,7 +1803,6 @@
       "planning": [],
       "plugins": [
         "PluginRegistry",
-        "ToolDefinition",
         "disable_plugins",
         "enable_plugins",
         "get_plugin_manager",
@@ -1816,9 +1816,6 @@
       "sandbox": [],
       "session": [],
       "skills": [],
-      "specialized": [
-        "AutoRagConfig"
-      ],
       "specialized_agents": [],
       "streaming": [],
       "task": [],
@@ -1827,6 +1824,7 @@
       "tools": [
         "FunctionTool",
         "Tool",
+        "ToolDefinition",
         "ToolRegistry",
         "ToolResult"
       ],

--- a/src/praisonai-rust/FEATURE_PARITY_TRACKER.json
+++ b/src/praisonai-rust/FEATURE_PARITY_TRACKER.json
@@ -1181,7 +1181,6 @@
         "WebSearchProvider"
       ],
       "config_loader": [
-        "AutoRagConfig",
         "SessionConfig"
       ],
       "context": [
@@ -1803,6 +1802,7 @@
       "planning": [],
       "plugins": [
         "PluginRegistry",
+        "ToolDefinition",
         "disable_plugins",
         "enable_plugins",
         "get_plugin_manager",
@@ -1816,6 +1816,9 @@
       "sandbox": [],
       "session": [],
       "skills": [],
+      "specialized": [
+        "AutoRagConfig"
+      ],
       "specialized_agents": [],
       "streaming": [],
       "task": [],
@@ -1824,7 +1827,6 @@
       "tools": [
         "FunctionTool",
         "Tool",
-        "ToolDefinition",
         "ToolRegistry",
         "ToolResult"
       ],

--- a/src/praisonai-ts/FEATURE_PARITY_TRACKER.json
+++ b/src/praisonai-ts/FEATURE_PARITY_TRACKER.json
@@ -14,7 +14,7 @@
     "priorityP3": 103
   },
   "pythonCoreSDK": {
-    "path": "/home/runner/work/PraisonAI/PraisonAI/src/praisonai-agents/praisonaiagents",
+    "path": "src/praisonai-agents/praisonaiagents",
     "exports": [
       "A2A",
       "A2UI",
@@ -901,7 +901,7 @@
     }
   },
   "pythonWrapper": {
-    "path": "/home/runner/work/PraisonAI/PraisonAI/src/praisonai/praisonai",
+    "path": "src/praisonai/praisonai",
     "cliFeatures": [
       "acp",
       "agent_scheduler",
@@ -927,7 +927,7 @@
     ]
   },
   "typescriptSDK": {
-    "path": "/home/runner/work/PraisonAI/PraisonAI/src/praisonai-ts/src",
+    "path": "src/praisonai-ts/src",
     "exports": [
       "A2A",
       "A2ARole",

--- a/src/praisonai-ts/PARITY.md
+++ b/src/praisonai-ts/PARITY.md
@@ -461,7 +461,7 @@
 
 ## Python Core SDK Exports
 
-**Path:** `/home/runner/work/PraisonAI/PraisonAI/src/praisonai-agents/praisonaiagents`
+**Path:** `src/praisonai-agents/praisonaiagents`
 
 <details>
 <summary><strong>agent</strong> (43 exports)</summary>
@@ -726,7 +726,7 @@ from praisonaiagents import AgentFlow, If, Include, Loop, MAX_NESTING_DEPTH, Par
 
 ## TypeScript SDK Exports
 
-**Path:** `/home/runner/work/PraisonAI/PraisonAI/src/praisonai-ts/src`
+**Path:** `src/praisonai-ts/src`
 
 <details>
 <summary><strong>agent</strong> (68 exports)</summary>

--- a/src/praisonai/praisonai/_dev/parity/generator.py
+++ b/src/praisonai/praisonai/_dev/parity/generator.py
@@ -119,11 +119,35 @@ class ParityTrackerGenerator:
             current = current.parent
         return Path("/Users/praison/praisonai-package")
     
+
+    def _refuse_empty(self, features, language: str, source: str) -> None:
+        """An extractor that found nothing has FAILED; it has not found parity.
+
+        Both extractors swallow their errors and return an empty result, and
+        every downstream number is a set difference -- so a missing or
+        unparseable source file produces a plausible tracker rather than an
+        error. Measured against a scratch tree with an unparseable
+        `__init__.py`: `{'pythonCoreFeatures': 0, 'gapCount': 0}`, exit 0, and
+        CI would have committed it as "no gaps".
+
+        Zero exports is never a real answer for either SDK, so it is refused
+        here rather than published.
+        """
+        count = len(getattr(features, "exports", ()) or ())
+        if count == 0:
+            raise RuntimeError(
+                f"{language} extractor found 0 exports in {source}. That is a "
+                f"read or parse failure, not parity -- refusing to write a "
+                f"tracker that would report zero gaps."
+            )
+
     def generate(self) -> dict:
         """Generate the parity tracker data structure."""
         # Extract features from both SDKs
         python_features = self.python_extractor.extract()
         ts_features = self.ts_extractor.extract()
+        self._refuse_empty(python_features, "Python", "praisonaiagents/__init__.py")
+        self._refuse_empty(ts_features, "TypeScript", "praisonai-ts/src/index.ts")
         
         # Get version from existing tracker or default
         version = self._get_current_version()
@@ -198,7 +222,7 @@ class ParityTrackerGenerator:
     def _build_python_section(self, features: PythonFeatures) -> dict:
         """Build Python SDK section."""
         return {
-            'path': str(self.repo_root / "src" / "praisonai-agents" / "praisonaiagents"),
+            'path': "src/praisonai-agents/praisonaiagents",
             'exports': sorted([e.name for e in features.exports]),
             'modules': {
                 name: sorted(mod.exports)
@@ -209,14 +233,14 @@ class ParityTrackerGenerator:
     def _build_wrapper_section(self, features: PythonFeatures) -> dict:
         """Build Python wrapper section."""
         return {
-            'path': str(self.repo_root / "src" / "praisonai" / "praisonai"),
+            'path': "src/praisonai/praisonai",
             'cliFeatures': sorted(features.cli_features),
         }
     
     def _build_typescript_section(self, features: TypeScriptFeatures) -> dict:
         """Build TypeScript SDK section."""
         return {
-            'path': str(self.repo_root / "src" / "praisonai-ts" / "src"),
+            'path': "src/praisonai-ts/src",
             'exports': sorted([e.name for e in features.exports if not e.is_type]),
             'modules': {
                 name: sorted(mod.exports)
@@ -334,7 +358,10 @@ class ParityTrackerGenerator:
             status = 'EARLY_DEVELOPMENT'
         elif rust_count < python_count * 0.75:
             status = 'IN_PROGRESS'
-        elif rust_count < python_count:
+        elif gap_count > 0:
+            # Was `rust_count < python_count`, which compared VOLUME: a crate
+            # exporting more names than Python scored PARITY_ACHIEVED with 129
+            # features missing. Any outstanding gap means parity is not achieved.
             status = 'NEAR_PARITY'
         else:
             status = 'PARITY_ACHIEVED'
@@ -349,13 +376,18 @@ class ParityTrackerGenerator:
                 'pythonCoreFeatures': python_count,
                 'rustFeatures': rust_count,
                 'gapCount': gap_count,
-                'parityPercentage': round((rust_count / python_count * 100) if python_count > 0 else 0, 1),
+                # IMPLEMENTED over expected, not total-exports over expected. Dividing
+                # the whole Rust surface by Python's produced 162.3% alongside a
+                # gapCount of 129 -- a number that cannot fall below 100% however
+                # much is missing, and that contradicted the PARITY.md written by
+                # the same run (69.8%). Volume is not parity.
+                'parityPercentage': round(((python_count - gap_count) / python_count * 100) if python_count > 0 else 0, 1),
             },
             'pythonCoreSDK': {
                 'exports': sorted([e.name for e in python_features.exports]),
             },
             'rustSDK': {
-                'path': str(self.repo_root / "src" / "praisonai-rust"),
+                'path': "src/praisonai-rust",
                 'exports': sorted(list(rust_exports)),
                 'modules': {
                     name: sorted(mod.exports)

--- a/src/praisonai/tests/unit/_dev/test_parity_tracker.py
+++ b/src/praisonai/tests/unit/_dev/test_parity_tracker.py
@@ -115,7 +115,12 @@ __all__ = [
         with tempfile.TemporaryDirectory() as tmpdir:
             pkg_dir = Path(tmpdir) / "src" / "praisonai-agents" / "praisonaiagents"
             pkg_dir.mkdir(parents=True)
-            (pkg_dir / "__init__.py").write_text("_LAZY_IMPORTS = {}")
+            # One real export: the generator now refuses a source it read nothing from,
+            # because "0 exports" was indistinguishable from "no gaps".
+            (pkg_dir / "__init__.py").write_text(
+                '_LAZY_IMPORTS = {"Agent": ("praisonaiagents.agent", "Agent")}\n'
+                '__all__ = ["Agent"]\n'
+            )
             
             features_dir = Path(tmpdir) / "src" / "praisonai" / "praisonai" / "cli" / "features"
             features_dir.mkdir(parents=True)
@@ -340,11 +345,16 @@ _LAZY_IMPORTS = {
         with tempfile.TemporaryDirectory() as tmpdir:
             pkg_dir = Path(tmpdir) / "src" / "praisonai-agents" / "praisonaiagents"
             pkg_dir.mkdir(parents=True)
-            (pkg_dir / "__init__.py").write_text("_LAZY_IMPORTS = {}")
+            # One real export: the generator now refuses a source it read nothing from,
+            # because "0 exports" was indistinguishable from "no gaps".
+            (pkg_dir / "__init__.py").write_text(
+                '_LAZY_IMPORTS = {"Agent": ("praisonaiagents.agent", "Agent")}\n'
+                '__all__ = ["Agent"]\n'
+            )
             
             ts_dir = Path(tmpdir) / "src" / "praisonai-ts" / "src"
             ts_dir.mkdir(parents=True)
-            (ts_dir / "index.ts").write_text("")
+            (ts_dir / "index.ts").write_text('export { Agent } from "./agent";\n')
             
             wrapper_dir = Path(tmpdir) / "src" / "praisonai" / "praisonai" / "cli" / "features"
             wrapper_dir.mkdir(parents=True)
@@ -367,11 +377,16 @@ _LAZY_IMPORTS = {
         with tempfile.TemporaryDirectory() as tmpdir:
             pkg_dir = Path(tmpdir) / "src" / "praisonai-agents" / "praisonaiagents"
             pkg_dir.mkdir(parents=True)
-            (pkg_dir / "__init__.py").write_text("_LAZY_IMPORTS = {}")
+            # One real export: the generator now refuses a source it read nothing from,
+            # because "0 exports" was indistinguishable from "no gaps".
+            (pkg_dir / "__init__.py").write_text(
+                '_LAZY_IMPORTS = {"Agent": ("praisonaiagents.agent", "Agent")}\n'
+                '__all__ = ["Agent"]\n'
+            )
             
             ts_dir = Path(tmpdir) / "src" / "praisonai-ts" / "src"
             ts_dir.mkdir(parents=True)
-            (ts_dir / "index.ts").write_text("")
+            (ts_dir / "index.ts").write_text('export { Agent } from "./agent";\n')
             
             wrapper_dir = Path(tmpdir) / "src" / "praisonai" / "praisonai" / "cli" / "features"
             wrapper_dir.mkdir(parents=True)
@@ -401,11 +416,16 @@ class TestGenerateParityTracker:
         with tempfile.TemporaryDirectory() as tmpdir:
             pkg_dir = Path(tmpdir) / "src" / "praisonai-agents" / "praisonaiagents"
             pkg_dir.mkdir(parents=True)
-            (pkg_dir / "__init__.py").write_text("_LAZY_IMPORTS = {}")
+            # One real export: the generator now refuses a source it read nothing from,
+            # because "0 exports" was indistinguishable from "no gaps".
+            (pkg_dir / "__init__.py").write_text(
+                '_LAZY_IMPORTS = {"Agent": ("praisonaiagents.agent", "Agent")}\n'
+                '__all__ = ["Agent"]\n'
+            )
             
             ts_dir = Path(tmpdir) / "src" / "praisonai-ts" / "src"
             ts_dir.mkdir(parents=True)
-            (ts_dir / "index.ts").write_text("")
+            (ts_dir / "index.ts").write_text('export { Agent } from "./agent";\n')
             
             wrapper_dir = Path(tmpdir) / "src" / "praisonai" / "praisonai" / "cli" / "features"
             wrapper_dir.mkdir(parents=True)
@@ -427,11 +447,16 @@ class TestGenerateParityTracker:
         with tempfile.TemporaryDirectory() as tmpdir:
             pkg_dir = Path(tmpdir) / "src" / "praisonai-agents" / "praisonaiagents"
             pkg_dir.mkdir(parents=True)
-            (pkg_dir / "__init__.py").write_text("_LAZY_IMPORTS = {}")
+            # One real export: the generator now refuses a source it read nothing from,
+            # because "0 exports" was indistinguishable from "no gaps".
+            (pkg_dir / "__init__.py").write_text(
+                '_LAZY_IMPORTS = {"Agent": ("praisonaiagents.agent", "Agent")}\n'
+                '__all__ = ["Agent"]\n'
+            )
             
             ts_dir = Path(tmpdir) / "src" / "praisonai-ts" / "src"
             ts_dir.mkdir(parents=True)
-            (ts_dir / "index.ts").write_text("")
+            (ts_dir / "index.ts").write_text('export { Agent } from "./agent";\n')
             
             wrapper_dir = Path(tmpdir) / "src" / "praisonai" / "praisonai" / "cli" / "features"
             wrapper_dir.mkdir(parents=True)
@@ -511,3 +536,58 @@ class TestRealExtraction:
         
         # Gap count should be reasonable
         assert tracker['summary']['gapCount'] >= 0
+
+
+class TestExtractorFailureIsNotParity:
+    """A source the extractor could not read must fail, not report zero gaps.
+
+    Both extractors swallow their errors and return an empty result, and every
+    downstream number is a set difference -- so a missing or unparseable source
+    produced a plausible tracker instead of an error. Measured before the fix:
+    an unparseable ``__init__.py`` yielded ``{'pythonCoreFeatures': 0,
+    'gapCount': 0}`` and exit 0, and CI would have committed that as "no gaps".
+    """
+
+    def _tree(self, tmpdir, init_source, index_source):
+        pkg = Path(tmpdir) / "src" / "praisonai-agents" / "praisonaiagents"
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text(init_source)
+        ts = Path(tmpdir) / "src" / "praisonai-ts" / "src"
+        ts.mkdir(parents=True)
+        (ts / "index.ts").write_text(index_source)
+        return Path(tmpdir)
+
+    def test_unparseable_python_source_raises_instead_of_reporting_no_gaps(self):
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._tree(tmpdir, "def broken(\n", 'export { Agent } from "./agent";\n')
+            with pytest.raises(RuntimeError, match="0 exports"):
+                ParityTrackerGenerator(root).generate()
+
+    def test_unreadable_typescript_source_raises_too(self):
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._tree(
+                tmpdir,
+                '_LAZY_IMPORTS = {"Agent": ("praisonaiagents.agent", "Agent")}\n__all__ = ["Agent"]\n',
+                "",  # present but exporting nothing
+            )
+            with pytest.raises(RuntimeError, match="TypeScript"):
+                ParityTrackerGenerator(root).generate()
+
+    def test_a_readable_source_still_generates__the_pair(self):
+        # Without this, a generator that raised unconditionally would satisfy
+        # both tests above and never produce a tracker again.
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._tree(
+                tmpdir,
+                '_LAZY_IMPORTS = {"Agent": ("praisonaiagents.agent", "Agent")}\n__all__ = ["Agent"]\n',
+                'export { Agent } from "./agent";\n',
+            )
+            tracker = ParityTrackerGenerator(root).generate()
+            assert tracker["summary"]["pythonCoreFeatures"] == 1
+            assert tracker["summary"]["gapCount"] == 0


### PR DESCRIPTION
Three agents audited how Python↔TypeScript parity is managed. This PR contains only the fixes that need **no design decision**. What the tracker *measures* is a separate problem, reported separately.

## The one real drift gate never fired on drift

`mobile.yml`'s `upstream parity` job typechecks the real praisonai-ts `Agent` against the structural contract in `agent-api.ts` — the only mechanism in this repo that **fails a build** on an upstream signature change. Its path filter watched `src/praisonai-mobile/**` only, so it fired when the *consumer* changed and was silent when the thing it watches did.

Verified against `71197fa80`, which edited `src/praisonai-ts/src/agent/simple.ts`:

```
checks on that commit: test-core (×8), legacy-unit, Greptile, claude-*
                       no "upstream parity", no praisonai-ts job at all
```

It now watches `src/praisonai-ts/src/**` as well.

## `--check` failed on every machine that is not the runner

The generator embedded `str(self.repo_root / …)` in four places, so the committed JSON carried `/home/runner/work/PraisonAI/…` and that field has flipped between it and `/Users/praison/…` across commits. Made repo-relative — `--check` now exits 0 locally for the first time.

## The tracker could not report failure

Both extractors swallow their errors and return empty, and every number downstream is a set difference. So an unparseable `__init__.py` produced:

```
{'pythonCoreFeatures': 0, 'typescriptFeatures': 1194, 'gapCount': 0}   exit 0
```

CI would have committed that as "no gaps". Zero exports is now refused with a **non-zero exit**, and the trackers are left untouched — verified by breaking `__init__.py` and confirming exit 1 with `gapCount` still 116.

Three existing fixtures built exactly that empty tree; they now declare one export, because an empty tree was never a state worth generating from.

## Rust reported 162.3% parity, "PARITY_ACHIEVED", with 129 gaps

| | before | after |
|---|---|---|
| `parityPercentage` | 162.3% (total Rust exports ÷ Python) | 68.6% (implemented ÷ expected) |
| `status` | `PARITY_ACHIEVED` whenever Rust exported more names | `NEAR_PARITY` while any gap remains |

The `PARITY.md` written by the *same run* said 69.8%. Two contradictory numbers for one thing.

## Rust never triggered either workflow

Both filtered on `src/praisonai-rust/src/**` — **that path does not exist**; the crate is at `src/praisonai-rust/praisonai/src/`. Rust numbers only refreshed incidentally, on an unrelated push. Also added the generator's own inputs (`_dev/parity/**`, `cli/features/**`), which it reads and neither workflow watched.

## `--check` is now a gate

It has existed since the script was written, exits 1 on staleness, and was invoked by nothing. A `pull_request` job runs it; the committing job is restricted to `push`, since regenerating onto a contributor's branch isn't this workflow's business and would fail on a fork anyway.

**This checks staleness, not parity.** What `DONE` means is unchanged and remains exactly what the tracker's own disclaimer says.

## Verification

- `generate_parity_tracker.py --check` → exit 0 on a non-CI machine (was: 3 of 4 files reported stale everywhere)
- broken `__init__.py` → exit 1, trackers untouched, `gapCount` still 116
- **22 tests pass** in `test_parity_tracker.py`, including three new ones covering the refusal and its pair, so a generator that raised unconditionally cannot pass either

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected parity tracking for Rust and TypeScript sources.
  - Fixed inaccurate parity status, percentages, and repository-relative paths.
  - Prevented parity reports from being generated when source extraction returns no exports.

- **Tests**
  - Added validation for empty, unreadable, and invalid source files.
  - Updated test fixtures to reflect required exported features.

- **Chores**
  - Expanded pull request checks for parity consistency across supported SDKs.
  - Corrected workflow path monitoring for Rust and TypeScript source changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->