### PR TITLE
fix(scheduler): declare croniter so daily and weekday schedules actually fire

### DIFF
--- a/src/praisonai-agents/praisonaiagents/scheduler/parser.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/parser.py
@@ -162,6 +162,25 @@ def _clock_to_next_at(hour: int, minute: int, tz: str | None) -> str:
     return target.isoformat()
 
 
+def _cron_schedule(cron_expr: str, tz: str | None) -> Schedule:
+    """Build a cron Schedule, refusing if nothing can evaluate it.
+
+    ``is_due()`` returns False for a cron job when ``croniter`` is missing --
+    a log line, no error, a job that never runs. A schedule the runtime
+    cannot evaluate must be rejected here, where the user can still see the
+    answer, not accepted and ignored. Every natural-language recurring form
+    ("every day at 9am") arrives through this path.
+    """
+    try:
+        import croniter  # noqa: F401  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise ValueError(
+            f"Schedule {cron_expr!r} needs the cron engine, which is not "
+            "installed. Install with: pip install croniter"
+        ) from exc
+    return Schedule(kind="cron", cron_expr=cron_expr, tz=tz)
+
+
 def parse_schedule(expr: str, tz: str | None = None) -> Schedule:
     """Parse a schedule expression string into a ``Schedule`` object.
 
@@ -185,7 +204,7 @@ def parse_schedule(expr: str, tz: str | None = None) -> Schedule:
         cron_expr = expr[5:].strip()
         if not cron_expr:
             raise ValueError("Empty cron expression after 'cron:' prefix")
-        return Schedule(kind="cron", cron_expr=cron_expr, tz=tz)
+        return _cron_schedule(cron_expr, tz)
 
     # At prefix (ISO timestamp)
     if lower.startswith("at:"):
@@ -231,7 +250,7 @@ def parse_schedule(expr: str, tz: str | None = None) -> Schedule:
         has_dow = cron_expr.rsplit(" ", 1)[-1] != "*"
         recurring = has_dow or bool(re.match(r"(?i)^\s*(every|daily|each)\b", expr))
         if recurring:
-            return Schedule(kind="cron", cron_expr=cron_expr, tz=tz)
+            return _cron_schedule(cron_expr, tz)
         minute, hour = cron_expr.split(" ")[:2]
         at = _clock_to_next_at(int(hour), int(minute), tz)
         return Schedule(kind="at", at=at, tz=tz)

--- a/src/praisonai-agents/pyproject.toml
+++ b/src/praisonai-agents/pyproject.toml
@@ -17,7 +17,12 @@ dependencies = [
     "openai>=1.68.2",
     "posthog>=3.0.0",
     "PyYAML>=6.0",
-    "aiohttp>=3.8.0"
+    "aiohttp>=3.8.0",
+    # The scheduler converts every natural-language recurring schedule
+    # ("every day at 9am", "weekdays at 9am") to cron; without this engine
+    # those jobs are accepted and silently never fire. Pure Python; pulls
+    # only python-dateutil.
+    "croniter>=6.0"
 ]
 
 [project.optional-dependencies]

--- a/src/praisonai-agents/tests/unit/test_schedule_cron_engine.py
+++ b/src/praisonai-agents/tests/unit/test_schedule_cron_engine.py
@@ -1,0 +1,69 @@
+"""Cron schedules must actually fire, and must be refused when they cannot.
+
+``croniter`` was declared in none of the nine pyproject.toml files, so on a
+default install every cron-kind schedule -- and every natural-language
+recurring one, since "every day at 9am" is converted to cron -- was accepted,
+persisted, and returned False from is_due() forever. No error at creation; a
+warning in a log nobody reads; a job that never runs.
+
+Three guards, one per layer of the failure:
+  * the dependency is declared, so a fresh install has the engine;
+  * a cron job genuinely becomes due, proving the runtime path end to end;
+  * creation refuses a cron schedule when the engine is absent, so the
+    failure is loud at the one moment the user can act on it.
+"""
+import pathlib
+import sys
+
+import pytest
+
+from praisonaiagents.scheduler.due import is_due
+from praisonaiagents.scheduler.models import ScheduleJob
+from praisonaiagents.scheduler.parser import parse_schedule
+
+_PYPROJECT = pathlib.Path(__file__).resolve().parents[2] / "pyproject.toml"
+EIGHT_DAYS = 8 * 86400   # covers daily AND weekly ("every monday") schedules
+
+
+def _job(expr: str) -> ScheduleJob:
+    return ScheduleJob(name="t", schedule=parse_schedule(expr), message="hi")
+
+
+def test_cron_engine_is_a_declared_dependency():
+    """Packaging, not code, was the defect; pin the packaging."""
+    text = _PYPROJECT.read_text()
+    deps = text[text.index("dependencies = ["):]
+    deps = deps[: deps.index("]")]
+    assert "croniter" in deps, "croniter missing from core dependencies"
+
+
+@pytest.mark.parametrize("expr", [
+    "every day at 9am",
+    "weekdays at 9am",
+    "every monday 9am",
+    "cron:0 9 * * *",
+])
+def test_recurring_schedule_actually_becomes_due(expr):
+    """The effect: eight days after creation, daily and weekly jobs are due."""
+    job = _job(expr)
+    assert job.schedule.kind == "cron", "these must route through cron"
+    assert is_due(job, job.created_at + EIGHT_DAYS), (
+        f"{expr!r} was accepted but never becomes due"
+    )
+
+
+def test_interval_and_one_shot_do_not_need_the_engine(monkeypatch):
+    """Do not over-restrict: 'hourly' and 'in 20 minutes' never used cron."""
+    monkeypatch.setitem(sys.modules, "croniter", None)
+    for expr in ("hourly", "*/30m", "in 20 minutes"):
+        job = _job(expr)
+        assert is_due(job, job.created_at + EIGHT_DAYS)
+
+
+def test_cron_schedule_is_refused_when_the_engine_is_missing(monkeypatch):
+    """Loud at creation. Setting the module to None makes import raise."""
+    monkeypatch.setitem(sys.modules, "croniter", None)
+    with pytest.raises(ValueError, match="cron engine"):
+        parse_schedule("every day at 9am")
+    with pytest.raises(ValueError, match="cron engine"):
+        parse_schedule("cron:0 9 * * *")

--- a/src/praisonai-agents/uv.lock
+++ b/src/praisonai-agents/uv.lock
@@ -851,6 +851,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/57/2e2a65aee2a70483cb28e2b7e15a072d00a523207593b44400d4717bb100/croniter-6.2.4.tar.gz", hash = "sha256:fc124f751b1b04805c2a04b061898b436b45ab2320b045e1e052ea895de65189", size = 166267, upload-time = "2026-07-10T09:52:59.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/ba/d678e5bd329646ca51d3c92addbc77804e86d21f4b6b6a027218e6abb010/croniter-6.2.4-py3-none-any.whl", hash = "sha256:8ef3d544107a5c05a150a2d78f8bf5a8eb9c5c4d93405a736b824109574e3f4d", size = 46677, upload-time = "2026-07-10T09:52:58.425Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1008,7 +1020,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -3115,6 +3127,7 @@ version = "1.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "croniter" },
     { name = "openai" },
     { name = "posthog" },
     { name = "pydantic" },
@@ -3227,6 +3240,7 @@ requires-dist = [
     { name = "chromadb", marker = "extra == 'knowledge'", specifier = ">=1.0.0" },
     { name = "chromadb", marker = "extra == 'memory'", specifier = ">=1.0.0" },
     { name = "crawl4ai", marker = "extra == 'crawl'", specifier = ">=0.4.0" },
+    { name = "croniter", specifier = ">=6.0" },
     { name = "dakera", marker = "extra == 'dakera'", specifier = ">=0.12.8" },
     { name = "ddgs", marker = "extra == 'search'", specifier = ">=9.0.0" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.115.0" },
@@ -4367,7 +4381,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4430,7 +4444,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4694,8 +4708,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts" },
-    { name = "standard-chunk" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [


### PR DESCRIPTION
Found during a feature-parity sweep against Claude's Scheduled/Routines. PraisonAI's scheduler is broad — 22 CLI subcommands, blueprints, webhook triggers, OS daemons — and **every cron schedule silently never fires on a default install.**

## The defect

`croniter` is declared in **none** of the nine `pyproject.toml` files. `is_due()` returns `False` for a cron job when it cannot import the engine: a warning in a log, no error at creation, a job that never runs.

`parse_schedule()` converts every natural-language recurring form to cron, so the schedules people actually write are the broken ones. Measured on `main` in a venv without croniter, three days after creation:

```
'hourly'            kind=every  is_due = True
'*/30m'             kind=every  is_due = True
'in 20 minutes'     kind=at     is_due = True
'every day at 9am'  kind=cron   is_due = False   <-- never fires
'weekdays at 9am'   kind=cron   is_due = False   <-- never fires
'cron:0 9 * * *'    kind=cron   is_due = False   <-- never fires
```

Interval and one-shot schedules never needed the engine, which is how this went unnoticed — the simplest cases pass.

## The fix — one change per layer

1. **`croniter>=6.0` joins core dependencies** (pure Python, pulls only `python-dateutil`). `uv.lock` regenerated.
2. **`parse_schedule()` refuses a cron schedule when the engine is absent**, raising `ValueError` with the install hint. Both call sites route through one `_cron_schedule()` helper. The failure moves from *silently at fire time* to *loudly at creation* — the only moment the user can act on it.

## Verification

7 new tests. They assert the **effect** (a daily job is due eight days after creation — eight, not three, so weekly `every monday` is covered too) and pin the **packaging** by reading `pyproject.toml`, since packaging, not code, was the defect. A third test proves interval and one-shot schedules still work with the engine absent, so the guard doesn't over-restrict.

| mutation | |
|---|---|
| undeclare croniter *(the original defect)* | killed |
| guard never raises | killed |
| unguard call site 1 only | killed |
| unguard call site 2 only | killed |

143 of 144 existing scheduler tests pass. The one failure, `test_update_cadence_resets_last_run`, **fails on `main` without this change** on any non-UTC machine: naive `at` timestamps are stamped UTC by `is_due()` while the test — and any user — means local time. Out of scope here; filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recurring schedules using natural-language and explicit cron expressions.
  * Added clear guidance when cron scheduling support is unavailable.
  * Interval and one-time schedules continue to work without cron support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->