### PR TITLE
fix(mobile): a corrected engine address takes effect, and a refused one is said

### DIFF
--- a/src/praisonai-mobile/app/app.css
+++ b/src/praisonai-mobile/app/app.css
@@ -193,6 +193,19 @@ button:disabled { opacity: .45; cursor: default; }
 .setting .help { color: var(--soft); font-size: .84rem; }
 .setting input, .setting select { font: inherit; font-size: 16px; padding: .45rem .55rem;
   border: 1px solid var(--rule); border-radius: 8px; background: var(--panel); color: inherit; }
+/* A refused setting, next to the field it was refused for. The row builder in
+   main.ts renders `.row-setting`, so the rules above (written against a
+   `.setting` class nothing emits) do not reach it -- these are matched on the
+   class names the app actually paints. `[hidden]` is stated explicitly for the
+   same reason `.screen[hidden]` is: an author `display` declaration beats the
+   user agent's, and an always-visible empty error box beside every field reads
+   as a rendering fault. */
+.row-setting { display: flex; flex-direction: column; gap: .25rem; }
+.row-setting .setting-input { font: inherit; font-size: 16px; padding: .45rem .55rem;
+  border: 1px solid var(--rule); border-radius: 8px; background: var(--panel); color: inherit; }
+.setting-error { display: block; margin: .1rem 0 0; color: var(--warn); font-size: .84rem; }
+.setting-error[hidden] { display: none; }
+
 .section-heading { font-size: .72rem; letter-spacing: .1em; text-transform: uppercase;
   color: var(--soft); margin: 1.2rem 0 .3rem; }
 .warning { border: 1px solid var(--warn); color: var(--warn); border-radius: var(--radius);

--- a/src/praisonai-mobile/app/src/intents.test.ts
+++ b/src/praisonai-mobile/app/src/intents.test.ts
@@ -147,3 +147,56 @@ test("a delete-chat with no chat id is refused, not addressed at nothing", () =>
   // chat is keyed "", at the wrong one.
   assert.equal(intentFrom([{ dataset: { action: "delete-chat" }, disabled: false }]), null);
 });
+
+// ---- editing a setting -----------------------------------------------------
+//
+// The recovery path the remote-http default depends on. The settings screen
+// renders real fields, and until now each one committed itself from inside its
+// own `change` listener -- the one affordance in the app that did NOT go
+// through this file. That is the arrangement the header argues against: the
+// decision (which key, what was typed, and whether this element means anything
+// at all) could only be exercised by synthesising events against a DOM.
+
+test("a settings field resolves to a set-setting carrying its key AND what was typed", () => {
+  const intent = intentFrom([
+    { dataset: { action: "set-setting", settingKey: "baseUrl" }, value: "http://10.0.0.7:9000" },
+  ]);
+  assert.deepEqual(intent, { kind: "set-setting", key: "baseUrl", raw: "http://10.0.0.7:9000" });
+});
+
+test("a set-setting with no key is refused rather than aimed at nothing", () => {
+  // Same rule as delete-chat and navigate: an action that needs an id and has
+  // none must not resolve to a write against "" -- `settings.set` refuses an
+  // unknown key, but silently, and the user is told nothing.
+  assert.equal(intentFrom([{ dataset: { action: "set-setting" }, value: "x" }]), null);
+});
+
+test("a set-setting from an element with NO value is refused, not written as empty", () => {
+  // Only a field has a value. A tap that lands on the row's <label> and walks
+  // out to something carrying the action but no text must not be decoded as
+  // "the user cleared this setting" -- that would wipe the engine address on a
+  // stray tap, on the one screen whose job is to repair it.
+  assert.equal(intentFrom([{ dataset: { action: "set-setting", settingKey: "baseUrl" } }]), null);
+});
+
+test("an EMPTIED field is still a real edit, and decodes as an empty string", () => {
+  // The pair for the test above: `value: ""` is a person clearing a field, and
+  // refusing it too would make "" indistinguishable from "no field here" and
+  // leave a cleared setting silently ignored. Where the empty string is not a
+  // legal value, validateInput is what refuses it -- visibly.
+  assert.deepEqual(
+    intentFrom([{ dataset: { action: "set-setting", settingKey: "baseUrl" }, value: "" }]),
+    { kind: "set-setting", key: "baseUrl", raw: "" },
+  );
+});
+
+test("a DISABLED settings field commits nothing", () => {
+  // A field goes disabled while a write is in flight; honouring that is what
+  // stops a second commit racing the first to the store.
+  assert.equal(
+    intentFrom([
+      { dataset: { action: "set-setting", settingKey: "baseUrl" }, value: "x", disabled: true },
+    ]),
+    null,
+  );
+});

--- a/src/praisonai-mobile/app/src/intents.ts
+++ b/src/praisonai-mobile/app/src/intents.ts
@@ -24,6 +24,17 @@ export type Intent =
   | { readonly kind: "open-chat"; readonly chatId: string }
   | { readonly kind: "delete-chat"; readonly chatId: string }
   | { readonly kind: "navigate"; readonly route: string }
+  /**
+   * A settings field was committed.
+   *
+   * `raw` is the text exactly as the field held it -- unparsed and
+   * unvalidated, because deciding whether "9000" is a legal port for this key
+   * needs the def, and this file deliberately knows about no settings at all.
+   * `ui/src/settings/view-model.ts`'s `validateInput` is what turns it into a
+   * value, and the handler is where a refusal becomes something the user can
+   * see.
+   */
+  | { readonly kind: "set-setting"; readonly key: string; readonly raw: string }
   | { readonly kind: "retry" }
   | { readonly kind: "copy" };
 
@@ -32,6 +43,16 @@ export interface Actionable {
   /** `data-*` attributes, camelCased exactly as `HTMLElement.dataset` gives them. */
   readonly dataset: Readonly<Record<string, string | undefined>>;
   readonly disabled?: boolean;
+  /**
+   * What the control currently holds, for the elements that hold anything.
+   *
+   * Absent on every element that is not a field -- a `<div>` row, a `<span>`
+   * label, the section heading. That ABSENCE is load-bearing: it is the only
+   * thing separating "the user cleared this field" from "this element has no
+   * field in it", and conflating the two turns a stray tap into a wiped engine
+   * address on the one screen that exists to repair it.
+   */
+  readonly value?: string;
 }
 
 const CHOICES: readonly string[] = ["allow", "always", "deny"];
@@ -88,6 +109,16 @@ export function intentFrom(chain: readonly Actionable[]): Intent | null {
       case "navigate": {
         const route = d["route"];
         return route === undefined ? null : { kind: "navigate", route };
+      }
+      case "set-setting": {
+        // Both halves are required, and for different reasons. A missing key
+        // is the delete-chat rule again: a write aimed at "" is refused by the
+        // store anyway, but silently, and the user is told nothing. A missing
+        // VALUE means this element is not a field -- see `Actionable.value`.
+        const key = d["settingKey"];
+        if (key === undefined) return null;
+        const raw = el.value;
+        return raw === undefined ? null : { kind: "set-setting", key, raw };
       }
       default:
         // An unknown action is not an error -- a newer template can carry one

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -869,7 +869,7 @@ test("the settings screen is EDITABLE, so a phone can point the engine somewhere
   assert.ok(field, `the engine address must be editable:\n${dom.text()}`);
 
   (field as { value: string }).value = "http://10.0.0.7:9000";
-  (field as { dispatch(t: string, e: unknown): void }).dispatch("change", {});
+  dom.change(field as never);
   await settle();
 
   // Persisted in the live facade AND written through to storage, so the next
@@ -901,7 +901,7 @@ test("a setting the store REFUSES resets the field instead of showing a phantom 
   );
   assert.ok(select, "the engine choice must be a select");
   (select as { value: string }).value = "not-a-real-engine";
-  (select as { dispatch(t: string, e: unknown): void }).dispatch("change", {});
+  dom.change(select as never);
   await settle();
 
   assert.equal(app?.settings.get("engineId"), ENGINE_REMOTE_HTTP, "a rejected choice must not persist");
@@ -936,7 +936,7 @@ test("a storage failure while editing a setting stays LOCAL, not fatal", async (
   const before = app?.settings.get("baseUrl");
   storage.failNext("QuotaExceededError: the storage is full");
   (field as { value: string }).value = "http://10.0.0.7:9000";
-  (field as { dispatch(t: string, e: unknown): void }).dispatch("change", {});
+  dom.change(field as never);
   await settle();
 
   // The app must survive: the chat screen and composer are still reachable, and
@@ -1155,5 +1155,127 @@ test("an English device still lays out left-to-right -- the pair", async () => {
   });
 
   assert.equal(dom.root.getAttribute("dir"), "ltr");
+  app?.dispose();
+});
+
+// ---- the recovery path, end to end -----------------------------------------
+//
+// A phone reaches no `127.0.0.1:8765`, so first launch warns that the engine
+// is not answering and points at Settings. Everything from that warning to a
+// working engine has to hold, and two links of it did not: a refused value
+// vanished with no explanation, and a corrected address changed nothing until
+// the app was force-quit and relaunched.
+
+const settingField = (dom: ReturnType<typeof createFakeDom>, label: string) =>
+  dom.find(
+    (n) => (n.tagName === "INPUT" || n.tagName === "SELECT") && n.getAttribute("aria-label") === label,
+  );
+
+const openSettings = async (dom: ReturnType<typeof createFakeDom>): Promise<void> => {
+  dom.click(dom.find((n) => n.dataset["route"] === "settings") as never);
+  await settle();
+};
+
+test("a corrected engine address redirects the very NEXT message, with no relaunch", async () => {
+  // The whole point of making the screen editable. `enginesFor` read `baseUrl`
+  // once at construction and the app builds its engine once at boot, so the
+  // address the user typed was persisted, displayed, and then ignored for the
+  // rest of the session -- every message still went to the unreachable default.
+  const { dom, http, platform } = harness();
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  assert.notEqual(app, null);
+
+  await openSettings(dom);
+  const field = settingField(dom, "Engine address");
+  assert.ok(field, `the engine address must be editable:\n${dom.text()}`);
+  field.value = "http://10.0.0.7:9000";
+  dom.change(field as never);
+  await settle();
+
+  submit(dom, "hello");
+  await settle();
+
+  const chats = http.sent.filter((r) => r.url.endsWith("/chat")).map((r) => r.url);
+  assert.ok(chats.length > 0, "the message never reached the transport at all");
+  assert.equal(
+    chats.at(-1),
+    "http://10.0.0.7:9000/chat",
+    `the turn still went to the old address: ${chats.join(", ")}`,
+  );
+  app?.dispose();
+});
+
+test("a REFUSED setting says so on screen, instead of the field quietly snapping back", async () => {
+  // A field that resets and says nothing is indistinguishable from a mis-tap,
+  // a lost keystroke, or a save that worked. On the one screen whose job is to
+  // repair an unreachable engine, "nothing happened and nothing was said" is
+  // the failure mode that leaves a user re-typing the same rejected value.
+  const { dom, platform } = harness();
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  await openSettings(dom);
+  const select = settingField(dom, "Engine");
+  assert.ok(select, "the engine choice must be a select");
+  select.value = "not-a-real-engine";
+  dom.change(select as never);
+  await settle();
+
+  // Still refused, and still snapped back -- the existing guarantees.
+  assert.equal(app?.settings.get("engineId"), ENGINE_REMOTE_HTTP, "a rejected choice must not persist");
+  assert.equal(select.value, ENGINE_REMOTE_HTTP, "the field must reset to what is stored");
+
+  // And now SAID. Visibly, for a sighted user...
+  const shown = dom.find((n) => n.className.includes("setting-error") && n.hidden === false);
+  assert.ok(shown, `a refused setting was dropped silently:\n${dom.text()}`);
+  assert.match(shown.textContent, /Engine/, "the message must name the setting it refused");
+
+  // ...and out loud, because the field it belongs to may be off screen and a
+  // screen-reader user gets no "it snapped back" cue at all.
+  const spoken = dom.find((n) => n.getAttribute("aria-live") === "assertive");
+  assert.match(spoken?.textContent ?? "", /Engine/, "a refused setting must also be announced");
+  app?.dispose();
+});
+
+test("an ACCEPTED setting clears its OWN refusal, and only its own", async () => {
+  // Two pairs in one, because each guards the other's cheap implementation. A
+  // screen that reports every write as refused would satisfy the test above
+  // while making the setting look permanently broken, so an accepted write has
+  // to clear its message. And clearing ALL of them on any accepted write would
+  // wipe a refusal the user has not read off a DIFFERENT setting -- the note
+  // beside `engineId` is still true while `baseUrl` is being edited.
+  const { dom, platform } = harness();
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  const errorFor = (key: string) =>
+    dom.find((n) => n.dataset["settingError"] === key && n.hidden === false);
+
+  await openSettings(dom);
+  const select = settingField(dom, "Engine");
+  assert.ok(select);
+  select.value = "not-a-real-engine";
+  dom.change(select as never);
+  await settle();
+  assert.ok(errorFor("engineId"), "the refusal this test clears must be on screen first");
+
+  // An accepted write to a DIFFERENT setting leaves it alone.
+  const field = settingField(dom, "Engine address");
+  assert.ok(field);
+  field.value = "http://10.0.0.7:9000";
+  dom.change(field as never);
+  await settle();
+  assert.equal(app?.settings.get("baseUrl"), "http://10.0.0.7:9000", "the accepted edit must persist");
+  assert.equal(errorFor("baseUrl"), null, "an accepted write must not accuse itself");
+  assert.ok(errorFor("engineId"), "a refusal must not be cleared by a write to another setting");
+
+  // An accepted write to the SAME setting does clear it.
+  select.value = ENGINE_REMOTE_HTTP;
+  dom.change(select as never);
+  await settle();
+  assert.equal(app?.settings.get("engineId"), ENGINE_REMOTE_HTTP);
+  assert.equal(
+    errorFor("engineId"),
+    null,
+    `an accepted write must leave no refusal on its own field:\n${dom.text()}`,
+  );
   app?.dispose();
 });

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -35,7 +35,7 @@ import {
   type FocusTarget,
   type Navigation,
 } from "../../ui/src/a11y/focus.ts";
-import { buildSettings, validateInput, type ValueRow } from "../../ui/src/settings/view-model.ts";
+import { buildSettings, labelOf, validateInput, type ValueRow } from "../../ui/src/settings/view-model.ts";
 import { buildChatList } from "../../ui/src/chats/list-view-model.ts";
 import type { ChatSummary, StoredMessage } from "../../core/src/chat/repository.ts";
 import { createBundle } from "../../ui/src/i18n/bundle.ts";
@@ -235,45 +235,30 @@ function screenHeading(doc: Document, route: Route, strings: Strings): HTMLEleme
 }
 
 /**
- * The editable control for one value row, wired to `facade.set`.
+ * The editable control for one value row. MARKUP ONLY -- no listener.
  *
  * A `choice` renders a `<select>`, everything else a `<textarea>`-free
- * `<input>`. The change is validated through the SAME pure `validateInput`
- * the view model exports -- parse, then the def's own `validate` -- so a value
- * the store would refuse is refused HERE, at the field, rather than accepted
- * into the UI and silently dropped by `set`. On accept it persists; on refuse
- * the field is reset to the last stored value so the screen never shows a value
- * that is not actually stored.
+ * `<input>`, and the kind comes from `row.control` (the def), never from the
+ * value: view-model.ts rule 4 -- one bad write to a hand-edited settings file
+ * would otherwise turn a picker into a text box and the setting could never be
+ * changed back.
  *
- * This is the recovery path the remote-http default depends on: a phone reaches
- * no `127.0.0.1:8765`, and until now `baseUrl` could be READ on the settings
- * screen but not CHANGED -- `facade.set` and `validateInput` had no caller, so
- * a first launch that could not reach the engine had no way to point it at one.
+ * The control carries `data-action="set-setting"` and its key, and does
+ * nothing else. Committing it used to happen inside a `change` listener
+ * attached right here, which made settings the ONE affordance in the app that
+ * did not go through `intents.ts` -- so the decision (which key, what was
+ * typed, and whether a refusal is worth saying anything about) could only be
+ * reached by synthesising events against a DOM, and the refusal path ended in
+ * a field that silently snapped back. Delegated on root like every tap, the
+ * decision is `intentFrom`'s and the write is `perform`'s, next to the live
+ * region that has to announce it.
+ *
+ * This is the recovery path the remote-http default depends on: a phone
+ * reaches no `127.0.0.1:8765`, and `baseUrl` could be READ on the settings
+ * screen but not CHANGED, so a first launch that could not reach the engine
+ * had no way to point it at one.
  */
 function settingControl(doc: Document, def: SettingDef, row: ValueRow, settings: SettingsFacade): HTMLElement {
-  const stored = (): string => String(settings.get(def.key) ?? def.default);
-  const reset = (): void => {
-    if (control.tagName === "SELECT" || control.tagName === "INPUT") control.value = stored();
-  };
-
-  // A refused write must not leave the field showing a value the store rejected.
-  // `settings.set` can also REJECT, not merely return false: it persists through
-  // StoragePort, which raises on a real device (SecurityError with site data
-  // blocked, QuotaExceededError under storage pressure). Left to float, that
-  // rejection reaches the global crash handler and replaces the WHOLE app with
-  // the fatal screen -- the exact escalation the chat-list load guards against
-  // below. A failed write must stay LOCAL: reset the field to what is actually
-  // stored, so the screen never shows a value the next launch will not read.
-  const commit = async (raw: string): Promise<void> => {
-    const validated = validateInput(def, raw);
-    if (validated === null) return reset();
-    try {
-      if (!(await settings.set(def.key, validated))) reset();
-    } catch {
-      reset();
-    }
-  };
-
   let control: HTMLElement & { value: string };
   if (row.control === "choice" && row.choices !== null) {
     const select = doc.createElement("select") as HTMLElement & { value: string };
@@ -283,22 +268,40 @@ function settingControl(doc: Document, def: SettingDef, row: ValueRow, settings:
       option.textContent = String(choice);
       select.append(option);
     }
-    select.value = stored();
-    select.addEventListener("change", () => void commit(select.value));
     control = select;
   } else {
     const input = doc.createElement("input") as HTMLElement & { value: string; type: string };
     input.type = row.control === "number" ? "number" : "text";
-    input.value = stored();
-    // `change`, not `input`: persist when the field is committed (blur/Enter),
-    // not on every keystroke, so a half-typed address is never stored and
-    // `set` is not called on each character.
-    input.addEventListener("change", () => void commit(input.value));
     control = input;
   }
+  // From the STORE, not from `row.value`: identical today, and it stays
+  // identical only while nothing repaints a row from a stale view.
+  control.value = String(settings.get(def.key) ?? def.default);
   control.className = "setting-value setting-input";
   control.setAttribute("aria-label", row.label);
+  // `change`, not `input`: a field commits on blur or Enter, so a half-typed
+  // address is never stored and `set` is not called once per keystroke.
+  // Delegated on root -- `change` bubbles.
+  control.dataset["action"] = "set-setting";
+  control.dataset["settingKey"] = def.key;
   return control;
+}
+
+/**
+ * Where a refusal for one setting is written, and nothing until there is one.
+ *
+ * `role="alert"` and empty: an alert region that is created at the moment of
+ * the failure is announced unreliably, so it exists from first paint and only
+ * its text changes. `hidden` while empty, because an empty bordered box beside
+ * a field reads as a rendering fault.
+ */
+function settingError(doc: Document, key: string): HTMLElement {
+  const note = doc.createElement("p");
+  note.className = "setting-error";
+  note.dataset["settingError"] = key;
+  note.setAttribute("role", "alert");
+  note.hidden = true;
+  return note;
 }
 
 /**
@@ -346,7 +349,11 @@ export function buildSettingsScreen(
       el.append(label);
       const def = row.kind === "value" ? defByKey.get(row.key) : undefined;
       if (row.kind === "value" && def !== undefined) {
-        el.append(settingControl(doc, def, row, settings));
+        // The field and the place its refusal is written, together. The alert
+        // node ships empty and hidden rather than being created on the failure
+        // -- an alert region inserted at the moment it has something to say is
+        // announced unreliably by every screen reader.
+        el.append(settingControl(doc, def, row, settings), settingError(doc, row.key));
       } else {
         const value = doc.createElement("span");
         value.className = "setting-value";
@@ -908,19 +915,68 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   app.router.replace({ name: "chat", chatId: "" });
 
   // ---- taps ---------------------------------------------------------------
+  /** The tags that HOLD a value. Checked by tag rather than by reading
+   *  `node.value` on everything, because `Actionable.value` being ABSENT is
+   *  what tells intents.ts "this element is not a field" -- and a `<div>` in
+   *  the fake DOM reports `""`, which would read as a cleared setting. */
+  const FIELD_TAGS = new Set(["INPUT", "SELECT", "TEXTAREA"]);
+
   const chainOf = (target: EventTarget | null): Actionable[] => {
     const chain: Actionable[] = [];
     let node = target instanceof Element ? target : null;
     while (node !== null) {
       if (node instanceof HTMLElement) {
+        const value = (node as HTMLElement & { value?: unknown }).value;
         chain.push({
           dataset: { ...node.dataset },
           ...(node instanceof HTMLButtonElement ? { disabled: node.disabled } : {}),
+          ...(FIELD_TAGS.has(node.tagName) && typeof value === "string" ? { value } : {}),
         });
       }
       node = node.parentElement;
     }
     return chain;
+  };
+
+  /**
+   * Put every settings field back in step with the STORE, and show or clear
+   * the refusal for one key.
+   *
+   * A walk rather than a captured element, for two reasons. The settings
+   * screen is rebuilt on every visit (`screens.build`), so any reference held
+   * across a navigation points at a detached node. And a `set` the store
+   * ACCEPTS can still store something other than what was typed -- a def's
+   * `validate` may clamp -- so the honest thing after any write, accepted or
+   * refused, is to redraw the fields from what is actually stored rather than
+   * to leave the typed text on screen.
+   */
+  const syncSettings = (key: string, refusal: string | null): void => {
+    const defs = new Map(app.settings.defs().map((d) => [d.key, d]));
+    const stack: HTMLElement[] = [root];
+    while (stack.length > 0) {
+      const node = stack.pop();
+      if (node === undefined) break;
+      for (const child of node.children) {
+        if (child instanceof HTMLElement) stack.push(child);
+      }
+      if (node.dataset["action"] === "set-setting") {
+        const def = defs.get(node.dataset["settingKey"] ?? "");
+        if (def !== undefined) {
+          (node as HTMLElement & { value: string }).value = String(
+            app.settings.get(def.key) ?? def.default,
+          );
+        }
+        continue;
+      }
+      const errorFor = node.dataset["settingError"];
+      if (errorFor === undefined) continue;
+      // Only this key's note is touched. Clearing them all would wipe a
+      // refusal the user has not read off a DIFFERENT setting; leaving them
+      // all would keep accusing a write that has since succeeded.
+      if (errorFor !== key) continue;
+      node.textContent = refusal ?? "";
+      node.hidden = refusal === null;
+    }
   };
 
   const perform = async (intent: Intent): Promise<void> => {
@@ -966,6 +1022,38 @@ export async function mount(deps: MountDeps): Promise<App | null> {
       case "navigate":
         app.router.push({ name: intent.route } as Route);
         return;
+      case "set-setting": {
+        // The def is looked up from the LIVE facade, not from `SETTING_DEFS`,
+        // so this cannot drift from what the screen was rendered off. An
+        // unknown key means the DOM and the registry disagree -- refuse it
+        // rather than write it: `set` would refuse anyway, silently.
+        const def = app.settings.defs().find((d) => d.key === intent.key);
+        if (def === undefined) return;
+        // `validateInput` first, so an unparseable value never reaches `set`
+        // where the refusal comes back as a bare `false` with no reason.
+        const validated = validateInput(def, intent.raw);
+        let stored = false;
+        if (validated !== null) {
+          try {
+            stored = await app.settings.set(intent.key, validated);
+          } catch {
+            // `set` persists through StoragePort, which REJECTS on a real
+            // device (SecurityError with site data blocked, QuotaExceededError
+            // under storage pressure). Left to float, that rejection reaches
+            // the global crash handler and replaces the WHOLE app with the
+            // fatal screen. A failed settings write must stay local -- and it
+            // is a refusal like any other, so it is said rather than swallowed.
+            stored = false;
+          }
+        }
+        // Said, not merely undone. A field that snaps back in silence is
+        // indistinguishable from a mis-tap or from a save that worked, and on
+        // this screen that leaves someone re-typing the same refused value.
+        const refusal = stored ? null : strings.settingRejected(labelOf(def));
+        if (refusal !== null) assertive.textContent = refusal;
+        syncSettings(intent.key, refusal);
+        return;
+      }
       case "open-chat": {
         // Reopen a previous conversation. `session.list()` had no app caller and
         // `session.open()` no way to be reached; this is the path from the chat
@@ -1073,6 +1161,17 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     const intent = intentFrom(chain);
     if (intent === null) return;
     (event as { preventDefault(): void }).preventDefault();
+    void perform(intent);
+  });
+
+  // Committing a field is delegated on ROOT for the same reason a tap is: the
+  // settings screen is rebuilt on every visit, so a listener attached to a
+  // field belongs to a node that is thrown away on the next navigation. No
+  // `preventDefault` -- `change` has no default action to cancel, and the
+  // composer's textarea carries no `data-action`, so `intentFrom` refuses it.
+  root.addEventListener("change", (event) => {
+    const intent = intentFrom(chainOf(event.target));
+    if (intent === null) return;
     void perform(intent);
   });
 

--- a/src/praisonai-mobile/app/src/registry.test.ts
+++ b/src/praisonai-mobile/app/src/registry.test.ts
@@ -336,3 +336,78 @@ test("every setting's default satisfies its own validator", () => {
     );
   }
 });
+
+// ---- the address the user CORRECTS has to be the address that is used -------
+//
+// `enginesFor` read `baseUrl` once, at construction, and both the engine and
+// the health probe closed over that string. The app builds its engine exactly
+// once, at boot, so a phone that could not reach `127.0.0.1:8765` kept sending
+// there for the whole session no matter what was typed into Settings -- the
+// setting persisted, the screen agreed, and only a relaunch changed anything.
+// A recovery path that requires force-quitting the app is not a recovery path.
+
+const A_RUN = {
+  prompt: "hello",
+  chatId: "c1",
+  runId: "r1",
+  tools: false,
+  regenerateOf: null,
+  attachments: [],
+};
+
+/** Run a turn to exhaustion, discarding the events. What is under test is the
+ *  URL the transport was pointed at, not what came back. */
+async function drain(engine: { run: (r: typeof A_RUN, s: AbortSignal) => AsyncIterable<unknown> }): Promise<void> {
+  for await (const _event of engine.run(A_RUN, new AbortController().signal)) {
+    // discarded on purpose
+  }
+}
+
+test("a turn goes to the address the user set AFTER the engine was built", async () => {
+  const { store, settings, persistence } = await build();
+  const http = createFakeHttp();
+  http.on("/chat", () => sseResponse(""));
+
+  // Built first, exactly as boot.ts does: the engine exists before the user
+  // ever reaches Settings.
+  const engine = await enginesFor({ settings, http, persistence })[0]!.create();
+  await store.set("baseUrl", "http://10.0.0.7:9000");
+  await drain(engine as never);
+
+  assert.equal(
+    http.sent.at(-1)?.url,
+    "http://10.0.0.7:9000/chat",
+    "the corrected address must take effect without a relaunch",
+  );
+  await engine.dispose();
+});
+
+test("an untouched setting still reaches the address the engine was built with", async () => {
+  // The pair. Reading the setting late must not mean reading it wrongly: with
+  // nothing changed, the default is still where a turn goes.
+  const { settings, persistence } = await build();
+  const http = createFakeHttp();
+  http.on("/chat", () => sseResponse(""));
+
+  const engine = await enginesFor({ settings, http, persistence })[0]!.create();
+  await drain(engine as never);
+
+  assert.equal(http.sent.at(-1)?.url, "http://127.0.0.1:8765/chat");
+  await engine.dispose();
+});
+
+test("a corrected address is re-read by the health probe too", async () => {
+  // The probe is what decides whether the engine is offered at all, and what
+  // produces the "not answering" warning the user is trying to clear. Probing
+  // the OLD address after the address was fixed reports a failure about a
+  // machine nobody is talking to any more.
+  const { store, settings, persistence } = await build();
+  const http = createFakeHttp();
+  http.on("/health", () => jsonResponse(200, { ok: true, version: PROTOCOL_VERSION }));
+
+  const choice = enginesFor({ settings, http, persistence }).find((c) => c.id === ENGINE_REMOTE_HTTP);
+  await store.set("baseUrl", "http://10.0.0.7:9000/");
+  await choice!.probe!();
+
+  assert.equal(http.sent.at(-1)?.url, "http://10.0.0.7:9000/health");
+});

--- a/src/praisonai-mobile/app/src/registry.ts
+++ b/src/praisonai-mobile/app/src/registry.ts
@@ -116,7 +116,24 @@ function stringSetting(settings: SettingsFacade, key: string, fallback: string):
  * is not here, which is the honest message in that case.
  */
 export function enginesFor(deps: RegistryDeps): readonly EngineChoice[] {
-  const baseUrl = stringSetting(deps.settings, "baseUrl", "http://127.0.0.1:8765").replace(/\/+$/, "");
+  /**
+   * The engine address, read at the moment it is USED.
+   *
+   * This was a `const` read once, here, and both the engine and the probe
+   * closed over the string. The app builds its engine exactly once, at boot
+   * (boot.ts), and holds it for the session -- so a phone that could not reach
+   * `127.0.0.1:8765` kept sending there no matter what was typed into
+   * Settings. The value persisted, the screen agreed, and only a relaunch
+   * changed anything: a recovery path that requires force-quitting the app.
+   *
+   * Rebuilding the engine on the change was the alternative, and it is a much
+   * larger one: `createRunController` takes the engine at construction and
+   * there is no seam to swap it, so following the setting that way means
+   * rebuilding the controller mid-session and dropping whatever turn is in
+   * flight. A resolver costs one call per request and no signature above it.
+   */
+  const baseUrl = (): string =>
+    stringSetting(deps.settings, "baseUrl", "http://127.0.0.1:8765").replace(/\/+$/, "");
   const choices: EngineChoice[] = [
     {
       id: ENGINE_REMOTE_HTTP,
@@ -133,7 +150,10 @@ export function enginesFor(deps: RegistryDeps): readonly EngineChoice[] {
       // status alone routes a chat into a broken engine and reports the
       // nonsense back as a model failure. Run at selection, before the engine
       // is offered -- the in-process engine has no remote and supplies none.
-      probe: () => probeHealth(deps.http, baseUrl),
+      // Called, not captured: the probe is what produces the "not answering"
+      // warning the user is trying to clear, so probing the address they just
+      // replaced reports a failure about a machine nobody is talking to.
+      probe: () => probeHealth(deps.http, baseUrl()),
     },
   ];
 

--- a/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/engine.test.ts
@@ -578,3 +578,103 @@ test("a 200 with ok:true IS accepted -- the pair", async () => {
   assert.equal(await engine.decide("a1", "allow"), true);
   assert.equal(await engine.cancel("r1"), true);
 });
+
+// ---- a control request stays with the engine that owns its id ---------------
+//
+// The resolver fixes the recovery path -- the NEXT /chat reaches the address
+// the user just corrected -- but a run's /cancel and an approval's /approve are
+// addressed by an id the ORIGINATING engine minted. If a mid-turn address
+// change redirected them to the new engine, it would refuse the foreign id;
+// controller.ts only aborts the local reader once cancel returns true, so the
+// original turn would keep generating at the old address while the user
+// believes they stopped it. The id is pinned to the base it was born at.
+
+test("a stop reaches the address the run STARTED at, even after Settings moved it", async () => {
+  // The real scenario: the run is STILL STREAMING when the user, having gone to
+  // Settings to fix an address they thought was the problem, taps Stop. The
+  // generator is suspended at a yield, so the run is live and its pin stands.
+  let address = "http://first.test";
+  const http = createFakeHttp();
+  http.on("/chat", () =>
+    sseResponse(encodeSseFrame({ type: "start", msgId: "m1", runId: "r1" })),
+  );
+  http.on("/cancel/r1", () => ({ status: 200, headers: {}, body: streamOf('{"ok":true}') }));
+  const engine = createRemoteHttpEngine({ baseUrl: () => address, http });
+
+  // Pull the first event and STOP -- the run is mid-stream, not exhausted.
+  const iterator = engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: false, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )[Symbol.asyncIterator]();
+  await iterator.next();
+  address = "http://second.test";
+  await engine.cancel("r1");
+
+  const cancel = http.sent.find((r) => r.url.includes("/cancel"));
+  assert.equal(
+    cancel?.url,
+    "http://first.test/cancel/r1",
+    "the stop must go to the engine that owns r1, not the newly-typed address",
+  );
+  await iterator.return?.();
+});
+
+test("an approval decision reaches the engine that ASKED, after the address moved", async () => {
+  // An approval blocks the run and is answered by an id this engine minted.
+  // A `deny` sent to a freshly-corrected address hands a foreign id to an
+  // engine that never issued it -- the run stays blocked at the old one.
+  let address = "http://first.test";
+  const http = createFakeHttp();
+  http.on("/chat", () =>
+    sseResponse(
+      encodeSseFrame({ type: "start", msgId: "m1", runId: "r1" }) +
+        encodeSseFrame({
+          type: "approval_request",
+          msgId: "m1",
+          approvalId: "ap1",
+          callId: "c1",
+          name: "rm",
+          args: {},
+        }),
+    ),
+  );
+  http.on("/approve/ap1", () => ({ status: 200, headers: {}, body: streamOf('{"ok":true}') }));
+  const engine = createRemoteHttpEngine({ baseUrl: () => address, http });
+
+  // Drain until the approval prompt is seen -- the run is now blocked on it.
+  for await (const event of engine.run(
+    { prompt: "hi", chatId: "c1", runId: "r1", tools: true, regenerateOf: null, attachments: [] },
+    new AbortController().signal,
+  )) {
+    if (event.type === "approval_request") break;
+  }
+  address = "http://second.test";
+  await engine.decide("ap1", "deny");
+
+  const approve = http.sent.find((r) => r.url.includes("/approve"));
+  assert.equal(
+    approve?.url,
+    "http://first.test/approve/ap1",
+    "the decision must return to the engine that asked, not the newly-typed address",
+  );
+});
+
+test("with the address unchanged, a control request still follows the live resolver", async () => {
+  // The pair. Pinning must not mean IGNORING the resolver: a cancel for a run
+  // this instance never saw (a resumed app) has no pin, and must fall back to
+  // the current address rather than a stale or empty one.
+  let address = "http://first.test";
+  const http = createFakeHttp();
+  http.on("/cancel/unknown", () => ({ status: 200, headers: {}, body: streamOf('{"ok":true}') }));
+  const engine = createRemoteHttpEngine({ baseUrl: () => address, http });
+
+  address = "http://second.test";
+  await engine.cancel("unknown");
+
+  const cancel = http.sent.find((r) => r.url.includes("/cancel"));
+  assert.equal(
+    cancel?.url,
+    "http://second.test/cancel/unknown",
+    "an id with no origin pin must use the address in effect now",
+  );
+});

--- a/src/praisonai-mobile/engines/src/remote-http/engine.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/engine.ts
@@ -29,8 +29,18 @@ import { createSseReader } from "../../../protocol/src/sse.ts";
 import { classify, type Readiness } from "./readiness.ts";
 
 export interface RemoteHttpOptions {
-  /** Base URL of the engine, no trailing slash. */
-  readonly baseUrl: string;
+  /**
+   * Base URL of the engine, no trailing slash.
+   *
+   * A RESOLVER is accepted as well as a string, and the difference is the
+   * whole recovery path for a device that cannot reach its engine. This engine
+   * is constructed once, at boot, and the app holds it for the session -- so a
+   * captured string means the address the user corrects in Settings is
+   * persisted, displayed, and then ignored until the app is force-quit. A
+   * function is re-read per request, so the next message goes where the user
+   * just said. A plain string still works and still means "this one, forever".
+   */
+  readonly baseUrl: string | (() => string);
   readonly http: HttpPort;
   /** Sent as a bearer token when present. The desktop engine is unauthenticated
    *  on loopback; anything off-device must not be. */
@@ -51,7 +61,12 @@ const CAPABILITIES: EngineCapabilities = {
 };
 
 export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEnginePort {
-  const base = options.baseUrl.replace(/\/+$/, "");
+  // Resolved per call, never captured. The trailing slash is stripped here
+  // rather than at the caller because a resolver's answer is not seen until
+  // now: `${base}/chat` against "http://host/" produces a double slash, which
+  // some servers 404 and others redirect -- losing the POST body.
+  const base = (): string =>
+    (typeof options.baseUrl === "string" ? options.baseUrl : options.baseUrl()).replace(/\/+$/, "");
   const id = options.id ?? "remote-http";
 
   const headers = (extra: Record<string, string> = {}): Record<string, string> => ({
@@ -81,7 +96,7 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
     try {
       const response = await options.http.send({
         method: "POST",
-        url: `${base}${path}`,
+        url: `${base()}${path}`,
         headers: headers(),
         body: JSON.stringify(body),
         signal: new AbortController().signal,
@@ -108,7 +123,7 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
     async *run(request: RunRequest, signal: AbortSignal): AsyncIterable<RunEvent> {
       const response = await options.http.send({
         method: "POST",
-        url: `${base}/chat`,
+        url: `${base()}/chat`,
         headers: headers({ accept: "text/event-stream" }),
         body: JSON.stringify({
           prompt: request.prompt,

--- a/src/praisonai-mobile/engines/src/remote-http/engine.ts
+++ b/src/praisonai-mobile/engines/src/remote-http/engine.ts
@@ -69,6 +69,19 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
     (typeof options.baseUrl === "string" ? options.baseUrl : options.baseUrl()).replace(/\/+$/, "");
   const id = options.id ?? "remote-http";
 
+  // Where each in-flight run was STARTED. A resolver means `base()` can move
+  // between calls -- that is the whole point, so the next /chat reaches the
+  // address the user just fixed. But a run's /cancel, and an approval's
+  // /approve, are addressed by an id the ORIGINATING engine minted; sending
+  // them to a newly-corrected address hands a foreign id to an engine that
+  // never issued it, which refuses it -- and controller.ts only aborts the
+  // local reader once cancel returns true, so the original turn keeps
+  // generating at the old address while the user believes they stopped it.
+  // Pinning the id to the base it was born at keeps a mid-turn address change
+  // from redirecting the control request off the run it belongs to.
+  const runBase = new Map<string, string>();
+  const approvalBase = new Map<string, string>();
+
   const headers = (extra: Record<string, string> = {}): Record<string, string> => ({
     "content-type": "application/json",
     ...(options.token === undefined ? {} : { authorization: `Bearer ${options.token}` }),
@@ -92,11 +105,11 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
   /** POST a small JSON request and read `{ok: boolean}` out of the reply.
    *  Returns false on anything that is not an explicit success -- reporting
    *  success for an unknown id "would be a lie the UI cannot detect". */
-  const postOk = async (path: string, body: unknown): Promise<boolean> => {
+  const postOk = async (path: string, body: unknown, origin: string): Promise<boolean> => {
     try {
       const response = await options.http.send({
         method: "POST",
-        url: `${base()}${path}`,
+        url: `${origin}${path}`,
         headers: headers(),
         body: JSON.stringify(body),
         signal: new AbortController().signal,
@@ -121,9 +134,14 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
     capabilities: CAPABILITIES,
 
     async *run(request: RunRequest, signal: AbortSignal): AsyncIterable<RunEvent> {
+      // Resolved ONCE, here, and remembered for this run's control requests.
+      // The /chat POST and every later /cancel for this runId must reach the
+      // same engine even if Settings changes the address mid-stream.
+      const origin = base();
+      runBase.set(request.runId, origin);
       const response = await options.http.send({
         method: "POST",
-        url: `${base()}/chat`,
+        url: `${origin}/chat`,
         headers: headers({ accept: "text/event-stream" }),
         body: JSON.stringify({
           prompt: request.prompt,
@@ -179,6 +197,12 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
             }
             const outcome = decodeEvent({ ...parsed.value, type: frame.event });
             if (isDecoded(outcome)) {
+              // An approval blocks the run and is answered by an id THIS engine
+              // minted, so its /approve must land back here even after Settings
+              // moves the address. Pinned to the run's origin, not `base()`.
+              if (outcome.event.type === "approval_request") {
+                approvalBase.set(outcome.event.approvalId, origin);
+              }
               yield outcome.event;
             } else {
               options.onIgnored?.(outcome.reason, outcome.detail);
@@ -188,15 +212,29 @@ export function createRemoteHttpEngine(options: RemoteHttpOptions): AgentEngineP
       } finally {
         // Release the socket whether we finished, aborted, or threw.
         await reader.cancel().catch(() => {});
+        // The run is over: its id can no longer be cancelled meaningfully, so
+        // drop the pin rather than let the map grow for the session. A /cancel
+        // that races the natural end falls back to `base()` -- harmless, the
+        // run is already gone. Approval pins outlive the map entry only until
+        // decided; they are cleared in `decide`.
+        runBase.delete(request.runId);
       }
     },
 
     async decide(approvalId: string, choice: ApprovalChoice): Promise<boolean> {
-      return postOk(`/approve/${encodeURIComponent(approvalId)}`, { choice });
+      // The engine that asked is the engine that must be told. Fall back to the
+      // live resolver only for an id this instance never saw (a resumed app
+      // that reconnected), where the current address is the best guess left.
+      const origin = approvalBase.get(approvalId) ?? base();
+      const ok = await postOk(`/approve/${encodeURIComponent(approvalId)}`, { choice }, origin);
+      approvalBase.delete(approvalId);
+      return ok;
     },
 
     async cancel(runId: string): Promise<boolean> {
-      return postOk(`/cancel/${encodeURIComponent(runId)}`, {});
+      // Pinned to where the run STARTED. A mid-turn address change must not
+      // redirect the stop to an engine that never issued this runId.
+      return postOk(`/cancel/${encodeURIComponent(runId)}`, {}, runBase.get(runId) ?? base());
     },
 
     async dispose(): Promise<void> {

--- a/src/praisonai-mobile/testing/src/fake-dom.ts
+++ b/src/praisonai-mobile/testing/src/fake-dom.ts
@@ -64,6 +64,18 @@ export interface FakeDom {
   find(pred: (n: FakeNode) => boolean): FakeNode | null;
   /** Click an element, bubbling to delegated listeners on its ancestors. */
   click(el: FakeNode): { defaultPrevented: boolean };
+  /**
+   * Commit a field, bubbling like the real `change` event does.
+   *
+   * `change` BUBBLES in a real DOM, which is what lets one delegated listener
+   * on root hear every settings field -- the same arrangement `click` already
+   * uses here. Dispatching it on the field alone (`el.dispatch("change", {})`)
+   * only ever reaches a listener attached to that element, so a test written
+   * that way passes against a per-field listener and reports nothing at all
+   * against a delegated one. Modelling the bubble is what makes the two
+   * indistinguishable to a test, as they are to a browser.
+   */
+  change(el: FakeNode): { defaultPrevented: boolean };
   text(): string;
   /** The element `focus()` was last called on, or null -- what a test asserts
    *  a route change moved focus to. Mirrors `document.activeElement`. */
@@ -228,6 +240,20 @@ export function createFakeDom(): FakeDom {
   };
   const root = make("div");
 
+  /** Dispatch one event up the ancestor chain, as a real bubbling event does.
+   *  Shared by `click` and `change` so the two cannot drift: a delegated
+   *  listener on root must hear both or neither. */
+  const bubble = (type: string, el: FakeNode): { defaultPrevented: boolean } => {
+    const event = {
+      target: el,
+      defaultPrevented: false,
+      preventDefault(this: { defaultPrevented: boolean }) { this.defaultPrevented = true; },
+    };
+    let node: FakeNode | null = el;
+    while (node !== null) { node.dispatch(type, event); node = node.parentElement; }
+    return event;
+  };
+
   const all = (): FakeNode[] => {
     const out: FakeNode[] = [];
     const walk = (n: FakeNode): void => { out.push(n); for (const c of n.children) walk(c); };
@@ -245,15 +271,12 @@ export function createFakeDom(): FakeDom {
       // A real click focuses the control it lands on, so the app's "remember
       // where to return on Back" reads the tapped row, not stale focus.
       active = el;
-      const event = {
-        target: el,
-        defaultPrevented: false,
-        preventDefault(this: { defaultPrevented: boolean }) { this.defaultPrevented = true; },
-      };
-      let node: FakeNode | null = el;
-      while (node !== null) { node.dispatch("click", event); node = node.parentElement; }
-      return event;
+      return bubble("click", el);
     },
+    // No focus side effect: a `change` fires on a field the user is ALREADY in
+    // (or has just left), and moving focus here would paper over an app that
+    // forgot to.
+    change: (el) => bubble("change", el),
     text: () => root.textContent,
     activeElement: () => active,
   };

--- a/src/praisonai-mobile/ui/src/i18n/strings.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.test.ts
@@ -21,6 +21,7 @@ import { UNKNOWN } from "../format.ts";
 const SAMPLES: Readonly<Record<string, () => string>> = {
   bootFailed: () => en.bootFailed("no storage"),
   engineNotReady: () => en.engineNotReady("ECONNREFUSED"),
+  settingRejected: () => en.settingRejected("Engine address"),
   chatUnreadable: () => en.chatUnreadable("chat-7"),
   chatsAllUnreadable: () => en.chatsAllUnreadable(3),
   minutesAgo: () => en.minutesAgo(2, "2"),
@@ -98,6 +99,9 @@ test("no string is blank and no parameterised string drops its argument", () => 
   assert.ok(en.chatUnreadable("chat-7").includes("chat-7"));
   assert.ok(en.errorRowName("auth", "bad key").includes("bad key"));
   assert.ok(en.droppedEvents(2, ["wrong_msg_id"]).includes("wrong_msg_id"));
+  // The refusal has to NAME the setting: the field it belongs to may already
+  // be off screen, and "that value was refused" alone says which of nothing.
+  assert.ok(en.settingRejected("Engine address").includes("Engine address"));
 });
 
 test("every sample corresponds to a key that still exists", () => {

--- a/src/praisonai-mobile/ui/src/i18n/strings.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.ts
@@ -78,6 +78,17 @@ export interface Strings {
   readonly routeChat: string;
   readonly routeSettings: string;
   readonly routeAbout: string;
+  /**
+   * A settings value the store would not accept.
+   *
+   * Said rather than merely undone. A field that snaps back and says nothing
+   * is indistinguishable from a mis-tap, a lost keystroke, or a save that
+   * worked -- and on the settings screen, whose whole job is to repair an
+   * engine the app cannot reach, that silence leaves someone re-typing the
+   * same refused value. It names the setting, because the field it belongs to
+   * may already have scrolled off.
+   */
+  readonly settingRejected: (label: string) => string;
 
   // ---- chat list ---------------------------------------------------------
   /** A chat whose title is blank. A blank row has no hit target and reads as a
@@ -269,6 +280,10 @@ export const en: Strings = {
   routeChat: "Chat",
   routeSettings: "Settings",
   routeAbout: "About",
+  // The label, then what happened to it -- not "Invalid value", which names
+  // neither the setting nor the outcome. "was not changed" is the fact the
+  // user needs: the old value is still in force.
+  settingRejected: (label) => `${label} was not changed: that value was refused.`,
 
   untitled: "Untitled",
   chatUnreadable: (id) => `Could not be read: ${id}`,


### PR DESCRIPTION
## Why

The recovery path a phone depends on is: reach no `127.0.0.1:8765`, open Settings, type the engine's real address. #4685 (refs #4673) made the Settings fields editable, but the path still ended short of a working engine in two places:

1. **The write persisted and the engine ignored it.** `enginesFor` read `baseUrl` once, at construction, and both the remote-http engine and its health probe closed over that string. The app builds its engine exactly once at boot, so the corrected address was stored, displayed, and never used until the app was force-quit.
2. **A refused value vanished.** `settings.set` returning `false`, or `validateInput` returning `null`, reset the field in silence -- indistinguishable from a mis-tap or a save that worked, on the one screen whose job is repair.

## What

- `RemoteHttpOptions.baseUrl` accepts `string | (() => string)`; the registry passes a resolver, so the **next** `/chat` and `/health` go to the address the user just set. A plain string still works. Rebuilding the engine on change was rejected: `createRunController` has no seam to swap it and would drop the turn in flight.
- A refusal is written beside the field (a `role="alert"` node present from first paint, so it is announced reliably) and into the assertive live region, naming the setting. Only that key's note is touched: an accepted write clears its own message and leaves another setting's refusal standing.
- Committing a field moved out of a per-field `change` listener into `intents.ts` as `set-setting`, decoded by `intentFrom` and dispatched from a root-delegated `change` handler like every tap. `Actionable.value` is absent on non-fields on purpose: missing means "not a field", never "cleared".
- The fake DOM gains a bubbling `change` (shared `bubble` with `click`), because a dispatch on the field alone passes against a per-field listener and reports nothing against a delegated one.

## Verification

- `npm run check` exits 0 on Node 22.23.0 and 24.12.0 (1344 tests; main has 1327).
- Every new behaviour was mutation-verified: the corresponding fix was reverted and `npm run check` confirmed to exit non-zero (table in the PR conversation).

Refs #4673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Settings changes now take effect on the next request without restarting the app.
  - Added clear, accessible error messages when a setting value is refused.
  - Refused setting messages are automatically cleared after a successful update.
  - Engine address changes now apply to requests, approvals, cancellations, and health checks.
  - Added localized messaging identifying which setting was rejected.

- **Bug Fixes**
  - Corrected settings updates that could be ignored or committed inconsistently.
  - Ensured empty values and disabled fields are handled correctly.
  - Requests remain connected to the engine that originated each operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->