### PR TITLE
fix(ts): praisonai/mobile is buildable for the chrome58 WebView again

### DIFF
--- a/src/praisonai-ts/scripts/webview-gate.mjs
+++ b/src/praisonai-ts/scripts/webview-gate.mjs
@@ -66,15 +66,29 @@ export const BUILT_ENTRIES = ["dist/esm/mobile.js", "dist/esm/agent/simple.js"];
  *  oldest iOS worth supporting rather than the newest Safari. */
 export const TARGETS = ["safari16", "chrome108"];
 
-export async function inspect(entry) {
-  const result = await esbuild.build({
+/**
+ * The SYNTAX floor, which is lower than the baseline above and checked
+ * separately because it fails differently.
+ *
+ * The mobile app declares Android minSdkVersion 26 (8.0), whose system WebView
+ * shipped as Chrome 58. Most modern syntax esbuild can lower for that target;
+ * top-level await it cannot, and refuses. That is not academic: the
+ * createRequire banner scripts/esm-shim.js prepended to three files on the
+ * mobile graph was a top-level await, so the published entry bundled fine at
+ * chrome108 -- the metafile check above passed -- and was unbuildable at the
+ * floor the app actually ships with. Laziness does not help here: esbuild
+ * rejects a top-level await anywhere on the graph, dynamically imported or not.
+ */
+export const FLOOR_TARGET = "chrome58";
+
+function buildOptions(entry, target) {
+  return {
     entryPoints: [entry],
     bundle: true,
     write: false,
-    metafile: true,
     platform: "browser",
     format: "esm",
-    target: TARGETS,
+    target,
     logLevel: "silent",
     plugins: [{
       name: "surface-bare",
@@ -84,7 +98,25 @@ export async function inspect(entry) {
         build.onResolve({ filter: /^[^.\/]/ }, (args) => ({ path: args.path, external: true }));
       },
     }],
-  });
+  };
+}
+
+/** Does the entry bundle at all for FLOOR_TARGET? esbuild's own errors are the
+ *  diagnosis (each names the file and line, e.g. the top-level await). */
+export async function bundlesAtFloor(entry) {
+  try {
+    await esbuild.build(buildOptions(entry, [FLOOR_TARGET]));
+    return { entry, ok: true, errors: [] };
+  } catch (e) {
+    const errors = (e.errors ?? [{ text: String(e) }]).map((m) =>
+      m.location ? `${m.text} (${m.location.file}:${m.location.line})` : m.text
+    );
+    return { entry, ok: false, errors };
+  }
+}
+
+export async function inspect(entry) {
+  const result = await esbuild.build({ ...buildOptions(entry, TARGETS), metafile: true });
 
   const fatal = new Set();
   const lazy = new Set();
@@ -131,6 +163,17 @@ if (invokedDirectly) {
       console.error(`       behind a Node-only entry point.`);
     } else {
       console.log(`  OK   ${entry}: loadable in a webview`);
+    }
+
+    const floor = await bundlesAtFloor(entry);
+    if (!floor.ok) {
+      failed = true;
+      console.error(`  FAIL ${entry}: does not bundle for ${FLOOR_TARGET} (the Android 8 WebView floor):`);
+      for (const err of floor.errors) console.error(`       - ${err}`);
+      console.error(`       A top-level await here usually means a file on the graph still uses`);
+      console.error(`       require()/__dirname and got the esm-shim createRequire banner.`);
+    } else {
+      console.log(`  OK   ${entry}: bundles for ${FLOOR_TARGET}`);
     }
   }
   if (failed) {

--- a/src/praisonai-ts/src/llm/backend-resolver.ts
+++ b/src/praisonai-ts/src/llm/backend-resolver.ts
@@ -12,6 +12,16 @@
 
 import type { LLMProvider, ProviderConfig } from './providers/types';
 import { getEnv } from './openaiClientOptions';
+// Static imports. resolveBackendSync() used to `require()` these inside its
+// body, which in the ESM build made scripts/esm-shim.js prepend a top-level-
+// await createRequire banner -- unbuildable for the Android 8 WebView that
+// `praisonai/mobile` targets -- and, worse, the shim repointed the require at
+// the CommonJS twin in dist/, so an ESM caller of the sync path got a SECOND
+// copy of the provider registry that could not see providers registered on the
+// first. Neither module imports this file back (no cycle), and neither loads
+// the AI SDK itself: backend.ts defers `import('ai')` until the first call.
+import { createAISDKBackend } from './providers/ai-sdk';
+import { createProvider } from './providers';
 
 export type BackendSource = 'ai-sdk' | 'native' | 'custom' | 'legacy';
 
@@ -138,9 +148,6 @@ export async function resolveBackend(
     
     if (aiSdkAvailable) {
       try {
-        // Lazy import AI SDK backend
-        const { createAISDKBackend } = await import('./providers/ai-sdk');
-
         // The AI-SDK backend keys credentials by provider id
         // (config.providers[providerId]), while ProviderConfig is flat
         // (apiKey/baseUrl). Map the flat per-agent key onto the resolved
@@ -194,7 +201,6 @@ export async function resolveBackend(
   
   // Try native provider registry
   try {
-    const { createProvider } = await import('./providers');
     const provider = createProvider(modelString, options.config);
     
     return {
@@ -230,9 +236,7 @@ export function resolveBackendSync(
   // If AI SDK availability is cached and available, try it first
   if (_aiSdkAvailable === true && (preferredBackend === 'ai-sdk' || preferredBackend === 'auto')) {
     try {
-      // This will throw if AI SDK module is not already loaded
-      const aiSdk = require('./providers/ai-sdk');
-      const backend = aiSdk.createAISDKBackend(modelString, {
+      const backend = createAISDKBackend(modelString, {
         ...options.config,
         attribution: options.attribution,
       });
@@ -249,7 +253,6 @@ export function resolveBackendSync(
   }
   
   // Use native provider
-  const { createProvider } = require('./providers');
   const provider = createProvider(modelString, options.config);
   
   return {

--- a/src/praisonai-ts/src/llm/providers/ai-sdk/index.ts
+++ b/src/praisonai-ts/src/llm/providers/ai-sdk/index.ts
@@ -82,21 +82,27 @@ export {
   type AISDKMiddleware,
 } from './middleware';
 
-// Lazy-loaded backend exports
-// These use getters to avoid importing the backend module until needed
-
-let _AISDKBackend: typeof import('./backend').AISDKBackend | null = null;
-let _createAISDKBackend: typeof import('./backend').createAISDKBackend | null = null;
+// Backend exports.
+//
+// These used to `require('./backend')` on first call "to avoid importing the
+// backend module until needed" -- but `export { AISDKBackend } from './backend'`
+// below already loads it statically, so the require deferred nothing. What IS
+// lazy, and stays lazy, lives inside backend.ts: the AI SDK itself
+// (`await import('ai')`) is not touched until the first generate call
+// (tests/unit/llm/ai-sdk/lazy-import.test.ts pins that). The bare require cost
+// the ESM build a top-level-await createRequire banner from scripts/esm-shim.js,
+// which made `praisonai/mobile` unbuildable for the Android 8 WebView (chrome58).
+import {
+  AISDKBackend as AISDKBackendClass,
+  createAISDKBackend as createAISDKBackendImpl,
+} from './backend';
+import { registerCustomProvider } from './provider-map';
 
 /**
- * Get the AISDKBackend class (lazy loaded)
+ * Get the AISDKBackend class
  */
-export function getAISDKBackendClass(): typeof import('./backend').AISDKBackend {
-  if (!_AISDKBackend) {
-    const backend = require('./backend');
-    _AISDKBackend = backend.AISDKBackend;
-  }
-  return _AISDKBackend!;
+export function getAISDKBackendClass(): typeof AISDKBackendClass {
+  return AISDKBackendClass;
 }
 
 /**
@@ -116,12 +122,8 @@ export function getAISDKBackendClass(): typeof import('./backend').AISDKBackend 
 export function createAISDKBackend(
   modelString: string,
   config?: import('./types').AISDKBackendConfig
-): import('./backend').AISDKBackend {
-  if (!_createAISDKBackend) {
-    const backend = require('./backend');
-    _createAISDKBackend = backend.createAISDKBackend;
-  }
-  return _createAISDKBackend!(modelString, config);
+): AISDKBackendClass {
+  return createAISDKBackendImpl(modelString, config);
 }
 
 // Re-export the class for direct instantiation
@@ -149,7 +151,6 @@ export function registerAISDKProviders(
 ): void {
   // Register custom providers if provided
   if (customProviders) {
-    const { registerCustomProvider } = require('./provider-map');
     for (const [id, factory] of Object.entries(customProviders)) {
       registerCustomProvider(id, factory);
     }
@@ -181,11 +182,21 @@ export async function getAISDKVersion(): Promise<string | null> {
     // Use variable to prevent TypeScript from resolving at compile time
     const moduleName = 'ai';
     await import(moduleName);
-    // AI SDK doesn't export version directly, so we check package.json
+    // AI SDK doesn't export version directly, so we check package.json.
+    // A dynamic import rather than require(): a bare require() in this file
+    // makes scripts/esm-shim.js prepend a top-level-await createRequire banner
+    // to the ESM build, which no chrome58 WebView can load. Under the CJS build
+    // tsc lowers this to require(); under the ESM build the attribute is kept,
+    // which native ESM demands for JSON. Both resolve 'ai' from this file's own
+    // location exactly as the require() did.
     try {
       const pkgPath = 'ai/package.json';
-      const pkg = require(pkgPath);
-      return pkg.version;
+      // The CJS build (module=commonjs) rejects a second import() argument at
+      // the grammar level (TS1324) yet emits the right thing -- `require(s)`
+      // with the attribute dropped. The ESM build accepts it as-is.
+      // @ts-ignore
+      const pkg = await import(pkgPath, { with: { type: 'json' } });
+      return (pkg.default ?? pkg).version;
     } catch {
       return 'installed';
     }

--- a/src/praisonai-ts/src/llm/providers/registry.ts
+++ b/src/praisonai-ts/src/llm/providers/registry.ts
@@ -6,6 +6,15 @@
  */
 
 import type { LLMProvider, ProviderConfig } from './types';
+// Static, not `require()`d inside the loaders below. The only importer of this
+// file is ./index.ts, which already re-exports all three classes statically, so
+// the lazy require deferred nothing -- while in the ESM build it forced the
+// esm-shim to prepend a top-level-await createRequire banner (Chrome 89+), which
+// made the `praisonai/mobile` entry unbuildable for the Android 8 WebView. None
+// of these modules imports the registry back, so there is no cycle to defer.
+import { OpenAIProvider } from './openai';
+import { AnthropicProvider } from './anthropic';
+import { GoogleProvider } from './google';
 
 /**
  * Provider constructor type
@@ -351,26 +360,15 @@ export function listProviders(): string[] {
 
 /**
  * Register built-in providers to a registry
- * Uses lazy loaders to avoid importing all providers at module load time
+ *
+ * Registered through loader functions (not bare constructors) so the registry
+ * entries keep the same shape they always had: `get('openai')` still returns
+ * the loader, and `resolve()` still calls it on first use.
  */
 export function registerBuiltinProviders(registry: ProviderRegistry): void {
-  // OpenAI - lazy loaded
-  registry.register('openai', () => {
-    const { OpenAIProvider } = require('./openai');
-    return OpenAIProvider;
-  }, { aliases: ['oai'] });
-
-  // Anthropic - lazy loaded
-  registry.register('anthropic', () => {
-    const { AnthropicProvider } = require('./anthropic');
-    return AnthropicProvider;
-  }, { aliases: ['claude'] });
-
-  // Google - lazy loaded
-  registry.register('google', () => {
-    const { GoogleProvider } = require('./google');
-    return GoogleProvider;
-  }, { aliases: ['gemini'] });
+  registry.register('openai', () => OpenAIProvider, { aliases: ['oai'] });
+  registry.register('anthropic', () => AnthropicProvider, { aliases: ['claude'] });
+  registry.register('google', () => GoogleProvider, { aliases: ['gemini'] });
 }
 
 /**

--- a/src/praisonai-ts/tests/unit/llm/ai-sdk/version.test.ts
+++ b/src/praisonai-ts/tests/unit/llm/ai-sdk/version.test.ts
@@ -1,0 +1,18 @@
+/**
+ * getAISDKVersion reads ai/package.json through a dynamic import (with a JSON
+ * import attribute for the ESM build) instead of a bare require(). Under the
+ * CommonJS build ts-jest runs here, tsc lowers that import() to require(), so
+ * this pins that the lowered form still finds the real installed version
+ * rather than falling back to 'installed'.
+ */
+
+import { getAISDKVersion } from '../../../../src/llm/providers/ai-sdk';
+
+describe('getAISDKVersion', () => {
+  it('returns the installed ai package version', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const expected = require('ai/package.json').version as string;
+    expect(typeof expected).toBe('string');
+    await expect(getAISDKVersion()).resolves.toBe(expected);
+  });
+});

--- a/src/praisonai-ts/tests/unit/llm/backend-resolver-sync.test.ts
+++ b/src/praisonai-ts/tests/unit/llm/backend-resolver-sync.test.ts
@@ -1,0 +1,92 @@
+/**
+ * resolveBackendSync — provider resolution through the synchronous path.
+ *
+ * The sync resolver used to reach its providers through bare require() calls
+ * inside its body. Replacing those with static imports must not change what it
+ * resolves: the native registry when asked for it (or when the AI SDK check has
+ * not run), the AI SDK backend once isAISDKAvailable() has cached a positive
+ * result, and — the case the require() version got WRONG under native ESM,
+ * where the shim repointed it at the CommonJS twin and hence at a second
+ * registry — providers registered on the default registry by the caller.
+ *
+ * resolveBackend (async) already has coverage in tests/unit/agent/model-routing.test.ts;
+ * the built-in native providers in tests/unit/llm/provider-registry.test.ts.
+ */
+
+import {
+  resolveBackendSync,
+  isAISDKAvailable,
+  resetAISDKAvailabilityCache,
+} from '../../../src/llm/backend-resolver';
+import { registerProvider, unregisterProvider } from '../../../src/llm/providers';
+import type {
+  LLMProvider,
+  ProviderConfig,
+  GenerateTextOptions,
+  GenerateTextResult,
+  StreamTextOptions,
+  StreamChunk,
+  GenerateObjectOptions,
+  GenerateObjectResult,
+} from '../../../src/llm/providers/types';
+
+class StubProvider implements LLMProvider {
+  readonly providerId = 'stub';
+  readonly modelId: string;
+  constructor(modelId: string, _config?: ProviderConfig) {
+    this.modelId = modelId;
+  }
+  async generateText(_options: GenerateTextOptions): Promise<GenerateTextResult> {
+    return { text: 'stub', usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 }, finishReason: 'stop' };
+  }
+  async streamText(_options: StreamTextOptions): Promise<AsyncIterable<StreamChunk>> {
+    return { async *[Symbol.asyncIterator]() { yield { text: 'stub' }; } };
+  }
+  async generateObject<T>(_options: GenerateObjectOptions<T>): Promise<GenerateObjectResult<T>> {
+    return { object: {} as T, usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } };
+  }
+}
+
+describe('resolveBackendSync', () => {
+  beforeEach(() => {
+    resetAISDKAvailabilityCache();
+  });
+
+  it('resolves a built-in native provider when the native backend is requested', () => {
+    const result = resolveBackendSync('openai/gpt-4o-mini', { backend: 'native' });
+    expect(result.source).toBe('native');
+    expect(result.providerId).toBe('openai');
+    expect(result.modelId).toBe('gpt-4o-mini');
+    expect(result.provider.providerId).toBe('openai');
+    expect(result.provider.modelId).toBe('gpt-4o-mini');
+  });
+
+  it('falls back to native while AI SDK availability has not been checked', () => {
+    // Cache is null: the sync path cannot await the check, so it must not guess.
+    const result = resolveBackendSync('anthropic/claude-3-5-sonnet-latest');
+    expect(result.source).toBe('native');
+    expect(result.provider.providerId).toBe('anthropic');
+  });
+
+  it('resolves through the AI SDK backend once availability is cached', async () => {
+    // `ai` is a devDependency, so the check caches true.
+    expect(await isAISDKAvailable()).toBe(true);
+    const result = resolveBackendSync('openai/gpt-4o-mini');
+    expect(result.source).toBe('ai-sdk');
+    expect(result.providerId).toBe('openai');
+    expect(result.provider.providerId).toBe('openai');
+    expect(result.provider.modelId).toBe('gpt-4o-mini');
+  });
+
+  it('resolves a provider the caller registered on the default registry', () => {
+    registerProvider('stub', StubProvider);
+    try {
+      const result = resolveBackendSync('stub/any-model', { backend: 'native' });
+      expect(result.source).toBe('native');
+      expect(result.provider).toBeInstanceOf(StubProvider);
+      expect(result.provider.modelId).toBe('any-model');
+    } finally {
+      unregisterProvider('stub');
+    }
+  });
+});

--- a/src/praisonai-ts/tests/unit/packaging/dual-build.test.ts
+++ b/src/praisonai-ts/tests/unit/packaging/dual-build.test.ts
@@ -178,3 +178,64 @@ describe('praisonai dual ESM+CJS packaging', () => {
     expect(out).toContain('SUBPATHS_OK');
   }, 120000);
 });
+
+/**
+ * The published `praisonai/mobile` entry must be buildable for the WebView floor
+ * the mobile app declares (Android minSdkVersion 26 => Chrome 58).
+ *
+ * The shim's createRequire banner is a top-level await, which esbuild cannot
+ * lower for chrome58 and refuses outright. Three files on the mobile graph used
+ * to earn that banner through a bare require() inside otherwise lazy provider
+ * loaders; the sources now import statically, so the built files need no
+ * banner and the entry bundles at the floor. Both halves are asserted here
+ * against the freshly built dist, because `npm test` runs in Node where a
+ * top-level await is perfectly fine and nothing else would notice.
+ */
+describe('praisonai/mobile entry has no top-level await on its graph', () => {
+  // The three built files that carried the banner (git log -S__praisonMod).
+  const MOBILE_GRAPH_FILES = [
+    'llm/backend-resolver.js',
+    'llm/providers/ai-sdk/index.js',
+    'llm/providers/registry.js',
+  ];
+
+  // Mechanical criterion, identical to:
+  //   grep -l "__praisonMod" dist/esm/llm/backend-resolver.js \
+  //     dist/esm/llm/providers/ai-sdk/index.js dist/esm/llm/providers/registry.js
+  // printing nothing. '__praisonMod' is the first binding of the banner; the
+  // second assertion is the banner-independent marker esm-shim-banner.test.ts
+  // uses, so a renamed banner still fails here.
+  it('emits the three former banner files with no createRequire banner', () => {
+    const bannered = MOBILE_GRAPH_FILES.filter((rel) => {
+      const code = fs.readFileSync(path.join(ESM_DIR, rel), 'utf8');
+      return code.includes('__praisonMod') || code.includes('const require =');
+    });
+    expect(bannered).toEqual([]);
+  });
+
+  it('has no bare require()/__dirname left in the sources the shim would banner', () => {
+    // The emit-time decision is needsCjsBanner() over the emitted JS; tsc's ESM
+    // emit neither adds nor removes require() calls, so the same detector over
+    // the TypeScript source is the build-independent form of the check above.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { needsCjsBanner } = require('../../../scripts/esm-shim.js');
+    const SRC = path.join(PKG_ROOT, 'src');
+    const offenders = MOBILE_GRAPH_FILES.map((rel) => rel.replace(/\.js$/, '.ts')).filter((rel) =>
+      needsCjsBanner(fs.readFileSync(path.join(SRC, rel), 'utf8'))
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('bundles dist/esm/mobile.js for chrome58 (scripts/webview-gate.mjs floor check)', () => {
+    // The gate owns the esbuild configuration (browser platform, bare specifiers
+    // external) and the floor target; run it rather than restate it. It exits
+    // non-zero on any failure, which execFileSync turns into a thrown error
+    // carrying esbuild's own diagnosis (file:line of the top-level await).
+    const out = execFileSync(process.execPath, ['scripts/webview-gate.mjs'], {
+      cwd: PKG_ROOT,
+      encoding: 'utf8',
+    });
+    expect(out).toContain('OK   dist/esm/mobile.js: bundles for chrome58');
+    expect(out).toContain('OK   dist/esm/mobile.js: loadable in a webview');
+  }, 120000);
+});


### PR DESCRIPTION
## What was wrong

`praisonai@1.7.4`'s `dist/esm/llm/{backend-resolver,providers/ai-sdk/index,providers/registry}.js` each start with a top-level `await Promise.all([import('module'), …])`. It is not in the source: `scripts/esm-shim.js` prepends that `createRequire` banner to any emitted ESM file that still calls a bare `require()`, and these three did, inside "lazy" provider loaders. Top-level await needs Chrome 89; the mobile app declares Android `minSdkVersion: 26`, whose system WebView is Chrome 58. esbuild refuses to lower it, so `praisonai/mobile` was unbuildable at the floor the app ships with, while the webview gate passed at chrome108.

Refs #4673 (the "green but never buildable for a device" gap). Upstream change in `praisonai-ts` only; `praisonai-mobile` is untouched.

## Why each `require()` was lazy (checked, not assumed)

Built the static import graph of `src/` and tried each static import; the build and the full suite decide.

| Site | Finding | Fix |
|---|---|---|
| `providers/registry.ts` ×3 (`./openai`, `./anthropic`, `./google`) | **No cycle.** Those files import only `base` and `openaiClientOptions`. The registry's sole importer, `providers/index.ts`, already re-exports all three classes statically, so the lazy `require` deferred nothing. | static import; loaders keep their `() => Ctor` shape so `registry.get()` returns what it always did |
| `providers/ai-sdk/index.ts` ×3 (`./backend` ×2, `./provider-map`) | **No cycle.** The same file already does `export { AISDKBackend } from './backend'` and re-exports `provider-map` statically. The laziness that matters, `import('ai')`, lives inside `backend.ts` and is untouched (`lazy-import.test.ts` pins it). | static import |
| `backend-resolver.ts` ×2 (`./providers/ai-sdk`, `./providers`) | **No cycle** — neither imports it back. Adds 13 first-party files and **zero new packages** to the mobile graph, all of which esbuild was already bundling through the `require()` edges. `resolveBackendSync` keeps its sync contract. | static import (the async path's redundant `await import()`s use the same bindings) |
| `ai-sdk/index.ts:187` `require('ai/package.json')` | Genuine runtime lookup. | `await import(pkgPath, { with: { type: 'json' } })`: tsc lowers it to `require(s)` in the CJS build and keeps the attribute in the ESM build, so both still return the real version (`6.0.275`) from this file's own location. One `@ts-ignore` for TS1324 in the CJS build, explained inline. |

Isolating the last `require` in a lazily-imported leaf file was tried and rejected: esbuild refuses a top-level await *anywhere* on the graph, dynamic import or not. A shim-side fix was not pursued for the same reason: a file that needs no shim beats a file with a cleverer one, and none of these needed it.

### Side effect, measured under native Node ESM
The shim repoints each relative `require()` at the CommonJS twin in `dist/`, so an ESM caller of `resolveBackendSync` got a **second** provider registry. On `origin/main`: `registerProvider('stub', …)` then `resolveBackendSync('stub/m')` → `Unknown provider: 'stub'`. Now it resolves from the same registry (`instanceof Stub`).

## Proof

```
$ npm run build && grep -l "__praisonMod" dist/esm/llm/backend-resolver.js \
    dist/esm/llm/providers/ai-sdk/index.js dist/esm/llm/providers/registry.js
(nothing)
$ node scripts/webview-gate.mjs
  OK   dist/esm/mobile.js: loadable in a webview
  OK   dist/esm/mobile.js: bundles for chrome58
  (same for src/mobile.ts, src/agent/simple.ts, dist/esm/agent/simple.js)
```
Before: `dist/esm/agent/simple.js` at chrome58 failed with three `Top-level await is not available in the configured target environment ("chrome58")` errors, one per file above.

## Guarding it
- `scripts/webview-gate.mjs`: new `FLOOR_TARGET = "chrome58"` check on every entry, failing with esbuild's own file:line diagnosis. The esbuild config is shared with the existing metafile check, not duplicated.
- `tests/unit/packaging/dual-build.test.ts`: asserts the grep above on the fresh dist, the same detector (`needsCjsBanner`) over the three sources, and runs the gate expecting `OK   dist/esm/mobile.js: bundles for chrome58`.
- `tests/unit/llm/backend-resolver-sync.test.ts`: first coverage of `resolveBackendSync` — native, cached-AI-SDK, and caller-registered provider. (`resolveBackend` was already covered in `model-routing.test.ts`; the built-in providers in `provider-registry.test.ts` and `provider-factory.test.ts`.)
- `tests/unit/llm/ai-sdk/version.test.ts`: `getAISDKVersion()` equals the installed `ai` version under the CJS lowering.

`npm test`: 78 suites / 1157 tests pass (was 76 / 1149). `npm run build` clean in both tsconfigs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for mobile builds targeting Android 8 WebView.
  * Improved backend and provider resolution reliability across synchronous and asynchronous usage.
  * Prevented duplicate provider instances in certain module-loading scenarios.

* **Tests**
  * Added coverage for AI SDK version detection, backend resolution, provider registration, and mobile packaging.
  * Added validation that mobile bundles build successfully for the Chrome 58 WebView compatibility floor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->