### PR TITLE
fix(code): keep user-invocable:false skills out of the interactive / menu

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/interactive/command_registry.py
+++ b/src/praisonai-code/praisonai_code/cli/interactive/command_registry.py
@@ -217,6 +217,13 @@ class SkillCommandSource:
             name = getattr(skill, "name", None)
             if not name:
                 continue
+            # ``user-invocable: false`` marks a skill as model-only: it must
+            # not be offered in the ``/`` menu nor dispatch as ``/name``.
+            # ``SkillManager.get_user_invocable_skills`` / ``invoke`` apply
+            # the same rule, so the menu and the agent agree on what a user
+            # may run. Missing attribute (older SDK) defaults to invocable.
+            if not getattr(skill, "user_invocable", True):
+                continue
             commands.append(
                 Command(
                     name=str(name),

--- a/src/praisonai-code/tests/unit/test_interactive_skill_menu.py
+++ b/src/praisonai-code/tests/unit/test_interactive_skill_menu.py
@@ -77,3 +77,103 @@ def test_skills_omitted_by_default(in_project):
 
     assert "/my-skill" not in registry.completions("/")
     assert registry.get("my-skill") is None
+
+
+# ---------------------------------------------------------------------------
+# Through the real interactive call sites (issue #4692 follow-up)
+#
+# The tests above call ``create_default_registry`` directly, so they cannot
+# notice if the REPL or TUI stops passing ``include_skills=True``. These go
+# through ``InteractiveREPL._get_registry`` / ``AsyncTUI._get_registry``
+# themselves, and also pin the ``user-invocable: false`` rule: such a skill is
+# model-only and must not be offered in the ``/`` menu at all.
+# ---------------------------------------------------------------------------
+
+
+def _install_hidden_skill(root, name: str, description: str) -> None:
+    skill_dir = root / ".praisonai" / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n"
+        "user-invocable: false\n---\n\nModel-only body.\n"
+    )
+
+
+@pytest.fixture
+def skills_project(tmp_path, monkeypatch):
+    """A project with one visible skill and one ``user-invocable: false`` skill.
+
+    ``PRAISONAI_HOME`` is pointed at a scratch dir so the developer's own
+    ``~/.praisonai/skills`` and remote-skill cache cannot leak into the menu.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PRAISONAI_HOME", str(tmp_path / "home"))
+    _install_skill(tmp_path, "hello", "Say hello to the user")
+    _install_hidden_skill(tmp_path, "hidden", "Internal, model-only")
+    return tmp_path
+
+
+class _MenuIO:
+    """Stand-in for the REPL's IO: records what ``_get_registry`` adds to ``/``."""
+
+    def __init__(self):
+        self.menu = {}
+
+    def add_commands(self, commands):
+        self.menu.update(commands)
+
+
+def _assert_menu(registry, menu):
+    # Visible skill: present in completion, lookup, and the ``/`` menu, with
+    # its own description rather than a placeholder.
+    assert "/hello" in registry.completions("/")
+    hello = registry.get("hello")
+    assert hello is not None
+    assert hello.kind is CommandKind.SKILL
+    assert hello.description == "Say hello to the user"
+    if menu is not None:
+        assert menu.get("hello") == "Say hello to the user"
+
+    # ``user-invocable: false`` skill: absent everywhere a user could reach it.
+    assert "/hidden" not in registry.completions("/")
+    assert registry.get("hidden") is None
+    if menu is not None:
+        assert "hidden" not in menu
+
+
+def test_repl_get_registry_offers_skills_and_hides_non_user_invocable(
+    skills_project,
+):
+    from praisonai_code.cli.interactive.repl import InteractiveREPL
+
+    io = _MenuIO()
+    stub = type("StubREPL", (), {})()
+    stub._registry = None
+    stub.io = io
+
+    registry = InteractiveREPL._get_registry(stub)
+
+    assert registry is not None, "REPL registry failed to build"
+    _assert_menu(registry, io.menu)
+
+
+def test_tui_get_registry_offers_skills_and_hides_non_user_invocable(
+    skills_project,
+):
+    from praisonai_code.cli.interactive.async_tui import AsyncTUI
+
+    stub = type("StubTUI", (), {})()
+    stub._registry = None
+    stub._BUILTIN_COMMANDS = AsyncTUI._BUILTIN_COMMANDS  # class attr read by _get_registry
+
+    registry = AsyncTUI._get_registry(stub)
+
+    assert registry is not None, "TUI registry failed to build"
+    _assert_menu(registry, menu=None)
+
+
+def test_skill_source_skips_user_invocable_false(skills_project):
+    registry = create_default_registry(
+        {"help": "Show help"}, include_custom=True, include_skills=True
+    )
+    _assert_menu(registry, menu=None)


### PR DESCRIPTION
## Defect

Issue #4692 reported that installed skills never appeared in the interactive `/` menu because both `repl.py` and `async_tui.py` built their registry with `include_skills=False`. PR #4703 flipped both call sites to `include_skills=True`, and that is what is on `main` today.

What #4703 did not cover: `SkillCommandSource.discover` registers **every** discovered skill unconditionally. A skill with `user-invocable: false` in its `SKILL.md` frontmatter was therefore offered in the `/` menu and dispatched as `/name`, contradicting `SkillManager.get_user_invocable_skills` / `SkillManager.invoke`, which treat that flag as "model-only, never user-runnable". Reproduced on `origin/main`: with a `hidden` skill marked `user-invocable: false`, `registry.completions("/h")` returned `['/hello', '/help', '/hidden', '/history']`.

## Fix

One `continue` in `SkillCommandSource.discover` (`command_registry.py`): skip skills where `getattr(skill, "user_invocable", True)` is false. `discover_skills()` already returns `SkillProperties` carrying this field, so no new plumbing. A missing attribute (older SDK) defaults to invocable. The `include_skills=True` call sites from #4703 are untouched and correct; flipping the default instead was not needed since all three callers already pass it explicitly.

## Tests

`tests/unit/test_interactive_skill_menu.py` gains three tests. The existing ones called `create_default_registry` directly, so they could not notice if `repl.py` or `async_tui.py` regressed. The new ones:

- go through `InteractiveREPL._get_registry` and `AsyncTUI._get_registry` themselves (same function, same kwargs, plus the REPL's `io.add_commands` menu feed),
- install `hello` (visible) and `hidden` (`user-invocable: false`) into a temp `.praisonai/skills/`,
- assert `/hello` is in completion, lookup and the menu **with its own description**, and `/hidden` is absent from all three,
- pin `PRAISONAI_HOME` to a scratch dir so a developer's `~/.praisonai/skills` cannot leak in.

### Mutation table

| # | Mutation | Result |
|---|----------|--------|
| A | `repl.py`: `include_skills=True` -> `False` at the REPL call site | killed (1 failed) |
| B | `async_tui.py`: `include_skills=True` -> `False` at the TUI call site | killed (1 failed) |
| C | `command_registry.py`: remove the `user_invocable` filter | killed (3 failed) |
| D | `command_registry.py`: replace skill description with the `"Skill"` placeholder | killed (3 failed) |

### Regressions

Ran `test_command_registry.py`, `test_interactive_skill_menu.py`, `test_btw_side_question.py`, `test_chat_auth_exit_code.py`, `test_onboarding_entrypoint_coverage.py`, `test_plan_mode_flag.py`, `test_shell_escape.py`: 70 passed, 4 failed. The 4 failures are all in `test_plan_mode_flag.py` with `ModuleNotFoundError: No module named 'toml'` and fail identically with this branch's changes stashed -- a local venv gap, unrelated to this PR.

Closes #4692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
