### PR TITLE
fix(agent): make the streaming fallback actually reach chat()

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -5296,7 +5296,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     self._rollback_chat_history_to(chat_history_length)
                     logging.error(f"OpenAI streaming error: {e}")
                     # Fall back to simulated streaming
-                    response = self.chat(prompt, **kwargs)
+                    response = self._stream_fallback_chat(prompt, kwargs, e)
                     if response:
                         words = str(response).split()
                         chunk_size = max(1, len(words) // 20)
@@ -5316,11 +5316,76 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         except Exception as e:
             # Restore verbose mode on any error
             self.verbose = original_verbose
+            if getattr(e, '_praisonai_stream_fallback_exhausted', False):
+                # The inner fallback already ran chat() and it failed too.
+                # Running it a second time would only bury the streaming
+                # error one level deeper; surface the chained failure as-is.
+                raise
             # Graceful fallback to non-streaming if streaming fails
             logging.warning(f"Streaming failed, falling back to regular response: {e}")
-            response = self.chat(prompt, **kwargs)
+            response = self._stream_fallback_chat(prompt, kwargs, e)
             if response:
                 yield response
+
+    def _stream_fallback_chat(self, prompt: str, kwargs: Dict[str, Any], streaming_error: BaseException) -> Optional[str]:
+        """Run the non-streaming ``chat()`` after a streaming attempt failed.
+
+        ``start(stream=True)`` hands ``_start_stream_impl`` the caller's raw
+        kwargs with ``stream=True`` already set. Forwarding them to ``chat()``
+        unchanged broke the fallback in two ways (#4719): ``stream=True``
+        reached the sync adapter, which refuses to stream; and any sampling
+        knob ``chat()`` does not declare (``max_tokens``, ``top_p``...) raised
+        ``TypeError`` before a request was made. The desktop passes
+        ``max_tokens`` on every turn, so its fallback never worked.
+
+        This builds the call from the subset of kwargs ``chat()`` actually
+        accepts (introspected, so subclass overrides are honoured), forces
+        ``stream=False``, and -- if the fallback fails as well -- raises that
+        failure chained ``from`` the original streaming exception so the real
+        cause is not lost.
+        """
+        import inspect
+
+        try:
+            parameters = inspect.signature(self.chat).parameters
+        except (TypeError, ValueError):
+            parameters = {}
+        accepts_var_kwargs = any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values()
+        )
+        accepted = {
+            name for name, p in parameters.items()
+            if p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        }
+        accepted.discard('prompt')
+
+        fallback_kwargs = {
+            key: value for key, value in kwargs.items()
+            if accepts_var_kwargs or key in accepted
+        }
+        dropped = sorted(set(kwargs) - set(fallback_kwargs))
+        if dropped:
+            logging.debug(
+                f"Streaming fallback: dropping kwargs chat() does not accept: {dropped}"
+            )
+        # The fallback is, by definition, the non-streaming path.
+        if accepts_var_kwargs or 'stream' in accepted:
+            fallback_kwargs['stream'] = False
+        else:
+            fallback_kwargs.pop('stream', None)
+
+        try:
+            return self.chat(prompt, **fallback_kwargs)
+        except Exception as fallback_error:
+            logging.error(
+                f"Streaming failed ({streaming_error!r}) and the non-streaming "
+                f"fallback also failed ({fallback_error!r})"
+            )
+            try:
+                fallback_error._praisonai_stream_fallback_exhausted = True
+            except Exception:
+                pass
+            raise fallback_error from streaming_error
 
     def _create_llm_summarize_function(self):
         """

--- a/src/praisonai-agents/tests/unit/streaming/test_stream_fallback.py
+++ b/src/praisonai-agents/tests/unit/streaming/test_stream_fallback.py
@@ -1,0 +1,128 @@
+"""Regression tests for the streaming -> non-streaming fallback (#4719).
+
+When the streaming transport raises, ``_start_stream_impl`` falls back to
+``chat()``. On main the fallback forwarded ``start()``'s raw kwargs, so it
+(1) carried ``stream=True`` into the sync path, which refuses to stream,
+(2) raised ``TypeError`` for any sampling knob ``chat()`` does not declare
+(the desktop passes ``max_tokens`` on every turn), and (3) when the fallback
+failed too, the original streaming exception was buried.
+
+These tests drive the real ``start(stream=True)`` -> ``_start_stream_impl``
+path with the OpenAI transport stubbed to raise, and assert the observable
+effect of the fallback -- not the shape of the code.
+"""
+
+import functools
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from praisonaiagents import Agent
+
+
+STREAMING_ERROR = "context too long"
+
+
+def _completion(text: str):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=text, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=None,
+    )
+
+
+@pytest.fixture
+def agent(monkeypatch):
+    """An OpenAI-path agent whose streaming transport always raises."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    agent = Agent(name="fallback-agent", instructions="test", llm="gpt-4o-mini")
+
+    fake_client = MagicMock()
+    fake_client.build_messages.return_value = (
+        [{"role": "user", "content": "x"}],
+        "x",
+    )
+    # The streaming transport: the sync client's streamed create() dies.
+    fake_client.sync_client.chat.completions.create.side_effect = RuntimeError(
+        STREAMING_ERROR
+    )
+    # The non-streaming path chat() ends up on (unified OpenAI adapter).
+    fake_client.achat_completion_with_tools = AsyncMock(
+        return_value=_completion("ok")
+    )
+    agent._Agent__openai_client = fake_client
+    return agent
+
+
+def _record_chat_calls(agent, result="ok", raise_with=None):
+    """Replace ``agent.chat`` with a recorder that keeps chat()'s signature.
+
+    ``functools.wraps`` exposes the real signature through ``__wrapped__`` so
+    the code under test sees exactly what the real ``chat()`` accepts, while
+    the recorder itself takes ``**kwargs`` so anything forwarded is captured
+    rather than exploding inside the stub.
+    """
+    calls = []
+
+    @functools.wraps(agent.chat)
+    def recording_chat(prompt, **kwargs):
+        calls.append(kwargs)
+        if raise_with is not None:
+            raise raise_with
+        return result
+
+    agent.chat = recording_chat
+    return calls
+
+
+class TestStreamFallbackKwargs:
+    def test_fallback_reaches_sync_path_with_only_accepted_kwargs(self, agent):
+        calls = _record_chat_calls(agent)
+
+        chunks = list(agent.start("x", stream=True, max_tokens=5))
+
+        assert "".join(chunks).strip() == "ok"
+        assert len(calls) == 1, "the fallback must run chat() exactly once"
+        received = calls[0]
+        # (1) the sync path must never be asked to stream
+        assert received.get("stream") is False
+        # (2) sampling knobs chat() does not declare must be filtered out
+        assert "max_tokens" not in received
+        accepted = set(inspect.signature(Agent.chat).parameters) - {"self", "prompt"}
+        assert set(received) <= accepted, (
+            f"fallback forwarded kwargs chat() cannot accept: {set(received) - accepted}"
+        )
+        # The sync transport was the one actually reached (the streaming
+        # transport raised first).
+        agent._Agent__openai_client.sync_client.chat.completions.create.assert_called_once()
+
+    def test_fallback_with_real_chat_survives_max_tokens(self, agent):
+        # No stub on chat(): the desktop's `max_tokens` must not raise
+        # TypeError and the fallback must produce the non-streamed answer.
+        chunks = list(agent.start("x", stream=True, max_tokens=5))
+
+        assert "".join(chunks).strip() == "ok"
+        agent._Agent__openai_client.achat_completion_with_tools.assert_awaited()
+        awaited_kwargs = agent._Agent__openai_client.achat_completion_with_tools.await_args.kwargs
+        assert awaited_kwargs.get("stream") is not True
+
+
+class TestStreamFallbackExceptionChaining:
+    def test_fallback_failure_surfaces_original_streaming_error(self, agent):
+        calls = _record_chat_calls(agent, raise_with=ValueError("fallback exploded"))
+
+        with pytest.raises(ValueError, match="fallback exploded") as exc_info:
+            list(agent.start("x", stream=True, max_tokens=5))
+
+        # (3) the original streaming failure is the explicit cause
+        cause = exc_info.value.__cause__
+        assert isinstance(cause, RuntimeError)
+        assert STREAMING_ERROR in str(cause)
+        # and the fallback was not retried a second time on the way out
+        assert len(calls) == 1


### PR DESCRIPTION
Closes #4719

## Defect

When streaming fails, `_start_stream_impl` falls back to `self.chat(prompt, **kwargs)`, forwarding the raw kwargs `start()` handed it. Three problems:

1. `start()` has already set `stream=True` (execution_mixin.py:988), so the fallback reaches the sync adapter with `stream=True` and dies with `Streaming is not supported in sync OpenAIAdapter` (unified_adapters.py:249).
2. `chat()` has a fixed signature with no `max_tokens`/`top_p`/`**kwargs`. The desktop passes `max_tokens` every turn, so the fallback raised `TypeError: chat() got an unexpected keyword argument 'max_tokens'` before making a request.
3. Both `except` blocks fell back, so when the fallback failed the user saw the *second* fallback's `TypeError`, with the original streaming error (e.g. "context too long") buried two `__context__` levels deep.

Reproduced against main: `list(agent.start("x", stream=True, max_tokens=5))` with the streaming transport raising `RuntimeError("context too long")` surfaces `TypeError ... 'max_tokens'` with `__cause__ = None`.

## Fix

Both fallback sites now call a new `ChatMixin._stream_fallback_chat(prompt, kwargs, streaming_error)`, which:

- introspects `inspect.signature(self.chat)` and forwards only the kwargs `chat()` accepts (subclass overrides with different signatures or `**kwargs` are honoured);
- forces `stream=False` (the fallback is, by definition, the non-streaming path);
- if `chat()` also raises, logs both failures and re-raises the fallback error `from streaming_error`, marking it so the outer `except` re-raises instead of running the fallback a second time.

## Test

`tests/unit/streaming/test_stream_fallback.py` drives the real `start(stream=True, max_tokens=5)` -> `_start_stream_impl` path with the OpenAI streaming transport stubbed to raise `RuntimeError("context too long")`:

- with `chat` replaced by a signature-preserving recorder: the sync path is reached exactly once, receives `stream=False`, no `max_tokens`, and nothing outside `inspect.signature(Agent.chat)`;
- with the **real** `chat()` and the unified adapter's client stubbed: no `TypeError`, the non-streamed answer is yielded, adapter never asked to stream;
- with the fallback also raising: the surfaced exception's `__cause__` is the original `RuntimeError("context too long")`, and `chat` was called once (no double fallback).

```
PYTHONPATH=src/praisonai-agents .venv/bin/python -m pytest src/praisonai-agents/tests/unit/streaming/test_stream_fallback.py -q
```

## Mutations

| Mutation | Result |
|---|---|
| Reintroduce raw `self.chat(prompt, **kwargs)` passthrough | killed (2 tests red: `TypeError ... 'max_tokens'`) |
| Drop `from streaming_error` chaining | killed (1 test red: `__cause__` is `None`) |
| Drop the "fallback exhausted" guard (double fallback) | killed (1 test red: `chat` called twice) |
| Stop forcing `stream=False` | killed (2 tests red: `Streaming is not supported in sync OpenAIAdapter`) |

## Regressions

`tests/unit/streaming` + `tests/unit/agent/test_durable_run.py`: 110 passed, 2 failed — the two `TestShellStreaming` tests already red on main (#4724).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
