### PR TITLE
fix(scheduler): stamp naive one-shot 'at' times with the zone the user meant

### DIFF
--- a/src/praisonai-agents/praisonaiagents/scheduler/due.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/due.py
@@ -32,6 +32,32 @@ def resolve_schedule_timezone(tz: str | None = None) -> ZoneInfo:
         raise ValueError(f"Unknown IANA timezone: {name!r}") from exc
 
 
+def localize_wall_clock(target: datetime, tz: str | None = None) -> datetime:
+    """Attach the zone a naive wall-clock timestamp was written in.
+
+    A naive ``at`` string is what a person typed from their own clock, so it
+    means *that wall-clock time in the schedule's zone*, resolved in order:
+    the schedule's explicit ``tz``, then ``PRAISONAI_SCHEDULE_TIMEZONE``, then
+    the system's local zone. It is never UTC by default -- stamping UTC is
+    exactly the defect that made one-shot jobs fire an hour off outside UTC.
+
+    An already-aware ``target`` is returned unchanged: an explicit offset in
+    the string always wins over any default.
+
+    The local-zone branch uses :meth:`datetime.astimezone` on the naive value
+    so the offset is the one in force *on that date* (DST-correct), not the
+    offset in force right now.
+
+    Raises ``ValueError`` when the named zone is not a known IANA zone.
+    """
+    if target.tzinfo is not None:
+        return target
+    name = tz or os.environ.get("PRAISONAI_SCHEDULE_TIMEZONE")
+    if name:
+        return target.replace(tzinfo=resolve_schedule_timezone(name))
+    return target.astimezone()
+
+
 def next_fire_time(
     cron_expr: str,
     base: float,
@@ -77,19 +103,17 @@ def is_due(
         if job.last_run_at is not None:
             return False  # Already ran
         try:
-            target = datetime.fromisoformat(sched.at)
-            if target.tzinfo is None:
-                # A naive ``at`` reflects the user's wall clock (they typed it
-                # from local time), so interpret it in the schedule's timezone:
-                # the explicit tz / PRAISONAI_SCHEDULE_TIMEZONE when set,
-                # otherwise the local zone rather than UTC — a naive string in a
-                # non-UTC zone would otherwise fire an hour (or more) off.
-                tz = sched.tz or default_timezone
-                if tz or os.environ.get("PRAISONAI_SCHEDULE_TIMEZONE"):
-                    tzinfo = resolve_schedule_timezone(tz)
-                else:
-                    tzinfo = datetime.now().astimezone().tzinfo
-                target = target.replace(tzinfo=tzinfo)
+            # ``parse_schedule`` stamps every ``at`` it produces with its zone,
+            # so a string reaching here is normally aware and evaluated as-is.
+            # A naive string (a job stored before zones were stamped, or a
+            # hand-written config.yaml entry) is a legacy wall-clock value:
+            # ``localize_wall_clock`` reads it in the schedule tz, else the
+            # instance default, else PRAISONAI_SCHEDULE_TIMEZONE, else the
+            # runner's local zone -- never UTC by default.
+            target = localize_wall_clock(
+                datetime.fromisoformat(sched.at),
+                sched.tz or default_timezone,
+            )
             # Evaluate against the caller-supplied ``now`` (not wall-clock) so
             # one-shot jobs are deterministic and consistent with every/cron.
             return now >= target.timestamp()

--- a/src/praisonai-agents/praisonaiagents/scheduler/parser.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/parser.py
@@ -13,7 +13,9 @@ Supported formats:
     "*/10s"                   → every 10s
     "3600"                    → every 3600s (raw seconds)
     "cron:0 7 * * *"          → cron expression
-    "at:2026-03-01T09:00:00"  → one-shot ISO timestamp
+    "at:2026-03-01T09:00:00"  → one-shot ISO timestamp (naive = wall clock in
+                                the schedule tz / PRAISONAI_SCHEDULE_TIMEZONE /
+                                the local zone; stored with that zone attached)
     "in 20 minutes"           → one-shot ~20min from now
     "at 9am"                  → one-shot next 09:00
     "every day at 9am"        → daily at 09:00 (cron)
@@ -21,6 +23,7 @@ Supported formats:
     "every monday 9am"        → day-of-week at clock time (cron)
 """
 
+import os
 import re
 from datetime import datetime, timedelta, timezone
 
@@ -146,20 +149,22 @@ def _natural_to_cron(expr: str):
 def _clock_to_next_at(hour: int, minute: int, tz: str | None) -> str:
     """Return the next ISO timestamp for the given clock time (one-shot).
 
-    The clock time denotes local time in the schedule's timezone (``tz`` or
-    the process default), so ``at 9am`` fires at 09:00 in that zone rather
-    than 09:00 UTC. Falls back to UTC when the timezone cannot be resolved.
+    The clock time is a wall-clock reading in the schedule's zone -- the
+    explicit ``tz``, else ``PRAISONAI_SCHEDULE_TIMEZONE``, else the system's
+    local zone -- so ``at 9am`` typed in London fires at 09:00 London time,
+    not 09:00 UTC. The result is always timezone-aware, so ``is_due()`` never
+    has to guess which zone the person meant.
     """
-    try:
-        from .due import resolve_schedule_timezone
-        tzinfo = resolve_schedule_timezone(tz)
-    except Exception:
-        tzinfo = timezone.utc
-    now = datetime.now(tzinfo)
+    from .due import localize_wall_clock, resolve_schedule_timezone
+
+    name = tz or os.environ.get("PRAISONAI_SCHEDULE_TIMEZONE")
+    now = datetime.now(resolve_schedule_timezone(name)) if name else datetime.now()
     target = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
     if target <= now:
         target += timedelta(days=1)
-    return target.isoformat()
+    # Re-localise a naive (local-zone) target so its offset is the one in
+    # force on the target date, not the one in force right now (DST edges).
+    return localize_wall_clock(target, tz).isoformat()
 
 
 def _cron_schedule(cron_expr: str, tz: str | None) -> Schedule:
@@ -206,11 +211,21 @@ def parse_schedule(expr: str, tz: str | None = None) -> Schedule:
             raise ValueError("Empty cron expression after 'cron:' prefix")
         return _cron_schedule(cron_expr, tz)
 
-    # At prefix (ISO timestamp)
+    # At prefix (ISO timestamp). A naive timestamp is the user's wall clock:
+    # stamp it with the schedule tz / PRAISONAI_SCHEDULE_TIMEZONE / local zone
+    # now, so the stored value names an unambiguous instant and is_due() never
+    # has to guess. An explicit offset in the string is kept as written.
     if lower.startswith("at:"):
         at_str = expr[3:].strip()
         if not at_str:
             raise ValueError("Empty timestamp after 'at:' prefix")
+        try:
+            parsed = datetime.fromisoformat(at_str)
+        except ValueError:
+            parsed = None  # unparseable: stored verbatim, is_due() logs it
+        if parsed is not None:
+            from .due import localize_wall_clock
+            at_str = localize_wall_clock(parsed, tz).isoformat()
         return Schedule(kind="at", at=at_str, tz=tz)
 
     # Interval pattern: */30m, */6h, */10s

--- a/src/praisonai-agents/tests/unit/test_schedule_at_wall_clock.py
+++ b/src/praisonai-agents/tests/unit/test_schedule_at_wall_clock.py
@@ -1,0 +1,159 @@
+"""Naive one-shot ``at`` timestamps mean the user's wall clock, not UTC.
+
+Regression for #4691: ``parse_schedule`` used to store ``at:<naive iso>``
+verbatim and ``_clock_to_next_at`` computed ``at 9am`` in UTC, so a person
+in London typing a local time got a job that fired an hour off. The parser
+now stamps every ``at`` it produces with the zone the person meant -- the
+schedule ``tz``, else ``PRAISONAI_SCHEDULE_TIMEZONE``, else the system's
+local zone -- so the stored value is an unambiguous instant and ``is_due()``
+never has to guess.
+
+The system zone is forced with ``TZ`` + ``time.tzset`` so these tests mean
+the same thing on a UTC CI runner as on a developer's laptop. Europe/London
+is the zone from the issue, UTC the control, and Asia/Kolkata (+05:30, no
+DST) the zone that keeps the assertions distinguishable from UTC in winter.
+"""
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from praisonaiagents.scheduler.due import is_due
+from praisonaiagents.scheduler.models import Schedule, ScheduleJob
+from praisonaiagents.scheduler.parser import parse_schedule
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(time, "tzset"), reason="time.tzset() is POSIX-only"
+)
+
+
+@pytest.fixture
+def system_tz(monkeypatch):
+    """Force the process-local zone; unset the scheduler's env default."""
+    monkeypatch.delenv("PRAISONAI_SCHEDULE_TIMEZONE", raising=False)
+    previous = os.environ.get("TZ")
+
+    def _set(name: str) -> None:
+        os.environ["TZ"] = name
+        time.tzset()
+
+    yield _set
+
+    if previous is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = previous
+    time.tzset()
+
+
+def _utc(year, month, day, hour, minute=0):
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def _job(schedule):
+    return ScheduleJob(name="wall-clock", schedule=schedule, message="x")
+
+
+@pytest.mark.parametrize("zone", ["Europe/London", "UTC", "Asia/Kolkata"])
+def test_naive_at_iso_is_due_at_the_local_wall_clock_time(system_tz, zone):
+    """The scenario from the issue: type a local time one minute ahead."""
+    system_tz(zone)
+    local = (datetime.now() + timedelta(minutes=1)).replace(microsecond=0)
+
+    job = _job(parse_schedule(f"at:{local.isoformat()}"))
+
+    # ``local.timestamp()`` is the instant that wall-clock reading denotes
+    # in the forced system zone. Due one second after it, not one before.
+    assert is_due(job, now=local.timestamp() + 1) is True
+    assert is_due(job, now=local.timestamp() - 1) is False
+
+
+@pytest.mark.parametrize("zone", ["Europe/London", "UTC", "Asia/Kolkata"])
+def test_naive_at_iso_is_stored_aware_in_the_local_zone(system_tz, zone):
+    """The stored string names an instant; nothing downstream has to guess."""
+    system_tz(zone)
+    local = (datetime.now() + timedelta(minutes=1)).replace(microsecond=0)
+
+    stored = datetime.fromisoformat(parse_schedule(f"at:{local.isoformat()}").at)
+
+    assert stored.tzinfo is not None
+    assert stored.replace(tzinfo=None) == local  # wall-clock reading kept
+    assert stored.timestamp() == local.timestamp()  # ...in the local zone
+
+
+def test_naive_at_iso_uses_the_offset_in_force_on_that_date(system_tz):
+    """London is +01:00 in summer and +00:00 in winter; each date gets its own."""
+    system_tz("Europe/London")
+
+    summer = datetime.fromisoformat(parse_schedule("at:2026-07-01T09:00:00").at)
+    winter = datetime.fromisoformat(parse_schedule("at:2026-12-01T09:00:00").at)
+
+    assert summer == _utc(2026, 7, 1, 8)
+    assert winter == _utc(2026, 12, 1, 9)
+
+
+def test_explicit_schedule_tz_beats_the_system_zone(system_tz):
+    system_tz("Europe/London")
+
+    stored = datetime.fromisoformat(
+        parse_schedule("at:2026-07-01T09:00:00", tz="America/New_York").at
+    )
+
+    assert stored == _utc(2026, 7, 1, 13)
+
+
+def test_env_default_beats_the_system_zone(system_tz, monkeypatch):
+    system_tz("Europe/London")
+    monkeypatch.setenv("PRAISONAI_SCHEDULE_TIMEZONE", "Asia/Singapore")
+
+    stored = datetime.fromisoformat(parse_schedule("at:2026-07-01T09:00:00").at)
+
+    assert stored == _utc(2026, 7, 1, 1)
+
+
+def test_explicit_offset_in_the_string_is_kept_verbatim(system_tz):
+    system_tz("Europe/London")
+
+    s = parse_schedule("at:2026-07-01T09:00:00+02:00", tz="America/New_York")
+
+    assert s.at == "2026-07-01T09:00:00+02:00"
+    assert datetime.fromisoformat(s.at) == _utc(2026, 7, 1, 7)
+
+
+# Asia/Kolkata is +05:30 all year: London coincides with UTC in winter, so a
+# UTC-stamping regression would go unnoticed there for half the year.
+@pytest.mark.parametrize("zone", ["Europe/London", "Asia/Kolkata"])
+def test_bare_clock_time_means_the_local_wall_clock(system_tz, zone):
+    """``at 9am`` typed in London is 09:00 London, not 09:00 UTC."""
+    system_tz(zone)
+
+    stored = datetime.fromisoformat(parse_schedule("at 9am").at)
+
+    assert stored.tzinfo is not None
+    local = stored.astimezone(ZoneInfo(zone))
+    assert (local.hour, local.minute) == (9, 0)
+    # And it is the *next* 09:00 in that zone, within the coming day.
+    now = datetime.now(ZoneInfo(zone))
+    assert now < stored <= now + timedelta(days=1)
+
+
+def test_legacy_naive_stored_string_is_read_as_the_local_wall_clock(system_tz):
+    """A job stored before zones were stamped is still read as local time.
+
+    Documents the fallback ``is_due()`` applies to a naive string that did
+    not come through the parser (an old job file, a hand-written
+    config.yaml): the schedule tz, else the instance default, else
+    PRAISONAI_SCHEDULE_TIMEZONE, else the runner's local zone -- with the
+    offset in force on that date.
+    """
+    system_tz("Europe/London")
+    summer = _job(Schedule(kind="at", at="2026-07-01T09:00:00"))
+    winter = _job(Schedule(kind="at", at="2026-12-01T09:00:00"))
+
+    assert is_due(summer, _utc(2026, 7, 1, 7, 59).timestamp()) is False
+    assert is_due(summer, _utc(2026, 7, 1, 8).timestamp()) is True
+    assert is_due(winter, _utc(2026, 12, 1, 8, 59).timestamp()) is False
+    assert is_due(winter, _utc(2026, 12, 1, 9).timestamp()) is True

--- a/src/praisonai-agents/tests/unit/test_schedule_tools.py
+++ b/src/praisonai-agents/tests/unit/test_schedule_tools.py
@@ -200,11 +200,20 @@ class TestScheduleParser:
         assert s.kind == "cron"
         assert s.cron_expr == "0 7 * * *"
 
-    def test_parse_at_iso(self):
+    def test_parse_at_iso(self, monkeypatch):
+        from datetime import datetime
         from praisonaiagents.scheduler.parser import parse_schedule
+        monkeypatch.delenv("PRAISONAI_SCHEDULE_TIMEZONE", raising=False)
         s = parse_schedule("at:2026-03-01T09:00:00")
         assert s.kind == "at"
-        assert s.at == "2026-03-01T09:00:00"
+        # A naive timestamp is the user's wall clock; the parser keeps the
+        # wall-clock reading and attaches the zone it was typed in, so the
+        # stored value is an unambiguous instant rather than a guess for
+        # is_due() to make later.
+        stored = datetime.fromisoformat(s.at)
+        assert stored.tzinfo is not None
+        assert stored.replace(tzinfo=None) == datetime(2026, 3, 1, 9, 0, 0)
+        assert stored == datetime(2026, 3, 1, 9, 0, 0).astimezone()
 
     def test_parse_numeric_seconds(self):
         from praisonaiagents.scheduler.parser import parse_schedule


### PR DESCRIPTION
## Defect

`parse_schedule` stored a naive `at:<iso>` string verbatim, and `_clock_to_next_at` computed `at 9am` in UTC because `resolve_schedule_timezone(None)` defaults to UTC. The stored value therefore did not say which zone it was in, and `is_due()` had to guess at fire time. Outside UTC the guess was wrong by the local offset, so one-shot jobs fired an hour (or more) off, and `test_update_cadence_resets_last_run` failed on any non-UTC machine.

#4705 closed the issue by changing the guess inside `is_due()` to prefer the local zone. That leaves the stored value ambiguous -- a job added on one machine and fired by a runner with a different `TZ` or `PRAISONAI_SCHEDULE_TIMEZONE` still moves -- and its local branch used the offset in force *now* (`replace(tzinfo=datetime.now().astimezone().tzinfo)`), which is an hour wrong for any date on the other side of a DST change.

## Fix

The zone is attached where the intent is known: at parse time.

- `parse_schedule("at:<naive iso>")` and the `at 9am` clock form now store a timezone-aware ISO string, localised in this order: the schedule's explicit `tz`, else `PRAISONAI_SCHEDULE_TIMEZONE`, else the system's local zone. An explicit offset in the input is kept as written. Unparseable strings are still stored verbatim so `is_due()` keeps logging them as before.
- The rule lives in one new helper, `praisonaiagents.scheduler.due.localize_wall_clock()`. Its local branch uses `datetime.astimezone()` on the naive value, so the offset is the one in force **on that date** (DST-correct), not today's.
- `is_due()` uses the same helper as its tolerant fallback for naive strings that did not come through the parser (jobs stored before this change, hand-written `config.yaml` entries, `Schedule(...)` built directly). The assumed zone is documented at the call site: schedule `tz`, else the store's instance default, else `PRAISONAI_SCHEDULE_TIMEZONE`, else the runner's local zone -- never UTC by default.

### Migration story (what happens to existing stored jobs)

- Jobs stored **before #4705** were being read as UTC; #4705 already moved them to the local-zone reading. This PR keeps that reading and does not move them again. The only difference is the DST correction: a legacy naive `at` on a date in the other DST half of the year is now read at the correct wall-clock time instead of one hour off.
- Jobs stored **after this PR** carry an explicit offset, so they no longer depend on the runner's environment at fire time. Adding or updating a job re-parses and re-stamps it.
- `in N minutes` was already stored aware (UTC instant) and is unchanged.
- Loud-failure change: an invalid `PRAISONAI_SCHEDULE_TIMEZONE` now raises `ValueError` from `parse_schedule` for `at:`/clock forms instead of being accepted and silently never firing. Explicit bad `tz` already raised.

## Tests

New file `tests/unit/test_schedule_at_wall_clock.py` (13 cases) forces the process zone with `TZ` + `time.tzset()` and clears `PRAISONAI_SCHEDULE_TIMEZONE`. Zones: **Europe/London** (the issue), **UTC** (control), **Asia/Kolkata** (+05:30, no DST -- keeps the assertions distinguishable from UTC in winter, when London *is* UTC). Covers: the issue's exact scenario (`at:<local iso 1 min ahead>` is due at `timestamp()+1`, not at `-1`), the stored string is aware and denotes the same instant, per-date DST offsets (July +01:00 / December +00:00 in London), explicit `tz` beats system zone, env default beats system zone, explicit offset kept verbatim, `at 9am` is 09:00 in the local zone, and the legacy naive-string fallback in `is_due()`.

`test_parse_at_iso` in `tests/unit/test_schedule_tools.py` pinned the old naive storage and is updated to assert the aware form with the wall-clock reading preserved.

The originally failing `test_update_cadence_resets_last_run` passes under `TZ=Europe/London` and `TZ=UTC`.

### Mutation table

| # | Mutant | Result |
|---|--------|--------|
| M1 | parser `at:` branch stamps `+00:00` instead of the resolved zone | **killed** -- 8 failures (London and Kolkata cases, `test_update_cadence_resets_last_run`) |
| M2 | parser `at:` branch stores the naive string verbatim (pre-fix; `is_due` fallback intact) | **killed** -- 7 failures (stored-aware assertions, `test_parse_at_iso`) |
| M3 | `_clock_to_next_at` back to UTC default | **killed** -- 2 failures (`test_bare_clock_time_means_the_local_wall_clock` London and Kolkata) |
| M4 | local branch uses today's offset (`replace(tzinfo=now-offset)`, the #4705 approach) | **killed** -- 3 failures (per-date DST test, legacy fallback test, `test_parse_at_iso`) |
| M5 | `localize_wall_clock` defaults naive to UTC | **killed** -- 9 failures |

### Regression

`TZ=Europe/London`, `TZ=UTC` and `TZ=Asia/Kolkata` runs of `tests/unit/test_schedule_*.py`, `test_scheduler_provider.py` and the heartbeat tests: 234 passed, 1 skipped (network) per zone (213 for the smaller Kolkata set).

`ruff check` on the changed files reports only the pre-existing unused `croniter` import probe in `due.py` (present on `main`, not touched).

Closes #4691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
