### PR TITLE
fix(agent): fire the 'tool_call' display callback from the streaming paths

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -107,7 +107,19 @@ class ChatMixin:
 
         Best-effort by design: a callback failure is logged and swallowed so
         it can never break the stream it is reporting on.
+
+        A durable run converts a raising tool into an ``{"error": ...}`` result
+        instead of re-raising (see ``DurableRunContext.wrap_sync``), so the
+        raising-tool ``except`` branch never fires for it. Detect that shape
+        here and report ``success=False`` so streaming UIs do not label a failed
+        tool as successful (Issue #4735 review).
         """
+        if (
+            success
+            and isinstance(tool_result, dict)
+            and tool_result.get("error") is not None
+        ):
+            success = False
         try:
             if tool_result is None:
                 result_str = None

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -95,6 +95,39 @@ class ChatMixin:
             return _TurnCancelToken(source)
         return _TurnCancelToken(source, turn_id=begin_turn())
 
+    @staticmethod
+    def _notify_tool_call(tool_name, tool_input, tool_result, elapsed_time=None, success=True):
+        """Fire the ``tool_call`` display callback for one tool execution.
+
+        The non-streaming path fires this from the OpenAI client after every
+        tool (``display_tool_call`` -> ``execute_sync_callback('tool_call')``),
+        which is how streaming UIs such as the desktop learn that a tool ran.
+        The streaming path executes tools inline here, so it has to fire the
+        same callback itself with the same kwargs (Issue #4716).
+
+        Best-effort by design: a callback failure is logged and swallowed so
+        it can never break the stream it is reporting on.
+        """
+        try:
+            if tool_result is None:
+                result_str = None
+            else:
+                try:
+                    result_str = json.dumps(tool_result)
+                except (TypeError, ValueError):
+                    result_str = str(tool_result)
+            _get_display_functions()['execute_sync_callback'](
+                'tool_call',
+                message=f"Calling function: {tool_name}",
+                tool_name=tool_name,
+                tool_input=tool_input,
+                tool_output=result_str[:200] if result_str else None,
+                elapsed_time=elapsed_time,
+                success=success,
+            )
+        except Exception as callback_error:
+            logging.debug(f"tool_call callback failed for '{tool_name}': {callback_error}")
+
     def _durable_sync_tool_executor(self, execute_tool_fn):
         """Wrap tool execution only while an opt-in durable run is active."""
         context = self._get_durable_run_context()
@@ -5156,11 +5189,34 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                         )
                                         else {}
                                     )
-                                    tool_result = executor(
+                                    _tool_started = time_module.perf_counter()
+                                    try:
+                                        tool_result = executor(
+                                            tool_call['function']['name'],
+                                            parsed_args,
+                                            tool_call_id=tool_call.get('id'),
+                                            **iteration_kwargs,
+                                        )
+                                    except Exception as _exec_error:
+                                        # Streaming UIs only learn about tool
+                                        # activity through this callback; report
+                                        # the failure before re-raising.
+                                        self._notify_tool_call(
+                                            tool_call['function']['name'],
+                                            parsed_args,
+                                            {"error": str(_exec_error)},
+                                            elapsed_time=time_module.perf_counter() - _tool_started,
+                                            success=False,
+                                        )
+                                        raise
+                                    # Parity with the non-streaming path, which
+                                    # fires 'tool_call' after every tool run.
+                                    self._notify_tool_call(
                                         tool_call['function']['name'],
                                         parsed_args,
-                                        tool_call_id=tool_call.get('id'),
-                                        **iteration_kwargs,
+                                        tool_result,
+                                        elapsed_time=time_module.perf_counter() - _tool_started,
+                                        success=True,
                                     )
                                     # Add tool result to chat history (multimodal-aware)
                                     from .tool_execution import build_tool_result_message_pair

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -4423,15 +4423,46 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         
                         # Execute batch and add results to conversation
                         # (forward optional per-tool timeout)
+                        # ``time`` is re-imported locally further down this
+                        # function, which makes the module-level name unbound
+                        # here; use a distinct alias.
+                        from time import perf_counter as _perf_counter
+                        _batch_started = _perf_counter()
                         tool_results = executor.execute_batch(
                             tool_calls_batch, execute_tool_fn,
                             timeout_ms=self.tool_timeout_ms,
                         )
+                        _batch_elapsed = _perf_counter() - _batch_started
                         
                         for tool_result in tool_results:
                             # Register any deferred handle so its eventual
                             # background result is re-injected, not lost.
                             self._register_deferred_if_any(tool_result)
+                            # Fire the 'tool_call' display callback exactly as
+                            # the non-streaming loop does, so streaming UIs
+                            # see tool activity (Issue #4716). Best-effort: a
+                            # callback error must never break the stream.
+                            try:
+                                if tool_result.result is None:
+                                    _result_str = None
+                                else:
+                                    try:
+                                        _result_str = json.dumps(tool_result.result)
+                                    except (TypeError, ValueError):
+                                        _result_str = str(tool_result.result)
+                                _get_display_functions()['execute_sync_callback'](
+                                    'tool_call',
+                                    message=f"Calling function: {tool_result.function_name}",
+                                    tool_name=tool_result.function_name,
+                                    tool_input=tool_result.arguments,
+                                    tool_output=_result_str[:200] if _result_str else None,
+                                    # Only the batch is timed; per-tool timing
+                                    # is not available from the executor.
+                                    elapsed_time=_batch_elapsed if len(tool_results) == 1 else None,
+                                    success=tool_result.error is None,
+                                )
+                            except Exception as _cb_error:
+                                logging.debug(f"tool_call callback failed for '{tool_result.function_name}': {_cb_error}")
                             if tool_result.error is None:
                                 # Successful execution
                                 tool_message = self._create_tool_message(

--- a/src/praisonai-agents/tests/unit/streaming/test_stream_tool_callback.py
+++ b/src/praisonai-agents/tests/unit/streaming/test_stream_tool_callback.py
@@ -1,0 +1,307 @@
+"""The streaming chat path must fire the ``tool_call`` display callback.
+
+Regression coverage for Issue #4716. The non-streaming path fires
+``execute_sync_callback('tool_call', ...)`` from the OpenAI client after every
+tool run; the streaming path executed its accumulated tool calls inline and
+never told anyone, so streaming UIs (the desktop) saw no tool activity.
+"""
+
+import types
+
+import pytest
+
+import praisonaiagents.main as main_module
+from praisonaiagents import Agent
+from praisonaiagents.llm.openai_client import OpenAIClient
+from praisonaiagents.main import register_display_callback
+
+
+@pytest.fixture
+def tool_call_events():
+    """Register a ``tool_call`` callback for the test and restore the old one after."""
+    events = []
+
+    def on_tool_call(**kwargs):
+        events.append(kwargs)
+
+    with main_module._callbacks_lock:
+        previous = main_module.sync_display_callbacks.get('tool_call')
+    register_display_callback('tool_call', on_tool_call)
+    try:
+        yield events
+    finally:
+        with main_module._callbacks_lock:
+            if previous is None:
+                main_module.sync_display_callbacks.pop('tool_call', None)
+            else:
+                main_module.sync_display_callbacks['tool_call'] = previous
+
+
+# --- fake streamed transport ------------------------------------------------
+
+def _chunk(content=None, tool_calls=None, finish_reason=None):
+    delta = types.SimpleNamespace(content=content, tool_calls=tool_calls)
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(delta=delta, finish_reason=finish_reason, index=0)]
+    )
+
+
+def _tool_call_delta(index, call_id, name, arguments):
+    return types.SimpleNamespace(
+        index=index,
+        id=call_id,
+        type="function",
+        function=types.SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+class _StreamRecorder:
+    """Scripted ``chat.completions.create``: each call returns the next stream."""
+
+    def __init__(self, streams):
+        self.streams = list(streams)
+        self.requests = []
+
+    def create(self, **kwargs):
+        self.requests.append(kwargs)
+        i = len(self.requests) - 1
+        if i >= len(self.streams):
+            return iter([_chunk(content="fallback", finish_reason="stop")])
+        return iter(self.streams[i])
+
+
+def _streaming_agent(tool, streams):
+    agent = Agent(name="A", instructions="x", llm="gpt-4o-mini", tools=[tool])
+    rec = _StreamRecorder(streams)
+    client = OpenAIClient(api_key="sk-not-a-real-key")
+    client._sync_client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=rec),
+        beta=types.SimpleNamespace(chat=types.SimpleNamespace(completions=rec)),
+        responses=None,
+    )
+    agent._Agent__openai_client = client
+    agent._unified_dispatcher = None
+    return agent, rec
+
+
+def _tool_round_then_answer(name, arguments_json):
+    """First stream requests tool ``name``; second stream is the answer."""
+    return [
+        [
+            _chunk(tool_calls=[_tool_call_delta(0, "call_1", name, "")]),
+            _chunk(tool_calls=[_tool_call_delta(0, None, None, arguments_json)]),
+            _chunk(finish_reason="tool_calls"),
+        ],
+        [
+            _chunk(content="The answer "),
+            _chunk(content="is 42."),
+            _chunk(finish_reason="stop"),
+        ],
+    ]
+
+
+# --- OpenAI streaming path (chat_mixin) ------------------------------------
+
+def test_stream_fires_tool_call_callback_once_per_tool(tool_call_events):
+    calls = []
+
+    def f(x: int) -> int:
+        """Double a number."""
+        calls.append(x)
+        return x * 2
+
+    agent, rec = _streaming_agent(f, _tool_round_then_answer("f", '{"x": 21}'))
+
+    text = "".join(agent.start("double 21", stream=True))
+
+    assert calls == [21], "the tool itself must still run exactly once"
+    assert text == "The answer is 42."
+    assert len(rec.requests) == 2, "tool round then follow-up answer"
+
+    assert len(tool_call_events) == 1, tool_call_events
+    event = tool_call_events[0]
+    assert event["tool_name"] == "f"
+    assert event["tool_input"] == {"x": 21}
+    assert "42" in event["tool_output"]
+    assert event["success"] is True
+    assert isinstance(event["elapsed_time"], float)
+    assert event["message"] == "Calling function: f"
+
+
+def test_stream_fires_callback_for_each_parallel_tool_call(tool_call_events):
+    def f(x: int) -> int:
+        """Double a number."""
+        return x * 2
+
+    def g(y: str) -> str:
+        """Shout a word."""
+        return y.upper()
+
+    streams = [
+        [
+            _chunk(tool_calls=[_tool_call_delta(0, "call_1", "f", '{"x": 1}')]),
+            _chunk(tool_calls=[_tool_call_delta(1, "call_2", "g", '{"y": "hi"}')]),
+            _chunk(finish_reason="tool_calls"),
+        ],
+        [_chunk(content="done"), _chunk(finish_reason="stop")],
+    ]
+    agent = Agent(name="A", instructions="x", llm="gpt-4o-mini", tools=[f, g])
+    rec = _StreamRecorder(streams)
+    client = OpenAIClient(api_key="sk-not-a-real-key")
+    client._sync_client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=rec),
+        beta=types.SimpleNamespace(chat=types.SimpleNamespace(completions=rec)),
+        responses=None,
+    )
+    agent._Agent__openai_client = client
+    agent._unified_dispatcher = None
+
+    assert "".join(agent.start("go", stream=True)) == "done"
+
+    assert [(e["tool_name"], e["tool_input"]) for e in tool_call_events] == [
+        ("f", {"x": 1}),
+        ("g", {"y": "hi"}),
+    ]
+
+
+def test_stream_survives_a_raising_tool_call_callback():
+    """The callback is best-effort: its exception must never break the stream."""
+    events = []
+
+    def exploding(**kwargs):
+        events.append(kwargs)
+        raise RuntimeError("UI is gone")
+
+    with main_module._callbacks_lock:
+        previous = main_module.sync_display_callbacks.get('tool_call')
+    register_display_callback('tool_call', exploding)
+    try:
+        def f(x: int) -> int:
+            """Double a number."""
+            return x * 2
+
+        agent, rec = _streaming_agent(f, _tool_round_then_answer("f", '{"x": 21}'))
+        text = "".join(agent.start("double 21", stream=True))
+    finally:
+        with main_module._callbacks_lock:
+            if previous is None:
+                main_module.sync_display_callbacks.pop('tool_call', None)
+            else:
+                main_module.sync_display_callbacks['tool_call'] = previous
+
+    assert len(events) == 1 and events[0]["tool_name"] == "f"
+    assert text == "The answer is 42."
+    assert len(rec.requests) == 2, "the follow-up answer still happened"
+    # The callback failure must not be mistaken for a tool failure either:
+    # the real tool result, not the callback's error, reaches the model.
+    tool_turns = [m for m in agent.chat_history if m.get("role") == "tool"]
+    assert len(tool_turns) == 1
+    assert tool_turns[0]["content"] == "42"
+    assert "UI is gone" not in tool_turns[0]["content"]
+    followup_tool_turns = [m for m in rec.requests[1]["messages"] if m.get("role") == "tool"]
+    assert [m["content"] for m in followup_tool_turns] == ["42"]
+
+
+# --- custom-LLM streaming path (LLM.get_response_stream) ---------------------
+
+def _custom_llm_with_tool_round():
+    """Bare ``LLM`` whose stream requests tool ``f`` then answers non-streamed."""
+    from praisonaiagents.llm.llm import LLM
+
+    llm = LLM.__new__(LLM)
+    llm.model = "gpt-4o"
+    llm.tool_timeout_ms = None
+    llm._build_messages = lambda **kwargs: ([{"role": "user", "content": kwargs["prompt"]}], kwargs["prompt"])
+    llm._format_tools_for_litellm = lambda tools: [{"type": "function", "function": {"name": "f"}}]
+    llm._supports_streaming_tools = lambda: True
+    llm._build_completion_params = lambda **kwargs: kwargs
+    llm._is_ollama_provider = lambda: False
+    llm._register_deferred_if_any = lambda result: None
+    # ``LLM._create_tool_message`` does not exist on main (the existing
+    # dispatch test stubs it too); without it the tool round falls back to
+    # non-streaming and this test would pass through the wrong path.
+    llm._create_tool_message = lambda name, result, call_id, is_ollama: {
+        "role": "tool", "tool_call_id": call_id, "content": str(result),
+    }
+
+    completion_calls = []
+
+    def completion(**kwargs):
+        completion_calls.append(kwargs)
+        if kwargs["stream"]:
+            return iter([
+                _chunk(tool_calls=[_tool_call_delta(0, "call_1", "f", "")]),
+                _chunk(tool_calls=[_tool_call_delta(0, None, None, '{"x": 21}')]),
+                _chunk(finish_reason="tool_calls"),
+            ])
+        message = types.SimpleNamespace(content="final answer", tool_calls=None)
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=message, finish_reason="stop")])
+
+    llm._completion_with_retry = completion
+
+    executed = []
+
+    def execute_tool_fn(function_name, arguments, tool_call_id=None, **_):
+        executed.append((function_name, arguments))
+        return arguments["x"] * 2
+
+    def run():
+        return list(llm.get_response_stream(
+            "double 21", tools=[lambda: None], execute_tool_fn=execute_tool_fn,
+        ))
+
+    return run, completion_calls, executed
+
+
+def test_get_response_stream_fires_tool_call_callback(tool_call_events):
+    run, completion_calls, executed = _custom_llm_with_tool_round()
+
+    chunks = run()
+
+    assert executed == [("f", {"x": 21})]
+    assert "".join(chunks) == "final answer"
+    # Streamed tool round, then the non-streaming follow-up that carries the
+    # tool result -- not the "streaming failed" fallback, which carries none.
+    assert [c["stream"] for c in completion_calls] == [True, False]
+    assert completion_calls[1]["messages"][-1] == {
+        "role": "tool", "tool_call_id": "call_1", "content": "42",
+    }
+
+    assert len(tool_call_events) == 1, tool_call_events
+    event = tool_call_events[0]
+    assert event["tool_name"] == "f"
+    assert event["tool_input"] == {"x": 21}
+    assert event["tool_output"] == "42"
+    assert event["success"] is True
+
+
+def test_get_response_stream_survives_a_raising_tool_call_callback():
+    """Best-effort on the custom-LLM path too: a raising callback must not
+    knock the stream into the 'streaming failed' fallback."""
+    events = []
+
+    def exploding(**kwargs):
+        events.append(kwargs)
+        raise RuntimeError("UI is gone")
+
+    with main_module._callbacks_lock:
+        previous = main_module.sync_display_callbacks.get('tool_call')
+    register_display_callback('tool_call', exploding)
+    try:
+        run, completion_calls, executed = _custom_llm_with_tool_round()
+        chunks = run()
+    finally:
+        with main_module._callbacks_lock:
+            if previous is None:
+                main_module.sync_display_callbacks.pop('tool_call', None)
+            else:
+                main_module.sync_display_callbacks['tool_call'] = previous
+
+    assert len(events) == 1 and events[0]["tool_name"] == "f"
+    assert executed == [("f", {"x": 21})]
+    assert "".join(chunks) == "final answer"
+    # The follow-up (not the fallback) ran: its last message is the tool result.
+    assert [c["stream"] for c in completion_calls] == [True, False]
+    assert completion_calls[1]["messages"][-1] == {
+        "role": "tool", "tool_call_id": "call_1", "content": "42",
+    }

--- a/src/praisonai-agents/tests/unit/streaming/test_stream_tool_callback.py
+++ b/src/praisonai-agents/tests/unit/streaming/test_stream_tool_callback.py
@@ -202,6 +202,27 @@ def test_stream_survives_a_raising_tool_call_callback():
     assert [m["content"] for m in followup_tool_turns] == ["42"]
 
 
+def test_notify_tool_call_reports_error_result_as_failure(tool_call_events):
+    """A durable run returns a raising tool as ``{"error": ...}`` instead of
+    re-raising, so the inline success branch would otherwise mislabel it.
+    ``_notify_tool_call`` must downgrade an error-shaped result to
+    ``success=False`` (Issue #4735 review)."""
+    from praisonaiagents.agent.chat_mixin import ChatMixin
+
+    ChatMixin._notify_tool_call(
+        "f",
+        {"x": 21},
+        {"error": "boom"},
+        elapsed_time=0.01,
+        success=True,
+    )
+
+    assert len(tool_call_events) == 1, tool_call_events
+    event = tool_call_events[0]
+    assert event["tool_name"] == "f"
+    assert event["success"] is False
+
+
 # --- custom-LLM streaming path (LLM.get_response_stream) ---------------------
 
 def _custom_llm_with_tool_round():

--- a/src/praisonai-ts/SIGNATURE_PARITY.md
+++ b/src/praisonai-ts/SIGNATURE_PARITY.md
@@ -205,7 +205,7 @@ TS-only members: `previousResult`?, `onToken`?, `signal`?, `onEvent`?
 
 ### `Agent.chat`
 
-- Python: `src/praisonai-agents/praisonaiagents/agent/chat_mixin.py:3056`
+- Python: `src/praisonai-agents/praisonaiagents/agent/chat_mixin.py:3089`
 - TypeScript: `src/praisonai-ts/src/agent/simple.ts:1310`
 - Counts: 17 python params: 1 exact, 0 camelCase, 1 alias, 0 flattened, 15 missing; 0 mismatches; 15 waived; 1 TS-only of 3
 

--- a/src/praisonai-ts/signature-parity.json
+++ b/src/praisonai-ts/signature-parity.json
@@ -1402,7 +1402,7 @@
         }
       ],
       "python": {
-        "location": "src/praisonai-agents/praisonaiagents/agent/chat_mixin.py:3056",
+        "location": "src/praisonai-agents/praisonaiagents/agent/chat_mixin.py:3089",
         "resolved_class": "ChatMixin"
       },
       "ts_only": [


### PR DESCRIPTION
## Defect

Streaming UIs (the desktop) learn that a tool ran only through the `tool_call` display callback registered with `praisonaiagents.main.register_display_callback`. The **non-streaming** path fires it from `openai_client.py` after every tool (`display_tool_call(...)` -> `execute_sync_callback('tool_call', ...)`). The **streaming** path never did:

- `ChatMixin` (`chat_mixin.py`, the `tool_calls_data` loop) executes accumulated tool calls inline through `_durable_sync_tool_executor` and fires nothing.
- `LLM.get_response_stream` (`llm.py`) executes its batch and fires only `llm_content`.

So with `stream=True` a tool could run, its result reach the model, and the UI show no tool activity at all.

## Fix

Both streaming executors now fire the same callback with the same kwargs the non-stream path passes (`message`, `tool_name`, `tool_input`, `tool_output`, `elapsed_time`, `success`), including the failure case before a tool error is re-raised.

The call is best-effort: a raising callback is logged at debug level and swallowed, so it can neither break the stream nor be mistaken for a tool failure. (Without the guard, the inline executor's `except Exception` would have replaced the real tool result in chat history with the callback's error text -- one of the mutations below caught exactly that.)

In `get_response_stream` the module-level `time` is unbound at the tool round because the function re-imports `time` locally further down, so the timing uses a distinct alias.

## Test

`tests/unit/streaming/test_stream_tool_callback.py` (5 tests) drives `Agent.start(..., stream=True)` through a scripted streamed transport (first stream requests tool `f`, second answers) and `LLM.get_response_stream` through a scripted `_completion_with_retry`. They assert the callback fired exactly once per tool with `tool_name == 'f'`, the parsed input, the output, `success`, and that the real tool result (not a callback error) reaches the follow-up request.

```
.venv/bin/python -m pytest tests/unit/streaming/test_stream_tool_callback.py -q
```

## Mutations

| # | Mutation | Result |
|---|----------|--------|
| 1 | Revert the `chat_mixin.py` change (inline executor fires no callback) | killed (3 tests red) |
| 2 | Revert the `llm.py` change (`get_response_stream` fires no callback) | killed (2 tests red) |
| 3 | Keep the callback but drop its try/except guard in `chat_mixin.py` | killed (1 test red: callback error replaced the tool result) |
| 4 | Keep the callback but drop its try/except guard in `llm.py` | killed (1 test red: stream fell into the non-streaming fallback) |

Mutations 3 and 4 initially survived; the tests were tightened (assert on the tool turn that reaches the follow-up request) until they bit.

## Regressions

`tests/unit/streaming`, `tests/unit/llm/test_stream_tool_dispatch.py`, `tests/unit/agent/test_tool_failure_not_relabelled.py`, `tests/unit/test_stream_preset.py`, `tests/unit/test_streaming_events.py`, `tests/unit/test_streaming_integration.py`, `tests/unit/agent/test_durable_run.py`, `tests/unit/agent/test_empty_response_is_not_object_repr.py`, `tests/unit/config/test_parallel_tool_calls_single_source.py`, `tests/unit/agent/test_execution_api.py`, `tests/unit/test_placement.py`: 247 passed, 2 failed -- the two `TestShellStreaming` tests already red on main (#4724).

## Found, not fixed

`LLM._create_tool_message` does not exist anywhere in the package, yet `get_response_stream` calls it after every tool in the streaming round (the existing `test_stream_tool_dispatch.py` stubs it, which is why it never showed). On a real custom-LLM stream with tools, the round raises `AttributeError`, is caught as "Streaming failed with unexpected error", and falls back to a non-streaming request whose messages already carry the assistant `tool_calls` turn but no tool results. Out of scope for #4716; the new test stubs it the same way the existing one does and notes why.

Closes #4716

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming tool executions now emit activity callbacks with tool names, results, duration, and success status.
  * Tool callbacks are reported consistently for parallel and custom streaming executions.

* **Bug Fixes**
  * Callback errors no longer interrupt streaming responses.
  * Error-containing tool results are correctly reported as failures.
  * Tool results and failures are surfaced reliably during streaming.

* **Tests**
  * Added coverage for callback payloads, parallel tools, callback failures, error results, and follow-up responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->