### PR TITLE
fix(code): make the lazy-command table the real source of resident command paths

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/app.py
+++ b/src/praisonai-code/praisonai_code/cli/app.py
@@ -157,18 +157,18 @@ _LAZY_COMMANDS: Dict[str, Tuple[str, str, str]] = {
     "diag": (".commands.diag", "app", "Diagnostics export"),
     "doctor": (".commands.doctor", "app", "Health checks and diagnostics"),
     "setup": (".commands.setup", "app", "Interactive onboarding / configuration wizard"),
-    "onboard": (".commands.onboard", "app", "Messaging bot onboarding wizard"),
+    "onboard": ("praisonai_bot.cli.commands.onboard", "app", "Messaging bot onboarding wizard"),
     "obs": (".commands.obs", "app", "Observability diagnostics and management"),
-    "validate": (".commands.validate", "app", "Validate YAML configuration files"),
+    "validate": ("praisonai.cli.commands.validate", "app", "Validate YAML configuration files"),
     "acp": (".commands.acp", "app", "Agent Client Protocol server"),
-    "mcp": (".commands.mcp", "app", "MCP server management"),
+    "mcp": ("praisonai_mcp.cli.commands.mcp", "app", "MCP server management"),
     "serve": (".commands.serve", "app", "API server management"),
     "daemon": (".commands.daemon", "app", "Warm local runtime (keeps MCP/provider clients hot)"),
     "attach": (".commands.attach", "app", "Attach to a live session on the warm runtime"),
-    "schedule": (".commands.schedule", "app", "Scheduler management"),
+    "schedule": ("praisonai.cli.commands.schedule", "app", "Scheduler management"),
     "run": (".commands.run", "app", "Run agents"),
     "checkpoint": (".commands.checkpoint", "app", "File-level checkpoint management (save/restore/diff)"),
-    "profile": (".commands.profile", "app", "Performance profiling and diagnostics"),
+    "profile": ("praisonai.cli.commands.profile", "app", "Performance profiling and diagnostics"),
     "benchmark": (".commands.benchmark", "app", "Comprehensive performance benchmarking"),
     "paths": (".commands.paths", "app", "Storage path inspection and migration"),
     
@@ -176,26 +176,26 @@ _LAZY_COMMANDS: Dict[str, Tuple[str, str, str]] = {
     "chat": (".commands.chat", "app", "Terminal-native interactive chat (REPL)"),
     "code": (".commands.code", "app", "Terminal-native code assistant"),
     "call": (".commands.call", "app", "Voice/call interaction mode"),
-    "realtime": (".commands.realtime", "app", "Realtime interaction mode"),
-    "train": (".commands.train", "app", "Model training and fine-tuning"),
+    "realtime": ("praisonai.cli.commands.realtime", "app", "Realtime interaction mode"),
+    "train": ("praisonai_train.cli.commands.train", "app", "Model training and fine-tuning"),
     "ui": (".commands.ui", "app", "Clean Chat UI (praisonaiui)"),
-    "context": (".commands.context", "app", "Context management"),
+    "context": ("praisonai.cli.commands.context", "app", "Context management"),
     "research": (".commands.research", "app", "Research and analysis"),
     "memory": (".commands.memory", "app", "Memory management"),
     "workflow": (".commands.workflow", "app", "Workflow management"),
     "tools": (".commands.tools", "app", "Tool management"),
-    "n8n": (".commands.n8n", "app", "n8n visual workflow editor integration"),
-    "knowledge": (".commands.knowledge", "app", "Knowledge base management (legacy)"),
-    "rag": (".commands.rag", "app", "RAG commands (legacy - use index/query instead)"),
+    "n8n": ("praisonai.cli.commands.n8n", "app", "n8n visual workflow editor integration"),
+    "knowledge": ("praisonai.cli.commands.knowledge", "app", "Knowledge base management (legacy)"),
+    "rag": ("praisonai.cli.commands.rag", "app", "RAG commands (legacy - use index/query instead)"),
     "agents": (".commands.agents", "app", "Agent management"),
     "agent": (".commands.agent", "app", "Custom agent definitions management"),
     "command": (".commands.command", "app", "Custom command definitions management"),
     "skills": (".commands.skills", "app", "Skill management"),
     "eval": (".commands.eval", "app", "Evaluation and testing"),
     "templates": (".commands.templates", "app", "Template management"),
-    "recipe": (".commands.recipe", "app", "Recipe management"),
+    "recipe": ("praisonai.cli.commands.recipe", "app", "Recipe management"),
     "todo": (".commands.todo", "app", "Todo/task management"),
-    "docs": (".commands.docs", "app", "Documentation management"),
+    "docs": ("praisonai.cli.commands.docs", "app", "Documentation management"),
     "commit": (".commands.commit", "app", "AI-assisted git commits"),
     "publish": (".commands.publish", "app", "Package publishing"),
     "hooks": (".commands.hooks", "app", "Hook management"),
@@ -205,44 +205,45 @@ _LAZY_COMMANDS: Dict[str, Tuple[str, str, str]] = {
     "package": (".commands.package", "app", "Package management"),
     "endpoints": (".commands.endpoints", "app", "API endpoint management"),
     "test": (".commands.test", "app", "Run test suite with tier and provider options"),
-    "examples": (".commands.examples", "app", "Run and manage example files"),
-    "batch": (".commands.batch", "app", "Run all PraisonAI scripts in current folder"),
-    "replay": (".commands.replay", "app", "Context replay for debugging agent execution"),
+    "examples": ("praisonai.cli.commands.examples", "app", "Run and manage example files"),
+    "batch": ("praisonai.cli.commands.batch", "app", "Run all PraisonAI scripts in current folder"),
+    "replay": ("praisonai.cli.commands.replay", "app", "Context replay for debugging agent execution"),
     "loop": (".commands.loop", "app", "Autonomous agent execution loops"),
     "tracker": (".commands.tracker", "app", "Autonomous agent tracking with step-by-step analysis"),
     "github": (".commands.github", "app", "GitHub native context tracking and Issue triage"),
-    "audit": (".commands.audit", "audit", "Compliance auditing"),
-    "managed": (".commands.managed", "app", "Managed Agents (Anthropic cloud-hosted backend)"),
+    "audit": ("praisonai.cli.commands.audit", "audit", "Compliance auditing"),
+    "managed": ("praisonai.cli.commands.managed", "app", "Managed Agents (Anthropic cloud-hosted backend)"),
     "models": (".commands.models", "app", "List and describe available models"),
     "backends": (".commands.backends", "app", "List registered CLI backends"),
 
-    # Wrapper-resident commands — see ``_WRAPPER_RESIDENT_COMMANDS`` below. These entries keep
-    # relative ``.commands.*`` paths so they are advertised in ``--help``, but
-    # ``get_command()`` re-routes them to the absolute ``praisonai.cli.commands.*``
-    # path at invocation time (the modules live in the main wrapper).
-    "bot": (".commands.bot", "app", "Messaging bots with full agent capabilities"),
-    "gateway": (".commands.gateway", "app", "Multi-bot WebSocket gateway server"),
-    "pairing": (".commands.pairing", "app", "Manage bot user pairing"),
-    "identity": (".commands.identity", "app", "Manage cross-platform user identity links"),
-    "kanban": (".commands.kanban", "app", "Kanban task management"),
-    "claw": (".commands.claw", "app", "PraisonAI Dashboard (full UI)"),
-    "mint_link": (".commands.mint_link", "app", "Generate gateway magic links"),
-    "dashboard": (".commands.dashboard", "app", "Unified Dashboard (Flow + Claw + UI)"),
+    # Resident commands — see ``_*_RESIDENT_COMMANDS`` below. Their implementation
+    # lives in a sibling package, so the entry carries that package's absolute
+    # module path (the dispatcher imports exactly what is written here). The
+    # entry itself is what advertises the command in ``--help``; the resident
+    # sets only decide whether it is shown/served when that package is missing.
+    "bot": ("praisonai_bot.cli.commands.bot", "app", "Messaging bots with full agent capabilities"),
+    "gateway": ("praisonai_bot.cli.commands.gateway", "app", "Multi-bot WebSocket gateway server"),
+    "pairing": ("praisonai_bot.cli.commands.pairing", "app", "Manage bot user pairing"),
+    "identity": ("praisonai_bot.cli.commands.identity", "app", "Manage cross-platform user identity links"),
+    "kanban": ("praisonai_bot.cli.commands.kanban", "app", "Kanban task management"),
+    "claw": ("praisonai_bot.cli.commands.claw", "app", "PraisonAI Dashboard (full UI)"),
+    "mint_link": ("praisonai_bot.cli.commands.mint_link", "app", "Generate gateway magic links"),
+    "dashboard": ("praisonai.cli.commands.dashboard", "app", "Unified Dashboard (Flow + Claw + UI)"),
 
-    "browser": (".commands.browser", "app", "Browser automation (extension bridge, CDP, Playwright)"),
+    "browser": ("praisonai_browser.cli.commands.browser", "app", "Browser automation (extension bridge, CDP, Playwright)"),
     "browser-tool": (".commands.browser_tool", "app", "praisonai-tools browser automation (snapshot/click/navigate)"),
     "plugins": (".commands.plugins", "app", "Plugin management and inspection"),
     "sandbox": (".commands.sandbox", "app", "Sandbox container management"),
-    "flow": (".commands.flow", "app", "Visual workflow builder (Langflow)"),
-    "langfuse": (".commands.langfuse", "app", "Langfuse observability platform"),
-    "langextract": (".commands.langextract", "app", "Langextract visual trace layer"),
+    "flow": ("praisonai.cli.commands.flow", "app", "Visual workflow builder (Langflow)"),
+    "langfuse": ("praisonai.cli.commands.langfuse", "app", "Langfuse observability platform"),
+    "langextract": ("praisonai.cli.commands.langextract", "app", "Langextract visual trace layer"),
     "port": (".commands.port", "app", "Manage port usage and resolve conflicts"),
     "up": (".commands.up", "app", "Start unified PraisonAI stack (Langfuse + Langflow)"),
 }
 
 # C9: Bot/channel commands implemented in ``praisonai_bot.cli.commands.*``.
-# ``get_command()`` loads them via ``praisonai_bot.cli.commands.{name}`` when the
-# bot package is installed; standalone ``praisonai-code`` hides them from ``--help``.
+# Their ``_LAZY_COMMANDS`` entries point there; ``get_command()`` serves them only
+# when the bot package is installed; standalone ``praisonai-code`` hides them from ``--help``.
 _BOT_RESIDENT_COMMANDS = frozenset({
     "bot",
     "gateway",
@@ -288,8 +289,8 @@ _WRAPPER_RESIDENT_COMMANDS = frozenset({
 })
 
 # C10: Training commands implemented in ``praisonai_train.cli.commands.*``.
-# ``get_command()`` loads them via ``praisonai_train.cli.commands.{name}`` when the
-# train package is installed; standalone ``praisonai-code`` hides them from ``--help``.
+# Their ``_LAZY_COMMANDS`` entries point there; ``get_command()`` serves them only
+# when the train package is installed; standalone ``praisonai-code`` hides them from ``--help``.
 _TRAIN_RESIDENT_COMMANDS = frozenset({
     "train",
 })
@@ -300,8 +301,8 @@ _DEPLOY_RESIDENT_COMMANDS = frozenset({
 })
 
 # C11: Browser automation commands implemented in ``praisonai_browser.cli.commands.*``.
-# ``get_command()`` loads them via ``praisonai_browser.cli.commands.{name}`` when the
-# browser package is installed; standalone ``praisonai-code`` hides them from ``--help``.
+# Their ``_LAZY_COMMANDS`` entries point there; ``get_command()`` serves them only
+# when the browser package is installed; standalone ``praisonai-code`` hides them from ``--help``.
 _BROWSER_RESIDENT_COMMANDS = frozenset({
     "browser",
 })
@@ -418,29 +419,26 @@ class LazyCommandGroup(TyperGroup):
         # Check regular lazy commands
         if name in _LAZY_COMMANDS:
             module_path, attr_name, _ = _LAZY_COMMANDS[name]
+            # Resident commands are implemented in a sibling package. Hide them
+            # (return ``None``, matching ``list_commands``) when that package is
+            # not installed, so a standalone install never tries the import.
+            if name in _BOT_RESIDENT_COMMANDS and not bot_package_available():
+                return None
+            if name in _TRAIN_RESIDENT_COMMANDS and not train_package_available():
+                return None
+            if name in _BROWSER_RESIDENT_COMMANDS and not browser_package_available():
+                return None
+            if name in _MCP_RESIDENT_COMMANDS and not mcp_package_available():
+                return None
+            if name in _WRAPPER_RESIDENT_COMMANDS and not wrapper_available():
+                return None
             try:
-                if name in _BOT_RESIDENT_COMMANDS:
-                    if not bot_package_available():
-                        return None
-                    module = importlib.import_module(f"praisonai_bot.cli.commands.{name}")
-                elif name in _TRAIN_RESIDENT_COMMANDS:
-                    if not train_package_available():
-                        return None
-                    module = importlib.import_module(f"praisonai_train.cli.commands.{name}")
-                elif name in _BROWSER_RESIDENT_COMMANDS:
-                    if not browser_package_available():
-                        return None
-                    module = importlib.import_module(f"praisonai_browser.cli.commands.{name}")
-                elif name in _MCP_RESIDENT_COMMANDS:
-                    if not mcp_package_available():
-                        return None
-                    module = importlib.import_module(f"praisonai_mcp.cli.commands.{name}")
-                elif name in _WRAPPER_RESIDENT_COMMANDS:
-                    if not wrapper_available():
-                        return None
-                    module = importlib.import_module(f"praisonai.cli.commands.{name}")
-                else:
-                    module = importlib.import_module(module_path, __package__)
+                # The table is the single source of truth for where a command
+                # lives: resident entries carry an absolute path (``__package__``
+                # is ignored for those), local ones a relative ``.commands.*``.
+                # ``tests/unit/test_lazy_command_paths.py`` imports every entry
+                # this same way so a dangling path fails in CI, not at first use.
+                module = importlib.import_module(module_path, __package__)
                 sub_app = getattr(module, attr_name)
                 if isinstance(sub_app, click.Command):
                     return sub_app

--- a/src/praisonai-code/tests/unit/test_lazy_command_paths.py
+++ b/src/praisonai-code/tests/unit/test_lazy_command_paths.py
@@ -1,59 +1,84 @@
 """Guard against dangling lazy-command module paths (issue #4693).
 
-``praisonai_code.cli.app._LAZY_COMMANDS`` is the authoritative registry that
-maps each CLI command to the module providing its Typer sub-app. Wrapper-,
-bot-, train-, browser-, mcp- and deploy-resident commands keep placeholder
-``.commands.*`` paths (they are re-routed to their external package at
-invocation time), so only *non-resident* entries are expected to resolve
-against ``praisonai_code.cli``.
+``praisonai_code.cli.app._LAZY_COMMANDS`` maps each CLI command to the module
+that provides its Typer sub-app. ``LazyCommandGroup._resolve_command`` imports
+exactly ``module_path`` from that table (after hiding resident commands whose
+owning package is not installed), so *every* entry must resolve — the resident
+ones (``praisonai``, ``praisonai_bot``, ``praisonai_train``, ``praisonai_browser``,
+``praisonai_mcp``) included.
 
-This test imports every non-resident lazy-command module so a genuinely
-dangling path fails in CI rather than at first use.
+History: resident entries used to carry placeholder ``.commands.<name>`` paths
+that named modules which do not exist in ``praisonai_code`` (``schedule`` after
+``66dcb788a`` was the reported one; there were 30). The dispatcher hard-coded the
+real path and never read the table, so the lie was invisible. The dispatcher now
+reads the table, and these tests import each entry the same way it does.
 
-A second parametrised test mirrors ``get_command()``'s resident dispatch: when
-the owning package (``praisonai``, ``praisonai_bot``, ``praisonai_train``,
-``praisonai_browser``, ``praisonai_mcp`` or ``praisonai_deploy``) is installed —
-as in the full monorepo CI — it imports the absolute ``…​.cli.commands.<name>``
-target the router re-routes to and asserts the attribute exists. This covers the
-``schedule`` re-route (praisonai-code → ``praisonai.cli.commands.schedule`` after
-``66dcb788a``) that the non-resident test intentionally excludes. It skips
-gracefully in a standalone ``praisonai-code`` install where those packages are
-absent.
+Resident entries whose owning package is not installed are skipped (standalone
+``praisonai-code`` install); the owning-package test below still bites there,
+because a placeholder ``.commands.*`` path resolves into ``praisonai_code``.
 """
 
 import importlib
+import importlib.util
 
+import click
 import pytest
 
 from praisonai_code.cli import app as cli_app
 
 
-def _non_resident_lazy_commands():
-    resident = (
-        cli_app._WRAPPER_RESIDENT_COMMANDS
-        | cli_app._BOT_RESIDENT_COMMANDS
-        | cli_app._TRAIN_RESIDENT_COMMANDS
-        | cli_app._BROWSER_RESIDENT_COMMANDS
-        | cli_app._MCP_RESIDENT_COMMANDS
-        | cli_app._DEPLOY_RESIDENT_COMMANDS
-    )
-    for name, (module_path, attr_name, _desc) in cli_app._LAZY_COMMANDS.items():
-        if name in resident:
-            continue
-        yield name, module_path, attr_name
+def _absolute(module_path: str) -> str:
+    """Resolve a table path exactly as the dispatcher's ``import_module`` does."""
+    return importlib.util.resolve_name(module_path, cli_app.__package__)
+
+
+def _root_package(module_path: str) -> str:
+    return _absolute(module_path).split(".")[0]
+
+
+_RESIDENT_OWNERS = (
+    (cli_app._WRAPPER_RESIDENT_COMMANDS, "praisonai"),
+    (cli_app._BOT_RESIDENT_COMMANDS, "praisonai_bot"),
+    (cli_app._TRAIN_RESIDENT_COMMANDS, "praisonai_train"),
+    (cli_app._BROWSER_RESIDENT_COMMANDS, "praisonai_browser"),
+    (cli_app._MCP_RESIDENT_COMMANDS, "praisonai_mcp"),
+)
 
 
 @pytest.mark.parametrize(
     "name,module_path,attr_name",
-    list(_non_resident_lazy_commands()),
+    [(n, mp, a) for n, (mp, a, _desc) in cli_app._LAZY_COMMANDS.items()],
     ids=lambda v: v if isinstance(v, str) else "",
 )
-def test_non_resident_lazy_command_module_resolves(name, module_path, attr_name):
+def test_every_lazy_command_module_resolves(name, module_path, attr_name):
+    """Import each table entry the way ``_resolve_command`` does."""
+    root = _root_package(module_path)
+    if importlib.util.find_spec(root) is None:
+        pytest.skip(f"owning package {root!r} for command {name!r} is not installed")
     module = importlib.import_module(module_path, cli_app.__package__)
     assert hasattr(module, attr_name), (
         f"lazy command {name!r} maps to {module_path}:{attr_name} "
         f"but attribute {attr_name!r} is missing"
     )
+
+
+def test_resident_entries_target_their_owning_package():
+    """A resident command's table path must live in the package that serves it.
+
+    This is what makes the original defect impossible even in a standalone
+    install where the sibling packages are absent: ``.commands.schedule`` resolves
+    into ``praisonai_code`` and fails here regardless of what is installed.
+    """
+    bad = []
+    for names, owner in _RESIDENT_OWNERS:
+        for name in sorted(names):
+            if name not in cli_app._LAZY_COMMANDS:
+                # ``app``/``standardise`` are resident but wired outside the table.
+                continue
+            module_path = cli_app._LAZY_COMMANDS[name][0]
+            if _root_package(module_path) != owner:
+                bad.append(f"{name!r} -> {module_path} (expected {owner}.cli.commands.*)")
+    assert not bad, "resident lazy-command entries point outside their owning package:\n  " + "\n  ".join(bad)
 
 
 def test_special_command_modules_resolve():
@@ -65,47 +90,15 @@ def test_special_command_modules_resolve():
         )
 
 
-def _resident_lazy_commands():
-    resident_groups = (
-        (cli_app._WRAPPER_RESIDENT_COMMANDS, "praisonai", cli_app.wrapper_available),
-        (cli_app._BOT_RESIDENT_COMMANDS, "praisonai_bot", cli_app.bot_package_available),
-        (cli_app._TRAIN_RESIDENT_COMMANDS, "praisonai_train", cli_app.train_package_available),
-        (cli_app._BROWSER_RESIDENT_COMMANDS, "praisonai_browser", cli_app.browser_package_available),
-        (cli_app._MCP_RESIDENT_COMMANDS, "praisonai_mcp", cli_app.mcp_package_available),
-        (cli_app._DEPLOY_RESIDENT_COMMANDS, "praisonai_deploy", cli_app.deploy_package_available),
-    )
-    deploy_names = cli_app._DEPLOY_RESIDENT_COMMANDS
-    seen = set()
-    for names, root, available in resident_groups:
-        for name in names:
-            if name in seen:
-                continue
-            if name in cli_app._LAZY_COMMANDS:
-                # Wrapper/bot/train/browser/mcp residents are dispatched through
-                # ``_LAZY_COMMANDS`` using its declared attribute name.
-                attr_name = cli_app._LAZY_COMMANDS[name][1]
-            elif name in deploy_names:
-                # Deploy commands are dispatched separately with a hardcoded
-                # ``app`` attribute and are absent from ``_LAZY_COMMANDS``.
-                attr_name = "app"
-            else:
-                # ``app``/``standardise`` are resident but handled outside the
-                # generic ``_LAZY_COMMANDS`` dispatch path, so skip them here.
-                continue
-            seen.add(name)
-            yield name, f"{root}.cli.commands.{name}", attr_name, available
+def test_schedule_dispatches_from_table_when_wrapper_installed():
+    """End-to-end: the reported command still resolves through the real dispatcher."""
+    if not cli_app.wrapper_available():
+        pytest.skip("requires the praisonai wrapper (schedule is wrapper-resident)")
+    from typer.main import get_command as typer_get_command
 
-
-@pytest.mark.parametrize(
-    "name,module_path,attr_name,available",
-    list(_resident_lazy_commands()),
-    ids=lambda v: v if isinstance(v, str) else "",
-)
-def test_resident_lazy_command_module_resolves(name, module_path, attr_name, available):
-    if not available():
-        pytest.skip(f"owning package for resident command {name!r} not installed")
-    module = importlib.import_module(module_path)
-    assert hasattr(module, attr_name), (
-        f"resident command {name!r} re-routes to {module_path}:{attr_name} "
-        f"but attribute {attr_name!r} is missing"
-    )
+    root = typer_get_command(cli_app.app)
+    ctx = click.Context(root)
+    cmd = root.get_command(ctx, "schedule")
+    assert isinstance(cmd, click.Command)
+    assert cmd.name == "schedule"
+    assert "schedule" in root.list_commands(ctx)


### PR DESCRIPTION
## Defect

`praisonai_code/cli/app.py` maps `"schedule"` to `.commands.schedule`, but `praisonai_code/cli/commands/schedule.py` was removed in 66dcb788a. It was not the only one: **30 resident entries** in `_LAZY_COMMANDS` (every wrapper-, bot-, train-, browser- and mcp-resident command) carried a placeholder `.commands.<name>` path naming a module that does not exist in `praisonai_code`.

This was masked because `LazyCommandGroup._resolve_command` never read those paths — it hard-coded `f"praisonai.cli.commands.{name}"` (and the bot/train/browser/mcp equivalents) for anything in a resident set. The moment a name is dropped from a resident set, the `else` branch imports the placeholder and raises `ModuleNotFoundError` at first use.

#4704 added a guard that imports the *non-resident* entries, but deliberately skipped resident ones — so the dead `.commands.schedule` path (and the 29 others) stayed in the table.

## Why not just remove the entry

`_LAZY_COMMANDS` is the name registry: `list_commands()` (app.py:350) and `_resolve_command()` (app.py:419) both key on it. Removing `"schedule"` would drop the command from `--help` and from dispatch whenever the wrapper is installed. The dispatch genuinely needs the entry (name, attribute, description) — it just never needed the lie in the path.

## Fix

- Resident entries now carry the absolute module path of the package that serves them (`praisonai.cli.commands.schedule`, `praisonai_bot.cli.commands.bot`, `praisonai_train.cli.commands.train`, …).
- `_resolve_command` keeps the per-package availability gate (a missing sibling package still hides the command, matching `list_commands`) and then imports exactly `module_path` from the table. The import string for every command is unchanged; there is now one place that says where a command lives.

## Test (`tests/unit/test_lazy_command_paths.py`, rewritten)

- `test_every_lazy_command_module_resolves[<name>]` — imports **every** table entry the way the dispatcher does; skips only entries whose owning package is not installed.
- `test_resident_entries_target_their_owning_package` — each resident entry must resolve into its owning package. This bites even in a standalone install where the import test would skip, because a placeholder `.commands.*` resolves into `praisonai_code`.
- `test_schedule_dispatches_from_table_when_wrapper_installed` — end-to-end through the real `LazyCommandGroup`.
- `test_special_command_modules_resolve` — kept from #4704.

## Mutation table

Baseline in the fixed state: 2 failures, both `config`/`run` importing `toml`, which the shared test venv lacks (identical on `main`).

| Mutation (on committed `app.py`, restored after) | Result |
|---|---|
| M1: add bogus `"does_not_exist": (".commands.does_not_exist", …)` | **killed** (+1: `test_every_lazy_command_module_resolves[does_not_exist]`) |
| M2: revert `schedule` to `.commands.schedule` (the original defect) | **killed** (+3: import, owning-package, end-to-end dispatch) |
| M3: point `schedule` at `praisonai_bot.cli.commands.schedule` (package not installed locally) | **killed** (+2: owning-package, end-to-end dispatch — import skipped as designed) |
| M4: `schedule` attribute `app` → `nope` | **killed** (+2: `hasattr`, end-to-end dispatch) |

Note: M2 would **not** have been caught by the #4704 test — it excludes resident entries.

## Regressions

- `src/praisonai-code/tests/unit` (full): 577 passed / 52 failed / 15 skipped / 10 errors vs `main` 576 / 51 / 16 / 10. The failure sets are identical apart from this file's renamed parametrisation (the `toml` env gap) — every failure/error here reproduces on `main` in the same venv.
- `src/praisonai/tests/unit/test_c7_1_boundaries.py`, `test_c10_train_backward_compat.py`, `test_c11_browser_backward_compat.py`, `test_c12_mcp_backward_compat.py` against this branch's `praisonai_code`: 53 passed, 1 skipped, 2 failed — the same 2 fail against `main` (`praisonaiagents.frameworks` missing in the venv).

## Also found, not fixed

`_DEPLOY_RESIDENT_COMMANDS` (`deploy`) is dispatched by a separate hard-coded block and is absent from `_LAZY_COMMANDS` entirely; `app`/`standardise` are likewise wired outside the table. Those are a different shape from this defect, so they are left alone.

Closes #4693

🤖 Generated with [Claude Code](https://claude.com/claude-code)
