### PR TITLE
feat(mobile): the web app is a third platform that actually boots in a browser

### DIFF
--- a/.github/workflows/mobile-web.yml
+++ b/.github/workflows/mobile-web.yml
@@ -1,0 +1,140 @@
+# The mobile package's WEB build: built, booted in a real browser, and
+# deployed to GitHub Pages.
+#
+# mobile.yml proves the package's tests pass. This workflow proves the thing
+# that ships to a browser actually ships: dist/ is built, served under the
+# repository subpath and driven through first paint, install, and an offline
+# reload by tools/web-boot.test.mjs, then published. A PR gets the build and
+# the proof; only main deploys.
+#
+# One setting is outside this file's reach: the repository's Pages source must
+# be "GitHub Actions" (Settings -> Pages -> Build and deployment -> Source).
+# Until a human turns that on, the deploy job SKIPS with a notice rather than
+# failing -- a red main every push because of a setting no workflow can set
+# would train people to ignore the mobile checks, which is how the last silent
+# breakage in this package survived.
+name: mobile web
+
+on:
+  push:
+    branches: [main]
+    paths: &watched
+      - 'src/praisonai-mobile/**'
+      - '.github/workflows/mobile-web.yml'
+      # `praisonai` is a `file:` link to ../praisonai-ts, and the web bundle is
+      # built FROM it -- so drift on that side changes what ships to a browser
+      # and must trigger this gate. mobile.yml watches these same paths for the
+      # same reason; a web gate that watched only praisonai-mobile would go
+      # quiet exactly when the dependency it bundles moved.
+      - 'src/praisonai-ts/src/**'
+      - 'src/praisonai-ts/scripts/**'
+      - 'src/praisonai-ts/package.json'
+  pull_request:
+    paths: *watched
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: src/praisonai-mobile
+
+jobs:
+  build:
+    name: build and boot
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: mobile-web-build-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.18'
+          cache: npm
+          cache-dependency-path: src/praisonai-mobile/package-lock.json
+      # `praisonai` is a `file:` link to ../praisonai-ts, so its dist/ must
+      # exist before this package can even INSTALL: npm runs the linked
+      # package's prepare/prebuild, which fails without its own node_modules.
+      # `npm install`, not `npm ci`: praisonai-ts gitignores its lockfile.
+      # `--legacy-peer-deps` for the bedrock-agentcore -> @strands-agents/sdk
+      # peer conflict, exactly as mobile.yml and praisonai-ts-webview.yml do.
+      - name: "Build praisonai-ts (the file: dependency)"
+        working-directory: src/praisonai-ts
+        run: |
+          npm install --no-audit --no-fund --legacy-peer-deps
+          npm run build
+      - run: npm ci
+      - name: Cache the Playwright browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('src/praisonai-mobile/package-lock.json') }}
+      - name: Install Chromium for the boot proof
+        run: npx playwright install --with-deps chromium
+      - name: Build
+        run: npm run build
+      - name: Boot proof
+        # Serves dist/ under /PraisonAI/ in headless Chromium: composer and
+        # Send render, manifest served as application/manifest+json, service
+        # worker activates with the subpath as scope, an offline reload still
+        # renders, and an injected inline script is blocked by the CSP.
+        run: npm run test:web
+      - name: dist contents
+        run: ls -lR dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mobile-web-dist
+          path: src/praisonai-mobile/dist
+          if-no-files-found: error
+      - uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          path: src/praisonai-mobile/dist
+
+  deploy:
+    name: deploy to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-22.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      # Never cancel a deployment in flight; queue behind it instead.
+      group: pages
+      cancel-in-progress: false
+    steps:
+      # Pages cannot be enabled from a workflow, so this job reports the
+      # setting rather than demanding it. `ready` false SKIPS the deploy with
+      # a notice; it does not fail the run. deploy-pages would otherwise fail
+      # with a bare 404 that says nothing about which setting is missing.
+      - name: Is the Pages source "GitHub Actions"?
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: .
+        run: |
+          site=$(gh api "repos/${{ github.repository }}/pages" 2>/dev/null || echo '{}')
+          build_type=$(echo "$site" | jq -r '.build_type // "none"')
+          cname=$(echo "$site" | jq -r '.cname // ""')
+          echo "build_type=$build_type cname=${cname:-<none>}"
+          if [ "$build_type" != "workflow" ]; then
+            echo "::notice::Skipping the Pages deploy: Pages is not set to build from GitHub Actions (build_type=$build_type). A repository admin must set it at https://github.com/${{ github.repository }}/settings/pages -> Build and deployment -> Source: GitHub Actions. The built site is attached to this run as the mobile-web-dist artifact."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -n "$cname" ]; then
+            echo "::notice::Skipping the Pages deploy: a custom domain ($cname) is set, so the app would be served there rather than at the github.io URL."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+      - uses: actions/configure-pages@v5
+        if: steps.check.outputs.ready == 'true'
+      - uses: actions/deploy-pages@v4
+        id: deployment
+        if: steps.check.outputs.ready == 'true'

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -82,6 +82,15 @@ jobs:
           npm install --no-audit --no-fund --legacy-peer-deps
           npm run build
       - run: npm ci
+      - name: Cache the Playwright browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('src/praisonai-mobile/package-lock.json') }}
+      - name: Install Chromium for the boot proof
+        # `npm test` includes tools/web-boot.test.mjs, which loads the built
+        # dist/ in a real browser. It fails rather than skips without one.
+        run: npx playwright install --with-deps chromium
       - name: Typecheck
         run: npm run typecheck
       - name: Layer boundaries

--- a/src/praisonai-mobile/app/index.html
+++ b/src/praisonai-mobile/app/index.html
@@ -3,6 +3,26 @@
   <head>
     <meta charset="utf-8" />
     <!--
+      The web build's Content-Security-Policy. tauri.conf.json's csp applies
+      only inside the Tauri shell; a browser serving dist/ over HTTP sees only
+      what is in this file. tools/web-csp.test.mjs pins it.
+
+      Two things about it are not obvious:
+        - Tauri APPENDS its own meta tag to this page rather than replacing
+          this one, so inside the shell BOTH policies apply and the effective
+          policy is their intersection. `ipc:` and `http://ipc.localhost` are
+          therefore listed here too: a browser ignores a scheme it does not
+          know, and without them the Android IPC channel would be blocked by
+          this tag with nothing but a console line to say so.
+        - script-src is 'self' and nothing else. Every script on the page is
+          an external file, including the service-worker registration, so
+          there is no inline script to whitelist and no hash to keep in step.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:* https:; manifest-src 'self'; worker-src 'self'; base-uri 'self'; form-action 'self'"
+    />
+    <!--
       viewport-fit=cover is NOT optional. Without it, env(safe-area-inset-*)
       resolves to 0px in WKWebView, every inset in the app collapses to flush,
       and content sits under the notch and the home indicator with no error
@@ -18,7 +38,17 @@
       content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no"
     />
     <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" content="#1f7a63" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="PraisonAI" />
     <title>PraisonAI</title>
+    <!-- Every URL below is relative on purpose: the web build is served from
+         a repository subpath on GitHub Pages, and an absolute /manifest or
+         /app.js resolves to the wrong site there. tools/web-boot.test.mjs
+         serves dist/ under a subpath to prove it. -->
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" href="./icons/32x32.png" sizes="32x32" type="image/png" />
+    <link rel="apple-touch-icon" href="./icons/icon.png" />
     <link rel="stylesheet" href="./app.css" />
   </head>
   <body>
@@ -28,5 +58,6 @@
     <div id="root"></div>
     <noscript>PraisonAI needs JavaScript to run.</noscript>
     <script type="module" src="./app.js"></script>
+    <script src="./register-sw.js"></script>
   </body>
 </html>

--- a/src/praisonai-mobile/app/manifest.webmanifest
+++ b/src/praisonai-mobile/app/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "id": "ai.praison.mobile",
+  "name": "PraisonAI",
+  "short_name": "PraisonAI",
+  "description": "AI agents on your phone",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#ffffff",
+  "theme_color": "#1f7a63",
+  "icons": [
+    { "src": "./icons/32x32.png", "sizes": "32x32", "type": "image/png" },
+    { "src": "./icons/128x128.png", "sizes": "128x128", "type": "image/png" },
+    { "src": "./icons/128x128@2x.png", "sizes": "256x256", "type": "image/png" },
+    { "src": "./icons/icon.png", "sizes": "512x512", "type": "image/png", "purpose": "any" }
+  ]
+}

--- a/src/praisonai-mobile/app/register-sw.js
+++ b/src/praisonai-mobile/app/register-sw.js
@@ -1,0 +1,25 @@
+// Registers the service worker for the WEB build only.
+//
+// An external file rather than an inline <script>, because index.html ships a
+// `script-src 'self'` CSP and an inline script would be blocked with nothing
+// but a console line to say so.
+//
+// Two guards, both deliberate:
+//   - `serviceWorker in navigator`: a browser without the API (or a page on an
+//     insecure origin, where the property is simply absent) boots normally
+//     without one.
+//   - `__TAURI_INTERNALS__`: inside the Tauri shell the page is served by a
+//     custom-protocol handler, and a worker caching those responses would put
+//     a second copy of the app between the shell and its own assets. The web
+//     platform is the only one that needs offline precaching; the app IS the
+//     offline copy everywhere else.
+(function () {
+  if (!("serviceWorker" in navigator)) return;
+  if ("__TAURI_INTERNALS__" in window) return;
+  if (!/^https?:$/.test(location.protocol)) return;
+  navigator.serviceWorker.register("./sw.js").catch(function (error) {
+    // Registration failing is a degraded page, not a broken one: the app still
+    // boots from the network. Say so rather than throwing into nowhere.
+    console.warn("praisonai: service worker not registered:", error);
+  });
+})();

--- a/src/praisonai-mobile/app/sw.js
+++ b/src/praisonai-mobile/app/sw.js
@@ -13,6 +13,7 @@
 //   anything else same-origin -- straight to the network. Cross-origin (the
 //                  engine at 127.0.0.1:8765, an https engine) is never touched.
 const CACHE = "praisonai-mobile-__BUILD_ID__";
+const CACHE_PREFIX = "praisonai-mobile-";
 const PRECACHE = __PRECACHE__;
 
 const INDEX = new URL("./index.html", self.location.href).href;
@@ -30,7 +31,13 @@ self.addEventListener("activate", (event) => {
   event.waitUntil(
     caches
       .keys()
-      .then((keys) => Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key))))
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE)
+            .map((key) => caches.delete(key)),
+        ),
+      )
       .then(() => self.clients.claim()),
   );
 });

--- a/src/praisonai-mobile/app/sw.js
+++ b/src/praisonai-mobile/app/sw.js
@@ -1,0 +1,78 @@
+// The web build's service worker. tools/build-webview.mjs writes the two
+// tokens below at build time: the precache list is exactly the files the
+// build emitted, and the cache name carries a hash of their bytes, so a new
+// build is a new cache and an old one is deleted on activate.
+//
+// Strategy:
+//   navigation  -- network-first, falling back to the precached index.html.
+//                  A user with a network gets the current page; one without
+//                  gets the last one that loaded, instead of the dinosaur.
+//   precached   -- cache-first. These bytes are the ones the cache name was
+//                  derived from; the network cannot have a different answer
+//                  without the worker itself having changed.
+//   anything else same-origin -- straight to the network. Cross-origin (the
+//                  engine at 127.0.0.1:8765, an https engine) is never touched.
+const CACHE = "praisonai-mobile-__BUILD_ID__";
+const PRECACHE = __PRECACHE__;
+
+const INDEX = new URL("./index.html", self.location.href).href;
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE)
+      .then((cache) => cache.addAll(PRECACHE))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key))))
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request;
+  if (request.method !== "GET") return;
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            const copy = response.clone();
+            event.waitUntil(caches.open(CACHE).then((cache) => cache.put(INDEX, copy)));
+          }
+          return response;
+        })
+        .catch(() => caches.match(INDEX)),
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request, { ignoreSearch: true }).then((hit) => {
+      if (hit) return hit;
+      // A same-origin file that is not precached is a LAZY chunk: the build
+      // leaves those out on purpose (see tools/build-webview.mjs) so a browser
+      // does not download 1.4MB it may never use. Cache each one as it is
+      // actually fetched, and a feature that has been used once still works
+      // offline. It goes into the SAME versioned cache, so a new build drops
+      // these along with everything else rather than leaving a chunk from an
+      // older app behind to be paired with a newer one.
+      return fetch(request).then((response) => {
+        if (response.ok && response.type === "basic") {
+          const copy = response.clone();
+          event.waitUntil(caches.open(CACHE).then((cache) => cache.put(request, copy)));
+        }
+        return response;
+      });
+    }),
+  );
+});

--- a/src/praisonai-mobile/package-lock.json
+++ b/src/praisonai-mobile/package-lock.json
@@ -19,6 +19,7 @@
         "@tauri-apps/cli": "^2",
         "@types/node": "^22.20.1",
         "esbuild": "^0.25.0",
+        "playwright": "^1.62.1",
         "typescript": "^5.7.3"
       },
       "engines": {
@@ -950,11 +951,58 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/praisonai": {
       "resolved": "../praisonai-ts",

--- a/src/praisonai-mobile/package.json
+++ b/src/praisonai-mobile/package.json
@@ -14,6 +14,7 @@
     "boundaries": "node tools/check-boundaries.mjs",
     "build": "node tools/build-webview.mjs",
     "test:bundle": "node --test --test-reporter=spec tools/bundle.test.mjs",
+    "test:web": "node --test --test-reporter=spec tools/web-boot.test.mjs",
     "check": "npm run typecheck && npm run boundaries && npm run test",
     "check:upstream": "node tools/check-upstream-parity.mjs",
     "build:webview": "node tools/build-webview.mjs",
@@ -24,6 +25,7 @@
     "@tauri-apps/cli": "^2",
     "@types/node": "^22.20.1",
     "esbuild": "^0.25.0",
+    "playwright": "^1.62.1",
     "typescript": "^5.7.3"
   },
   "dependencies": {

--- a/src/praisonai-mobile/tools/build-webview.mjs
+++ b/src/praisonai-mobile/tools/build-webview.mjs
@@ -1,11 +1,17 @@
 /**
- * The webview build: bundle the app, and copy the two files a page needs.
+ * The webview build: bundle the app, and copy the files a page needs.
  *
  * Deliberately separate from tools/bundle.mjs, which is a GATE rather than a
  * build system -- its header is explicit that every check fails the build
  * rather than warning, and mixing a copy step into it would blur that.
+ *
+ * dist/ serves two consumers from one output: the Tauri shell (frontendDist)
+ * and the web build deployed by .github/workflows/mobile-web.yml. The web
+ * additions -- manifest, icons, service worker -- are inert inside the shell
+ * (app/register-sw.js declines to register there), so one build is enough.
  */
-import { mkdir, copyFile, rm } from "node:fs/promises";
+import { mkdir, copyFile, rm, readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { dirname, join, resolve } from "node:path";
 import { bundle, isShippable, SHELL_BUDGET_BYTES, LAZY_BUDGET_BYTES } from "./bundle.mjs";
 
@@ -18,13 +24,26 @@ const pkg = resolve(process.argv[2] ?? here + "/..");
 const dist = join(pkg, "dist");
 
 await rm(dist, { recursive: true, force: true });
-await mkdir(dist, { recursive: true });
+await mkdir(join(dist, "icons"), { recursive: true });
 
-// The page and the stylesheet are copied verbatim: neither is compiled, and a
-// transform step would be one more thing between what is written and what
-// ships.
-await copyFile(join(pkg, "app/index.html"), join(dist, "index.html"));
-await copyFile(join(pkg, "app/app.css"), join(dist, "app.css"));
+// The page, the stylesheet, the manifest and the registration script are
+// copied verbatim: none is compiled, and a transform step would be one more
+// thing between what is written and what ships.
+const verbatim = ["index.html", "app.css", "manifest.webmanifest", "register-sw.js"];
+for (const name of verbatim) {
+  await copyFile(join(pkg, "app", name), join(dist, name));
+}
+
+// The icons are whichever the manifest names, read from the Tauri icon set so
+// the two platforms cannot drift: an icon the manifest lists but the shell
+// does not have fails here, not on a phone's home screen.
+const manifest = JSON.parse(await readFile(join(pkg, "app/manifest.webmanifest"), "utf8"));
+const icons = manifest.icons.map((icon) => icon.src);
+for (const src of icons) {
+  if (!src.startsWith("./icons/")) throw new Error(`manifest icon must live under ./icons/: ${src}`);
+  const name = src.slice("./icons/".length);
+  await copyFile(join(pkg, "src-tauri/icons", name), join(dist, "icons", name));
+}
 
 // `outdir`, not `outfile`: esbuild's `splitting` needs a directory to put the
 // shared and lazily-loaded chunks in. `entryNames` pins the entry to app.js so
@@ -55,3 +74,37 @@ if (!isShippable(report)) {
   console.error("\nThe webview bundle is not shippable. See above.");
   process.exit(1);
 }
+
+// The service worker is the one file whose contents depend on the build: it
+// precaches exactly what was just written, under a cache name derived from
+// those bytes. A hash rather than the package version, because two builds of
+// one version differ the moment a source file does, and a worker that thinks
+// they are the same serves the old one forever.
+// What the worker precaches is every file needed to RENDER the app with no
+// network: the page, the stylesheet, the manifest, the icons, and the entry
+// plus every chunk esbuild marked EAGER.
+//
+// Read off `report.eager` rather than hand-written. A hand-written list was
+// wrong the moment code splitting landed: `splitting` gave app.js an eager
+// chunk-*.js sibling that nothing precached, so the app rendered online and
+// died on an offline reload -- tools/web-boot.test.mjs caught exactly that.
+//
+// The LAZY chunks are deliberately not here. Splitting exists so a browser
+// does not pay 1.4MB it may never use, and precaching them would undo the
+// whole point; app/sw.js caches them as they are fetched instead, so a
+// feature keeps working offline once it has been used.
+const eager = [...report.eager].sort().map((name) => `./${name}`);
+const precache = [...verbatim.map((name) => `./${name}`), ...eager, ...icons];
+const hash = createHash("sha256");
+for (const entry of precache) {
+  hash.update(entry);
+  hash.update(await readFile(join(dist, entry)));
+}
+const buildId = hash.digest("hex").slice(0, 16);
+const template = await readFile(join(pkg, "app/sw.js"), "utf8");
+for (const token of ["__BUILD_ID__", "__PRECACHE__"]) {
+  if (!template.includes(token)) throw new Error(`app/sw.js has lost its ${token} token`);
+}
+const sw = template.replace("__BUILD_ID__", buildId).replace("__PRECACHE__", JSON.stringify(precache));
+await writeFile(join(dist, "sw.js"), sw);
+console.log(`service worker: cache praisonai-mobile-${buildId}, ${precache.length} files precached`);

--- a/src/praisonai-mobile/tools/build-webview.test.mjs
+++ b/src/praisonai-mobile/tools/build-webview.test.mjs
@@ -1,31 +1,89 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 const SCRIPT = join(import.meta.dirname, "build-webview.mjs");
+const REAL_SW = readFileSync(join(import.meta.dirname, "../app/sw.js"), "utf8");
 
-/** A minimal package tree the real build script can be pointed at. */
+/** Everything a build emits, relative to dist/. */
+const SHIPPED = [
+  "index.html",
+  "app.css",
+  "app.js",
+  "manifest.webmanifest",
+  "register-sw.js",
+  "sw.js",
+  "icons/a.png",
+  "icons/b.png",
+];
+
+/** A minimal package tree the real build script can be pointed at. The
+ * manifest and sw.js are the real shapes (two icons, both tokens) so the
+ * build's handling of them is exercised, not a stand-in's. */
 function fixture(main) {
   const dir = mkdtempSync(join(tmpdir(), "webview-build-"));
   mkdirSync(join(dir, "app/src"), { recursive: true });
+  mkdirSync(join(dir, "src-tauri/icons"), { recursive: true });
   writeFileSync(join(dir, "app/index.html"), "<!doctype html><div id=root></div>\n");
   writeFileSync(join(dir, "app/app.css"), ":root { color: red }\n");
+  writeFileSync(join(dir, "app/register-sw.js"), "// register\n");
+  writeFileSync(join(dir, "app/sw.js"), REAL_SW);
+  writeFileSync(
+    join(dir, "app/manifest.webmanifest"),
+    JSON.stringify({ icons: [{ src: "./icons/a.png" }, { src: "./icons/b.png" }] }),
+  );
+  writeFileSync(join(dir, "src-tauri/icons/a.png"), "PNG-A");
+  writeFileSync(join(dir, "src-tauri/icons/b.png"), "PNG-B");
   writeFileSync(join(dir, "app/src/main.ts"), main);
   return dir;
 }
 
 const build = (dir) => spawnSync(process.execPath, [SCRIPT, dir], { encoding: "utf8" });
+const CLEAN = "export const hi: string = 'hi';\ndocument.title = hi;\n";
 
-test("a shippable app builds, and dist carries the page and the stylesheet", () => {
-  const dir = fixture("export const hi: string = 'hi';\ndocument.title = hi;\n");
+test("a shippable app builds, and dist carries every file the web page needs", () => {
+  const dir = fixture(CLEAN);
   const r = build(dir);
   assert.equal(r.status, 0, `a clean app must build:\n${r.stdout}${r.stderr}`);
-  for (const f of ["index.html", "app.css", "app.js"]) {
+  for (const f of SHIPPED) {
     assert.ok(existsSync(join(dir, "dist", f)), `dist/${f} must exist`);
   }
+  assert.equal(readFileSync(join(dir, "dist/icons/a.png"), "utf8"), "PNG-A", "icons come from src-tauri/icons");
+});
+
+test("the service worker precaches exactly what was built, under a build-derived cache name", () => {
+  const dir = fixture(CLEAN);
+  assert.equal(build(dir).status, 0);
+  const sw = readFileSync(join(dir, "dist/sw.js"), "utf8");
+  assert.doesNotMatch(sw, /__BUILD_ID__|__PRECACHE__/, "no template token may survive into dist");
+
+  const precache = JSON.parse(/const PRECACHE = (\[.*?\]);/s.exec(sw)[1]);
+  const shippedExceptSelf = SHIPPED.filter((f) => f !== "sw.js").map((f) => `./${f}`);
+  assert.deepEqual([...precache].sort(), [...shippedExceptSelf].sort(), "precache = built files, minus the worker");
+
+  const name = /const CACHE = "praisonai-mobile-([0-9a-f]{16})";/.exec(sw)?.[1];
+  assert.ok(name, "the cache name carries a 16-hex-digit build id");
+
+  // Change one byte of one asset: the cache name must change, or a new build
+  // serves the old bytes from the old cache until the user clears site data.
+  writeFileSync(join(dir, "app/app.css"), ":root { color: blue }\n");
+  assert.equal(build(dir).status, 0);
+  const again = /const CACHE = "praisonai-mobile-([0-9a-f]{16})";/.exec(readFileSync(join(dir, "dist/sw.js"), "utf8"))[1];
+  assert.notEqual(again, name, "a different asset must yield a different cache name");
+});
+
+test("an icon the manifest names but the shell does not have fails the build", () => {
+  const dir = fixture(CLEAN);
+  writeFileSync(
+    join(dir, "app/manifest.webmanifest"),
+    JSON.stringify({ icons: [{ src: "./icons/a.png" }, { src: "./icons/missing.png" }] }),
+  );
+  const r = build(dir);
+  assert.notEqual(r.status, 0, "a manifest pointing at a missing icon must not build");
+  assert.match(r.stdout + r.stderr, /missing\.png/, "and it must say which icon");
 });
 
 test("a stale file from a previous build does not survive into dist", () => {
@@ -34,24 +92,23 @@ test("a stale file from a previous build does not survive into dist", () => {
   // machine dist DOES exist -- that is the whole point of a build directory --
   // so a renamed or deleted asset stays in the shipped output forever, and the
   // page keeps loading a file nobody can find in the source any more.
-  const dir = fixture("export const hi: string = 'hi';\ndocument.title = hi;\n");
-  mkdirSync(join(dir, "dist"), { recursive: true });
+  const dir = fixture(CLEAN);
+  mkdirSync(join(dir, "dist/icons"), { recursive: true });
   writeFileSync(join(dir, "dist/left-over.js"), "// from a build two versions ago\n");
   writeFileSync(join(dir, "dist/app.css"), "/* a stale stylesheet */\n");
+  writeFileSync(join(dir, "dist/icons/renamed-away.png"), "PNG-OLD");
+  writeFileSync(join(dir, "dist/sw.js"), 'const CACHE = "praisonai-mobile-stale";\n');
+  writeFileSync(join(dir, "dist/manifest.webmanifest"), '{"name":"stale"}\n');
 
   const r = build(dir);
   assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
 
-  assert.equal(
-    existsSync(join(dir, "dist/left-over.js")),
-    false,
-    "a file the build no longer produces must not be shipped",
-  );
-  assert.match(
-    readFileSync(join(dir, "dist/app.css"), "utf8"),
-    /color: red/,
-    "and a file it DOES produce must be the fresh one, not the stale one",
-  );
+  assert.equal(existsSync(join(dir, "dist/left-over.js")), false, "a file the build no longer produces must not be shipped");
+  assert.equal(existsSync(join(dir, "dist/icons/renamed-away.png")), false, "nor an icon the manifest no longer names");
+  assert.match(readFileSync(join(dir, "dist/app.css"), "utf8"), /color: red/, "a file it DOES produce must be the fresh one");
+  assert.doesNotMatch(readFileSync(join(dir, "dist/sw.js"), "utf8"), /stale/, "the worker is regenerated, never left over");
+  assert.match(readFileSync(join(dir, "dist/manifest.webmanifest"), "utf8"), /icons/, "so is the manifest");
+  assert.deepEqual(readdirSync(join(dir, "dist/icons")).sort(), ["a.png", "b.png"], "dist/icons holds the manifest's icons and nothing else");
 });
 
 test("an unshippable bundle FAILS the build, it does not merely print", () => {
@@ -63,6 +120,7 @@ test("an unshippable bundle FAILS the build, it does not merely print", () => {
   const out = r.stdout + r.stderr;
   assert.notEqual(r.status, 0, `an unshippable bundle was reported and then shipped:\n${out}`);
   assert.match(out, /crypto/, "and it must say which module made it unshippable");
+  assert.equal(existsSync(join(dir, "dist/sw.js")), false, "and no worker is written to precache a broken bundle");
 });
 
 test("a chunk behind an import() is written beside app.js, where the page can reach it", () => {
@@ -84,4 +142,48 @@ test("a chunk behind an import() is written beside app.js, where the page can re
     assert.ok(existsSync(join(dir, "dist", ref)), `${ref} must be written beside app.js`);
   }
   assert.ok(existsSync(join(dir, "dist/index.html")), "and the page is in that same directory");
+});
+
+test("the worker precaches the EAGER chunks and leaves the lazy ones to be fetched", () => {
+  // The regression this pins, in full: code splitting gives app.js a chunk it
+  // imports STATICALLY whenever a module is shared between the entry and a
+  // lazy branch. The precache list was hand-written -- index.html, app.css,
+  // app.js and the assets -- so that sibling was not in it. The app rendered
+  // perfectly online, and an offline reload got a cache miss on a file app.js
+  // cannot start without. Nothing in Node noticed; only a browser did.
+  //
+  // The other half matters just as much: the LAZY chunks must stay OUT. They
+  // are why `splitting` is on at all, and precaching them would make install
+  // download the whole engine on first paint.
+  const dir = fixture(
+    "import { shared } from './shared.ts';\nexport const load = () => import('./lazy.ts');\ndocument.title = shared;\n",
+  );
+  writeFileSync(join(dir, "app/src/shared.ts"), "export const shared: string = 'shared'.repeat(40);\n");
+  writeFileSync(
+    join(dir, "app/src/lazy.ts"),
+    "import { shared } from './shared.ts';\nexport const lazy: string = shared + 'lazy'.repeat(40);\n",
+  );
+
+  const r = build(dir);
+  assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+
+  const sw = readFileSync(join(dir, "dist/sw.js"), "utf8");
+  const precache = JSON.parse(/const PRECACHE = (\[.*?\]);/s.exec(sw)[1]);
+  const app = readFileSync(join(dir, "dist/app.js"), "utf8");
+
+  // Read eager and lazy off app.js itself rather than trusting the build's
+  // own report: a static `from "./chunk-X.js"` is needed to boot, a
+  // `import("./chunk-X.js")` is not.
+  const eager = [...app.matchAll(/(?:from|import)\s*"\.\/(chunk-[A-Z0-9]+\.js)"/g)].map((m) => m[1]);
+  const lazy = [...app.matchAll(/import\("\.\/(chunk-[A-Z0-9]+\.js)"\)/g)].map((m) => m[1]);
+  assert.ok(eager.length > 0, "this fixture must produce a statically imported chunk, or it proves nothing");
+  assert.ok(lazy.length > 0, "and a lazily imported one");
+
+  for (const name of eager) {
+    assert.ok(precache.includes(`./${name}`), `${name} is imported statically by app.js, so it must be precached`);
+  }
+  for (const name of lazy) {
+    assert.ok(!precache.includes(`./${name}`), `${name} is only behind import(); precaching it defeats the split`);
+  }
+  assert.ok(precache.includes("./app.js"), "and the entry itself is precached");
 });

--- a/src/praisonai-mobile/tools/web-boot.test.mjs
+++ b/src/praisonai-mobile/tools/web-boot.test.mjs
@@ -276,10 +276,17 @@ test("a redeployed site replaces the cached one instead of being pinned behind i
 
   // A cache left behind by a build older than this browser session. `activate`
   // is the only thing that will ever remove it.
-  await page.evaluate(async () => {
+  // ...and a cache owned by a DIFFERENT app on this same GitHub Pages origin
+  // (all of an account's project sites share one *.github.io origin, and Cache
+  // Storage is partitioned by origin, not by worker scope). `activate` must
+  // leave this one alone -- deleting it would wipe a sibling site's offline data.
+  const siblingCache = "some-other-app-cache";
+  await page.evaluate(async (sibling) => {
     const old = await caches.open("praisonai-mobile-000000000000dead");
     await old.put("./stale.js", new Response("// from a build two deploys ago"));
-  });
+    const other = await caches.open(sibling);
+    await other.put("./other.js", new Response("// a different app's asset"));
+  }, siblingCache);
 
   // ---- the site is redeployed: new HTML, same worker ----------------------
   // The worker's bytes are untouched, so NO new worker installs and nothing
@@ -304,17 +311,28 @@ test("a redeployed site replaces the cached one instead of being pinned behind i
     await reg.update();
   });
 
+  // `activate` deletes only THIS app's stale caches: the old praisonai-mobile
+  // cache is gone, the current one remains, and the sibling app's cache is
+  // untouched. The expected set is sorted -- "praisonai-mobile-1..." precedes
+  // "some-other-app-cache".
+  const expected = [v2Cache, siblingCache].sort();
+  const settled = (k) => k.length === expected.length && k.every((v, i) => v === expected[i]);
   const deadline = Date.now() + 20_000;
   let keys = await activeCaches();
-  while (!(keys.length === 1 && keys[0] === v2Cache) && Date.now() < deadline) {
+  while (!settled(keys) && Date.now() < deadline) {
     await new Promise((ok) => setTimeout(ok, 100));
     keys = await activeCaches();
   }
   assert.deepEqual(
     keys,
-    [v2Cache],
+    expected,
     "after the new worker activated the old caches are still there: `activate` must delete every " +
-      "cache but the current one, or a replaced build's bytes live on the user's disk forever",
+      "praisonai-mobile cache but the current one, or a replaced build's bytes live on the user's disk forever",
+  );
+  assert.ok(
+    keys.includes(siblingCache),
+    "`activate` deleted a cache owned by a DIFFERENT app on the same origin: cleanup must be scoped " +
+      "to the praisonai-mobile- prefix, or updating this app wipes a sibling GitHub Pages site's offline data",
   );
 
   // The new build is the one being served, from its own cache.

--- a/src/praisonai-mobile/tools/web-boot.test.mjs
+++ b/src/praisonai-mobile/tools/web-boot.test.mjs
@@ -1,0 +1,324 @@
+/**
+ * Boot proof: the built dist/ loads in a real browser and works as a PWA.
+ *
+ * Every other test here runs in Node. This one serves dist/ over HTTP -- under
+ * a repository subpath, because that is how GitHub Pages serves it -- and
+ * drives headless Chromium through the states a user actually meets:
+ *
+ *   1. first load: the page boots, the composer and Send render, and the only
+ *      console error is the engine at 127.0.0.1:8765 not answering (which the
+ *      page reports as a notice, not a crash);
+ *   2. the manifest is linked and served as application/manifest+json, and its
+ *      start_url resolves inside the subpath;
+ *   3. the service worker registers with the subpath as its scope and finishes
+ *      precaching;
+ *   4. the server is then shut down and the page reloaded: it must render from
+ *      the cache with no network at all;
+ *   5. the CSP is enforced: an inline script injected at runtime does not run.
+ *
+ * The engine port is intercepted and refused, so the outcome does not depend
+ * on whether a desktop engine happens to be running on this machine.
+ *
+ * The browser is Playwright's Chromium (`npx playwright install chromium`),
+ * falling back to an installed Google Chrome. Neither being present FAILS the
+ * suite rather than skipping it: a boot proof that skips is a page nobody has
+ * seen boot.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, extname, join, normalize, resolve } from "node:path";
+import { chromium } from "playwright";
+
+const pkg = resolve(dirname(new URL(import.meta.url).pathname), "..");
+const dist = join(pkg, "dist");
+/** The subpath GitHub Pages serves a project site from. */
+const BASE = "/PraisonAI/";
+const ENGINE = "http://127.0.0.1:8765";
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".webmanifest": "application/manifest+json",
+  ".png": "image/png",
+};
+
+/**
+ * dist/ under BASE, and nothing else.
+ *
+ * `overrides` maps a dist-relative path to the bytes to serve INSTEAD of the
+ * file on disk. That is how the redeploy test below stands up a "v2" of the
+ * site without rebuilding or touching a source file: the deployed bytes
+ * change under a browser that already has the old ones cached, which is
+ * exactly the situation a service worker either handles or makes permanent.
+ */
+function serveDist(overrides = new Map()) {
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url, "http://x");
+    if (!url.pathname.startsWith(BASE)) {
+      res.writeHead(404).end("outside the site's subpath");
+      return;
+    }
+    let rel = url.pathname.slice(BASE.length);
+    if (rel === "" || rel.endsWith("/")) rel += "index.html";
+    if (overrides.has(rel)) {
+      res.writeHead(200, { "content-type": MIME[extname(rel)] ?? "application/octet-stream", "cache-control": "no-store" });
+      res.end(overrides.get(rel));
+      return;
+    }
+    const file = normalize(join(dist, rel));
+    if (!file.startsWith(dist) || !existsSync(file)) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, { "content-type": MIME[extname(file)] ?? "application/octet-stream", "cache-control": "no-store" });
+    res.end(await readFile(file));
+  });
+  return new Promise((ok) => server.listen(0, "127.0.0.1", () => ok(server)));
+}
+
+async function launch() {
+  try {
+    return await chromium.launch();
+  } catch (bundled) {
+    try {
+      return await chromium.launch({ channel: "chrome" });
+    } catch (system) {
+      throw new Error(
+        "no browser for the boot proof: run `npx playwright install chromium` (or install Google Chrome).\n" +
+          `  bundled: ${bundled.message.split("\n")[0]}\n  system: ${system.message.split("\n")[0]}`,
+      );
+    }
+  }
+}
+
+test("the built web app boots, installs, and survives going offline", async (t) => {
+  const built = spawnSync(process.execPath, [join(pkg, "tools/build-webview.mjs")], { encoding: "utf8" });
+  assert.equal(built.status, 0, `the build must succeed before it can be booted:\n${built.stdout}${built.stderr}`);
+
+  const server = await serveDist();
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  const site = origin + BASE;
+  const browser = await launch();
+  t.after(async () => {
+    await browser.close();
+    server.closeAllConnections?.();
+    await new Promise((ok) => server.close(ok));
+  });
+
+  const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  const page = await context.newPage();
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
+  page.on("console", (m) => {
+    if (m.type() === "error") errors.push(`console.error: ${m.text()} @ ${m.location().url}`);
+  });
+  // Refuse the engine deterministically: this proof must not depend on a
+  // desktop engine being up or down on the machine running it.
+  await page.route((u) => u.href.startsWith(ENGINE), (route) => route.abort("connectionrefused"));
+
+  // ---- 1. first load ------------------------------------------------------
+  const response = await page.goto(site, { waitUntil: "load" });
+  assert.equal(response.status(), 200);
+  await page.locator('textarea[aria-label="Message"]').waitFor({ timeout: 15_000 });
+  const send = page.locator('button[data-action="send"]');
+  await send.waitFor();
+  assert.equal(await send.textContent(), "Send", "the Send control renders with its label");
+  await page.locator('.row-notice[data-tone="warning"]').waitFor({ timeout: 15_000 });
+  assert.match(
+    await page.locator('.row-notice[data-tone="warning"]').first().textContent(),
+    /not answering/,
+    "no engine reachable is reported as a notice, and the composer stays usable",
+  );
+  const unexpected = errors.filter((e) => !e.includes(ENGINE));
+  assert.deepEqual(unexpected, [], `console errors on boot:\n${unexpected.join("\n")}`);
+
+  // ---- 2. manifest ----------------------------------------------------------
+  const manifestHref = await page.evaluate(() => document.querySelector('link[rel="manifest"]')?.href ?? null);
+  assert.ok(manifestHref, "index.html must link a web app manifest");
+  assert.ok(manifestHref.startsWith(site), `the manifest resolves inside the subpath, got ${manifestHref}`);
+  const manifestRes = await page.request.get(manifestHref);
+  assert.equal(manifestRes.status(), 200);
+  assert.match(manifestRes.headers()["content-type"], /^application\/manifest\+json/);
+  const manifest = await manifestRes.json();
+  assert.equal(manifest.display, "standalone");
+  assert.equal(new URL(manifest.start_url, manifestHref).href, site, "start_url resolves to the subpath root");
+  assert.equal(new URL(manifest.scope, manifestHref).href, site, "and so does scope");
+  for (const icon of manifest.icons) {
+    const r = await page.request.get(new URL(icon.src, manifestHref).href);
+    assert.equal(r.status(), 200, `icon ${icon.src} must be served`);
+    assert.match(r.headers()["content-type"], /^image\/png/);
+  }
+  assert.ok(manifest.icons.some((i) => i.sizes === "512x512"), "a 512x512 icon is required to be installable");
+
+  // ---- 3. service worker --------------------------------------------------
+  // An explicit poll rather than page.waitForFunction: with an async
+  // predicate that one resolved on a falsy value instead of polling, so it
+  // could return before activation -- or, with no registration at all,
+  // return null instantly and make the next line the failure.
+  const activeScope = () =>
+    page.evaluate(async () => {
+      const reg = await navigator.serviceWorker.getRegistration();
+      return reg?.active?.state === "activated" ? reg.scope : null;
+    });
+  const deadline = Date.now() + 20_000;
+  let scope = await activeScope();
+  while (scope === null && Date.now() < deadline) {
+    await new Promise((ok) => setTimeout(ok, 100));
+    scope = await activeScope();
+  }
+  assert.ok(scope !== null, "no service worker became active within 20s: is it registered?");
+  assert.equal(scope, site, "the worker's scope is the subpath");
+  const swRes = await page.request.get(site + "sw.js");
+  assert.match(swRes.headers()["content-type"], /^text\/javascript/);
+  const cached = await page.evaluate(async () => {
+    const keys = await caches.keys();
+    const hits = {};
+    for (const rel of ["index.html", "app.js", "app.css", "manifest.webmanifest", "register-sw.js"]) {
+      hits[rel] = (await caches.match(new URL(rel, location.href).href)) !== undefined;
+    }
+    return { keys, hits };
+  });
+  assert.equal(cached.keys.length, 1, `exactly one cache, got ${cached.keys}`);
+  assert.match(cached.keys[0], /^praisonai-mobile-[0-9a-f]{16}$/);
+  for (const [rel, hit] of Object.entries(cached.hits)) assert.ok(hit, `${rel} must be precached`);
+
+  // ---- 4. offline ---------------------------------------------------------
+  // Take the page under the worker's control, then take the network away for
+  // real: the server stops accepting connections, and the browser is told it
+  // is offline as well. If the reload renders, it rendered from the cache.
+  await page.reload({ waitUntil: "load" });
+  assert.ok(await page.evaluate(() => navigator.serviceWorker.controller !== null), "the page is controlled by the worker");
+  server.closeAllConnections?.();
+  await new Promise((ok) => server.close(ok));
+  await context.setOffline(true);
+  const offlineErrors = [];
+  page.on("pageerror", (e) => offlineErrors.push(e.message));
+  await page.goto(site, { waitUntil: "load" });
+  await page.locator('textarea[aria-label="Message"]').waitFor({ timeout: 15_000 });
+  assert.equal(await page.locator('button[data-action="send"]').textContent(), "Send", "Send renders offline");
+  assert.deepEqual(offlineErrors, [], "no script error offline");
+  assert.equal(await page.evaluate(() => document.styleSheets.length > 0 && getComputedStyle(document.body).margin), "0px", "the stylesheet came from the cache too");
+
+  // ---- 5. CSP is enforced -------------------------------------------------
+  const ran = await page.evaluate(() => {
+    const s = document.createElement("script");
+    s.textContent = "window.__inline_ran = true";
+    document.body.append(s);
+    return window.__inline_ran === true;
+  });
+  assert.equal(ran, false, "script-src 'self' must block an inline script");
+});
+
+test("a redeployed site replaces the cached one instead of being pinned behind it", async (t) => {
+  // A stale-cache service worker is worse than no service worker: it pins
+  // every returning visitor to a build that has been replaced, and the user
+  // cannot tell, cannot fix it, and will not report it. Two mechanisms stop
+  // that, and BOTH survived being deleted until this test existed:
+  //
+  //   - navigation is network-first. A cache-first HTML entry serves the old
+  //     page for as long as the cache lives, so a deploy reaches nobody.
+  //   - `activate` deletes every cache but the current one. Without it the
+  //     old build's bytes stay on disk forever, and the first bug in the
+  //     eviction order pairs an old chunk with a new page.
+  //
+  // The first test's assertions could not see either: one browser context,
+  // one build, one cache, so "exactly one cache" was true whether or not
+  // anything was ever deleted. This one deploys a SECOND version under a
+  // browser that already holds the first.
+  const built = spawnSync(process.execPath, [join(pkg, "tools/build-webview.mjs")], { encoding: "utf8" });
+  assert.equal(built.status, 0, `${built.stdout}${built.stderr}`);
+
+  const v1Html = await readFile(join(dist, "index.html"), "utf8");
+  const v1Sw = await readFile(join(dist, "sw.js"), "utf8");
+  const v1Cache = /const CACHE = "(praisonai-mobile-[0-9a-f]{16})";/.exec(v1Sw)?.[1];
+  assert.ok(v1Cache, "the built worker must name a versioned cache for this test to version it");
+
+  const overrides = new Map();
+  const server = await serveDist(overrides);
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  const site = origin + BASE;
+  const browser = await launch();
+  t.after(async () => {
+    await browser.close();
+    server.closeAllConnections?.();
+    await new Promise((ok) => server.close(ok));
+  });
+  const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  const page = await context.newPage();
+  await page.route((u) => u.href.startsWith(ENGINE), (route) => route.abort("connectionrefused"));
+
+  const activeCaches = () => page.evaluate(() => caches.keys().then((k) => k.sort()));
+  const waitForActive = async (why) => {
+    const deadline = Date.now() + 20_000;
+    for (;;) {
+      const state = await page.evaluate(async () => {
+        const reg = await navigator.serviceWorker.getRegistration();
+        return reg?.active?.state === "activated";
+      });
+      if (state) return;
+      assert.ok(Date.now() < deadline, `no worker became active within 20s (${why})`);
+      await new Promise((ok) => setTimeout(ok, 100));
+    }
+  };
+
+  // ---- v1 is installed and controlling ------------------------------------
+  await page.goto(site, { waitUntil: "load" });
+  await page.locator('textarea[aria-label="Message"]').waitFor({ timeout: 15_000 });
+  await waitForActive("first load");
+  await page.reload({ waitUntil: "load" });
+  assert.ok(await page.evaluate(() => navigator.serviceWorker.controller !== null), "v1 must be controlling the page");
+  assert.deepEqual(await activeCaches(), [v1Cache], "v1 holds exactly its own cache");
+
+  // A cache left behind by a build older than this browser session. `activate`
+  // is the only thing that will ever remove it.
+  await page.evaluate(async () => {
+    const old = await caches.open("praisonai-mobile-000000000000dead");
+    await old.put("./stale.js", new Response("// from a build two deploys ago"));
+  });
+
+  // ---- the site is redeployed: new HTML, same worker ----------------------
+  // The worker's bytes are untouched, so NO new worker installs and nothing
+  // re-precaches. The only thing that can put the new page in front of the
+  // user is the navigation handler going to the network first.
+  const marker = "redeployed-build-marker";
+  overrides.set("index.html", v1Html.replace("</body>", `<div id="${marker}"></div></body>`));
+  await page.reload({ waitUntil: "load" });
+  await page.locator('textarea[aria-label="Message"]').waitFor({ timeout: 15_000 });
+  assert.equal(
+    await page.locator(`#${marker}`).count(),
+    1,
+    "a reload served the CACHED page, not the redeployed one: navigation must be network-first, " +
+      "or every returning visitor stays on the old build",
+  );
+
+  // ---- and now a new worker ships ----------------------------------------
+  const v2Cache = "praisonai-mobile-1111111111111111";
+  overrides.set("sw.js", v1Sw.replace(v1Cache, v2Cache));
+  await page.evaluate(async () => {
+    const reg = await navigator.serviceWorker.getRegistration();
+    await reg.update();
+  });
+
+  const deadline = Date.now() + 20_000;
+  let keys = await activeCaches();
+  while (!(keys.length === 1 && keys[0] === v2Cache) && Date.now() < deadline) {
+    await new Promise((ok) => setTimeout(ok, 100));
+    keys = await activeCaches();
+  }
+  assert.deepEqual(
+    keys,
+    [v2Cache],
+    "after the new worker activated the old caches are still there: `activate` must delete every " +
+      "cache but the current one, or a replaced build's bytes live on the user's disk forever",
+  );
+
+  // The new build is the one being served, from its own cache.
+  await page.reload({ waitUntil: "load" });
+  await page.locator('textarea[aria-label="Message"]').waitFor({ timeout: 15_000 });
+  assert.ok(await page.evaluate(() => navigator.serviceWorker.controller !== null), "v2 controls the page");
+});

--- a/src/praisonai-mobile/tools/web-csp.test.mjs
+++ b/src/praisonai-mobile/tools/web-csp.test.mjs
@@ -1,0 +1,103 @@
+/**
+ * The web build's Content-Security-Policy, as written in app/index.html.
+ *
+ * tauri.conf.json's csp reaches only the Tauri shell; a browser loading dist/
+ * from GitHub Pages sees the meta tag and nothing else. And because Tauri
+ * appends its own tag rather than replacing this one, the shell enforces
+ * BOTH -- so this one must not be tighter than Tauri's anywhere the shell
+ * needs room (the IPC origins), or the Android app breaks with a console line.
+ *
+ * tools/web-boot.test.mjs proves the policy is enforced by a real browser;
+ * this file pins its text so a loosening is a visible diff.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const html = readFileSync(join(import.meta.dirname, "../app/index.html"), "utf8");
+const tauri = JSON.parse(readFileSync(join(import.meta.dirname, "../src-tauri/tauri.conf.json"), "utf8"));
+
+/** The meta tag's policy, or null when there is none. */
+function metaCsp(page) {
+  const m = /<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]*)"/i.exec(page);
+  return m ? m[1] : null;
+}
+const directives = (csp) =>
+  Object.fromEntries(
+    csp
+      .split(";")
+      .map((d) => d.trim())
+      .filter(Boolean)
+      .map((d) => {
+        const [name, ...sources] = d.split(/\s+/);
+        return [name, sources];
+      }),
+  );
+
+const csp = metaCsp(html);
+const web = csp === null ? null : directives(csp);
+const shell = directives(tauri.app.security.csp);
+
+test("the page carries a CSP meta tag, placed before anything it must govern", () => {
+  assert.ok(csp !== null, "app/index.html must carry a <meta http-equiv=\"Content-Security-Policy\">");
+  const at = html.indexOf('http-equiv="Content-Security-Policy"');
+  for (const tag of ["<link", "<script", "<style"]) {
+    const first = html.indexOf(tag);
+    if (first !== -1) assert.ok(at < first, `the CSP must precede the first ${tag}, or that element loads ungoverned`);
+  }
+});
+
+test("script-src is 'self' and nothing else", () => {
+  assert.deepEqual(web["script-src"], ["'self'"], "no 'unsafe-inline', no 'unsafe-eval', no host, no nonce, no hash");
+  assert.deepEqual(web["default-src"], ["'self'"]);
+});
+
+test("there is no inline script for that policy to silently block", () => {
+  // A `<script>` with a body would be dropped by script-src 'self' with only
+  // a console line to say so -- the page would boot without it and nobody
+  // would know. Every script is an external file.
+  const inline = [...html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/g)].filter(
+    ([, attrs, body]) => !/\bsrc=/.test(attrs) || body.trim() !== "",
+  );
+  assert.deepEqual(inline.map((m) => m[0]), [], "an inline <script> would be blocked by the CSP");
+  assert.match(html, /<script\s+src="\.\/register-sw\.js"><\/script>/, "the registration is an external file");
+});
+
+test("connect-src reaches the engines the settings allow", () => {
+  const connect = web["connect-src"];
+  for (const source of ["'self'", "http://127.0.0.1:*", "http://localhost:*", "https:"]) {
+    assert.ok(connect.includes(source), `connect-src must include ${source}`);
+  }
+  assert.ok(!connect.includes("*"), "and must not be a wildcard");
+  assert.ok(!connect.includes("http:"), "nor allow every plain-http host");
+});
+
+test("the web CSP is never tighter than the shell's where the shell needs room", () => {
+  // Both tags apply inside Tauri. Every source the shell's connect-src allows
+  // must be allowed here too, or the shell's own IPC is blocked.
+  for (const source of shell["connect-src"]) {
+    assert.ok(web["connect-src"].includes(source), `tauri.conf.json allows ${source}; the web CSP must too`);
+  }
+  for (const name of Object.keys(shell)) {
+    assert.ok(name in web, `the shell sets ${name}; the web CSP must set it too rather than fall back to default-src`);
+  }
+});
+
+test("the manifest and the worker are permitted, and <base> cannot be injected", () => {
+  assert.deepEqual(web["manifest-src"], ["'self'"]);
+  assert.deepEqual(web["worker-src"], ["'self'"]);
+  assert.deepEqual(web["base-uri"], ["'self'"], "a <base> injection would redirect every relative URL");
+  // Chrome ignores these when delivered via <meta> and logs a console error
+  // for each -- which the boot proof counts as a failure. They belong in a
+  // response header, which GitHub Pages does not let us set.
+  for (const headerOnly of ["frame-ancestors", "report-uri", "sandbox"]) {
+    assert.ok(!(headerOnly in web), `${headerOnly} is ignored in a <meta> CSP`);
+  }
+});
+
+test("every asset URL in the page is relative, so a subpath deployment works", () => {
+  for (const [, url] of html.matchAll(/\b(?:href|src)="([^"]+)"/g)) {
+    assert.match(url, /^\.\//, `${url} must be relative: GitHub Pages serves this from /PraisonAI/`);
+  }
+});


### PR DESCRIPTION
Third leg of "iOS should work, Android should work, and the web app if it is compatible". iOS and Android build in CI (#4737). The web build produced files and nobody had ever watched one load. This makes it a real target, proved in a headless browser rather than asserted from a file listing.

Refs #4673.

## What ships

- `app/manifest.webmanifest`, `app/register-sw.js`, `app/sw.js` — the PWA. Every URL is relative: GitHub Pages serves a project site from `/PraisonAI/`, and an absolute `/app.js` resolves to the wrong site there.
- A CSP `<meta>` in `index.html`. `tauri.conf.json`'s csp reaches only the Tauri shell; a browser sees this tag and nothing else. Tauri **appends** its own rather than replacing it, so inside the shell both apply and this one must not be tighter than Tauri's where the IPC channel needs room.
- `build-webview.mjs` writes the worker: the precache list is what the build emitted, and the cache name is a hash of those bytes — a new build is a new cache, and the old one is deleted on `activate`.
- `.github/workflows/mobile-web.yml` — build, boot proof, `dist` artifact, and a Pages deploy on `main`.

The engine picker is coherent with this: `defaultEngineIdFor("web")` returns remote-HTTP (a browser tab talks to a server) while `"tauri"` returns the in-process `praisonai-ts` engine. The boot proof asserts the browser reports "engine not answering" as a notice with the composer still usable, rather than crashing.

## Three things were wrong, and are fixed here rather than shipped

1. **The precache list missed an eager chunk.** It was hand-written, and code splitting (#4727) had since given `app.js` a chunk it imports *statically*. That chunk was in no list, so the app rendered online and **died on an offline reload**. The list is now read off the bundle's own eager set. The lazy chunks stay out — precaching 1.4MB would undo the whole point of the split — and the worker caches them as they are fetched, so a feature works offline once it has been used.
2. **`mobile-web.yml` never built `praisonai-ts`**, which is a `file:` dependency. Its `npm ci` could not have installed at all (reproduced locally: the linked package's prebuild fails without its own `node_modules`).
3. **Its `paths` filter watched only `src/praisonai-mobile`.** The web bundle is built *from* `praisonai-ts`, so drift there must trigger this gate — the same reason `mobile.yml` watches `src/praisonai-ts/src/**`, `scripts/**` and `package.json`.

## Mutation table

Every gate was mutation-tested, one edit at a time, each mutation asserting its anchor text was actually found so a silent no-op cannot read as "survived".

| Mutation | Killed by |
| --- | --- |
| Remove the manifest `<link>` from `index.html` | `the built web app boots, installs, and survives going offline` — *"index.html must link a web app manifest"* |
| CSP `script-src` gains `'unsafe-inline'` | `script-src is 'self' and nothing else`, and the boot proof's *"script-src 'self' must block an inline script"* |
| App throws on mount | `the built web app boots, installs, and survives going offline` — times out waiting for the composer |
| Cache name stops depending on the built bytes | `the service worker precaches exactly what was built, under a build-derived cache name` |
| Precache drops the eager chunks | `the worker precaches the EAGER chunks and leaves the lazy ones to be fetched` |
| `activate` stops deleting old caches | `a redeployed site replaces the cached one instead of being pinned behind it` |
| Navigation becomes cache-first | `a redeployed site replaces the cached one instead of being pinned behind it` |

The last two **initially survived**. One build in one browser context only ever has one cache, so the existing "exactly one cache" assertion was true whether or not anything was deleted, and a cache-first HTML entry was invisible. The added test deploys a v2 under a browser already holding v1 and kills both. A stale-cache worker that pins visitors to a replaced build is worse than no worker at all, so that gap mattered more than the ones that were already covered.

## Verification

- `npm run check` → **exit 0**, 1372 tests, 0 fail, 0 cancelled (judged by exit code, not the `fail: 0` line).
- `npm run test:web` → exit 0. The boot proof serves `dist/` over HTTP under `/PraisonAI/`, and asserts the composer and Send render, the manifest is served as `application/manifest+json` with `start_url`/`scope` resolving inside the subpath, all icons 200 as `image/png`, the worker activates scoped to the subpath, an offline reload still renders from cache, and a runtime-injected inline script does not execute.
- Both `mobile.yml` and `mobile-web.yml` parsed with `yaml.safe_load`, and every step `name` containing a `file:` colon was confirmed to parse as a string — the bug that once made GitHub silently skip an entire workflow while the PR looked green.

## Human follow-up: GitHub Pages is not enabled

Nothing here enables Pages and nothing needs a secret the repo does not have. **A repository admin must set Settings → Pages → Build and deployment → Source to "GitHub Actions"** for the site to publish.

Until then the `deploy` job **skips with a notice rather than failing** — it queries the Pages API, and on `build_type != workflow` (or a custom domain being set) writes an actionable notice and exits 0. No workflow can set that setting, and a red `main` on every push because of it is exactly how mobile checks get ignored. The built site is attached to every run as the `mobile-web-dist` artifact in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for installing the mobile web app as a progressive web app, including app icons, standalone display, and portrait orientation.
  - Added offline support so previously loaded app content remains available without a network connection.
  - Added automatic web deployment to GitHub Pages when configuration requirements are met.

- **Security**
  - Added Content Security Policy protections for web content and connections.

- **Reliability**
  - Improved web build validation, browser compatibility checks, and service-worker update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->