### PR TITLE
fix(mobile): the platform builds are broken on main, and nothing was watching

### DIFF
--- a/.github/workflows/mobile-platforms.yml
+++ b/.github/workflows/mobile-platforms.yml
@@ -38,9 +38,18 @@ name: mobile platforms
 on:
   workflow_dispatch:
   pull_request:
-    paths:
+    paths: &watched
       - 'src/praisonai-mobile/**'
+      - 'src/praisonai-ts/src/**'
       - '.github/workflows/mobile-platforms.yml'
+  # Without this, no platform build had ever run on main -- so a break
+  # introduced by two PRs that were each green apart could sit on main
+  # unnoticed. That is exactly what happened: #4737 branched from before
+  # #4727 added the `file:` dependency, so the two were never installed
+  # together until they had both landed.
+  push:
+    branches: [main]
+    paths: *watched
 
 concurrency:
   group: mobile-platforms-${{ github.ref }}
@@ -72,6 +81,18 @@ jobs:
         with:
           workspaces: src/praisonai-mobile/src-tauri
           key: ios-sim
+      - name: "Build praisonai-ts (the file: dependency)"
+        # praisonai-mobile depends on praisonai by `file:`, so `npm ci`
+        # here runs praisonai-ts's own `prepare` -> `rimraf dist`. On a
+        # fresh runner praisonai-ts has no node_modules, so rimraf is not
+        # installed and `npm ci` dies with code 127 before a single
+        # platform step runs. mobile.yml gives all four of its jobs this
+        # step; these two were written against the tree from before the
+        # dependency existed and never got it.
+        working-directory: src/praisonai-ts
+        run: |
+          npm install --no-audit --no-fund --legacy-peer-deps
+          npm run build
       - run: npm ci
 
       - name: Generate the Xcode project (only if gen/apple is not committed)
@@ -255,6 +276,18 @@ jobs:
         with:
           workspaces: src/praisonai-mobile/src-tauri
           key: android-apk
+      - name: "Build praisonai-ts (the file: dependency)"
+        # praisonai-mobile depends on praisonai by `file:`, so `npm ci`
+        # here runs praisonai-ts's own `prepare` -> `rimraf dist`. On a
+        # fresh runner praisonai-ts has no node_modules, so rimraf is not
+        # installed and `npm ci` dies with code 127 before a single
+        # platform step runs. mobile.yml gives all four of its jobs this
+        # step; these two were written against the tree from before the
+        # dependency existed and never got it.
+        working-directory: src/praisonai-ts
+        run: |
+          npm install --no-audit --no-fund --legacy-peer-deps
+          npm run build
       - run: npm ci
 
       - name: Generate the Android project (only if gen/android is not committed)


### PR DESCRIPTION
## The break

`mobile-platforms.yml` fails at `npm ci` on `main`, in about two seconds, on both runners. Everything it exists to produce — the simulator `.app`, the debug APK, and both "is the Rust actually inside it?" guards — is skipped.

Dispatched on `main` to confirm, run [`33728309565`](https://github.com/MervinPraison/PraisonAI/actions/runs/33728309565):

```
npm error code 127
npm error path .../src/praisonai-ts
npm error command sh -c npm run build
npm error > praisonai@1.7.4 clean
npm error > rimraf dist
npm error sh: rimraf: command not found
```

## Two defects, and the second is what let the first land

**1. Neither job builds the `file:` dependency.**

#4727 made `praisonai` a `file:` link to the sibling package, so `npm ci` in praisonai-mobile now runs praisonai-ts's own `prepare` → `prebuild` → `rimraf dist`. `rimraf` is a praisonai-ts devDependency, and a fresh runner has no praisonai-ts `node_modules`.

`mobile.yml` gives all four of its jobs a `Build praisonai-ts` step and so survives. These two jobs were written against the tree from before the dependency existed, and never got it.

**2. The workflow had no `push` trigger, so it had never run on `main` at all.**

That is why this was invisible. #4737 branched from `28ab7f1cb`, which predates #4727 — `git merge-base --is-ancestor 6885c1276 9ea153d65` returns 1. Its platform run was *genuinely* green (iOS 3m13s, Android 3m), but green on a tree where `dependencies` was empty and `prepare` therefore never fired.

Two PRs, each correct on its own, broke `main` the moment both had landed. No gate on `main` was looking.

## Verified locally, both directions

From a clean state — praisonai-ts `node_modules` and `dist` and praisonai-mobile `node_modules` all removed:

| sequence | exit |
|---|---|
| `npm ci` alone (what `main` does today) | **127** |
| praisonai-ts `npm install --legacy-peer-deps` → `npm run build` → `npm ci` | **0** |

Deterministic on three independent machines: two CI runners and locally.

## The fix

- The same `Build praisonai-ts (the file: dependency)` step `mobile.yml` uses, ahead of `npm ci` in both `ios-simulator` and `android-apk`.
- `push: branches: [main]`, sharing the paths filter with `pull_request` through a YAML anchor so the two cannot drift apart.
- The filter gains `src/praisonai-ts/src/**` — that is the side of the `file:` link that drifts, and a gate blind to it is a gate that will miss the next one.

## Why this keeps happening

A gate that quietly does not run is worse than one that fails, and this is the third instance in this package:

1. a path filter blind to praisonai-ts,
2. an unquoted `file:` in a step name, which made GitHub skip an entire workflow with no annotation and no failing check,
3. and now a workflow with no trigger on the branch it was meant to protect.

Each time the PR page was green. Each time the reason was that nothing ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Mobile platform builds now also run automatically when changes are pushed to the main branch.
  - Mobile build validation now includes updates to the TypeScript package.
  - Improved fresh-runner setup for iOS simulator and Android APK builds to ensure local package preparation completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->