### PR TITLE
fix(tests): assert the approval resolver's real backend, not a stale class name

### DIFF
--- a/src/praisonai-agents/tests/unit/approval/test_cli_approval_resolver.py
+++ b/src/praisonai-agents/tests/unit/approval/test_cli_approval_resolver.py
@@ -1,5 +1,6 @@
 """Tests for praisonai.cli.features.approval — resolve_approval_backend."""
 
+import inspect
 import os
 import sys
 import pytest
@@ -41,8 +42,11 @@ class TestResolveApprovalBackend:
             assert isinstance(b, InteractiveCLIApprovalBackend), value
             # registry.py and tool_execution.py both probe for the sync variant
             # with hasattr and fall back when it is absent, so only the async
-            # entry point is part of the contract every backend must honour.
-            assert callable(getattr(b, "request_approval", None)), value
+            # entry point is part of the contract every backend must honour —
+            # and the async path awaits it, so it must be a coroutine function.
+            assert inspect.iscoroutinefunction(
+                getattr(b, "request_approval", None)
+            ), value
 
     def test_auto_returns_auto_approve_backend(self):
         b = self._resolve("auto")

--- a/src/praisonai-agents/tests/unit/approval/test_cli_approval_resolver.py
+++ b/src/praisonai-agents/tests/unit/approval/test_cli_approval_resolver.py
@@ -22,13 +22,27 @@ class TestResolveApprovalBackend:
         assert self._resolve("none") is None
         assert self._resolve("None") is None
 
-    def test_console_returns_console_backend(self):
-        b = self._resolve("console")
-        assert type(b).__name__ == "InteractiveCLIApprovalBackend"
+    def test_console_returns_the_interactive_cli_backend(self):
+        """"console" resolves to the interactive CLI backend, not ConsoleBackend.
 
-    def test_true_returns_console_backend(self):
-        b = self._resolve("true")
-        assert type(b).__name__ == "InteractiveCLIApprovalBackend"
+        These two tests asserted `type(b).__name__ == "ConsoleBackend"` and had
+        been red ever since #2037 replaced it with the persisting interactive
+        backend and c9 moved the resolver into praisonai-bot. Nothing caught it:
+        praisonai-agents' unit tree is run by no CI workflow (#4748).
+
+        Asserting a class *name* is what made this brittle, so assert the thing
+        that actually matters instead: the resolver hands back the real class,
+        and that class satisfies the backend contract callers rely on.
+        """
+        from praisonai_code.cli.approval_backend import InteractiveCLIApprovalBackend
+
+        for value in ("console", "true"):
+            b = self._resolve(value)
+            assert isinstance(b, InteractiveCLIApprovalBackend), value
+            # registry.py and tool_execution.py both probe for the sync variant
+            # with hasattr and fall back when it is absent, so only the async
+            # entry point is part of the contract every backend must honour.
+            assert callable(getattr(b, "request_approval", None)), value
 
     def test_auto_returns_auto_approve_backend(self):
         b = self._resolve("auto")
@@ -82,10 +96,11 @@ class TestResolveApprovalBackend:
             self._resolve("foobar")
 
     def test_case_insensitive(self):
-        b = self._resolve("Console")
-        assert type(b).__name__ == "InteractiveCLIApprovalBackend"
-        b = self._resolve("AUTO")
-        assert type(b).__name__ == "AutoApproveBackend"
+        """Casing must not change which backend is chosen."""
+        from praisonai_code.cli.approval_backend import InteractiveCLIApprovalBackend
+
+        assert isinstance(self._resolve("Console"), InteractiveCLIApprovalBackend)
+        assert type(self._resolve("AUTO")).__name__ == "AutoApproveBackend"
 
 
 class TestValidBackends:


### PR DESCRIPTION
Three `TestResolveApprovalBackend` tests fail on `main` in every run:

```
E   AssertionError: assert 'InteractiveCLIApprovalBackend' == 'ConsoleBackend'
```

## Cause

`resolve_approval_backend("console")` stopped returning `ConsoleBackend` when #2037 added the persisting interactive CLI backend, and the c9 extraction moved the resolver into `praisonai-bot` behind the `praisonai.cli.features.approval` shim. The behaviour change was deliberate. The assertions were never updated.

## I checked whether this was actually a production defect first

`InteractiveCLIApprovalBackend` is missing `request_approval_sync`, which `ConsoleBackend` has — which looked like it could be a real crash. It isn't:

- `approval/registry.py:515` and `agent/tool_execution.py:1722` both probe with `hasattr(backend, 'request_approval_sync')` and fall back to the async entry point;
- the one unguarded caller, `praisonai_code/cli/features/job_workflow.py:669`, constructs `ConsoleBackend()` itself rather than going through the resolver.

So only the async `request_approval` is part of the contract every backend must honour.

## Fix

Assert identity against the imported class plus that contract method. Asserting a class name as a string is what let this rot in the first place.

## Why nothing caught it

`src/praisonai-agents/tests/unit/` is run by no CI workflow — 8,962 tests, zero gates. Filed as #4748.

104 tests in `tests/unit/approval/` pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated console approval backend coverage into a parameterized test.
  * Strengthened assertions to verify the expected backend type and asynchronous approval-request behavior.
  * Updated case-insensitivity coverage for console backend resolution.
  * Added clearer test documentation and comments describing the console backend contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->