### PR TITLE
fix(mobile): stop main's platform build cancelling itself

### DIFF
--- a/.github/workflows/mobile-platforms.yml
+++ b/.github/workflows/mobile-platforms.yml
@@ -53,7 +53,17 @@ on:
 
 concurrency:
   group: mobile-platforms-${{ github.ref }}
-  cancel-in-progress: true
+  # On a PR, superseding an in-flight build is right: only the tip
+  # matters and these jobs cost ~3 minutes on two runners.
+  #
+  # On main it is actively harmful, and measurably so. Adding the push
+  # trigger was supposed to make main's platform build observable;
+  # with cancel-in-progress the first two runs on main were BOTH
+  # cancelled by the next merge before finishing (33729635382,
+  # 33730049750). During a busy merge window main would never complete
+  # one -- the trigger would exist and prove nothing, which is the
+  # blindness the trigger was added to remove.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 defaults:
   run:

--- a/.github/workflows/mobile-platforms.yml
+++ b/.github/workflows/mobile-platforms.yml
@@ -52,17 +52,22 @@ on:
     paths: *watched
 
 concurrency:
-  group: mobile-platforms-${{ github.ref }}
+  # Per-ref on a PR, per-SHA on main. This is the crux of the fix, not
+  # cancel-in-progress alone: a concurrency group holds at most ONE
+  # running run and ONE pending run, and a newer arrival always replaces
+  # the pending one -- cancel-in-progress: false spares only the RUNNING
+  # run, never the queued one. So with a single mobile-platforms-main
+  # group, three merges in one ~3-minute window would still drop the
+  # middle commit's run (it is only ever pending), which is precisely the
+  # blindness the push trigger was added to remove. Giving each main SHA
+  # its own group makes every commit a candidate release with its own
+  # answer, with nothing to contend for and so nothing to cancel.
+  group: mobile-platforms-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   # On a PR, superseding an in-flight build is right: only the tip
-  # matters and these jobs cost ~3 minutes on two runners.
-  #
-  # On main it is actively harmful, and measurably so. Adding the push
-  # trigger was supposed to make main's platform build observable;
-  # with cancel-in-progress the first two runs on main were BOTH
-  # cancelled by the next merge before finishing (33729635382,
-  # 33730049750). During a busy merge window main would never complete
-  # one -- the trigger would exist and prove nothing, which is the
-  # blindness the trigger was added to remove.
+  # matters and these jobs cost ~3 minutes on two runners. On main each
+  # group has a single run, so this is a no-op there -- left true because
+  # the condition that mattered is now expressed in the group name above,
+  # and this keeps the PR behaviour explicit.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 defaults:


### PR DESCRIPTION
#4746 added `push: branches: [main]` so the iOS and Android platform builds would finally be gated on `main` rather than only on PRs.

**They still are not**, because `cancel-in-progress: true` applies to `main` too, and merges land faster than a ~3 minute build on two runners completes.

## Measured, not predicted

The first two runs the new trigger ever produced were both cancelled by the following merge before either finished:

| run | sha | result |
|---|---|---|
| [33729635382](https://github.com/MervinPraison/PraisonAI/actions/runs/33729635382) | `fa7caf775` | **cancelled** — both jobs |
| [33730049750](https://github.com/MervinPraison/PraisonAI/actions/runs/33730049750) | `e8006cc9c` | **cancelled** — both jobs |

So the trigger exists and proves nothing — which is precisely the blindness it was added to remove, reintroduced one line further down the same file. I put that line there, and only found it by watching the runs it produced instead of assuming the fix worked.

## The change

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

On a PR the old behaviour is right: only the tip matters, and superseding saves two runners. On `main` every commit is a candidate release and wants its own answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI/CD**
  - Main-branch mobile platform builds now run independently for each commit and are not cancelled or left pending when subsequent merges occur.
  - Pull request builds continue to use per-branch concurrency, allowing newer updates to supersede earlier runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->