### PR TITLE
fix(agent): compact the custom-LLM streaming branch too

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -4973,7 +4973,26 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 try:
                     # Use the new streaming generator from LLM class
                     response_content = ""
-                    stream_history = self.chat_history
+                    # Compact before sending, exactly as the OpenAI-client
+                    # branch below does. #4729 added compaction to that branch
+                    # only, so a configured ContextManager -- auto-enabled
+                    # whenever tools are present -- was still skipped for every
+                    # agent routed through the custom-LLM path. The trigger is
+                    # the routing flag, not the vendor: llm="openai/gpt-4o-mini"
+                    # takes this branch too. Zero overhead when context=False.
+                    stream_system_prompt = self._build_system_prompt(
+                        tool_param,
+                        memory_prefetch_context=memory_prefetch_context,
+                    )
+                    if self.context_manager:
+                        stream_history, _ = self._apply_context_management(
+                            messages=self.chat_history,
+                            system_prompt=stream_system_prompt or "",
+                            tools=tool_param,
+                        )
+                        stream_history = list(stream_history)
+                    else:
+                        stream_history = self.chat_history
                     durable_context = self._get_durable_run_context()
                     if durable_context is not None:
                         stream_history = durable_context.restore_messages(
@@ -4986,10 +5005,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         stream_sampling_kwargs['top_p'] = kwargs['top_p']
                     for chunk in self.llm_instance.get_response_stream(
                         prompt=actual_prompt,
-                        system_prompt=self._build_system_prompt(
-                            tool_param,
-                            memory_prefetch_context=memory_prefetch_context,
-                        ),
+                        system_prompt=stream_system_prompt,
                         chat_history=stream_history,
                         temperature=kwargs.get('temperature', 1.0),
                         tools=tool_param,

--- a/src/praisonai-agents/tests/unit/context/test_stream_context_management_custom_llm.py
+++ b/src/praisonai-agents/tests/unit/context/test_stream_context_management_custom_llm.py
@@ -1,0 +1,89 @@
+"""The custom-LLM streaming branch must compact too.
+
+#4729 added context compaction to `_start_stream_impl`, but only inside the
+OpenAI-client branch. Every agent routed through the custom-LLM path still
+streamed its entire history uncompacted, so a long conversation was sent in
+full and rejected by the provider for exceeding the context window.
+
+The trigger is the routing flag, not the vendor: `llm="openai/gpt-4o-mini"`
+takes this branch too, so this was not limited to Anthropic or Ollama users.
+
+test_stream_context_management.py pins the OpenAI branch and hardcodes
+`_using_custom_llm = False`, which is exactly why it stayed green while this
+half was broken.
+"""
+import os
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from praisonaiagents import Agent
+
+
+def _agent_with_history(messages: int, words: int):
+    agent = Agent(name="t", instructions="x", llm="openai/gpt-4o-mini",
+                  tools=[lambda x: x], context=True)
+    agent.chat_history = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": "filler " * words}
+        for i in range(messages)
+    ]
+    sent = {}
+
+    def fake_stream(**kwargs):
+        sent["history"] = list(kwargs.get("chat_history") or [])
+        yield "ok"
+
+    agent._using_custom_llm = True
+    agent.llm_instance = type("L", (), {"get_response_stream": staticmethod(fake_stream)})()
+    return agent, sent
+
+
+def _drain(agent, sent):
+    list(agent._start_stream_impl("hello", stream=True))
+    return sent.get("history")
+
+
+class TestCustomLlmStreamCompaction:
+
+    def test_an_oversized_history_is_compacted_before_sending(self):
+        """Without this, 801 messages (~1.7M tokens) go at a 128k-token model."""
+        agent, sent = _agent_with_history(800, 1200)
+        history = _drain(agent, sent)
+        assert history is not None, "the custom-LLM stream was never called"
+        assert len(history) < 801, (
+            "the whole history was streamed uncompacted; the provider would "
+            "reject this turn for exceeding the context window"
+        )
+
+    def test_a_small_history_is_left_alone(self):
+        """Compaction must not fire when it is not needed."""
+        agent, sent = _agent_with_history(6, 5)
+        history = _drain(agent, sent)
+        assert len(history) == 7, "a short history was compacted unnecessarily"
+
+    def test_the_context_manager_is_actually_configured_here(self):
+        """Guards the premise: tools present auto-enable context management."""
+        agent, _ = _agent_with_history(4, 5)
+        assert agent.context_manager is not None
+
+    def test_the_system_prompt_still_reaches_the_provider(self):
+        """The prompt is built once now and reused; it must still be passed."""
+        agent = Agent(name="t", instructions="be terse", llm="openai/gpt-4o-mini",
+                      tools=[lambda x: x], context=True)
+        agent.chat_history = []
+        seen = {}
+
+        def fake_stream(**kwargs):
+            seen.update(kwargs)
+            yield "ok"
+
+        agent._using_custom_llm = True
+        agent.llm_instance = type("L", (), {"get_response_stream": staticmethod(fake_stream)})()
+        list(agent._start_stream_impl("hello", stream=True))
+        assert "system_prompt" in seen
+        assert seen["system_prompt"], "system_prompt was dropped when it was hoisted"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## The gap

#4729 fixed "the streaming path never compacts" — but only for the OpenAI-client branch of `_start_stream_impl`. The custom-LLM branch builds `stream_history` straight from `self.chat_history` and streams it whole.

So a configured `ContextManager` — auto-enabled whenever tools are present — is silently skipped for every agent routed through that branch.

**The trigger is the routing flag, not the vendor.** `llm="openai/gpt-4o-mini"` takes this branch too, so this was never confined to Anthropic or Ollama users.

## Measured

Against a 128k-token model with an 801-message history:

| | messages sent |
|---|---|
| `main` | **801** (~1.7M tokens — certain provider rejection) |
| with this fix | **48** |

And compaction still doesn't fire when it isn't needed — 121 messages at ~84k tokens sends all 121.

## Change

- Apply `_apply_context_management` in the custom-LLM branch, mirroring what the OpenAI branch already does.
- Build the system prompt once and reuse it for both the compaction call and the stream call, instead of constructing it twice.

## Why nothing caught it

`tests/unit/context/test_stream_context_management.py`, added with #4729, hardcodes `_using_custom_llm = False` — it pins the half that worked. The new test sets it `True`; reverting the fix turns it red.

## Verification

6 passed across both stream-compaction test files. Full `tests/unit/context`, `tests/unit/compaction` and `tests/unit/streaming` run: this change fixes one test and breaks none. The 5 that still fail are pre-existing on `main` — two are #4724 (fixed in #4744), three are `TestContextCompactor` failures tracked under #4748.

Found by a multi-agent post-merge sweep and re-verified by running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved custom-model streaming by compacting oversized conversation history before sending it for processing.
  - Preserved shorter conversation histories without unnecessary changes.
  - Ensured system instructions continue to be included during streaming responses.

- **Tests**
  - Added coverage for conversation-history compaction and system-instruction handling in custom-model streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->