### PR TITLE
fix(ci): harden merge gate dispatch and stop false merge-ready labels

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -213,6 +213,33 @@ assert(
   mg.findMergeGateVerdict(recentVerdictOnHead, null, '2026-06-27T09:55:00Z') === 'APPROVE'
 );
 
+assert(
+  'scan kickoff text is not a verdict',
+  mg.findMergeGateVerdict([
+    {
+      body: '**Merge gate scan** — eligible for assessment. Claude merge gate will assess and may auto-merge if `MERGE_GATE_VERDICT: APPROVE`.',
+      created_at: '2026-06-27T10:05:00Z',
+    },
+  ], null, '2026-06-27T09:55:00Z') === null
+);
+
+const finalWithFinished = [
+  { user: { login: 'MervinPraison' }, body: '@claude You are the FINAL architecture reviewer.', created_at: '2026-06-27T10:00:00Z' },
+  { user: { login: 'praisonai-triage-agent[bot]' }, body: 'Claude finished', created_at: '2026-06-27T10:05:00Z' },
+];
+assert('final complete requires Claude finished reply', mg.finalClaudeCompletedOnSha(finalWithFinished, '2026-06-27T09:55:00Z'));
+assert('final trigger alone is incomplete', !mg.finalClaudeCompletedOnSha(
+  [{ user: { login: 'MervinPraison' }, body: '@claude You are the FINAL architecture reviewer.', created_at: '2026-06-27T10:00:00Z' }],
+  '2026-06-27T09:55:00Z'
+));
+
+assert('recent scan comment detected', mg.hasRecentMergeGateScanComment([
+  { body: '**Merge gate scan** — eligible', created_at: new Date().toISOString() },
+]));
+assert('old scan comment not recent', !mg.hasRecentMergeGateScanComment([
+  { body: '**Merge gate scan** — eligible', created_at: '2020-01-01T00:00:00Z' },
+]));
+
 // Sensitive + secrets
 assert('workflow path sensitive', mg.sensitivePathReasons([{ filename: '.github/workflows/foo.yml' }]).length === 1);
 assert('ci-only label exempts workflows', mg.sensitivePathReasons(
@@ -257,8 +284,13 @@ const finalAfterRebase = {
   body: '@claude You are the FINAL architecture reviewer.',
   created_at: conflictIso(-20 * 60 * 1000),
 };
+const claudeFinishedAfterRebase = {
+  user: { login: 'praisonai-triage-agent[bot]' },
+  body: 'Claude finished',
+  created_at: conflictIso(-19 * 60 * 1000),
+};
 const headAfterRebase = conflictIso(-21 * 60 * 1000);
-const rebaseComments = [conflictTrigger, rebaseDone, finalAfterRebase];
+const rebaseComments = [conflictTrigger, rebaseDone, finalAfterRebase, claudeFinishedAfterRebase];
 assert('conflict blocks before rebase done', mg.hasRecentConflictComment([conflictTrigger], headAfterRebase));
 assert('conflict clears after rebase + FINAL on HEAD', !mg.hasRecentConflictComment(rebaseComments, headAfterRebase));
 assert('conflict still blocks without FINAL on HEAD', mg.hasRecentConflictComment(
@@ -325,5 +357,26 @@ assert('substantive dispatches still counted', mg.countSubstantiveMergeGateRuns(
   { event: 'schedule' },
 ]) === 2);
 assert('countSubstantiveMergeGateRuns null-safe', mg.countSubstantiveMergeGateRuns(null) === 0);
+assert('rate limit threshold is 200', mg.MIN_CORE_RATE_LIMIT_REMAINING === 200);
 
-process.exit(failed ? 1 : 0);
+(async () => {
+  const skipLow = await mg.shouldSkipMergeGateDispatch(
+    {
+      rest: {
+        rateLimit: {
+          get: async () => ({ data: { resources: { core: { remaining: 50 } } } }),
+        },
+      },
+    },
+    'owner',
+    'repo',
+    1,
+    { info: () => {} }
+  );
+  assert('rate limit low skips dispatch', skipLow === true);
+
+  process.exit(failed ? 1 : 0);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -315,7 +315,16 @@ function shouldSkipStaleFinalRecovery(comments, headPushedAt, headPusherLogin = 
 function finalClaudeCompletedOnSha(comments, headPushedAt) {
   if (!hasFinalClaudeReviewTrigger(comments)) return false;
   if (isStaleFinalAfterPush(comments, headPushedAt)) return false;
-  return true;
+  const finals = comments.filter(isFinalClaudeTriggerComment);
+  if (finals.length === 0) return false;
+  const latestFinal = finals.reduce((a, b) =>
+    new Date(a.created_at) > new Date(b.created_at) ? a : b
+  );
+  const finalTime = new Date(latestFinal.created_at).getTime();
+  return comments.some((c) => {
+    if (!isClaudeFinalReplyComment(c)) return false;
+    return new Date(c.created_at).getTime() >= finalTime - 60000;
+  });
 }
 
 const FINAL_CLAUDE_REVIEW_BODY =
@@ -478,6 +487,7 @@ function hasBlockingClaudeRunForPr(runs, headRef) {
 const MERGE_GATE_WORKFLOW_FILE = 'claude-merge-gate.yml';
 const MERGE_GATE_ACTIVE_LABEL = 'claude-merge-gate-active';
 const MAX_PENDING_MERGE_GATE_RUNS = 3;
+const MIN_CORE_RATE_LIMIT_REMAINING = 200;
 
 function mergeGateDispatchBlockedReason({ labels, pendingRuns, maxPending = MAX_PENDING_MERGE_GATE_RUNS }) {
   if ((labels || []).includes(MERGE_GATE_ACTIVE_LABEL)) {
@@ -514,8 +524,25 @@ async function countPendingMergeGateRuns(github, owner, repo) {
   return pending;
 }
 
+async function getCoreRateLimitRemaining(github) {
+  try {
+    const { data } = await github.rest.rateLimit.get();
+    return data?.resources?.core?.remaining ?? null;
+  } catch {
+    return null;
+  }
+}
+
 async function shouldSkipMergeGateDispatch(github, owner, repo, prNumber, core, options = {}) {
   const maxPending = options.maxPending ?? MAX_PENDING_MERGE_GATE_RUNS;
+  const minCoreRemaining = options.minCoreRemaining ?? MIN_CORE_RATE_LIMIT_REMAINING;
+  const remaining = await getCoreRateLimitRemaining(github);
+  if (remaining !== null && remaining < minCoreRemaining) {
+    core?.info?.(
+      `Skip merge gate dispatch for PR #${prNumber}: rate limit low (${remaining} core remaining)`
+    );
+    return true;
+  }
   const ctx = await loadPrContext(github, owner, repo, prNumber);
   const pendingRuns = await countPendingMergeGateRuns(github, owner, repo);
   const reason = mergeGateDispatchBlockedReason({
@@ -1002,9 +1029,24 @@ async function selectMergeGateCandidates(github, owner, repo, prNumbers, maxCand
 }
 
 const AUTOMATED_FALLBACK_MARKER = 'Automated fallback —';
+const MERGE_GATE_SCAN_MARKER = 'Merge gate scan';
 
 function isAutomatedFallbackVerdict(body) {
   return (body || '').includes(AUTOMATED_FALLBACK_MARKER);
+}
+
+function isMergeGateVerdictComment(body) {
+  const text = body || '';
+  if (text.includes(MERGE_GATE_SCAN_MARKER)) return false;
+  return /(?:^|\n)\s*MERGE_GATE_VERDICT:\s*(APPROVE|BLOCK)\b/m.test(text);
+}
+
+function hasRecentMergeGateScanComment(comments, withinMinutes = 30) {
+  const cutoff = Date.now() - withinMinutes * 60 * 1000;
+  return (comments || []).some((c) => {
+    if (!(c.body || '').includes(MERGE_GATE_SCAN_MARKER)) return false;
+    return new Date(c.created_at).getTime() > cutoff;
+  });
 }
 
 function findMergeGateVerdict(comments, minCreatedAt = null, headPushedAt = null, options = {}) {
@@ -1013,7 +1055,7 @@ function findMergeGateVerdict(comments, minCreatedAt = null, headPushedAt = null
   const headTime = headPushedAt ? new Date(headPushedAt).getTime() - 60000 : 0;
   const gateComments = comments
     .filter((c) => {
-      if (!(c.body || '').includes('MERGE_GATE_VERDICT:')) return false;
+      if (!isMergeGateVerdictComment(c.body)) return false;
       if (excludeAutomatedFallback && isAutomatedFallbackVerdict(c.body)) return false;
       const created = new Date(c.created_at).getTime();
       if (minTime && created < minTime) return false;
@@ -1023,8 +1065,8 @@ function findMergeGateVerdict(comments, minCreatedAt = null, headPushedAt = null
     .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
   if (gateComments.length === 0) return null;
   const body = gateComments[0].body || '';
-  if (body.includes('MERGE_GATE_VERDICT: APPROVE')) return 'APPROVE';
-  if (body.includes('MERGE_GATE_VERDICT: BLOCK')) return 'BLOCK';
+  if (/MERGE_GATE_VERDICT:\s*APPROVE\b/.test(body)) return 'APPROVE';
+  if (/MERGE_GATE_VERDICT:\s*BLOCK\b/.test(body)) return 'BLOCK';
   return null;
 }
 
@@ -1095,10 +1137,14 @@ module.exports = {
   selectMergeGateCandidates,
   isAutomatedFallbackVerdict,
   AUTOMATED_FALLBACK_MARKER,
+  isMergeGateVerdictComment,
+  hasRecentMergeGateScanComment,
   findMergeGateVerdict,
   MERGE_GATE_WORKFLOW_FILE,
   MERGE_GATE_ACTIVE_LABEL,
   MAX_PENDING_MERGE_GATE_RUNS,
+  MIN_CORE_RATE_LIMIT_REMAINING,
+  getCoreRateLimitRemaining,
   mergeGateDispatchBlockedReason,
   countSubstantiveMergeGateRuns,
   countPendingMergeGateRuns,

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -201,17 +201,26 @@ jobs:
                 '**Actions:** wait for CI and the Claude review chain, or add label `needs-manual-review` and merge manually.',
                 '**Opt out:** label `no-auto-merge`.',
               ].join('\n');
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: skipped[0].pr, body,
-              });
+              const ctx = await mergeGate.loadPrContext(github, owner, repo, skipped[0].pr);
+              if (!mergeGate.hasRecentMergeGateScanComment(ctx.comments)) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: skipped[0].pr, body,
+                });
+              }
             } else if (inputPr && candidates.length === 1) {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: candidates[0].pr_number,
-                body: '**Merge gate scan** — eligible for assessment. Claude merge gate will assess and may auto-merge if `MERGE_GATE_VERDICT: APPROVE`.',
-              });
+              const prNum = candidates[0].pr_number;
+              const ctx = await mergeGate.loadPrContext(github, owner, repo, prNum);
+              if (!mergeGate.hasRecentMergeGateScanComment(ctx.comments)) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: prNum,
+                  body: '**Merge gate scan** — eligible for assessment. Claude merge gate will assess and may auto-merge on an APPROVE verdict.',
+                });
+              }
             }
 
-            await ps.syncOpenPullRequests(github, owner, repo, { maxPrs: 10 }, core);
+            await ps.syncOpenPullRequests(
+              github, owner, repo, { maxPrs: 10, dispatchMergeGate: false }, core
+            );
 
   claude-assess:
     needs: scan-candidates
@@ -267,6 +276,7 @@ jobs:
 
       - name: Claude merge gate assessment (read-only)
         id: assess
+        continue-on-error: true
         uses: ./.github/actions/claude-code-action
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -355,7 +365,8 @@ jobs:
             });
             core.info('Posted fallback BLOCK — Opus verdict required');
 
-      - name: Require Opus MERGE_GATE_VERDICT
+      - name: Capture Opus MERGE_GATE_VERDICT
+        id: capture_verdict
         uses: actions/github-script@v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -371,14 +382,14 @@ jobs:
             const verdict = mergeGate.findMergeGateVerdict(
               comments, minCreatedAt, ctx.headPushedAt, { excludeAutomatedFallback: true }
             );
+            core.setOutput('verdict', verdict || 'NONE');
             if (!verdict) {
-              core.setFailed(
-                'Opus merge gate assessment must post MERGE_GATE_VERDICT on this PR (automated fallback APPROVE is not accepted).'
+              core.warning(
+                'Opus MERGE_GATE_VERDICT not posted yet (OAuth may be rate-limited). Merge waits for Opus APPROVE.'
               );
-              return;
+            } else {
+              core.info(`Opus merge gate verdict: ${verdict}`);
             }
-            core.info(`Opus merge gate verdict: ${verdict}`);
-            core.setOutput('verdict', verdict);
 
       - name: Remove merge gate active label
         if: always()
@@ -398,10 +409,6 @@ jobs:
             } catch (e) {
               core.info(`Label claude-merge-gate-active already removed or missing on PR #${prNumber}`);
             }
-
-      - name: Fail job if assessment failed
-        if: steps.assess.outcome == 'failure'
-        run: exit 1
 
   merge-only:
     needs: [scan-candidates, claude-assess]


### PR DESCRIPTION
## Summary
- Ignore merge gate scan kickoff comments when parsing `MERGE_GATE_VERDICT`
- Require a Claude finished reply after the latest FINAL trigger before marking merge-ready
- Dedupe scan comments (30 min) and stop re-dispatching merge gate from the scan job
- Skip merge gate dispatch when GitHub core rate limit remaining is below 200
- Continue assess on OAuth errors but require real Opus APPROVE for merge (no fallback auto-merge)

## Test plan
- [x] `node .github/scripts/merge-gate-selftest.js` passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge-gate scans now distinguish status updates from actual approval or blocking decisions.
  * Final checks require a valid Claude completion after the latest final trigger.
  * Duplicate scan comments are prevented, and missing verdicts are handled without failing the workflow.
  * Merge-gate dispatch is skipped when API capacity is too low, reducing avoidable failures.
  * Assessment failures now allow fallback handling to proceed while still requiring approval before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->