### PR TITLE
fix(desktop): stop suggesting model ids the app cannot run

### DIFF
--- a/src/praisonai-desktop/frontend/src/settings-registry.js
+++ b/src/praisonai-desktop/frontend/src/settings-registry.js
@@ -24,12 +24,10 @@ const clampNum = (min, max) => (v) =>
 const SETTINGS = [
   // ---- Models -------------------------------------------------------------
   { key: "model", section: "model", label: "Default model",
-    description: "Any OpenAI-compatible model id. New chats use this.",
+    description: "Any OpenAI-compatible model id. New chats use this. For another provider, set a Base URL and use that endpoint’s bare model id.",
     keywords: ["llm", "gpt", "claude", "provider"],
     control: { kind: "combobox", suggestions: [
       "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "o4-mini",
-      "claude-sonnet-4-20250514", "claude-opus-4-20250514",
-      "gemini-2.0-flash", "ollama/llama3.2",
     ]},
     default: "gpt-4o-mini" },
 

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -653,12 +653,10 @@ const clampNum = (min, max) => (v) =>
 const SETTINGS = [
   // ---- Models -------------------------------------------------------------
   { key: "model", section: "model", label: "Default model",
-    description: "Any OpenAI-compatible model id. New chats use this.",
+    description: "Any OpenAI-compatible model id. New chats use this. For another provider, set a Base URL and use that endpoint’s bare model id.",
     keywords: ["llm", "gpt", "claude", "provider"],
     control: { kind: "combobox", suggestions: [
       "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "o4-mini",
-      "claude-sonnet-4-20250514", "claude-opus-4-20250514",
-      "gemini-2.0-flash", "ollama/llama3.2",
     ]},
     default: "gpt-4o-mini" },
 

--- a/src/praisonai-desktop/ui/settings-registry.js
+++ b/src/praisonai-desktop/ui/settings-registry.js
@@ -24,12 +24,10 @@ const clampNum = (min, max) => (v) =>
 const SETTINGS = [
   // ---- Models -------------------------------------------------------------
   { key: "model", section: "model", label: "Default model",
-    description: "Any OpenAI-compatible model id. New chats use this.",
+    description: "Any OpenAI-compatible model id. New chats use this. For another provider, set a Base URL and use that endpoint’s bare model id.",
     keywords: ["llm", "gpt", "claude", "provider"],
     control: { kind: "combobox", suggestions: [
       "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "o4-mini",
-      "claude-sonnet-4-20250514", "claude-opus-4-20250514",
-      "gemini-2.0-flash", "ollama/llama3.2",
     ]},
     default: "gpt-4o-mini" },
 


### PR DESCRIPTION
The Default model picker offers eight suggestions. Four of them cannot work in the shipped app.

| suggestion | what happens |
|---|---|
| `ollama/llama3.2` | **Rejected outright.** #4722 added a guard refusing slashed ids because the desktop venv has no litellm — so the picker suggested a value the engine now refuses. |
| `claude-sonnet-4-20250514`<br>`claude-opus-4-20250514`<br>`gemini-2.0-flash` | Bare ids, so they take the plain-OpenAI client path. With no Base URL set, they are sent to `api.openai.com` **carrying the user's OpenAI key**, and fail with an OpenAI error naming `platform.openai.com` — which tells the user nothing about what actually went wrong. |

## This is not "those models are unreachable"

The engine reaches any OpenAI-compatible endpoint with a bare id plus a Base URL override — that is exactly what the `model_needs_litellm` guard already tells the user to do. The defect is offering these as **one-click suggestions**, where nothing indicates a Base URL is required.

## Change

- The suggestion list is now the ids that work with no further configuration.
- The field description states the supported route to any other provider.
- The combobox stays free text, so a user with a Base URL can still type any id.

## Verification

All three registry copies updated; `registry-drift.test.mjs` keeps them in step. **190 frontend tests** and **240 engine tests** pass.

Found by a multi-agent post-merge sweep, confirmed against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the model setting guidance for non-default providers, including how to configure a Base URL and enter the endpoint’s bare model ID.

- **Updates**
  - Removed four model suggestions from the model selection list: Claude Sonnet 4, Claude Opus 4, Gemini 2.0 Flash, and Ollama Llama 3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->