### PR TITLE
fix(llm): make tool calls survive get_response_stream

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -4546,6 +4546,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 try:
                     is_ollama = self._is_ollama_provider()
                     fallback_iterations = 0
+                    tool_call_count = 0
                     max_fallback_iterations = kwargs.pop("max_iterations", self.max_iter)
                     while fallback_iterations < max_fallback_iterations:
                         fallback_iterations += 1
@@ -4592,7 +4593,23 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         if content:
                             yield content
 
+                        # Enforce the same per-turn guardrail the streaming and
+                        # non-streaming loops apply, so the fallback cannot run
+                        # tools past the caller's configured limit.
+                        if tool_call_count >= max_tool_calls_per_turn:
+                            logging.warning(
+                                f"Tool call limit reached ({max_tool_calls_per_turn}). "
+                                "Stopping to prevent infinite loop.")
+                            break
+                        if tool_call_count + len(tool_calls) > max_tool_calls_per_turn:
+                            remaining_calls = max_tool_calls_per_turn - tool_call_count
+                            tool_calls = tool_calls[:remaining_calls]
+                            logging.warning(
+                                f"Limiting batch to {remaining_calls} tool calls to stay "
+                                f"within limit of {max_tool_calls_per_turn}.")
+
                         for tool_call in tool_calls:
+                            tool_call_count += 1
                             function_name, arguments, tool_call_id = (
                                 self._extract_tool_call_info(tool_call, is_ollama))
                             if self._tool_arguments_parse_failed(arguments):

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -4530,26 +4530,104 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     use_streaming = False
             
             if not use_streaming:
-                # Fall back to non-streaming and yield the complete response
+                # Fall back to non-streaming. This branch is taken whenever the
+                # provider cannot stream WITH tools -- Anthropic, Gemini and
+                # Ollama all report False from _supports_streaming_tools() --
+                # and also whenever the streaming attempt above failed.
+                #
+                # It used to read message.content and nothing else. The request
+                # carried `tools`, so the model answered with tool_calls and an
+                # empty content, and every one of those calls was dropped: the
+                # tool never ran, nothing was yielded, and no warning was
+                # raised. A turn that needed a tool produced an empty stream.
+                #
+                # Run the tool loop here too, bounded by max_iter the same way
+                # the non-streaming path is.
                 try:
-                    response = self._completion_with_retry(
-                        **self._build_completion_params(
-                            messages=messages,
-                            tools=formatted_tools,
-                            temperature=temperature,
-                            stream=False,
-                            output_json=output_json,
-                            output_pydantic=output_pydantic,
-                            **kwargs
+                    is_ollama = self._is_ollama_provider()
+                    fallback_iterations = 0
+                    max_fallback_iterations = kwargs.pop("max_iterations", self.max_iter)
+                    while fallback_iterations < max_fallback_iterations:
+                        fallback_iterations += 1
+                        response = self._completion_with_retry(
+                            **self._build_completion_params(
+                                messages=messages,
+                                tools=formatted_tools,
+                                temperature=temperature,
+                                stream=False,
+                                output_json=output_json,
+                                output_pydantic=output_pydantic,
+                                **kwargs
+                            )
                         )
-                    )
-                    
-                    if response and response.choices:
-                        content = response.choices[0].message.content
+
+                        if not (response and response.choices):
+                            break
+
+                        message = response.choices[0].message
+                        content = getattr(message, "content", None)
+                        tool_calls = getattr(message, "tool_calls", None)
+
+                        if not tool_calls or not execute_tool_fn:
+                            # Nothing to dispatch: emit whatever prose we have.
+                            # An answer with no content AND no tool calls is the
+                            # provider's business, not ours to invent.
+                            if content:
+                                yield content
+                            break
+
+                        # Record the assistant turn before the tool replies, so
+                        # the follow-up request is a valid conversation.
+                        if is_ollama:
+                            messages.append({"role": "assistant", "content": content or ""})
+                        else:
+                            messages.append({
+                                "role": "assistant",
+                                "content": content or "",
+                                "tool_calls": self._serialize_tool_calls(tool_calls),
+                            })
+
+                        # Any prose the model emitted alongside the calls is
+                        # still part of the answer.
                         if content:
-                            # Yield the complete response as a single chunk
                             yield content
-                            
+
+                        for tool_call in tool_calls:
+                            function_name, arguments, tool_call_id = (
+                                self._extract_tool_call_info(tool_call, is_ollama))
+                            if self._tool_arguments_parse_failed(arguments):
+                                messages.append(
+                                    self._tool_parse_error_message(function_name, tool_call_id))
+                                continue
+                            try:
+                                tool_result = execute_tool_fn(function_name, arguments)
+                            except Exception as tool_error:  # noqa: BLE001
+                                # Report the failure to the model rather than
+                                # aborting the run, matching the streaming loop.
+                                logging.warning(
+                                    f"Tool '{function_name}' failed: {tool_error}")
+                                tool_result = {"error": str(tool_error)}
+                            try:
+                                _get_display_functions()['execute_sync_callback'](
+                                    'tool_call',
+                                    message=f"Calling function: {function_name}",
+                                    tool_name=function_name,
+                                    tool_input=arguments,
+                                    tool_output=str(tool_result)[:200],
+                                    success=not (isinstance(tool_result, dict)
+                                                 and 'error' in tool_result),
+                                )
+                            except Exception as cb_error:  # noqa: BLE001
+                                logging.debug(
+                                    f"tool_call callback failed for '{function_name}': {cb_error}")
+                            messages.append(self._create_tool_message(
+                                function_name, tool_result, tool_call_id, is_ollama))
+                        # Loop: ask again now the results are in the messages.
+                    else:
+                        logging.warning(
+                            f"Tool call limit reached ({max_fallback_iterations}) on the "
+                            "non-streaming fallback.")
+
                 except Exception as e:
                     logging.error(f"Non-streaming fallback failed: {e}")
                     raise
@@ -6652,6 +6730,43 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 if tc.function.arguments:
                     tool_calls[tc.index]["function"]["arguments"] += tc.function.arguments
         return tool_calls
+
+    def _create_tool_message(self, function_name: str, result: Any,
+                             tool_call_id: Optional[str], is_ollama: bool = False) -> Dict[str, Any]:
+        """Build the message that carries a tool's result back to the model.
+
+        get_response_stream called this from its streaming tool loop and it was
+        never defined, so the first tool result raised AttributeError. The
+        broad `except Exception` around that loop swallowed it, set
+        use_streaming = False, and dropped through to the non-streaming branch
+        -- which discarded the tool calls too. The net effect was that tool
+        calling appeared to do nothing on every streaming turn, with the real
+        cause visible only as a logged warning.
+
+        Two unit tests exercised this loop by assigning `_create_tool_message`
+        onto the instance themselves, so they passed against a method
+        production never had.
+
+        Mirrors the formatting the non-streaming loop uses, including Ollama's
+        natural-language variant.
+        """
+        if is_ollama:
+            return self._format_ollama_tool_result_message(function_name, result)
+        if result is None:
+            content = "Function returned an empty output"
+        elif isinstance(result, dict) and 'error' in result:
+            content = (f"Error: {result.get('error', 'Unknown error')}. "
+                       "Please inform the user that the operation could not be completed.")
+        elif (isinstance(result, list) and result
+                and isinstance(result[0], dict) and 'error' in result[0]):
+            content = (f"Error: {result[0].get('error', 'Unknown error')}. "
+                       "Please inform the user that the operation could not be completed.")
+        else:
+            try:
+                content = json.dumps(result)
+            except (TypeError, ValueError):
+                content = str(result)
+        return {"role": "tool", "tool_call_id": tool_call_id, "content": content}
 
     def _serialize_tool_calls(self, tool_calls) -> List[Dict]:
         """Convert tool calls to a serializable format for all providers."""

--- a/src/praisonai-agents/tests/unit/llm/test_stream_tools_reach_the_model.py
+++ b/src/praisonai-agents/tests/unit/llm/test_stream_tools_reach_the_model.py
@@ -137,6 +137,27 @@ class TestNonStreamingFallbackRunsTools:
         assert state["turns"] == 2, "a failing tool aborted the turn"
         assert "".join(out).strip()
 
+    def test_it_stops_at_max_tool_calls_per_turn(self):
+        """The fallback must honour the same per-turn guardrail as the other loops."""
+        llm = LLM(model="anthropic/claude-sonnet-4-20250514")
+        state = {"ran": 0}
+
+        def always_calls(**kwargs):
+            message = types.SimpleNamespace(content=None, tool_calls=[_tool_call()])
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=message, finish_reason="tool_calls")])
+
+        def execute(name, args, *a, **kw):
+            state["ran"] += 1
+            return get_weather(**args)
+
+        llm._completion_with_retry = always_calls
+        list(llm.get_response_stream(prompt="weather?", system_prompt="x",
+                                     tools=[get_weather], execute_tool_fn=execute,
+                                     max_tool_calls_per_turn=3))
+        assert state["ran"] == 3, (
+            "the fallback ran tools past max_tool_calls_per_turn")
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/src/praisonai-agents/tests/unit/llm/test_stream_tools_reach_the_model.py
+++ b/src/praisonai-agents/tests/unit/llm/test_stream_tools_reach_the_model.py
@@ -1,0 +1,142 @@
+"""Tool calls must survive both paths of get_response_stream.
+
+Two defects made streaming tool calls do nothing at all, and they compounded:
+
+1. `_create_tool_message` was called from the streaming tool loop
+   (llm.py, twice) and never defined anywhere in the package. The first tool
+   result raised AttributeError. The broad `except Exception` around that loop
+   swallowed it, logged a warning, set `use_streaming = False`, and fell
+   through to the non-streaming branch.
+
+2. That non-streaming branch read `message.content` and nothing else. It sent
+   `tools=` in the request, so the model answered with `tool_calls` and empty
+   content -- and every call was discarded. The tool never ran, nothing was
+   yielded, and no error surfaced.
+
+Net effect: on a turn that needed a tool, the user got an empty answer. The
+second branch is not an edge case -- Anthropic, Gemini and Ollama all report
+False from `_supports_streaming_tools()`, so they take it on every tools turn.
+
+The two tests that covered the streaming loop assigned `_create_tool_message`
+onto the instance themselves, so they passed against a method production did
+not have. These tests never patch it.
+"""
+import os
+import types
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from praisonaiagents.llm.llm import LLM
+
+
+def _tool_call(name="get_weather", args='{"city":"Paris"}', call_id="call_1"):
+    return types.SimpleNamespace(
+        index=0, id=call_id, type="function",
+        function=types.SimpleNamespace(name=name, arguments=args))
+
+
+def get_weather(city: str) -> str:
+    return f"sunny in {city}"
+
+
+class TestCreateToolMessageExists:
+    """Guards the premise: production must own this method, not the tests."""
+
+    def test_the_method_is_defined_on_the_class(self):
+        assert hasattr(LLM, "_create_tool_message"), (
+            "_create_tool_message is called by the streaming tool loop; if only "
+            "tests define it, every streaming tool turn raises AttributeError"
+        )
+
+    def test_it_builds_a_standard_tool_message(self):
+        llm = LLM(model="gpt-4o-mini")
+        msg = llm._create_tool_message("get_weather", "sunny", "call_1", False)
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "call_1"
+        assert "sunny" in msg["content"]
+
+    def test_an_error_result_is_reported_as_an_error(self):
+        llm = LLM(model="gpt-4o-mini")
+        msg = llm._create_tool_message("f", {"error": "boom"}, "call_1", False)
+        assert "boom" in msg["content"]
+
+    def test_an_empty_result_is_named_rather_than_dropped(self):
+        llm = LLM(model="gpt-4o-mini")
+        msg = llm._create_tool_message("f", None, "call_1", False)
+        assert msg["content"], "an empty tool result must still say something"
+
+
+class TestNonStreamingFallbackRunsTools:
+    """Anthropic, Gemini and Ollama take this branch on every tools turn."""
+
+    def _llm_with_two_turns(self, model="anthropic/claude-sonnet-4-20250514"):
+        llm = LLM(model=model)
+        state = {"turns": 0, "ran": 0}
+
+        def fake_completion(**kwargs):
+            state["turns"] += 1
+            if state["turns"] == 1:
+                message = types.SimpleNamespace(content=None, tool_calls=[_tool_call()])
+            else:
+                message = types.SimpleNamespace(content="It is sunny in Paris.",
+                                                tool_calls=None)
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=message, finish_reason="stop")])
+
+        def execute(name, args, *a, **kw):
+            state["ran"] += 1
+            return get_weather(**args)
+
+        llm._completion_with_retry = fake_completion
+        return llm, state, execute
+
+    def test_the_provider_really_takes_this_branch(self):
+        for model in ("anthropic/claude-sonnet-4-20250514",
+                      "gemini/gemini-2.0-flash", "ollama/llama3.2"):
+            assert LLM(model=model)._supports_streaming_tools() is False, model
+
+    def test_the_tool_actually_runs(self):
+        llm, state, execute = self._llm_with_two_turns()
+        list(llm.get_response_stream(prompt="weather?", system_prompt="x",
+                                     tools=[get_weather], execute_tool_fn=execute))
+        assert state["ran"] == 1, "the tool call was discarded"
+
+    def test_the_answer_reaches_the_caller(self):
+        llm, state, execute = self._llm_with_two_turns()
+        out = list(llm.get_response_stream(prompt="weather?", system_prompt="x",
+                                           tools=[get_weather], execute_tool_fn=execute))
+        assert "".join(out).strip(), "a tool turn produced an empty stream"
+
+    def test_it_asks_the_model_again_with_the_result(self):
+        llm, state, execute = self._llm_with_two_turns()
+        list(llm.get_response_stream(prompt="weather?", system_prompt="x",
+                                     tools=[get_weather], execute_tool_fn=execute))
+        assert state["turns"] == 2, "the tool result was never sent back"
+
+    def test_a_turn_with_no_tool_calls_still_yields_its_prose(self):
+        llm = LLM(model="anthropic/claude-sonnet-4-20250514")
+        message = types.SimpleNamespace(content="plain answer", tool_calls=None)
+        llm._completion_with_retry = lambda **kw: types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=message, finish_reason="stop")])
+        out = list(llm.get_response_stream(prompt="hi", system_prompt="x",
+                                           tools=[get_weather],
+                                           execute_tool_fn=lambda *a, **k: None))
+        assert "".join(out) == "plain answer"
+
+    def test_a_failing_tool_is_reported_not_raised(self):
+        """A broken tool must reach the model as an error, not abort the run."""
+        llm, state, _ = self._llm_with_two_turns()
+
+        def boom(name, args, *a, **kw):
+            raise RuntimeError("tool exploded")
+
+        out = list(llm.get_response_stream(prompt="weather?", system_prompt="x",
+                                           tools=[get_weather], execute_tool_fn=boom))
+        assert state["turns"] == 2, "a failing tool aborted the turn"
+        assert "".join(out).strip()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This is the root cause of "tool calling seems not to work" on streaming turns.

## Two defects, compounding

**1. `_create_tool_message` was never defined.** It is called twice from the streaming tool loop in `get_response_stream`. `grep -rn "def _create_tool_message"` across the package returns nothing — the only definitions in the repo are two *tests* that assign it onto the instance:

```
tests/unit/llm/test_stream_tool_dispatch.py:29
    llm._create_tool_message = lambda *args: {"role": "tool", "content": "ok"}
tests/unit/streaming/test_stream_tool_callback.py:244
    llm._create_tool_message = lambda name, result, call_id, is_ollama: {...}
```

So the tests supplied the method they were testing, and passed. In production the first tool result raised `AttributeError`, which the broad `except Exception` around that loop swallowed — logging `Streaming failed with unexpected error`, setting `use_streaming = False`, and falling through to the non-streaming branch.

**2. That branch discarded tool calls.** It read `message.content` and nothing else, while still sending `tools=` in the request. The model replied with `tool_calls` and empty content; all of it was dropped. The tool never ran, nothing was yielded, no error surfaced.

**This is not an edge case.** Anthropic, Gemini and Ollama all report `False` from `_supports_streaming_tools()`, so they take branch 2 on *every* tools turn — and after defect 1, so did everyone else.

## Measured, with a stubbed transport

Before:

```
anthropic/claude-sonnet-4   chunks=[]   tool executed 0 times
gpt-4o-mini                 AttributeError: 'LLM' object has no attribute '_create_tool_message'
```

After:

```
anthropic/claude-sonnet-4   chunks=['It is sunny in Paris.']   tool ran 1x, 2 round trips
gpt-4o-mini                 tool ran 1x, 2 round trips
```

## Change

- `_create_tool_message` is now a real method, mirroring the formatting the non-streaming loop already uses — including Ollama's natural-language variant via the existing `_format_ollama_tool_result_message`.
- The fallback runs a bounded tool loop: execute, append results, ask again, stop at `max_iter`. Prose emitted alongside tool calls is still yielded. A failing tool is reported back to the model rather than aborting the run, matching the streaming loop.

## Verification

10 new tests, which never patch `_create_tool_message`. Mutations:

| mutation | |
|---|---|
| remove `_create_tool_message` (the original defect) | killed |
| fallback ignores `tool_calls` again | killed |
| fallback never loops back to the model | killed |
| tool errors abort instead of being reported | killed |

235 pass across `tests/unit/llm` and `tests/unit/streaming`. The single failure there, `test_rate_limit_backward_compat`, is pre-existing on `main` — one of the 109 in #4748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-calling support for providers that use non-streaming fallbacks.
  * Tool calls are now executed, results returned to the model, and final responses displayed correctly.
  * Prevented tool-related failures from producing empty responses.
  * Added safeguards for tool-call limits and clearer reporting of tool errors.

* **Tests**
  * Added coverage for successful, empty, and failed tool results, fallback behavior, and tool-call limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->