### PR TITLE
fix(mobile): conversations that actually survive a device (refs #4673)

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contract-fixture.ts
@@ -69,11 +69,15 @@ function secrets(): SecretsPort {
 
 // ---- storage ---------------------------------------------------------------
 
-function storage(): StoragePort {
+function storage(files: Map<string, string> = new Map()): StoragePort {
   // Inline rather than importing a fake: `adapters` may not import `testing`,
   // and the layer rule is right to say so. The engine fixture one directory
   // over builds its broken engines the same way.
-  const files = new Map<string, string>();
+  //
+  // The map is a PARAMETER, so a "relaunch" is a new port over the same
+  // bytes -- a real reopen rather than the same object handed back, which
+  // would make the durability cases vacuous. Defaulting to a fresh map keeps
+  // every case isolated from the one before it.
   const key = (ref: { namespace: string; id: string }): string =>
     mode === "storage_namespaces_collide" ? ref.id : `${ref.namespace}/${ref.id}`;
   return {
@@ -86,6 +90,15 @@ function storage(): StoragePort {
       return mode === "storage_missing_is_undefined" ? (undefined as never) : null;
     },
     async write(ref, value) {
+      if (mode === "storage_torn_write") {
+        // The defect: truncate, then fill -- which is what a plain
+        // `fs::write` does, and what tauri-plugin-store's `save()` does. A
+        // reader that arrives in between sees half a chat. On iOS, where a
+        // suspended app is killed with no further callback, the half is what
+        // is left on disk.
+        files.set(key(ref), value.slice(0, Math.floor(value.length / 2)));
+        await Promise.resolve();
+      }
       files.set(key(ref), value);
     },
     async remove(ref) {
@@ -249,6 +262,25 @@ function shellHarness(): ShellHarness {
 }
 
 describeSecretsContract("fixture secrets", () => secrets());
-describeStorageContract("fixture storage", () => storage());
+// Registered WITH a reopen, so the durability cases run here too and can be
+// reddened by `storage_forgets_on_relaunch`. A store that forgets when the
+// process ends is what makes "Your conversations are saved" a lie, and the
+// contract can only catch that if something asks it to relaunch.
+const fixtureBackings = new WeakMap<StoragePort, Map<string, string>>();
+const openFixtureStorage = (files: Map<string, string>): StoragePort => {
+  const port = storage(files);
+  fixtureBackings.set(port, files);
+  return port;
+};
+describeStorageContract(
+  "fixture storage",
+  () => openFixtureStorage(new Map()),
+  (previous) =>
+    mode === "storage_forgets_on_relaunch"
+      ? // The defect: a "reopened" store that is actually a fresh empty one --
+        // every conversation gone on the next launch, silently.
+        openFixtureStorage(new Map())
+      : openFixtureStorage(fixtureBackings.get(previous) ?? new Map()),
+);
 describeTimeContract("fixture time", () => time(), advance, true);
 describeShellContract("fixture shell", shellHarness);

--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -25,6 +25,16 @@ import { describeShellContract, type ShellHarness } from "./shell-contract.ts";
 import { createFakeStorage } from "../../../testing/src/fake-storage.ts";
 import { createFakeShell, PHONE_INSETS } from "../../../testing/src/fake-shell.ts";
 import { createWebStorage } from "../web/storage.ts";
+import {
+  createTauriStorage,
+  STORAGE_COMMANDS,
+  type StrictInvoke,
+} from "../tauri/storage.ts";
+import {
+  MIGRATION_MARKER,
+  migrateStorage,
+  preparedStorage,
+} from "../storage/migrate.ts";
 import { createWebSecrets } from "../web/secrets.ts";
 import { createWebTime } from "../web/time.ts";
 import { createFakeSecrets } from "../../../testing/src/fake-secrets.ts";
@@ -61,7 +71,111 @@ function memoryStorage(): Storage {
 // ---- both adapters must agree ---------------------------------------------
 
 describeStorageContract("fake storage", () => createFakeStorage());
-describeStorageContract("web storage", () => createWebStorage(memoryStorage()));
+
+// The web adapter is asked to survive a RELAUNCH: a second adapter over the
+// same backing Storage is exactly what the next launch builds. The fake is
+// not, and deliberately -- it is in-memory by design and claims no
+// durability, and asking it would be asserting that the fake is broken.
+//
+// Each `make()` gets its OWN backing, so the contract's cases stay isolated
+// from one another; the WeakMap is what lets `reopen` find the one backing
+// that particular port was built over. Sharing a single backing across every
+// case instead makes half the contract fail on the previous case's leftovers,
+// which is a test-harness bug wearing an adapter's clothes.
+{
+  const backings = new WeakMap<StoragePort, Storage>();
+  const openWeb = (backing: Storage): StoragePort => {
+    const port = createWebStorage(backing);
+    backings.set(port, backing);
+    return port;
+  };
+  describeStorageContract(
+    "web storage",
+    () => openWeb(memoryStorage()),
+    (previous) => {
+      const backing = backings.get(previous);
+      assert.ok(backing, "reopen was handed a port this registration did not build");
+      return openWeb(backing);
+    },
+  );
+}
+
+// ---- the Tauri adapter, against a stand-in for the Rust commands ----------
+//
+// What this proves and what it does not, stated plainly because the difference
+// matters. It proves the ADAPTER: that it invokes the five command names the
+// Rust side declares, with the argument names the Rust parameters are called,
+// that it keeps namespaces apart, that it turns a reply into the port's own
+// vocabulary, and that a value written before a "relaunch" is asked for again
+// afterwards. It does NOT prove the file store is atomic or durable -- that is
+// `src-tauri/src/store.rs`'s own test suite, where the filesystem actually is,
+// and `tools/storage-seam.test.mjs` is what stops the two sides drifting apart
+// on a name.
+//
+// The host is STRICT on purpose: an unknown command or a missing argument
+// throws rather than resolving to null. A forgiving stand-in would let the
+// adapter send `chatId` to a command expecting `id` and stay green, which is
+// the exact bug that costs a device every write with no error anywhere.
+function nativeHost(files: Map<string, string>): StrictInvoke {
+  const need = (args: Record<string, unknown> | undefined, name: string): string => {
+    const value = args?.[name];
+    if (typeof value !== "string") {
+      throw new Error(`missing string argument "${name}"`);
+    }
+    return value;
+  };
+  const prefixOf = (ns: string): string => `${ns}/`;
+
+  return async (command, args) => {
+    switch (command) {
+      case STORAGE_COMMANDS.read: {
+        const at = `${need(args, "namespace")}/${need(args, "id")}`;
+        return files.get(at) ?? null;
+      }
+      case STORAGE_COMMANDS.write: {
+        const at = `${need(args, "namespace")}/${need(args, "id")}`;
+        files.set(at, need(args, "value"));
+        return null;
+      }
+      case STORAGE_COMMANDS.remove: {
+        files.delete(`${need(args, "namespace")}/${need(args, "id")}`);
+        return null;
+      }
+      case STORAGE_COMMANDS.listIds: {
+        const prefix = prefixOf(need(args, "namespace"));
+        return [...files.keys()]
+          .filter((k) => k.startsWith(prefix))
+          .map((k) => k.slice(prefix.length));
+      }
+      case STORAGE_COMMANDS.clear: {
+        const prefix = prefixOf(need(args, "namespace"));
+        for (const k of [...files.keys()]) if (k.startsWith(prefix)) files.delete(k);
+        return null;
+      }
+      default:
+        throw new Error(`no such command: ${command}`);
+    }
+  };
+}
+
+{
+  const hosts = new WeakMap<StoragePort, Map<string, string>>();
+  const openNative = (files: Map<string, string>): StoragePort => {
+    const port = createTauriStorage({ invoke: nativeHost(files) });
+    hosts.set(port, files);
+    return port;
+  };
+  describeStorageContract(
+    "tauri storage",
+    () => openNative(new Map()),
+    // A relaunch: a brand new adapter over a store that outlived it.
+    (previous) => {
+      const files = hosts.get(previous);
+      assert.ok(files, "reopen was handed a port this registration did not build");
+      return openNative(files);
+    },
+  );
+}
 
 // The SecretsPort had no contract and no test of any kind. Collapsing the web
 // adapter's key from `${slot}:${account}` to `${slot}` survived the whole
@@ -279,6 +393,13 @@ function probeBridge(options: { readonly slowListen?: boolean } = {}): BridgePro
     bridge: {
       isPresent: () => true,
       invoke(command, args) {
+        invocations.push({ command, args: args ?? {} });
+        return Promise.resolve(null);
+      },
+      // The shell probe never reaches for storage, but the interface it stands
+      // in for now carries the strict form -- and a probe that omits it would
+      // stop compiling the day the shell does use it.
+      invokeStrict(command, args) {
         invocations.push({ command, args: args ?? {} });
         return Promise.resolve(null);
       },
@@ -1107,6 +1228,11 @@ const ADAPTER_BREAKS: readonly { readonly mode: string; readonly expects: RegExp
   // hollowed out with a green build. One break mode per hollowable case is
   // what closes that, because a mode reddens the case BY NAME.
   { mode: "storage_empty_is_absent", expects: /an empty string is a value, not an absence/ },
+  // The port's atomicity clause had NO case and therefore no break mode: the
+  // one sentence in storage.ts that names a data-loss bug rather than a
+  // theoretical one was the only clause nothing tested.
+  { mode: "storage_torn_write", expects: /a concurrent read never sees a torn value/ },
+  { mode: "storage_forgets_on_relaunch", expects: /a written value survives a relaunch/ },
   { mode: "time_unsubscribe_does_nothing", expects: /the unsubscribe actually stops it/ },
   { mode: "shell_scheme_case_sensitive", expects: /an uppercase JAVASCRIPT: URL is refused/ },
   { mode: "shell_negative_insets", expects: /no inset is negative/ },
@@ -1154,7 +1280,7 @@ test("a contract cannot quietly shrink", () => {
     passed.filter((line) => line.includes(`fixture ${prefix}:`)).length;
 
   assert.ok(casesFor("secrets") >= 9, `the secrets contract shrank to ${casesFor("secrets")} cases`);
-  assert.ok(casesFor("storage") >= 11, `the storage contract shrank to ${casesFor("storage")} cases`);
+  assert.ok(casesFor("storage") >= 15, `the storage contract shrank to ${casesFor("storage")} cases`);
   assert.ok(casesFor("time") >= 8, `the time contract shrank to ${casesFor("time")} cases`);
   assert.ok(casesFor("shell") >= 37, `the shell contract shrank to ${casesFor("shell")} cases`);
 
@@ -1162,7 +1288,7 @@ test("a contract cannot quietly shrink", () => {
   // ADAPTER_BREAKS, or lowering a count above, removes a defence and the only
   // signal is a smaller number that nothing reads. Guarding the guard.
   assert.ok(
-    ADAPTER_BREAKS.length >= 13,
+    ADAPTER_BREAKS.length >= 15,
     `the break table shrank to ${ADAPTER_BREAKS.length} modes`,
   );
 });
@@ -1269,6 +1395,221 @@ test("the web storage adapter namespaces its keys", () => {
       assert.match(keys[0] ?? "", /^praisonai\./, `the key was not namespaced: ${keys[0]}`);
       assert.match(keys[0] ?? "", /chats/);
     });
+});
+
+// ---- the native store's seam ----------------------------------------------
+
+test("the tauri storage adapter invokes the command names Rust declares", () => {
+  // A rename on either side is SILENT on a device: every chat write rejects,
+  // the repository reports `unreadable`, and the app keeps running. Asserting
+  // the literals here is half of the defence; tools/storage-seam.test.mjs
+  // compares them against the Rust source, which is the other half.
+  assert.deepEqual(STORAGE_COMMANDS, {
+    read: "storage_read",
+    write: "storage_write",
+    remove: "storage_remove",
+    listIds: "storage_list_ids",
+    clear: "storage_clear",
+  });
+});
+
+test("the tauri storage adapter sends the argument names the Rust parameters have", async () => {
+  // Tauri deserialises a command's arguments by NAME. `chatId` where Rust says
+  // `id` is a rejected call on every single write, and the only symptom is
+  // that nothing is ever saved.
+  const calls: { command: string; args: Record<string, unknown> | undefined }[] = [];
+  const storage = createTauriStorage({
+    invoke: async (command, args) => {
+      calls.push({ command, args });
+      return command === STORAGE_COMMANDS.listIds ? [] : null;
+    },
+  });
+
+  await storage.write({ namespace: "chats", id: "c1" }, "body");
+  await storage.read({ namespace: "chats", id: "c1" });
+  await storage.remove({ namespace: "chats", id: "c1" });
+  await storage.listIds("chats");
+  await storage.clear("chats");
+
+  assert.deepEqual(calls[0], {
+    command: "storage_write",
+    args: { namespace: "chats", id: "c1", value: "body" },
+  });
+  assert.deepEqual(calls[1], { command: "storage_read", args: { namespace: "chats", id: "c1" } });
+  assert.deepEqual(calls[2], { command: "storage_remove", args: { namespace: "chats", id: "c1" } });
+  assert.deepEqual(calls[3], { command: "storage_list_ids", args: { namespace: "chats" } });
+  assert.deepEqual(calls[4], { command: "storage_clear", args: { namespace: "chats" } });
+});
+
+test("a native reply of the wrong shape is an I/O failure, not an empty chat list", async () => {
+  // The defect this guards is the quiet one. `undefined` read as `null` means
+  // "no such chat": every conversation reads as missing, `list()` returns
+  // nothing, and the user is shown an empty app with no error at all -- while
+  // the next save writes over what is still on disk. Throwing routes it
+  // through repository.load's `unreadable` branch, which the UI reports.
+  const undefinedReply = createTauriStorage({ invoke: async () => undefined });
+  await assert.rejects(
+    () => undefinedReply.read({ namespace: "chats", id: "c1" }),
+    /not a string or null/,
+  );
+
+  const objectReply = createTauriStorage({ invoke: async () => ({ oops: true }) });
+  await assert.rejects(() => objectReply.read({ namespace: "chats", id: "c1" }), /not a string/);
+
+  const notAList = createTauriStorage({ invoke: async () => "nope" });
+  await assert.rejects(() => notAList.listIds("chats"), /not an array/);
+
+  const badIds = createTauriStorage({ invoke: async () => [1, 2] });
+  await assert.rejects(() => badIds.listIds("chats"), /non-string id/);
+
+  // The pair: a genuine null is an ABSENCE and must not throw.
+  const missing = createTauriStorage({ invoke: async () => null });
+  assert.equal(await missing.read({ namespace: "chats", id: "c1" }), null);
+});
+
+test("a failing native store rejects rather than reporting an empty one", async () => {
+  const failing = createTauriStorage({
+    invoke: async () => {
+      throw new Error("disk is full");
+    },
+  });
+  await assert.rejects(() => failing.read({ namespace: "chats", id: "c1" }), /disk is full/);
+  await assert.rejects(() => failing.write({ namespace: "chats", id: "c1" }, "x"), /disk is full/);
+  await assert.rejects(() => failing.listIds("chats"), /disk is full/);
+});
+
+test("invokeStrict rejects where invoke resolves to null", async () => {
+  // The two must not be collapsed into one. `invoke` swallowing a failure is
+  // right for a haptic tap and catastrophic for a chat write.
+  const angry = {
+    invoke: () => Promise.reject(new Error("plugin missing")),
+    transformCallback: () => 1,
+  };
+  const bridge = createTauriBridge({ scope: { __TAURI_INTERNALS__: angry } });
+
+  assert.equal(await bridge.invoke("anything"), null, "the forgiving invoke still forgives");
+  await assert.rejects(() => bridge.invokeStrict("anything"), /plugin missing/);
+});
+
+test("invokeStrict rejects when there is no native host at all", async () => {
+  // Resolving to null here would present "there is no storage on this device"
+  // as "you have no conversations", which is the failure this whole change
+  // exists to remove.
+  const bridge = createTauriBridge({ scope: {} });
+  await assert.rejects(() => bridge.invokeStrict("storage_read"), /no native host/);
+});
+
+// ---- the one-time migration off localStorage -------------------------------
+
+test("migration carries an existing install's chats onto the new store", async () => {
+  // Without this, switching the Tauri build to the native store would empty
+  // every existing install on upgrade -- indistinguishable, to the user, from
+  // the eviction bug being fixed.
+  const from = createFakeStorage();
+  await from.write({ namespace: "chats", id: "c1" }, "first conversation");
+  await from.write({ namespace: "chats", id: "c2" }, "second conversation");
+  await from.write({ namespace: "settings", id: "engineId" }, "praisonai-ts");
+  await from.write({ namespace: "drafts", id: "c1" }, "half-typed");
+
+  const to = createFakeStorage();
+  const result = await migrateStorage(from, to);
+
+  assert.equal(result.ran, true);
+  assert.equal(result.copied, 4);
+  assert.equal(await to.read({ namespace: "chats", id: "c1" }), "first conversation");
+  assert.equal(await to.read({ namespace: "chats", id: "c2" }), "second conversation");
+  assert.equal(await to.read({ namespace: "settings", id: "engineId" }), "praisonai-ts");
+  assert.equal(await to.read({ namespace: "drafts", id: "c1" }), "half-typed");
+  // The source is left intact, so a rollback to the previous build still has
+  // its data.
+  assert.equal(await from.read({ namespace: "chats", id: "c1" }), "first conversation");
+});
+
+test("migration runs once and never overwrites newer data", async () => {
+  // The way a migration destroys what it is protecting: run it twice and the
+  // second run rolls a conversation back to the stale copy the old store still
+  // holds.
+  const from = createFakeStorage();
+  await from.write({ namespace: "chats", id: "c1" }, "the OLD copy");
+
+  const to = createFakeStorage();
+  await migrateStorage(from, to);
+  await to.write({ namespace: "chats", id: "c1" }, "the NEW copy, written since");
+
+  const second = await migrateStorage(from, to);
+  assert.equal(second.ran, false, "the marker must stop a second run");
+  assert.equal(await to.read({ namespace: "chats", id: "c1" }), "the NEW copy, written since");
+
+  // And even with the marker gone -- a cleared cache namespace -- an existing
+  // key still wins.
+  await to.remove(MIGRATION_MARKER);
+  const third = await migrateStorage(from, to);
+  assert.equal(third.ran, true);
+  assert.equal(third.copied, 0);
+  assert.equal(third.kept, 1);
+  assert.equal(await to.read({ namespace: "chats", id: "c1" }), "the NEW copy, written since");
+});
+
+test("an unreadable old store does not stop the app from starting", async () => {
+  // localStorage can be absent or throwing -- a host with none, a quota error,
+  // an eviction mid-read. None of those is a reason to refuse to boot on a
+  // store that works.
+  const throwing: StoragePort = {
+    async read() { throw new Error("localStorage is gone"); },
+    async write() { throw new Error("localStorage is gone"); },
+    async remove() { throw new Error("localStorage is gone"); },
+    async listIds() { throw new Error("localStorage is gone"); },
+    async clear() { throw new Error("localStorage is gone"); },
+  };
+  const to = createFakeStorage();
+  const result = await migrateStorage(throwing, to);
+  assert.equal(result.copied, 0);
+  assert.equal(result.ran, true, "a missing source is a clean install, not a failure");
+});
+
+test("preparedStorage runs its migration ONCE, before the first read", async () => {
+  // detectPlatform is synchronous, so the copy cannot happen during it. If it
+  // ran after the first read instead, the boot sequence's very first `list()`
+  // would return nothing and the user would see an empty app that fills in
+  // later -- or never, since boot only lists once.
+  const target = createFakeStorage();
+  const order: string[] = [];
+  let runs = 0;
+  const storage = preparedStorage(target, async () => {
+    runs += 1;
+    await Promise.resolve();
+    order.push("migrated");
+    await target.write({ namespace: "chats", id: "old" }, "carried over");
+  });
+
+  const [first] = await Promise.all([
+    storage.read({ namespace: "chats", id: "old" }).then((v) => {
+      order.push("read");
+      return v;
+    }),
+    storage.listIds("chats"),
+    storage.write({ namespace: "chats", id: "new" }, "x"),
+  ]);
+
+  assert.equal(first, "carried over", "the first read must see the migrated data");
+  assert.equal(runs, 1, "concurrent calls at boot must not run the migration three times");
+  assert.equal(order[0], "migrated");
+});
+
+test("a failed migration leaves the new store usable", async () => {
+  // Blocking every read on the copy would turn "we could not find your old
+  // chats" into "the app does not start".
+  const target = createFakeStorage();
+  const reported: unknown[] = [];
+  const storage = preparedStorage(
+    target,
+    () => Promise.reject(new Error("the old store exploded")),
+    (error) => void reported.push(error),
+  );
+
+  await storage.write({ namespace: "chats", id: "c1" }, "still works");
+  assert.equal(await storage.read({ namespace: "chats", id: "c1" }), "still works");
+  assert.equal(reported.length, 1, "a failure must be reported, not swallowed");
 });
 
 test("the web shell re-pushes history after consuming a back gesture", () => {

--- a/src/praisonai-mobile/adapters/src/conformance/storage-contract.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/storage-contract.ts
@@ -15,14 +15,28 @@ import rawAssert from "node:assert/strict";
 import { ledger, type Ledger } from "./assert-ledger.ts";
 
 /** How many assertions the cases below make in one run. Deleting one makes
- *  the count short and the last case fail by name. */
-const EXPECTED_ASSERTIONS = 15;
+ *  the count short and the last case fail by name. The durability branch adds
+ *  three, so the expected total depends on whether the adapter claims to
+ *  survive a relaunch. */
+const EXPECTED_ASSERTIONS = 17;
+const DURABLE_ASSERTIONS = 3;
 
 import type { StoragePort } from "../../../core/src/ports/storage.ts";
+
+/**
+ * Build a SECOND port over the same backing store, as the next launch does.
+ *
+ * Supplied only by adapters that claim durability, which is the property the
+ * crash screen's "Your conversations are saved" depends on. The fake is
+ * in-memory by design and does not claim it, so it is not asked to.
+ */
+export type Reopen = (storage: StoragePort) => Promise<StoragePort> | StoragePort;
 
 export function describeStorageContract(
   name: string,
   make: () => StoragePort | Promise<StoragePort>,
+  /** Present for a store that must survive the process ending. */
+  reopen?: Reopen,
 ): void {
   // Every assertion below is counted, and the last case in this contract
   // asserts the total. See ./assert-ledger.ts: the break-mode fixture can
@@ -122,6 +136,50 @@ export function describeStorageContract(
     assert.deepEqual(await storage.listIds("chats"), []);
   });
 
+  test(`${name}: a concurrent read never sees a torn value`, async () => {
+    // The port's atomicity clause, exercised rather than asserted in prose.
+    //
+    // "A concurrent read sees either the old value or the new one, never a
+    // truncated file." On a phone this is not theoretical: iOS kills a
+    // suspended app with no further callback, so a write interrupted halfway
+    // is a normal occurrence. The standard implementation is write-to-temp
+    // then rename; a plain truncate-and-write fails here, and the fixture's
+    // `storage_torn_write` mode is exactly that defect.
+    const storage = await make();
+    const key = { namespace: "chats", id: "hot" } as const;
+    const payloads = ["a", "b", "c"].map((c) => c.repeat(4096));
+
+    await storage.write(key, payloads[0]!);
+    const observed = new Set<string>();
+    let running = true;
+    const reader = (async () => {
+      while (running) {
+        const value = await storage.read(key);
+        if (value !== null) observed.add(value);
+      }
+    })();
+
+    try {
+      // Several rounds, because one interleaving proves less than several.
+      for (let round = 0; round < 5; round++) {
+        await Promise.all(payloads.map((payload) => storage.write(key, payload)));
+      }
+    } finally {
+      running = false;
+      await reader;
+    }
+
+    const torn = [...observed].filter((value) => !payloads.includes(value));
+    assert.deepEqual(
+      torn.map((value) => `${value.length} bytes`),
+      [],
+      "a reader saw a value that was never written whole",
+    );
+    // The control. A reader that observed nothing at all would report no
+    // tearing while proving nothing.
+    assert.ok(observed.size > 0, "the reader never observed a value; this case proved nothing");
+  });
+
   test(`${name}: an empty string is a value, not an absence`, async () => {
     // `""` is falsy, so an adapter using `||` instead of `??` turns a
     // deliberately-empty setting back into its default on every read.
@@ -130,16 +188,56 @@ export function describeStorageContract(
     assert.equal(await storage.read({ namespace: "settings", id: "empty" }), "");
   });
 
+  if (reopen !== undefined) {
+    test(`${name}: a written value survives a relaunch`, async () => {
+      // THE claim. ui/src/i18n/strings.ts tells the user after a crash that
+      // "Your conversations are saved", and this is the only place that is
+      // decided: a store that forgets when the process ends makes that string
+      // a lie, and nothing else in the suite would notice.
+      const storage = await make();
+      await storage.write({ namespace: "chats", id: "c1" }, "the conversation");
+      const relaunched = await reopen(storage);
+      assert.equal(
+        await relaunched.read({ namespace: "chats", id: "c1" }),
+        "the conversation",
+        "the conversation did not come back after a relaunch",
+      );
+    });
+
+    test(`${name}: the chat list survives a relaunch`, async () => {
+      // Reading a key you already know the id of is not enough: the chat list
+      // is built from listIds, so a store that keeps values but rebuilds its
+      // index empty shows the user no conversations at all.
+      const storage = await make();
+      await storage.write({ namespace: "chats", id: "a" }, "1");
+      await storage.write({ namespace: "chats", id: "b" }, "2");
+      const relaunched = await reopen(storage);
+      assert.deepEqual((await relaunched.listIds("chats")).slice().sort(), ["a", "b"]);
+    });
+
+    test(`${name}: a deletion survives a relaunch too`, async () => {
+      // The pair. A store that persisted writes and forgot deletes would
+      // resurrect a conversation the user deliberately removed on every
+      // launch -- which is worse than losing one.
+      const storage = await make();
+      await storage.write({ namespace: "chats", id: "gone" }, "x");
+      await storage.remove({ namespace: "chats", id: "gone" });
+      const relaunched = await reopen(storage);
+      assert.equal(await relaunched.read({ namespace: "chats", id: "gone" }), null);
+    });
+  }
+
   // Registered last, so every case above has already run by the time it does.
   // Not a style check: the fixture in ./contract-fixture.ts can only protect
   // the FIRST assertion in each case, so without this an assertion can be
   // deleted and the run just reports one test fewer. See ./assert-ledger.ts.
   test(`${name}: this contract made every assertion it is supposed to make`, () => {
     const actual = made();
+    const expected = EXPECTED_ASSERTIONS + (reopen === undefined ? 0 : DURABLE_ASSERTIONS);
     rawAssert.equal(
       actual,
-      EXPECTED_ASSERTIONS,
-      `${name}: this contract ran ${actual} assertions, not ${EXPECTED_ASSERTIONS}. ` +
+      expected,
+      `${name}: this contract ran ${actual} assertions, not ${expected}. ` +
         `If you deliberately added or removed one, update the constant in ` +
         `${'storage-contract.ts'} -- and consider whether the new assertion also needs a break ` +
         `mode in contract-fixture.ts, which is what proves it has teeth.`,

--- a/src/praisonai-mobile/adapters/src/storage/migrate.ts
+++ b/src/praisonai-mobile/adapters/src/storage/migrate.ts
@@ -1,0 +1,173 @@
+/**
+ * Moving an existing install's conversations from one StoragePort to another.
+ *
+ * WHY IT IS WARRANTED. Every Tauri build up to now wrote chats and settings to
+ * `localStorage`, because `platform.ts` handed the web adapter to both
+ * platforms. Switching the Tauri build to the native file store without this
+ * would not lose that data to a bug -- it would lose it to the change itself:
+ * the next launch reads an empty store, `list()` returns nothing, and every
+ * conversation the user had is simply not there. The user cannot tell that
+ * apart from the eviction bug this change exists to fix, which would make the
+ * fix indistinguishable from the disease.
+ *
+ * It is cheap, one-time, and testable, and the alternative -- "the app has not
+ * shipped, so nobody has data" -- is a claim about other people's devices that
+ * nobody in this repo can check. Dev builds, TestFlight builds and sideloads
+ * all have real `localStorage` today.
+ *
+ * THREE RULES, each of which is a way this could destroy what it is protecting:
+ *
+ *  - It never OVERWRITES. A key already in the target wins, always. Running
+ *    twice, or running after the user has already had a session on the new
+ *    store, must not roll a conversation back to its older copy.
+ *  - It never DELETES the source. The old copy stays where it was, so a
+ *    rollback to a previous build finds its data intact. `localStorage` is
+ *    evictable, which is why it is not the destination -- but a copy that
+ *    might be evicted is strictly better than one that was deleted.
+ *  - It is marked DONE in the target, not in the source. The source is the
+ *    thing that can disappear; a marker written there would be lost with it
+ *    and the migration would run again over an emptied store forever.
+ */
+import type { Namespace, StoragePort } from "../../../core/src/ports/storage.ts";
+
+/**
+ * Written to the target once the copy has finished.
+ *
+ * In `cache` because it is derived state: clearing the cache namespace at
+ * worst re-runs a migration that copies nothing, since every key it would copy
+ * is already present and skipped.
+ */
+export const MIGRATION_MARKER = { namespace: "cache", id: "migrated-from-web-storage" } as const;
+
+/**
+ * The namespaces worth carrying over.
+ *
+ * `cache` is deliberately absent: it is by definition rebuildable, and copying
+ * it would also copy the marker, which would make a second migration think it
+ * had already run before it had copied anything.
+ */
+export const MIGRATED_NAMESPACES: readonly Namespace[] = ["chats", "settings", "drafts"];
+
+export interface MigrationResult {
+  /** Keys actually copied. `0` with `ran: true` is a clean install. */
+  readonly copied: number;
+  /** Keys skipped because the target already had them. */
+  readonly kept: number;
+  /** False when the marker said this had already happened. */
+  readonly ran: boolean;
+}
+
+/**
+ * Copy every key the app cares about from `from` into `to`, once.
+ *
+ * Throws if the TARGET cannot be read or written -- that is the store the app
+ * is about to depend on, and a failure there is worth surfacing. A failure
+ * reading the SOURCE is not fatal: `localStorage` may be gone (evicted, or a
+ * host that has none), which is precisely the situation with nothing to
+ * migrate.
+ */
+export async function migrateStorage(
+  from: StoragePort,
+  to: StoragePort,
+): Promise<MigrationResult> {
+  if ((await to.read(MIGRATION_MARKER)) !== null) {
+    return { copied: 0, kept: 0, ran: false };
+  }
+
+  let copied = 0;
+  let kept = 0;
+
+  for (const namespace of MIGRATED_NAMESPACES) {
+    let ids: readonly string[];
+    try {
+      ids = await from.listIds(namespace);
+    } catch {
+      // No source to read. Not an error: an install with no old data is the
+      // common case, and refusing to boot over it would be absurd.
+      continue;
+    }
+
+    for (const id of ids) {
+      const key = { namespace, id };
+      // Never overwrite. The target's copy is the newer one by construction --
+      // it can only exist because the app already wrote it on the new store.
+      if ((await to.read(key)) !== null) {
+        kept += 1;
+        continue;
+      }
+      let value: string | null;
+      try {
+        value = await from.read(key);
+      } catch {
+        continue; // one unreadable key must not abandon the rest
+      }
+      if (value === null) continue;
+      await to.write(key, value);
+      copied += 1;
+    }
+  }
+
+  // Written LAST. A marker written first would, on a crash mid-copy, declare a
+  // half-finished migration complete and strand whatever had not been copied.
+  await to.write(MIGRATION_MARKER, JSON.stringify({ copied, kept }));
+  return { copied, kept, ran: true };
+}
+
+/**
+ * `target`, with a one-time preparation step that every call awaits.
+ *
+ * `detectPlatform` is synchronous -- `ShellPort.insets` has to be readable
+ * during the first paint, and platform.ts's header explains why that decision
+ * cannot become a promise. So the migration cannot happen during detection. It
+ * happens on the first storage call instead, and every StoragePort method is
+ * already async, so no signature above this changes.
+ *
+ * The promise is memoised, so ten concurrent reads at boot run one migration
+ * rather than ten interleaved ones.
+ *
+ * A failed migration does NOT take the store down with it. The new store still
+ * works; the old data is still in `localStorage` and can be tried again next
+ * launch, because the marker is only written on success. Blocking every read
+ * on it would turn "we could not copy your old chats" into "the app does not
+ * start".
+ */
+export function preparedStorage(
+  target: StoragePort,
+  prepare: () => Promise<unknown>,
+  onError: (error: unknown) => void = (error) => console.warn("storage-migration", error),
+): StoragePort {
+  let started: Promise<void> | null = null;
+
+  const ready = (): Promise<void> => {
+    started ??= prepare().then(
+      () => {},
+      (error: unknown) => {
+        onError(error);
+      },
+    );
+    return started;
+  };
+
+  return {
+    async read(key) {
+      await ready();
+      return target.read(key);
+    },
+    async write(key, value) {
+      await ready();
+      return target.write(key, value);
+    },
+    async remove(key) {
+      await ready();
+      return target.remove(key);
+    },
+    async listIds(namespace) {
+      await ready();
+      return target.listIds(namespace);
+    },
+    async clear(namespace) {
+      await ready();
+      return target.clear(namespace);
+    },
+  };
+}

--- a/src/praisonai-mobile/adapters/src/tauri/bridge.ts
+++ b/src/praisonai-mobile/adapters/src/tauri/bridge.ts
@@ -92,6 +92,23 @@ export interface TauriBridge {
   invoke(command: string, args?: Record<string, unknown>): Promise<unknown>;
 
   /**
+   * `invoke`, but a failure REJECTS instead of resolving to `null`.
+   *
+   * The swallowing above is right for a haptic tap and wrong for a chat write.
+   * `StoragePort.read` uses `null` to mean "no such key", so an adapter built
+   * on the forgiving `invoke` would report a failing disk as an EMPTY chat
+   * list -- the user's conversations look deleted rather than unreadable, and
+   * the next save writes over them. `core/src/chat/repository.ts` already
+   * distinguishes `missing` from `unreadable`; it can only do that if
+   * something down here still knows the difference.
+   *
+   * Rejects rather than resolving when Tauri is absent, for the same reason: a
+   * silent "no storage here" is the failure mode this whole change exists to
+   * remove.
+   */
+  invokeStrict(command: string, args?: Record<string, unknown>): Promise<unknown>;
+
+  /**
    * Resolves to an Unsubscribe -- a no-op one when there is nothing to listen
    * to. Callers therefore never branch on presence, which is what stops
    * "if (tauri)" from spreading back above this file.
@@ -228,6 +245,15 @@ export function createTauriBridge(deps: TauriBridgeDeps = {}): TauriBridge {
     isPresent: () => internals !== null,
 
     invoke,
+
+    async invokeStrict(command, args) {
+      if (internals === null) {
+        // A message a device log can be read against. "undefined is not a
+        // function" three frames up is not.
+        throw new Error(`no native host for ${command}`);
+      }
+      return await internals.invoke(command, args ?? {});
+    },
 
     async listen(event, handler) {
       if (internals !== null) {

--- a/src/praisonai-mobile/adapters/src/tauri/storage.ts
+++ b/src/praisonai-mobile/adapters/src/tauri/storage.ts
@@ -1,0 +1,120 @@
+/**
+ * StoragePort over the native file store in `src-tauri/src/store.rs`.
+ *
+ * WHY THIS EXISTS. Until now the Tauri build used `adapters/src/web/storage.ts`
+ * -- `localStorage` -- and `platform.ts` said so in a comment it called "the
+ * honest interim". On iOS `localStorage` lives in a WebKit data store the
+ * system may EVICT under storage pressure, so a user who does nothing wrong can
+ * open the app and find their history gone, with no error and nothing to
+ * report. Android's WebView survives that but is emptied by ordinary "clear
+ * cache" flows. `ui/src/i18n/strings.ts` meanwhile tells the user after a crash
+ * that "Your conversations are saved"; this adapter is what makes the sentence
+ * true on a device.
+ *
+ * The five commands are all this file knows. Serialisation stays in
+ * `core/src/chat/repository.ts` exactly as the port's header requires, so the
+ * JSON shape and the schema version are unchanged by the swap and no migration
+ * of FORMAT is needed -- only of location, which `../storage/migrate.ts` does.
+ *
+ * `invokeStrict`, not `invoke`. The bridge's forgiving `invoke` resolves to
+ * `null` on failure, and `null` is `StoragePort.read`'s word for "no such
+ * key". Built on that, a failing disk would present as an empty chat list --
+ * the conversations look deleted rather than unreadable, and the next save
+ * writes over them.
+ */
+import type { Namespace, StorageKey, StoragePort } from "../../../core/src/ports/storage.ts";
+
+/**
+ * The seam with `src-tauri/src/store.rs`, which declares the same five
+ * strings as `pub const`s. `tools/storage-seam.test.mjs` reads both files and
+ * compares them: a rename on one side alone is silent, and silent here means
+ * every chat write rejects while the app carries on looking fine.
+ */
+export const STORAGE_COMMANDS = {
+  read: "storage_read",
+  write: "storage_write",
+  remove: "storage_remove",
+  listIds: "storage_list_ids",
+  clear: "storage_clear",
+} as const;
+
+/** What `TauriBridge.invokeStrict` provides. Taken as a function rather than
+ *  as the whole bridge so this file is testable with four lines of stub, and
+ *  so a React Native port supplies its own without pretending to be Tauri. */
+export type StrictInvoke = (
+  command: string,
+  args?: Record<string, unknown>,
+) => Promise<unknown>;
+
+export interface TauriStorageDeps {
+  readonly invoke: StrictInvoke;
+}
+
+/**
+ * A reply that is not the shape the command promises is an I/O FAILURE, not an
+ * absence.
+ *
+ * The distinction is the whole reason this function exists. If a native reply
+ * of `undefined` -- a command name that no longer exists, a Tauri version that
+ * returns something else -- were read as `null`, every chat would read as
+ * missing, `list()` would return nothing, and the app would show an empty
+ * conversation list with no error at all. Throwing puts it through
+ * `repository.load`'s `unreadable` branch, which the UI already reports.
+ */
+function asStringOrNull(command: string, value: unknown): string | null {
+  if (value === null) return null;
+  if (typeof value === "string") return value;
+  throw new Error(`${command} returned ${typeof value}, not a string or null`);
+}
+
+function asStringArray(command: string, value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${command} returned ${typeof value}, not an array`);
+  }
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      throw new Error(`${command} returned a non-string id: ${typeof entry}`);
+    }
+  }
+  return value as readonly string[];
+}
+
+export function createTauriStorage(deps: TauriStorageDeps): StoragePort {
+  // The argument names are the Rust parameter names. Tauri maps a JS key onto
+  // a `snake_case` Rust parameter, and every one of these is a single
+  // lowercase word precisely so there is no case convention to get wrong -- a
+  // mismatch is a deserialisation error on EVERY call, reported to the webview
+  // as "storage failed" with nothing pointing at the cause.
+  const of = (key: StorageKey): Record<string, unknown> => ({
+    namespace: key.namespace,
+    id: key.id,
+  });
+
+  return {
+    async read(key) {
+      const value = await deps.invoke(STORAGE_COMMANDS.read, of(key));
+      return asStringOrNull(STORAGE_COMMANDS.read, value);
+    },
+
+    async write(key, value) {
+      // Atomicity lives in Rust: temp file, fsync, rename, fsync the
+      // directory. It cannot live here -- a webview has no way to make two
+      // IPC calls atomic -- which is exactly why the port's contract had to be
+      // satisfied one layer down. See src-tauri/src/store.rs.
+      await deps.invoke(STORAGE_COMMANDS.write, { ...of(key), value });
+    },
+
+    async remove(key) {
+      await deps.invoke(STORAGE_COMMANDS.remove, of(key));
+    },
+
+    async listIds(namespace: Namespace) {
+      const ids = await deps.invoke(STORAGE_COMMANDS.listIds, { namespace });
+      return asStringArray(STORAGE_COMMANDS.listIds, ids);
+    },
+
+    async clear(namespace: Namespace) {
+      await deps.invoke(STORAGE_COMMANDS.clear, { namespace });
+    },
+  };
+}

--- a/src/praisonai-mobile/app/src/crash-recovery.test.ts
+++ b/src/praisonai-mobile/app/src/crash-recovery.test.ts
@@ -1,0 +1,234 @@
+/**
+ * "Something went wrong. Your conversations are saved."
+ *
+ * That sentence is `en.crashed` in ui/src/i18n/strings.ts, it is what the user
+ * reads after `crash.ts` fires, and until now it was FALSE on a device: every
+ * Tauri build wrote chats to `localStorage`, which WKWebView is free to evict
+ * under storage pressure. The fix is a durable StoragePort; this file is the
+ * proof that the promise is kept, end to end, rather than an assertion in
+ * prose next to the string.
+ *
+ * The shape of the proof is deliberately a RELAUNCH, not a re-read: a second
+ * `createApp` over the same backing store is exactly what the next launch
+ * does, and it is the only arrangement in which "the conversation came back"
+ * means anything. Re-reading through the same in-memory session would pass
+ * against a store that keeps nothing at all.
+ *
+ * WHAT IT DOES NOT CLAIM. A turn still in flight when the app dies is gone,
+ * and that is by design rather than by omission: `session.record` writes the
+ * user's message and the answer TOGETHER, when the turn completes, precisely
+ * so a crash cannot leave a persisted transcript with a dangling question and
+ * no reply under it. The string says conversations are saved, and the
+ * conversation -- every completed exchange in it -- is. The case below pins
+ * that boundary so a future author cannot mistake it for a bug and "fix" it by
+ * writing half a turn.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp, type AppDeps } from "./boot.ts";
+import { installCrashHandler } from "./crash.ts";
+import { createWebStorage } from "../../adapters/src/web/storage.ts";
+import { createTauriStorage } from "../../adapters/src/tauri/storage.ts";
+import { createFakeSecrets } from "../../testing/src/fake-secrets.ts";
+import { createFakeShell } from "../../testing/src/fake-shell.ts";
+import { createFakeTime } from "../../testing/src/fake-time.ts";
+import { createScriptedEngine } from "../../testing/src/scripted-engine.ts";
+import { SCRIPTS } from "../../testing/src/scripts.ts";
+import { persistenceFor } from "../../core/src/chat/session.ts";
+import { en } from "../../ui/src/i18n/strings.ts";
+import type { StoragePort } from "../../core/src/ports/storage.ts";
+import type { SettingDef } from "../../core/src/settings/store.ts";
+
+const DEFS: readonly SettingDef[] = [{ key: "engineId", default: "scripted" }];
+
+/**
+ * A backing `Storage` that OUTLIVES the app that wrote to it.
+ *
+ * The stand-in for a device's durable store: the process ends, the bytes
+ * remain. Which real adapter provides that is decided in platform.ts and
+ * proved by the storage contract's relaunch cases (adapters/src/conformance/
+ * storage-contract.ts) and by src-tauri/src/store.rs's own suite; this file
+ * asks the question one layer up -- given a store that keeps its bytes, does
+ * the APP get the conversation back?
+ */
+function durableBacking(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() { return map.size; },
+    key: (i: number) => [...map.keys()][i] ?? null,
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+  } as Storage;
+}
+
+/** A launch of the app over a given store. */
+async function launch(storage: StoragePort, over: Partial<AppDeps> = {}) {
+  const engine = createScriptedEngine({ script: SCRIPTS.happy });
+  const result = await createApp({
+    storage,
+    secrets: createFakeSecrets(),
+    time: createFakeTime(),
+    shell: createFakeShell(),
+    engines: () => [{ id: "scripted", create: () => engine }],
+    settingDefs: DEFS,
+    engineId: "scripted",
+    onPublish: () => {},
+    now: () => 1_700_000_000_000,
+    newChatId: () => "chat-1",
+    ...over,
+  });
+  assert.equal(result.ok, true, result.ok ? "" : `boot failed: ${result.detail}`);
+  if (!result.ok) throw new Error("boot failed");
+  return result.app;
+}
+
+test("a conversation written before a crash comes back after the relaunch", async () => {
+  const backing = durableBacking();
+
+  // ---- launch one: a turn completes, then the app dies ---------------------
+  const first = await launch(createWebStorage(backing));
+  // Through the SAME seam the engine uses. Calling repository.save directly
+  // would prove the repository works and nothing about whether the app ever
+  // reaches it -- which is exactly the gap that shipped once already, when the
+  // session and the engine's persistence port both existed and nothing joined
+  // them.
+  const recorded = await persistenceFor(first.session).record(
+    { prompt: "what is the capital of France?" },
+    "Paris.",
+  );
+  assert.notEqual(recorded, null, "the turn was never persisted, so nothing can come back");
+
+  // The crash. A real one, through the real handler: an uncaught error is
+  // dispatched at the window, `crash.ts` fires, and the screen the user reads
+  // is the one that makes the promise. No dispose, no flush, no cooperation of
+  // any kind -- which is what "the OS killed us" looks like.
+  const handlers = new Map<string, Set<(e: unknown) => void>>();
+  const view = {
+    addEventListener(type: string, cb: (e: unknown) => void) {
+      handlers.set(type, (handlers.get(type) ?? new Set()).add(cb));
+    },
+    removeEventListener() {},
+  } as unknown as Window;
+
+  let promised: string | null = null;
+  installCrashHandler({
+    view,
+    // What main.ts paints: en.crashed, the sentence under test.
+    onCrash: () => { promised = en.crashed; },
+    report: () => {},
+  });
+  for (const cb of handlers.get("error") ?? []) cb({ error: new Error("the webview fell over") });
+
+  assert.equal(
+    promised,
+    "Something went wrong. Your conversations are saved.",
+    "the crash screen did not fire, so the rest of this case proves nothing",
+  );
+
+  // ---- launch two: a brand new app over the same bytes ---------------------
+  const second = await launch(createWebStorage(backing));
+  const chats = await second.session.list();
+  assert.deepEqual(
+    chats.map((c) => c.title),
+    ["what is the capital of France?"],
+    "the conversation did not survive the relaunch, so the crash screen lies",
+  );
+
+  const opened = await second.session.open(chats[0]!.id);
+  assert.equal(opened, true);
+  assert.deepEqual(
+    second.session.current()?.messages.map((m) => `${m.role}: ${m.content}`),
+    ["user: what is the capital of France?", "assistant: Paris."],
+    "the transcript came back incomplete",
+  );
+
+  await second.dispose();
+});
+
+test("the SAME proof over the tauri adapter, against a store that outlives it", async () => {
+  // The web adapter above is durable only because the test handed it a backing
+  // map that outlives the app. On a device the durable store is the native one
+  // -- so the same relaunch is run through `createTauriStorage`, over a host
+  // that keeps its bytes across both launches, and the argument names and
+  // reply shapes of the real seam are exercised on the way.
+  //
+  // What this cannot reach is the filesystem itself; the atomicity and the
+  // durability of the file store are proved in src-tauri/src/store.rs, where
+  // there is a real disk to interrupt.
+  const files = new Map<string, string>();
+  const invoke = async (command: string, args?: Record<string, unknown>): Promise<unknown> => {
+    const ns = String(args?.["namespace"]);
+    const at = `${ns}/${String(args?.["id"])}`;
+    switch (command) {
+      case "storage_read":
+        return files.get(at) ?? null;
+      case "storage_write":
+        files.set(at, String(args?.["value"]));
+        return null;
+      case "storage_remove":
+        files.delete(at);
+        return null;
+      case "storage_list_ids":
+        return [...files.keys()]
+          .filter((k) => k.startsWith(`${ns}/`))
+          .map((k) => k.slice(ns.length + 1));
+      case "storage_clear":
+        for (const k of [...files.keys()]) if (k.startsWith(`${ns}/`)) files.delete(k);
+        return null;
+      default:
+        throw new Error(`no such command: ${command}`);
+    }
+  };
+
+  const first = await launch(createTauriStorage({ invoke }));
+  await persistenceFor(first.session).record({ prompt: "remember this" }, "remembered.");
+
+  const second = await launch(createTauriStorage({ invoke }));
+  const chats = await second.session.list();
+  assert.deepEqual(chats.map((c) => c.title), ["remember this"]);
+  await second.dispose();
+});
+
+test("a store that forgets makes the crash screen a lie -- the control", async () => {
+  // Without this, a `list()` that always returned the chat -- or a test that
+  // never really relaunched -- would pass the two cases above while proving
+  // nothing. Here the second launch gets a FRESH backing store, exactly as an
+  // evicted WKWebView `localStorage` would, and the conversation must be gone.
+  // That is the behaviour this change exists to make impossible on a device.
+  const first = await launch(createWebStorage(durableBacking()));
+  await persistenceFor(first.session).record({ prompt: "into the void" }, "gone.");
+
+  const second = await launch(createWebStorage(durableBacking()));
+  assert.deepEqual(
+    await second.session.list(),
+    [],
+    "the relaunch is not real: a fresh store still had the conversation",
+  );
+  await second.dispose();
+});
+
+test("a turn still in flight when the app dies is NOT claimed to be saved", async () => {
+  // The boundary of the promise, pinned. `session.record` writes the question
+  // and the answer together, when the turn completes -- so a crash mid-answer
+  // loses that exchange and keeps every completed one. Writing half a turn to
+  // "improve" this would leave a persisted transcript with a dangling question
+  // and no reply under it, which repository.ts refuses on purpose.
+  const backing = durableBacking();
+  const first = await launch(createWebStorage(backing));
+  await persistenceFor(first.session).record({ prompt: "the first question" }, "the first answer.");
+  // ... and then the user asks a second thing, and the app dies mid-answer.
+
+  const second = await launch(createWebStorage(backing));
+  const chats = await second.session.list();
+  assert.equal(chats.length, 1);
+  await second.session.open(chats[0]!.id);
+  assert.equal(
+    second.session.current()?.messages.length,
+    2,
+    "an in-flight turn must not be half-written into a persisted transcript",
+  );
+  await second.dispose();
+});

--- a/src/praisonai-mobile/app/src/platform.test.ts
+++ b/src/praisonai-mobile/app/src/platform.test.ts
@@ -89,3 +89,151 @@ test("the web platform stores chats in localStorage, not sessionStorage", () => 
   assert.ok(used.includes("local"), `the chat store must be localStorage, got ${used.join(",") || "none"}`);
   assert.equal(used.includes("session"), false, "sessionStorage dies with the tab");
 });
+
+// ---- the store a device actually gets ---------------------------------------
+
+/** A `__TAURI_INTERNALS__` that records what the app invoked. */
+function nativeScope(): { scope: object; calls: { command: string; args: unknown }[] } {
+  const calls: { command: string; args: unknown }[] = [];
+  const files = new Map<string, string>();
+  return {
+    calls,
+    scope: {
+      __TAURI_INTERNALS__: {
+        invoke: (command: string, args: Record<string, unknown>) => {
+          calls.push({ command, args });
+          const at = `${String(args["namespace"])}/${String(args["id"])}`;
+          switch (command) {
+            case "storage_read":
+              return Promise.resolve(files.get(at) ?? null);
+            case "storage_write":
+              files.set(at, String(args["value"]));
+              return Promise.resolve(null);
+            case "storage_list_ids":
+              return Promise.resolve([]);
+            default:
+              return Promise.resolve(null);
+          }
+        },
+        transformCallback: () => 1,
+      },
+    },
+  };
+}
+
+test("a native host stores chats in the NATIVE store, not localStorage", async () => {
+  // The mutation this exists to kill: `storageFor` handing the Tauri build the
+  // web adapter. That is not a hypothetical -- it is what this file did until
+  // now, and platform.ts's own comment called it "the honest interim". Nothing
+  // failed, on any platform, and on iOS the WebKit data store `localStorage`
+  // lives in is evictable, so the user's history disappears with no error.
+  const touched: string[] = [];
+  const spy = {
+    getItem: () => { touched.push("localStorage.getItem"); return null; },
+    setItem: () => void touched.push("localStorage.setItem"),
+    removeItem: () => void touched.push("localStorage.removeItem"),
+    key: () => null,
+    clear: () => void touched.push("localStorage.clear"),
+    length: 0,
+  } as unknown as Storage;
+
+  const fake = createFakeWindow();
+  (fake.window as unknown as { localStorage: Storage }).localStorage = spy;
+  const host = nativeScope();
+
+  const platform = detectPlatform({
+    isNative: () => true,
+    view: fake.window as unknown as Window,
+    scope: host.scope,
+  });
+
+  await platform.storage.write({ namespace: "chats", id: "c1" }, "a conversation");
+  assert.equal(await platform.storage.read({ namespace: "chats", id: "c1" }), "a conversation");
+
+  const commands = host.calls.map((c) => c.command);
+  assert.ok(commands.includes("storage_write"), `the write never reached Rust: ${commands.join(",")}`);
+  assert.ok(commands.includes("storage_read"), `the read never reached Rust: ${commands.join(",")}`);
+  assert.equal(
+    touched.includes("localStorage.setItem"),
+    false,
+    `a chat was written to evictable localStorage: ${touched.join(",")}`,
+  );
+});
+
+test("the browser keeps localStorage -- the pair", async () => {
+  // A `storageFor` that always returned the native store would break the web
+  // build completely: there is no Tauri host in a browser, and invokeStrict
+  // rejects rather than degrading.
+  const touched: string[] = [];
+  const spy = {
+    getItem: () => { touched.push("get"); return null; },
+    setItem: () => void touched.push("set"),
+    removeItem: () => {},
+    key: () => null,
+    clear: () => {},
+    length: 0,
+  } as unknown as Storage;
+
+  const fake = createFakeWindow();
+  (fake.window as unknown as { localStorage: Storage }).localStorage = spy;
+
+  const platform = detectPlatform({ isNative: () => false, view: fake.window as unknown as Window });
+  await platform.storage.write({ namespace: "chats", id: "c1" }, "a conversation");
+  assert.ok(touched.includes("set"), "the web build must still use localStorage");
+});
+
+test("an existing install's chats are carried onto the native store", async () => {
+  // The upgrade path. Without the migration, the first launch on the new build
+  // reads an empty store and every conversation appears to have been deleted
+  // by the update -- which the user cannot tell apart from the eviction bug
+  // this change fixes.
+  const backing = new Map<string, string>([["praisonai.chats.old", "a conversation from before"]]);
+  const legacy = {
+    getItem: (k: string) => backing.get(k) ?? null,
+    setItem: (k: string, v: string) => void backing.set(k, v),
+    removeItem: (k: string) => void backing.delete(k),
+    key: (i: number) => [...backing.keys()][i] ?? null,
+    clear: () => backing.clear(),
+    get length() { return backing.size; },
+  } as unknown as Storage;
+
+  const fake = createFakeWindow();
+  (fake.window as unknown as { localStorage: Storage }).localStorage = legacy;
+
+  // A native host with a real map behind it, so the copy has somewhere to land.
+  const files = new Map<string, string>();
+  const scope = {
+    __TAURI_INTERNALS__: {
+      invoke: (command: string, args: Record<string, unknown>) => {
+        const ns = String(args["namespace"]);
+        const at = `${ns}/${String(args["id"])}`;
+        switch (command) {
+          case "storage_read":
+            return Promise.resolve(files.get(at) ?? null);
+          case "storage_write":
+            files.set(at, String(args["value"]));
+            return Promise.resolve(null);
+          case "storage_list_ids":
+            return Promise.resolve(
+              [...files.keys()].filter((k) => k.startsWith(`${ns}/`)).map((k) => k.slice(ns.length + 1)),
+            );
+          default:
+            return Promise.resolve(null);
+        }
+      },
+      transformCallback: () => 1,
+    },
+  };
+
+  const platform = detectPlatform({
+    isNative: () => true,
+    view: fake.window as unknown as Window,
+    scope,
+  });
+
+  assert.equal(
+    await platform.storage.read({ namespace: "chats", id: "old" }),
+    "a conversation from before",
+    "the upgrade lost an existing install's conversation",
+  );
+});

--- a/src/praisonai-mobile/app/src/platform.ts
+++ b/src/praisonai-mobile/app/src/platform.ts
@@ -16,10 +16,12 @@ import type { StoragePort } from "../../core/src/ports/storage.ts";
 import type { SecretsPort } from "../../core/src/ports/secrets.ts";
 import type { HttpPort } from "../../core/src/ports/http.ts";
 import type { TimePort } from "../../core/src/ports/time.ts";
-import { createTauriBridge } from "../../adapters/src/tauri/bridge.ts";
+import { createTauriBridge, type TauriBridge } from "../../adapters/src/tauri/bridge.ts";
 import { createTauriShell } from "../../adapters/src/tauri/shell.ts";
 import { createWebShell } from "../../adapters/src/web/shell.ts";
 import { createWebStorage } from "../../adapters/src/web/storage.ts";
+import { createTauriStorage } from "../../adapters/src/tauri/storage.ts";
+import { migrateStorage, preparedStorage } from "../../adapters/src/storage/migrate.ts";
 import { createWebSecrets } from "../../adapters/src/web/secrets.ts";
 import { createWebHttp } from "../../adapters/src/web/http.ts";
 import { createWebTime } from "../../adapters/src/web/time.ts";
@@ -39,26 +41,62 @@ export interface PlatformDeps {
   /** Injected so a test can force either branch without a Tauri global. */
   readonly isNative?: () => boolean;
   readonly view?: Window;
+  /**
+   * Where `__TAURI_INTERNALS__` is looked up, forwarded to the bridge.
+   *
+   * Injected so the NATIVE storage path is exercised in CI rather than only
+   * the web one. Without it a test can flip `isNative` and still get a bridge
+   * with no host behind it, which is how "the Tauri build silently used
+   * localStorage" survived a full suite in the first place.
+   */
+  readonly scope?: object;
+}
+
+/**
+ * The StoragePort each platform gets.
+ *
+ * The per-platform default, in one named function, for the same reason
+ * `defaultEngineIdFor` is one: a `? :` buried in the object literal below is a
+ * decision no test can name. On a device this is the native file store; in a
+ * browser it stays `localStorage`, which is the only store a browser has.
+ *
+ * The Tauri store is WRAPPED, not replaced: `preparedStorage` runs the
+ * one-time copy out of `localStorage` before the first read, so an existing
+ * install's conversations move with it instead of appearing to have been
+ * deleted by the upgrade. See adapters/src/storage/migrate.ts.
+ */
+export function storageFor(
+  kind: Platform["kind"],
+  bridge: TauriBridge,
+  view: Window,
+): StoragePort {
+  const web = createWebStorage(view.localStorage);
+  if (kind !== "tauri") return web;
+
+  const native = createTauriStorage({ invoke: bridge.invokeStrict });
+  return preparedStorage(native, () => migrateStorage(web, native));
 }
 
 export function detectPlatform(deps: PlatformDeps = {}): Platform {
-  const bridge = createTauriBridge();
+  const bridge = createTauriBridge(deps.scope === undefined ? {} : { scope: deps.scope });
   const native = deps.isNative?.() ?? bridge.isPresent();
   const view = deps.view ?? globalThis.window;
 
-  // Storage, secrets and http are still the web adapters under Tauri today.
-  // That is a deliberate, temporary state and not an oversight: a Tauri
-  // StoragePort over the store plugin, a keychain SecretsPort, and an HttpPort
-  // that sends from Rust (so a request is not subject to the webview's CORS,
-  // and a hardware-backed key never crosses into JS) are each their own piece
-  // of work. Naming it here means the next author finds the seam rather than
-  // assuming it was considered and rejected.
+  // Secrets and http are still the web adapters under Tauri. That is a
+  // deliberate, temporary state and not an oversight: a keychain SecretsPort,
+  // and an HttpPort that sends from Rust (so a request is not subject to the
+  // webview's CORS, and a hardware-backed key never crosses into JS) are each
+  // their own piece of work. Naming it here means the next author finds the
+  // seam rather than assuming it was considered and rejected.
+  //
+  // STORAGE is no longer on that list. `localStorage` in WKWebView is
+  // EVICTABLE under storage pressure -- the user does nothing wrong and their
+  // history is gone -- so on a device it is now the native file store in
+  // src-tauri/src/store.rs, which writes to the app's data directory with
+  // temp-then-rename.
   return {
     shell: native ? createTauriShell({ bridge }) : createWebShell(view),
-    // localStorage in WKWebView is EVICTABLE under storage pressure, so chat
-    // history can disappear without an error. A Tauri store-file StoragePort
-    // is the fix; this is the honest interim.
-    storage: createWebStorage(view.localStorage),
+    storage: storageFor(native ? "tauri" : "web", bridge, view),
     secrets: createWebSecrets(),
     http: createWebHttp(),
     time: createWebTime(),

--- a/src/praisonai-mobile/docs/gaps.md
+++ b/src/praisonai-mobile/docs/gaps.md
@@ -456,8 +456,16 @@ broken:
   stack nothing reads.
 - **Every screen except the transcript.** Settings, chat list and about have
   complete view models and no renderer.
-- **Tauri-native storage, secrets and HTTP.** Declared honestly at
-  `app/src/platform.ts`, including that WKWebView `localStorage` is evictable.
+- **Tauri-native secrets and HTTP.** Declared honestly at
+  `app/src/platform.ts`. Storage is no longer on this list: the Tauri build now
+  writes chats to the app's data directory through `src-tauri/src/store.rs`
+  (temp file, fsync, rename, fsync the directory), because the WKWebView
+  `localStorage` it used before is evictable under storage pressure -- so
+  `en.crashed`'s "Your conversations are saved" was false on a device. The
+  StoragePort contract gained an atomicity case and three relaunch cases, both
+  with break modes, and an existing install's `localStorage` data is migrated
+  once (`adapters/src/storage/migrate.ts`) so the fix cannot look like the
+  disease.
 - **The in-process praisonai-ts engine as a shipping option.** Its stated
   blocker — bare `crypto` and `events` imports on the Agent graph — is fixed
   upstream; the wiring here is not done.

--- a/src/praisonai-mobile/src-tauri/src/lib.rs
+++ b/src/praisonai-mobile/src-tauri/src/lib.rs
@@ -22,6 +22,9 @@
 //! bridge speaks to — those invokes reject and the bridge degrades.
 
 pub mod shell;
+pub mod store;
+
+use tauri::Manager;
 
 /// The single entry point for all three platforms.
 ///
@@ -39,6 +42,33 @@ pub mod shell;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     configure(tauri::Builder::default())
+        .setup(|app| {
+            // The store's root, resolved ONCE at startup.
+            //
+            // `app_data_dir()` is the app container: on iOS
+            // Library/Application Support inside the sandbox, which is backed
+            // up and — unlike the WebKit data store `localStorage` lives in —
+            // NOT evictable when the device runs low on space. That eviction is
+            // the entire bug this exists to close: the user does nothing wrong
+            // and their conversations are gone.
+            //
+            // A failure here is fatal ON PURPOSE. Booting with no store means
+            // every chat write fails for the whole session while the crash
+            // screen keeps promising the conversations are saved, and that is
+            // a worse outcome than refusing to start with a message.
+            //
+            // It lives on `run`, not in `configure`, because `configure` is what
+            // `tests/wiring.rs` builds on the mock runtime, where there is no
+            // app container to resolve; the store commands themselves are in
+            // `configure`'s `generate_handler!` so the webview can reach them.
+            let dir = app
+                .path()
+                .app_data_dir()
+                .map_err(|e| format!("no app data directory to store conversations in: {e}"))?
+                .join(store::STORE_DIR);
+            app.manage(store::StoreState(store::FileStore::new(dir)));
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .expect("error while running the PraisonAI mobile shell");
 }
@@ -54,13 +84,25 @@ pub fn run() {
 /// the `on_window_event` line and nothing at all is emitted. Neither shows up
 /// as a failure anywhere except on a device, which is why
 /// `tests/wiring.rs` builds this and asserts on the result.
+///
+/// The five `store::storage_*` commands are registered here too: a command in
+/// `store.rs` but missing from `generate_handler!` is unreachable, the invoke
+/// rejects with "command not found", and only that one operation silently stops
+/// working. `tools/storage-seam.test.mjs` asserts all five are present.
 pub fn configure<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
     builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_back_gesture::init(commands::on_back_pressed))
         .manage(commands::BackState::default())
         .manage(shell::LifecycleState::default())
-        .invoke_handler(tauri::generate_handler![commands::back_gesture_result])
+        .invoke_handler(tauri::generate_handler![
+            commands::back_gesture_result,
+            store::storage_read,
+            store::storage_write,
+            store::storage_remove,
+            store::storage_list_ids,
+            store::storage_clear
+        ])
         .on_window_event(shell::on_window_event)
 }
 

--- a/src/praisonai-mobile/src-tauri/src/store.rs
+++ b/src/praisonai-mobile/src-tauri/src/store.rs
@@ -1,0 +1,682 @@
+//! Durable, atomic storage for the webview.
+//!
+//! WHY THIS CRATE HAS TO OWN IT. Until now `StoragePort` had exactly one
+//! implementation, `adapters/src/web/storage.ts`, over `localStorage` — and
+//! `platform.ts` handed it to the Tauri build too. In WKWebView `localStorage`
+//! lives in a WebKit data store the system is free to EVICT under storage
+//! pressure: the user does nothing wrong, opens the app, and their history is
+//! gone with no error anywhere. Android's WebView is better but is still
+//! emptied by ordinary "clear cache" flows. Meanwhile `ui/src/i18n/strings.ts`
+//! tells the user after a crash that "Your conversations are saved". This
+//! module is what makes that sentence true.
+//!
+//! WHY NOT `tauri-plugin-store`. It was the obvious candidate and it fails the
+//! one clause that matters. Its `save()` serialises the WHOLE store and writes
+//! it with a plain `fs::write` — truncate, then write — so a process killed
+//! mid-write leaves a truncated JSON file, and the next launch loses not one
+//! chat but ALL of them. It is also a single in-memory map per file, so one
+//! chat write rewrites every chat. `StoragePort` is a key/value store of
+//! opaque strings with an explicit atomicity clause; one file per key plus
+//! write-temp-then-rename satisfies it in about a hundred lines, with no new
+//! dependency and no ACL surface.
+//!
+//! THE ATOMICITY RULE, spelled out because it is the whole point:
+//!
+//!   write(tmp) -> fsync(tmp) -> rename(tmp, final) -> fsync(dir)
+//!
+//! `rename(2)` within a directory is atomic: a concurrent reader opening the
+//! final path sees either the complete old file or the complete new one, never
+//! a prefix. The `fsync` before the rename is what stops the rename from being
+//! ordered ahead of the data on a crash, which would leave a file that exists,
+//! has the right name, and contains zeroes. iOS kills suspended apps with no
+//! further callback, so "interrupted halfway" is a normal Tuesday rather than a
+//! crash scenario — `core/src/ports/storage.ts` says so in as many words.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The command names the webview invokes. `adapters/src/tauri/storage.ts`
+/// names the same five strings, and `tools/storage-seam.test.mjs` compares the
+/// two files — a rename on one side alone is otherwise SILENT, and silent here
+/// means every chat write fails and the app carries on looking fine.
+pub const CMD_READ: &str = "storage_read";
+pub const CMD_WRITE: &str = "storage_write";
+pub const CMD_REMOVE: &str = "storage_remove";
+pub const CMD_LIST_IDS: &str = "storage_list_ids";
+pub const CMD_CLEAR: &str = "storage_clear";
+
+/// The directory under the app's data dir that everything below lives in.
+pub const STORE_DIR: &str = "store";
+
+/// The namespaces `core/src/ports/storage.ts` declares, and no others.
+///
+/// This list is the path-traversal defence, not a nicety: the namespace is a
+/// directory name, so accepting an arbitrary string would let `..` out of the
+/// app's data directory entirely. An allowlist cannot be talked around by a
+/// cleverer escape sequence.
+pub const NAMESPACES: [&str; 4] = ["chats", "settings", "drafts", "cache"];
+
+/// The longest encoded file name we will create.
+///
+/// Refused with a NAME rather than passed to the OS, which would fail with
+/// ENAMETOOLONG on one filesystem and silently truncate — and therefore
+/// collide two chats into one file — on another.
+const MAX_ENCODED_LEN: usize = 200;
+
+/// Distinguishes concurrent temp files within one process. The pid alone is
+/// not enough: two threads writing the same key at once would otherwise pick
+/// the same temp name and interleave into it, which is exactly the torn write
+/// this module exists to prevent.
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Bytes that may appear literally in a file name.
+///
+/// LOWERCASE ONLY, deliberately. iOS ships APFS case-INSENSITIVE by default
+/// and macOS has for two decades, so `chat-A` and `chat-a` would be one file
+/// on a phone and two files in every test written on a case-sensitive box.
+/// Encoding uppercase means the mapping is injective on every filesystem.
+/// `.` is excluded too, so no encoded id can ever look like a temp file.
+fn is_literal(byte: u8) -> bool {
+    byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-' || byte == b'_'
+}
+
+/// A storage id as a file name. Injective, reversible, and incapable of
+/// naming a parent directory.
+pub fn encode_id(id: &str) -> String {
+    let mut out = String::with_capacity(id.len());
+    for byte in id.as_bytes() {
+        if is_literal(*byte) {
+            out.push(*byte as char);
+        } else {
+            // `~` is itself encoded (as `~7e`), so the escape can never be
+            // confused with a literal and decoding is unambiguous.
+            out.push('~');
+            out.push_str(&format!("{byte:02x}"));
+        }
+    }
+    out
+}
+
+/// The inverse. `None` for anything this module did not write — a temp file, a
+/// `.DS_Store`, a file dropped in by a backup tool — so `list_ids` reports
+/// only real ids rather than inventing one.
+pub fn decode_id(name: &str) -> Option<String> {
+    let bytes = name.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'~' {
+            let hex = name.get(i + 1..i + 3)?;
+            out.push(u8::from_str_radix(hex, 16).ok()?);
+            i += 3;
+        } else {
+            if !is_literal(bytes[i]) {
+                return None;
+            }
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+/// A namespace, or an error naming the one that was refused.
+fn checked_namespace(namespace: &str) -> Result<&str, String> {
+    NAMESPACES
+        .iter()
+        .find(|known| **known == namespace)
+        .copied()
+        .ok_or_else(|| format!("unknown storage namespace {namespace:?}"))
+}
+
+/// Files under the app's data directory, one per key.
+#[derive(Debug, Clone)]
+pub struct FileStore {
+    root: PathBuf,
+}
+
+impl FileStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn namespace_dir(&self, namespace: &str) -> Result<PathBuf, String> {
+        Ok(self.root.join(checked_namespace(namespace)?))
+    }
+
+    fn path_for(&self, namespace: &str, id: &str) -> Result<PathBuf, String> {
+        let encoded = encode_id(id);
+        if encoded.is_empty() {
+            return Err("a storage id may not be empty".to_string());
+        }
+        if encoded.len() > MAX_ENCODED_LEN {
+            return Err(format!(
+                "storage id is too long to store ({} bytes encoded, limit {MAX_ENCODED_LEN})",
+                encoded.len()
+            ));
+        }
+        Ok(self.namespace_dir(namespace)?.join(encoded))
+    }
+
+    /// `Ok(None)` for a missing key. Absence is not an error; only I/O is —
+    /// which is the difference between "no such chat" and "the disk is
+    /// failing", and the caller treats those very differently.
+    pub fn read(&self, namespace: &str, id: &str) -> Result<Option<String>, String> {
+        let path = self.path_for(namespace, id)?;
+        match fs::read(&path) {
+            Ok(bytes) => String::from_utf8(bytes)
+                .map(Some)
+                // Not `from_utf8_lossy`: replacing bytes with U+FFFD would
+                // hand the repository a JSON document that parses to the wrong
+                // text, and it would then be saved back that way.
+                .map_err(|error| format!("{} is not valid UTF-8: {error}", path.display())),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(format!("could not read {}: {error}", path.display())),
+        }
+    }
+
+    /// Atomic. See the module header: temp, fsync, rename, fsync the directory.
+    pub fn write(&self, namespace: &str, id: &str, value: &str) -> Result<(), String> {
+        let path = self.path_for(namespace, id)?;
+        let dir = path
+            .parent()
+            .ok_or_else(|| format!("{} has no parent directory", path.display()))?
+            .to_path_buf();
+        fs::create_dir_all(&dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
+
+        let temp = dir.join(format!(
+            ".tmp.{}.{}",
+            std::process::id(),
+            TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+
+        // Scoped, so the handle is closed before the rename. Windows refuses to
+        // rename over an open file, and this crate builds for desktop too.
+        let written = (|| -> io::Result<()> {
+            let mut file = fs::File::create(&temp)?;
+            file.write_all(value.as_bytes())?;
+            // The one line that makes the rename meaningful. Without it the
+            // metadata operation can reach the disk before the data, and a
+            // power loss leaves a correctly-named file full of zeroes.
+            file.sync_all()?;
+            Ok(())
+        })();
+
+        if let Err(error) = written {
+            // Best effort: a leftover temp is invisible to `list_ids` (it
+            // does not decode) but there is no reason to leave it.
+            let _ = fs::remove_file(&temp);
+            return Err(format!("could not write {}: {error}", temp.display()));
+        }
+
+        if let Err(error) = fs::rename(&temp, &path) {
+            let _ = fs::remove_file(&temp);
+            return Err(format!(
+                "could not replace {}: {error}",
+                path.display()
+            ));
+        }
+
+        // The rename itself is a directory operation and needs its own flush to
+        // survive a power loss. Best effort: a filesystem that refuses to open
+        // a directory for sync (Windows) is not a reason to report the write
+        // as failed, because the data is already durable and in place.
+        sync_dir(&dir);
+        Ok(())
+    }
+
+    /// Removing an absent key succeeds — the caller wanted it gone and it is.
+    pub fn remove(&self, namespace: &str, id: &str) -> Result<(), String> {
+        let path = self.path_for(namespace, id)?;
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(format!("could not remove {}: {error}", path.display())),
+        }
+        if let Some(dir) = path.parent() {
+            sync_dir(dir);
+        }
+        Ok(())
+    }
+
+    /// Ids in one namespace. An untouched namespace has no directory yet and
+    /// lists empty rather than failing.
+    pub fn list_ids(&self, namespace: &str) -> Result<Vec<String>, String> {
+        let dir = self.namespace_dir(namespace)?;
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(format!("could not list {}: {error}", dir.display())),
+        };
+
+        let mut ids = Vec::new();
+        // A `HashSet` because a case-insensitive filesystem can hand back the
+        // same name twice under some sync tools, and a duplicated chat id
+        // renders as two identical rows that both open the same conversation.
+        let mut seen = HashSet::new();
+        for entry in entries {
+            let entry = entry.map_err(|e| format!("could not list {}: {e}", dir.display()))?;
+            let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            // Anything this module did not write — a temp file mid-rename, a
+            // .DS_Store, a backup tool's droppings — decodes to None and is
+            // skipped rather than reported as a chat that cannot be read.
+            let Some(id) = decode_id(&name) else { continue };
+            if seen.insert(id.clone()) {
+                ids.push(id);
+            }
+        }
+        Ok(ids)
+    }
+
+    /// Empties one namespace and leaves the others.
+    pub fn clear(&self, namespace: &str) -> Result<(), String> {
+        let dir = self.namespace_dir(namespace)?;
+        for id in self.list_ids(namespace)? {
+            self.remove(namespace, &id)?;
+        }
+        sync_dir(&dir);
+        Ok(())
+    }
+}
+
+/// Flush a directory entry, so a rename survives a power loss.
+#[cfg(unix)]
+fn sync_dir(dir: &Path) {
+    if let Ok(handle) = fs::File::open(dir) {
+        let _ = handle.sync_all();
+    }
+}
+
+/// Windows cannot open a directory as a file, and has no equivalent call.
+/// The data is already durable; only the ordering guarantee is weaker.
+#[cfg(not(unix))]
+fn sync_dir(_dir: &Path) {}
+
+// ---------------------------------------------------------------------------
+// the Tauri commands
+// ---------------------------------------------------------------------------
+
+/// Where the store lives, resolved once at startup and held in Tauri state.
+///
+/// Resolved ONCE rather than per call, because `app_data_dir()` can fail and a
+/// failure that surfaces on the fiftieth write is a failure nobody can
+/// reproduce.
+pub struct StoreState(pub FileStore);
+
+/// Every argument is a single lowercase word on purpose: Tauri 2 maps JS
+/// `camelCase` onto Rust `snake_case` parameters, and a two-word name is the
+/// standing way to get a command that rejects every call with a deserialisation
+/// error the webview reports as "storage failed".
+#[tauri::command]
+pub fn storage_read(
+    state: tauri::State<'_, StoreState>,
+    namespace: String,
+    id: String,
+) -> Result<Option<String>, String> {
+    state.0.read(&namespace, &id)
+}
+
+#[tauri::command]
+pub fn storage_write(
+    state: tauri::State<'_, StoreState>,
+    namespace: String,
+    id: String,
+    value: String,
+) -> Result<(), String> {
+    state.0.write(&namespace, &id, &value)
+}
+
+#[tauri::command]
+pub fn storage_remove(
+    state: tauri::State<'_, StoreState>,
+    namespace: String,
+    id: String,
+) -> Result<(), String> {
+    state.0.remove(&namespace, &id)
+}
+
+#[tauri::command]
+pub fn storage_list_ids(
+    state: tauri::State<'_, StoreState>,
+    namespace: String,
+) -> Result<Vec<String>, String> {
+    state.0.list_ids(&namespace)
+}
+
+#[tauri::command]
+pub fn storage_clear(
+    state: tauri::State<'_, StoreState>,
+    namespace: String,
+) -> Result<(), String> {
+    state.0.clear(&namespace)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scratch directory under the OS temp dir. No `tempfile` dependency:
+    /// adding one to reach an offline CI cache is a worse trade than eight
+    /// lines here.
+    struct Scratch(PathBuf);
+
+    impl Scratch {
+        fn new(label: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "praisonai-store-{label}-{}-{}",
+                std::process::id(),
+                TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+            ));
+            let _ = fs::remove_dir_all(&dir);
+            fs::create_dir_all(&dir).expect("scratch dir");
+            Self(dir)
+        }
+        fn store(&self) -> FileStore {
+            FileStore::new(&self.0)
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn a_value_round_trips_through_the_filesystem() {
+        let scratch = Scratch::new("round-trip");
+        let store = scratch.store();
+        let payload = "{\"a\":\"line1\nline2\",\"b\":\"quo\\\"te\",\"c\":\"日本語 🎉\"}";
+        store.write("chats", "c1", payload).unwrap();
+        assert_eq!(store.read("chats", "c1").unwrap(), Some(payload.to_string()));
+    }
+
+    #[test]
+    fn a_missing_key_is_absent_rather_than_an_error() {
+        let scratch = Scratch::new("missing");
+        assert_eq!(scratch.store().read("chats", "nope").unwrap(), None);
+    }
+
+    #[test]
+    fn an_empty_string_is_a_value_not_an_absence() {
+        // `||` instead of `??`, one language down. A deliberately blank
+        // setting must not read back as "never configured".
+        let scratch = Scratch::new("empty");
+        let store = scratch.store();
+        store.write("settings", "blank", "").unwrap();
+        assert_eq!(store.read("settings", "blank").unwrap(), Some(String::new()));
+    }
+
+    #[test]
+    fn a_value_survives_a_relaunch() {
+        // The crash-recovery claim, at the layer that has to keep it. A second
+        // FileStore over the same root is exactly what the next launch builds.
+        let scratch = Scratch::new("relaunch");
+        scratch.store().write("chats", "c1", "kept").unwrap();
+        drop(scratch.store());
+        let after_relaunch = FileStore::new(&scratch.0);
+        assert_eq!(after_relaunch.read("chats", "c1").unwrap(), Some("kept".into()));
+        assert_eq!(after_relaunch.list_ids("chats").unwrap(), vec!["c1".to_string()]);
+    }
+
+    #[test]
+    fn a_write_interrupted_before_the_rename_leaves_the_old_value_intact() {
+        // The iOS case, simulated: the app is killed after the temp file is
+        // written and before the rename. `fs::write` straight to the final
+        // path would have truncated it by now and the chat would be gone.
+        let scratch = Scratch::new("interrupted");
+        let store = scratch.store();
+        store.write("chats", "c1", "the old conversation").unwrap();
+
+        let dir = scratch.0.join("chats");
+        let orphan = dir.join(".tmp.9999.0");
+        fs::write(&orphan, "half of the new one").unwrap();
+
+        assert_eq!(
+            store.read("chats", "c1").unwrap(),
+            Some("the old conversation".to_string()),
+            "an unfinished write must not be visible at the real key"
+        );
+        assert_eq!(
+            store.list_ids("chats").unwrap(),
+            vec!["c1".to_string()],
+            "a temp file must never be reported as a chat"
+        );
+    }
+
+    #[test]
+    fn a_completed_write_leaves_no_temp_file_behind() {
+        let scratch = Scratch::new("no-temp");
+        let store = scratch.store();
+        for n in 0..5 {
+            store.write("chats", "c1", &format!("value {n}")).unwrap();
+        }
+        let leftovers: Vec<String> = fs::read_dir(scratch.0.join("chats"))
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    #[test]
+    fn a_concurrent_reader_never_sees_a_torn_value() {
+        // THE atomicity clause, exercised rather than asserted in prose.
+        //
+        // Ten threads rewrite one key with ten distinct 256KB payloads while a
+        // reader reads it a thousand times. Every observation must be one of
+        // the whole payloads or absent — never a prefix, never a mixture.
+        // Replace the temp-then-rename with a plain `fs::write` and this test
+        // fails within a few iterations; that mutation was run.
+        use std::sync::mpsc;
+        use std::thread;
+
+        let scratch = Scratch::new("torn");
+        let store = scratch.store();
+
+        let payloads: Vec<String> = (0..10)
+            .map(|n| char::from(b'a' + n as u8).to_string().repeat(256 * 1024))
+            .collect();
+
+        let (stop_tx, stop_rx) = mpsc::channel::<()>();
+        let reader_store = store.clone();
+        let reader_payloads = payloads.clone();
+        let reader = thread::spawn(move || {
+            let mut torn: Option<usize> = None;
+            let mut reads = 0usize;
+            while stop_rx.try_recv().is_err() {
+                match reader_store.read("chats", "hot").unwrap() {
+                    None => {}
+                    Some(seen) => {
+                        reads += 1;
+                        if !reader_payloads.contains(&seen) {
+                            torn = Some(seen.len());
+                            break;
+                        }
+                    }
+                }
+            }
+            (torn, reads)
+        });
+
+        let mut writers = Vec::new();
+        for payload in payloads.clone() {
+            let writer_store = store.clone();
+            writers.push(thread::spawn(move || {
+                for _ in 0..20 {
+                    writer_store.write("chats", "hot", &payload).unwrap();
+                }
+            }));
+        }
+        for writer in writers {
+            writer.join().unwrap();
+        }
+        let _ = stop_tx.send(());
+        let (torn, reads) = reader.join().unwrap();
+
+        assert_eq!(torn, None, "a reader saw a partial value of {torn:?} bytes");
+        // The control. A reader that observed NOTHING would report no tearing
+        // while proving nothing at all.
+        assert!(reads > 0, "the reader never observed a value; the test proved nothing");
+        assert!(payloads.contains(&store.read("chats", "hot").unwrap().unwrap()));
+    }
+
+    #[test]
+    fn namespaces_are_separate_directories() {
+        let scratch = Scratch::new("namespaces");
+        let store = scratch.store();
+        store.write("chats", "same", "chat value").unwrap();
+        store.write("settings", "same", "settings value").unwrap();
+        assert_eq!(store.read("chats", "same").unwrap(), Some("chat value".into()));
+        assert_eq!(store.read("settings", "same").unwrap(), Some("settings value".into()));
+        assert_eq!(store.list_ids("chats").unwrap(), vec!["same".to_string()]);
+    }
+
+    #[test]
+    fn an_unknown_namespace_is_refused_rather_than_created() {
+        // The traversal defence. `..` as a namespace would otherwise write
+        // outside the app's data directory entirely.
+        let scratch = Scratch::new("unknown-ns");
+        let store = scratch.store();
+        for bad in ["..", "../../etc", "keychain", ""] {
+            assert!(store.write(bad, "x", "y").is_err(), "{bad:?} was accepted");
+            assert!(store.read(bad, "x").is_err(), "{bad:?} was accepted");
+            assert!(store.list_ids(bad).is_err(), "{bad:?} was accepted");
+            assert!(store.clear(bad).is_err(), "{bad:?} was accepted");
+            assert!(store.remove(bad, "x").is_err(), "{bad:?} was accepted");
+        }
+    }
+
+    #[test]
+    fn an_id_cannot_escape_its_namespace() {
+        // `/` and `.` are encoded, so this is a file called `~2e~2e~2fboot`
+        // inside chats/ rather than a write two directories up.
+        let scratch = Scratch::new("escape");
+        let store = scratch.store();
+        store.write("chats", "../../boot", "payload").unwrap();
+        assert_eq!(store.read("chats", "../../boot").unwrap(), Some("payload".into()));
+        assert_eq!(store.list_ids("chats").unwrap(), vec!["../../boot".to_string()]);
+        assert!(
+            scratch.0.join("chats").join("~2e~2e~2f~2e~2e~2fboot").exists(),
+            "the id was not encoded into a single flat file name"
+        );
+    }
+
+    #[test]
+    fn ids_differing_only_in_case_are_different_chats() {
+        // macOS and iOS are case-insensitive by default. Without encoding the
+        // uppercase, two chats share one file and one of them is overwritten —
+        // on a phone, and never on a Linux CI box.
+        let scratch = Scratch::new("case");
+        let store = scratch.store();
+        store.write("chats", "Chat-A", "upper").unwrap();
+        store.write("chats", "chat-a", "lower").unwrap();
+        assert_eq!(store.read("chats", "Chat-A").unwrap(), Some("upper".into()));
+        assert_eq!(store.read("chats", "chat-a").unwrap(), Some("lower".into()));
+        let mut ids = store.list_ids("chats").unwrap();
+        ids.sort();
+        assert_eq!(ids, vec!["Chat-A".to_string(), "chat-a".to_string()]);
+    }
+
+    #[test]
+    fn encoding_round_trips_every_id_the_app_can_produce() {
+        for id in [
+            "c1",
+            "0198f2b0-1c2d-7000-8000-a1b2c3d4e5f6",
+            "Chat-A",
+            "../escape",
+            "spaces and 日本語 🎉",
+            "~already~escaped",
+            ".hidden",
+            "UPPER_CASE-99",
+        ] {
+            let encoded = encode_id(id);
+            assert_eq!(decode_id(&encoded).as_deref(), Some(id), "round trip failed for {id:?}");
+            assert!(!encoded.contains('/'), "{encoded} can name another directory");
+            assert!(!encoded.contains('.'), "{encoded} can be mistaken for a temp file");
+        }
+    }
+
+    #[test]
+    fn a_temp_file_name_never_decodes_to_an_id() {
+        // The other half of the filter: if a temp name decoded, an interrupted
+        // write would appear in the chat list as an unreadable conversation.
+        assert_eq!(decode_id(".tmp.4321.7"), None);
+        assert_eq!(decode_id(".DS_Store"), None);
+        assert_eq!(decode_id("~zz"), None, "a bad escape is not an id");
+        assert_eq!(decode_id("~7"), None, "a truncated escape is not an id");
+    }
+
+    #[test]
+    fn an_over_long_id_is_refused_by_name_rather_than_by_the_os() {
+        let scratch = Scratch::new("long");
+        let store = scratch.store();
+        let long = "x".repeat(MAX_ENCODED_LEN + 1);
+        let error = store.write("chats", &long, "v").unwrap_err();
+        assert!(error.contains("too long"), "unhelpful error: {error}");
+    }
+
+    #[test]
+    fn removing_an_absent_key_succeeds() {
+        let scratch = Scratch::new("remove-absent");
+        assert!(scratch.store().remove("chats", "ghost").is_ok());
+    }
+
+    #[test]
+    fn a_removed_key_reads_as_absent_again() {
+        let scratch = Scratch::new("removed");
+        let store = scratch.store();
+        store.write("chats", "c1", "x").unwrap();
+        store.remove("chats", "c1").unwrap();
+        assert_eq!(store.read("chats", "c1").unwrap(), None);
+        assert!(store.list_ids("chats").unwrap().is_empty());
+    }
+
+    #[test]
+    fn clear_empties_one_namespace_and_leaves_the_others() {
+        let scratch = Scratch::new("clear");
+        let store = scratch.store();
+        for id in ["a", "b", "c", "d", "e"] {
+            store.write("chats", id, id).unwrap();
+        }
+        store.write("settings", "keep", "1").unwrap();
+
+        store.clear("chats").unwrap();
+        // Every key, not every other one — the index-shifting bug the web
+        // adapter has a named case for.
+        assert!(store.list_ids("chats").unwrap().is_empty());
+        assert_eq!(store.list_ids("settings").unwrap(), vec!["keep".to_string()]);
+    }
+
+    #[test]
+    fn an_untouched_namespace_lists_empty_rather_than_failing() {
+        let scratch = Scratch::new("untouched");
+        assert!(scratch.store().list_ids("drafts").unwrap().is_empty());
+    }
+
+    #[test]
+    fn the_command_names_are_the_ones_the_webview_invokes() {
+        // Literals on purpose, exactly as tests/contract.rs does for the shell
+        // seam. A rename here is silent on a device: every chat write rejects
+        // and the app keeps running.
+        assert_eq!(CMD_READ, "storage_read");
+        assert_eq!(CMD_WRITE, "storage_write");
+        assert_eq!(CMD_REMOVE, "storage_remove");
+        assert_eq!(CMD_LIST_IDS, "storage_list_ids");
+        assert_eq!(CMD_CLEAR, "storage_clear");
+    }
+
+    #[test]
+    fn the_namespaces_are_the_four_the_port_declares() {
+        assert_eq!(NAMESPACES, ["chats", "settings", "drafts", "cache"]);
+    }
+}

--- a/src/praisonai-mobile/tools/storage-seam.test.mjs
+++ b/src/praisonai-mobile/tools/storage-seam.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * The Rust and TypeScript sides of the STORAGE seam must agree on five command
+ * names and on four namespaces.
+ *
+ * A rename on either side alone is silent in the worst possible way: Tauri
+ * rejects the unknown command, `createTauriStorage` propagates the rejection,
+ * `repository.load` reports `unreadable`, and the app keeps running while
+ * every conversation the user has fails to save. Nothing crashes and nothing
+ * in either language's own test suite fails -- the Rust tests pin the Rust
+ * constants to literals, the TypeScript tests pin the TypeScript ones, and
+ * both stay green while the two drift apart.
+ *
+ * The same argument as tools/shell-seam.test.mjs, one seam over, written at
+ * the same time as the seam rather than after the first device bug.
+ *
+ * Deliberately reads the files rather than importing: the Rust cannot be
+ * imported, and parsing it is the only way to compare the two.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = join(here, ".."); // tools/ -> the package root
+
+const rust = readFileSync(join(pkg, "src-tauri/src/store.rs"), "utf8");
+const ts = readFileSync(join(pkg, "adapters/src/tauri/storage.ts"), "utf8");
+const port = readFileSync(join(pkg, "core/src/ports/storage.ts"), "utf8");
+
+/**
+ * Rust source with its comment lines removed.
+ *
+ * Not a nicety -- a measured false green. The `app_data_dir` check below was
+ * written against the raw source, and this file's own mutation sweep caught it:
+ * swapping the real `.app_data_dir()` call for `.app_cache_dir()` left the test
+ * PASSING, because `lib.rs`'s doc comment explains what `app_data_dir()` is and
+ * the regex was happily matching the explanation. A gate that reads prose is a
+ * gate that passes when the prose is right and the code is wrong, which is the
+ * precise failure mode this package keeps a file of notes about.
+ */
+function code(source) {
+  return source
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("//"))
+    .join("\n");
+}
+
+/**
+ * The SHIPPING half of store.rs -- everything before `#[cfg(test)]`.
+ *
+ * The test module deliberately calls `fs::write` to simulate a write
+ * interrupted before its rename, so a check for "no fs::write anywhere" would
+ * be red on correct code. Cutting at the cfg(test) line keeps the check aimed
+ * at the code that runs on a phone.
+ */
+const rustCode = code(rust).split("#[cfg(test)]")[0];
+
+/** `pub const NAME: &str = "value";` */
+function rustConst(name) {
+  const m = new RegExp(`pub const ${name}: &str = "([^"]+)"`).exec(rust);
+  assert.ok(m, `${name} not found in the Rust store module`);
+  return m[1];
+}
+
+/** A key in the TypeScript `STORAGE_COMMANDS` table. */
+function tsCommand(key) {
+  const m = new RegExp(`${key}: "([^"]+)"`).exec(ts);
+  assert.ok(m, `${key} not found in adapters/src/tauri/storage.ts`);
+  return m[1];
+}
+
+test("the five storage command names agree across the seam", () => {
+  assert.equal(rustConst("CMD_READ"), tsCommand("read"));
+  assert.equal(rustConst("CMD_WRITE"), tsCommand("write"));
+  assert.equal(rustConst("CMD_REMOVE"), tsCommand("remove"));
+  assert.equal(rustConst("CMD_LIST_IDS"), tsCommand("listIds"));
+  assert.equal(rustConst("CMD_CLEAR"), tsCommand("clear"));
+});
+
+test("every command the adapter can send is registered with Tauri", () => {
+  // A command that exists in `store.rs` but is missing from
+  // `generate_handler!` is not reachable AT ALL -- the invoke rejects with
+  // "command not found" and, again, only that one operation silently stops
+  // working. `clear` would be the one nobody notices for months.
+  const lib = readFileSync(join(pkg, "src-tauri/src/lib.rs"), "utf8");
+  const handler = /generate_handler!\[([\s\S]*?)\]/.exec(lib);
+  assert.ok(handler, "no generate_handler! block in lib.rs");
+  for (const key of ["read", "write", "remove", "listIds", "clear"]) {
+    const command = tsCommand(key);
+    assert.ok(
+      handler[1].includes(command),
+      `${command} is not in generate_handler!; the webview cannot reach it`,
+    );
+  }
+});
+
+test("the store resolves its root under the app data directory", () => {
+  // `app_data_dir()` -> `temp_dir()` or `cache_dir()` compiles, passes every
+  // Rust test (they all run against a scratch root), and ships a store the OS
+  // is free to delete -- which is the exact bug this whole change exists to
+  // fix, reintroduced one directory down.
+  const lib = code(readFileSync(join(pkg, "src-tauri/src/lib.rs"), "utf8"));
+  assert.match(lib, /\.app_data_dir\(\)/, "the store must live in the app's data directory");
+  assert.doesNotMatch(lib, /cache_dir\(\)/, "a cache directory is evictable by the OS");
+  assert.doesNotMatch(lib, /temp_dir\(\)/, "a temp directory is not a place to keep chat history");
+});
+
+/**
+ * The body of `FileStore::write`, and nothing else.
+ *
+ * Scoped, because a whole-file search is not a gate. Measured, by this file's
+ * own mutation sweep: deleting the directory flush from `write` left the check
+ * GREEN, because `indexOf` happily found the identical call in `clear` further
+ * down the file and it was, of course, after the rename. The first version of
+ * this test could not fail for the defect it was written for.
+ */
+function writeBody() {
+  const at = rustCode.indexOf("pub fn write(");
+  assert.notEqual(at, -1, "FileStore::write not found");
+  const rest = rustCode.slice(at);
+  const next = rest.indexOf("\n    pub fn ", 1);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+test("the write path is write-temp-then-rename, with the data flushed first", () => {
+  // The port's atomicity clause is behaviourally tested in store.rs (a reader
+  // thread against ten concurrent writers). The two FLUSHES are the part of it
+  // no in-process test can reach: `sync_all` only matters across a power loss
+  // or a kernel panic, and dropping either leaves every test green while
+  // shipping a store that can come back with a correctly-named file full of
+  // zeroes -- which is worse than a missing file, because it reads as
+  // corruption rather than as absence. Measured: removing each of those two
+  // lines survived the entire suite, Rust and TypeScript alike.
+  //
+  // So they are pinned at the only level available, on the CODE of the one
+  // function that performs the write.
+  const body = writeBody();
+
+  assert.doesNotMatch(
+    body,
+    /fs::write\(/,
+    "fs::write truncates in place: a kill mid-write loses the whole conversation",
+  );
+
+  // Order, not just presence. A flush after the rename guarantees nothing, and
+  // a rename of something never written guarantees less.
+  const steps = ["File::create(&temp)", "file.sync_all()", "fs::rename(&temp, &path)", "sync_dir(&dir)"];
+  const at = steps.map((step) => body.indexOf(step));
+  for (const [n, step] of steps.entries()) {
+    assert.notEqual(at[n], -1, `FileStore::write no longer does: ${step}`);
+  }
+  assert.deepEqual(
+    at,
+    [...at].sort((a, b) => a - b),
+    `the write path is out of order: ${steps.join(" -> ")}`,
+  );
+});
+
+test("the namespaces Rust accepts are the ones the port declares", () => {
+  // The Rust allowlist is the path-traversal defence AND the list of what can
+  // be stored at all. A namespace added to the port and not to the allowlist
+  // fails every write in that namespace, at runtime, on a device.
+  const declared = [...port.matchAll(/"(chats|settings|drafts|cache)"/g)].map((m) => m[1]);
+  const unique = [...new Set(declared)].sort();
+  const m = /pub const NAMESPACES: \[&str; \d+\] = \[([^\]]+)\]/.exec(rustCode);
+  assert.ok(m, "NAMESPACES not found in the Rust store module");
+  const allowed = [...m[1].matchAll(/"([^"]+)"/g)].map((x) => x[1]).sort();
+  assert.deepEqual(allowed, unique, "the Rust allowlist and the Namespace union disagree");
+});
+
+test("the comparison is real, not three lookups of the same file", () => {
+  // The way this test could quietly stop working: if the helpers read the same
+  // source, every assertion above passes forever.
+  assert.notEqual(rust, ts);
+  assert.notEqual(ts, port);
+  assert.ok(rust.includes("pub const"), "the Rust source was not read");
+  assert.ok(ts.includes("STORAGE_COMMANDS"), "the TypeScript adapter was not read");
+  assert.ok(port.includes("export type Namespace"), "the port was not read");
+});


### PR DESCRIPTION
## The gap

`StoragePort` had exactly one implementation — `adapters/src/web/storage.ts`, over `localStorage` — and `app/src/platform.ts` handed it to the **Tauri** build as well, with a comment calling that "the honest interim".

On iOS, `localStorage` lives in a WebKit data store the system may **evict under storage pressure**. The user does nothing wrong, opens the app, and their conversations are gone — no error, nothing to report. Android's WebView survives eviction but is emptied by ordinary "clear cache" flows.

Meanwhile `ui/src/i18n/strings.ts:277` tells the user, after a crash:

> Something went wrong. Your conversations are saved.

That was false on a device. This makes it true rather than editing the sentence.

The port's own header already named the intended path — serialisation lives in `core/src/chat/repository.ts` precisely so the backing store can be swapped with no format change and no data loss — so this is a new adapter, not a new format.

## What changed

**`src-tauri/src/store.rs`** — one file per key under the app's data directory.

The write is `temp → fsync → rename → fsync the directory`. That is what the port's atomicity clause requires: `rename(2)` is atomic within a directory, so a concurrent reader sees the complete old file or the complete new one, never a prefix. The `fsync` before the rename is what stops the metadata reaching disk ahead of the data — otherwise a power loss leaves a correctly-named file full of zeroes, which reads as corruption rather than as absence. `iOS kills a suspended app with no further callback`, so "interrupted halfway" is normal rather than exotic.

Ids are hex-escaped into a single flat file name (`a-z0-9-_` literal, everything else `~XX`). Two reasons, both device-only bugs: `../` in an id would otherwise escape the app's data directory, and **uppercase is escaped too** because iOS and macOS ship case-insensitive filesystems — `Chat-A` and `chat-a` would be one file on a phone and two on a Linux CI box. Namespaces are an allowlist, which is the traversal defence for the directory component.

**Why not `tauri-plugin-store`.** It was the obvious candidate and it fails the clause that matters: its `save()` serialises the whole store and writes it with a plain `fs::write` — truncate, then write — so a kill mid-write loses not one chat but *all* of them. It is also one in-memory blob per file, so writing one chat rewrites every chat. One file per key plus temp-then-rename satisfies the contract in ~200 lines, with no new dependency and no ACL surface.

**`adapters/src/tauri/storage.ts`** — the five commands, over a new `bridge.invokeStrict`.

`invokeStrict` is a strict sibling of the existing `invoke`, not a replacement. Swallowing a rejection is right for a haptic tap and catastrophic for a chat write: `null` is `StoragePort.read`'s word for "no such key", so an adapter built on the forgiving `invoke` would present a failing disk as an **empty chat list** — the conversations look deleted rather than unreadable, and the next save writes over them. A reply that is not a string or null is likewise an I/O failure, not an absence.

**`app/src/platform.ts`** — `storageFor(kind, bridge, view)`, the per-platform default in one named function, following `defaultEngineIdFor`'s precedent. Tauri gets the native store; web keeps `localStorage`, which is the only store a browser has.

**`adapters/src/storage/migrate.ts`** — a one-time copy out of `localStorage`.

Judged warranted. Not because of a bug, but because of the change itself: without it, the first launch on the new build reads an empty store and every existing conversation is simply not there — which the user cannot tell apart from the eviction bug being fixed. "The app has not shipped, so nobody has data" is a claim about other people's devices that nobody here can check; dev builds, TestFlight builds and sideloads all have real `localStorage` today. It never overwrites, never deletes the source (so a rollback still finds its data), and writes its done-marker in the *target* — the source is the thing that can disappear. `preparedStorage` runs it once before the first read, since `detectPlatform` must stay synchronous for the first paint; a failed migration is reported and the store still works.

## Verification

Every gate judged by **process exit code**.

| gate | result |
|---|---|
| `npm run check` (`src/praisonai-mobile`) | **exit 0** — 1407 tests, pass 1407, fail 0, cancelled 0, skipped 0 |
| `npm run test:bundle` | **exit 0** — 30 pass, 0 fail |
| `cargo test` | **exit 0** — 20 new `store::` tests + 13 existing |
| `cargo clippy --all-targets -- -D warnings` | **exit 0** |

### Contract work

`describeStorageContract` gained an **atomicity** case (concurrent writers against a live reader; every observation must be a whole payload or absent) and three **relaunch** cases (a value, the chat list, and a deletion each survive a second port over the same backing store). The ledger count moves `15` → `17 + 3 when durable`, following `time-contract.ts`'s conditional-branch precedent.

Two new break modes in `contract-fixture.ts` prove those cases have teeth — `storage_torn_write` (truncate, yield, fill: what `fs::write` does) and `storage_forgets_on_relaunch` — and both floors in `contracts.test.ts` were raised (`storage >= 15` cases, `ADAPTER_BREAKS >= 15`).

The Tauri adapter is now run against the same contract, through a **strict** stand-in host that throws on an unknown command or a missing argument. Stated plainly in the file: that proves the adapter — command names, argument names, reply handling, namespacing — and *not* that the filesystem is atomic. The filesystem is `store.rs`'s own tests, where there is a real disk to interrupt, and `tools/storage-seam.test.mjs` is what stops the two sides drifting on a name.

### The crash-recovery claim, proved

`app/src/crash-recovery.test.ts` records a turn through the same `persistenceFor(session)` seam the engine uses, fires a real uncaught error through `installCrashHandler`, then boots a **second** `createApp` over the same bytes and asserts the transcript comes back — once over the web adapter and once over `createTauriStorage`. A control case gives the second launch a *fresh* store and requires the conversation to be gone, so "the relaunch is not real" cannot pass.

It also pins the boundary: a turn **in flight** when the app dies is lost, by design — `session.record` writes the question and the answer together so a crash cannot leave a persisted transcript with a dangling question and no reply. The string says conversations are saved, and every completed exchange is. The i18n string is unchanged.

### Mutation testing — 28 applied, 28 killed

Every mutation asserts its anchor was found and unique before editing, so a silent no-op cannot report SURVIVED.

| mutation | killed by |
|---|---|
| tauri `read` always returns null | `tauri storage: a written value reads back exactly` (+5) |
| tauri `listIds` ignores its namespace | `tauri storage: listIds returns only its own namespace` |
| tauri `write` drops the value argument | `tauri storage: a written value reads back exactly` (+5) |
| a wrong-shaped native reply reads as an absence | `a native reply of the wrong shape is an I/O failure, not an empty chat list` |
| a command renamed on the TypeScript side only | `the five storage command names agree across the seam` |
| `invokeStrict` swallows the failure like `invoke` | `invokeStrict rejects where invoke resolves to null` |
| **the registry hands Tauri the web store** | `a native host stores chats in the NATIVE store, not localStorage` |
| the migration is dropped from the wiring | `an existing install's chats are carried onto the native store` |
| the migration overwrites newer data | `migration runs once and never overwrites newer data` |
| the migration marker is never written | `migration runs once and never overwrites newer data` |
| `preparedStorage` does not wait for the migration | `preparedStorage runs its migration ONCE, before the first read` |
| a failed migration takes the whole store down | `a failed migration leaves the new store usable` |
| the contract's atomicity case is deleted | `a contract cannot quietly shrink` + 3 ledgers |
| the contract's relaunch case is deleted | `a contract cannot quietly shrink` + 3 ledgers |
| the torn-write break mode is removed from the table | `a contract cannot quietly shrink` |
| the session stops persisting a completed turn | `a conversation written before a crash comes back after the relaunch` |
| the chat list is rebuilt empty on relaunch | `a conversation written before a crash comes back after the relaunch` |
| **rust write is a plain `fs::write`** | `a_concurrent_reader_never_sees_a_torn_value` (+5) |
| rust drops the fsync before the rename | `the write path is write-temp-then-rename, with the data flushed first` |
| rust drops the directory flush after the rename | same |
| rust flushes the directory *before* the rename | same |
| rust ids are not encoded | `ids_differing_only_in_case_are_different_chats` (+2) |
| rust accepts any namespace | `an_unknown_namespace_is_refused_rather_than_created` |
| rust `list_ids` reports temp files as chats | `a_write_interrupted_before_the_rename_leaves_the_old_value_intact` |
| rust `clear` removes every other key | `clear_empties_one_namespace_and_leaves_the_others` |
| rust `read` reports a missing key as an error | `a_missing_key_is_absent_rather_than_an_error` (+2) |
| rust store moves to the cache directory | `the store resolves its root under the app data directory` |
| a storage command dropped from `generate_handler!` | `every command the adapter can send is registered with Tauri` |

**Two of those started as survivors, and both were false greens in the gates I had just written** — which is the point of running the sweep rather than trusting the green:

1. `app_data_dir()` → `app_cache_dir()` **passed**, because the regex was matching the *doc comment* explaining what `app_data_dir()` is. The seam test now strips comment lines and matches `.app_data_dir()`.
2. Deleting the directory flush from `write` **passed**, because `indexOf` found the identical `sync_dir(&dir)` in `clear` further down the file — and it was, of course, after the rename. The check is now scoped to the body of `FileStore::write` and asserts the four steps in order.

No test reads a gitignored build output; the seam test reads source, and the crash-recovery test builds its store in memory.

## Not done, deliberately

- **Secrets and HTTP are still the web adapters under Tauri.** A keychain `SecretsPort` and a Rust-side `HttpPort` are each their own piece of work; `platform.ts` still says so.
- **`sync_all` cannot be proved behaviourally.** It only matters across a power loss or a kernel panic, so it is pinned on the write function's source. That is weaker than a behavioural test and is labelled as such in the file — but a check that reads code beats an invariant nothing reads at all, and three separate mutations of that write path now go red.

Closes the storage half of #4673's device readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added durable native storage for conversations and related app data.
  - Existing browser-stored conversations are migrated once to native storage on first launch.
  - Data persists across app relaunches and is stored atomically to prevent partial writes.
  - Web platforms continue using browser storage.

- **Bug Fixes**
  - Improved crash recovery for completed conversations after an app restart.
  - Prevented incomplete turns from being saved as partial transcripts.
  - Improved handling of storage failures and invalid native responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->