### PR TITLE
fix(mobile): the Pages skip-notice never runs, so main goes red on every push

### DIFF
--- a/.github/workflows/mobile-web.yml
+++ b/.github/workflows/mobile-web.yml
@@ -92,25 +92,28 @@ jobs:
         with:
           path: src/praisonai-mobile/dist
 
-  deploy:
-    name: deploy to GitHub Pages
+  # The readiness check is its OWN job, and deliberately declares no
+  # `environment:`. A job that names `environment: github-pages` cannot START
+  # until that environment exists, so when Pages is off the runner fails the
+  # job outright -- zero steps, about one second -- and every carefully
+  # written skip inside it is unreachable. Measured: run 33730322658 on main,
+  # "deploy to GitHub Pages" failed with steps: 0.
+  #
+  # Splitting the decision out means the check runs with no preconditions and
+  # the environment-bearing job is never scheduled unless it can succeed.
+  pages-ready:
+    name: is GitHub Pages enabled?
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-22.04
     permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    concurrency:
-      # Never cancel a deployment in flight; queue behind it instead.
-      group: pages
-      cancel-in-progress: false
+      contents: read
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
     steps:
-      # Pages cannot be enabled from a workflow, so this job reports the
-      # setting rather than demanding it. `ready` false SKIPS the deploy with
-      # a notice; it does not fail the run. deploy-pages would otherwise fail
+      # Pages cannot be enabled from a workflow, so this reports the setting
+      # rather than demanding it. `ready` false SKIPS the deploy with a
+      # notice; it does not fail the run. deploy-pages would otherwise fail
       # with a bare 404 that says nothing about which setting is missing.
       - name: Is the Pages source "GitHub Actions"?
         id: check
@@ -133,8 +136,23 @@ jobs:
             exit 0
           fi
           echo "ready=true" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    name: deploy to GitHub Pages
+    needs: pages-ready
+    if: needs.pages-ready.outputs.ready == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      # Never cancel a deployment in flight; queue behind it instead.
+      group: pages
+      cancel-in-progress: false
+    steps:
       - uses: actions/configure-pages@v5
-        if: steps.check.outputs.ready == 'true'
       - uses: actions/deploy-pages@v4
         id: deployment
-        if: steps.check.outputs.ready == 'true'

--- a/.github/workflows/mobile-web.yml
+++ b/.github/workflows/mobile-web.yml
@@ -108,6 +108,12 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      # `gh api repos/<owner>/<repo>/pages` needs Pages read. Without it the
+      # request is rejected on a private repo, `2>/dev/null || echo '{}'`
+      # swallows the error to `{}`, build_type falls to "none", and the deploy
+      # SKIPS even though Pages is on -- the exact silent skip this file exists
+      # to prevent. `contents: read` alone leaves this permission at `none`.
+      pages: read
     outputs:
       ready: ${{ steps.check.outputs.ready }}
     steps:


### PR DESCRIPTION
`mobile-web.yml`'s deploy job checks whether Pages is enabled and, when it is not, prints a notice and skips — **deliberately**, so `main` stays green until a repository admin flips the switch.

The logic is right. It never executes.

## Why

A job declaring `environment: github-pages` **cannot start** until that environment exists. With Pages off, the runner fails the job outright before any step runs, and every carefully written skip inside it is unreachable.

Measured on `main`, run [33730322658](https://github.com/MervinPraison/PraisonAI/actions/runs/33730322658):

```json
{
  "name": "deploy to GitHub Pages",
  "conclusion": "failure",
  "steps": 0,
  "startedAt":   "2026-09-03T07:54:29Z",
  "completedAt": "2026-09-03T07:54:30Z"
}
```

**Zero steps. One second.** The guard was placed after the thing that fails.

## The fix

Split the decision out from the deployment:

| job | `environment:` | gated on |
|---|---|---|
| `pages-ready` | **no** | `push` to `main` |
| `deploy` | yes | `needs.pages-ready.outputs.ready == 'true'` |

The readiness check now runs with no preconditions and exposes `ready` as an output. The environment-bearing job is never scheduled unless it can succeed.

Same notice, same behaviour once Pages is on, and `main` stays green while it is off — which was the intent all along.

## Note

This does not enable Pages, and nothing here needs a secret. To publish the web app: **Settings → Pages → Build and deployment → Source: GitHub Actions**. Until then the built site is attached to every run as the `mobile-web-dist` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment workflow handling when the Pages environment is unavailable.
  * Deployments now proceed only after Pages readiness is confirmed, avoiding unnecessary deployment attempts.
  * Improved reliability for deployments in private repositories by ensuring Pages availability is checked before deployment steps begin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->