### PR TITLE
fix(parity): a line number moving is not a parity failure

### DIFF
--- a/.github/workflows/update-parity-tracker.yml
+++ b/.github/workflows/update-parity-tracker.yml
@@ -46,15 +46,38 @@ jobs:
     - name: Install dependencies
       run: pip install pyyaml
 
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Install the TypeScript compiler only
+      # The signature extractor needs `typescript` and nothing else;
+      # praisonai-ts's own dependency tree does not install cleanly.
+      run: |
+        mkdir -p "$RUNNER_TEMP/parity-ts"
+        npm install --prefix "$RUNNER_TEMP/parity-ts" --no-audit --no-fund typescript@5.7.3
+        echo "PARITY_TS_NODE_MODULES=$RUNNER_TEMP/parity-ts/node_modules" >> "$GITHUB_ENV"
+
     - name: Generate parity trackers
       run: |
         cd $GITHUB_WORKSPACE
         python3 src/praisonai/scripts/generate_parity_tracker.py
 
+    - name: Regenerate the signature report
+      # Source locations in the report drift whenever a covered file is edited.
+      # The pull-request gate ignores line-number-only drift so it never reddens
+      # a build over it; refreshing here keeps the committed line numbers true.
+      env:
+        PYTHONPATH: src/praisonai
+      run: |
+        cd $GITHUB_WORKSPACE
+        python3 -m praisonai._dev.parity.signatures --write
+
     - name: Check for changes
       id: check_changes
       run: |
-        if git diff --quiet src/praisonai-ts/FEATURE_PARITY_TRACKER.json src/praisonai-ts/PARITY.md src/praisonai-rust/FEATURE_PARITY_TRACKER.json src/praisonai-rust/PARITY.md 2>/dev/null; then
+        if git diff --quiet src/praisonai-ts/FEATURE_PARITY_TRACKER.json src/praisonai-ts/PARITY.md src/praisonai-rust/FEATURE_PARITY_TRACKER.json src/praisonai-rust/PARITY.md src/praisonai-ts/SIGNATURE_PARITY.md src/praisonai-ts/signature-parity.json 2>/dev/null; then
           echo "changes=false" >> $GITHUB_OUTPUT
           echo "No changes to parity trackers"
         else
@@ -68,7 +91,7 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: "docs: auto-update feature parity trackers [skip ci]"
-        file_pattern: 'src/praisonai-ts/FEATURE_PARITY_TRACKER.json src/praisonai-ts/PARITY.md src/praisonai-rust/FEATURE_PARITY_TRACKER.json src/praisonai-rust/PARITY.md'
+        file_pattern: 'src/praisonai-ts/FEATURE_PARITY_TRACKER.json src/praisonai-ts/PARITY.md src/praisonai-rust/FEATURE_PARITY_TRACKER.json src/praisonai-rust/PARITY.md src/praisonai-ts/SIGNATURE_PARITY.md src/praisonai-ts/signature-parity.json'
         commit_user_name: "MervinPraison"
         commit_user_email: "454862+MervinPraison@users.noreply.github.com"
         commit_author: "MervinPraison <454862+MervinPraison@users.noreply.github.com>"

--- a/src/praisonai-ts/SIGNATURE_PARITY.md
+++ b/src/praisonai-ts/SIGNATURE_PARITY.md
@@ -39,7 +39,7 @@ This complements `PARITY.md`, which only tracks whether an export exists.
 
 ### `Agent.__init__`
 
-- Python: `src/praisonai-agents/praisonaiagents/agent/agent.py:583`
+- Python: `src/praisonai-agents/praisonaiagents/agent/agent.py:603`
 - TypeScript: `src/praisonai-ts/src/agent/simple.ts:112` (ctor `src/praisonai-ts/src/agent/simple.ts:744`)
 - Counts: 42 python params: 29 exact, 8 camelCase, 3 alias, 2 flattened, 0 missing; 4 mismatches; 4 waived; 14 TS-only of 59
 
@@ -198,7 +198,7 @@ TS-only members: `dependencies`?
 
 ### `Agent.start`
 
-- Python: `src/praisonai-agents/praisonaiagents/agent/execution_mixin.py:831`
+- Python: `src/praisonai-agents/praisonaiagents/agent/execution_mixin.py:832`
 - TypeScript: `src/praisonai-ts/src/agent/simple.ts:1778`
 - Counts: 1 python params: 1 exact, 0 camelCase, 0 alias, 0 flattened, 0 missing; 1 mismatches; 1 waived; 20 TS-only of 21
 

--- a/src/praisonai-ts/signature-parity.json
+++ b/src/praisonai-ts/signature-parity.json
@@ -1069,7 +1069,7 @@
         }
       ],
       "python": {
-        "location": "src/praisonai-agents/praisonaiagents/agent/agent.py:583",
+        "location": "src/praisonai-agents/praisonaiagents/agent/agent.py:603",
         "resolved_class": "Agent"
       },
       "ts_only": [
@@ -1737,7 +1737,7 @@
         }
       ],
       "python": {
-        "location": "src/praisonai-agents/praisonaiagents/agent/execution_mixin.py:831",
+        "location": "src/praisonai-agents/praisonaiagents/agent/execution_mixin.py:832",
         "resolved_class": "ExecutionMixin"
       },
       "ts_only": [

--- a/src/praisonai/praisonai/_dev/parity/README.md
+++ b/src/praisonai/praisonai/_dev/parity/README.md
@@ -39,7 +39,10 @@ python3 -m praisonai._dev.parity.signatures --prune               # delete waive
 
 CI (`.github/workflows/parity-gate.yml`) runs both `--check` modes on pull requests and fails on:
 un-waived drift, a waiver that has expired, a waiver whose gap no longer exists, or a run that compared nothing.
-`update-parity-tracker.yml` still regenerates the names layer on push to main.
+It does **not** fail on source line numbers moving: `--check` compares the report with `file.ext:123`
+masked to `file.ext`, so editing an unrelated part of a covered file cannot redden a build.
+`update-parity-tracker.yml` regenerates both layers on push to main, which is what keeps the committed
+line numbers true.
 
 ## Adding a surface
 

--- a/src/praisonai/praisonai/_dev/parity/signatures/compare.py
+++ b/src/praisonai/praisonai/_dev/parity/signatures/compare.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -715,6 +716,20 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+# A source location is `path/to/file.ext:LINE`. Editing an unrelated part of a
+# covered file shifts those line numbers without changing a single fact about
+# parity, and comparing the reports byte for byte turned that into a red build
+# on main -- the same "a number moved, nothing happened" noise this checker was
+# built to remove. Staleness is judged on the report with line numbers masked;
+# `--write` still records the real ones.
+_SOURCE_LOCATION_RE = re.compile(r'(?P<path>[\w./-]+\.(?:py|ts|mjs|tsx)):(?P<line>\d+)')
+
+
+def strip_source_lines(text: str) -> str:
+    """The report with `file.ext:123` reduced to `file.ext`, for staleness checks."""
+    return _SOURCE_LOCATION_RE.sub(lambda m: m.group('path'), text)
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     args = build_parser().parse_args(argv)
     try:
@@ -762,7 +777,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 rel = path.relative_to(repo_root)
                 if not path.is_file():
                     evaluation.failures.append(f'{rel} does not exist -- run --write and commit it')
-                elif path.read_text(encoding='utf-8') != content:
+                elif strip_source_lines(path.read_text(encoding='utf-8')) != strip_source_lines(content):
                     evaluation.failures.append(f'{rel} is out of date -- run --write and commit the result')
 
         _print_report(evaluation, comparisons)

--- a/src/praisonai/tests/unit/_dev/test_signature_parity.py
+++ b/src/praisonai/tests/unit/_dev/test_signature_parity.py
@@ -662,6 +662,38 @@ export class Detector {
         assert 'threshold' in params and params['threshold']['default'] == 3
 
 
+class TestStalenessIgnoresLineNumbers:
+    """A pure line-number shift is not staleness; a content change still is."""
+
+    REPORT = (
+        "# Signature Parity\n\n"
+        "### `Agent.__init__`\n\n"
+        "- Python: `src/praisonai-agents/praisonaiagents/agent/agent.py:583`\n"
+        "- TypeScript: `src/praisonai-ts/src/agent/simple.ts:116`\n"
+        "| `name` | positional | null | exact |\n"
+    )
+
+    def test_line_shift_is_not_staleness(self):
+        shifted = self.REPORT.replace('agent.py:583', 'agent.py:603').replace('simple.ts:116', 'simple.ts:141')
+        assert shifted != self.REPORT
+        assert C.strip_source_lines(shifted) == C.strip_source_lines(self.REPORT)
+
+    def test_content_change_is_still_staleness(self):
+        """Control: masking line numbers must not hide a real difference."""
+        changed = self.REPORT.replace('| `name` |', '| `renamed` |')
+        assert C.strip_source_lines(changed) != C.strip_source_lines(self.REPORT)
+
+    def test_a_changed_path_is_still_staleness(self):
+        """Control: the file a surface points at is content, not a line number."""
+        moved = self.REPORT.replace('agent/simple.ts:116', 'agent/team.ts:116')
+        assert C.strip_source_lines(moved) != C.strip_source_lines(self.REPORT)
+
+    def test_masking_only_touches_source_locations(self):
+        """Control: a bare number in prose is left alone."""
+        text = 'Compared 15 surfaces, 219 python params: 121 exact'
+        assert C.strip_source_lines(text) == text
+
+
 class TestPruneWaivers:
     def _comparison_with_gap(self, gap_name='auth'):
         py = C.signatures_from_json([sig('python', [py_param(gap_name), py_param('name')])])[SURFACE]


### PR DESCRIPTION
## The problem, live on main right now

`python -m praisonai._dev.parity.signatures --check` **fails on main today**:

```
FAILURES (2):
  - src/praisonai-ts/SIGNATURE_PARITY.md is out of date
  - src/praisonai-ts/signature-parity.json is out of date
```

The only difference:

```diff
-- Python: `praisonaiagents/agent/agent.py:583`
+- Python: `praisonaiagents/agent/agent.py:603`
```

#4765 added twenty lines above `Agent.__init__`. No parameter changed, no waiver changed, nothing about parity changed — and the gate went red. Every future PR touching a covered file would hit the same thing.

This is the noise the checker was built to remove, in a new costume: it is why the name tracker stopped committing `lastUpdated` on its own.

## Fix

- `--check` compares the report with `file.ext:123` masked to `file.ext`. A pure line shift passes.
- A changed parameter, a changed waiver, or a surface that moved to a **different file** still fails — three controls assert exactly that, plus one that a bare number in prose is untouched.
- `--write` still records real line numbers, and `update-parity-tracker.yml` now regenerates the signature report on push to main next to the name tracker, so committed locations stay true without any PR carrying the churn.

## Verification

```
python -m praisonai._dev.parity.signatures --check   # OK against main's committed report
pytest tests/unit/_dev/                              # 123 passed (119 + 4 new)
python3 src/praisonai/scripts/generate_parity_tracker.py --check  # up to date
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Signature parity checks now ignore source-line-number changes, reducing false stale-report alerts when code moves without changing API signatures.
  - Parity reports are automatically regenerated and tracked alongside existing compatibility reports.

- **Documentation**
  - Updated developer guidance to explain line-number handling during parity checks.
  - Clarified that automated parity tracking updates both API names and signatures.

- **Tests**
  - Added coverage confirming that line-only changes are ignored while meaningful report differences are still detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->