### PR TITLE
fix(llm): keep the rate-limit indicator list in step with the classifier

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -786,12 +786,13 @@ Respond with ONLY a valid JSON tool call in this format:
         error_str = str(error).lower()
         error_type = type(error).__name__.lower()
 
-        # Check for common rate limit indicators. Kept in step with
-        # error_classifier.classify_error(), which is the one the runtime
-        # actually consults -- this helper has no production callers, only
-        # tests, so the two silently diverged when the classifier learned
-        # 'quota exceeded' (Gemini's phrasing for a per-minute limit) and this
-        # list did not.
+        # Check for common rate limit indicators. This helper has no production
+        # callers (the runtime retry path uses classify_error_kind() /
+        # resolve_failover_decision()); it exists only for tests and is kept in
+        # step with error_classifier.classify_error() via
+        # test_rate_limit_backward_compat. The two silently diverged when that
+        # classifier learned 'quota exceeded' (Gemini's phrasing for a
+        # per-minute limit) and this list did not.
         indicators = [
             '429',
             'rate limit',

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -786,13 +786,19 @@ Respond with ONLY a valid JSON tool call in this format:
         error_str = str(error).lower()
         error_type = type(error).__name__.lower()
 
-        # Check for common rate limit indicators
+        # Check for common rate limit indicators. Kept in step with
+        # error_classifier.classify_error(), which is the one the runtime
+        # actually consults -- this helper has no production callers, only
+        # tests, so the two silently diverged when the classifier learned
+        # 'quota exceeded' (Gemini's phrasing for a per-minute limit) and this
+        # list did not.
         indicators = [
             '429',
             'rate limit',
             'ratelimit',
             'too many request',
             'resource_exhausted',
+            'quota exceeded',
             'tokens per minute',
         ]
 

--- a/src/praisonai-ts/SIGNATURE_PARITY.md
+++ b/src/praisonai-ts/SIGNATURE_PARITY.md
@@ -39,7 +39,7 @@ This complements `PARITY.md`, which only tracks whether an export exists.
 
 ### `Agent.__init__`
 
-- Python: `src/praisonai-agents/praisonaiagents/agent/agent.py:583`
+- Python: `src/praisonai-agents/praisonaiagents/agent/agent.py:603`
 - TypeScript: `src/praisonai-ts/src/agent/simple.ts:112` (ctor `src/praisonai-ts/src/agent/simple.ts:744`)
 - Counts: 42 python params: 29 exact, 8 camelCase, 3 alias, 2 flattened, 0 missing; 4 mismatches; 4 waived; 14 TS-only of 59
 
@@ -198,7 +198,7 @@ TS-only members: `dependencies`?
 
 ### `Agent.start`
 
-- Python: `src/praisonai-agents/praisonaiagents/agent/execution_mixin.py:831`
+- Python: `src/praisonai-agents/praisonaiagents/agent/execution_mixin.py:832`
 - TypeScript: `src/praisonai-ts/src/agent/simple.ts:1778`
 - Counts: 1 python params: 1 exact, 0 camelCase, 0 alias, 0 flattened, 0 missing; 1 mismatches; 1 waived; 20 TS-only of 21
 

--- a/src/praisonai-ts/signature-parity.json
+++ b/src/praisonai-ts/signature-parity.json
@@ -1069,7 +1069,7 @@
         }
       ],
       "python": {
-        "location": "src/praisonai-agents/praisonaiagents/agent/agent.py:583",
+        "location": "src/praisonai-agents/praisonaiagents/agent/agent.py:603",
         "resolved_class": "Agent"
       },
       "ts_only": [
@@ -1737,7 +1737,7 @@
         }
       ],
       "python": {
-        "location": "src/praisonai-agents/praisonaiagents/agent/execution_mixin.py:831",
+        "location": "src/praisonai-agents/praisonaiagents/agent/execution_mixin.py:832",
         "resolved_class": "ExecutionMixin"
       },
       "ts_only": [


### PR DESCRIPTION
`test_rate_limit_backward_compat` has been red on `main`. It asserts that `LLM._is_rate_limit_error` agrees with `error_classifier.classify_error`, and they disagreed on exactly one phrasing:

```
'rate limit exceeded'      _is_rate_limit=True   classify=True
'429 Too Many Requests'    _is_rate_limit=True   classify=True
'resource_exhausted'       _is_rate_limit=True   classify=True
'quota exceeded'           _is_rate_limit=False  classify=True   <-- DISAGREE
'tokens per minute'        _is_rate_limit=True   classify=True
```

## Which one is right

`classify_error` is what the runtime consults. `_is_rate_limit_error` has **no production callers** — grepping the monorepo finds only its definition and three test files — so the two drifted with nothing to notice.

The classifier is also deliberately precise here, and worth preserving:

```
'quota exceeded'                  -> RATE_LIMIT   (Gemini's per-minute phrasing, retryable)
'You exceeded your current quota' -> PERMANENT    (billing, not retryable)
'insufficient_quota'              -> PERMANENT
```

Substring matching keeps that distinction intact — neither permanent phrasing contains `quota exceeded`.

## Verification

45 tests pass in `tests/unit/llm/test_error_classifier.py`.

The one remaining failure in `tests/test_rate_limiter_retry.py` — `test_no_retry_on_non_rate_limit_error` — is **pre-existing on `main`** and unrelated; I verified it fails identically on a clean checkout with this change stashed. It's one of the 109 tracked in #4748.

## Why nothing caught it

`src/praisonai-agents/tests/unit/` is run by no CI workflow — #4748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit error recognition for quota-exceeded messages, including Gemini’s per-minute limit wording.

* **Documentation**
  * Updated signature parity references to reflect current source locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->