### PR TITLE
docs: remove download release heading from root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ curl -fsSL https://praison.ai/install.sh | bash
 </div>
 
 <div align="center">
-  <h3>⬇️ Download the latest release</h3>
   <a href="https://github.com/MervinPraison/PraisonAI/releases/latest">
     <img src="https://img.shields.io/badge/Download_for_macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" />
   </a>


### PR DESCRIPTION
## Summary
- Removes the `⬇️ Download the latest release` heading from the root `README.md`
- macOS/Windows/Linux download badge links are unchanged

## Test plan
- [x] Visual check — badges still render under docs link section

Made with [Cursor](https://cursor.com)