### PR TITLE
fix(desktop): offer non-OpenAI models in the form that actually works

### DIFF
--- a/src/praisonai-desktop/frontend/src/settings-registry.js
+++ b/src/praisonai-desktop/frontend/src/settings-registry.js
@@ -24,7 +24,7 @@ const clampNum = (min, max) => (v) =>
 const SETTINGS = [
   // ---- Models -------------------------------------------------------------
   { key: "model", section: "model", label: "Default model",
-    description: "Any OpenAI-compatible model id. New chats use this. For another provider, set a Base URL and use that endpoint’s bare model id.",
+    description: "Any OpenAI-compatible model id. New chats use this. A provider-prefixed id (anthropic/…, gemini/…, ollama/…) routes through litellm to that provider — set its API key in the environment, or run Ollama locally. For an OpenAI-compatible endpoint instead, set a Base URL and use that endpoint’s bare model id.",
     keywords: ["llm", "gpt", "claude", "provider"],
     control: { kind: "combobox", suggestions: [
       "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "o4-mini",

--- a/src/praisonai-desktop/frontend/src/settings-registry.js
+++ b/src/praisonai-desktop/frontend/src/settings-registry.js
@@ -28,6 +28,8 @@ const SETTINGS = [
     keywords: ["llm", "gpt", "claude", "provider"],
     control: { kind: "combobox", suggestions: [
       "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "o4-mini",
+        "anthropic/claude-sonnet-4-20250514", "gemini/gemini-2.0-flash",
+        "ollama/llama3.2",
     ]},
     default: "gpt-4o-mini" },
 

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -657,6 +657,8 @@ const SETTINGS = [
     keywords: ["llm", "gpt", "claude", "provider"],
     control: { kind: "combobox", suggestions: [
       "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "o4-mini",
+        "anthropic/claude-sonnet-4-20250514", "gemini/gemini-2.0-flash",
+        "ollama/llama3.2",
     ]},
     default: "gpt-4o-mini" },
 

--- a/src/praisonai-desktop/ui/index.html
+++ b/src/praisonai-desktop/ui/index.html
@@ -653,7 +653,7 @@ const clampNum = (min, max) => (v) =>
 const SETTINGS = [
   // ---- Models -------------------------------------------------------------
   { key: "model", section: "model", label: "Default model",
-    description: "Any OpenAI-compatible model id. New chats use this. For another provider, set a Base URL and use that endpoint’s bare model id.",
+    description: "Any OpenAI-compatible model id. New chats use this. A provider-prefixed id (anthropic/…, gemini/…, ollama/…) routes through litellm to that provider — set its API key in the environment, or run Ollama locally. For an OpenAI-compatible endpoint instead, set a Base URL and use that endpoint’s bare model id.",
     keywords: ["llm", "gpt", "claude", "provider"],
     control: { kind: "combobox", suggestions: [
       "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "o4-mini",

--- a/src/praisonai-desktop/ui/settings-registry.js
+++ b/src/praisonai-desktop/ui/settings-registry.js
@@ -24,7 +24,7 @@ const clampNum = (min, max) => (v) =>
 const SETTINGS = [
   // ---- Models -------------------------------------------------------------
   { key: "model", section: "model", label: "Default model",
-    description: "Any OpenAI-compatible model id. New chats use this. For another provider, set a Base URL and use that endpoint’s bare model id.",
+    description: "Any OpenAI-compatible model id. New chats use this. A provider-prefixed id (anthropic/…, gemini/…, ollama/…) routes through litellm to that provider — set its API key in the environment, or run Ollama locally. For an OpenAI-compatible endpoint instead, set a Base URL and use that endpoint’s bare model id.",
     keywords: ["llm", "gpt", "claude", "provider"],
     control: { kind: "combobox", suggestions: [
       "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "o4-mini",

--- a/src/praisonai-desktop/ui/settings-registry.js
+++ b/src/praisonai-desktop/ui/settings-registry.js
@@ -28,6 +28,8 @@ const SETTINGS = [
     keywords: ["llm", "gpt", "claude", "provider"],
     control: { kind: "combobox", suggestions: [
       "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "o4-mini",
+        "anthropic/claude-sonnet-4-20250514", "gemini/gemini-2.0-flash",
+        "ollama/llama3.2",
     ]},
     default: "gpt-4o-mini" },
 


### PR DESCRIPTION
**This corrects my own #4756.** That PR pruned Claude, Gemini and Ollama from the model picker on the premise that the engine rejects them. A follow-up audit caught that the premise no longer holds, and it was right.

## What changed underneath

#4721 added the `praisonai` wrapper to `ENGINE_PACKAGES`, and `praisonai` declares `litellm>=1.83.14,<2` in its **core dependencies**. So a freshly provisioned desktop venv now has litellm, #4722's guard —

```python
if model_needs_litellm(model) and not litellm_available():
```

— does not fire, and slashed ids run fine.

## What was actually wrong with the original list

The **form**, not the models. `claude-sonnet-4-20250514` and `gemini-2.0-flash` are *bare* ids, so they take the plain-OpenAI client path and are sent to `api.openai.com` carrying the user's OpenAI key — failing with an OpenAI error naming `platform.openai.com`. Only a **slashed** id routes through litellm to the right provider.

So the suggestions come back as:

```
gpt-4o-mini, gpt-4o, gpt-4.1-mini, o4-mini,
anthropic/claude-sonnet-4-20250514, gemini/gemini-2.0-flash, ollama/llama3.2
```

On an install predating #4721, with no litellm, #4722's guard still refuses the slashed ones — with a message that names the remedy. That is a *good* error, unlike the OpenAI one the bare ids produced.

## Verification

Checked every suggestion against the guard: all seven are accepted where litellm is present. **240 engine tests** and **190 frontend tests** pass; `registry-drift.test.mjs` keeps the three registry copies in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the **Default model** suggestions with:
    * Anthropic Claude Sonnet 4
    * Google Gemini 2.0 Flash
    * Ollama Llama 3.2

* **Documentation**
  * Clarified provider-prefixed model routing through LiteLLM.
  * Documented environment-based API key configuration and local Ollama usage.
  * Clarified that the Base URL supports OpenAI-compatible endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->