### PR TITLE
fix(agent): send reasoning effort to the provider on the streaming paths

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -5010,6 +5010,14 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         stream_sampling_kwargs['max_tokens'] = kwargs['max_tokens']
                     if kwargs.get('top_p') is not None:
                         stream_sampling_kwargs['top_p'] = kwargs['top_p']
+                    # reasoning_effort travelled the same route as max_tokens
+                    # and top_p -- collected by the caller, forwarded into
+                    # start(), and then dropped, because this enumeration never
+                    # listed it. llm.py already consumes it from here.
+                    _stream_effort = kwargs.get(
+                        'reasoning_effort', getattr(self, 'reasoning_effort', None))
+                    if _stream_effort is not None:
+                        stream_sampling_kwargs['reasoning_effort'] = _stream_effort
                     for chunk in self.llm_instance.get_response_stream(
                         prompt=actual_prompt,
                         system_prompt=stream_system_prompt,
@@ -5134,6 +5142,21 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         completion_args["max_tokens"] = kwargs['max_tokens']
                     if kwargs.get('top_p') is not None:
                         completion_args["top_p"] = kwargs['top_p']
+                    # Native reasoning control. resolve_reasoning_params returns
+                    # {} for "off", for an unset level, and for a model with no
+                    # reasoning knob, so the default stays a no-op; a reasoning
+                    # model gets reasoning_effort and Anthropic/Gemini get their
+                    # thinking budget. completion_args is copied into
+                    # followup_args below, so tool follow-ups inherit it.
+                    _effort = kwargs.get(
+                        'reasoning_effort', getattr(self, 'reasoning_effort', None))
+                    if _effort is not None:
+                        try:
+                            from ..thinking.effort import resolve_reasoning_params
+                            completion_args.update(
+                                resolve_reasoning_params(_effort, self.llm))
+                        except ImportError:
+                            pass
                     if formatted_tools:
                         completion_args["tools"] = formatted_tools
                     

--- a/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/chat_mixin.py
@@ -5153,8 +5153,20 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     if _effort is not None:
                         try:
                             from ..thinking.effort import resolve_reasoning_params
-                            completion_args.update(
-                                resolve_reasoning_params(_effort, self.llm))
+                            _reasoning = resolve_reasoning_params(_effort, self.llm)
+                            for _key, _value in _reasoning.items():
+                                # ``reasoning_effort`` is a native OpenAI SDK
+                                # keyword; anything else (e.g. an extended-thinking
+                                # ``thinking`` budget for an Anthropic/Gemini-named
+                                # model reached over an OpenAI-compatible endpoint)
+                                # is a provider-specific body field the OpenAI SDK
+                                # rejects as a top-level kwarg, so route it through
+                                # ``extra_body`` instead of raising TypeError.
+                                if _key == "reasoning_effort":
+                                    completion_args[_key] = _value
+                                else:
+                                    completion_args.setdefault(
+                                        "extra_body", {})[_key] = _value
                         except ImportError:
                             pass
                     if formatted_tools:

--- a/src/praisonai-agents/tests/unit/llm/test_reasoning_effort_reaches_provider.py
+++ b/src/praisonai-agents/tests/unit/llm/test_reasoning_effort_reaches_provider.py
@@ -1,0 +1,109 @@
+"""reasoning_effort must reach the provider, not just the kwargs dict.
+
+The desktop's Settings -> Models -> "Reasoning effort" control is persisted,
+forwarded into `agent.start(**kwargs)`, and was then discarded: neither
+streaming branch of `_start_stream_impl` read it. `grep -c reasoning_effort
+chat_mixin.py` returned 0. Every level from minimal to high produced a
+byte-identical provider request, with no error and no warning, while the UI
+promised "Maps to each backend's native knob".
+
+The guard that was supposed to catch this asserts against a *stub agent* that
+records the kwargs it was handed, so it passed while the real Agent dropped
+the value. These tests assert on what the transport actually receives.
+
+resolve_reasoning_params returns {} for "off", for an unset level, and for a
+model with no reasoning control, so wiring it through stays a no-op except
+where it means something.
+"""
+import os
+import types
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from praisonaiagents import Agent
+from praisonaiagents.llm import get_openai_client
+
+
+def _request_for(model, **start_kwargs):
+    """Drive a real Agent, faking only the transport, and return the request."""
+    seen = {}
+    real = get_openai_client(api_key="sk-test-not-real")
+
+    class _Completions:
+        def create(self, **kw):
+            seen.update(kw)
+            delta = types.SimpleNamespace(content="ok", tool_calls=None)
+            return iter([types.SimpleNamespace(
+                choices=[types.SimpleNamespace(delta=delta, finish_reason="stop")])])
+
+    class _Proxy:
+        sync_client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=_Completions()))
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    agent = Agent(name="t", instructions="x", llm=model)
+    agent._Agent__openai_client = _Proxy()
+    list(agent.start("hi", stream=True, **start_kwargs))
+    return seen
+
+
+class TestReasoningEffortReachesTheProvider:
+
+    def test_a_reasoning_model_gets_the_native_knob(self):
+        req = _request_for("o4-mini", reasoning_effort="high")
+        assert req.get("reasoning_effort") == "high", (
+            "reasoning_effort never reached the provider request"
+        )
+
+    def test_off_sends_nothing(self):
+        req = _request_for("o4-mini", reasoning_effort="off")
+        assert "reasoning_effort" not in req
+        assert "thinking" not in req
+
+    def test_an_unset_level_sends_nothing(self):
+        req = _request_for("o4-mini")
+        assert "reasoning_effort" not in req
+
+    def test_a_model_without_a_reasoning_knob_is_untouched(self):
+        """Wiring this through must not change ordinary chat models."""
+        req = _request_for("gpt-4o-mini", reasoning_effort="high")
+        assert "reasoning_effort" not in req
+        assert "thinking" not in req
+
+    def test_the_ordinary_request_still_looks_right(self):
+        """Guards against the merge clobbering the rest of the payload."""
+        req = _request_for("gpt-4o-mini")
+        for key in ("model", "messages", "stream"):
+            assert key in req, key
+
+    def test_the_agent_attribute_is_used_when_no_kwarg_is_passed(self):
+        """Construction-time configuration must work on this path too."""
+        seen = {}
+        real = get_openai_client(api_key="sk-test-not-real")
+
+        class _Completions:
+            def create(self, **kw):
+                seen.update(kw)
+                delta = types.SimpleNamespace(content="ok", tool_calls=None)
+                return iter([types.SimpleNamespace(
+                    choices=[types.SimpleNamespace(delta=delta, finish_reason="stop")])])
+
+        class _Proxy:
+            sync_client = types.SimpleNamespace(
+                chat=types.SimpleNamespace(completions=_Completions()))
+
+            def __getattr__(self, name):
+                return getattr(real, name)
+
+        agent = Agent(name="t", instructions="x", llm="o4-mini", reasoning_effort="high")
+        agent._Agent__openai_client = _Proxy()
+        list(agent.start("hi", stream=True))
+        assert seen.get("reasoning_effort") == "high"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/praisonai-agents/tests/unit/llm/test_reasoning_effort_reaches_provider.py
+++ b/src/praisonai-agents/tests/unit/llm/test_reasoning_effort_reaches_provider.py
@@ -74,6 +74,29 @@ class TestReasoningEffortReachesTheProvider:
         assert "reasoning_effort" not in req
         assert "thinking" not in req
 
+    def test_extended_thinking_budget_goes_through_extra_body(self):
+        """A ``thinking`` budget is not a native OpenAI SDK keyword.
+
+        resolve_reasoning_params emits ``{"thinking": ...}`` for an
+        extended-thinking-named model. On this direct path the request is
+        handed to the raw OpenAI SDK, which rejects unknown top-level kwargs
+        with TypeError, so the budget must ride inside ``extra_body`` while
+        ``reasoning_effort`` stays top-level.
+        """
+        req = _request_for("claude-3-7-sonnet", reasoning_effort="high")
+        assert "thinking" not in req, (
+            "thinking must not be a top-level kwarg; the OpenAI SDK rejects it"
+        )
+        assert req.get("extra_body", {}).get("thinking") == {
+            "type": "enabled", "budget_tokens": 16000,
+        }
+
+    def test_native_effort_stays_top_level_not_in_extra_body(self):
+        """reasoning_effort is native; it must not be buried in extra_body."""
+        req = _request_for("o4-mini", reasoning_effort="high")
+        assert req.get("reasoning_effort") == "high"
+        assert "reasoning_effort" not in req.get("extra_body", {})
+
     def test_the_ordinary_request_still_looks_right(self):
         """Guards against the merge clobbering the rest of the payload."""
         req = _request_for("gpt-4o-mini")


### PR DESCRIPTION
The desktop ships a **Settings → Models → "Reasoning effort"** control whose help text says *"Maps to each backend's native knob."* The engine persists it and forwards it into `agent.start(**kwargs)`.

Neither streaming branch of `_start_stream_impl` ever read it. `grep -c reasoning_effort chat_mixin.py` returned **0**. Every level from minimal to high produced a byte-identical provider request — no error, no warning.

## Measured against a real Agent, faking only the transport

```
before  o4-mini, reasoning_effort="high"
        provider request keys: ['messages', 'model', 'stream', 'temperature']

after   o4-mini      high  -> {'reasoning_effort': 'high'}
        o4-mini      off   -> {}
        o4-mini      unset -> {}
        gpt-4o-mini  high  -> {}          (no reasoning knob; untouched)
```

## Change

Both branches resolve the level from the call kwarg, falling back to the agent attribute. The plain-OpenAI branch routes it through the existing `thinking.effort.resolve_reasoning_params`, which returns `{}` for `"off"`, for an unset level, and for a model with no reasoning control — so the default stays a no-op, and Anthropic/Gemini get a thinking budget rather than an OpenAI-shaped key.

`completion_args` is copied into `followup_args`, so tool follow-up turns inherit it.

## This is the third one

Same shape as #4725: an explicit enumeration of forwarded kwargs that a new setting was never added to. `max_tokens` and `top_p` were the first two; `reasoning_effort` is the third.

## Why the existing guard missed it

`engine/test_chat_stream.py` asserts against a **stub agent** that records the kwargs it was handed — so it passed while the real `Agent` discarded the value. The new tests assert on what the transport actually receives.

3 mutations killed: dropping it again, forcing it on regardless of model, and removing the agent-attribute fallback.

Found by the second multi-agent sweep and confirmed under adversarial refutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reasoning-effort settings are now correctly passed to providers during streaming responses.
  - Provider-specific thinking parameters are routed through the appropriate request structure, preventing unsupported options from being sent directly.
  - Native reasoning controls remain available as top-level provider parameters.
  - Reasoning options are omitted when unset or unavailable for the selected model.
  - Existing request details remain intact while reasoning settings are applied consistently across supported models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->