### PR TITLE
fix(runtime): resolve_runtime drops config_overrides, so every resolver call raises TypeError

### DIFF
--- a/src/praisonai-agents/praisonaiagents/runtime/registry.py
+++ b/src/praisonai-agents/praisonaiagents/runtime/registry.py
@@ -349,11 +349,15 @@ def list_runtimes() -> list[str]:
     return [e.runtime_id for e in entries]
 
 
-def resolve_runtime(runtime_id: str) -> AgentRuntimeProtocol:
+def resolve_runtime(
+    runtime_id: str,
+    config_overrides: Optional[Dict[str, Any]] = None,
+) -> AgentRuntimeProtocol:
     """Resolve a runtime by ID using the global registry.
     
     Args:
         runtime_id: Runtime identifier (e.g., "praisonai")
+        config_overrides: Optional configuration overrides
         
     Returns:
         AgentRuntimeProtocol instance
@@ -361,7 +365,7 @@ def resolve_runtime(runtime_id: str) -> AgentRuntimeProtocol:
     Raises:
         ValueError: If runtime_id is not registered
     """
-    return _global_registry.resolve(runtime_id)
+    return _global_registry.resolve(runtime_id, config_overrides)
 
 
 def add_runtime_alias(alias: str, canonical_runtime_id: str) -> None:

--- a/src/praisonai-agents/tests/unit/runtime/test_registry.py
+++ b/src/praisonai-agents/tests/unit/runtime/test_registry.py
@@ -109,6 +109,31 @@ def test_resolve_unknown_runtime():
         resolve_runtime("non-existent-runtime")
 
 
+def test_resolve_runtime_accepts_config_overrides():
+    """The module-level wrapper must forward configuration overrides.
+
+    ``RuntimeResolver.resolve_runtime_instance`` calls
+    ``resolve_runtime(runtime_id=..., config_overrides=...)`` and
+    ``RuntimeRegistry.resolve`` already declares that argument, so the wrapper
+    has to accept it too -- otherwise every registry-backed resolution through
+    the resolver raises TypeError instead of returning a runtime.
+    """
+    runtime_id = "test-runtime-overrides"
+    register_runtime(runtime_id, lambda: TestRuntime(runtime_id))
+    try:
+        runtime = resolve_runtime(
+            runtime_id=runtime_id,
+            config_overrides={"temperature": 0.1},
+        )
+        assert isinstance(runtime, TestRuntime)
+        assert runtime.runtime_id == runtime_id
+
+        # The single-argument form used by every other call site still works.
+        assert resolve_runtime(runtime_id).runtime_id == runtime_id
+    finally:
+        unregister_runtime(runtime_id)
+
+
 def test_alias_to_unknown_runtime():
     """Test creating alias to unknown runtime raises ValueError."""
     with pytest.raises(ValueError, match="Cannot create alias"):


### PR DESCRIPTION
## Problem

`RuntimeResolver.resolve_runtime_instance` resolves through the global registry like this:

```python
# src/praisonai-agents/praisonaiagents/runtime/resolver.py:242
runtime_instance = resolve_runtime(
    runtime_id=config.runtime,
    config_overrides=config.config_overrides
)
```

but the module-level wrapper in `registry.py` takes only `runtime_id`:

```python
# src/praisonai-agents/praisonaiagents/runtime/registry.py:352
def resolve_runtime(runtime_id: str) -> AgentRuntimeProtocol:
    return _global_registry.resolve(runtime_id)
```

so every registry-backed resolution raises `TypeError: resolve_runtime() got an unexpected keyword argument 'config_overrides'`. The surrounding `except ValueError` does not catch it, so it propagates to the caller.

## Why add the parameter rather than drop the argument

The argument is the intended contract in three separate places in this package — the wrapper is the odd one out:

| where | signature |
|---|---|
| `RuntimeRegistryProtocol.resolve` (`registry.py:101`) | `resolve(self, runtime_id, config_overrides: Optional[Dict[str, Any]] = None)` |
| `RuntimeRegistry.resolve` (`registry.py:272`) | `resolve(self, runtime_id, config_overrides: Optional[Dict[str, Any]] = None)` |
| `test_resolver.py:236` | `mock_resolve_runtime.assert_called_once_with(runtime_id="claude-code", config_overrides={})` |

The existing resolver test does not catch this because it patches with a bare `Mock` (`@patch('praisonaiagents.runtime.resolver.resolve_runtime')`, no `autospec`), which accepts any signature — while its own assertion documents that `config_overrides` is supposed to be part of the call.

## Validation

Against `praisonaiagents==1.7.3` from PyPI (same signature as `main`), running the real public API:

```text
--- unpatched ---
RuntimeResolver().resolve_runtime_instance(context=RuntimeResolutionContext(model_name="gpt-4o"))
  FAIL -> TypeError: resolve_runtime() got an unexpected keyword argument 'config_overrides'

--- with this patch ---
  OK -> PraisonAIRuntime | runtime_id = praisonai | source = default
```

`tests/unit/runtime/test_registry.py`, with the new regression test added:

```text
unpatched:  1 failed, 9 passed   <- only the new test fails, with the TypeError above
patched:   10 passed
```

The new test also re-checks the single-argument form that the other nine tests and every other call site use, so the added keyword cannot regress them.

## Risk

One signature gains a defaulted keyword and forwards it to a method that already declares it. No existing caller changes: every other `resolve_runtime` call site in the repo passes exactly one argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime resolution now supports optional configuration overrides.

* **Bug Fixes**
  * Preserved existing runtime resolution behavior when no overrides are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->