### PR TITLE
ci(ts): run praisonai-ts's own tests, and fix the suite that was failing

### DIFF
--- a/.github/workflows/praisonai-ts-tests.yml
+++ b/.github/workflows/praisonai-ts-tests.yml
@@ -1,0 +1,70 @@
+# Does praisonai-ts still pass its own tests?
+#
+# It has a suite -- 2,000+ tests -- and until now nothing ran it. The only
+# workflow with `working-directory: src/praisonai-ts` builds the package and
+# checks the webview bundle; the two other mentions of `npm test` in this
+# directory are a comment and a line of prose telling a reviewer to run it by
+# hand. So the suite was green the way an unread report is green.
+#
+# That mattered the moment the suite grew: PR #4755 added ~880 tests for the
+# Python-parity port and not one of them would have run here. A test nobody
+# executes is worse than no test, because it is counted as cover.
+#
+# Deliberately narrow, like its webview sibling: it runs only when
+# praisonai-ts changes, installs only what it needs, and asserts two things --
+# the package typechecks, and its tests pass.
+name: praisonai-ts tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/praisonai-ts/src/**'
+      - 'src/praisonai-ts/tests/**'
+      - 'src/praisonai-ts/package.json'
+      - 'src/praisonai-ts/jest.config.ts'
+      - 'src/praisonai-ts/tsconfig*.json'
+      - '.github/workflows/praisonai-ts-tests.yml'
+  pull_request:
+    paths:
+      - 'src/praisonai-ts/src/**'
+      - 'src/praisonai-ts/tests/**'
+      - 'src/praisonai-ts/package.json'
+      - 'src/praisonai-ts/jest.config.ts'
+      - 'src/praisonai-ts/tsconfig*.json'
+      - '.github/workflows/praisonai-ts-tests.yml'
+
+concurrency:
+  group: praisonai-ts-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: unit tests
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: src/praisonai-ts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.18'
+      # `npm install --legacy-peer-deps`, matching praisonai-ts-webview.yml:
+      # the lockfile is gitignored so `npm ci` has nothing to read, and the
+      # dependency tree does not resolve without the flag (bedrock-agentcore
+      # wants a peer of @strands-agents/sdk that is not installed).
+      - name: Install
+        run: npm install --no-audit --no-fund --legacy-peer-deps
+      - name: Typecheck
+        run: npx tsc --noEmit -p .
+      # PRAISONAI_PARITY_SILENT quiets the one-line notices that options
+      # accepted for Python parity print when they are not yet honoured; they
+      # are deliberate output, not failures, and they drown the test log.
+      - name: Tests
+        run: npm test
+        env:
+          PRAISONAI_PARITY_SILENT: '1'

--- a/src/praisonai-ts/tests/integration/parity-features.test.ts
+++ b/src/praisonai-ts/tests/integration/parity-features.test.ts
@@ -159,13 +159,19 @@ describe('Parity Features Integration Tests', () => {
   // P1: KNOWLEDGE / SESSION / CHUNKING
   // =========================================================================
   describe('P1: Knowledge, Session, Chunking', () => {
-    test('Knowledge - add then search (text fallback without embeddings)', async () => {
+    test('Knowledge - store then search (Python knowledge.py surface)', async () => {
+      // `Knowledge` is the store class ported from praisonaiagents/knowledge/knowledge.py:
+      // text goes in through store(), files through add(), and search() returns a
+      // SearchResult envelope rather than a bare array.
       const kb = new Knowledge();
-      await kb.add({ id: 'doc-1', content: 'test source' });
-      const results = await kb.search('test');
-      expect(results).toHaveLength(1);
-      expect(results[0].document.id).toBe('doc-1');
-      expect(await kb.search('unrelated')).toHaveLength(0);
+      const added = await kb.store('test source', { userId: 'u1' });
+      expect(added.success).toBe(true);
+      const found = await kb.search('test', { userId: 'u1' });
+      expect(found.query).toBe('test');
+      expect(found.results.map((r) => r.text)).toContain('test source');
+      // Control: a query that matches nothing returns the same envelope, empty.
+      const empty = await kb.search('unrelated-xyzzy', { userId: 'u1' });
+      expect(empty.results).toHaveLength(0);
     });
 
     test('Session - state and message management', () => {

--- a/src/praisonai-ts/tests/unit/llm/backend-resolver-sync.test.ts
+++ b/src/praisonai-ts/tests/unit/llm/backend-resolver-sync.test.ts
@@ -48,8 +48,26 @@ class StubProvider implements LLMProvider {
 }
 
 describe('resolveBackendSync', () => {
+  // Provider constructors require a key (AnthropicProvider throws
+  // 'ANTHROPIC_API_KEY is required'), so these tests passed only on a machine
+  // that happened to have one exported and failed in CI. Resolution is what is
+  // under test, not authentication: pin placeholder keys and restore them.
+  const KEY_VARS = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_API_KEY'] as const;
+  const savedKeys: Record<string, string | undefined> = {};
+
   beforeEach(() => {
+    for (const name of KEY_VARS) {
+      savedKeys[name] = process.env[name];
+      process.env[name] = `test-${name.toLowerCase()}`;
+    }
     resetAISDKAvailabilityCache();
+  });
+
+  afterEach(() => {
+    for (const name of KEY_VARS) {
+      if (savedKeys[name] === undefined) delete process.env[name];
+      else process.env[name] = savedKeys[name] as string;
+    }
   });
 
   it('resolves a built-in native provider when the native backend is requested', () => {


### PR DESCRIPTION
## praisonai-ts has 2,000 tests and nothing ran them

The only workflow with `working-directory: src/praisonai-ts` builds the package and checks the webview bundle. The two other mentions of `npm test` under `.github/` are:

- `praisonai-ts-webview.yml:8` — a comment explaining why that gate is *not* `npm test`
- `claude.yml:345` — a line of prose telling a reviewer to run it by hand

So the suite was green the way an unread report is green. #4755 added ~880 tests for the Python-parity port; not one of them would have run in CI.

## The cost was already banked

`npm test` **fails on main right now**:

```
tests/integration/parity-features.test.ts:164 - error TS2353:
  Object literal may only specify known properties, and 'id' does not exist in type 'string[]'
```

#4755 pointed the `Knowledge` export at the real store class (ported from `praisonaiagents/knowledge/knowledge.py`, where text goes in through `store()` and `search()` returns a `SearchResult` envelope) and left that test calling the old `add({id, content})` shape against a bare array.

Worth noting: **`tsc --noEmit -p .` does not catch this** — tests are outside the project's tsconfig, so only running them finds it. That is the argument for the job in one line.

## Changes

- **New `praisonai-ts-tests.yml`** — deliberately narrow, like its webview sibling: runs only when praisonai-ts changes, installs only what it needs (`--legacy-peer-deps`, for the same pre-existing `bedrock-agentcore` peer conflict documented in `praisonai-ts-webview.yml`), and asserts two things: the package typechecks, and its tests pass.
- **Fixed `parity-features.test.ts`** against the real `Knowledge` surface, with a control for the empty-result case.

## Verification

Run with the workflow's exact commands:

```
npx tsc --noEmit -p .   # clean
npm test                # 2,162 passed, 0 failed, 5 suites skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated Knowledge integration coverage to verify user-scoped storage and search responses, including empty results for unmatched queries.
  - Improved backend resolution tests by using safe placeholder credentials during test execution.
  - Added type-checking and automated test execution for the TypeScript package in supported repository changes.

- **Chores**
  - Added continuous integration checks for relevant pushes and pull requests, with automatic cancellation of superseded runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->