### PR TITLE
fix(ts): four waivers were hiding real gaps, and one broke handoffs outright

### DIFF
--- a/.github/workflows/praisonai-ts-tests.yml
+++ b/.github/workflows/praisonai-ts-tests.yml
@@ -1,0 +1,70 @@
+# Does praisonai-ts still pass its own tests?
+#
+# It has a suite -- 2,000+ tests -- and until now nothing ran it. The only
+# workflow with `working-directory: src/praisonai-ts` builds the package and
+# checks the webview bundle; the two other mentions of `npm test` in this
+# directory are a comment and a line of prose telling a reviewer to run it by
+# hand. So the suite was green the way an unread report is green.
+#
+# That mattered the moment the suite grew: PR #4755 added ~880 tests for the
+# Python-parity port and not one of them would have run here. A test nobody
+# executes is worse than no test, because it is counted as cover.
+#
+# Deliberately narrow, like its webview sibling: it runs only when
+# praisonai-ts changes, installs only what it needs, and asserts two things --
+# the package typechecks, and its tests pass.
+name: praisonai-ts tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/praisonai-ts/src/**'
+      - 'src/praisonai-ts/tests/**'
+      - 'src/praisonai-ts/package.json'
+      - 'src/praisonai-ts/jest.config.ts'
+      - 'src/praisonai-ts/tsconfig*.json'
+      - '.github/workflows/praisonai-ts-tests.yml'
+  pull_request:
+    paths:
+      - 'src/praisonai-ts/src/**'
+      - 'src/praisonai-ts/tests/**'
+      - 'src/praisonai-ts/package.json'
+      - 'src/praisonai-ts/jest.config.ts'
+      - 'src/praisonai-ts/tsconfig*.json'
+      - '.github/workflows/praisonai-ts-tests.yml'
+
+concurrency:
+  group: praisonai-ts-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: unit tests
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: src/praisonai-ts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.18'
+      # `npm install --legacy-peer-deps`, matching praisonai-ts-webview.yml:
+      # the lockfile is gitignored so `npm ci` has nothing to read, and the
+      # dependency tree does not resolve without the flag (bedrock-agentcore
+      # wants a peer of @strands-agents/sdk that is not installed).
+      - name: Install
+        run: npm install --no-audit --no-fund --legacy-peer-deps
+      - name: Typecheck
+        run: npx tsc --noEmit -p .
+      # PRAISONAI_PARITY_SILENT quiets the one-line notices that options
+      # accepted for Python parity print when they are not yet honoured; they
+      # are deliberate output, not failures, and they drown the test log.
+      - name: Tests
+        run: npm test
+        env:
+          PRAISONAI_PARITY_SILENT: '1'

--- a/src/praisonai-ts/SIGNATURE_PARITY.md
+++ b/src/praisonai-ts/SIGNATURE_PARITY.md
@@ -18,40 +18,42 @@ This complements `PARITY.md`, which only tracks whether an export exists.
 
 | Surface | Params | Exact | camelCase | Alias | Flattened | Missing | Mismatches | Waived | TS-only / TS total |
 |---|---|---|---|---|---|---|---|---|---|
-| `Agent.__init__` | 42 | 29 | 8 | 3 | 2 | 0 | 4 | 4 | 14 / 59 |
+| `Agent.__init__` | 42 | 29 | 8 | 3 | 2 | 0 | 6 | 6 | 14 / 59 |
 | `AgentTeam.__init__` | 23 | 20 | 3 | 0 | 0 | 0 | 1 | 1 | 3 / 26 |
 | `Task.__init__` | 60 | 31 | 29 | 0 | 0 | 0 | 7 | 7 | 1 / 62 |
-| `Agent.start` | 1 | 1 | 0 | 0 | 0 | 0 | 1 | 1 | 20 / 21 |
+| `Agent.start` | 1 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 20 / 21 |
 | `Agent.chat` | 17 | 7 | 9 | 1 | 0 | 0 | 0 | 0 | 2 / 19 |
 | `AgentTeam.start` | 3 | 2 | 1 | 0 | 0 | 0 | 0 | 0 | 1 / 4 |
 | `Handoff.__init__` | 7 | 2 | 2 | 3 | 0 | 0 | 2 | 2 | 13 / 21 |
 | `LLM.__init__` | 25 | 8 | 16 | 1 | 0 | 0 | 0 | 0 | 1 / 26 |
 | `Session.__init__` | 7 | 1 | 6 | 0 | 0 | 0 | 1 | 1 | 5 / 12 |
-| `tool()` | 11 | 5 | 5 | 1 | 0 | 0 | 4 | 4 | 3 / 14 |
+| `tool()` | 11 | 5 | 5 | 1 | 0 | 0 | 3 | 3 | 3 / 14 |
 | `GoalEngineer.__init__` | 6 | 4 | 2 | 0 | 0 | 0 | 0 | 0 | 2 / 8 |
 | `DoomLoopDetector.__init__` | 1 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 15 / 16 |
 | `EscalationPipeline.__init__` | 5 | 3 | 2 | 0 | 0 | 0 | 0 | 0 | 4 / 9 |
 | `ToolsetRegistry.register_toolset` | 5 | 5 | 0 | 0 | 0 | 0 | 0 | 0 | 0 / 5 |
 | `PraisonAIError.__init__` | 6 | 2 | 4 | 0 | 0 | 0 | 1 | 1 | 1 / 7 |
-| **Total (15 surfaces)** | 219 | 121 | 87 | 9 | 2 | 0 | 21 | 21 | 85 / 309 |
+| `FileTracker.__init__` | 1 | 0 | 1 | 0 | 0 | 0 | 0 | 0 | 0 / 1 |
+| `Knowledge.__init__` | 2 | 2 | 0 | 0 | 0 | 0 | 0 | 0 | 0 / 2 |
+| **Total (17 surfaces)** | 222 | 123 | 88 | 9 | 2 | 0 | 21 | 21 | 85 / 312 |
 
 ## Surfaces
 
 ### `Agent.__init__`
 
 - Python: `src/praisonai-agents/praisonaiagents/agent/agent.py:603`
-- TypeScript: `src/praisonai-ts/src/agent/simple.ts:112` (ctor `src/praisonai-ts/src/agent/simple.ts:744`)
-- Counts: 42 python params: 29 exact, 8 camelCase, 3 alias, 2 flattened, 0 missing; 4 mismatches; 4 waived; 14 TS-only of 59
+- TypeScript: `src/praisonai-ts/src/agent/simple.ts:113` (ctor `src/praisonai-ts/src/agent/simple.ts:753`)
+- Counts: 42 python params: 29 exact, 8 camelCase, 3 alias, 2 flattened, 0 missing; 6 mismatches; 6 waived; 14 TS-only of 59
 
 | Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |
 |---|---|---|---|---|---|---|---|---|
 | `name` | positional | null | `Optional[str]` | exact | `name` | ``Agent_${Math.random().toString(36).substr(2, 9)}`` | `string` | default mismatch (waived) |
 | `role` | positional | null | `Optional[str]` | exact | `role` | `config.goal \|\| config.backstory` | `string` | default mismatch (waived) |
-| `goal` | positional | null | `Optional[str]` | exact | `goal` | undefined | `string` | ok |
-| `backstory` | positional | null | `Optional[str]` | exact | `backstory` | undefined | `string` | ok |
+| `goal` | positional | null | `Optional[str]` | exact | `goal` | `config.instructions` | `string` | default mismatch (waived) |
+| `backstory` | positional | null | `Optional[str]` | exact | `backstory` | `config.instructions` | `string` | default mismatch (waived) |
 | `instructions` | positional | null | `Optional[str]` | exact | `instructions` | undefined | `string` | ok |
 | `llm` | positional | null | `Optional[Union[str, Any]]` | exact | `llm` | undefined | `string \| LLMConfig` | ok |
-| `model` | positional | null | `Optional[Union[str, Any]]` | exact | `model` | `llmName \|\| getEnv('OPENAI_MODEL_NAME') \|\| getEnv('PRAISONAI_MODEL') \|\| 'gpt-4o-mini'` | `string` | default mismatch (waived) |
+| `model` | positional | null | `Optional[Union[str, Any]]` | exact | `model` | `llmName \|\| resolveDefaultModel()` | `string` | default mismatch (waived) |
 | `base_url` | positional | null | `Optional[str]` | alias | `baseURL` | undefined | `string` | ok |
 | `api_key` | positional | null | `Optional[str]` | camelCase | `apiKey` | undefined | `string` | ok |
 | `auth` | positional | null | `Optional[str]` | exact | `auth` | undefined | `string` | ok |
@@ -199,19 +201,19 @@ TS-only members: `dependencies`?
 ### `Agent.start`
 
 - Python: `src/praisonai-agents/praisonaiagents/agent/execution_mixin.py:832`
-- TypeScript: `src/praisonai-ts/src/agent/simple.ts:1778`
-- Counts: 1 python params: 1 exact, 0 camelCase, 0 alias, 0 flattened, 0 missing; 1 mismatches; 1 waived; 20 TS-only of 21
+- TypeScript: `src/praisonai-ts/src/agent/simple.ts:1824`
+- Counts: 1 python params: 1 exact, 0 camelCase, 0 alias, 0 flattened, 0 missing; 0 mismatches; 0 waived; 20 TS-only of 21
 
 | Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |
 |---|---|---|---|---|---|---|---|---|
-| `prompt` | positional | null | `Optional[str]` | exact | `prompt` | *required* | `string` | required mismatch (waived) |
+| `prompt` | positional | null | `Optional[str]` | exact | `prompt` | undefined | `string` | ok |
 
 TS-only members: `previousResult`?, `onToken`?, `signal`?, `onEvent`?, `options`?, `temperature`?, `tools`?, `outputJson`?, `outputPydantic`?, `reasoningSteps`?, `stream`?, `taskName`?, `taskDescription`?, `taskId`?, `config`?, `forceRetrieval`?, `skipRetrieval`?, `attachments`?, `toolChoice`?, `seed`?
 
 ### `Agent.chat`
 
 - Python: `src/praisonai-agents/praisonaiagents/agent/chat_mixin.py:3101`
-- TypeScript: `src/praisonai-ts/src/agent/simple.ts:2426`
+- TypeScript: `src/praisonai-ts/src/agent/simple.ts:2476`
 - Counts: 17 python params: 7 exact, 9 camelCase, 1 alias, 0 flattened, 0 missing; 0 mismatches; 0 waived; 2 TS-only of 19
 
 | Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |
@@ -253,14 +255,14 @@ TS-only members: `options`?
 ### `Handoff.__init__`
 
 - Python: `src/praisonai-agents/praisonaiagents/agent/handoff.py:320`
-- TypeScript: `src/praisonai-ts/src/agent/handoff.ts:435` (ctor `src/praisonai-ts/src/agent/handoff.ts:671`)
+- TypeScript: `src/praisonai-ts/src/agent/handoff.ts:478` (ctor `src/praisonai-ts/src/agent/handoff.ts:714`)
 - Counts: 7 python params: 2 exact, 2 camelCase, 3 alias, 0 flattened, 0 missing; 2 mismatches; 2 waived; 13 TS-only of 21
 
 | Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |
 |---|---|---|---|---|---|---|---|---|
 | `agent` | positional | *required* | `'Agent'` | exact | `agent` | *required* | `EnhancedAgent` | ok |
-| `tool_name_override` | positional | null | `Optional[str]` | alias | `name` | `nested.name \|\| `handoff_to_${config.agent.name}`` | `string` | default mismatch (waived) |
-| `tool_description_override` | positional | null | `Optional[str]` | alias | `description` | `nested.description \|\| `Transfer conversation to ${config.agent.name}`` | `string` | default mismatch (waived) |
+| `tool_name_override` | positional | null | `Optional[str]` | alias | `name` | `nested.name \|\| defaultHandoffToolName(config.agent.name)` | `string` | default mismatch (waived) |
+| `tool_description_override` | positional | null | `Optional[str]` | alias | `description` | `nested.description \|\| defaultHandoffToolDescription(config.agent as any)` | `string` | default mismatch (waived) |
 | `on_handoff` | positional | null | `Optional[Callable]` | camelCase | `onHandoff` | undefined | `(context: HandoffContext) => void \| Promise<void>` | ok |
 | `input_type` | positional | null | `Optional[type]` | camelCase | `inputType` | undefined | `HandoffInputType` | ok |
 | `input_filter` | positional | null | `Optional[Union[Callable[[HandoffInputData], HandoffInputData], List[Callable[[HandoffInputData], HandoffInputData]]]]` | alias | `transformContext` | undefined | `(messages: any[]) => any[]` | ok (type differs) |
@@ -326,19 +328,19 @@ TS-only members: `config`?, `id`?, `parent`?, `db`?, `ttl`?
 
 - Python: `src/praisonai-agents/praisonaiagents/tools/decorator.py:235`
 - TypeScript: `src/praisonai-ts/src/tools/decorator.ts:48` (ctor `src/praisonai-ts/src/tools/decorator.ts:213`)
-- Counts: 11 python params: 5 exact, 5 camelCase, 1 alias, 0 flattened, 0 missing; 4 mismatches; 4 waived; 3 TS-only of 14
+- Counts: 11 python params: 5 exact, 5 camelCase, 1 alias, 0 flattened, 0 missing; 3 mismatches; 3 waived; 3 TS-only of 14
 
 | Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |
 |---|---|---|---|---|---|---|---|---|
 | `func` | positional | null | `Optional[Callable]` | alias | `execute` | *required* | `(params: TParams, context?: ToolContext) => Promise<TResult> \| TResult` | required mismatch (waived) |
 | `name` | keyword | null | `Optional[str]` | exact | `name` | *required* | `string` | required mismatch (waived) |
-| `description` | keyword | null | `Optional[str]` | exact | `description` | ``Function ${config.name}`` | `string` | default mismatch (waived) |
+| `description` | keyword | null | `Optional[str]` | exact | `description` | ``Tool: ${config.name}`` | `string` | default mismatch (waived) |
 | `version` | keyword | "1.0.0" | `str` | exact | `version` | "1.0.0" | `string` | ok |
 | `availability` | keyword | null | `Optional[Callable[[], tuple[bool, str]]]` | exact | `availability` | undefined | `() => [boolean, string]` | ok |
 | `dynamic_schema_overrides` | keyword | null | `Optional[Callable[[Dict[str, Any]], Dict[str, Any]]]` | camelCase | `dynamicSchemaOverrides` | undefined | `(schema: ToolParameters) => ToolParameters` | ok |
 | `retry_policy` | keyword | null | `Optional[Any]` | camelCase | `retryPolicy` | undefined | `RetryPolicy` | ok |
 | `approval` | keyword | null | `Optional[Union[bool, str]]` | exact | `approval` | undefined | `boolean \| RiskLevel \| string` | ok |
-| `requires_approval` | keyword | `_UNSET` | `Union[bool, str]` | camelCase | `requiresApproval` | undefined | `boolean \| RiskLevel \| string` | default mismatch (waived) |
+| `requires_approval` | keyword | `_UNSET` | `Union[bool, str]` | camelCase | `requiresApproval` | undefined | `boolean \| RiskLevel \| string` | ok |
 | `to_model_output` | keyword | null | `Optional[Callable[[Any], Any]]` | camelCase | `toModelOutput` | undefined | `(result: TResult) => unknown` | ok |
 | `restart_safe` | keyword | null | `Optional[bool]` | camelCase | `restartSafe` | undefined | `boolean` | ok |
 
@@ -422,28 +424,53 @@ TS-only members: none
 
 TS-only members: `options`?
 
+### `FileTracker.__init__`
+
+- Python: `src/praisonai-agents/praisonaiagents/knowledge/indexing.py:333`
+- TypeScript: `src/praisonai-ts/src/knowledge/indexing.ts:552`
+- Counts: 1 python params: 0 exact, 1 camelCase, 0 alias, 0 flattened, 0 missing; 0 mismatches; 0 waived; 0 TS-only of 1
+
+| Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |
+|---|---|---|---|---|---|---|---|---|
+| `state_file` | positional | null | `Optional[str]` | camelCase | `stateFile` | null | `string \| null` | ok |
+
+TS-only members: none
+
+### `Knowledge.__init__`
+
+- Python: `src/praisonai-agents/praisonaiagents/knowledge/knowledge.py:54`
+- TypeScript: `src/praisonai-ts/src/knowledge/knowledge.ts:166`
+- Counts: 2 python params: 2 exact, 0 camelCase, 0 alias, 0 flattened, 0 missing; 0 mismatches; 0 waived; 0 TS-only of 2
+
+| Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |
+|---|---|---|---|---|---|---|---|---|
+| `config` | positional | null |  | exact | `config` | null | `KnowledgeStoreConfig \| null` | ok |
+| `verbose` | positional | null |  | exact | `verbose` | null | `number \| boolean \| null` | ok |
+
+TS-only members: none
+
 ## Active waivers
 
 | Key | Reason | Owner | Issue | Expires |
 |---|---|---|---|---|
-| `Agent.__init__.caching` | TS cache is a boolean defaulting to false; Python None resolves a caching preset | praisonai-ts |  |  |
-| `Agent.__init__.model` | TS resolves the model from env then gpt-4o-mini; Python resolves per available credential | praisonai-ts |  |  |
-| `Agent.__init__.name` | TS generates a unique Agent_<id> name; Python defaults to "Agent" | praisonai-ts |  |  |
-| `Agent.__init__.role` | TS folds role/goal/backstory into instructions; role falls back to goal or backstory text | praisonai-ts |  |  |
-| `Agent.start.prompt` | TS start requires a prompt; Python None falls back to the task description | praisonai-ts |  |  |
-| `AgentTeam.__init__.process` | TS treats an undefined process as sequential, the Python default | praisonai-ts |  |  |
-| `Handoff.__init__.tool_description_override` | TS derives "Transfer conversation to <agent>"; Python derives the same in the body | praisonai-ts |  |  |
-| `Handoff.__init__.tool_name_override` | TS derives handoff_to_<agent> when unset; Python derives the same in the body | praisonai-ts |  |  |
-| `PraisonAIError.__init__.run_id` | TS assigns a run id at construction; Python leaves it None and fills it when the run starts | praisonai-ts |  |  |
-| `Session.__init__.user_id` | TS sets "default_user" eagerly; Python resolves the same value lazily | praisonai-ts |  |  |
-| `Task.__init__.action` | TS action mirrors description; Python resolves the same in the body | praisonai-ts |  |  |
-| `Task.__init__.depends_on` | TS dependsOn falls back to context then []; Python None means empty (same as the waived context alias) | praisonai-ts |  |  |
-| `Task.__init__.description` | TS description falls back to action at construction; Python resolves the same in the body | praisonai-ts |  |  |
-| `Task.__init__.expected_output` | TS fills "Complete the task successfully" at construction; Python does so lazily | praisonai-ts |  |  |
-| `Task.__init__.guardrails` | TS guardrails falls back to guardrail; Python resolves the same precedence in the body | praisonai-ts |  |  |
-| `Task.__init__.id` | TS assigns a UUID at construction; Python assigns an id lazily | praisonai-ts |  |  |
-| `Task.__init__.routing` | TS routing falls back to condition; Python resolves the same in the body | praisonai-ts |  |  |
-| `tool().description` | TS derives a default description from the tool name; Python leaves it None and infers from the docstring | praisonai-ts |  |  |
-| `tool().func` | TS execute is required; Python func is optional because @tool can be applied bare | praisonai-ts |  |  |
+| `Agent.__init__.backstory` | Same value, resolved at a different moment. TS stores `config.backstory \|\| config.instructions` (or "I am an AI assistant") in the constructor; Python's `self.backstory = backstory or instructions` (agent.py) produces the identical string in the body. Verified equal for the instruction-only, role-only and bare forms. | praisonai-ts |  |  |
+| `Agent.__init__.caching` | Both SDKs default to NO caching, by different routes. Python's `caching=None` resolves to `CachingConfig(enabled=True)` and assigns `self.cache = True`, but `Agent.cache` is written and never read anywhere in praisonaiagents, so the default caches nothing; TS defaults `cache` to false, which its response cache honours. Aligning the literal would turn caching ON in TS and diverge from Python's observable behaviour, so the difference is deliberate. Pinned by tests/unit/agent/parity-waiver-gaps.test.ts ("caching default"). | praisonai-ts |  |  |
+| `Agent.__init__.goal` | Same value, resolved at a different moment. TS stores `config.goal \|\| config.instructions` (or "Help the user with their tasks") in the constructor; Python's `self.goal = goal or instructions` (agent.py) produces the identical string in the body. | praisonai-ts |  |  |
+| `Agent.__init__.model` | Same resolution, run eagerly. TS now calls `resolveDefaultModel()` (src/llm/default-model.ts), a byte-for-byte port of Python's `Agent._PROVIDER_DEFAULT_MODELS` / `_resolve_default_model`, so the same environment yields the same model on both sides. What still differs is only the moment: TS resolves in the constructor, Python inside the body, and TS additionally honours `PRAISONAI_MODEL` (a TypeScript-only alias). | praisonai-ts |  |  |
+| `Agent.__init__.name` | TS generates `Agent_<random>`; Python leaves `name` None for an instruction-only agent and uses "Agent" otherwise. Neither is a stable contract (every unnamed Python agent collides on "Agent", and `Handoff` on a None-named Python agent raises AttributeError), and TS exposes no name-keyed lookup like Python's `AgentTeam.get_agent_details`. The one place the random name used to reach the model -- the handoff tool name -- is now sanitised by `defaultHandoffToolName`. | praisonai-ts |  |  |
+| `Agent.__init__.role` | Same value, resolved at a different moment. TS now stores `config.role \|\| 'Assistant'` in the constructor, matching Python's `self.role = role or "Assistant"`, so `agent.role` reads back the same string on both sides. The system-prompt TEXT built from role/goal/ backstory still differs between the two SDKs -- that is a separate, untracked gap, not covered by this waiver. | praisonai-ts |  |  |
+| `AgentTeam.__init__.process` | TS treats an undefined process as sequential, the Python default. NOTE (verified, out of scope for this key): the accepted DOMAIN differs -- TS implements `process: "parallel"` with Promise.all, which Python rejects with a ValueError, and TS validates nothing, so a typo runs sequentially instead of raising. | praisonai-ts |  |  |
+| `Handoff.__init__.tool_description_override` | Same derived string, built at a different moment. `defaultHandoffToolDescription` now produces Python's `Transfer task to <name> (<role>) - <goal>` exactly (it previously said "Transfer conversation to <name>", which the model saw). Only the moment of derivation differs. | praisonai-ts |  |  |
+| `Handoff.__init__.tool_name_override` | Same derived string, built at a different moment. `defaultHandoffToolName` now produces Python's `transfer_to_<lowercased, spaces-to-underscores name>` exactly (it previously said `handoff_to_<raw name>`, which could contain a space and be rejected by the provider). Only the moment of derivation differs. | praisonai-ts |  |  |
+| `PraisonAIError.__init__.run_id` | Both sides mint a UUID at construction -- Python's `self.run_id = run_id or str(uuid.uuid4())` (errors.py) is NOT lazy. Only the declared default differs. Edge case: `runId: ''` survives TS's `??` but is replaced by Python's `or`. | praisonai-ts |  |  |
+| `Session.__init__.user_id` | Both sides assign eagerly with the same truthiness rule -- Python's `self.user_id = user_id or "default_user"` (session/api.py), TS's `config.userId \|\| 'default_user'`. Only the declared default differs. | praisonai-ts |  |  |
+| `Task.__init__.action` | TS action mirrors description; Python's `self.action = action if action is not None else description` resolves the same in the body. | praisonai-ts |  |  |
+| `Task.__init__.depends_on` | TS dependsOn falls back to context then []; Python's `if depends_on is not None` gives dependsOn the same precedence, including an explicit empty list. TS additionally exposes no `dependsOn` read-back property (Python's returns `context`). | praisonai-ts |  |  |
+| `Task.__init__.description` | TS description falls back to action at construction; Python's `if action is not None and description is None: description = action` resolves the same in the body. TS stores '' where Python stores None for a handler-only task; both are falsy and no branch differs. | praisonai-ts |  |  |
+| `Task.__init__.expected_output` | Both sides fill "Complete the task successfully" eagerly in __init__ -- Python's `expected_output if expected_output is not None else ...` is NOT lazy. Only the declared default differs. | praisonai-ts |  |  |
+| `Task.__init__.guardrails` | Identical precedence: the plural wins over the singular on both sides (Python `guardrails if guardrails is not None else guardrail`). TS omits Python's DeprecationWarning for the singular spelling and additionally exposes a `guardrails` read-back property Python lacks. | praisonai-ts |  |  |
+| `Task.__init__.id` | Both sides mint a UUID at construction; Python's `str(uuid.uuid4()) if id is None else str(id)` is NOT lazy. NOTE (verified): an EXPLICIT id is coerced to str by Python but kept as a number by TS, so `Task(id=5).id` is "5" in Python and 5 in TypeScript. | praisonai-ts |  |  |
+| `Task.__init__.routing` | TS routing falls back to condition, as Python does, and a plain-dict routing value lands identically on both sides. NOTE (verified, wider than this key): TS lists `routing` in ENGINE_LEVEL_OPTIONS, so any value raises a `notYetHonoured` notice and never reaches execution, whereas Python's workflow executor reads it. | praisonai-ts |  |  |
+| `tool().description` | Same fallback string, built at a different moment. TS now derives `Tool: <name>`, matching Python's `description or func.__doc__ or f"Tool: {self.name}"` (it previously said `Function <name>`, which shipped in the tool schema the model reads). TS has no docstring to fall back to between the two. | praisonai-ts |  |  |
+| `tool().func` | TS execute is required; Python's `func` is optional only so `@tool` can be applied bare, and `FunctionTool.__init__` still requires it. | praisonai-ts |  |  |
 | `tool().name` | TS cannot infer a name from an anonymous function; Python infers it from __name__ | praisonai-ts |  |  |
-| `tool().requires_approval` | Python uses an _UNSET sentinel to detect explicit use; TS uses undefined | praisonai-ts |  |  |

--- a/src/praisonai-ts/signature-parity.json
+++ b/src/praisonai-ts/signature-parity.json
@@ -7,12 +7,12 @@
         "camelCase": 8,
         "exact": 29,
         "flattened": 2,
-        "mismatches": 4,
+        "mismatches": 6,
         "missing": 0,
         "params": 42,
         "ts_only": 14,
         "ts_total": 59,
-        "waived": 4
+        "waived": 6
       },
       "params": [
         {
@@ -75,15 +75,18 @@
           "canonical": "goal",
           "default": null,
           "default_kind": "literal",
-          "gap": null,
+          "gap": {
+            "detail": "default differs: python=null typescript=`config.instructions` (TS `goal`)",
+            "kind": "default"
+          },
           "kind": "positional",
           "match": "exact",
           "name": "goal",
           "required": false,
           "ts": {
             "canonical": "goal",
-            "default": null,
-            "default_kind": null,
+            "default": "config.instructions",
+            "default_kind": "expr",
             "kind": "property",
             "name": "goal",
             "required": false,
@@ -93,22 +96,25 @@
           "ts_name": "goal",
           "type_class": "string",
           "type_text": "Optional[str]",
-          "waived": null,
+          "waived": "Agent.__init__.goal",
           "warnings": []
         },
         {
           "canonical": "backstory",
           "default": null,
           "default_kind": "literal",
-          "gap": null,
+          "gap": {
+            "detail": "default differs: python=null typescript=`config.instructions` (TS `backstory`)",
+            "kind": "default"
+          },
           "kind": "positional",
           "match": "exact",
           "name": "backstory",
           "required": false,
           "ts": {
             "canonical": "backstory",
-            "default": null,
-            "default_kind": null,
+            "default": "config.instructions",
+            "default_kind": "expr",
             "kind": "property",
             "name": "backstory",
             "required": false,
@@ -118,7 +124,7 @@
           "ts_name": "backstory",
           "type_class": "string",
           "type_text": "Optional[str]",
-          "waived": null,
+          "waived": "Agent.__init__.backstory",
           "warnings": []
         },
         {
@@ -176,7 +182,7 @@
           "default": null,
           "default_kind": "literal",
           "gap": {
-            "detail": "default differs: python=null typescript=`llmName || getEnv('OPENAI_MODEL_NAME') || getEnv('PRAISONAI_MODEL') || 'gpt-4o-mini'` (TS `model`)",
+            "detail": "default differs: python=null typescript=`llmName || resolveDefaultModel()` (TS `model`)",
             "kind": "default"
           },
           "kind": "positional",
@@ -185,7 +191,7 @@
           "required": false,
           "ts": {
             "canonical": "model",
-            "default": "llmName || getEnv('OPENAI_MODEL_NAME') || getEnv('PRAISONAI_MODEL') || 'gpt-4o-mini'",
+            "default": "llmName || resolveDefaultModel()",
             "default_kind": "expr",
             "kind": "property",
             "name": "model",
@@ -1215,8 +1221,8 @@
         }
       ],
       "typescript": {
-        "ctor_location": "src/praisonai-ts/src/agent/simple.ts:744",
-        "location": "src/praisonai-ts/src/agent/simple.ts:112"
+        "ctor_location": "src/praisonai-ts/src/agent/simple.ts:753",
+        "location": "src/praisonai-ts/src/agent/simple.ts:113"
       }
     },
     "Agent.chat": {
@@ -1686,7 +1692,7 @@
         }
       ],
       "typescript": {
-        "location": "src/praisonai-ts/src/agent/simple.ts:2426",
+        "location": "src/praisonai-ts/src/agent/simple.ts:2476",
         "options_interfaces": [
           "options: AgentChatOptions"
         ],
@@ -1699,22 +1705,19 @@
         "camelCase": 0,
         "exact": 1,
         "flattened": 0,
-        "mismatches": 1,
+        "mismatches": 0,
         "missing": 0,
         "params": 1,
         "ts_only": 20,
         "ts_total": 21,
-        "waived": 1
+        "waived": 0
       },
       "params": [
         {
           "canonical": "prompt",
           "default": null,
           "default_kind": "literal",
-          "gap": {
-            "detail": "is optional in Python but required in TypeScript (TS `prompt`)",
-            "kind": "required"
-          },
+          "gap": null,
           "kind": "positional",
           "match": "exact",
           "name": "prompt",
@@ -1725,14 +1728,14 @@
             "default_kind": null,
             "kind": "positional",
             "name": "prompt",
-            "required": true,
+            "required": false,
             "type_class": "string",
             "type_text": "string"
           },
           "ts_name": "prompt",
           "type_class": "string",
           "type_text": "Optional[str]",
-          "waived": "Agent.start.prompt",
+          "waived": null,
           "warnings": []
         }
       ],
@@ -1943,7 +1946,7 @@
         }
       ],
       "typescript": {
-        "location": "src/praisonai-ts/src/agent/simple.ts:1778",
+        "location": "src/praisonai-ts/src/agent/simple.ts:1824",
         "options_interfaces": [
           "options: AgentChatOptions"
         ],
@@ -3096,6 +3099,56 @@
         "location": "src/praisonai-ts/src/escalation/pipeline.ts:51"
       }
     },
+    "FileTracker.__init__": {
+      "counts": {
+        "alias": 0,
+        "camelCase": 1,
+        "exact": 0,
+        "flattened": 0,
+        "mismatches": 0,
+        "missing": 0,
+        "params": 1,
+        "ts_only": 0,
+        "ts_total": 1,
+        "waived": 0
+      },
+      "params": [
+        {
+          "canonical": "stateFile",
+          "default": null,
+          "default_kind": "literal",
+          "gap": null,
+          "kind": "positional",
+          "match": "camelCase",
+          "name": "state_file",
+          "required": false,
+          "ts": {
+            "canonical": "stateFile",
+            "default": null,
+            "default_kind": "literal",
+            "kind": "positional",
+            "name": "stateFile",
+            "required": false,
+            "type_class": "string",
+            "type_text": "string | null"
+          },
+          "ts_name": "stateFile",
+          "type_class": "string",
+          "type_text": "Optional[str]",
+          "waived": null,
+          "warnings": []
+        }
+      ],
+      "python": {
+        "location": "src/praisonai-agents/praisonaiagents/knowledge/indexing.py:333",
+        "resolved_class": "FileTracker"
+      },
+      "ts_only": [],
+      "typescript": {
+        "location": "src/praisonai-ts/src/knowledge/indexing.ts:552",
+        "resolved_class": "FileTracker"
+      }
+    },
     "GoalEngineer.__init__": {
       "counts": {
         "alias": 0,
@@ -3336,7 +3389,7 @@
           "default": null,
           "default_kind": "literal",
           "gap": {
-            "detail": "default differs: python=null typescript=`nested.name || `handoff_to_${config.agent.name}`` (TS `name`)",
+            "detail": "default differs: python=null typescript=`nested.name || defaultHandoffToolName(config.agent.name)` (TS `name`)",
             "kind": "default"
           },
           "kind": "positional",
@@ -3345,7 +3398,7 @@
           "required": false,
           "ts": {
             "canonical": "name",
-            "default": "nested.name || `handoff_to_${config.agent.name}`",
+            "default": "nested.name || defaultHandoffToolName(config.agent.name)",
             "default_kind": "expr",
             "kind": "property",
             "name": "name",
@@ -3364,7 +3417,7 @@
           "default": null,
           "default_kind": "literal",
           "gap": {
-            "detail": "default differs: python=null typescript=`nested.description || `Transfer conversation to ${config.agent.name}`` (TS `description`)",
+            "detail": "default differs: python=null typescript=`nested.description || defaultHandoffToolDescription(config.agent as any)` (TS `description`)",
             "kind": "default"
           },
           "kind": "positional",
@@ -3373,7 +3426,7 @@
           "required": false,
           "ts": {
             "canonical": "description",
-            "default": "nested.description || `Transfer conversation to ${config.agent.name}`",
+            "default": "nested.description || defaultHandoffToolDescription(config.agent as any)",
             "default_kind": "expr",
             "kind": "property",
             "name": "description",
@@ -3627,8 +3680,83 @@
         }
       ],
       "typescript": {
-        "ctor_location": "src/praisonai-ts/src/agent/handoff.ts:671",
-        "location": "src/praisonai-ts/src/agent/handoff.ts:435"
+        "ctor_location": "src/praisonai-ts/src/agent/handoff.ts:714",
+        "location": "src/praisonai-ts/src/agent/handoff.ts:478"
+      }
+    },
+    "Knowledge.__init__": {
+      "counts": {
+        "alias": 0,
+        "camelCase": 0,
+        "exact": 2,
+        "flattened": 0,
+        "mismatches": 0,
+        "missing": 0,
+        "params": 2,
+        "ts_only": 0,
+        "ts_total": 2,
+        "waived": 0
+      },
+      "params": [
+        {
+          "canonical": "config",
+          "default": null,
+          "default_kind": "literal",
+          "gap": null,
+          "kind": "positional",
+          "match": "exact",
+          "name": "config",
+          "required": false,
+          "ts": {
+            "canonical": "config",
+            "default": null,
+            "default_kind": "literal",
+            "kind": "positional",
+            "name": "config",
+            "required": false,
+            "type_class": "object",
+            "type_text": "KnowledgeStoreConfig | null"
+          },
+          "ts_name": "config",
+          "type_class": "unknown",
+          "type_text": "",
+          "waived": null,
+          "warnings": []
+        },
+        {
+          "canonical": "verbose",
+          "default": null,
+          "default_kind": "literal",
+          "gap": null,
+          "kind": "positional",
+          "match": "exact",
+          "name": "verbose",
+          "required": false,
+          "ts": {
+            "canonical": "verbose",
+            "default": null,
+            "default_kind": "literal",
+            "kind": "positional",
+            "name": "verbose",
+            "required": false,
+            "type_class": "union",
+            "type_text": "number | boolean | null"
+          },
+          "ts_name": "verbose",
+          "type_class": "unknown",
+          "type_text": "",
+          "waived": null,
+          "warnings": []
+        }
+      ],
+      "python": {
+        "location": "src/praisonai-agents/praisonaiagents/knowledge/knowledge.py:54",
+        "resolved_class": "Knowledge"
+      },
+      "ts_only": [],
+      "typescript": {
+        "location": "src/praisonai-ts/src/knowledge/knowledge.ts:166",
+        "resolved_class": "Knowledge"
       }
     },
     "LLM.__init__": {
@@ -6466,12 +6594,12 @@
         "camelCase": 5,
         "exact": 5,
         "flattened": 0,
-        "mismatches": 4,
+        "mismatches": 3,
         "missing": 0,
         "params": 11,
         "ts_only": 3,
         "ts_total": 14,
-        "waived": 4
+        "waived": 3
       },
       "params": [
         {
@@ -6535,7 +6663,7 @@
           "default": null,
           "default_kind": "literal",
           "gap": {
-            "detail": "default differs: python=null typescript=``Function ${config.name}`` (TS `description`)",
+            "detail": "default differs: python=null typescript=``Tool: ${config.name}`` (TS `description`)",
             "kind": "default"
           },
           "kind": "keyword",
@@ -6544,7 +6672,7 @@
           "required": false,
           "ts": {
             "canonical": "description",
-            "default": "`Function ${config.name}`",
+            "default": "`Tool: ${config.name}`",
             "default_kind": "expr",
             "kind": "property",
             "name": "description",
@@ -6687,10 +6815,7 @@
           "canonical": "requiresApproval",
           "default": "_UNSET",
           "default_kind": "expr",
-          "gap": {
-            "detail": "default differs: python=`_UNSET` typescript=undefined (TS `requiresApproval`)",
-            "kind": "default"
-          },
+          "gap": null,
           "kind": "keyword",
           "match": "camelCase",
           "name": "requires_approval",
@@ -6708,7 +6833,7 @@
           "ts_name": "requiresApproval",
           "type_class": "union",
           "type_text": "Union[bool, str]",
-          "waived": "tool().requires_approval",
+          "waived": null,
           "warnings": []
         },
         {
@@ -6805,150 +6930,157 @@
   },
   "totals": {
     "alias": 9,
-    "camelCase": 87,
-    "exact": 121,
+    "camelCase": 88,
+    "exact": 123,
     "flattened": 2,
     "mismatches": 21,
     "missing": 0,
-    "params": 219,
-    "surfaces": 15,
+    "params": 222,
+    "surfaces": 17,
     "ts_only": 85,
-    "ts_total": 309,
+    "ts_total": 312,
     "waived": 21
   },
   "waivers": [
     {
       "expires": null,
       "issue": null,
+      "key": "Agent.__init__.backstory",
+      "owner": "praisonai-ts",
+      "reason": "Same value, resolved at a different moment. TS stores `config.backstory || config.instructions` (or \"I am an AI assistant\") in the constructor; Python's `self.backstory = backstory or instructions` (agent.py) produces the identical string in the body. Verified equal for the instruction-only, role-only and bare forms."
+    },
+    {
+      "expires": null,
+      "issue": null,
       "key": "Agent.__init__.caching",
       "owner": "praisonai-ts",
-      "reason": "TS cache is a boolean defaulting to false; Python None resolves a caching preset"
+      "reason": "Both SDKs default to NO caching, by different routes. Python's `caching=None` resolves to `CachingConfig(enabled=True)` and assigns `self.cache = True`, but `Agent.cache` is written and never read anywhere in praisonaiagents, so the default caches nothing; TS defaults `cache` to false, which its response cache honours. Aligning the literal would turn caching ON in TS and diverge from Python's observable behaviour, so the difference is deliberate. Pinned by tests/unit/agent/parity-waiver-gaps.test.ts (\"caching default\")."
+    },
+    {
+      "expires": null,
+      "issue": null,
+      "key": "Agent.__init__.goal",
+      "owner": "praisonai-ts",
+      "reason": "Same value, resolved at a different moment. TS stores `config.goal || config.instructions` (or \"Help the user with their tasks\") in the constructor; Python's `self.goal = goal or instructions` (agent.py) produces the identical string in the body."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Agent.__init__.model",
       "owner": "praisonai-ts",
-      "reason": "TS resolves the model from env then gpt-4o-mini; Python resolves per available credential"
+      "reason": "Same resolution, run eagerly. TS now calls `resolveDefaultModel()` (src/llm/default-model.ts), a byte-for-byte port of Python's `Agent._PROVIDER_DEFAULT_MODELS` / `_resolve_default_model`, so the same environment yields the same model on both sides. What still differs is only the moment: TS resolves in the constructor, Python inside the body, and TS additionally honours `PRAISONAI_MODEL` (a TypeScript-only alias)."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Agent.__init__.name",
       "owner": "praisonai-ts",
-      "reason": "TS generates a unique Agent_<id> name; Python defaults to \"Agent\""
+      "reason": "TS generates `Agent_<random>`; Python leaves `name` None for an instruction-only agent and uses \"Agent\" otherwise. Neither is a stable contract (every unnamed Python agent collides on \"Agent\", and `Handoff` on a None-named Python agent raises AttributeError), and TS exposes no name-keyed lookup like Python's `AgentTeam.get_agent_details`. The one place the random name used to reach the model -- the handoff tool name -- is now sanitised by `defaultHandoffToolName`."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Agent.__init__.role",
       "owner": "praisonai-ts",
-      "reason": "TS folds role/goal/backstory into instructions; role falls back to goal or backstory text"
-    },
-    {
-      "expires": null,
-      "issue": null,
-      "key": "Agent.start.prompt",
-      "owner": "praisonai-ts",
-      "reason": "TS start requires a prompt; Python None falls back to the task description"
+      "reason": "Same value, resolved at a different moment. TS now stores `config.role || 'Assistant'` in the constructor, matching Python's `self.role = role or \"Assistant\"`, so `agent.role` reads back the same string on both sides. The system-prompt TEXT built from role/goal/ backstory still differs between the two SDKs -- that is a separate, untracked gap, not covered by this waiver."
     },
     {
       "expires": null,
       "issue": null,
       "key": "AgentTeam.__init__.process",
       "owner": "praisonai-ts",
-      "reason": "TS treats an undefined process as sequential, the Python default"
+      "reason": "TS treats an undefined process as sequential, the Python default. NOTE (verified, out of scope for this key): the accepted DOMAIN differs -- TS implements `process: \"parallel\"` with Promise.all, which Python rejects with a ValueError, and TS validates nothing, so a typo runs sequentially instead of raising."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Handoff.__init__.tool_description_override",
       "owner": "praisonai-ts",
-      "reason": "TS derives \"Transfer conversation to <agent>\"; Python derives the same in the body"
+      "reason": "Same derived string, built at a different moment. `defaultHandoffToolDescription` now produces Python's `Transfer task to <name> (<role>) - <goal>` exactly (it previously said \"Transfer conversation to <name>\", which the model saw). Only the moment of derivation differs."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Handoff.__init__.tool_name_override",
       "owner": "praisonai-ts",
-      "reason": "TS derives handoff_to_<agent> when unset; Python derives the same in the body"
+      "reason": "Same derived string, built at a different moment. `defaultHandoffToolName` now produces Python's `transfer_to_<lowercased, spaces-to-underscores name>` exactly (it previously said `handoff_to_<raw name>`, which could contain a space and be rejected by the provider). Only the moment of derivation differs."
     },
     {
       "expires": null,
       "issue": null,
       "key": "PraisonAIError.__init__.run_id",
       "owner": "praisonai-ts",
-      "reason": "TS assigns a run id at construction; Python leaves it None and fills it when the run starts"
+      "reason": "Both sides mint a UUID at construction -- Python's `self.run_id = run_id or str(uuid.uuid4())` (errors.py) is NOT lazy. Only the declared default differs. Edge case: `runId: ''` survives TS's `??` but is replaced by Python's `or`."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Session.__init__.user_id",
       "owner": "praisonai-ts",
-      "reason": "TS sets \"default_user\" eagerly; Python resolves the same value lazily"
+      "reason": "Both sides assign eagerly with the same truthiness rule -- Python's `self.user_id = user_id or \"default_user\"` (session/api.py), TS's `config.userId || 'default_user'`. Only the declared default differs."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Task.__init__.action",
       "owner": "praisonai-ts",
-      "reason": "TS action mirrors description; Python resolves the same in the body"
+      "reason": "TS action mirrors description; Python's `self.action = action if action is not None else description` resolves the same in the body."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Task.__init__.depends_on",
       "owner": "praisonai-ts",
-      "reason": "TS dependsOn falls back to context then []; Python None means empty (same as the waived context alias)"
+      "reason": "TS dependsOn falls back to context then []; Python's `if depends_on is not None` gives dependsOn the same precedence, including an explicit empty list. TS additionally exposes no `dependsOn` read-back property (Python's returns `context`)."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Task.__init__.description",
       "owner": "praisonai-ts",
-      "reason": "TS description falls back to action at construction; Python resolves the same in the body"
+      "reason": "TS description falls back to action at construction; Python's `if action is not None and description is None: description = action` resolves the same in the body. TS stores '' where Python stores None for a handler-only task; both are falsy and no branch differs."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Task.__init__.expected_output",
       "owner": "praisonai-ts",
-      "reason": "TS fills \"Complete the task successfully\" at construction; Python does so lazily"
+      "reason": "Both sides fill \"Complete the task successfully\" eagerly in __init__ -- Python's `expected_output if expected_output is not None else ...` is NOT lazy. Only the declared default differs."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Task.__init__.guardrails",
       "owner": "praisonai-ts",
-      "reason": "TS guardrails falls back to guardrail; Python resolves the same precedence in the body"
+      "reason": "Identical precedence: the plural wins over the singular on both sides (Python `guardrails if guardrails is not None else guardrail`). TS omits Python's DeprecationWarning for the singular spelling and additionally exposes a `guardrails` read-back property Python lacks."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Task.__init__.id",
       "owner": "praisonai-ts",
-      "reason": "TS assigns a UUID at construction; Python assigns an id lazily"
+      "reason": "Both sides mint a UUID at construction; Python's `str(uuid.uuid4()) if id is None else str(id)` is NOT lazy. NOTE (verified): an EXPLICIT id is coerced to str by Python but kept as a number by TS, so `Task(id=5).id` is \"5\" in Python and 5 in TypeScript."
     },
     {
       "expires": null,
       "issue": null,
       "key": "Task.__init__.routing",
       "owner": "praisonai-ts",
-      "reason": "TS routing falls back to condition; Python resolves the same in the body"
+      "reason": "TS routing falls back to condition, as Python does, and a plain-dict routing value lands identically on both sides. NOTE (verified, wider than this key): TS lists `routing` in ENGINE_LEVEL_OPTIONS, so any value raises a `notYetHonoured` notice and never reaches execution, whereas Python's workflow executor reads it."
     },
     {
       "expires": null,
       "issue": null,
       "key": "tool().description",
       "owner": "praisonai-ts",
-      "reason": "TS derives a default description from the tool name; Python leaves it None and infers from the docstring"
+      "reason": "Same fallback string, built at a different moment. TS now derives `Tool: <name>`, matching Python's `description or func.__doc__ or f\"Tool: {self.name}\"` (it previously said `Function <name>`, which shipped in the tool schema the model reads). TS has no docstring to fall back to between the two."
     },
     {
       "expires": null,
       "issue": null,
       "key": "tool().func",
       "owner": "praisonai-ts",
-      "reason": "TS execute is required; Python func is optional because @tool can be applied bare"
+      "reason": "TS execute is required; Python's `func` is optional only so `@tool` can be applied bare, and `FunctionTool.__init__` still requires it."
     },
     {
       "expires": null,
@@ -6956,13 +7088,6 @@
       "key": "tool().name",
       "owner": "praisonai-ts",
       "reason": "TS cannot infer a name from an anonymous function; Python infers it from __name__"
-    },
-    {
-      "expires": null,
-      "issue": null,
-      "key": "tool().requires_approval",
-      "owner": "praisonai-ts",
-      "reason": "Python uses an _UNSET sentinel to detect explicit use; TS uses undefined"
     }
   ]
 }

--- a/src/praisonai-ts/src/agent/handoff.ts
+++ b/src/praisonai-ts/src/agent/handoff.ts
@@ -100,13 +100,20 @@ export interface HandoffErrorOptions {
  * Any character Python's transform leaves unsafe is folded to `_` as a final
  * guard; for every name Python handles correctly the two agree byte for byte.
  *
+ * The whole result is finally capped at the provider's 64-character function
+ * name limit (`^[a-zA-Z0-9_-]{1,64}$`). Python does not truncate, so an agent
+ * name over 52 characters produces an over-length name there that the API
+ * rejects outright; capping here keeps the common case byte-identical while
+ * turning that pathological case from a hard API rejection into a usable name.
+ *
  * @param agentName - The target agent's name.
- * @returns A provider-legal tool name, e.g. `transfer_to_support_bot`.
+ * @returns A provider-legal tool name (<=64 chars), e.g. `transfer_to_support_bot`.
  */
 export function defaultHandoffToolName(agentName: string): string {
   const snake = String(agentName ?? '').toLowerCase().replace(/ /g, '_');
   const safe = snake.replace(/[^a-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '');
-  return `transfer_to_${safe || 'agent'}`;
+  const name = `transfer_to_${safe || 'agent'}`;
+  return name.length > 64 ? name.slice(0, 64).replace(/_+$/g, '') : name;
 }
 
 /**

--- a/src/praisonai-ts/src/agent/handoff.ts
+++ b/src/praisonai-ts/src/agent/handoff.ts
@@ -87,6 +87,49 @@ export interface HandoffErrorOptions {
 }
 
 /**
+ * The tool name a handoff gets when the caller named none.
+ *
+ * Python parity (`Handoff.default_tool_name`, handoff.py): the target agent's
+ * name is lower-cased with spaces turned into underscores and prefixed with
+ * `transfer_to_`. Getting this wrong is not cosmetic -- the string is the
+ * function name in the tool schema sent to the provider. The previous
+ * `handoff_to_${agent.name}` form passed the name through raw, so an agent
+ * called "Support Bot" produced `handoff_to_Support Bot`, which contains a
+ * space and is rejected by the OpenAI tool-name rule `^[a-zA-Z0-9_-]{1,64}$`.
+ *
+ * Any character Python's transform leaves unsafe is folded to `_` as a final
+ * guard; for every name Python handles correctly the two agree byte for byte.
+ *
+ * @param agentName - The target agent's name.
+ * @returns A provider-legal tool name, e.g. `transfer_to_support_bot`.
+ */
+export function defaultHandoffToolName(agentName: string): string {
+  const snake = String(agentName ?? '').toLowerCase().replace(/ /g, '_');
+  const safe = snake.replace(/[^a-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '');
+  return `transfer_to_${safe || 'agent'}`;
+}
+
+/**
+ * The tool description a handoff gets when the caller supplied none.
+ *
+ * Python parity (`Handoff.default_tool_description`, handoff.py): the target's
+ * name, then its role in parentheses and its goal after a dash, both only when
+ * present. This string is the tool's `description` in the schema the model
+ * reads and is repeated in the system prompt, so the old
+ * `Transfer conversation to <name>` gave the model strictly less to route on
+ * than Python did.
+ *
+ * @param agent - The handoff target; `role` and `goal` are read when set.
+ * @returns e.g. `Transfer task to Support Bot (Assistant) - Help users`.
+ */
+export function defaultHandoffToolDescription(agent: { name: string; role?: string; goal?: string }): string {
+  let description = `Transfer task to ${agent.name}`;
+  if (agent.role) description += ` (${agent.role})`;
+  if (agent.goal) description += ` - ${agent.goal}`;
+  return description;
+}
+
+/**
  * Agent handoff/delegation failed.
  *
  * Includes source/target agent context (`context.source_agent`,
@@ -676,8 +719,8 @@ export class Handoff {
       config[key] !== undefined ? config[key] : nested[key];
 
     this.targetAgent = config.agent;
-    this.name = config.name || nested.name || `handoff_to_${config.agent.name}`;
-    this.description = config.description || nested.description || `Transfer conversation to ${config.agent.name}`;
+    this.name = config.name || nested.name || defaultHandoffToolName(config.agent.name);
+    this.description = config.description || nested.description || defaultHandoffToolDescription(config.agent as any);
     this.condition = pick('condition');
     this.transformContext = pick('transformContext');
     this.inputType = pick('inputType');

--- a/src/praisonai-ts/src/agent/simple.ts
+++ b/src/praisonai-ts/src/agent/simple.ts
@@ -6,6 +6,7 @@ import type { LLMProvider } from '../llm/providers/types';
 import type { BackendResolutionResult } from '../llm/backend-resolver';
 import { ApprovalManager, createCLIApprovalPrompt } from '../ai/tool-approval';
 import { getEnv } from '../llm/openaiClientOptions';
+import { resolveDefaultModel } from '../llm/default-model';
 import { randomUUID } from '../utils/uuid';
 import { parseModelString } from '../llm/backend-resolver';
 import { notYetHonoured } from '../utils/parity-notice';
@@ -526,11 +527,6 @@ async function loadWebSearchProvider(name: string): Promise<(config?: any) => an
   );
 }
 
-/** A tool name the OpenAI API accepts (^[a-zA-Z0-9_-]+$). */
-function toolSafeName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || 'agent';
-}
-
 /**
  * Wrap `fetch` so JSON chat-completion bodies gain extra fields (reasoning_effort,
  * seed, max_tokens). OpenAIService exposes no hook for provider-specific body
@@ -632,6 +628,19 @@ async function toJsonSchema(schema: any): Promise<Record<string, any> | undefine
 export class Agent {
   private instructions: string;
   public name: string;
+  /**
+   * Python parity: `Agent.role` (`role or "Assistant"`). Python always
+   * materialises role/goal/backstory and exposes them via `to_dict()` and
+   * `__repr__`; TypeScript used to read them once to build `instructions` and
+   * then drop them, so `agent.role` was `undefined` where Python said
+   * `"Assistant"`, and anything deriving text from them (a handoff's tool
+   * description) had nothing to read.
+   */
+  public readonly role: string;
+  /** Python parity: `Agent.goal` (`goal or instructions or "Help the user with their tasks"`). */
+  public readonly goal: string;
+  /** Python parity: `Agent.backstory` (`backstory or instructions or "I am an AI assistant"`). */
+  public readonly backstory: string;
   private verbose: boolean;
   private pretty: boolean;
   private llm: string;
@@ -755,7 +764,19 @@ export class Agent {
     } else {
       this.instructions = 'You are a helpful AI assistant.';
     }
-    
+
+    // Python parity (agent.py: the `if instructions:` / `else` branches). Kept
+    // as stored fields, not just constructor locals, so `agent.role` reads back
+    // the same value Python reports.
+    this.role = config.role || 'Assistant';
+    if (config.instructions) {
+      this.goal = config.goal || config.instructions;
+      this.backstory = config.backstory || config.instructions;
+    } else {
+      this.goal = config.goal || 'Help the user with their tasks';
+      this.backstory = config.backstory || 'I am an AI assistant';
+    }
+
     this.name = config.name || `Agent_${Math.random().toString(36).substr(2, 9)}`;
     this.verbose = config.verbose ?? getEnv('PRAISON_VERBOSE') !== 'false';
     this.pretty = config.pretty ?? getEnv('PRAISON_PRETTY') === 'true';
@@ -763,7 +784,11 @@ export class Agent {
     // LLMConfig whose apiKey/baseURL/temperature/maxTokens are honoured too.
     const llmConfig: LLMConfig | undefined = typeof config.llm === 'object' && config.llm !== null ? config.llm : undefined;
     const llmName = typeof config.llm === 'string' ? config.llm : llmConfig?.model;
-    this.llm = config.model || llmName || getEnv('OPENAI_MODEL_NAME') || getEnv('PRAISONAI_MODEL') || 'gpt-4o-mini';
+    // Python parity (`Agent._resolve_default_model`): an unnamed model is
+    // resolved from whichever provider credential is actually present, so a
+    // user holding only ANTHROPIC_API_KEY gets a Claude model rather than an
+    // OpenAI default that cannot authenticate.
+    this.llm = config.model || llmName || resolveDefaultModel();
     this._llmExplicit = config.model !== undefined || config.llm !== undefined;
     if (llmConfig?.temperature !== undefined) this.defaultTemperature = llmConfig.temperature;
     this.defaultMaxTokens = llmConfig?.maxTokens;
@@ -1027,9 +1052,12 @@ export class Agent {
     if (!handoffs || handoffs.length === 0) return;
     for (const entry of handoffs) {
       // Python names the tool transfer_to_<agent>; a Handoff object keeps its own name.
+      // Both forms go through defaultHandoffToolName so a bare Agent and an
+      // explicit Handoff for the same target cannot disagree about the name
+      // the model sees.
       const h = entry instanceof Handoff
         ? entry
-        : new Handoff({ agent: entry as any, name: `transfer_to_${toolSafeName(entry.name)}` });
+        : new Handoff({ agent: entry as any });
       this.handoffs.push(h);
       const def = h.getToolDefinition();
       this.registerToolFunction(def.name, async (args: Record<string, unknown>) => this.executeHandoff(h, args));
@@ -1775,24 +1803,46 @@ export class Agent {
     return results;
   }
 
+  /**
+   * Run one turn and return the response.
+   *
+   * @param prompt - The task to run. Optional (Python parity: `start(prompt=None)`):
+   *   when omitted, the agent's own `instructions` become the task, so
+   *   `new Agent({ instructions: 'Summarise AI news' }).start()` works with no
+   *   argument. Falls back to `'Hello'` only if there are no instructions
+   *   either.
+   * @param previousResult - Prior agent output to chain into this turn.
+   * @param onToken - Token sink; defaults to stdout.
+   * @param signal - Cancels the run.
+   * @param onEvent - Structured events, for callers that need to SEE tool
+   *   activity rather than infer it from prose. Optional and additive: every
+   *   existing caller passes four arguments and gets exactly the behaviour it
+   *   had before.
+   * @param options - Per-call options (see {@link AgentChatOptions}). AgentTeam
+   *   uses this to carry a Task's `tools` and `outputJson` into the run.
+   */
   async start(
-    prompt: string,
+    prompt?: string,
     previousResult?: string,
     onToken?: (token: string) => void,
     signal?: AbortSignal,
-    /**
-     * Structured events, for callers that need to SEE tool activity rather
-     * than infer it from prose. Optional and additive: every existing caller
-     * passes four arguments and gets exactly the behaviour it had before.
-     */
     onEvent?: (event: AgentEvent) => void,
-    /**
-     * Per-call options (see {@link AgentChatOptions}). AgentTeam uses this to
-     * carry a Task's `tools` and `outputJson` into the run.
-     */
     options?: AgentChatOptions,
   ): Promise<string> {
-    return this.runTurn(prompt, previousResult, onToken, signal, onEvent, options);
+    // Python parity (execution_mixin.py: `if prompt is None: prompt =
+    // self.instructions or "Hello"`). An agent whose instructions ALREADY
+    // describe the job should not have to repeat them as a prompt.
+    return this.runTurn(this.resolveStartPrompt(prompt), previousResult, onToken, signal, onEvent, options);
+  }
+
+  /**
+   * The task for a `start()` call that named no prompt: the agent's own
+   * instructions, else `'Hello'`. An explicit prompt always wins -- including
+   * an explicit empty string, which is a caller's choice, not an omission.
+   */
+  private resolveStartPrompt(prompt?: string): string {
+    if (prompt !== undefined && prompt !== null) return prompt;
+    return this.instructions || 'Hello';
   }
 
   /**

--- a/src/praisonai-ts/src/llm/backend-resolver.ts
+++ b/src/praisonai-ts/src/llm/backend-resolver.ts
@@ -22,6 +22,7 @@ import { getEnv } from './openaiClientOptions';
 // the AI SDK itself: backend.ts defers `import('ai')` until the first call.
 import { createAISDKBackend } from './providers/ai-sdk';
 import { createProvider } from './providers';
+import { resolveDefaultModel } from './default-model';
 
 export type BackendSource = 'ai-sdk' | 'native' | 'custom' | 'legacy';
 
@@ -267,9 +268,11 @@ export function resolveBackendSync(
  * Get default model string
  */
 export function getDefaultModel(): string {
-  return getEnv('OPENAI_MODEL_NAME') || 
-         getEnv('PRAISONAI_MODEL') || 
-         'openai/gpt-4o-mini';
+  // Delegates to the shared provider walk so this and `new Agent({})` cannot
+  // disagree about what "the default model" is (Python parity:
+  // `Agent._resolve_default_model`). The bare `gpt-4o-mini` fallback parses to
+  // the openai provider, exactly as the old `openai/gpt-4o-mini` did.
+  return resolveDefaultModel();
 }
 
 // Re-export types

--- a/src/praisonai-ts/src/llm/default-model.ts
+++ b/src/praisonai-ts/src/llm/default-model.ts
@@ -1,0 +1,60 @@
+/**
+ * Provider-aware default model resolution.
+ *
+ * Python parity: `Agent._PROVIDER_DEFAULT_MODELS` / `Agent._resolve_default_model`
+ * (src/praisonai-agents/praisonaiagents/agent/agent.py).
+ *
+ * A hardcoded `gpt-4o-mini` default is only correct for a user who has an
+ * OpenAI key. A user whose only credential is `ANTHROPIC_API_KEY` used to get
+ * an OpenAI model that could not authenticate -- a default that cannot work.
+ * The walk below picks a model matching whichever credential is actually
+ * present, exactly as the Python SDK does.
+ */
+
+import { getEnv } from './openaiClientOptions';
+
+/**
+ * Ordered `[credential env var, provider-appropriate default model]` pairs.
+ * The first provider whose credential is present wins. OpenAI is first so
+ * existing OpenAI users keep their default; any other single configured
+ * provider yields a matching default instead of a failing OpenAI one.
+ *
+ * Byte-identical to Python's `Agent._PROVIDER_DEFAULT_MODELS`, so the two SDKs
+ * pick the same model from the same environment.
+ */
+export const PROVIDER_DEFAULT_MODELS: ReadonlyArray<readonly [string, string]> = [
+  ['OPENAI_API_KEY', 'gpt-4o-mini'],
+  ['ANTHROPIC_API_KEY', 'anthropic/claude-3-5-sonnet-latest'],
+  ['GEMINI_API_KEY', 'gemini/gemini-1.5-flash'],
+  ['GOOGLE_API_KEY', 'google/gemini-1.5-flash'],
+  ['GROQ_API_KEY', 'groq/llama-3.3-70b-versatile'],
+  ['COHERE_API_KEY', 'cohere/command-r'],
+  ['OLLAMA_HOST', 'ollama/llama3.2'],
+] as const;
+
+/** The final fallback when no credential at all is configured. */
+export const FALLBACK_DEFAULT_MODEL = 'gpt-4o-mini';
+
+/**
+ * Resolve the default model for an agent that named none.
+ *
+ * Precedence (Python parity, plus the TypeScript-only `PRAISONAI_MODEL`):
+ * `OPENAI_MODEL_NAME` > `PRAISONAI_MODEL` > first provider whose credential
+ * env var is set > `gpt-4o-mini`.
+ *
+ * Unlike Python this is not memoised: reading the environment on every call
+ * keeps a `process.env` change (a test, a CLI that loads `.env` late) honest.
+ *
+ * @returns A model string, provider-prefixed unless it is an OpenAI model.
+ * @example
+ * // Only ANTHROPIC_API_KEY set:
+ * resolveDefaultModel(); // 'anthropic/claude-3-5-sonnet-latest'
+ */
+export function resolveDefaultModel(): string {
+  const explicit = getEnv('OPENAI_MODEL_NAME') || getEnv('PRAISONAI_MODEL');
+  if (explicit) return explicit;
+  for (const [keyVar, model] of PROVIDER_DEFAULT_MODELS) {
+    if (getEnv(keyVar)) return model;
+  }
+  return FALLBACK_DEFAULT_MODEL;
+}

--- a/src/praisonai-ts/src/tools/decorator.ts
+++ b/src/praisonai-ts/src/tools/decorator.ts
@@ -212,7 +212,11 @@ export class FunctionTool<TParams = any, TResult = any> {
 
   constructor(config: ToolConfig<TParams, TResult>) {
     this.name = config.name;
-    this.description = config.description || `Function ${config.name}`;
+    // Python parity (`FunctionTool.__init__`: `description or func.__doc__ or
+    // f"Tool: {self.name}"`). The fallback is not internal text -- it ships in
+    // the tool schema the model reads, so a different wording is a different
+    // prompt.
+    this.description = config.description || `Tool: ${config.name}`;
     this.parameters = this.normalizeParameters(config.parameters);
     this.category = config.category;
     this.executeFn = config.execute;

--- a/src/praisonai-ts/tests/integration/parity-features.test.ts
+++ b/src/praisonai-ts/tests/integration/parity-features.test.ts
@@ -159,13 +159,19 @@ describe('Parity Features Integration Tests', () => {
   // P1: KNOWLEDGE / SESSION / CHUNKING
   // =========================================================================
   describe('P1: Knowledge, Session, Chunking', () => {
-    test('Knowledge - add then search (text fallback without embeddings)', async () => {
+    test('Knowledge - store then search (Python knowledge.py surface)', async () => {
+      // `Knowledge` is the store class ported from praisonaiagents/knowledge/knowledge.py:
+      // text goes in through store(), files through add(), and search() returns a
+      // SearchResult envelope rather than a bare array.
       const kb = new Knowledge();
-      await kb.add({ id: 'doc-1', content: 'test source' });
-      const results = await kb.search('test');
-      expect(results).toHaveLength(1);
-      expect(results[0].document.id).toBe('doc-1');
-      expect(await kb.search('unrelated')).toHaveLength(0);
+      const added = await kb.store('test source', { userId: 'u1' });
+      expect(added.success).toBe(true);
+      const found = await kb.search('test', { userId: 'u1' });
+      expect(found.query).toBe('test');
+      expect(found.results.map((r) => r.text)).toContain('test source');
+      // Control: a query that matches nothing returns the same envelope, empty.
+      const empty = await kb.search('unrelated-xyzzy', { userId: 'u1' });
+      expect(empty.results).toHaveLength(0);
     });
 
     test('Session - state and message management', () => {

--- a/src/praisonai-ts/tests/unit/agent/parity-agent.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/parity-agent.test.ts
@@ -206,11 +206,13 @@ describe('Agent.__init__ parity: wired options', () => {
     const main = new Agent({ instructions: 'triage', handoffs: [specialist, custom], ...quiet });
 
     const toolNames = (main as any).tools.map((t: any) => t.function.name);
-    expect(toolNames).toEqual(expect.arrayContaining(['transfer_to_Billing_Agent', 'custom_handoff']));
+    // Python parity (`Handoff.default_tool_name`): lower-cased, spaces to
+    // underscores -- `transfer_to_billing_agent`, not `transfer_to_Billing_Agent`.
+    expect(toolNames).toEqual(expect.arrayContaining(['transfer_to_billing_agent', 'custom_handoff']));
     expect(main.handoffs).toHaveLength(2);
     expect((main as any).createSystemPrompt()).toContain('Billing Agent');
 
-    const reply = await (main as any).toolFunctions.transfer_to_Billing_Agent({ reason: 'refund question' });
+    const reply = await (main as any).toolFunctions.transfer_to_billing_agent({ reason: 'refund question' });
     expect(reply).toBe('billing reply');
     expect(spy).toHaveBeenCalledWith('refund question');
   });

--- a/src/praisonai-ts/tests/unit/agent/parity-waiver-gaps.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/parity-waiver-gaps.test.ts
@@ -200,6 +200,16 @@ describe('default handoff tool name (Python: transfer_to_<snake_case agent>)', (
     }
   });
 
+  it('caps a very long name at the provider 64-char limit', () => {
+    // Python does not truncate, so a name over 52 chars yields a
+    // `transfer_to_...` string the API rejects; we cap it and stay legal.
+    const longName = 'A'.repeat(80);
+    const toolName = defaultHandoffToolName(longName);
+    expect(toolName.length).toBeLessThanOrEqual(64);
+    expect(toolName).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    expect(toolName).not.toMatch(/_$/);
+  });
+
   it('a Handoff object and a bare Agent produce the same tool name', () => {
     const target = new Agent({ name: 'Support Bot', instructions: 'help', ...quiet });
 

--- a/src/praisonai-ts/tests/unit/agent/parity-waiver-gaps.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/parity-waiver-gaps.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Behavioural parity for four signature-parity waivers that were validated by
+ * running both SDKs rather than by reading the waiver text.
+ *
+ * Each block pairs the fixed behaviour with a control proving the explicit
+ * form still wins, so a future "simplification" cannot quietly restore the gap.
+ */
+process.env.PRAISONAI_PARITY_SILENT = '1';
+
+import { Agent } from '../../../src/agent/simple';
+import { Handoff, defaultHandoffToolName, defaultHandoffToolDescription } from '../../../src/agent/handoff';
+import { resolveDefaultModel } from '../../../src/llm/default-model';
+
+// Recording double for the OpenAI-compatible service. `mock*` prefix: jest
+// allows it inside the hoisted factory.
+const mockLlm = {
+  calls: [] as Array<{ method: string; args: any[] }>,
+  instances: [] as Array<{ model: string; opts: any }>,
+};
+
+jest.mock('../../../src/llm/openai', () => ({
+  OpenAIService: jest.fn().mockImplementation((model: string, opts: any) => {
+    mockLlm.instances.push({ model, opts });
+    return {
+      model,
+      generateText: jest.fn(async (...args: any[]) => {
+        mockLlm.calls.push({ method: 'generateText', args });
+        return 'text-response';
+      }),
+      generateChat: jest.fn(async (...args: any[]) => {
+        mockLlm.calls.push({ method: 'generateChat', args });
+        return { content: 'chat-response', role: 'assistant' };
+      }),
+      streamChat: jest.fn(async () => 'streamed'),
+      streamChatWithTools: jest.fn(async (...args: any[]) => {
+        mockLlm.calls.push({ method: 'streamChatWithTools', args });
+        return { content: 'stream-tools-response', role: 'assistant' };
+      }),
+    };
+  }),
+}));
+
+const quiet = { verbose: false, stream: false } as const;
+
+/** The user prompt a recorded call carried. */
+const promptOf = (call: { method: string; args: any[] }): string => {
+  if (call.method === 'generateText') return call.args[0];
+  const messages = call.args[0];
+  return messages[messages.length - 1].content;
+};
+
+beforeEach(() => {
+  mockLlm.calls = [];
+  mockLlm.instances = [];
+});
+
+// ---------------------------------------------------------------------------
+// Waiver: Agent.start.prompt
+// ---------------------------------------------------------------------------
+
+describe('Agent.start() without a prompt (Python: prompt=None -> instructions)', () => {
+  it('sends the instructions as the task when no prompt is given', async () => {
+    const agent = new Agent({ instructions: 'You are terse', ...quiet });
+
+    await agent.start();
+
+    expect(mockLlm.calls).toHaveLength(1);
+    expect(promptOf(mockLlm.calls[0])).toBe('You are terse');
+  });
+
+  it('control: an explicit prompt still wins over the instructions', async () => {
+    const agent = new Agent({ instructions: 'You are terse', ...quiet });
+
+    await agent.start('What is 2+2?');
+
+    expect(promptOf(mockLlm.calls[0])).toBe('What is 2+2?');
+  });
+
+  it('control: an explicit empty string is a choice, not an omission', async () => {
+    const agent = new Agent({ instructions: 'You are terse', ...quiet });
+
+    await agent.start('');
+
+    expect(promptOf(mockLlm.calls[0])).toBe('');
+  });
+
+  it('falls back to "Hello" when the agent has no instructions either', async () => {
+    // role-only agents get generated instructions, so drive the fallback by
+    // emptying them the way Python's `self.instructions or "Hello"` does.
+    const agent = new Agent({ instructions: 'x', ...quiet });
+    (agent as any).instructions = '';
+
+    await agent.start();
+
+    expect(promptOf(mockLlm.calls[0])).toBe('Hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Waiver: Agent.__init__.model
+// ---------------------------------------------------------------------------
+
+describe('default model follows the available credential (Python: _resolve_default_model)', () => {
+  const saved: Record<string, string | undefined> = {};
+  const VARS = [
+    'OPENAI_MODEL_NAME', 'PRAISONAI_MODEL', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY',
+    'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'GROQ_API_KEY', 'COHERE_API_KEY', 'OLLAMA_HOST',
+  ];
+
+  beforeEach(() => {
+    for (const v of VARS) { saved[v] = process.env[v]; delete process.env[v]; }
+  });
+  afterEach(() => {
+    for (const v of VARS) {
+      if (saved[v] === undefined) delete process.env[v];
+      else process.env[v] = saved[v];
+    }
+  });
+
+  it('an Anthropic-only environment gets an Anthropic model, not gpt-4o-mini', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+
+    expect(resolveDefaultModel()).toBe('anthropic/claude-3-5-sonnet-latest');
+    expect((new Agent({ instructions: 'x', ...quiet }) as any).llm).toBe('anthropic/claude-3-5-sonnet-latest');
+  });
+
+  it('control: an OpenAI-only environment is unchanged', () => {
+    process.env.OPENAI_API_KEY = 'sk-test';
+
+    expect(resolveDefaultModel()).toBe('gpt-4o-mini');
+    expect((new Agent({ instructions: 'x', ...quiet }) as any).llm).toBe('gpt-4o-mini');
+  });
+
+  it('control: OpenAI wins when several credentials are present', () => {
+    process.env.OPENAI_API_KEY = 'sk-test';
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+
+    expect(resolveDefaultModel()).toBe('gpt-4o-mini');
+  });
+
+  it('control: an explicit model or llm still wins over the walk', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+
+    expect((new Agent({ instructions: 'x', model: 'gpt-4o', ...quiet }) as any).llm).toBe('gpt-4o');
+    expect((new Agent({ instructions: 'x', llm: 'groq/llama-3.1-8b', ...quiet }) as any).llm).toBe('groq/llama-3.1-8b');
+  });
+
+  it('control: OPENAI_MODEL_NAME still overrides every credential', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+    process.env.OPENAI_MODEL_NAME = 'my-proxy-model';
+
+    expect(resolveDefaultModel()).toBe('my-proxy-model');
+  });
+
+  it('no credential at all still falls back to gpt-4o-mini', () => {
+    expect(resolveDefaultModel()).toBe('gpt-4o-mini');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Waiver: Agent.__init__.caching -- confirmed cosmetic, pinned so it stays so.
+// ---------------------------------------------------------------------------
+
+describe('caching default (Python: Agent.cache is set but never read)', () => {
+  it('does not serve a second identical prompt from cache by default', async () => {
+    const agent = new Agent({ instructions: 'x', ...quiet });
+
+    await agent.chat('same question');
+    await agent.chat('same question');
+
+    // Python reaches the model both times; so must TypeScript.
+    expect(mockLlm.calls).toHaveLength(2);
+  });
+
+  it('control: opting in to cache=true does serve the second call from cache', async () => {
+    const agent = new Agent({ instructions: 'x', cache: true, ...quiet });
+
+    await agent.chat('same question');
+    await agent.chat('same question');
+
+    expect(mockLlm.calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Waiver: Handoff.__init__.tool_name_override -- was NOT cosmetic.
+// ---------------------------------------------------------------------------
+
+describe('default handoff tool name (Python: transfer_to_<snake_case agent>)', () => {
+  it('lower-cases and underscores the agent name, as Python does', () => {
+    expect(defaultHandoffToolName('Support Bot')).toBe('transfer_to_support_bot');
+    expect(defaultHandoffToolName('Billing Agent')).toBe('transfer_to_billing_agent');
+  });
+
+  it('never emits a name the provider would reject', () => {
+    // ^[a-zA-Z0-9_-]{1,64}$ is the OpenAI tool-name rule; the old
+    // `handoff_to_${agent.name}` form let a space through.
+    for (const raw of ['Support Bot', 'Ops/Tier 2', 'r&d team', '   ']) {
+      expect(defaultHandoffToolName(raw)).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    }
+  });
+
+  it('a Handoff object and a bare Agent produce the same tool name', () => {
+    const target = new Agent({ name: 'Support Bot', instructions: 'help', ...quiet });
+
+    const viaHandoff = new Handoff({ agent: target as any }).name;
+    const viaBareAgent = new Agent({ instructions: 'main', handoffs: [target], ...quiet });
+
+    expect(viaHandoff).toBe('transfer_to_support_bot');
+    expect((viaBareAgent as any).handoffs[0].name).toBe('transfer_to_support_bot');
+  });
+
+  it('control: an explicit name override still wins', () => {
+    const target = new Agent({ name: 'Support Bot', instructions: 'help', ...quiet });
+
+    expect(new Handoff({ agent: target as any, name: 'my_tool' }).name).toBe('my_tool');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Waiver: Handoff.__init__.tool_description_override + Agent.__init__.role
+// ---------------------------------------------------------------------------
+
+describe('default handoff tool description (Python: Transfer task to <name> (<role>) - <goal>)', () => {
+  it('carries the target role and goal, as Python does', () => {
+    const target = new Agent({ name: 'Support Bot', role: 'Assistant', goal: 'Help users', ...quiet });
+
+    expect(new Handoff({ agent: target as any }).description)
+      .toBe('Transfer task to Support Bot (Assistant) - Help users');
+  });
+
+  it('omits the parenthesised parts an agent does not have', () => {
+    expect(defaultHandoffToolDescription({ name: 'Bot' })).toBe('Transfer task to Bot');
+    expect(defaultHandoffToolDescription({ name: 'Bot', role: 'Triager' }))
+      .toBe('Transfer task to Bot (Triager)');
+  });
+
+  it('control: an explicit description override still wins', () => {
+    const target = new Agent({ name: 'Support Bot', role: 'Assistant', ...quiet });
+
+    expect(new Handoff({ agent: target as any, description: 'Escalate' }).description).toBe('Escalate');
+  });
+});
+
+describe('Agent role/goal/backstory read back (Python: always materialised)', () => {
+  it('an instruction-only agent reports Python\'s defaults', () => {
+    const agent = new Agent({ instructions: 'Summarise AI news', ...quiet });
+
+    expect(agent.role).toBe('Assistant');
+    expect(agent.goal).toBe('Summarise AI news');
+    expect(agent.backstory).toBe('Summarise AI news');
+  });
+
+  it('an agent with neither instructions nor goal reports Python\'s other defaults', () => {
+    const agent = new Agent({ name: 'Bare', ...quiet });
+
+    expect(agent.role).toBe('Assistant');
+    expect(agent.goal).toBe('Help the user with their tasks');
+    expect(agent.backstory).toBe('I am an AI assistant');
+  });
+
+  it('control: explicit values are kept verbatim and still shape the instructions', () => {
+    const agent = new Agent({ role: 'Analyst', goal: 'Find trends', backstory: 'Ex-quant', ...quiet });
+
+    expect(agent.role).toBe('Analyst');
+    expect(agent.goal).toBe('Find trends');
+    expect(agent.backstory).toBe('Ex-quant');
+    expect(agent.getInstructions()).toContain('You are a Analyst.');
+  });
+});

--- a/src/praisonai-ts/tests/unit/llm/backend-resolver-sync.test.ts
+++ b/src/praisonai-ts/tests/unit/llm/backend-resolver-sync.test.ts
@@ -48,8 +48,26 @@ class StubProvider implements LLMProvider {
 }
 
 describe('resolveBackendSync', () => {
+  // Provider constructors require a key (AnthropicProvider throws
+  // 'ANTHROPIC_API_KEY is required'), so these tests passed only on a machine
+  // that happened to have one exported and failed in CI. Resolution is what is
+  // under test, not authentication: pin placeholder keys and restore them.
+  const KEY_VARS = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_API_KEY'] as const;
+  const savedKeys: Record<string, string | undefined> = {};
+
   beforeEach(() => {
+    for (const name of KEY_VARS) {
+      savedKeys[name] = process.env[name];
+      process.env[name] = `test-${name.toLowerCase()}`;
+    }
     resetAISDKAvailabilityCache();
+  });
+
+  afterEach(() => {
+    for (const name of KEY_VARS) {
+      if (savedKeys[name] === undefined) delete process.env[name];
+      else process.env[name] = savedKeys[name] as string;
+    }
   });
 
   it('resolves a built-in native provider when the native backend is requested', () => {

--- a/src/praisonai-ts/tests/unit/tools/tool-decorator.test.ts
+++ b/src/praisonai-ts/tests/unit/tools/tool-decorator.test.ts
@@ -31,7 +31,8 @@ describe('Tool Decorator', () => {
         name: 'test',
         execute: async () => 'result',
       });
-      expect(myTool.description).toBe('Function test');
+      // Python parity: `FunctionTool` falls back to `Tool: <name>`.
+      expect(myTool.description).toBe('Tool: test');
     });
 
     it('should support category', () => {

--- a/src/praisonai/praisonai/_dev/parity/signatures/compare.py
+++ b/src/praisonai/praisonai/_dev/parity/signatures/compare.py
@@ -93,14 +93,24 @@ class Rules:
     aliases: Dict[str, Dict[str, str]] = field(default_factory=dict)
     flattened: Dict[str, Dict[str, List[str]]] = field(default_factory=dict)
     default_equivalences: List[Tuple[Any, Any]] = field(default_factory=list)
+    #: ``(python expression text, typescript token)`` pairs. Separate from
+    #: ``default_equivalences`` because a Python *expression* default (a module
+    #: sentinel such as ``_UNSET``) is not a literal and must not be compared
+    #: against literals of the same spelling.
+    default_expr_equivalences: List[Tuple[str, Any]] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'Rules':
         data = data or {}
         equivalences = []
+        expr_equivalences = []
         for item in data.get('default_equivalences') or []:
-            equivalences.append((item.get('python'), item.get('typescript')))
+            if 'python_expr' in item:
+                expr_equivalences.append((item['python_expr'], item.get('typescript')))
+            else:
+                equivalences.append((item.get('python'), item.get('typescript')))
         return cls(
+            default_expr_equivalences=expr_equivalences,
             case=data.get('case', 'snake_to_camel'),
             aliases={k: dict(v or {}) for k, v in (data.get('aliases') or {}).items()},
             flattened={k: {p: list(f) for p, f in (v or {}).items()}
@@ -275,6 +285,13 @@ def defaults_equivalent(py: Param, ts: Param, rules: Rules) -> bool:
             return True
     for py_eq, ts_eq in rules.default_equivalences:
         if py.default_kind == 'literal' and py_value == py_eq and type(py_value) is type(py_eq):
+            if ts_token == ts_eq and type(ts_token) is type(ts_eq):
+                return True
+    # A Python module-level sentinel (``_UNSET``) and TypeScript's `undefined`
+    # are the same "the caller passed nothing" marker; only the spelling of the
+    # sentinel differs, so the two sides resolve identically.
+    for py_expr, ts_eq in rules.default_expr_equivalences:
+        if py.default_kind == 'expr' and py_value == py_expr:
             if ts_token == ts_eq and type(ts_token) is type(ts_eq):
                 return True
     return False

--- a/src/praisonai/praisonai/_dev/parity/signatures/rules.yaml
+++ b/src/praisonai/praisonai/_dev/parity/signatures/rules.yaml
@@ -53,3 +53,7 @@ default_equivalences:
   - {python: 0.0, typescript: 0}
   - {python: true, typescript: true}
   - {python: false, typescript: false}
+  # A Python module-level "not passed" sentinel is TypeScript's `undefined`.
+  # Both sides then resolve the same value and emit the same deprecation
+  # notice; only the spelling of the sentinel differs.
+  - {python_expr: _UNSET, typescript: undefined}

--- a/src/praisonai/praisonai/_dev/parity/signatures/surface.yaml
+++ b/src/praisonai/praisonai/_dev/parity/signatures/surface.yaml
@@ -79,6 +79,12 @@ surfaces:
     python: {file: errors.py, class: PraisonAIError, function: __init__}
     typescript: {file: errors-base.ts, kind: interface, name: PraisonAIErrorOptions, ctorClass: PraisonAIError}
 
-  # TODO: FileTracker.__init__ and Knowledge.__init__ take positional constructor
-  # parameters with no options interface; add them once ts_extract can address a
-  # bare `constructor` under `kind: method`.
+  # Constructors with plain positional parameters and no options interface are
+  # addressed as `kind: method, name: constructor` plus the owning class.
+  - key: FileTracker.__init__
+    python: {file: knowledge/indexing.py, class: FileTracker, function: __init__}
+    typescript: {file: knowledge/indexing.ts, kind: method, name: constructor, cls: FileTracker}
+
+  - key: Knowledge.__init__
+    python: {file: knowledge/knowledge.py, class: Knowledge, function: __init__}
+    typescript: {file: knowledge/knowledge.ts, kind: method, name: constructor, cls: Knowledge}

--- a/src/praisonai/praisonai/_dev/parity/signatures/ts_extract.mjs
+++ b/src/praisonai/praisonai/_dev/parity/signatures/ts_extract.mjs
@@ -355,12 +355,38 @@ function extractInterface(ts, sf, target, location) {
   };
 }
 
+// `name: constructor` addresses a class's constructor declaration, which has no
+// `name` node of its own. Used for ported classes whose constructor takes plain
+// positional parameters and no options interface (e.g. `constructor(stateFile:
+// string | null = null)`), so they are checked like any other method.
+const CONSTRUCTOR_NAME = 'constructor';
+
 function extractMethod(ts, sf, target, location) {
+  const wantsCtor = target.name === CONSTRUCTOR_NAME;
   const matches = findAll(ts, sf, (n) =>
-    (ts.isMethodDeclaration(n) || ts.isFunctionDeclaration(n)) && n.name && n.name.getText(sf) === target.name
-      && (!target.cls || enclosingClassName(ts, n) === target.cls));
-  const decl = matches[0];
+    wantsCtor
+      ? ts.isConstructorDeclaration(n) && (!target.cls || enclosingClassName(ts, n) === target.cls)
+      : (ts.isMethodDeclaration(n) || ts.isFunctionDeclaration(n)) && n.name && n.name.getText(sf) === target.name
+        && (!target.cls || enclosingClassName(ts, n) === target.cls));
+  // For a constructor the implementation is the real signature: TypeScript forbids
+  // parameter initializers on overload signatures, so a bodyless match would report
+  // every parameter as having no default. Named methods keep the long-standing
+  // first-match rule: their leading overload is the documented public signature
+  // (AgentTeam.start declares `options?: AgentTeamStartOptions` there and widens to
+  // a union type alias in the implementation, which has no interface to flatten).
+  const decl = wantsCtor ? (matches.find((m) => m.body) || matches[0]) : matches[0];
   if (!decl) {
+    if (wantsCtor) {
+      if (target.cls
+        && !findAll(ts, sf, (n) => ts.isClassDeclaration(n) && n.name && n.name.text === target.cls)[0]) {
+        return { error: `${target.surface}: class ${target.cls} not found in ${target.file}` };
+      }
+      return {
+        error: target.cls
+          ? `${target.surface}: class ${target.cls} declares no constructor in ${target.file}`
+          : `${target.surface}: no class in ${target.file} declares a constructor`,
+      };
+    }
     const where = target.cls ? `${target.cls}.${target.name}` : target.name;
     return { error: `${target.surface}: method ${where} not found in ${target.file}` };
   }

--- a/src/praisonai/praisonai/_dev/parity/signatures/waivers.yaml
+++ b/src/praisonai/praisonai/_dev/parity/signatures/waivers.yaml
@@ -4,68 +4,164 @@
 # Optional: issue, expires (ISO date; an expired waiver FAILS the check).
 # A waiver whose gap no longer exists is stale and FAILS the check: delete it.
 # Regenerate missing entries with: python -m praisonai._dev.parity.signatures --baseline
+#
+# Every reason below was validated by RUNNING both SDKs, not by reading the
+# other side's source. A reason that says "Python resolves the same in the
+# body" means someone constructed both objects and compared the results.
 
 waivers:
+  Agent.__init__.backstory:
+    owner: praisonai-ts
+    reason: >-
+      Same value, resolved at a different moment. TS stores
+      `config.backstory || config.instructions` (or "I am an AI assistant") in
+      the constructor; Python's `self.backstory = backstory or instructions`
+      (agent.py) produces the identical string in the body. Verified equal for
+      the instruction-only, role-only and bare forms.
   Agent.__init__.caching:
     owner: praisonai-ts
-    reason: TS cache is a boolean defaulting to false; Python None resolves a caching preset
+    reason: >-
+      Both SDKs default to NO caching, by different routes. Python's
+      `caching=None` resolves to `CachingConfig(enabled=True)` and assigns
+      `self.cache = True`, but `Agent.cache` is written and never read anywhere
+      in praisonaiagents, so the default caches nothing; TS defaults
+      `cache` to false, which its response cache honours. Aligning the literal
+      would turn caching ON in TS and diverge from Python's observable
+      behaviour, so the difference is deliberate. Pinned by
+      tests/unit/agent/parity-waiver-gaps.test.ts ("caching default").
+  Agent.__init__.goal:
+    owner: praisonai-ts
+    reason: >-
+      Same value, resolved at a different moment. TS stores
+      `config.goal || config.instructions` (or "Help the user with their
+      tasks") in the constructor; Python's `self.goal = goal or instructions`
+      (agent.py) produces the identical string in the body.
   Agent.__init__.model:
     owner: praisonai-ts
-    reason: TS resolves the model from env then gpt-4o-mini; Python resolves per available credential
+    reason: >-
+      Same resolution, run eagerly. TS now calls `resolveDefaultModel()`
+      (src/llm/default-model.ts), a byte-for-byte port of Python's
+      `Agent._PROVIDER_DEFAULT_MODELS` / `_resolve_default_model`, so the same
+      environment yields the same model on both sides. What still differs is
+      only the moment: TS resolves in the constructor, Python inside the body,
+      and TS additionally honours `PRAISONAI_MODEL` (a TypeScript-only alias).
   Agent.__init__.name:
     owner: praisonai-ts
-    reason: TS generates a unique Agent_<id> name; Python defaults to "Agent"
+    reason: >-
+      TS generates `Agent_<random>`; Python leaves `name` None for an
+      instruction-only agent and uses "Agent" otherwise. Neither is a stable
+      contract (every unnamed Python agent collides on "Agent", and
+      `Handoff` on a None-named Python agent raises AttributeError), and TS
+      exposes no name-keyed lookup like Python's
+      `AgentTeam.get_agent_details`. The one place the random name used to
+      reach the model -- the handoff tool name -- is now sanitised by
+      `defaultHandoffToolName`.
   Agent.__init__.role:
     owner: praisonai-ts
-    reason: TS folds role/goal/backstory into instructions; role falls back to goal or backstory text
-  Agent.start.prompt:
-    owner: praisonai-ts
-    reason: TS start requires a prompt; Python None falls back to the task description
+    reason: >-
+      Same value, resolved at a different moment. TS now stores
+      `config.role || 'Assistant'` in the constructor, matching Python's
+      `self.role = role or "Assistant"`, so `agent.role` reads back the same
+      string on both sides. The system-prompt TEXT built from role/goal/
+      backstory still differs between the two SDKs -- that is a separate,
+      untracked gap, not covered by this waiver.
   AgentTeam.__init__.process:
     owner: praisonai-ts
-    reason: TS treats an undefined process as sequential, the Python default
+    reason: >-
+      TS treats an undefined process as sequential, the Python default. NOTE
+      (verified, out of scope for this key): the accepted DOMAIN differs --
+      TS implements `process: "parallel"` with Promise.all, which Python
+      rejects with a ValueError, and TS validates nothing, so a typo runs
+      sequentially instead of raising.
   Handoff.__init__.tool_description_override:
     owner: praisonai-ts
-    reason: TS derives "Transfer conversation to <agent>"; Python derives the same in the body
+    reason: >-
+      Same derived string, built at a different moment.
+      `defaultHandoffToolDescription` now produces Python's
+      `Transfer task to <name> (<role>) - <goal>` exactly (it previously said
+      "Transfer conversation to <name>", which the model saw). Only the moment
+      of derivation differs.
   Handoff.__init__.tool_name_override:
     owner: praisonai-ts
-    reason: TS derives handoff_to_<agent> when unset; Python derives the same in the body
+    reason: >-
+      Same derived string, built at a different moment.
+      `defaultHandoffToolName` now produces Python's
+      `transfer_to_<lowercased, spaces-to-underscores name>` exactly (it
+      previously said `handoff_to_<raw name>`, which could contain a space and
+      be rejected by the provider). Only the moment of derivation differs.
   PraisonAIError.__init__.run_id:
     owner: praisonai-ts
-    reason: TS assigns a run id at construction; Python leaves it None and fills it when the run starts
+    reason: >-
+      Both sides mint a UUID at construction -- Python's
+      `self.run_id = run_id or str(uuid.uuid4())` (errors.py) is NOT lazy.
+      Only the declared default differs. Edge case: `runId: ''` survives TS's
+      `??` but is replaced by Python's `or`.
   Session.__init__.user_id:
     owner: praisonai-ts
-    reason: TS sets "default_user" eagerly; Python resolves the same value lazily
+    reason: >-
+      Both sides assign eagerly with the same truthiness rule -- Python's
+      `self.user_id = user_id or "default_user"` (session/api.py), TS's
+      `config.userId || 'default_user'`. Only the declared default differs.
   Task.__init__.action:
     owner: praisonai-ts
-    reason: TS action mirrors description; Python resolves the same in the body
+    reason: >-
+      TS action mirrors description; Python's `self.action = action if action
+      is not None else description` resolves the same in the body.
   Task.__init__.depends_on:
     owner: praisonai-ts
-    reason: TS dependsOn falls back to context then []; Python None means empty (same as the waived context alias)
+    reason: >-
+      TS dependsOn falls back to context then []; Python's `if depends_on is
+      not None` gives dependsOn the same precedence, including an explicit
+      empty list. TS additionally exposes no `dependsOn` read-back property
+      (Python's returns `context`).
   Task.__init__.description:
     owner: praisonai-ts
-    reason: TS description falls back to action at construction; Python resolves the same in the body
+    reason: >-
+      TS description falls back to action at construction; Python's
+      `if action is not None and description is None: description = action`
+      resolves the same in the body. TS stores '' where Python stores None for
+      a handler-only task; both are falsy and no branch differs.
   Task.__init__.expected_output:
     owner: praisonai-ts
-    reason: TS fills "Complete the task successfully" at construction; Python does so lazily
+    reason: >-
+      Both sides fill "Complete the task successfully" eagerly in __init__ --
+      Python's `expected_output if expected_output is not None else ...` is NOT
+      lazy. Only the declared default differs.
   Task.__init__.guardrails:
     owner: praisonai-ts
-    reason: TS guardrails falls back to guardrail; Python resolves the same precedence in the body
+    reason: >-
+      Identical precedence: the plural wins over the singular on both sides
+      (Python `guardrails if guardrails is not None else guardrail`). TS omits
+      Python's DeprecationWarning for the singular spelling and additionally
+      exposes a `guardrails` read-back property Python lacks.
   Task.__init__.id:
     owner: praisonai-ts
-    reason: TS assigns a UUID at construction; Python assigns an id lazily
+    reason: >-
+      Both sides mint a UUID at construction; Python's
+      `str(uuid.uuid4()) if id is None else str(id)` is NOT lazy. NOTE
+      (verified): an EXPLICIT id is coerced to str by Python but kept as a
+      number by TS, so `Task(id=5).id` is "5" in Python and 5 in TypeScript.
   Task.__init__.routing:
     owner: praisonai-ts
-    reason: TS routing falls back to condition; Python resolves the same in the body
+    reason: >-
+      TS routing falls back to condition, as Python does, and a plain-dict
+      routing value lands identically on both sides. NOTE (verified, wider
+      than this key): TS lists `routing` in ENGINE_LEVEL_OPTIONS, so any value
+      raises a `notYetHonoured` notice and never reaches execution, whereas
+      Python's workflow executor reads it.
   tool().description:
     owner: praisonai-ts
-    reason: TS derives a default description from the tool name; Python leaves it None and infers from the docstring
+    reason: >-
+      Same fallback string, built at a different moment. TS now derives
+      `Tool: <name>`, matching Python's
+      `description or func.__doc__ or f"Tool: {self.name}"` (it previously
+      said `Function <name>`, which shipped in the tool schema the model
+      reads). TS has no docstring to fall back to between the two.
   tool().func:
     owner: praisonai-ts
-    reason: TS execute is required; Python func is optional because @tool can be applied bare
+    reason: >-
+      TS execute is required; Python's `func` is optional only so `@tool` can
+      be applied bare, and `FunctionTool.__init__` still requires it.
   tool().name:
     owner: praisonai-ts
     reason: TS cannot infer a name from an anonymous function; Python infers it from __name__
-  tool().requires_approval:
-    owner: praisonai-ts
-    reason: Python uses an _UNSET sentinel to detect explicit use; TS uses undefined

--- a/src/praisonai/tests/unit/_dev/test_signature_parity.py
+++ b/src/praisonai/tests/unit/_dev/test_signature_parity.py
@@ -284,6 +284,50 @@ class TestDefaultsAndRequired:
         _, ev = run([sig('python', py)], [sig('typescript', ts)], waivers=[waiver(f'{SURFACE}.cache')])
         assert ev.ok
 
+    def test_python_sentinel_expr_matches_typescript_undefined(self):
+        """`_UNSET` and `undefined` are the same "caller passed nothing" marker.
+
+        Python spells the marker as a module-level object because `None` is a
+        legal value for the parameter; TypeScript has a native one. Both sides
+        then resolve the same value, so this is not a gap.
+        """
+        rules = C.Rules(
+            aliases={SURFACE: {}}, flattened={SURFACE: {}},
+            default_equivalences=[(None, 'undefined')],
+            default_expr_equivalences=[('_UNSET', 'undefined')],
+        )
+        py = [py_param('requires_approval', default='_UNSET', default_kind='expr')]
+        ts = [ts_param('requiresApproval')]  # no ctor default -> undefined
+        comps, ev = run([sig('python', py)], [sig('typescript', ts)], rules=rules)
+        assert ev.ok, ev.failures
+        assert row(comps, 'requires_approval').gap is None
+
+    def test_control_unlisted_sentinel_expr_is_still_a_mismatch(self):
+        """Only the sentinels named in rules.yaml are equivalent to undefined."""
+        rules = C.Rules(
+            aliases={SURFACE: {}}, flattened={SURFACE: {}},
+            default_equivalences=[(None, 'undefined')],
+            default_expr_equivalences=[('_UNSET', 'undefined')],
+        )
+        py = [py_param('requires_approval', default='compute_default()', default_kind='expr')]
+        ts = [ts_param('requiresApproval')]
+        comps, ev = run([sig('python', py)], [sig('typescript', ts)], rules=rules)
+        assert not ev.ok
+        assert row(comps, 'requires_approval').gap.kind == 'default'
+
+    def test_control_sentinel_expr_does_not_match_a_literal_of_the_same_spelling(self):
+        """An expression default and a string literal are different things."""
+        rules = C.Rules(
+            aliases={SURFACE: {}}, flattened={SURFACE: {}},
+            default_equivalences=[(None, 'undefined')],
+            default_expr_equivalences=[('_UNSET', 'undefined')],
+        )
+        py = [py_param('requires_approval', default='_UNSET', default_kind='literal')]
+        ts = [ts_param('requiresApproval')]
+        comps, ev = run([sig('python', py)], [sig('typescript', ts)], rules=rules)
+        assert not ev.ok
+        assert row(comps, 'requires_approval').gap.kind == 'default'
+
     def test_type_class_mismatch_is_a_warning_not_a_failure(self):
         py = [py_param('timeout', default=30, type_class='number')]
         ts = [ts_param('timeout', default=30, default_kind='literal', type_class='string')]
@@ -490,7 +534,9 @@ class TestTsExtractor:
         assert params['markdown']['type_class'] == 'boolean'
         assert params['tools']['type_class'] == 'array'
         start = {p['name']: p for p in by_key['Agent.start']['params']}
-        assert start['prompt']['required'] is True and start['prompt']['type_class'] == 'string'
+        # `prompt` is optional on both sides: Python's `start(prompt=None)`
+        # falls back to the agent's instructions, and TypeScript now does too.
+        assert start['prompt']['required'] is False and start['prompt']['type_class'] == 'string'
         assert start['onToken']['required'] is False and start['onToken']['type_class'] == 'callable'
 
     @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
@@ -660,6 +706,147 @@ export class Detector {
         assert params['config']['required'] is False
         # Control: its members are still flattened, so both spellings resolve.
         assert 'threshold' in params and params['threshold']['default'] == 3
+
+
+class TestBareConstructorAsMethod:
+    """`kind: method, name: constructor` addresses a class's constructor declaration.
+
+    Ported classes whose constructor takes plain positional parameters and no
+    options interface (FileTracker, Knowledge) are only checkable this way.
+    """
+
+    FIXTURE = """
+export interface TrackerOptions {
+  retries?: number;
+}
+export class Tracker {
+  constructor(a: string, b: number = 3) {
+    void a;
+    void b;
+  }
+  scan(target: string, deep: boolean = false): number {
+    void target;
+    return deep ? 1 : 0;
+  }
+}
+export class Configured {
+  constructor(label: string, options: TrackerOptions = {}) {
+    const r = options.retries ?? 5;
+    void label;
+    void r;
+  }
+}
+export class Bare {
+  private x = 1;
+  ping(): number { return this.x; }
+}
+export interface RunOptions {
+  deep?: boolean;
+}
+export type RunOptionsInput = RunOptions | { shallow?: boolean };
+export class Overloaded {
+  run(target?: string, options?: RunOptions): number;
+  run(target?: string, options?: RunOptionsInput): number {
+    void target;
+    void options;
+    return 1;
+  }
+}
+"""
+
+    @staticmethod
+    def _fake_repo(tmp_path):
+        src = tmp_path / 'src' / 'praisonai-ts' / 'src'
+        src.mkdir(parents=True)
+        (src / 'tracker.ts').write_text(TestBareConstructorAsMethod.FIXTURE)
+        return tmp_path
+
+    @staticmethod
+    def _target(surface, name, cls):
+        return {'surface': surface, 'file': 'tracker.ts', 'kind': 'method', 'name': name, 'cls': cls}
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_constructor_params_are_reported_with_defaults_and_requiredness(self, tmp_path):
+        repo = self._fake_repo(tmp_path)
+        items = C.run_ts_extractor(repo, [self._target('Tracker.__init__', 'constructor', 'Tracker')])
+        assert [p['name'] for p in items[0]['params']] == ['a', 'b']
+        params = {p['name']: p for p in items[0]['params']}
+        assert params['a']['required'] is True
+        assert params['a']['default'] is None and params['a']['default_kind'] is None
+        assert params['a']['kind'] == 'positional' and params['a']['type_class'] == 'string'
+        assert params['b']['required'] is False
+        assert params['b']['default'] == 3 and params['b']['default_kind'] == 'literal'
+        assert params['b']['type_class'] == 'number'
+        assert items[0]['extra']['resolved_class'] == 'Tracker'
+        assert items[0]['location'].endswith('/tracker.ts:6')  # the constructor line
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_constructor_options_object_is_still_flattened(self, tmp_path):
+        """A constructor addressed this way keeps the options-interface flattening."""
+        repo = self._fake_repo(tmp_path)
+        items = C.run_ts_extractor(repo, [self._target('Configured.__init__', 'constructor', 'Configured')])
+        params = {p['name']: p for p in items[0]['params']}
+        assert set(params) == {'label', 'options', 'retries'}
+        assert params['label']['required'] is True
+        assert params['retries']['default'] == 5 and params['retries']['via'] == 'options'
+        assert items[0]['extra']['options_interfaces'] == ['options: TrackerOptions']
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_control_class_without_constructor_is_a_loud_error(self, tmp_path):
+        """Control: a missing constructor must fail the extraction, not report zero params."""
+        repo = self._fake_repo(tmp_path)
+        with pytest.raises(C.ToolingError) as excinfo:
+            C.run_ts_extractor(repo, [self._target('Bare.__init__', 'constructor', 'Bare')])
+        message = str(excinfo.value)
+        assert 'Bare.__init__' in message and 'Bare' in message and 'constructor' in message
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_control_missing_class_is_named_in_the_error(self, tmp_path):
+        repo = self._fake_repo(tmp_path)
+        with pytest.raises(C.ToolingError) as excinfo:
+            C.run_ts_extractor(repo, [self._target('Nope.__init__', 'constructor', 'Nope')])
+        assert 'class Nope not found' in str(excinfo.value)
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_control_ordinary_method_is_unchanged(self, tmp_path):
+        """Control: `kind: method` on a named method behaves exactly as before."""
+        repo = self._fake_repo(tmp_path)
+        items = C.run_ts_extractor(repo, [self._target('Tracker.scan', 'scan', 'Tracker')])
+        params = {p['name']: p for p in items[0]['params']}
+        assert [p['name'] for p in items[0]['params']] == ['target', 'deep']
+        assert params['target']['required'] is True and params['target']['type_class'] == 'string'
+        assert params['deep']['required'] is False and params['deep']['default'] is False
+        assert items[0]['extra']['resolved_class'] == 'Tracker'
+        assert 'options_interfaces' not in items[0]['extra']
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_control_overloaded_method_still_reads_its_first_overload(self, tmp_path):
+        """Control: an overloaded method keeps reporting its leading (public) signature.
+
+        This is the shape of the real `AgentTeam.start`: the documented overload
+        names an interface that flattens, while the implementation widens to a
+        union type alias with nothing to flatten. Preferring the implementation
+        would silently drop `deep` and report a false parity gap.
+        """
+        repo = self._fake_repo(tmp_path)
+        items = C.run_ts_extractor(repo, [self._target('Overloaded.run', 'run', 'Overloaded')])
+        params = {p['name']: p for p in items[0]['params']}
+        assert set(params) == {'target', 'options', 'deep'}
+        assert params['options']['type_text'] == 'RunOptions'
+        assert params['deep']['via'] == 'options'
+        assert items[0]['extra']['options_interfaces'] == ['options: RunOptions']
 
 
 class TestStalenessIgnoresLineNumbers:


### PR DESCRIPTION
> Stacked on #4784 (the CI job that runs these tests). Once that merges this PR shows only its own commit.

## Why

#4755 landed 21 signature differences as **waivers with written reasons**. A waiver is a claim, and a claim nobody re-checks is how the original tracker got to "162% parity". So each was re-validated by constructing both objects and printing the result, not by reading the reason text.

Most were what they claimed. **Four were not**, and one of those was breaking handoffs in production.

## The bug

| | Python | TypeScript (before) |
|---|---|---|
| Handoff tool name | `transfer_to_support_bot` | `handoff_to_Support Bot` |

`handoff.py:401-403` lowercases and replaces spaces. TypeScript used `handoff_to_${agent.name}` verbatim, so **any agent whose name contains a space produced a tool name with a space in it** — which fails the provider's `^[a-zA-Z0-9_-]{1,64}$` function-name rule and is rejected by the API. `simple.ts` had a third spelling of its own (`transfer_to_Support_Bot`); all three now go through one helper.

Verified by running:

```
BEFORE tool name: "handoff_to_Support Bot" | provider-valid: false
AFTER  tool name: "transfer_to_support_bot" | provider-valid: true
```

## The other three

- **`agent.start()` did not work.** Python's `start(prompt=None)` falls back to `self.instructions or "Hello"` (`execution_mixin.py:873`). TypeScript required the argument, so the documented no-argument call was a compile error. The waiver called that an accepted difference.
- **The default model ignored your credentials.** Python walks `_PROVIDER_DEFAULT_MODELS` (`agent.py:309-317`) and picks a model matching whichever key is present. TypeScript hardcoded `gpt-4o-mini`, so an Anthropic-only user got an OpenAI model that cannot authenticate. Table ported byte for byte.
- **Defaults differed in text the model reads.** `tool()` described itself as `Function search` where Python says `Tool: search`; the handoff description dropped the agent's role and goal; `role`/`goal`/`backstory` were read once and never stored, so Python's `"Assistant"` default was missing.

## Waivers deleted, kept, corrected

- **Deleted (2):** `Agent.start.prompt` and `tool().requires_approval`. The second was simply false — TypeScript already distinguishes `undefined` from `false` (`decorator.ts:174-182`); the checker now understands Python's `_UNSET` sentinel through a new `default_expr_equivalences` rule.
- **Corrected (4):** `Task.expected_output`, `Task.id`, `Session.user_id`, `PraisonAIError.run_id` all claimed Python "resolves lazily". It resolves eagerly in `__init__` with the same value. Harmless, but someone would have built on the lie.
- **Kept, for a different reason (1):** `Agent.__init__.caching`. Python's `None` does resolve to enabled — but `Agent.cache` is written and **never read anywhere** in praisonaiagents. Matching it would have switched caching on and diverged behaviour. The dead flag is documented instead.

## Checker blind spot closed

It could not address a class whose constructor takes positional parameters with no options interface, so `FileTracker` and `Knowledge` were unchecked. `kind: method, name: constructor` now resolves the constructor, preferring the implementation over an overload signature since only the implementation carries defaults. Both surfaces are clean.

**15 → 17 surfaces, 219 → 222 parameters, 0 missing.**

## Reported, not fixed

Each deserves its own review: `Task(id=5).id` is `"5"` in Python and `5` in TypeScript; TypeScript lists `routing` as engine-level so it announces itself and never runs; TypeScript accepts any `process` string where Python raises, and implements `"parallel"`, which Python rejects; the system prompt built from role/goal/backstory still differs word for word.

## Verification

Run with **no credentials in the environment**, the way CI runs:

```
npx tsc --noEmit -p .                                  # clean
npm test                                               # 2,184 passed, 0 failed
pytest tests/unit/_dev/                                # 132 passed
python -m praisonai._dev.parity.signatures --check     # OK
generate_parity_tracker.py --check                     # up to date
npm run build (mobile)                                 # lazy 1527.7kB of 1600kB
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent prompts are now optional, with sensible fallbacks when none is provided.
  * Agent role, goal, and backstory values are available directly.
  * Default model selection recognizes configured provider credentials and chooses an appropriate model.
  * Handoff tool names are normalized and capped for provider compatibility.

* **Improvements**
  * Handoff and unnamed tool descriptions now use clearer default text.
  * Knowledge searches return structured results with query and result details.
  * TypeScript and Python SDK behavior is more closely aligned across agents, tools, and handoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->