### PR TITLE
docs(agents): add local-model-layer implementation ledger

### DIFF
--- a/src/praisonai-agents/AGENTS.md
+++ b/src/praisonai-agents/AGENTS.md
@@ -2,6 +2,13 @@
 
 > **For AI Agents and Developers**: This document provides the complete context needed to work with the PraisonAI ecosystem, including design principles, architecture, repository structure, and implementation guidelines.
 
+> **Active workstream — local model runtimes.** If your task touches local inference
+> (Ollama, LM Studio, llama.cpp, vLLM, MLX, `transformers serve`), provider detection,
+> `llm/adapters/`, or the `praisonaiagents/local/` package, read
+> [`docs/local-model-layer/README.md`](docs/local-model-layer/README.md) **before editing**.
+> It carries the measured ground truth, the invariants, and a file-ownership table that
+> prevents concurrent work orders from corrupting each other.
+
 ---
 
 ## 1. What is PraisonAI?

--- a/src/praisonai-agents/docs/local-model-layer/00-ground-truth.md
+++ b/src/praisonai-agents/docs/local-model-layer/00-ground-truth.md
@@ -292,3 +292,33 @@ Three facts follow, and they reframe the work:
   re-implements `_is_ollama_provider`, `_apply_ollama_defaults`, `_validate_tool_call`,
   `_should_force_tool_usage` and both prompt templates. It cannot fail in response to any change
   in `llm.py`. Do not treat it as a safety net.
+
+
+## 9. Test-gating facts (order 04)
+
+- **`not network`, not `provider_ollama`, is what deselects the mocked base_url suite.** The gating
+  plugin implies `network` from *any* provider marker (`test_gating.py:235-238`) and every CI
+  expression contains `not network`. Editing the workflows' `-m` strings accomplishes nothing.
+- `tests/unit/**` is **exempt** from provider auto-detection (`test_gating.py:215`,
+  `test_type != 'unit'`). That is why `tests/unit/llm/test_ollama_tool_reliability.py` runs in CI
+  while the integration file does not — and why live tests placed under `tests/unit/` need an
+  **explicit** marker.
+- `-m provider_ollama` currently selects **32 tests across 5 files**; only 7 are Ollama tests.
+- **4 of the 7 tests in `test_base_url_api_base_fix.py` fail when actually executed** —
+  `LLMResponseError: 'str' object has no attribute 'choices'`. The mock returns a dict; the
+  tool-calling loop needs an object with `.choices`.
+- **`tests/test_double_api_fix.py` makes a real network call when forced to run.** `llm.py` routes
+  `gpt-4o-mini` through `litellm.responses` (`llm.py:6434`), not `litellm.completion`, so its patch
+  no longer intercepts (verified: 401 from `api.openai.com/v1/responses`). It is currently masked
+  by an unconditional auto-skip — **anyone who "fixes" the skip without fixing the mock gets live
+  billed calls.**
+- **`network_guard.py` disables itself** for anything under `/integration/`, `/e2e/`, `/live/`
+  (lines 103-105) and for any `provider_*`-marked test (96-100). The suite's network blocker does
+  not cover the tests most likely to make network calls.
+- **A live Ollama suite already exists** and has never run:
+  `tests/integration/test_ollama_tool_calling_live.py`, 230 lines, 7 tests, gated on
+  `PRAISONAI_TEST_OLLAMA`. It is broken against `main` — all 7 pass `verbose=True` to `Agent()`,
+  and two pass `force_tool_usage=` / `max_tool_repairs=`; all three now raise `TypeError`.
+- **`qwen3:0.6b` is 522 MB** (not ~400 MB) and reports `completion, tools, thinking` — **no
+  vision**. Reliability through `Agent`: default 3/4; `force_tool_usage="always"` + `temperature=0`
+  **6/6**; multi-step arithmetic 0/2 (one hung past 90 s).

--- a/src/praisonai-agents/docs/local-model-layer/00-ground-truth.md
+++ b/src/praisonai-agents/docs/local-model-layer/00-ground-truth.md
@@ -225,8 +225,12 @@ dakera, graph, knowledge, llm, mcp, memory, mongodb, os, sandbox, search, teleme
 **none of them is local**. `import praisonaiagents` measures 0.04 s, so imports are lazy and
 cheap; discovery latency is the only startup cost to manage.
 
-**Conclusion:** `local/` should use `httpx`. It is guaranteed present, gives sync and async
-from one client with clean timeouts, and adds no dependency — satisfying I6.
+**Conclusion (superseded).** This section originally concluded `local/` should use `httpx`.
+That was reversed by the normative decision in `07-local-package-spec.md` §3: `httpx` is present
+only as an **undeclared transitive** edge (`openai -> httpx`), so building the dependency sink on
+it means a future `openai` release dropping `httpx` would silently break `local/`. The client is
+therefore stdlib `urllib.request`, and the boundary test forbids `httpx`/`requests`/`aiohttp`.
+The measurement above stands; only the recommendation drawn from it was wrong.
 
 ---
 

--- a/src/praisonai-agents/docs/local-model-layer/00-ground-truth.md
+++ b/src/praisonai-agents/docs/local-model-layer/00-ground-truth.md
@@ -1,0 +1,290 @@
+# Ground truth
+
+Every claim here was measured, not estimated. Each carries **how** it was obtained so it can
+be re-checked cheaply. Measured 2026-09-03 against `origin/main` at `2591aa405`, with a live
+Ollama 0.33.2 (`b79067b0`) on `127.0.0.1:11434`.
+
+If a work order contradicts something here, re-measure before acting. Numbers drift.
+
+> **Capabilities are per-model, not per-server.** An early draft of this file attributed the
+> 9B model's capability list to `qwen3:0.6b`. Re-verified 2026-09-03: `qwen3:0.6b` is
+> `["completion","tools","thinking"]` — **no vision**. Always name the model when quoting a
+> capability set.
+
+---
+
+## 1. Runtime facts, verified live
+
+| Fact | Value | How to re-verify |
+|---|---|---|
+| Ollama liveness probe | `GET /` returns `200` with body `Ollama is running` | `curl -sI 127.0.0.1:11434/` |
+| Ollama version probe | `{"version":"0.33.2"}` | `curl -s 127.0.0.1:11434/api/version` |
+| Capability probe works | `qwen3:0.6b` → `["completion","tools","thinking"]` (the 9B tamil model, separately, → `[...,"vision"]`) | `curl -s :11434/api/show -d '{"model":"qwen3:0.6b"}' \| jq .capabilities` |
+| Unknown `options` keys are silently dropped | `{"totally_bogus_key":123}` → HTTP 200, no warning | send it to `/api/chat`; response is a normal completion |
+| Tool-param schema keywords are stripped | `minLength`, `format`, `default`, `additionalProperties` all absent from the rendered prompt | `/api/chat` with `_debug_render_only: true` and those keys set |
+| `parameters.type` must be a bare string | `"type": ["object","null"]` → **HTTP 400** `cannot unmarshal array into Go struct field ToolFunctionParameters...type of type string` | send that tool definition to `/api/chat` |
+| **`format` + `tools` are mutually destructive** | Tool call silently suppressed; model fabricates. Same request without `format` calls the tool correctly. | see §2 below |
+
+### Installed on this machine
+
+`ollama` (0.33.2), `llama-server` (b7620, Homebrew), `mlx_lm.server`, `hf` CLI.
+**Not** installed: `lms` (LM Studio), `vllm`.
+Ports open at time of measurement: `11434` only.
+
+---
+
+## 2. The reproduction that matters most
+
+`format` (JSON schema) plus `tools`, sent to Ollama, produces a **confident fabrication** with
+an HTTP 200 and no warning. The JSON grammar makes the tool-call tag unemittable, so the
+model cannot call the tool and answers from nothing instead.
+
+```
+POST /api/chat   model=qwen3:0.6b   think=false
+prompt: "What is the weather in Paris? Use the tool."
+tools:  [get_weather(city: string)]
+
+WITH format + tools                     -> HTTP 200
+  message.tool_calls : null
+  message.content    : {"answer": "The weather in Paris is sunny with a temperature of 15C."}
+
+TOOLS ONLY (format removed)             -> HTTP 200
+  message.tool_calls : [{"function": {"name": "get_weather",
+                                      "arguments": {"city": "Paris"}}}]
+  message.content    : ""
+```
+
+Consequence for design: this combination must **raise**, not be silently repaired. A
+fabricated answer that looks correct is worse than an error.
+
+---
+
+## 3. Codebase measurements
+
+All obtained by script over `praisonaiagents/` at `2591aa405`.
+
+### Scale
+
+| Metric | Value |
+|---|---|
+| Python files / lines | 595 / 238,936 |
+| Files over 2,000 lines | 13 |
+| `agent/agent.py` | 7,701 |
+| `llm/llm.py` | 7,160 |
+| `agent/chat_mixin.py` | 6,151 |
+| `llm/openai_client.py` | 2,691 |
+| `llm/adapters/__init__.py` | 340 |
+
+### `LLM` class cohesion
+
+95 methods, 6,779 lines. Three largest methods total 3,087 lines — 43% of the file.
+
+| Lines | Location | Method | Branch/loop/try nodes |
+|---|---|---|---|
+| 1,675 | `llm.py:2557` | `get_response` | **194** |
+| 969 | `llm.py:4706` | `get_response_async` | 115 |
+| 443 | `llm.py:4233` | `get_response_stream` | 56 |
+| 249 | `llm.py:5966` | `_build_completion_params` | 52 |
+| 199 | `llm.py:413` | `__init__` | 10 |
+
+### Adapter call sites — the A1 finding
+
+`DefaultAdapter` declares **17 methods** (an earlier draft said 18; the 18th item,
+`add_provider_adapter`, is a module-level function). Eleven methods have **zero** call sites
+anywhere, and with the three module functions that is 12 dead items. Note also that
+`LLMProviderAdapterProtocol` declares only **16** — it omits `get_streaming_adapter`, so that
+method is not part of the protocol it claims to implement.
+
+```
+supports_streaming                        2
+format_tool_result_message                1   (llm.py:1712)
+get_default_settings                      1   (llm.py:690)
+should_summarize_tools                    1
+supports_prompt_caching                   1
+supports_streaming_with_tools             1
+--- zero call sites ---
+recover_tool_calls_from_text              0   (inline copy at llm.py:3468-3500)
+parse_tool_calls                          0
+handle_empty_response_with_tools          0
+post_tool_iteration                       0
+format_tools                              0
+get_streaming_adapter                     0
+get_max_iteration_threshold               0
+should_skip_streaming_with_tools          0
+supports_structured_output                0
+inject_cache_control                      0
+extract_reasoning_tokens                  0
+add_provider_adapter                      0   (public registration hook)
+```
+
+Ollama references (case-insensitive): `llm/llm.py` **145**, `llm/adapters/__init__.py` 19,
+`llm/streaming_protocol.py` 11, `tools/call_executor.py` 6.
+
+### Compensation coverage across the three response paths — the A2 finding
+
+```
+                                        get_response   _async   _stream
+                                             1675 L     969 L     443 L
+tool_result_mapping  (value fix-up)          8          0         0
+max_tool_repairs     (repair loop)           2          0         0
+force_tool_usage     (prompt inject)         1          0         0
+_validate_and_filter_ollama_arguments        1          1         0
+_generate_ollama_tool_summary                1          1         0
+_handle_ollama_sequential_logic              1          1         0
+_format_ollama_tool_result_message           1          1         1*  (indirect)
+```
+
+`get_response_stream` has none of the seven — except `_format_ollama_tool_result_message`,
+which it reaches indirectly via `_create_tool_message` (`llm.py:6791`), so that row overstated
+the gap. A fuller re-measurement found **16** divergent compensations, not 7; three of them run
+*against* the sync path. The full matrix is in `06-adapter-revival.md` §2.6. `difflib` similarity of `get_response` against
+`get_response_async` is **22.3%**, while the file's other four sync/async pairs are 76–91% —
+so those two have diverged, not merely duplicated.
+
+### Import graph — the I6 constraint
+
+65 subpackages, 212 directed edges, **26 mutually-importing pairs**. Heaviest:
+
+```
+agent   <-> tools       53 + 1        llm/ imports: tools 10, streaming 7,
+agent   <-> approval    28 + 1                      agent 4, telemetry 2,
+agent   <-> config      25 + 1                      auth 2, compaction 2,
+agent   <-> llm         19 + 4                      context 1, thinking 1
+llm     <-> tools       10 + 1
+context <-> llm          2 + 1        15 subpackages import llm/
+```
+
+### Reachability — the A3 finding
+
+21 modules call a provider SDK directly, bypassing both clients: 23 `litellm.completion/acompletion`,
+7 `litellm.embedding/aembedding`, 16 `chat.completions.create`, 3 bare `OpenAI()`.
+
+These nine contain **zero** occurrences of `api_base` or `base_url`, so there is no parameter
+to set — "run everything locally" is currently unachievable, not merely unconfigured:
+
+```
+memory/memory.py          workflows/workflows.py     eval/judge.py
+eval/grader.py            eval/accuracy.py           context/compressor.py
+context/optimizer.py      lite/__init__.py           telemetry/performance_monitor.py
+```
+
+Worst single case, `memory/memory.py:2186-2192`:
+
+```python
+from openai import OpenAI
+client = OpenAI()                    # no base_url, no api_key
+response = client.chat.completions.create(
+    model=llm or "gpt-4o-mini", ...
+```
+
+Hardcoded defaults in code (excluding docstrings): **105** `"gpt-4o-mini"`, **17**
+`"text-embedding-3-small"`. Sixteen of the 105 are the identical line
+`self.llm if hasattr(self,'llm') else "gpt-4o-mini"` in `agent/context_agent.py`.
+
+### Stringly-typed provider identity — the A6 finding
+
+**77 occurrences of 23 distinct string predicates** across `src/`. The same provider is
+tested inconsistently, which is precisely how D3 and D4 arose:
+
+```
+ 9  startswith("anthropic/")     gemini tested 3 ways:   gpt tested 4 ways:
+ 8  startswith("ollama/")          startswith("gemini")    startswith('gpt-')
+ 7  "ollama" in                    startswith("gemini/")   startswith("gpt-")
+ 6  startswith("gemini")           startswith('gemini-')   startswith("gpt")
+ 5  startswith("openai/")                                  "gpt" in
+ 5  startswith("claude")
+ 3  ":11434" in
+```
+
+### Accretion history — why boundaries matter here
+
+| File | First | Now | Commits | Ever shrank |
+|---|---|---|---|---|
+| `llm/llm.py` | 1,212 (Jan 2025) | 7,160 | 251 | never, in 18 sampled months |
+| `agent/agent.py` | 1,251 (Jan 2025) | 7,701 | 472 | once — the split below |
+| `agent/chat_mixin.py` | created Apr 2026 | 6,151 | 150 | — |
+
+On **2026-04-01** `agent.py` was split 8,915 → 5,030 by extracting `chat_mixin.py`. Five
+months later the two halves total **13,852 lines — 55% above the pre-split file**, growing
+~33 lines/day. Moving code did not create a boundary. This is the argument for I6 being a
+*test* rather than a convention.
+
+---
+
+## 4. Dependency facts
+
+| Package | Version present | Status |
+|---|---|---|
+| `httpx` | 0.28.1 | **hard transitive dep** of required `openai>=2.0.0` (`httpx<1,>=0.23.0`) |
+| `aiohttp` | 3.14.1 | direct required core dep |
+| `openai` | 2.44.0 | direct required core dep |
+| `litellm` | 1.90.2 | optional (`llm`, `memory` extras) |
+
+`pyproject.toml` declares **17 optional extras** — `a2ui, api, all, auth, autonomy, crawl,
+dakera, graph, knowledge, llm, mcp, memory, mongodb, os, sandbox, search, telemetry` — and
+**none of them is local**. `import praisonaiagents` measures 0.04 s, so imports are lazy and
+cheap; discovery latency is the only startup cost to manage.
+
+**Conclusion:** `local/` should use `httpx`. It is guaranteed present, gives sync and async
+from one client with clean timeouts, and adds no dependency — satisfying I6.
+
+---
+
+## 5. litellm prefix resolution vs ours
+
+litellm 1.90.2 resolves all of these; PraisonAI's `_detect_provider` recognises only `ollama/`:
+
+```
+ollama/llama3.2       -> ollama   OllamaAdapter    repairs=2
+ollama_chat/llama3.2  -> openai   DefaultAdapter   repairs=0     <- litellm's RECOMMENDED prefix
+lm_studio/qwen        -> openai   DefaultAdapter   repairs=0
+vllm/x                -> openai   DefaultAdapter   repairs=0
+hosted_vllm/x         -> openai   DefaultAdapter   repairs=0
+huggingface/x         -> openai   DefaultAdapter   repairs=0
+```
+
+---
+
+## 6. Known-bad environment note
+
+`mervinpraison/praisonai-qwen3.5-9b-tamil-en2ta:latest` does **not load** on Ollama 0.33.2:
+`Failed to load CLIP model from ...sha256-11540ddc21b3...`, HTTP 500. The vision projector
+blob is the failing piece. Use `qwen3:0.6b` for local verification instead. Unrelated to this
+work, but it will waste an agent's time if not known.
+
+
+---
+
+## 7. The three response paths disagree — measured, not inferred
+
+Live Ollama, `temperature=0`, identical prompt and tool, two trials, reproducible
+(script in `06-adapter-revival.md` §2.7):
+
+```
+### sync   tool_calls=1   out='{\n\n\n}'
+### async  tool_calls=1   out='Paris: 21C sunny'
+### stream tool_calls=10  out=''
+```
+
+Three facts follow, and they reframe the work:
+
+1. **The best-compensated path produces the worst answer.** `get_response` carries 16 of the 18
+   compensations and returns `'{\n\n\n}'`; `get_response_async` carries 8 and returns the
+   correct answer. More compensation is not the goal — *the same* compensation is.
+2. **The stream path is not under-compensated, it is broken.** It burns all 10 iterations of
+   `max_iter`, invokes the tool **ten times** for a one-tool question, and yields nothing. That
+   is a cost and side-effect amplifier, not a formatting defect.
+3. Leading hypothesis for the sync/async split: `OLLAMA_FINAL_ANSWER_PROMPT` (`llm.py:5302`,
+   async only). **Hypothesis, not measurement** — Step 06.0 settles it and records the result here.
+
+## 8. Two test-infrastructure traps
+
+- **`src/praisonai-agents/tests/` is almost entirely outside CI.** The only tests any workflow
+  runs from it are `tests/smoke/test_subscription_auth.py` and
+  `tests/unit/auth/test_agent_auth_wiring.py`. `tests/unit/test_adapter_registry.py` (38 tests)
+  and all 13 files in `tests/unit/llm/` run **nowhere**. Put new tests in
+  `src/praisonai/tests/unit/llm/`, which is run.
+- **`test_ollama_tool_reliability.py` tests a copy, not the product.** Its `MockLLM`
+  re-implements `_is_ollama_provider`, `_apply_ollama_defaults`, `_validate_tool_call`,
+  `_should_force_tool_usage` and both prompt templates. It cannot fail in response to any change
+  in `llm.py`. Do not treat it as a safety net.

--- a/src/praisonai-agents/docs/local-model-layer/00-ground-truth.md
+++ b/src/praisonai-agents/docs/local-model-layer/00-ground-truth.md
@@ -265,21 +265,28 @@ Live Ollama, `temperature=0`, identical prompt and tool, two trials, reproducibl
 (script in `06-adapter-revival.md` §2.7):
 
 ```
-### sync   tool_calls=1   out='{\n\n\n}'
-### async  tool_calls=1   out='Paris: 21C sunny'
-### stream tool_calls=10  out=''
+sync    calls=2   'Paris: 21C sunny. Paris: 21C sunny.'
+async   calls=1   'Paris: 21C sunny'
+stream  calls=10  ''
 ```
+
+> **Corrected 2026-09-03.** An earlier draft recorded the sync path returning
+> `'{\n\n\n}'` with one tool call. That did not reproduce; the figures above did,
+> across two trials. The finding is unchanged — the paths disagree and the stream
+> path is broken — but the `'{\n\n\n}'` sample should not be cited.
 
 Three facts follow, and they reframe the work:
 
 1. **The best-compensated path produces the worst answer.** `get_response` carries 16 of the 18
-   compensations and returns `'{\n\n\n}'`; `get_response_async` carries 8 and returns the
-   correct answer. More compensation is not the goal — *the same* compensation is.
+   compensations and calls the tool twice, returning a doubled answer;
+   `get_response_async` carries 8 and returns the correct answer once. More compensation is
+   not the goal — *the same* compensation is.
 2. **The stream path is not under-compensated, it is broken.** It burns all 10 iterations of
    `max_iter`, invokes the tool **ten times** for a one-tool question, and yields nothing. That
    is a cost and side-effect amplifier, not a formatting defect.
 3. Leading hypothesis for the sync/async split: `OLLAMA_FINAL_ANSWER_PROMPT` (`llm.py:5302`,
-   async only). **Hypothesis, not measurement** — Step 06.0 settles it and records the result here.
+   async only). **Still a hypothesis, not a measurement** — it was not settled during order 06,
+   because the corrected baseline changed what needs explaining.
 
 ## 8. Two test-infrastructure traps
 

--- a/src/praisonai-agents/docs/local-model-layer/04-test-gating.md
+++ b/src/praisonai-agents/docs/local-model-layer/04-test-gating.md
@@ -1,0 +1,372 @@
+# 04 — D7: provider markers are assigned per file, so mocked tests are gated as if live
+
+**Branch:** `fix/gating-per-test-provider-markers`
+**Measured:** clean worktree at `origin/main` (`2591aa405`), working tree clean.
+**Owns:** `src/praisonai/tests/_pytest_plugins/test_gating.py`, both `pytest.ini` files,
+`src/praisonai/tests/conftest.py`, `tests/integration/test_base_url_api_base_fix.py`,
+`tests/unit/cli/test_test_command.py`.
+**Must not edit:** any `praisonaiagents/` source; `.github/workflows/**` (order 05).
+
+> **The audit's stated root cause was wrong, and the correction changes the fix.**
+> `provider_ollama` is a red herring. **`not network` deselects all 7 tests on its own**, because
+> the plugin implies `network` from *any* provider marker and the file also matches
+> `provider_openai`. **Removing `not provider_ollama` from the workflows would change nothing.**
+> The fix must be marker-side, not workflow-side. This is why order 04 touches no YAML.
+
+---
+
+## 1. Corrections to the audit
+
+| # | Claim | Verdict |
+|---|---|---|
+| 1 | 4 CI marker expressions carry `not provider_ollama` | **True but incomplete** — there is a 5th, non-CI location: `src/praisonai-code/praisonai_code/cli/commands/test.py:67` (`praisonai test --tier main`). |
+| 2 | 7 tests, all deselected | **Exactly true** (`collected 7 items / 7 deselected / 0 selected`). **Stated cause is wrong** — see the callout above. |
+| 3 | The file never inspects `litellm.completion` kwargs | **True** (only `mock_completion.assert_called()`). **And worse: 4 of the 7 tests fail outright when executed.** They are not merely toothless, they are broken. |
+| 4 | `test_double_api_fix.py`: 0 asserts, 34 prints | **True. And worse:** all 3 tests are auto-`skip`ped in every configuration, and when forced to run its `patch('litellm.completion')` no longer intercepts — `llm.py` routes `gpt-4o-mini` through `litellm.responses`, so it makes a **real network call** (verified: 401 from `api.openai.com/v1/responses`). |
+| 5 | `test_ollama_tool_reliability.py` asserts against MockLLM | **True.** 541 lines, MockLLM at 23–197, 28 tests, all pass. **Quantified:** 2 of the 8 re-implemented methods (`_apply_ollama_defaults`, `_try_parse_tool_call_json`) **do not exist on the real `LLM` at all.** |
+| 6 | agents-side ollama tests gated only by `OLLAMA_HOST` | **True**, and `test_ollama_fix_openai` is gated only by `OPENAI_API_KEY` — a live **billed** call on a plain `pytest`. Mitigating: no CI workflow runs these two files. |
+| 7 | No ollama live job | **True for CI**, but the audit **missed that the suite already exists**: `tests/integration/test_ollama_tool_calling_live.py`, 230 lines, 7 tests, gated on `PRAISONAI_TEST_OLLAMA=1`. It is **broken against current `main`**. See order 05. |
+
+---
+
+## 2. Reproduce before the fix
+
+```bash
+cd src/praisonai && export PYTHONPATH=$(cd ../praisonai-agents && pwd)
+CI_M="not slow and not network and not local_service and not provider_anthropic and not provider_google and not provider_ollama and not provider_grok_xai and not provider_groq and not provider_cohere"
+```
+
+**R1 — 100% deselected:**
+```bash
+python -m pytest tests/integration/test_base_url_api_base_fix.py -m "$CI_M" --collect-only -q --disable-warnings
+# collected 7 items / 7 deselected / 0 selected
+```
+
+**R2 — `provider_ollama` is a red herring.** Rerun R1 with `and not provider_ollama` **removed**:
+still `7 deselected / 0 selected`. `not network` does it alone.
+
+**R3 — the whole file is tagged.** With a marker-dump plugin, all seven items carry the identical
+set `['integration', 'network', 'provider_ollama', 'provider_openai', 'skip']` — including the six
+that never mention Ollama.
+
+**R4 — 4 of 7 fail when actually executed:**
+```bash
+PRAISONAI_ALLOW_NETWORK=1 PRAISONAI_TEST_PROVIDERS=all OPENAI_API_KEY=sk-fake-offline \
+  python -m pytest tests/integration/test_base_url_api_base_fix.py -o addopts="" -q --tb=no -rA
+# 4 failed, 3 passed
+```
+All four fail with `LLMResponseError: ... 'str' object has no attribute 'choices'`. The three that
+pass are the three that never call `get_response()`.
+
+**R5 — `-m provider_ollama` selects 4× more than it should:**
+```
+   7 tests/integration/test_base_url_api_base_fix.py
+   7 tests/integration/test_ollama_tool_calling_live.py
+  11 tests/integration/test_rag_integration.py
+   4 tests/integration/test_setup_integration.py
+   3 tests/test_double_api_fix.py
+```
+**32 selected; only 7 are Ollama tests.** This is why order 04 is a hard prerequisite for order 05 —
+`-m provider_ollama` is currently not a usable selector.
+
+---
+
+## 3. Root cause
+
+`test_gating.py:153-166` scans the **entire file**:
+
+```python
+153  def _detect_providers_in_file(filepath: Path) -> Set[str]:
+154      """Detect which providers are referenced in a test file."""
+...
+161      content = _get_file_content(filepath)
+162      detected = set()
+163      for marker, pattern in PROVIDER_PATTERNS.items():
+164          if pattern.search(content):
+165              detected.add(marker)
+166      return detected
+```
+
+Line 28 is `'provider_ollama': re.compile(r'\b(ollama)\b', re.IGNORECASE)`. One occurrence inside
+`test_ollama_environment_variable_compatibility` tags all seven items (applied at lines 213–230).
+
+Note line 215: `if item.fspath and test_type != 'unit'` — **`tests/unit/**` is exempt**, which is
+why `tests/unit/llm/test_ollama_tool_reliability.py` runs in CI while the integration file does not.
+
+**The second mechanism, which the audit missed**, is lines 235–238:
+
+```python
+235          # 3. Add network marker if any provider marker is present
+236          provider_markers = {m for m in existing_markers if m.startswith('provider_')}
+237          if provider_markers and 'network' not in existing_markers:
+238              item.add_marker(pytest.mark.network)
+```
+
+A mocked test that merely *mentions* `openai` gets `network`, and every CI expression contains
+`not network`. Lines 262–267 then convert it into a runtime skip.
+
+**Sub-defect 3.** Lines 59, 145, 177, 234 are all bare `mock_completion.assert_called()`. Nothing
+reads `call_args`. Measured: `LLM(model='openai/mistral', base_url='http://localhost:4000',
+api_key='sk-test').get_response("test", stream=False)` calls `litellm.completion` with
+`base_url='http://localhost:4000'` and `api_base=None`. **So the file's title is stale** — the real
+invariant is *`base_url` survives into the call*, not "maps to `api_base`".
+
+---
+
+## 4. The change
+
+**Design decision: AST per-test marking, not file splitting.**
+
+- *Split the file* — cost cheap, **benefit zero** (measured, R2): the six non-Ollama tests still
+  match `provider_openai`, still get `network`, still get deselected. It also leaves `-m
+  provider_ollama` selecting 32 tests and fixes nothing for the other 14 mixed-provider files.
+  **Rejected.**
+- *AST per-test marking* — one change in one plugin, fixes the class of problem, and is the
+  prerequisite for order 05's selector to mean anything. **Recommended.**
+
+### Sub-change 1 — per-test provider detection via AST
+
+Keep `_detect_providers_in_file` (it now serves only the `network` marker) and add:
+
+```python
+def _detect_providers_in_text(text: str) -> Set[str]:
+    """Return every provider marker whose pattern appears in ``text``."""
+    detected = set()
+    for marker, pattern in PROVIDER_PATTERNS.items():
+        if pattern.search(text):
+            detected.add(marker)
+    return detected
+
+
+def _build_per_test_provider_map(filepath: Path) -> Optional[Dict[tuple, Set[str]]]:
+    """Map ``(class_name, func_name)`` -> provider markers for one test file.
+
+    The text considered for a test is that test's own source segment plus its
+    decorators -- not the whole file. Returns ``None`` if the file cannot be
+    parsed, so callers fall back to whole-file rather than under-marking.
+    """
+    key = str(filepath)
+    if key in _file_provider_cache:
+        return _file_provider_cache[key]
+    result: Optional[Dict[tuple, Set[str]]] = None
+    try:
+        source = _get_file_content(filepath)
+        tree = ast.parse(source)
+        result = {}
+
+        def _visit(node, class_name=None):
+            for child in getattr(node, 'body', ()):
+                if isinstance(child, ast.ClassDef):
+                    _visit(child, child.name)
+                elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    segment = ast.get_source_segment(source, child) or ""
+                    for decorator in child.decorator_list:
+                        segment += "\n" + (ast.get_source_segment(source, decorator) or "")
+                    result[(class_name, child.name)] = _detect_providers_in_text(segment)
+
+        _visit(tree)
+    except (SyntaxError, ValueError, RecursionError):
+        result = None
+    _file_provider_cache[key] = result
+    return result
+
+
+def _detect_providers_for_item(item) -> Set[str]:
+    """Provider markers for a single collected item (per test, not per file)."""
+    filepath = Path(item.fspath)
+    if _is_excluded_path(str(filepath)):
+        return set()
+    per_test = _build_per_test_provider_map(filepath)
+    if per_test is None:
+        return _detect_providers_in_file(filepath)
+    parts = item.nodeid.split("::")[1:]
+    if not parts:
+        return _detect_providers_in_file(filepath)
+    func = parts[-1].split("[")[0]
+    cls = parts[-2] if len(parts) >= 2 else None
+    if (cls, func) in per_test:
+        return set(per_test[(cls, func)])
+    if (None, func) in per_test:
+        return set(per_test[(None, func)])
+    # Dynamically generated item we cannot locate in the AST: stay conservative.
+    return _detect_providers_in_file(filepath)
+```
+
+Add `import ast`, a `_file_provider_cache: Dict[str, Optional[Dict[tuple, Set[str]]]] = {}` next to
+`_file_content_cache` (line 46), and clear it in `pytest_configure` (186) and
+`pytest_sessionfinish` (294).
+
+### Sub-change 2 — `offline` opt-out, and pin `network` to the file
+
+Replace lines 213–230 with a version that (a) honours an explicit `offline` marker, (b) calls
+`_detect_providers_for_item`, and (c) **keeps `network` whole-file derived**:
+
+```python
+                offline = 'offline' in existing_markers
+                if not offline:
+                    detected_providers = _detect_providers_for_item(item)
+                    for marker, pattern in PROVIDER_PATTERNS.items():
+                        if pattern.search(item.nodeid):
+                            detected_providers.add(marker)
+                    for provider in detected_providers:
+                        if provider not in existing_markers:
+                            item.add_marker(getattr(pytest.mark, provider))
+                    # The `network` marker stays WHOLE-FILE derived. Narrowing
+                    # the provider markers must not, by itself, un-deselect a
+                    # test that is really live -- only `offline` does that.
+                    if _detect_providers_in_file(filepath) and 'network' not in existing_markers:
+                        item.add_marker(pytest.mark.network)
+```
+
+**Why `network` stays file-derived — this is the whole backward-compatibility story and is not
+optional.** Measured: if per-test narrowing were also allowed to narrow `network`, **48 currently-
+deselected integration tests would newly select, 25 of them with no `skipif` — they would actually
+execute**, across nine files including `test_rag_live.py` and `test_model_routing_real.py`, in a
+suite where the network guard is disabled for everything under `/integration/`
+(`network_guard.py:103-105`). Pinning `network` to the file makes sub-change 1 provably
+**selection-neutral** under every existing `-m` expression, while still making `-m provider_ollama`
+mean what it says.
+
+Register the marker in both `pytest.ini` files and `tests/conftest.py`:
+```
+    offline: Fully mocked - opt out of provider/network auto-marking
+```
+
+### Sub-change 3 — opt the file in, and make it guard its bug
+
+Add `pytestmark = pytest.mark.offline` plus a response factory:
+
+```python
+def make_completion_response(text="Test response"):
+    """A litellm.completion stand-in the LLM tool-calling loop can consume.
+
+    A bare dict is NOT sufficient: the loop reads ``.choices[0].message`` and a
+    dict raises ``'str' object has no attribute 'choices'``.
+    """
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = text
+    resp.choices[0].message.tool_calls = None
+    resp.choices[0].finish_reason = "stop"
+    return resp
+```
+
+For each of the four broken tests: replace the dict `return_value` with
+`make_completion_response(...)`, pass `stream=False` to `get_response`, and replace
+`mock_completion.assert_called()` with a real kwarg assertion:
+
+```python
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs['base_url'] == 'http://localhost:4000'
+        assert kwargs['api_key'] == 'sk-test'
+        assert kwargs['model'] == 'openai/mistral'
+```
+
+- `test_koboldcpp_specific_scenario` → `kwargs['base_url'] == "http://127.0.0.1:5001/v1"`
+- `test_litellm_documentation_example_compatibility` → `kwargs['base_url'] == "http://0.0.0.0:4000"`
+- `test_ollama_environment_variable_compatibility` → `kwargs['model'] == 'ollama/llama2'` **and**
+  `'base_url' not in kwargs` (none was configured; the env path must not inject one)
+
+All four were run standalone against `main` and pass. Leave the three currently-passing tests alone.
+
+Update the stale module docstring ("maps base_url to api_base" → "base_url must reach litellm") but
+**do not rename the test functions** — the nodeids are referenced in issue discussion, and renaming
+would change what the nodeid scan at plugin lines 224–226 sees.
+
+---
+
+## 5. Backward-compatibility contract
+
+Baseline, measured (`tests/integration/`, CI ignores applied): **290 collected, 187 selected,
+103 deselected** under the CI marker expression.
+
+> Caveat for the executing agent: a cold first invocation on a fresh interpreter has been observed
+> to report `157/260`, apparently an optional-dependency import warming effect. **Run it twice**;
+> `187/290/103` is stable from the second run on. Take your own baseline before touching anything.
+
+**Tests whose selection status changes: exactly 7**, all in `test_base_url_api_base_fix.py`, all
+deselected → selected. Post-fix expectation: **194/290 (96 deselected)**. Nothing else moves in
+either direction — that is what the file-derived `network` guarantees.
+
+Intended change under `-m provider_ollama` (32 → 9):
+
+| file | before | after |
+|---|---|---|
+| `test_ollama_tool_calling_live.py` | 7 | 7 |
+| `test_base_url_api_base_fix.py` | 7 | 0 (`offline`) |
+| `test_rag_integration.py` | 11 | 1 |
+| `test_setup_integration.py` | 4 | 0 |
+| `test_double_api_fix.py` | 3 | 1 |
+
+**The risk, stated plainly.** Un-deselecting tests turns CI red if any fail. **They do: 4 of the 7
+fail today** (R4). This is not hypothetical.
+
+**Mitigation — mandatory, not optional: land the gating fix and the four repairs in the same PR.**
+Do not merge sub-changes 1+2 with the `pytestmark` but without the repairs. **Quarantining with
+`xfail` is explicitly rejected** — the repairs are ~10 lines each, verified working, and an `xfail`
+here would recreate the exact defect being fixed (a test that names a bug and does not guard it).
+
+**Escape hatch.** If the 7 prove flaky in CI for a reason not reproducible locally, revert
+**sub-change 3 only**. Selection returns to 187/290/103 and the plugin improvements stay.
+
+---
+
+## 6. Tests to add
+
+In `tests/unit/cli/test_test_command.py` (the existing home of gating-plugin tests, and already in
+`EXCLUDED_PATHS`, so these cannot be auto-marked by the thing they test), add
+`class TestProviderMarkerGranularity` with:
+
+- `test_ollama_does_not_leak_to_sibling_tests` — **THE meta-test.** If this fails, D7 has regressed.
+- `test_openai_does_not_leak_to_sibling_tests`
+- `test_plain_test_gets_no_provider_markers`
+- `test_decorators_are_scanned` — a `@pytest.mark.parametrize("m", ["ollama/llama2"])` must mark it
+- `test_unparseable_file_falls_back_to_whole_file` — conservative over-marking on a parse failure
+- `test_network_marker_remains_whole_file_derived` — pins the decision that keeps this change
+  selection-neutral for the 96 still-deselected tests
+- `test_offline_marker_is_registered` — both `pytest.ini` files, or every use warns
+
+No new dependency: `ast`, `tmp_path` and `configparser` are stdlib/pytest builtins.
+
+---
+
+## 7. Verification and acceptance
+
+```bash
+# 1. The 7 are now selected
+python -m pytest tests/integration/test_base_url_api_base_fix.py -m "$CI_M" --collect-only -q
+# expect: 7 selected, 0 deselected
+
+# 2. They pass offline, with no keys and no services
+env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u OLLAMA_HOST \
+  python -m pytest tests/integration/test_base_url_api_base_fix.py -m "$CI_M" -o addopts="" -q
+# expect: 7 passed
+
+# 3. Selection neutral everywhere else
+python -m pytest tests/integration/ $IG -o addopts="" -q --collect-only -m "$CI_M" | tail -1
+# expect: 194/290 tests collected (96 deselected)
+
+# 4. `-m provider_ollama` now means Ollama  -> 7 + 1 + 1, not 32
+# 5. Meta-tests pass
+# 6. The three CI shards reproduced verbatim do not regress
+# 7. The two pytest.ini marker tables stay in sync
+```
+
+**Acceptance gate:** `tests/integration/` collects **194/290 (96 deselected)** — exactly seven more
+than baseline, all seven from `test_base_url_api_base_fix.py` — **and passes with
+`OPENAI_API_KEY`, `ANTHROPIC_API_KEY` and `OLLAMA_HOST` all unset and no Ollama server running.**
+
+**PR title:** `fix(tests): mark provider tests per test function, not per file`
+
+---
+
+## 8. Filed for separate PRs
+
+- **`tests/test_double_api_fix.py`'s mock no longer intercepts.** `llm.py` routes `gpt-4o-mini`
+  through `litellm.responses` (`llm.py:6434`), not `litellm.completion`. Forced to run, it makes a
+  **real OpenAI request** (verified: 401 for `https://api.openai.com/v1/responses`). Today it is
+  masked by an unconditional auto-`skip` — **anyone who "fixes" the skip without fixing the mock
+  gets live billed calls.**
+- **`network_guard.py` disables itself for `/integration/`, `/e2e/`, `/live/`** (lines 103–105) and
+  for any `provider_*`-marked test (96–100). The suite's network blocker does not cover the tests
+  most likely to make network calls.

--- a/src/praisonai-agents/docs/local-model-layer/05-live-ci-job.md
+++ b/src/praisonai-agents/docs/local-model-layer/05-live-ci-job.md
@@ -1,0 +1,298 @@
+# 05 — Live local-model CI job
+
+**Branch:** `feat/ci-ollama-live-job`
+**Depends on:** order `04` must merge first. Before it, `-m provider_ollama` selects 32 tests
+across 5 files (25 of which are not Ollama tests) and this job is unbuildable.
+**Owns:** `.github/workflows/test-optimized.yml`,
+`src/praisonai/tests/integration/test_ollama_tool_calling_live.py`.
+**Must not edit:** `test_gating.py` (order 04); the `smoke` / `main` / `openai-live` jobs; anything
+in `test-core.yml`; `src/praisonai-agents/tests/test_ollama_{fix,async_fix}.py`.
+
+---
+
+## 1. The suite already exists — and is broken
+
+The audit concluded "no ollama live job, and no live suite". The first half is right; **the second
+is wrong**. `src/praisonai/tests/integration/test_ollama_tool_calling_live.py` is 230 lines,
+7 tests, gated at lines 19–22 on `PRAISONAI_TEST_OLLAMA`. It has never run anywhere.
+
+Measured against `main`, **it cannot run** — three `Agent()` kwargs are now rejected:
+
+```
+$ python -c "from praisonaiagents import Agent; Agent(name='C', llm='ollama/qwen3:0.6b', verbose=True)"
+TypeError: Agent.__init__() got unexpected keyword argument(s): verbose
+  verbose: verbosity moved into output=; use output='verbose' (or output=OutputConfig(verbose=True)).
+
+$ ... Agent(..., force_tool_usage="always")   -> TypeError: unexpected keyword argument(s): force_tool_usage
+$ ... Agent(..., max_tool_repairs=3)          -> TypeError: unexpected keyword argument(s): max_tool_repairs
+```
+
+All 7 tests use `verbose=True`; two also use the other two. **Every test errors on construction.**
+The modern form, verified working:
+
+```python
+Agent(name="C",
+      llm={"model": "ollama/qwen3:0.6b", "force_tool_usage": "always", "max_tool_repairs": 3},
+      tools=[calculator])
+# -> llm_instance.force_tool_usage == 'always', llm_instance.max_tool_repairs == 3
+```
+
+So this order is **"fix a dead test file and wire it up"**, not "write a live suite".
+
+---
+
+## 2. Model selection
+
+Measured on a real Ollama 0.33.2 host:
+
+```
+$ ollama list
+qwen3:0.6b   7df6b6e09427   522 MB
+$ ollama show qwen3:0.6b
+  parameters       751.63M      quantization  Q4_K_M      context length  40960
+  Capabilities:    completion, tools, thinking
+```
+
+**Two corrections:** the blob is **522 MB**, not ~400 MB; and it is **not vision capable** —
+`completion, tools, thinking` only. Tools + thinking is all this job needs.
+
+**Reliability, measured end-to-end through `praisonaiagents.Agent`:**
+
+| configuration | trials | tool invoked + correct answer | latency |
+|---|---|---|---|
+| default | 4 | **3/4** — one run returned `{}` with no tool call | 0.5–5.4 s |
+| `force_tool_usage="always"`, `temperature=0` | 6 | **6/6** | 0.4–4.0 s |
+| indirect prompt ("I know it's easy, but use the tool") | 1 | 0/1 — emitted `{"type": "calculator", ...}`, wrong key | 0.6 s |
+| multi-step `(17+25)+(8+9)` | 2 | 1 hung past 90 s; 1 answered 42 instead of 59 | — |
+
+**Conclusion: `qwen3:0.6b` is the right model, but only the forced, zero-temperature, single-call
+prompt is CI-deterministic.**
+
+Rejected alternatives: `qwen2.5:0.5b` (~400 MB, older tool calling, unmeasured — no reason to
+prefer it over a verified model); `llama3.2:1b` (~1.3 GB, 2.5× the cache for no measured gain);
+`smollm2:135m` (**no `tools` capability — disqualifying**); `olmo-3` (the file's current default,
+~7B, far too large per run). Keep `olmo-3` as the *local* default so developer workflow is
+unchanged; let CI override via env var.
+
+**Cache:** `~/.ollama/models`, keyed `${{ runner.os }}-ollama-models-${{ env.OLLAMA_TEST_MODEL }}`.
+**No `restore-keys`** — a partial restore of a *different* model's blobs is worse than a clean
+pull, and a stale key would silently test the wrong model.
+
+**Install:** pinned release tarball, not `curl https://ollama.com/install.sh | sh`. The install
+script tracks latest, so the job would silently change what it tests, and it pulls GPU runtimes a
+CPU-only runner never uses. Expect ~20–60 s tarball + ~30–90 s cold model pull, near-zero on a
+cache hit — **the executing agent must confirm real timings on the first green run and write them
+into a YAML comment.**
+
+**Gating:** `if: github.event_name == 'schedule' || github.event.inputs.tier == 'extended' ||
+github.event.inputs.tier == 'nightly'` — byte-identical to `extended-anthropic` (line 467),
+`extended-google` (525), `extended-groq` (585), `extended-xai` (644), `extended-cohere` (703).
+**It never runs on a pull request.**
+
+---
+
+## 3. One deliberate departure from the sibling jobs
+
+Every existing live job ends `|| echo "... tests completed"`, so **it can never fail**. That is
+defensible for key-dependent jobs — a rotated secret should not page anyone — but it is exactly
+the "test that cannot fail" pattern this whole effort exists to remove, and **Ollama needs no
+secret**: availability is fully under the job's control.
+
+So the job has **two run steps**:
+1. a **required** minimum-contract step with **no `|| echo`**;
+2. an **informational** step for the measured-flaky remainder, keeping the sibling style.
+
+**Do not merge them.**
+
+---
+
+## 4. Test-file changes
+
+1. After `pytestmark`, add the model indirection:
+   ```python
+   # CI overrides this with a small, fast model; local runs keep olmo-3.
+   OLLAMA_MODEL = "ollama/" + os.getenv("PRAISONAI_OLLAMA_TEST_MODEL", "olmo-3")
+   ```
+2. Replace all 7 hard-coded `llm="ollama/olmo-3"` with `llm=OLLAMA_MODEL`.
+3. Remove `verbose=True` from all 7 `Agent(...)` calls. Where verbosity is wanted: `output="verbose"`.
+4. Move `force_tool_usage="always"` and `max_tool_repairs=3` into an `llm` dict.
+5. Add the CI-minimum test as a new first class — **the only assertion in the file with a measured
+   6/6 pass rate**:
+
+```python
+class TestOllamaCIMinimum:
+    """The minimum contract a local model must satisfy: a tool call round-trips.
+
+    Deliberately narrow. Measured on qwen3:0.6b: this exact configuration
+    (forced tool usage, temperature 0, single arithmetic step) passed 6/6.
+    The default configuration passed 3/4 and multi-step prompts were worse --
+    those live in TestOllamaToolCallingLive, which CI runs informationally.
+    """
+
+    def test_tool_call_round_trips(self, ollama_available):
+        from praisonaiagents import Agent
+
+        invocations = []
+
+        def add(a: int, b: int) -> int:
+            """Add two integers together.
+
+            Args:
+                a: First number to add
+                b: Second number to add
+            """
+            invocations.append((a, b))
+            return a + b
+
+        agent = Agent(
+            name="CI Calculator",
+            llm={"model": OLLAMA_MODEL, "force_tool_usage": "always", "temperature": 0},
+            tools=[add],
+        )
+        result = agent.chat("Compute 17 + 25. You MUST use the calculator tool.")
+
+        # 1. the model actually called our function, with the right arguments
+        assert invocations == [(17, 25)], f"tool was not invoked: {invocations!r}"
+        # 2. the tool's return value made it back into the model's answer
+        assert "42" in str(result), f"tool result did not round-trip: {result!r}"
+```
+
+Reuse the existing `ollama_available` fixture (lines 48–53) — it already probes
+`http://localhost:11434/api/tags` and skips cleanly. Do not add a second probe.
+
+### Why both assertions are needed
+
+`qwen3:0.6b` answers `17 + 25 = 42` **correctly with no tools at all** (measured, 1.2 s,
+`tools=[]`). So a bare `assert "42" in result` is satisfied by a model that ignores tools entirely.
+The `invocations == [(17, 25)]` half is what proves the tool call was emitted, parsed and
+dispatched with the right arguments; the `"42"` half proves the return value was fed back and
+reached the final answer. Anything beyond this — multi-step chains, repair loops, resisting
+distraction — is measured-flaky on a 0.6B model and belongs in the informational step.
+
+---
+
+## 5. The YAML
+
+Insert after `extended-cohere`'s `Skip notice` step (ends line 760), before the `legacy-unit`
+banner. Key fragments:
+
+```yaml
+  extended-ollama:
+    if: github.event_name == 'schedule' || github.event.inputs.tier == 'extended' || github.event.inputs.tier == 'nightly'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Bump deliberately; the cache key and what we test both follow this.
+      OLLAMA_VERSION: v0.33.2
+      OLLAMA_TEST_MODEL: qwen3:0.6b
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Cache Ollama model blobs
+      uses: actions/cache@v4
+      with:
+        path: ~/.ollama/models
+        # No restore-keys: a partial hit from a different model would
+        # silently test something other than OLLAMA_TEST_MODEL.
+        key: ${{ runner.os }}-ollama-models-${{ env.OLLAMA_TEST_MODEL }}
+    - name: Install Ollama
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -fsSL -o /tmp/ollama.tgz \
+          "https://github.com/ollama/ollama/releases/download/${OLLAMA_VERSION}/ollama-linux-amd64.tgz"
+        sudo tar -C /usr -xzf /tmp/ollama.tgz
+        ollama --version
+    - name: Start Ollama and pull model
+      shell: bash
+      run: |
+        set -euo pipefail
+        ollama serve > /tmp/ollama-serve.log 2>&1 &
+        for i in $(seq 1 30); do
+          if curl -sf http://127.0.0.1:11434/api/tags > /dev/null; then
+            echo "Ollama is up after ${i}s"; break
+          fi
+          sleep 1
+        done
+        curl -sf http://127.0.0.1:11434/api/tags > /dev/null
+        ollama pull "$OLLAMA_TEST_MODEL"
+        ollama list
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install pytest pytest-asyncio pytest-timeout
+    - uses: ./.github/actions/install-monorepo-packages
+      with:
+        agents-extras: ".[all]"
+    - name: Run Ollama minimum contract (required)
+      env:
+        PRAISONAI_TEST_TIER: extended
+        PRAISONAI_ALLOW_NETWORK: '1'
+        PRAISONAI_LIVE_TESTS: '1'
+        PRAISONAI_TEST_PROVIDERS: 'ollama'
+        PRAISONAI_TEST_OLLAMA: '1'
+        PRAISONAI_OLLAMA_TEST_MODEL: ${{ env.OLLAMA_TEST_MODEL }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd src/praisonai
+        # No "|| echo" here on purpose: no secret is involved, so a failure
+        # here is a real regression in local-model tool calling.
+        python -m pytest tests/integration/test_ollama_tool_calling_live.py::TestOllamaCIMinimum \
+          -m "provider_ollama" -v --tb=short --timeout=120
+    - name: Run remaining Ollama live tests (informational)
+      if: always()
+      env: { ...same... }
+      run: |
+        cd src/praisonai
+        python -m pytest tests/integration/test_ollama_tool_calling_live.py \
+          -m "provider_ollama" \
+          --deselect tests/integration/test_ollama_tool_calling_live.py::TestOllamaCIMinimum \
+          -v --tb=short --timeout=180 \
+          || echo "Ollama exploratory tests completed (small models are non-deterministic)"
+    - name: Ollama server log
+      if: failure()
+      run: tail -100 /tmp/ollama-serve.log
+```
+
+And in `test-summary` (line 838): extend `needs: [smoke, main, extended-ollama]` and add the
+summary rows. `test-summary` is already `if: always()`, so a skipped `extended-ollama` on PRs
+reports `skipped` rather than blocking.
+
+---
+
+## 6. Verification and acceptance
+
+```bash
+ollama pull qwen3:0.6b
+cd src/praisonai && export PYTHONPATH=$(cd ../praisonai-agents && pwd)
+
+# Must be 6/6 before this ships.
+for i in $(seq 1 6); do
+  PRAISONAI_TEST_OLLAMA=1 PRAISONAI_ALLOW_NETWORK=1 PRAISONAI_LIVE_TESTS=1 \
+  PRAISONAI_TEST_PROVIDERS=ollama PRAISONAI_OLLAMA_TEST_MODEL=qwen3:0.6b \
+    python -m pytest tests/integration/test_ollama_tool_calling_live.py::TestOllamaCIMinimum \
+    -o addopts="" -q --timeout=120 2>&1 | tail -1
+done
+
+# The gate still holds with the env var absent:
+python -m pytest tests/integration/test_ollama_tool_calling_live.py -o addopts="" -q --collect-only
+# expect: collected, all skipped by the module pytestmark
+
+# Nothing leaked onto the PR path:
+grep -n "extended-ollama" -A3 .github/workflows/test-optimized.yml | grep "if:"
+python -c "import yaml; yaml.safe_load(open('.github/workflows/test-optimized.yml')); print('yaml ok')"
+
+# Then: gh workflow run "Optimized Test Suite" -f tier=extended
+```
+
+**Acceptance gate:** a manual `workflow_dispatch` with `tier=extended` shows `extended-ollama`
+**green**, with "Run Ollama minimum contract (required)" reporting `1 passed` — **and** the same
+workflow triggered by a pull request shows `extended-ollama` **skipped**.
+
+**PR title:** `ci: add nightly live-Ollama job exercising a real local model`

--- a/src/praisonai-agents/docs/local-model-layer/06-adapter-revival.md
+++ b/src/praisonai-agents/docs/local-model-layer/06-adapter-revival.md
@@ -117,15 +117,27 @@ _format_ollama_tool_result_message        1       1        1*     3762 / 5267 / 
 
 ### 2.7 The divergence is observable — and not in the direction assumed
 
-Live Ollama, `temperature=0`, identical prompt and tool, two trials:
+> **CORRECTED 2026-09-03, during step 06.4.** The original figures in this section
+> recorded the sync path returning `'{\n\n\n}'` with 1 tool call. **That does not
+> reproduce.** Re-measured on `origin/main`, twice, `temperature=0`, same prompt and
+> tool, the sync path returns 2 tool calls and a doubled answer. The stream result
+> reproduced exactly. Every branch of the 06.1–06.6 stack was then bisected against
+> `main` and all produce byte-identical output, confirming the stack is
+> refactor-only.
+>
+> **The headline finding stands** — the three paths disagree and the stream path is
+> broken. Only the specific `'{\n\n\n}'` sample was unreproducible. Do not cite it,
+> and do not treat it as a regression signal.
+
+Live Ollama, `temperature=0`, identical prompt and tool, two trials (corrected):
 
 ```
-### t0 sync   tool_calls=1   out='{\n\n\n}'
-### t0 async  tool_calls=1   out='Paris: 21C sunny'
-### t0 stream tool_calls=10  out=''
-### t1 sync   tool_calls=1   out='{\n\n\n}'
-### t1 async  tool_calls=1   out='Paris: 21C sunny'
-### t1 stream tool_calls=10  out=''
+T1 sync    calls=2   out='Paris: 21C sunny. Paris: 21C sunny.'
+T1 async   calls=1   out='Paris: 21C sunny'
+T1 stream  calls=10  out=''
+T2 sync    calls=2   out='Paris: 21C sunny. Paris: 21C sunny.'
+T2 async   calls=1   out='Paris: 21C sunny'
+T2 stream  calls=10  out=''
 ```
 
 Reproduce:
@@ -152,16 +164,18 @@ EOF
 Three consequences, and they reframe the order:
 
 1. **The best-compensated path produces the worst answer.** `get_response` has 16 of the 18
-   compensations and returns `'{\n\n\n}'`. `get_response_async` has 8 and returns the correct
-   answer. More compensation is not the goal; *the same* compensation is.
+   compensations and calls the tool twice, returning a doubled answer.
+   `get_response_async` has 8 and returns the correct answer once. More compensation is
+   not the goal; *the same* compensation is.
 2. **The stream path is not under-compensated, it is broken.** It burns all 10 iterations of
    `max_iter`, invokes the tool **10 times** for a one-tool question, and yields nothing. That
    is a real cost and side-effect amplifier, not a formatting defect.
 3. **Leading hypothesis for the sync/async split: `OLLAMA_FINAL_ANSWER_PROMPT`**
    (`llm.py:5302`, async only). Async appends *"Based on the tool results above, please provide
-   the final answer"* and re-requests; sync does not, so at iteration 1 the model emits
-   `{\n\n\n}`, which is non-empty, so the `3844` empty-response guard does not fire and the
-   garbage is returned verbatim. **This is a hypothesis, not a measurement.** Step 06.0 settles it.
+   the final answer"* and re-requests; sync does not, so it runs another tool iteration
+   instead and concatenates the result twice. **This is a hypothesis, not a measurement**,
+   and it was not settled during order 06 — the corrected baseline changed what needs
+   explaining. Whoever takes the §5.7 follow-up should settle it first.
 
 **None of the three baselines may change during Steps 06.1–06.6.** Every step is a
 behaviour-preserving refactor. `'{\n\n\n}'` stays `'{\n\n\n}'`. Fixing it is this order's

--- a/src/praisonai-agents/docs/local-model-layer/06-adapter-revival.md
+++ b/src/praisonai-agents/docs/local-model-layer/06-adapter-revival.md
@@ -1,0 +1,1073 @@
+# 06 — A1/A2: make the provider adapter load-bearing
+
+**Measured against:** `origin/main` @ `2591aa405`, 2026-09-03, live Ollama 0.33.2 on
+`127.0.0.1:11434`, model `qwen3:0.6b`.
+**Blocked by:** order `02-d3-provider-detection` (both edit `llm/llm.py`; land 02 first).
+**Owns:** `llm/adapters/__init__.py`, `llm/protocols.py` (`LLMProviderAdapterProtocol` only),
+`llm/llm.py` (the three response paths), new tests under `src/praisonai/tests/unit/llm/`.
+**Must not edit:** `agent/agent.py`, `llm/llm.py:_detect_provider`,
+`llm/llm.py:_is_ollama_provider` (order 02), `tests/_pytest_plugins/test_gating.py`,
+`.github/workflows/**` (orders 04 and 05).
+
+> **This order overturns the ledger's first framing.** The README originally said "wire the
+> twelve dead methods". Measurement says otherwise: **12 of 20 items should be DELETED**, only
+> **3 wired**. Six of the deletions have no inline equivalent anywhere — they are pure
+> speculative API, and an agent told to "wire up the adapter" would *invent* an implementation
+> with no test that could ever have failed. That is the specific failure §1.1 exists to prevent.
+
+---
+
+## 1. Decision table — the deliverable
+
+`DefaultAdapter` declares **17 methods** (not 18 — see §2.1). With the module-level hook
+`add_provider_adapter` and two module functions, that is the 20 items below. Six methods are
+live; eleven are dead.
+
+| # | Item | `DefaultAdapter` returns | Overridden by | Live calls | Inline equivalent in `llm.py` | **Decision** | Justification |
+|---|---|---|---|---|---|---|---|
+| 1 | `supports_prompt_caching()` | `False` | Anthropic→`True` | 1 — `llm.py:1533` | none (adapter *is* the impl) | **LEAVE** | Already the single source of truth. |
+| 2 | `should_summarize_tools(iter)` | `iter >= 5` | Ollama→`>= 1` | 1 — `llm.py:1992` | none | **LEAVE** | Live, pinned by an existing test. |
+| 3 | `format_tools(tools)` | identity | Gemini→wraps internal tools | **0** | `llm.py:2449-2457` — **opposite shape** (inline passes internal tools through unwrapped; adapter wraps in `{'type':'function','function':tool}`) | **DELETE** | Wiring it would change what Gemini receives. Adapter version untested against a real Gemini request. |
+| 4 | `post_tool_iteration(state)` | `pass` | Ollama→sets `state['needs_summary']` | **0** | `llm.py:3572-3579` (sync), `5170-5177` (async) | **DELETE** | Sets a flag no code reads. The real behaviour is *append a message and `continue`* — not expressible through a `None`-returning state mutator. |
+| 5 | `supports_structured_output()` | `False` | Anthropic, Gemini→`True` | **0** | `model_capabilities.supports_structured_outputs(model)` at `llm.py:2293, 6090, 6399` | **DELETE** | A working, litellm-backed, per-*model* implementation is already live. The adapter's per-*provider* boolean is a strictly worse duplicate. |
+| 6 | `supports_streaming()` | `True` | Anthropic→`False` | 2 — `llm.py:5075, 5360` | none | **LEAVE** | Live, but async-only **by design** — see §5.10. Do not widen it. |
+| 7 | `supports_streaming_with_tools()` | `True` | Ollama/Anthropic/Gemini→`False` | 1 — `llm.py:2172`, consumed by all three paths | none | **LEAVE** | The one adapter method genuinely load-bearing today. |
+| 8 | `get_streaming_adapter()` | `get_streaming_adapter("default")` | all three override | **0** | **none** | **DELETE** | Pure speculative API. It is the *only* production reference to `llm/streaming_protocol.py` (387 lines) — that whole module is reachable from nothing else. See §7. |
+| 9 | `get_max_iteration_threshold()` | `10` | Ollama→`1` | **0** | `OLLAMA_SUMMARY_ITERATION_THRESHOLD = 1` (`llm.py:273`), used at `3821`, `5446` | **DELETE** | Duplicates #2 under a different name with no consumer. Wiring it would change the threshold from 1 to 10 for every non-Ollama provider — a behaviour change, not a refactor. |
+| 10 | `format_tool_result_message(fn, result, id)` | OpenAI `role:tool` | Ollama→natural-language `role:user` | 1 — `llm.py:1712` (Ollama branch only) | **default branch inlined 3×**: `3773-3785` (sync), `5278-5290` (async), `6793-6807` (`_create_tool_message`, stream) | **WIRE** | Its default body has zero consumers, so aligning it with the three copies is unobservable — then all three collapse to one call. Step 06.3. |
+| 11 | `handle_empty_response_with_tools(state)` | `False` | Ollama→`iter>=1 and results and not text` | **0** | `llm.py:3844-3845` (sync), `5467-5468` (async) — **exact predicate match** | **WIRE** | The one dead method whose inline equivalent matches its signature exactly, in two paths. Step 06.4. |
+| 12 | `get_default_settings()` | `{}` | Ollama→`{max_tool_repairs:2, force_tool_usage:'auto'}` | 1 — `llm.py:690` | none | **LEAVE** | Live — and it is *why* A2 is a silent failure: it sets knobs two of three paths ignore (§5.3). |
+| 13 | `parse_tool_calls(raw)` | `raw["choices"][0]["message"].get("tool_calls")` | none | **0** | `llm.py:3465` (dict), `4591` (`getattr` on object), `5146`, `5378` | **DELETE** | The `Dict[str, Any]` signature cannot express the litellm `ModelResponse` object that `4591` actually receives. Wiring requires changing the signature — i.e. inventing API. No provider overrides it, so there is no divergence to abstract. |
+| 14 | `should_skip_streaming_with_tools()` | `False` | Gemini→`True` | **0** | `llm.py:3122-3124` (sync only) — **and that branch is unreachable** | **DELETE** | `GeminiAdapter.supports_streaming_with_tools()` is already `False`, so `llm.py:3117` sets `use_streaming = False` before `3122` is evaluated. Delete the method *and* the dead branch. |
+| 15 | `recover_tool_calls_from_text(text, tools)` | `None` | Ollama→JSON parse | **0** | `llm.py:3468-3500` (sync only) | **WIRE** | A1's flagship duplicate: 33 inline lines vs 30 adapter lines doing the same job. Highest value, hence last. Step 06.5. |
+| 16 | `inject_cache_control(messages)` | identity | **none — not even `AnthropicAdapter`** | **0** | `llm.py:2312-2326` + four helpers at `2191/2205/2233/2244` | **DELETE** | A stub with no implementation anywhere. The real behaviour needs a 4-breakpoint budget and a history index; a flat `messages -> messages` signature carries neither. |
+| 17 | `extract_reasoning_tokens(response)` | `0` | **none** | **0** | `llm.py:5807-5810` inside `_track_token_usage` | **DELETE** | No provider overrides it and none needs to — `_usage_value`/`_detail_value` already handle every shape litellm returns. |
+| 18 | `add_provider_adapter(name, adapter)` *(module fn)* | registers into `_provider_adapters` | — | **0** anywhere incl. tests/docs | none | **LEAVE — hand off to order 02** | A registered name is **unreachable**: the sole caller `get_provider_adapter` (`llm.py:682`) is only ever passed `_detect_provider()`'s output, which can be exactly `ollama\|anthropic\|gemini\|openai\|default`. Fixing it is a 3-line change in a region order 02 owns. |
+| 19 | `list_provider_adapters()` *(module fn)* | sorted keys | — | **0** anywhere | none | **DELETE** | Exported, undocumented, zero consumers including tests. |
+| 20 | `has_provider_adapter(name)` *(module fn)* | `name in _provider_adapters` | — | **0** anywhere | none | **DELETE** | Same — plus it is *wrong*: no `.lower()`, so `has_provider_adapter("Ollama")` is `False` while `get_provider_adapter("Ollama")` succeeds. Untested dead code with a latent bug. |
+
+**Totals: 4 LEAVE, 1 LEAVE-and-hand-off, 12 DELETE, 3 WIRE.**
+
+### 1.1 Why "no inline equivalent" is the decisive column
+
+Six of the twelve deletions have **no inline equivalent at all** — nothing in `llm.py` does the
+job they declare: `get_streaming_adapter`, `inject_cache_control`, `extract_reasoning_tokens`,
+`add_provider_adapter`, `list_provider_adapters`, `has_provider_adapter`.
+
+These are **pure speculative API**. There is no behaviour to move into them. An agent handed
+"wire up the adapter" without this column will invent an implementation, and that invented code
+will have no test that could ever have failed.
+
+The other six deletions have an inline equivalent that is **incompatible** (different output
+shape: #3; different type signature: #13), **strictly worse** (#5, #9), **unreachable** (#14),
+or **not expressible through the declared signature** (#4). Wiring any of them is a behaviour
+change wearing a refactor's clothes.
+
+---
+
+## 2. Measurement corrections
+
+Method: `ast` walk of `llm.py` for function extents and node counts; repo-wide `grep` for call
+sites, re-run receiver-aware (§6) to eliminate same-name false positives;
+`difflib.SequenceMatcher` on function source slices.
+
+**Confirmed exactly:** `adapters/__init__.py` 340 lines; `llm.py` 7,160; `get_response` at
+`2557`, 1,675 lines, **194** branch nodes; `get_response_stream` at `4233`, 443 lines, **56**;
+`get_response_async` at `4706`, 969 lines; similarity 22.3% vs 75.6/77.8/84.4/90.5% for the
+other four pairs; Ollama references `llm.py` **145 lines** / 154 occurrences,
+`adapters/__init__.py` **19 lines** / 20; all 20 call-site counts as listed; the
+`recover_tool_calls_from_text` duplicate at `3468-3500` vs `160-189`.
+
+**Five corrections:**
+
+| # | Claim | Measured | Note |
+|---|---|---|---|
+| 2.1 | "`DefaultAdapter` defines 18 methods" | **17 methods** | The 18th listed item, `add_provider_adapter`, is a module-level function. `LLMProviderAdapterProtocol` declares only **16** — it omits `get_streaming_adapter`, so that method is not even part of the protocol it claims to implement. |
+| 2.2 | `get_response_async` = 109 branch nodes | **115** under the metric that yields 194 and 56 for the other two; **112** excluding `ExceptHandler` | 109 matches neither metric. Correct `00-ground-truth.md`. |
+| 2.3 | `max_tool_repairs`: 2 in `get_response` | **2 lines, 3 occurrences** (`3583`×2, `3599`×1) | The original table mixes line counts and occurrence counts. |
+| 2.4 | `_format_ollama_tool_result_message`: 1 / 1 / **0** | 1 / 1 / **1 (indirect)** | The stream path reaches it via `_create_tool_message` (`6791-6792`), called at `4489`, `4497`, `4661`. **The stream path is not missing Ollama tool-result formatting** — the original table overstates the gap. |
+| 2.5 | Seven compensations diverge | **Sixteen** | Nine further asymmetries, three of which run *against* the sync path. §2.6. |
+
+### 2.6 Complete compensation matrix (line hits per path)
+
+```
+                                        sync    async   stream    lines
+                                       1675 L   969 L    443 L
+tool_result_mapping                       8       0        0      3649,3682,3685,3687,3688,3728,3733,3735
+max_tool_repairs                          2       0        0      3583,3599
+_validate_tool_call                       1       0        0      3587
+TOOL_CALL_REPAIR_PROMPT                   1       0        0      3595
+_should_force_tool_usage                  1       0        0      3561
+FORCE_TOOL_USAGE_PROMPT                   1       0        0      3563
+_supports_xml_tool_format (XML recovery)  1       0        0      3506
+json.loads(response_text) (JSON recovery) 1       0        0      3472
+OLLAMA_FINAL_ANSWER_PROMPT                0       1        0      -    / 5302 / -      <- async-only
+_register_deferred_if_any                 1       0        1      2918 / -    / 4461   <- async-only gap
+OLLAMA_TOOL_USAGE_PROMPT                  1       1        0      3576 / 5174 / -
+_validate_and_filter_ollama_arguments     1       1        0      3690 / 5240 / -
+_generate_ollama_tool_summary             1       1        0      3847 / 5470 / -
+_handle_ollama_sequential_logic           1       1        0      3813 / 5438 / -
+OLLAMA_SUMMARY_ITERATION_THRESHOLD        1       1        0      3821 / 5446 / -
+_manage_context_in_loop                   1       1        0      2751 / 4882 / -
+_finalise_on_limit                        2       2        0      2971,3828 / 5008,5453 / -
+_format_ollama_tool_result_message        1       1        1*     3762 / 5267 / via _create_tool_message
+```
+
+`*` indirect — correction 2.4.
+
+### 2.7 The divergence is observable — and not in the direction assumed
+
+Live Ollama, `temperature=0`, identical prompt and tool, two trials:
+
+```
+### t0 sync   tool_calls=1   out='{\n\n\n}'
+### t0 async  tool_calls=1   out='Paris: 21C sunny'
+### t0 stream tool_calls=10  out=''
+### t1 sync   tool_calls=1   out='{\n\n\n}'
+### t1 async  tool_calls=1   out='Paris: 21C sunny'
+### t1 stream tool_calls=10  out=''
+```
+
+Reproduce:
+
+```bash
+cd src/praisonai-agents && python3 - <<'EOF'
+import sys, os, asyncio; sys.path.insert(0,'.'); os.environ.setdefault('OPENAI_API_KEY','x')
+from praisonaiagents.llm.llm import LLM
+def get_weather(city: str) -> str:
+    """Get the weather for a city."""
+    return f"{city}: 21C sunny"
+P = "What is the weather in Paris? Use the tool."
+for path in ("sync","async","stream"):
+    calls=[]
+    def exec_tool(name,args,**kw): calls.append(name); return get_weather(**args)
+    llm=LLM(model="ollama/qwen3:0.6b", base_url="http://127.0.0.1:11434")
+    if path=="sync":     out=llm.get_response(prompt=P,tools=[get_weather],execute_tool_fn=exec_tool,temperature=0)
+    elif path=="async":  out=asyncio.run(llm.get_response_async(prompt=P,tools=[get_weather],execute_tool_fn=exec_tool,temperature=0))
+    else:                out="".join(str(c) for c in llm.get_response_stream(prompt=P,tools=[get_weather],execute_tool_fn=exec_tool,temperature=0))
+    print(f"### {path:6} tool_calls={len(calls)} out={out!r}")
+EOF
+```
+
+Three consequences, and they reframe the order:
+
+1. **The best-compensated path produces the worst answer.** `get_response` has 16 of the 18
+   compensations and returns `'{\n\n\n}'`. `get_response_async` has 8 and returns the correct
+   answer. More compensation is not the goal; *the same* compensation is.
+2. **The stream path is not under-compensated, it is broken.** It burns all 10 iterations of
+   `max_iter`, invokes the tool **10 times** for a one-tool question, and yields nothing. That
+   is a real cost and side-effect amplifier, not a formatting defect.
+3. **Leading hypothesis for the sync/async split: `OLLAMA_FINAL_ANSWER_PROMPT`**
+   (`llm.py:5302`, async only). Async appends *"Based on the tool results above, please provide
+   the final answer"* and re-requests; sync does not, so at iteration 1 the model emits
+   `{\n\n\n}`, which is non-empty, so the `3844` empty-response guard does not fire and the
+   garbage is returned verbatim. **This is a hypothesis, not a measurement.** Step 06.0 settles it.
+
+**None of the three baselines may change during Steps 06.1–06.6.** Every step is a
+behaviour-preserving refactor. `'{\n\n\n}'` stays `'{\n\n\n}'`. Fixing it is this order's
+*successor*, and it needs these characterization tests to be safe.
+
+---
+
+## 3. Preconditions for every step
+
+```bash
+# 1. Order 02 must have landed.
+git log --oneline origin/main | head -20 | grep -i "provider.detection\|_detect_provider"
+
+# 2. Branch from origin/main, never from a sibling order's branch.
+git fetch origin main && git worktree add /path/to/wt-06 -b <step-branch> origin/main
+
+# 3. Ollama up, correct model present.
+curl -s 127.0.0.1:11434/api/version                                  # {"version":"0.33.2"}
+curl -s 127.0.0.1:11434/api/show -d '{"model":"qwen3:0.6b"}' | \
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["capabilities"])'
+                                                # ['completion','tools','thinking']
+
+# 4. Green baseline on the two suites this order can break.
+cd src/praisonai-agents && PYTHONPATH=. python -m pytest tests/unit/test_adapter_registry.py -q  # 38 passed
+cd src/praisonai && PYTHONPATH=../praisonai-agents python -m pytest tests/unit/llm/ -q
+```
+
+### 3.1 Three test-infrastructure traps
+
+**Trap A — `src/praisonai-agents/tests/` is almost entirely outside CI.** Grepping every
+workflow: the only tests run from that directory are `tests/smoke/test_subscription_auth.py`
+and `tests/unit/auth/test_agent_auth_wiring.py` (`test-optimized.yml:110-113`).
+**`tests/unit/test_adapter_registry.py` (38 tests) and all 13 files in `tests/unit/llm/` are run
+by no workflow at all.** Consequences:
+
+- Deleting `GeminiAdapter.format_tools` breaks
+  `test_adapter_registry.py::test_gemini_adapter_formats_internal_tools` and **no CI job will
+  tell you**. Run that file by hand in every step.
+- **All new tests in this order go to `src/praisonai/tests/unit/llm/`**, which *is* run — by
+  `test-core.yml` (`subdirs` shard) and `test-optimized.yml` (main job).
+- Do not fix the CI gap here; `.github/workflows/**` belongs to orders 04 and 05. §7 hands it over.
+
+**Trap B — `test_ollama_tool_reliability.py` tests a copy, not the product.**
+`src/praisonai/tests/unit/llm/test_ollama_tool_reliability.py` (541 lines, 28 tests, all green)
+defines `class MockLLM` which *re-implements* `_is_ollama_provider`, `_apply_ollama_defaults`,
+`_validate_tool_call`, `_should_force_tool_usage` and both prompt templates. Its own docstring
+says *"copied from actual LLM class"*. **It cannot fail in response to any change in `llm.py`.**
+Do not treat it as a safety net and do not extend it. Every characterization test in this order
+instantiates the real `praisonaiagents.llm.llm.LLM`.
+
+**Trap C — the auto provider-marker does not apply under `tests/unit/`.** `test_gating.py:214`
+guards provider auto-detection with `if item.fspath and test_type != 'unit'`. So a file under
+`tests/unit/llm/` mentioning "ollama" is *not* auto-gated and **will** run in CI. Live-server
+tests therefore need an **explicit** `pytestmark`; verified that the CI marker expression then
+deselects them (`1 collected / 1 deselected`).
+
+---
+
+## 4. The WIRE sequence
+
+Six steps, each one branch, one commit, one adapter method, independently revertible. Lowest
+risk first.
+
+### Step 06.0 — record the `OLLAMA_FINAL_ANSWER_PROMPT` experiment (no ship)
+
+Branch: none. Deliverable: one row appended to `00-ground-truth.md` recording whether adding the
+async-only final-answer append at `llm.py:3838` changes the sync path's `'{\n\n\n}'`. Revert the
+local patch with `git checkout --`. This exists so the successor order need not re-derive it.
+
+### Step 06.1 — the reachability ratchet (test only, zero source change)
+
+**Branch:** `test/adapter-reachability-ratchet`
+**Source changes:** none. If your diff touches `praisonaiagents/`, you are on the wrong step.
+
+Add `src/praisonai/tests/unit/llm/test_llm_adapter_seam.py` — full text in §6. It carries a
+`KNOWN_DEAD` frozenset seeded with exactly the eleven names measured today. Later steps delete
+names from that set; the set never grows.
+
+**Verify:**
+```bash
+cd src/praisonai && PYTHONPATH=../praisonai-agents python -m pytest \
+  tests/unit/llm/test_llm_adapter_seam.py -q            # expect 4 passed
+```
+Then prove the ratchet bites — temporarily drop one name from `KNOWN_DEAD` and confirm
+`test_no_new_dead_adapter_methods` fails. **A ratchet you have not seen fail is not a ratchet.**
+
+**Rollback:** `git revert <sha>` — deletes one test file.
+
+### Step 06.2 — delete the twelve speculative surfaces
+
+**Branch:** `refactor/delete-dead-adapter-surface`
+
+**Delete from `llm/adapters/__init__.py`:**
+
+| Lines | What |
+|---|---|
+| `26-27` | `DefaultAdapter.format_tools` |
+| `29-30` | `DefaultAdapter.post_tool_iteration` |
+| `32-33` | `DefaultAdapter.supports_structured_output` |
+| `41-44` | `DefaultAdapter.get_streaming_adapter` |
+| `46-47` | `DefaultAdapter.get_max_iteration_threshold` |
+| `68-73` | `DefaultAdapter.parse_tool_calls` |
+| `75-76` | `DefaultAdapter.should_skip_streaming_with_tools` |
+| `81-82` | `DefaultAdapter.inject_cache_control` |
+| `84-85` | `DefaultAdapter.extract_reasoning_tokens` |
+| `108-110` | `OllamaAdapter.get_streaming_adapter` |
+| `112-113` | `OllamaAdapter.get_max_iteration_threshold` |
+| `191-197` | `OllamaAdapter.post_tool_iteration` |
+| `212-213` | `AnthropicAdapter.supports_structured_output` |
+| `223-225` | `AnthropicAdapter.get_streaming_adapter` |
+| `238-240` | `GeminiAdapter.should_skip_streaming_with_tools` |
+| `242-243` | `GeminiAdapter.supports_structured_output` |
+| `245-258` | `GeminiAdapter.format_tools` |
+| `264-266` | `GeminiAdapter.get_streaming_adapter` |
+| `321-328` | `list_provider_adapters`, `has_provider_adapter` |
+| `13` | `from ..streaming_protocol import ...` — now unused |
+| `12` | `from ..model_capabilities import GEMINI_INTERNAL_TOOLS` — now unused |
+| `338-339` | the two `__all__` entries |
+
+**Keep** `add_provider_adapter` and its `__all__` entry (§7 hands it to order 02).
+
+**Delete from `llm/protocols.py`** the matching stubs: `294-296`, `298-300`, `302-304`,
+`314-316`, `330-332`, `334-336`, `342-344`, `346-348`. Also strip the
+`format_tools`/`post_tool_iteration` lines from the class docstring example at `276-282`, which
+would otherwise document deleted API.
+
+`LLMProviderAdapterProtocol` is `@runtime_checkable`, so `isinstance` only checks method
+presence — deleting a name from both the protocol and `DefaultAdapter` keeps the two
+`..._implements_protocol` tests green.
+
+**Delete the one unreachable inline branch** in `llm/llm.py`, verbatim:
+
+```python
+3120:                        
+3121:                        # Gemini has issues with streaming + tools, disable streaming for Gemini when tools are present
+3122:                        if use_streaming and formatted_tools and self._is_gemini_model():
+3123:                            logging.debug("Disabling streaming for Gemini model with tools due to JSON parsing issues")
+3124:                            use_streaming = False
+3125:                        
+```
+
+Replace `3120-3125` with a single blank line. **Proof it is unreachable** — three lines above:
+
+```python
+3116:                        use_streaming = stream
+3117:                        if formatted_tools and not self._supports_streaming_tools():
+3118:                            # Provider doesn't support streaming with tools, use non-streaming
+3119:                            use_streaming = False
+```
+
+`_supports_streaming_tools()` returns `self._provider_adapter.supports_streaming_with_tools()`
+(`llm.py:2172`), which `GeminiAdapter` overrides to `False`. So for Gemini-with-tools, `3119`
+already sets `use_streaming = False` and the `3122` guard can never be true. Verified:
+
+```
+$ python3 -c "from praisonaiagents.llm.adapters import get_provider_adapter as g; \
+  print(g('gemini/gemini-2.0-flash').supports_streaming_with_tools())"
+False
+```
+
+`get_response_async` and `get_response_stream` have no equivalent branch. One-path edit, so §8's
+two-path rule does not apply.
+
+**Also update `KNOWN_DEAD`**: remove the nine deleted method names, leaving
+`{"handle_empty_response_with_tools", "recover_tool_calls_from_text"}`.
+
+**Non-Ollama behaviour identical**, asserted three ways: (1) Step 06.1's
+`test_no_dead_name_is_actually_live` proves every deleted name had zero call sites; (2) new test
+`test_gemini_with_tools_never_streams` pins the deletion at the level of the surviving guard;
+(3) `test_adapter_registry.py` must still pass with **one deletion** —
+`test_gemini_adapter_formats_internal_tools` (lines `347-363`) tests `GeminiAdapter.format_tools`
+and must be removed in the same commit. That is the only test in the repo exercising any deleted
+surface (verified by repo-wide `grep` for each of the twelve names).
+
+**Characterization tests first**, in
+`src/praisonai/tests/unit/llm/test_llm_response_path_characterization.py`:
+- `test_gemini_with_tools_never_streams` — assert `_supports_streaming_tools()` is `False` and
+  `_is_gemini_model()` is `True`; assert the value of `_supports_streaming_tools()` for every
+  `(model, tools_present)` in `{gemini, gpt-4o, ollama/qwen3:0.6b} × {True, False}` matches a
+  hard-coded expectation table.
+- `test_deleted_adapter_names_are_absent` — `not hasattr(DefaultAdapter, name)` for each of the
+  nine, so a later merge cannot silently resurrect them.
+
+**Verify live:** run the §2.7 script. All three outputs byte-identical to baseline
+(`'{\n\n\n}'`, `'Paris: 21C sunny'`, `''`), stream tool-call count still 10. A change means you
+deleted something live.
+
+**Rollback:** `git revert <sha>`. Pure deletion, no state, no migration.
+
+### Step 06.3 — WIRE `format_tool_result_message` for the default branch
+
+**Branch:** `refactor/wire-default-tool-result-message`
+
+**Why safe:** `DefaultAdapter.format_tool_result_message`'s body currently has **zero**
+consumers. `llm.py:1712` is reached only through `_format_ollama_tool_result_message`, whose
+call sites are guarded by `_is_ollama_provider()` and which forces an `OllamaAdapter` if
+`_provider_adapter` is something else. So the default body can be rewritten to match the three
+inline copies with no observable change.
+
+The three inline copies to be replaced are at `llm.py:3770-3785` (sync), `5275-5290` (async),
+and `6791-6807` (`_create_tool_message`, the stream path's formatter). All three implement the
+same cascade: `None` → `"Function returned an empty output"`; a dict with `'error'` → an error
+sentence; a list whose first element has `'error'` → the same; otherwise `json.dumps`. Path 3
+differs in one respect — it wraps `json.dumps` in `try/except (TypeError, ValueError)` and falls
+back to `str(result)`.
+
+**Replacement.** Give `DefaultAdapter.format_tool_result_message` the union body, adopting path
+3's guard (strictly safer — paths 1 and 2 raise on a non-serializable result):
+
+```python
+    def format_tool_result_message(self, function_name: str, tool_result: Any, tool_call_id: Optional[str] = None) -> Dict[str, Any]:
+        # Standard OpenAI-style tool result message.
+        if tool_result is None:
+            content = "Function returned an empty output"
+        elif isinstance(tool_result, dict) and 'error' in tool_result:
+            content = (f"Error: {tool_result.get('error', 'Unknown error')}. "
+                       "Please inform the user that the operation could not be completed.")
+        elif (isinstance(tool_result, list) and tool_result
+                and isinstance(tool_result[0], dict) and 'error' in tool_result[0]):
+            content = (f"Error: {tool_result[0].get('error', 'Unknown error')}. "
+                       "Please inform the user that the operation could not be completed.")
+        else:
+            try:
+                content = json.dumps(tool_result)
+            except (TypeError, ValueError):
+                content = str(tool_result)
+        message = {"role": "tool", "content": content}
+        message["tool_call_id"] = tool_call_id if tool_call_id is not None else f"call_{function_name}"
+        return message
+```
+
+(`import json` at module top of `adapters/__init__.py`; `OllamaAdapter.recover_tool_calls_from_text`
+imports it function-locally at line 166 — leave that alone in this step.)
+
+Then make `_create_tool_message` (`llm.py:6772`) the single formatter and delegate:
+
+```python
+        if is_ollama:
+            return self._format_ollama_tool_result_message(function_name, result)
+        adapter = getattr(self, '_provider_adapter', None)
+        if adapter is None:
+            from .adapters import DefaultAdapter
+            adapter = DefaultAdapter()
+        return adapter.format_tool_result_message(function_name, result, tool_call_id)
+```
+
+and replace `3770-3785` with
+
+```python
+                            else:
+                                messages.append(self._create_tool_message(
+                                    function_name, tool_result, tool_call_id, is_ollama=False))
+```
+
+and `5275-5290` with the same at async indentation. Path 3 needs no call-site change — it *is*
+`_create_tool_message`.
+
+**This edits two of the three response paths, so §8's rule applies:** the commit must carry
+`test_tool_result_message_identical_across_paths`, parametrized over all three. Without it,
+split into two commits (sync first, async second), each with a path-specific test.
+
+**Tests, written and passing against `main` first:**
+- `test_default_tool_result_message_matches_legacy_shape` — nine `tool_result` fixtures
+  (`None`, `{}`, `{"error": "x"}`, `[{"error":"y"}]`, `[]`, `"str"`, `3`, `{"a":1}`, and a
+  `set()` — the non-serializable case) × expected message dict, hard-coded from the *pre-change*
+  inline bodies.
+- `test_non_serializable_tool_result_no_longer_raises` — marked `xfail(strict=True)` on `main`.
+  **This is a deliberate divergence:** for a `set()`, paths 1 and 2 previously raised
+  `TypeError` and now produce `str(...)`. That is a bug fix, not a preservation. Call it out in
+  the commit message so it appears as a test-outcome diff rather than a silent edit.
+- `test_tool_result_message_identical_across_paths` — parametrized over `("sync","async","stream")`;
+  patch `_completion_with_retry` / `_acompletion_with_retry` to return a canned tool call, then
+  assert the `messages` list is **equal across all three paths** for a `DefaultAdapter` model.
+  Fails on `main` for the `set()` fixture; passes after. That is the intended ratchet.
+
+**Verify live:** §2.7 script must reproduce all three baselines exactly. Ollama takes the
+`is_ollama` branch, so this step must not perturb it at all.
+
+> **Trap when testing the non-Ollama path locally:** `_is_ollama_provider` (`llm.py:719`) matches
+> `:11434` in `base_url`, so pointing at a local Ollama through the OpenAI-compatible route
+> *still* yields `OllamaAdapter`. Use a proxy or a mocked transport. **Do not** work around it by
+> editing `_is_ollama_provider` — that method belongs to order 02.
+
+**Rollback:** `git revert <sha>`. Adapter body and three call sites revert together.
+
+### Step 06.4 — WIRE `handle_empty_response_with_tools`
+
+**Branch:** `refactor/wire-handle-empty-response-with-tools`
+
+The only dead method whose signature already matches its inline predicate. Inline at
+`llm.py:3842-3852` (sync) and `5465-5475` (async); `get_response_stream` has no equivalent (§5.5).
+
+**Replace the predicate only** (lines `3844-3845` and `5467-5468`) with:
+
+```python
+                        if self._provider_adapter.handle_empty_response_with_tools({
+                            'iteration_count': iteration_count,
+                            'accumulated_tool_results': accumulated_tool_results,
+                            'response_text': response_text or '',
+                        }):
+```
+
+The body (`3846-3852` / `5469-5475`) stays exactly where it is, unreflowed. **Do not** move
+`_generate_ollama_tool_summary` into the adapter in this step — it is 82 lines with a
+`_format_search_results_summary` dependency and is shared by `_handle_ollama_sequential_logic`.
+One method per step.
+
+**Semantic equivalence — and the one real risk.** The current predicate leads with
+`self._is_ollama_provider()`. After the change, Ollama-treatment is decided by *dispatch*:
+`OllamaAdapter` returns the predicate, `DefaultAdapter` returns `False`. **That is not identical
+to `_is_ollama_provider()`** — `_detect_provider` (`llm.py:640-671`) maps by route prefix and
+base-url hints, and `get_provider_adapter` (`adapters:311`) additionally matches
+`"ollama" in name_lower`. The union is *wider*: e.g. `model="my-ollama-model"` with no ollama
+base-url gets `OllamaAdapter` while `_is_ollama_provider()` is `False`.
+
+**Therefore this step must add the exact-equivalence assertion, or it is not behaviour-preserving:**
+
+`test_ollama_adapter_selection_matches_is_ollama_provider` — parametrized over 14
+model/base_url combinations (`ollama/llama3`, `ollama/qwen3:0.6b`, `my-ollama-model`,
+`ollama_chat/llama3`, `llama3`+`base_url=...:11434`, `llama3`+`OPENAI_BASE_URL=...:11434`,
+`gpt-4o`, `claude-3-5-sonnet`, `gemini/gemini-2.0-flash`, `bedrock/anthropic.claude-3`,
+`vertex_ai/gemini-1.5-pro`, `openrouter/anthropic/claude-3`, `""`, `None`), asserting
+`isinstance(llm._provider_adapter, OllamaAdapter) == llm._is_ollama_provider()`.
+
+**Run it on `main` first.** If any row fails, that row is a pre-existing divergence and **this
+step is blocked** until order 02 reconciles the two functions — record the failing rows in
+`00-ground-truth.md` and stop. Do not paper over it by keeping `_is_ollama_provider()` in the
+condition alongside the adapter call; that would leave the adapter non-load-bearing, which is
+the whole defect.
+
+**Characterization tests first**, `src/praisonai/tests/unit/llm/test_llm_empty_response_compensation.py`:
+- `test_empty_response_after_tools_yields_summary_sync` / `..._async` — mocked completion:
+  iteration 0 returns a tool call, iteration 1 returns `content=""`. Assert the returned string
+  equals the `_generate_ollama_tool_summary` output.
+- `test_whitespace_only_response_counts_as_empty` — iteration 1 returns `"   \n "`. Pins the
+  `.strip()` semantics; the adapter's `state.get('response_text','').strip()` and the inline
+  `response_text.strip() == ""` agree **only if `response_text` is never `None`** — hence the
+  `response_text or ''` in the replacement.
+- `test_non_empty_response_after_tools_returns_model_text` — iteration 1 returns `"{\n\n\n}"`.
+  Must return `'{\n\n\n}'`. **This is the §2.7 sync baseline; it must not improve in this step.**
+- `test_default_adapter_never_takes_empty_response_branch` — `gpt-4o`; patch
+  `_generate_ollama_tool_summary` with a `Mock` and assert `not called`. The non-Ollama identity
+  assertion.
+- `test_iteration_zero_never_takes_branch` — empty response at iteration 0 must fall through to
+  the `3572` tool-usage prompt, not the summary.
+
+All six against `main` first, then committed **with** the refactor (they cover both edited paths).
+
+**Update `KNOWN_DEAD`** → `{"recover_tool_calls_from_text"}`.
+
+**Rollback:** `git revert <sha>`.
+
+### Step 06.5 — WIRE `recover_tool_calls_from_text`
+
+**Branch:** `refactor/wire-recover-tool-calls-from-text`
+Highest value, highest risk, therefore last. Inline at `llm.py:3468-3500`, **sync only**.
+
+**Replacement for all 33 lines:**
+
+```python
+                    # Recover tool calls the provider emitted as response text.
+                    if not tool_calls and response_text and formatted_tools:
+                        recovered = self._provider_adapter.recover_tool_calls_from_text(
+                            response_text, formatted_tools)
+                        if recovered:
+                            tool_calls = recovered
+                            logging.debug(f"Recovered tool calls from response text: {tool_calls}")
+```
+
+**Four measured behavioural deltas, each argued inert:**
+
+| Delta | Inline | Adapter | Resolution |
+|---|---|---|---|
+| `id` format | `f"tool_{iteration_count}"` / `f"tool_{i}_{idx}"` | `f"call_{name}_{idx}_{hash(text)%10000}"` | **Inert for Ollama.** The id never reaches the model: the assistant turn omits `tool_calls` entirely for Ollama (`3633-3638`) and the tool reply is `role:"user"` with no `tool_call_id` (`3760-3762`). Pin with `test_recovered_tool_call_id_never_reaches_messages`. |
+| List with no `"name"` entries | `[]` | `None` | Equivalent at every consumer: `3504` (`if not tool_calls and ...`) and `3623` (`if tool_calls and ...`) treat them alike, as does the replacement's `if recovered:`. Pin with `test_list_without_name_keys_does_not_dispatch`. |
+| Exceptions caught | `(JSONDecodeError, KeyError)` | `(JSONDecodeError, TypeError, KeyError)` | Adapter is strictly wider — can only stop a failure, never cause one. Note in the commit message. |
+| Guard | `_is_ollama_provider() and ...` | dispatch | Same widening as 06.4. **Reuse `test_ollama_adapter_selection_matches_is_ollama_provider` as a hard precondition** — do not land 06.5 unless it is green. |
+| Debug logging | two distinct messages | none in adapter | The replacement logs one message at the call site, so the "recovery happened" signal survives. The single-vs-multiple distinction is lost; state that in the commit message. |
+
+**Non-Ollama identity.** `DefaultAdapter`, `AnthropicAdapter` and `GeminiAdapter` all inherit
+`recover_tool_calls_from_text -> None`, so no non-Ollama provider can enter the branch.
+Asserted by `test_no_text_recovery_for_default_adapter` — `gpt-4o`, mocked response whose
+`content` is exactly `'{"name": "get_weather", "arguments": {"city": "Paris"}}'` and whose
+`tool_calls` is `None`. Assert `execute_tool_fn` is never called and the returned string is that
+JSON text verbatim. **This test must pass identically on `main` and after** — it is the single
+most important assertion in this step, because it is the one an over-eager wiring would break.
+Parametrize for `claude-3-5-sonnet` and `gemini/gemini-2.0-flash` too.
+
+**Characterization tests first**, `src/praisonai/tests/unit/llm/test_llm_text_tool_call_recovery.py`:
+
+| Test | Input `content` | Asserted |
+|---|---|---|
+| `test_recovers_single_json_tool_call` | `'{"name":"get_weather","arguments":{"city":"Paris"}}'` | called once with `("get_weather", {"city":"Paris"})` |
+| `test_recovers_multiple_json_tool_calls` | `'[{"name":"a","arguments":{}},{"name":"b","arguments":{}}]'` | called twice, in order |
+| `test_dict_without_name_key_does_not_dispatch` | `'{"arguments":{"city":"Paris"}}'` | not called; text returned verbatim |
+| `test_list_without_name_keys_does_not_dispatch` | `'[{"arguments":{}}]'` | not called |
+| `test_malformed_json_does_not_dispatch` | `'{"name": "get_weather"'` | not called; no exception escapes |
+| `test_empty_text_does_not_dispatch` | `''` | not called |
+| `test_no_tools_means_no_recovery` | valid JSON call, `tools=None` | not called |
+| `test_native_tool_calls_take_precedence` | valid JSON text **and** a native `tool_calls` naming `other_tool` | `other_tool` runs; text not parsed |
+| `test_xml_recovery_still_reachable_after_json_recovery_fails` | `'<tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}</tool_call>'`, Qwen model | dispatches via the XML block at `3502-3558` |
+| `test_recovered_tool_call_id_never_reaches_messages` | valid JSON call | no appended message contains `tool_call_id` or `tool_calls` |
+| `test_arguments_are_json_encoded_string` | `'{"name":"a","arguments":{"n":1}}'` | `function.arguments` is the **string** `'{"n": 1}'`, not a dict — what `_parse_tool_call_arguments` expects |
+
+`test_xml_recovery_still_reachable_after_json_recovery_fails` is the guard for a subtle
+interaction: the inline list branch sets `tool_calls = []` *before* recovery, and the XML block
+at `3504` re-checks `if not tool_calls`. The replacement never assigns a falsy value, so the XML
+path stays reachable — but only this test proves it.
+
+**Update `KNOWN_DEAD`** → `frozenset()`, and change `test_no_new_dead_adapter_methods` to assert
+the set is empty. Leave the allowlist mechanism in place (empty) so a future addition has an
+obvious, reviewable place to be justified.
+
+**Verify live — mandatory for this step**, because `qwen3:0.6b` emits JSON-as-text reliably at
+`temperature=0`:
+
+```bash
+git checkout origin/main
+for i in 1 2 3; do <§2.7 script>; done > /tmp/before.txt 2>&1
+git checkout refactor/wire-recover-tool-calls-from-text
+for i in 1 2 3; do <§2.7 script>; done > /tmp/after.txt 2>&1
+diff <(grep '^### sync'   /tmp/before.txt) <(grep '^### sync'   /tmp/after.txt)
+diff <(grep '^### async'  /tmp/before.txt) <(grep '^### async'  /tmp/after.txt)
+diff <(grep '^### stream' /tmp/before.txt) <(grep '^### stream' /tmp/after.txt)
+```
+
+Expected: empty diffs. `tool_calls=1` on sync in particular — a change to `tool_calls=0` means
+recovery stopped firing (the adapter is not being reached); a change in `out` means the id or
+the `[]`/`None` delta was not as inert as measured.
+
+Also run the server-free adapter equivalence check:
+```bash
+python3 -c "
+from praisonaiagents.llm.adapters import OllamaAdapter
+a = OllamaAdapter()
+for txt in ['{\"name\":\"w\",\"arguments\":{\"c\":\"P\"}}',
+            '[{\"name\":\"a\",\"arguments\":{}},{\"name\":\"b\",\"arguments\":{}}]',
+            '{\"arguments\":{}}', '[{\"arguments\":{}}]', '{\"name\":\"w\"', '']:
+    r = a.recover_tool_calls_from_text(txt, [{'name':'w'}])
+    print(repr(txt)[:40], '->', [(c['function']['name'], c['function']['arguments']) for c in (r or [])])
+"
+```
+
+**Rollback:** `git revert <sha>`. The 33 inline lines come back intact; `KNOWN_DEAD` must be
+restored to `{"recover_tool_calls_from_text"}` in the same revert.
+
+### Step 06.6 — port `_validate_and_filter_ollama_arguments` to the stream path
+
+**Branch:** `fix/stream-path-ollama-argument-filtering`
+
+The one A2 gap that belongs in *this* order rather than a follow-up, because it is
+**pre-dispatch, provider-shaped and streaming-safe**: it runs before `execute_tool_fn`, so
+nothing has been yielded that would need retracting.
+
+Present at `3690` (sync) and `5240` (async); absent from both stream branches. Insert after
+`llm.py:4433` (streaming branch) and after `4639` (fallback branch), mirroring `5238-5240`:
+
+```python
+                            # Validate and filter arguments for Ollama provider
+                            if is_ollama and tools:
+                                arguments = self._validate_and_filter_ollama_arguments(function_name, arguments, tools)
+```
+
+One response path (twice), so §8's two-path rule does not apply — but both insertion points
+need coverage: `test_stream_filters_ollama_arguments_streaming_branch` and
+`..._fallback_branch`, in `src/praisonai/tests/unit/llm/test_llm_stream_ollama_parity.py`.
+
+Drive the fallback branch with an Ollama model (which reports
+`supports_streaming_with_tools() is False`, so `4304-4306` sends it there). Drive the streaming
+branch with `gpt-4o` plus a monkeypatched `_provider_adapter` reporting Ollama — and assert in
+the test that this is the only way to reach it, which documents that **the streaming branch is
+unreachable for real Ollama today**.
+
+**Non-Ollama:** the `if is_ollama and tools` guard makes it a no-op; assert with
+`test_stream_does_not_filter_arguments_for_default_adapter` (patch with a `Mock`, assert
+`not called` for `gpt-4o`).
+
+**Verify live:** §2.7 script. The stream line must **still** read `tool_calls=10 out=''`.
+**Do not fix that here** — it is the successor order's job (§5.5). Any improvement means you
+changed more than one thing.
+
+**Rollback:** `git revert <sha>`.
+
+---
+
+## 5. The async/stream gap — disposition per compensation
+
+Every row of §2.6 gets one of: **(a)** part of an order-06 step, **(b)** a separate follow-up
+order, **(c)** deliberately out of scope. No row is left unassigned.
+
+### 5.1 `tool_result_mapping` — 8/0/0 → **(c) out of scope, and recommend deletion**
+
+Do **not** port it. Read what it does (`llm.py:3682-3688`, `3724-3735`):
+
+```python
+3684:  for arg_name, arg_value in list(arguments.items()):
+3685:      if isinstance(arg_value, str) and arg_value in tool_result_mapping:
+3686:          # Replace function name with its result
+3687:          arguments[arg_name] = tool_result_mapping[arg_value]
+...
+3729:  elif isinstance(tool_result, str):
+3730:      import re
+3731:      match = re.search(r'\b(\d+)\b', tool_result)
+3732:      if match:
+3733:          tool_result_mapping[function_name] = int(match.group(1))
+```
+
+It silently rewrites a user-supplied tool argument whenever that argument's *string value
+happens to equal a previously-called function's name*, substituting the first integer found
+anywhere in that function's string result. `get_weather` returning `"Paris: 21C sunny"`
+registers `21`; a later call with `city="get_weather"` would receive `21`.
+
+This is a **data-corruption hazard, not a compensation**. Porting it to async and stream would
+triple the exposure and violate the ledger's closing obligation ("no order may add a fifth copy
+of any compensation"). **Recommendation:** a separate order to remove it, gated on a
+characterization test proving no example or test depends on it.
+
+### 5.2 `max_tool_repairs` + `_validate_tool_call` + `TOOL_CALL_REPAIR_PROMPT` — 2/1/1 sync only
+
+→ **(b) follow-up for async; (b) follow-up for stream's fallback branch only; (c) impossible in
+the true streaming branch.**
+
+*Async:* mechanically portable — same request/response shape, same `messages` list, same
+`iteration_count` accounting. But it is *schema validation*, provider-independent, and not
+adapter-shaped, so it is not A1 work. Separate order.
+
+*Stream — the honest split:*
+- **The non-streaming fallback branch (`4553-4667`) can have it.** This is where Ollama,
+  Anthropic and Gemini with tools actually land (`4304-4306`), so in practice it covers every
+  provider that would need repair. Nothing has been yielded at validation time when `content` is
+  empty — and when `content` is non-empty it has already been yielded at `4614`, so
+  repair-and-retry would produce a *duplicate* prose emission. Correct rule: validate before
+  dispatch; on failure append the repair prompt and loop **without** re-yielding prose already sent.
+- **The true streaming branch (`4308-4551`) cannot have repair-and-retry.** A tool call is
+  assembled from deltas (`_process_tool_calls_from_stream`, `llm.py:6752`) and is complete only
+  when the stream ends — by which time every content delta has already been `yield`ed to the
+  caller's `for` loop. **You cannot un-yield.** What *is* possible while streaming: (i) refuse to
+  dispatch an invalid call; (ii) yield additional chunks; (iii) raise. What is not possible:
+  retract, rewrite, or replace anything already emitted.
+
+  **Honest user-facing behaviour:** on a validation failure in the true streaming branch, do not
+  silently drop the call (today's behaviour is worse — it drops it *and* yields nothing) and do
+  not attempt a repair round. Raise `LLMResponseError` naming the tool and the validation error.
+  A caller that wants repair should not be streaming; the SDK already knows how to express that
+  choice — `_supports_streaming_tools()` — and the honest extension is for repair-requiring
+  configurations to report `False` there, sending the turn to the fallback branch where repair
+  is possible. Title that order: *"tool-call repair is a non-streaming capability; make the
+  streaming gate say so."*
+
+### 5.3 `force_tool_usage` / `_should_force_tool_usage` / `FORCE_TOOL_USAGE_PROMPT` — 1/0/0
+
+→ **(b) immediate follow-up, elevated priority.** This should be order 06's direct successor.
+
+`get_default_settings()` (live, `llm.py:690`) sets `force_tool_usage = 'auto'` for **every**
+Ollama `LLM`, on all three paths. `_should_force_tool_usage` is consulted **only** at
+`llm.py:3561`, inside `get_response`. So `Agent(llm="ollama/...", stream=True)` accepts the
+setting, reports it on `self.force_tool_usage`, and never acts on it. **A setting accepted and
+ignored is exactly what root `AGENTS.md` forbids.**
+
+Portability: `_should_force_tool_usage` (`1768-1788`) is pure —
+`(response_text, tool_calls, formatted_tools, iteration_count) -> bool` — and the action is one
+`messages.append` plus `continue`. Trivial for async. For stream: fine in the fallback branch;
+in the true streaming branch it is an *additional* request after prose was already yielded,
+which is legal (yielding more is always possible) but changes the stream's shape. That order
+must state which of the two it does.
+
+### 5.4 `_validate_and_filter_ollama_arguments` — 1/1/0 → **(a) Step 06.6**
+
+Pre-dispatch, streaming-safe, guarded by `is_ollama and tools`. Done in this order.
+
+### 5.5 `_generate_ollama_tool_summary` + `_handle_ollama_sequential_logic` + `OLLAMA_SUMMARY_ITERATION_THRESHOLD` — 1/1/0
+
+→ **(b) separate follow-up — and this is where the measured stream failure lives.**
+
+The §2.7 stream result — 10 tool invocations, zero output — is caused by their absence: nothing
+breaks the fallback `while fallback_iterations < max_fallback_iterations` loop (`4572`) when
+Ollama keeps re-emitting a tool call with empty `content`, and nothing synthesizes an answer at
+the end. The loop exhausts `max_iter`, logs at `4665-4667`, and falls off the end of the
+generator having yielded nothing.
+
+Streaming feasibility: **fully possible.** Yielding a synthesized summary as a final chunk is
+additive — the impossibility in §5.2 is about *retracting*, not appending.
+
+Why it is a separate order: it **changes the stream contract**. A turn that currently yields
+nothing would begin yielding synthesized text the model never produced. That needs its own
+characterization baseline and its own answer to the alternative. The two options, stated plainly
+for that order to choose between:
+- **Synthesize** (matches sync/async): consistent across paths; risks presenting
+  `str(tool_result)` as if the model wrote it.
+- **Raise** (`LLMResponseError("provider produced no answer after N tool iterations")`): honest,
+  and consistent with `00-ground-truth.md` §2's rule that a fabricated answer is worse than an error.
+
+**Recommendation for that order: raise on the stream path, keep synthesis on sync/async**, and
+record the asymmetry as intentional — a streaming consumer has already rendered partial output
+and a synthesized tail is indistinguishable from model text, whereas a sync caller gets one
+return value it can inspect. But that is a product decision and must be made in its own order
+with its own review, not smuggled in here.
+
+### 5.6 `OLLAMA_TOOL_USAGE_PROMPT` — 1/1/0 → **(b) follow-up, bundled with §5.5**
+
+Same shape (append a message, re-request), same branch, same tests. Bundle it.
+
+### 5.7 `OLLAMA_FINAL_ANSWER_PROMPT` — 0/**1**/0 → **(b) follow-up; the gap runs against `get_response`**
+
+`llm.py:5298-5303`, async only. The "sync compensates most" framing is wrong here, and per §2.7
+this is the leading candidate for why sync returns `'{\n\n\n}'` while async returns the right
+answer. Step 06.0 settles it.
+
+The follow-up that adds it to sync is a **behaviour change** — sync output would go from
+`'{\n\n\n}'` to `'Paris: 21C sunny'` — so it needs Step 06.4's characterization tests in place
+first, with `test_non_empty_response_after_tools_returns_model_text` deliberately updated in
+that commit. **That test failing is the signal that the fix landed.**
+
+### 5.8 `_register_deferred_if_any` — 1/**0**/1 → **(b) follow-up; async is the odd one out**
+
+Present in sync (`2918`) and stream (`4461`), missing from async. Deferred media follow-ups
+registered by a tool are dropped on the async path. Not adapter-shaped, not Ollama-specific.
+
+### 5.9 `_manage_context_in_loop` (1/1/0) and `_finalise_on_limit` (2/2/0) → **(b) follow-up**
+
+`get_response_stream` performs no in-loop context management and no max-steps finalisation. Both
+are provider-independent and streaming-compatible (context trimming happens before the request;
+finalisation appends a final chunk). One order, both fixes, one test per branch.
+
+### 5.10 `supports_streaming()` — live in async only → **(c) out of scope; do not "fix" this**
+
+It looks like an asymmetry to close. It is not. `AnthropicAdapter.supports_streaming()` returns
+`False` for a reason its own comment states:
+
+```python
+215:    def supports_streaming(self) -> bool:
+216:        # litellm.acompletion with stream=True returns a ModelResponse (not async generator)
+217:        # for Anthropic in the async path, causing 'async for requires __aiter__' error
+218:        return False
+```
+
+The defect is **specific to `litellm.acompletion`**. Consulting it from `get_response` or
+`get_response_stream` would disable Anthropic streaming entirely in the sync and generator
+paths, **where it works** — a real regression for users, dressed as consistency. Leave the call
+sites as they are. The honest cleanup is a rename (`supports_async_streaming`) or a docstring,
+both public-surface changes needing their own order and a deprecation shim under I1.
+
+---
+
+## 6. The anti-regression test
+
+Location: `src/praisonai/tests/unit/llm/test_llm_adapter_seam.py` — chosen because that
+directory **is** run by CI and `src/praisonai-agents/tests/unit/` is not (§3.1 Trap A).
+
+```python
+"""Anti-regression: the provider adapter must stay load-bearing.
+
+A1 (measured 2026-09-03 on origin/main @2591aa405): DefaultAdapter declared 17
+methods and 11 of them had zero call sites anywhere in praisonaiagents, while
+llm/llm.py carried 145 lines of hand-written Ollama dispatch doing the same
+jobs. Nothing failed. This file is what makes that state fail.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+# Methods known to have zero call sites, with the ledger decision for each.
+# This set may only ever SHRINK. Removing a name is the last step of the work
+# order that wires or deletes it. Adding a name requires a documented reason in
+# 06-adapter-revival.md -- a new adapter method with no consumer is the exact
+# defect this file exists to prevent (root AGENTS.md: no exports without a live
+# consumer).
+KNOWN_DEAD = frozenset({
+    "extract_reasoning_tokens",          # DELETE  - no override, no divergence
+    "format_tools",                      # DELETE  - inline behaviour is inverse
+    "get_max_iteration_threshold",       # DELETE  - duplicates should_summarize_tools
+    "get_streaming_adapter",             # DELETE  - pure speculative API
+    "handle_empty_response_with_tools",  # WIRE    - step 06.4
+    "inject_cache_control",              # DELETE  - stub, no impl anywhere
+    "parse_tool_calls",                  # DELETE  - signature cannot express ModelResponse
+    "post_tool_iteration",               # DELETE  - sets a flag nothing reads
+    "recover_tool_calls_from_text",      # WIRE    - step 06.5
+    "should_skip_streaming_with_tools",  # DELETE  - subsumed by supports_streaming_with_tools
+    "supports_structured_output",        # DELETE  - model_capabilities already does this
+})
+
+# Attribute-call receivers that denote a provider adapter. Restricting to these
+# is what stops OpenAIClient.format_tools (an unrelated same-named method) from
+# being counted as a call site for DefaultAdapter.format_tools.
+ADAPTER_RECEIVERS = frozenset({"_provider_adapter", "adapter", "provider_adapter"})
+
+
+def _llm_package_root() -> pathlib.Path:
+    import praisonaiagents.llm as llm_pkg
+    return pathlib.Path(llm_pkg.__file__).parent
+
+
+def _adapter_methods() -> frozenset:
+    from praisonaiagents.llm.adapters import DefaultAdapter
+    return frozenset(
+        name for name, value in vars(DefaultAdapter).items()
+        if callable(value) and not name.startswith("_")
+    )
+
+
+def _receiver_name(func: ast.Attribute):
+    """Best-effort name of the object a method is called on."""
+    value = func.value
+    if isinstance(value, ast.Name):            # adapter.foo()
+        return value.id
+    if isinstance(value, ast.Attribute):       # self._provider_adapter.foo()
+        return value.attr
+    if isinstance(value, ast.Call):            # get_provider_adapter(p).foo()
+        inner = value.func
+        if isinstance(inner, ast.Name):
+            return inner.id
+        if isinstance(inner, ast.Attribute):
+            return inner.attr
+    return None
+
+
+def _call_sites() -> dict:
+    """Map adapter method name -> ['relative/path.py:lineno', ...].
+
+    Scans every module under praisonaiagents/llm/ except the adapter module
+    itself (where these names are definitions, not calls).
+    """
+    root = _llm_package_root()
+    adapters_file = (root / "adapters" / "__init__.py").resolve()
+    methods = _adapter_methods()
+    found = {}
+    for path in sorted(root.rglob("*.py")):
+        if path.resolve() == adapters_file:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError) as exc:   # pragma: no cover
+            pytest.fail(f"could not parse {path}: {exc}")
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                continue
+            name = node.func.attr
+            if name in methods and _receiver_name(node.func) in ADAPTER_RECEIVERS:
+                found.setdefault(name, []).append(
+                    f"{path.relative_to(root)}:{node.lineno}")
+    return found
+
+
+def test_every_adapter_method_has_a_call_site():
+    """Every DefaultAdapter method is invoked on an adapter instance somewhere."""
+    methods = _adapter_methods()
+    called = _call_sites()
+    dead = sorted(methods - set(called) - KNOWN_DEAD)
+    assert not dead, (
+        "Adapter method(s) with no call site and no entry in KNOWN_DEAD: "
+        f"{dead}. Either wire them into llm/llm.py, delete them, or add them "
+        "to KNOWN_DEAD with a justification in 06-adapter-revival.md. "
+        "An adapter method that nothing calls is a lie about the extension point."
+    )
+
+
+def test_no_dead_name_is_actually_live():
+    """KNOWN_DEAD may not name a method that now has a call site.
+
+    Without this, KNOWN_DEAD rots into a permanent blanket exemption: a method
+    gets wired, nobody removes it from the set, and the next dead method added
+    beside it is never noticed.
+    """
+    called = _call_sites()
+    stale = sorted(name for name in KNOWN_DEAD if name in called)
+    assert not stale, (
+        f"KNOWN_DEAD lists live method(s) {stale} -- called at "
+        f"{ {n: called[n] for n in stale} }. Remove them from KNOWN_DEAD."
+    )
+
+
+def test_known_dead_names_all_exist():
+    """KNOWN_DEAD may not name a method that no longer exists.
+
+    Keeps the set honest after a deletion step: a stale entry would silently
+    widen the exemption for a future method that happens to reuse the name.
+    """
+    methods = _adapter_methods()
+    missing = sorted(KNOWN_DEAD - methods)
+    assert not missing, (
+        f"KNOWN_DEAD names non-existent method(s) {missing}. "
+        "Remove them from KNOWN_DEAD in the same commit as the deletion."
+    )
+
+
+def test_protocol_and_default_adapter_agree():
+    """Every method the protocol declares exists on DefaultAdapter.
+
+    LLMProviderAdapterProtocol is @runtime_checkable, so isinstance() only
+    checks name presence -- it cannot notice a protocol method that no adapter
+    implements. This does.
+    """
+    from praisonaiagents.llm.protocols import LLMProviderAdapterProtocol
+    declared = frozenset(
+        name for name in getattr(LLMProviderAdapterProtocol, "__protocol_attrs__", ())
+        if not name.startswith("_")
+    ) or frozenset(
+        name for name, value in vars(LLMProviderAdapterProtocol).items()
+        if callable(value) and not name.startswith("_")
+    )
+    missing = sorted(declared - _adapter_methods())
+    assert not missing, (
+        f"Protocol declares {missing} but DefaultAdapter does not implement it."
+    )
+```
+
+### 6.1 What this test cannot do — stated so nobody mistakes it for a ceiling
+
+1. **It cannot detect an unreachable call site.** `should_skip_streaming_with_tools` is the
+   proof: had `llm.py:3122` called it, this test would pass — while the branch stayed dead
+   because `3117` short-circuits first. Reachability is semantic; this test measures syntax.
+2. **It cannot detect a call site never *taken* at runtime** — behind `if False`, behind a config
+   flag nobody sets, or in a `try` whose `except` swallows everything (which is how
+   `_create_tool_message`'s absence hid for so long, per its own docstring at `6776-6786`).
+3. **One call site is enough to satisfy it. This test does not detect A2 at all.** A method
+   called only from `get_response` passes just as well as one called from all three. A2's guard
+   is the per-path parity tests in Steps 06.3, 06.4 and 06.6, and there is no cheap general form.
+4. **The receiver allowlist is a heuristic.** A call through an unusually-named local
+   (`a = get_provider_adapter(p); a.foo()`) is invisible. Mitigation: `ADAPTER_RECEIVERS` covers
+   every naming used in `llm/` today, and a new name is a reviewable one-line addition. Dropping
+   the allowlist instead produces false *positives* — `openai_client.format_tools` would mask
+   `DefaultAdapter.format_tools` — which is worse, because it hides dead code rather than
+   over-reporting it.
+5. **It scans `praisonaiagents/llm/` only.** An adapter method called from `agent/` or `memory/`
+   would be reported dead. No such call exists today (verified repo-wide); widen the root if that
+   changes.
+6. **It runs only where CI runs it.** If order 04 or 05 later brings
+   `src/praisonai-agents/tests/unit/` into CI, move it next to `test_adapter_registry.py` — but
+   not before.
+
+---
+
+## 7. Handoffs — work this order deliberately does not do
+
+| To | What | Why not here |
+|---|---|---|
+| **order 02** | Make `add_provider_adapter` reachable: have `_detect_provider` consult the adapter registry (e.g. `if has_provider_adapter(prefix): return prefix`) before falling back to `"openai"`, plus `test_registered_custom_adapter_is_selected`. Today a registered name can never be passed to `get_provider_adapter` — **the hook is a lie**. If order 02 declines, the correct disposition flips to **DELETE** under root `AGENTS.md`. | `_detect_provider` belongs to order 02. Related: `00-ground-truth.md` §5 shows `ollama_chat/`, `lm_studio/`, `vllm/` all resolving to `DefaultAdapter` — the same registry gap. |
+| **order 02** | Reconcile `_is_ollama_provider()` with `isinstance(adapter, OllamaAdapter)`. Steps 06.4 and 06.5 replace the former with the latter and are **blocked** if `test_ollama_adapter_selection_matches_is_ollama_provider` fails on `main`. | Same ownership. |
+| **orders 04 / 05** | `src/praisonai-agents/tests/unit/` — incl. `test_adapter_registry.py` (38 tests) and all 13 files in `tests/unit/llm/` — is run by **no** workflow. Add it to a shard. | `.github/workflows/**` is theirs. |
+| **a new order** | `llm/streaming_protocol.py`: 387 lines, 4 adapter classes, 3 public functions, 11 Ollama references. After Step 06.2 deletes `DefaultAdapter.get_streaming_adapter`, its only production importer is gone and **the whole module is dead** (only `tests/test_architectural_fixes.py` — itself outside CI — imports it). Decide: delete, or wire as the streaming seam. | Deleting a 387-line module is not "one adapter method"; it needs its own risk assessment. Do not fold it into 06.2. |
+| **a new order** | `OLLAMA_SUMMARY_ITERATION_THRESHOLD = 1` (`llm.py:273`) is applied to **all** providers at `3821` and `5446`: `elif tool_summary_text is None and iteration_count > self.OLLAMA_SUMMARY_ITERATION_THRESHOLD: continue`. For a non-Ollama provider at `iteration_count >= 2` this `continue` skips both the `max_iterations` safety check (`3826`) and the `response_text = ""` reset (`3837`). Latent, provider-independent, a behaviour change to fix. | Not adapter wiring; §1 row 9 explains why `get_max_iteration_threshold` is not the answer. |
+| **follow-up orders** | §5.2, §5.3, §5.5, §5.6, §5.7, §5.8, §5.9 — one order each, in that priority order. **§5.3 first**: it is the only one where a live setting is silently ignored. | Each changes behaviour; order 06 is refactor-only. |
+
+---
+
+## 8. Hard constraints — and what each means concretely here
+
+1. **Never edit two of the three response paths in one commit without a test covering both.**
+   Steps 06.2, 06.5, 06.6 touch one path each — the rule is inert. Step 06.3 touches sync +
+   async + the stream's formatter: it ships `test_tool_result_message_identical_across_paths`,
+   parametrized over all three. Step 06.4 touches sync + async: it ships both
+   `..._sync` and `..._async` in the same commit. Both, or split.
+
+2. **No new abstraction layer.** `llm/adapters/` is the abstraction; this order makes it
+   load-bearing. Do not add a quirk registry, a compensation table, a strategy object, a mixin,
+   or a new module (ledger I7). Twelve of the twenty decisions are DELETE precisely because the
+   temptation here is to build rather than remove. Step 06.3 is the only step that *adds* code to
+   the adapter, and only by moving three identical copies into the method that already declares
+   the job.
+
+3. **Backward compatibility is mandatory (I1).** Nothing in `praisonaiagents.llm.adapters` is
+   re-exported from `praisonaiagents.llm` or `praisonaiagents` (verified: no adapter name appears
+   in either `__init__.py`'s lazy-import map), and none is documented under `docs/`. The Step
+   06.2 deletions are therefore not public-surface removals in practice. `add_provider_adapter`
+   is kept anyway, being the one name a third party would plausibly have found. If a reviewer
+   disagrees about `list_provider_adapters` / `has_provider_adapter`, keep them and add them to
+   `KNOWN_DEAD` with that reason — do not argue about it mid-step.
+
+4. **`get_response` is 1,675 lines with 194 branch points.** Any diff inside `llm.py:2557-4231`
+   must: quote at least three unmodified lines above and below the change; change **only** the
+   lines named in this order — no reindentation of neighbours, no reflowing long lines, no
+   comment tidy-ups, no `black`/`ruff --fix` over the file, no import reordering; keep the diff's
+   line count within a few lines of the replacement's, so `git show --stat` is a truthful summary
+   of scope; and be reviewed with `git diff -U10` before pushing. If the diff shows a hunk you
+   did not intend, revert the file and redo the edit by hand.
+
+5. **One adapter method per commit, one commit per branch, every step independently revertible.**
+
+6. **Characterization test first, always.** Every step's tests must be written against
+   `origin/main`, run, and observed green *before* the source edit. A test written after the
+   change pins the change, not the behaviour. Where a step intentionally changes behaviour (only
+   Step 06.3's non-serializable-result case), the test asserting the old behaviour must be marked
+   `xfail(strict=True)` in the same commit, so the change is visible as a test-outcome diff
+   rather than a silent edit.
+
+7. **Update `README.md` §4 row 06 in the same commit as each step** — one line only, to avoid
+   conflicts with concurrent orders.
+
+---
+
+## 9. Step summary
+
+| Step | Branch | Item | Paths edited | Risk | Reverts to |
+|---|---|---|---|---|---|
+| 06.0 | — | — | none (throwaway probe) | none | n/a |
+| 06.1 | `test/adapter-reachability-ratchet` | ratchet | none | none | 1 test file |
+| 06.2 | `refactor/delete-dead-adapter-surface` | 9 methods + 2 module fns | sync ×1 (dead branch) | very low — zero call sites, proven | pure deletion |
+| 06.3 | `refactor/wire-default-tool-result-message` | `format_tool_result_message` | sync, async, stream-formatter | low — default body has no consumers today | 3 inline copies |
+| 06.4 | `refactor/wire-handle-empty-response-with-tools` | `handle_empty_response_with_tools` | sync, async | medium — guard widens from `_is_ollama_provider()` to adapter dispatch | 2 predicates |
+| 06.5 | `refactor/wire-recover-tool-calls-from-text` | `recover_tool_calls_from_text` | sync | medium-high — 4 measured deltas, all argued inert | 33 inline lines |
+| 06.6 | `fix/stream-path-ollama-argument-filtering` | A2 port | stream (both branches) | low — pre-dispatch, guarded | 2 insertions |
+
+**End state:** `KNOWN_DEAD` empty, `DefaultAdapter` at 8 methods all with live call sites,
+`llm.py` shorter by ~90 lines, and a CI-enforced test that makes A1 recurrence a red build.
+
+A2 is **measured, dispositioned and partly closed — not solved.** §5 names the seven successor
+orders and which of them is genuinely impossible while streaming.

--- a/src/praisonai-agents/docs/local-model-layer/07-local-package-spec.md
+++ b/src/praisonai-agents/docs/local-model-layer/07-local-package-spec.md
@@ -2,7 +2,11 @@
 
 **Branch:** `feat/local-model-resolver`
 **Status:** normative specification. No implementation exists yet.
-**Owns:** `praisonaiagents/local/**` (new), `tests/unit/local/**` (new). Touches nothing else.
+**Owns:** `praisonaiagents/local/**` (new), `src/praisonai/tests/unit/llm/local/**` (new).
+Touches nothing else. Tests live under `src/praisonai/tests/` — **not** `src/praisonai-agents/tests/` —
+because CI runs `cd src/praisonai && pytest tests/unit/` and collects nothing from the
+agents-package tree (see `00-ground-truth.md`). Tests placed there run nowhere, so the
+import-boundary and no-socket guards below would silently never execute.
 **Verified on:** 2026-09-03, macOS (Darwin 27.0.0), Ollama 0.33.2 live on `127.0.0.1:11434`,
 `llama-server` build 7620 present, `mlx_lm.server` present.
 
@@ -830,10 +834,12 @@ __all__ = [
 
 ## 12. Tests
 
-All under `src/praisonai-agents/tests/unit/local/`. Every test carries
-`pytestmark = pytest.mark.unit`. The markers `network`, `local_service` and `provider_ollama`
-are **forbidden** in this directory — a test needing a live server belongs in
-`tests/integration/`, out of scope here.
+All under `src/praisonai/tests/unit/llm/local/` — the tree CI actually collects
+(`cd src/praisonai && pytest tests/unit/`). Do **not** place them under
+`src/praisonai-agents/tests/`, which no workflow runs (see `00-ground-truth.md`); the guards
+below would then never execute. Every test carries `pytestmark = pytest.mark.unit`. The markers
+`network`, `local_service` and `provider_ollama` are **forbidden** in this directory — a test
+needing a live server belongs in `tests/integration/`, out of scope here.
 
 **Files:** `__init__.py`, `conftest.py`, `fixtures/`, `test_import_boundary.py`,
 `test_discover.py`, `test_capabilities.py`, `test_quirktable.py`, `test_target.py`,
@@ -842,7 +848,7 @@ are **forbidden** in this directory — a test needing a live server belongs in
 ### 12.1 `conftest.py` provides exactly three things
 
 - **`no_sockets`** (autouse, session-scoped): monkeypatches `socket.socket.__init__` to
-  `raise AssertionError("tests/unit/local must not open a socket")`. This is *the* mechanism
+  `raise AssertionError("tests/unit/llm/local must not open a socket")`. This is *the* mechanism
   that proves offline safety — a test that forgets to inject a transport fails loudly instead
   of silently hitting a developer's live Ollama.
 - **`fake_transport(routes, *, default=HttpReply(0, b"", "refused"))`** — a `Transport`

--- a/src/praisonai-agents/docs/local-model-layer/07-local-package-spec.md
+++ b/src/praisonai-agents/docs/local-model-layer/07-local-package-spec.md
@@ -1,0 +1,1104 @@
+# 07 — `praisonaiagents/local/` API specification
+
+**Branch:** `feat/local-model-resolver`
+**Status:** normative specification. No implementation exists yet.
+**Owns:** `praisonaiagents/local/**` (new), `tests/unit/local/**` (new). Touches nothing else.
+**Verified on:** 2026-09-03, macOS (Darwin 27.0.0), Ollama 0.33.2 live on `127.0.0.1:11434`,
+`llama-server` build 7620 present, `mlx_lm.server` present.
+
+An implementing agent may implement **one module in isolation** by reading only §2
+(constraints), §4 (layering), and that module's own section. Claims marked *unverified* are
+unproven data, not fact — do not promote them without a live check.
+
+---
+
+## 1. Purpose
+
+`local/` answers three questions and returns the answers as frozen data:
+
+1. **What is running on this machine?** — `discover.py`
+2. **What can that model actually do?** — `capabilities.py`
+3. **What will it silently get wrong?** — `quirktable.py`
+
+`target.py` folds those into one `LocalTarget`. `manage.py` returns *remedy data* (command
+lines, PATH facts) without executing anything. `embed.py` returns an `EmbeddingTarget`.
+
+Behaviour — request mutation, retries, schema rewriting, streaming repair — lives in
+`llm/adapters/` and is out of scope. See §12.
+
+---
+
+## 2. The two hard constraints
+
+### 2.1 Dependency sink
+
+Every file in `local/` may import **only** (a) the Python standard library and (b) sibling
+modules inside `local/` via **single-dot** relative imports.
+
+Forbidden without exception: any `praisonaiagents` import (absolute or `..`-relative),
+`litellm`, `openai`, `pydantic`, `httpx`, `requests`, `aiohttp`, `anyio`, `rich`, `yaml`,
+`posthog`, and any other distribution.
+
+### 2.2 Data, never behaviour
+
+Every public return value is a frozen, slotted, hashable dataclass, or a `frozenset`/`tuple`
+of them. `local/` must never mutate a request payload, retry, sleep-and-retry, issue a
+chat/completion/embedding **inference** call, start or stop a process, write to disk, or read
+a config file. The only writes anywhere are two process-local dicts in `target.py` (§9).
+
+Allowed HTTP: `GET`, plus exactly one `POST` — `POST {base}/api/show {"model": ...}` — which
+reads a manifest, performs no inference, and does not load weights (verified).
+
+---
+
+## 3. Decision: HTTP client is stdlib `urllib.request`
+
+**This overrides the ledger's earlier suggestion of `httpx`.** The reasoning:
+
+`httpx==0.28.1` is installed, but only **transitively**: `openai -> httpx`. `pyproject.toml`
+never declares it. Building a dependency sink on an undeclared transitive edge means a future
+`openai` release that drops `httpx` silently breaks `local/` — exactly the class of silent
+failure this package exists to catalogue. Declaring it would either add an 18th extra (making
+the sink optional, so the bypass sites still cannot rely on it) or add a hard dependency to
+the one package whose selling point is that everything can import it.
+
+`aiohttp` *is* a hard dependency, but it is async-only — forcing an event loop into the
+synchronous `Agent.__init__` — and costs ~40 ms to import on a hot path.
+
+The cited weaknesses of `urllib.request` do not bite here. **No pooling:** a full resolve
+issues at most 4 loopback requests, then caches for 30 s. **Clumsy timeouts:**
+`urlopen(req, timeout=t)` applies `t` to connect and to each socket read, which is all
+loopback needs; the total budget is enforced by the caller. **No concurrency:**
+`concurrent.futures.ThreadPoolExecutor` is stdlib and handles the port fan-out.
+
+The boundary test hard-forbids `httpx`/`requests`/`aiohttp` so this cannot drift.
+
+---
+
+## 4. Layering and naming
+
+### 4.1 Module layers (acyclic; layer *n* imports only layers < *n*)
+
+| Layer | Module | May import |
+|---|---|---|
+| 0 | `capabilities.py` | stdlib only (`enum`, `dataclasses`, `typing`, `json`) |
+| 1 | `quirktable.py` | stdlib, `.capabilities` |
+| 1 | `discover.py` | stdlib (`urllib.request`, `urllib.error`, `json`, `os`, `socket`, `time`, `concurrent.futures`, `dataclasses`, `enum`, `typing`), `.capabilities` |
+| 2 | `target.py` | stdlib (`os`, `time`, `threading`, `asyncio`, `functools`, `urllib.parse`, `ipaddress`, `dataclasses`, `typing`), `.capabilities`, `.quirktable`, `.discover` |
+| 3 | `manage.py` | stdlib (`shutil`, `dataclasses`, `enum`, `typing`), `.capabilities`, `.discover`, `.target` |
+| 3 | `embed.py` | stdlib, `.capabilities`, `.discover`, `.target` |
+| 4 | `__init__.py` | the five above |
+
+`capabilities.py` is the **vocabulary module**: it owns `LocalEngine`, `ApiStyle`, `Cap` and
+`Evidence` in addition to the capability parsers. This is the only placement that yields a
+cycle-free graph across the fixed 7-file layout.
+
+### 4.2 Naming collision audit
+
+The name `runtime` is **taken**: `praisonaiagents/runtime/` is the agent-execution harness,
+`pyproject.toml` declares a `praisonai.runtimes` entry-point group, and examples use
+"runtime" for tool sandboxes.
+
+| Name | Already exists at | Ruling |
+|---|---|---|
+| `runtime`, `Runtime`, `*Runtime*` | `praisonaiagents/runtime/` | **Banned.** Use `engine`. |
+| `RuntimeCapability`, `RuntimeCapabilityMatrix` | `runtime/capabilities.py:19,50` | Banned. Ours is `Cap`. |
+| `resolve_runtime()` | `runtime/resolve.py:232` | Ours is `local.resolve()`, namespace-qualified only. Never re-export a bare `resolve`; if ever promoted, the name is `resolve_local`. |
+| `RuntimeResolver`, `RuntimeResolutionResult` | `runtime/resolve.py:67`, `runtime/resolver.py:37` | Banned. |
+| `ProbeResult` | `bots/protocols.py:651` | **Banned.** Ours are `ProbeSpec`, `Discovery`, `HttpReply`. |
+| `CapabilityValidator`, `CapabilityDescriptor` | `skills/capability_validator.py:74`, `gateway/protocols.py:5460` | Banned. |
+| `capabilities.py`, `embed.py` (basenames) | `runtime/`, `embedding/` | **Allowed** — different dotted paths, relative imports only. Do not "fix" by renaming. Note `embedding/embed.py` exposes `embedding()`; ours exposes `embedding_target()`. Never name anything in `local/` `embedding()`. |
+| `engine`, `Engine`, `LocalEngine`, `Quirk`, `ApiStyle`, `LocalTarget`, `Cap` | no hits | **Free.** Adopted. |
+
+`local/` is **not** added to `_LAZY_IMPORTS` in `praisonaiagents/__init__.py`, and **no** new
+extra is added to `pyproject.toml`.
+
+### 4.3 Sync vs async
+
+**Both, sync-primary.** `discover()`, `resolve()`, `capabilities()`, `models()`,
+`embedding_target()` are the primitives. Each has an `a`-prefixed twin implemented as exactly:
+
+```python
+async def aresolve(*args: Any, **kwargs: Any) -> LocalTarget:
+    """Async twin of resolve(); runs the sync probe in the default executor."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, functools.partial(resolve, *args, **kwargs))
+```
+
+`Agent.__init__` is synchronous and may be called from inside a running event loop; an
+async-native core would force `asyncio.run()` (which raises there) or a hand-rolled asyncio
+HTTP parser. The executor costs one thread for <= 1.5 s, and only on a cache miss. Both twins
+share one cache and one lock.
+
+### 4.4 `LocalTarget` carries `litellm_model`
+
+**Yes**, as `Optional[str]`, computed by the pure function `litellm_model_for(engine, model_id)`.
+
+Without it, each bypass site re-derives a prefix, and they have already diverged:
+`llm/llm.py:_detect_provider()` knows only `ollama/`; `llm/model_providers.py` matches only
+`model.startswith("ollama/")`; `llm/openai_client.py:_supports_responses_api` knows `ollama/`
+**and** `ollama_chat/`; `agent/agent.py:_PROVIDER_DEFAULT_MODELS` hardcodes `ollama/llama3.2`.
+A pure `(engine, model_id) -> str` mapping is data, so §2.2 holds.
+
+| `engine` | `litellm_model` | Caller must also pass |
+|---|---|---|
+| `OLLAMA` | `f"ollama/{model_id}"` | `api_base=target.base_url` |
+| `LM_STUDIO` | `f"lm_studio/{model_id}"` | `api_base=target.openai_base_url` |
+| `VLLM` | `f"hosted_vllm/{model_id}"` | `api_base=target.openai_base_url` |
+| all others | `f"openai/{model_id}"` | `api_base=target.openai_base_url`, `api_key=target.api_key` |
+| any engine with `model_id is None` | `None` | — |
+
+**`OLLAMA` maps to `ollama/`, never `ollama_chat/`** — even though `ollama_chat/` is the
+better litellm route — because `_detect_provider()` returns `"openai"` for an `ollama_chat/`
+model, silently losing `OllamaAdapter` and its streaming guard. Revisit only after work order
+`02` teaches that call site the extra prefixes.
+
+---
+
+## 5. Data model
+
+### 5.1 `capabilities.py` — vocabulary
+
+```python
+class LocalEngine(str, Enum):
+    OLLAMA = "ollama"
+    LLAMA_CPP = "llama_cpp"                    # llama.cpp llama-server
+    MLX_LM = "mlx_lm"                          # mlx_lm.server (Apple silicon)
+    LM_STUDIO = "lm_studio"
+    VLLM = "vllm"                              # Linux only
+    TRANSFORMERS_SERVE = "transformers_serve"
+    LLAMAFILE = "llamafile"
+    LOCALAI = "localai"
+    RAMALAMA = "ramalama"
+    UNKNOWN = "unknown"                        # OpenAI-shaped server; identity not established
+
+class ApiStyle(str, Enum):
+    OPENAI_CHAT = "openai_chat"                # POST {base}/v1/chat/completions
+    OPENAI_COMPLETIONS = "openai_completions"  # POST {base}/v1/completions only
+    OLLAMA_NATIVE = "ollama_native"            # POST {base}/api/chat
+
+class Cap(str, Enum):
+    CHAT = "chat"
+    COMPLETION = "completion"
+    TOOLS = "tools"                            # model trained for tool calls AND server exposes them
+    VISION = "vision"
+    AUDIO_IN = "audio_in"
+    THINKING = "thinking"
+    JSON_OBJECT = "json_object"
+    JSON_SCHEMA = "json_schema"
+    STREAMING = "streaming"
+    STREAMING_WITH_TOOLS = "streaming_with_tools"
+    PARALLEL_TOOL_CALLS = "parallel_tool_calls"
+    EMBEDDINGS_ENDPOINT = "embeddings_endpoint"    # engine-level, always Evidence.TABLE
+
+class Evidence(str, Enum):
+    SERVER = "server"    # read out of a live response field
+    TABLE = "table"      # this package's static per-engine default
+    ENV = "env"          # asserted by an environment variable
+    SPEC = "spec"        # asserted by the caller's `spec` argument
+    UNKNOWN = "unknown"
+```
+
+### 5.2 `quirktable.py` — the silent-failure catalogue
+
+```python
+class Severity(str, Enum):
+    SILENT = "silent"  # wrong result, no error surface — the dangerous class
+    HARD = "hard"      # the request fails loudly (4xx/5xx)
+    COST = "cost"      # correct result, unexpected latency or resource cost
+
+class Quirk(str, Enum):
+    # --- Ollama, verified 0.33.2 ---
+    FORMAT_AND_TOOLS_MUTUALLY_DESTRUCTIVE = "format_and_tools_mutually_destructive"
+    TOOL_SCHEMA_KEYWORDS_STRIPPED = "tool_schema_keywords_stripped"
+    TOOL_PARAM_TYPE_MUST_BE_BARE_STRING = "tool_param_type_must_be_bare_string"
+    UNKNOWN_OPTIONS_ACCEPTED_AND_IGNORED = "unknown_options_accepted_and_ignored"
+    THINK_FIELD_IGNORED_ON_OPENAI_ROUTE = "think_field_ignored_on_openai_route"
+    THINKING_WITH_TOOLS_YIELDS_EMPTY_TURN = "thinking_with_tools_yields_empty_turn"
+    NATIVE_ROUTE_NEVER_SETS_TOOL_FINISH_REASON = "native_route_never_sets_tool_finish_reason"
+    TOOL_CALLS_ARRIVE_WHOLE_NOT_INCREMENTAL = "tool_calls_arrive_whole_not_incremental"
+    STREAM_ERROR_ENDS_WITHOUT_DONE = "stream_error_ends_without_done"
+    SAMPLING_DEFAULTS_FORCED_TO_ONE = "sampling_defaults_forced_to_one"
+    CONTEXT_OPTION_CHANGE_RELOADS_MODEL = "context_option_change_reloads_model"
+    KEEP_ALIVE_IS_GLOBAL_LAST_WRITER_WINS = "keep_alive_is_global_last_writer_wins"
+    BODYLESS_403_ON_NON_LOCAL_HOST_HEADER = "bodyless_403_on_non_local_host_header"
+    # --- other engines ---
+    TOOLS_REQUIRE_SERVER_FLAGS = "tools_require_server_flags"
+    NO_JSON_SCHEMA_SUPPORT = "no_json_schema_support"
+    NO_EMBEDDINGS_ENDPOINT = "no_embeddings_endpoint"
+    SINGLE_MODEL_PER_PROCESS = "single_model_per_process"
+    MODEL_ID_IS_A_FILE_PATH = "model_id_is_a_file_path"
+    CAPS_ASSUMED_ENGINE_UNIDENTIFIED = "caps_assumed_engine_unidentified"
+
+@dataclass(frozen=True, slots=True)
+class QuirkNote:
+    quirk: Quirk
+    engines: tuple[LocalEngine, ...]
+    api_styles: tuple[ApiStyle, ...]   # empty == all styles
+    severity: Severity
+    symptom: str          # one line, what the user observes
+    workaround: str       # one line, what a caller in llm/adapters/ should do
+    verified_on: str      # "ollama 0.33.2 @ 2026-09-03" or "unverified: vendor docs"
+    requires_caps: frozenset[Cap] = frozenset()
+```
+
+Meaning of each Ollama quirk, one line each:
+
+| Quirk | Symptom | Severity |
+|---|---|---|
+| `FORMAT_AND_TOOLS_MUTUALLY_DESTRUCTIVE` | JSON format + tools suppresses the tool call; the model fabricates an answer | SILENT |
+| `TOOL_SCHEMA_KEYWORDS_STRIPPED` | `minLength`, `format`, `default`, `additionalProperties`, `$ref`, `oneOf` dropped before the model sees them | SILENT |
+| `TOOL_PARAM_TYPE_MUST_BE_BARE_STRING` | `"type": ["object","null"]` 400s the whole request | HARD |
+| `UNKNOWN_OPTIONS_ACCEPTED_AND_IGNORED` | Unrecognised `options` keys return 200 and change nothing | SILENT |
+| `THINK_FIELD_IGNORED_ON_OPENAI_ROUTE` | `think` dropped on `/v1/*`; use `reasoning_effort` | SILENT |
+| `THINKING_WITH_TOOLS_YIELDS_EMPTY_TURN` | Empty content, zero tool calls, `finish_reason="stop"` | SILENT |
+| `NATIVE_ROUTE_NEVER_SETS_TOOL_FINISH_REASON` | `/api/chat` reports "stop" even with `tool_calls` present | SILENT |
+| `TOOL_CALLS_ARRIVE_WHOLE_NOT_INCREMENTAL` | Streamed tool calls come in one chunk, not deltas | SILENT |
+| `STREAM_ERROR_ENDS_WITHOUT_DONE` | Mid-stream failure yields an empty delta and no `[DONE]` | SILENT |
+| `SAMPLING_DEFAULTS_FORCED_TO_ONE` | Omitted `temperature`/`top_p` become 1.0, not the model's defaults | SILENT |
+| `CONTEXT_OPTION_CHANGE_RELOADS_MODEL` | Changing `num_ctx`/`num_batch`/`num_gpu` forces a full reload | COST |
+| `KEEP_ALIVE_IS_GLOBAL_LAST_WRITER_WINS` | `keep_alive` is per-model and process-wide, not per-request | SILENT |
+| `BODYLESS_403_ON_NON_LOCAL_HOST_HEADER` | Non-local `Host` header gets HTTP 403 with a zero-byte body | HARD |
+| `TOOLS_REQUIRE_SERVER_FLAGS` | Tool calls come back as assistant text (vLLM needs BOTH `--enable-auto-tool-choice` AND `--tool-call-parser`; llama-server needs `--jinja`) | SILENT |
+| `SINGLE_MODEL_PER_PROCESS` | The request's `model` field is ignored — asking for B gets A's answer | SILENT |
+| `MODEL_ID_IS_A_FILE_PATH` | The reported model id is a filesystem path | SILENT |
+| `CAPS_ASSUMED_ENGINE_UNIDENTIFIED` | Engine is `UNKNOWN`; every `Cap` is `Evidence.TABLE` guesswork | SILENT |
+
+Route scoping (normative): `NATIVE_ROUTE_NEVER_SETS_TOOL_FINISH_REASON` is
+`api_styles=(OLLAMA_NATIVE,)`; `THINK_FIELD_IGNORED_ON_OPENAI_ROUTE` and
+`SAMPLING_DEFAULTS_FORCED_TO_ONE` are `api_styles=(OPENAI_CHAT, OPENAI_COMPLETIONS)`;
+`THINKING_WITH_TOOLS_YIELDS_EMPTY_TURN` is `requires_caps={Cap.THINKING, Cap.TOOLS}`;
+`TOOLS_REQUIRE_SERVER_FLAGS` is `engines=(VLLM, LLAMA_CPP, LLAMAFILE)`;
+`CAPS_ASSUMED_ENGINE_UNIDENTIFIED` is `engines=(UNKNOWN,)`. Everything else in the Ollama
+block is `engines=(OLLAMA,)`, all styles.
+
+`quirktable.py` performs no network, no I/O and reads no environment variable.
+
+### 5.3 `discover.py` — probing types
+
+```python
+@dataclass(frozen=True, slots=True)
+class HttpReply:
+    status: int            # 0 == transport failure (refused/timeout/DNS)
+    body: bytes            # b"" when bodyless
+    error: str | None      # "refused" | "timeout" | "reset" | "http" | None
+
+class RuleKind(str, Enum):
+    BODY_PREFIX = "body_prefix"          # 200 and body.lstrip() startswith value
+    JSON_KEY = "json_key"                # 200, body is a JSON object, value is a top-level key
+    JSON_KEY_PREFIX = "json_key_prefix"  # value "key=prefix"; str(obj[key]).startswith(prefix)
+    STATUS_OK = "status_ok"              # 200 <= status < 300, body ignored
+    ABSENT = "absent"                    # status is 404/405, or body does not parse as JSON
+
+@dataclass(frozen=True, slots=True)
+class Rule:
+    method: str            # "GET" or "POST"
+    path: str              # appended to base_url verbatim, e.g. "/api/version"
+    kind: RuleKind
+    value: str = ""
+
+@dataclass(frozen=True, slots=True)
+class ProbeSpec:
+    engine: LocalEngine
+    default_ports: tuple[int, ...]
+    identity: tuple[Rule, ...]     # ALL must hold; evaluated in order, short-circuit
+    version_path: str | None
+    version_key: str | None
+    models_path: str | None
+    models_key: str | None         # "models[].model" or "data[].id"
+    model_caps: Rule | None
+    api_style: ApiStyle
+    verified: bool
+    note: str
+
+@dataclass(frozen=True, slots=True)
+class Discovery:
+    engine: LocalEngine
+    base_url: str                  # "http://127.0.0.1:11434" — no trailing slash, no /v1
+    api_style: ApiStyle
+    engine_version: str | None
+    models: tuple[str, ...]        # () when unknown
+    raw_identity: str              # first 200 chars of the identity reply, for diagnostics
+    latency_ms: int
+    blocked: str | None            # None | "host_header_rejected" | "auth_required"
+    evidence: Evidence
+
+class Transport(Protocol):
+    def __call__(self, method: str, url: str, body: bytes | None, timeout: float) -> HttpReply: ...
+```
+
+The default `Transport` is built inside `discover.py` and is the only thing in the package
+that touches a socket.
+
+### 5.4 `target.py` — the product
+
+```python
+@dataclass(frozen=True, slots=True)
+class LocalTarget:
+    engine: LocalEngine
+    base_url: str                                # no trailing slash, no /v1
+    openai_base_url: str                         # base_url + "/v1"
+    api_style: ApiStyle
+    model_id: str | None
+    caps: frozenset[Cap]
+    quirks: frozenset[Quirk]
+    litellm_model: str | None
+    api_key: str                                 # placeholder "local"; never "" (openai rejects "")
+    engine_version: str | None
+    evidence: tuple[tuple[str, Evidence], ...]   # sorted by field name; per-field provenance
+    extra: tuple[tuple[str, str], ...]           # sorted by key; engine-specific facts
+    probed_at: float
+
+    def supports(self, cap: Cap) -> bool: ...
+    def has_quirk(self, quirk: Quirk) -> bool: ...
+    def evidence_for(self, field: str) -> Evidence: ...   # Evidence.UNKNOWN if absent
+    def get_extra(self, key: str, default: str | None = None) -> str | None: ...
+    def as_dict(self) -> dict[str, object]: ...           # JSON-safe, for logs and doctors
+```
+
+`evidence`/`extra` are **tuples of pairs, not dicts**, so `LocalTarget` stays frozen *and*
+hashable — a `dict` field would make the generated `__hash__` raise `TypeError` at runtime.
+
+### 5.5 Exceptions (defined in `target.py`)
+
+```python
+class LocalError(Exception): ...
+class NoLocalEngineError(LocalError): ...
+class EngineUnreachableError(LocalError):
+    base_url: str
+    reason: str          # "refused" | "timeout" | "reset" | "http_<status>"
+    source: str          # "spec" | "PRAISONAI_LOCAL_BASE_URL" | "OLLAMA_HOST" | ...
+class HostHeaderRejectedError(EngineUnreachableError): ...
+class ModelNotAvailableError(LocalError):
+    model_id: str
+    available: tuple[str, ...]
+class InvalidLocalSpecError(LocalError, ValueError): ...
+```
+
+`local/` deliberately does **not** subclass `praisonaiagents.errors.PraisonAIError` — that
+would import upward and break §2.1. Wrapping is the integration layer's job.
+
+---
+
+## 6. `capabilities.py`
+
+```python
+"""Local-engine vocabulary and capability resolution (layer 0: stdlib only)."""
+
+DEFAULT_CAPS: Mapping[LocalEngine, frozenset[Cap]]   # exhaustive over LocalEngine
+
+def default_caps(engine: LocalEngine) -> frozenset[Cap]:
+    """Return the static per-engine capability floor (no network, Evidence.TABLE)."""
+    # Raises nothing; an unrecognised value returns DEFAULT_CAPS[LocalEngine.UNKNOWN].
+
+def parse_ollama_capabilities(payload: Mapping[str, Any]) -> frozenset[Cap]:
+    """Map an Ollama /api/show or /api/tags entry's `capabilities` list onto Cap.
+
+    "completion"->COMPLETION+CHAT, "tools"->TOOLS, "vision"->VISION,
+    "thinking"->THINKING, "embedding"->EMBEDDINGS_ENDPOINT, "insert"->ignored.
+    Unknown strings are ignored, never raised on.
+    """
+
+def parse_llama_cpp_props(payload: Mapping[str, Any]) -> frozenset[Cap]: ...
+def parse_lm_studio_models(payload: Mapping[str, Any], model_id: str | None) -> frozenset[Cap]: ...
+def parse_openai_models(payload: Mapping[str, Any]) -> tuple[str, ...]: ...
+
+def capabilities(
+    discovery: Discovery,
+    model_id: str | None = None,
+    *,
+    timeout: float = 0.4,
+    transport: Transport | None = None,
+) -> tuple[frozenset[Cap], Evidence]:
+    """Resolve capabilities for one model on one discovered engine.
+
+    Issues at most one request (the engine's ProbeSpec.model_caps). Returns
+    (caps, Evidence.SERVER) when it answered and parsed, else
+    (default_caps(engine), Evidence.TABLE). Server caps are unioned with the
+    engine's EMBEDDINGS_ENDPOINT / STREAMING floor from DEFAULT_CAPS.
+    """
+    # Raises nothing. Every transport and parse failure degrades to TABLE.
+
+async def acapabilities(...) -> tuple[frozenset[Cap], Evidence]: ...
+```
+
+`DEFAULT_CAPS` (normative floor):
+
+| engine | caps |
+|---|---|
+| `OLLAMA` | `CHAT, COMPLETION, STREAMING, JSON_OBJECT, JSON_SCHEMA, EMBEDDINGS_ENDPOINT` |
+| `LLAMA_CPP` | `CHAT, COMPLETION, STREAMING, JSON_SCHEMA, JSON_OBJECT, EMBEDDINGS_ENDPOINT` |
+| `MLX_LM` | `CHAT, COMPLETION, STREAMING` |
+| `LM_STUDIO` | `CHAT, COMPLETION, STREAMING, JSON_SCHEMA, JSON_OBJECT, EMBEDDINGS_ENDPOINT` |
+| `VLLM` | `CHAT, COMPLETION, STREAMING, JSON_SCHEMA, JSON_OBJECT, EMBEDDINGS_ENDPOINT, PARALLEL_TOOL_CALLS` |
+| `TRANSFORMERS_SERVE` | `CHAT, STREAMING` |
+| `LLAMAFILE`, `LOCALAI`, `RAMALAMA` | `CHAT, COMPLETION, STREAMING` |
+| `UNKNOWN` | `CHAT, STREAMING` |
+
+`Cap.TOOLS` and `Cap.VISION` are **never** in `DEFAULT_CAPS` — claiming them without server
+evidence is exactly the silent failure this package prevents. `Cap.STREAMING_WITH_TOOLS` is
+granted only when the server reports `TOOLS` **and** the engine's quirk set lacks
+`TOOL_CALLS_ARRIVE_WHOLE_NOT_INCREMENTAL`.
+
+---
+
+## 7. `discover.py` and the probe table
+
+```python
+PROBES: tuple[ProbeSpec, ...]
+LOOPBACK_HOST: str = "127.0.0.1"
+DEFAULT_PROBE_TIMEOUT: float = 0.4     # seconds, per request
+DEFAULT_TOTAL_BUDGET: float = 1.5      # seconds, whole scan
+
+def probe_table() -> tuple[ProbeSpec, ...]: ...
+
+def probe_endpoint(
+    base_url: str, *, expect: LocalEngine | None = None,
+    timeout: float = DEFAULT_PROBE_TIMEOUT, transport: Transport | None = None,
+) -> Discovery | None:
+    """Identify the server at base_url, or None if nothing identifiable answered.
+
+    A 200 matching no discriminator yields Discovery(engine=UNKNOWN). A bodyless
+    403 yields Discovery(..., blocked="host_header_rejected").
+    """
+    # Raises InvalidLocalSpecError for a URL with no host or an unsupported scheme.
+    # Never raises for any network or parse condition.
+
+def discover(
+    *, ports: Sequence[int] | None = None, include: Sequence[LocalEngine] | None = None,
+    host: str = LOOPBACK_HOST, timeout: float = DEFAULT_PROBE_TIMEOUT,
+    budget: float = DEFAULT_TOTAL_BUDGET, transport: Transport | None = None,
+) -> tuple[Discovery, ...]:
+    """Scan the probe table's default ports; return every server found.
+
+    Ports probed concurrently (ThreadPoolExecutor, max_workers=8). Ordered by
+    PROBES order, then port. Includes `blocked` discoveries.
+    """
+    # Raises nothing.
+
+async def adiscover(...) -> tuple[Discovery, ...]: ...
+def models(discovery, *, timeout=0.4, transport=None) -> tuple[str, ...]: ...
+async def amodels(...) -> tuple[str, ...]: ...
+```
+
+### 7.1 The probe table (actual literal)
+
+Port collisions are real: **8080** is claimed by `llama-server`, `mlx_lm`, `llamafile`,
+LocalAI and RamaLama; **8000** by vLLM and `transformers serve`. Identity is therefore
+**never** inferred from a port — a `ProbeSpec` matches only when every `Rule` in `identity`
+holds, and `RuleKind.ABSENT` rules exist specifically to separate co-tenants of one port.
+
+```python
+PROBES: tuple[ProbeSpec, ...] = (
+    ProbeSpec(
+        engine=LocalEngine.OLLAMA,
+        default_ports=(11434,),
+        identity=(Rule("GET", "/", RuleKind.BODY_PREFIX, "Ollama is running"),),
+        version_path="/api/version", version_key="version",
+        models_path="/api/tags", models_key="models[].model",
+        model_caps=Rule("POST", "/api/show", RuleKind.JSON_KEY, "capabilities"),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=True,
+        note="verified 0.33.2 @ 2026-09-03: GET / -> 'Ollama is running'; "
+             "/api/version -> {'version':'0.33.2'}; /api/tags entries carry both "
+             "`capabilities` and `modified_at`; POST /api/show carries capabilities, "
+             "details and model_info.",
+    ),
+    ProbeSpec(
+        engine=LocalEngine.LLAMA_CPP,
+        default_ports=(8080,),
+        identity=(Rule("GET", "/health", RuleKind.STATUS_OK),
+                  Rule("GET", "/props", RuleKind.JSON_KEY, "build_info")),
+        version_path="/props", version_key="build_info",
+        models_path="/v1/models", models_key="data[].id",
+        model_caps=Rule("GET", "/props", RuleKind.JSON_KEY, "modalities"),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note="binary present (build 7620), --port default 8080 confirmed from --help; "
+             "GET /props reply shape NOT re-verified live. Tool calls need a "
+             "tools-capable template (--jinja).",
+    ),
+    ProbeSpec(
+        engine=LocalEngine.MLX_LM,
+        default_ports=(8080,),
+        identity=(Rule("GET", "/health", RuleKind.STATUS_OK),
+                  Rule("GET", "/props", RuleKind.ABSENT),
+                  Rule("GET", "/v1/models", RuleKind.JSON_KEY, "data")),
+        version_path=None, version_key=None,
+        models_path="/v1/models", models_key="data[].id",
+        model_caps=None,
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note="mlx_lm.server present on PATH; default port 8080; identity is "
+             "'/health answers AND /props does not' to separate it from llama.cpp on "
+             "the same port. No JSON-schema support, no embeddings endpoint.",
+    ),
+    ProbeSpec(
+        engine=LocalEngine.LM_STUDIO,
+        default_ports=(1234,),
+        identity=(Rule("GET", "/api/v0/models", RuleKind.JSON_KEY, "data"),),
+        version_path=None, version_key=None,
+        models_path="/api/v0/models", models_key="data[].id",
+        model_caps=Rule("GET", "/api/v0/models", RuleKind.JSON_KEY, "data"),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note="LM Studio not installed on this machine. /api/v0/models is richer than "
+             "/v1/models and is the discriminator. Use HTTP, not the Python SDK "
+             "(last release Aug 2025, WebSocket-based, stale).",
+    ),
+    ProbeSpec(
+        engine=LocalEngine.VLLM,
+        default_ports=(8000,),
+        identity=(Rule("GET", "/version", RuleKind.JSON_KEY, "version"),),
+        version_path="/version", version_key="version",
+        models_path="/v1/models", models_key="data[].id",
+        model_caps=Rule("GET", "/server_info", RuleKind.JSON_KEY, "vllm_config"),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note="Linux only; not installable on this machine. Tools require BOTH "
+             "--enable-auto-tool-choice AND --tool-call-parser, otherwise tool calls "
+             "come back as plain text (Quirk.TOOLS_REQUIRE_SERVER_FLAGS).",
+    ),
+    ProbeSpec(
+        engine=LocalEngine.TRANSFORMERS_SERVE,
+        default_ports=(8000,),
+        identity=(Rule("GET", "/version", RuleKind.ABSENT),
+                  Rule("GET", "/health", RuleKind.STATUS_OK),
+                  Rule("GET", "/v1/models", RuleKind.JSON_KEY, "data")),
+        version_path=None, version_key=None,
+        models_path="/v1/models", models_key="data[].id",
+        model_caps=None,
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note="`transformers serve`, default 8000; /health is undocumented. Identity is "
+             "'/version absent AND /health ok' to separate it from vLLM on 8000.",
+    ),
+)
+```
+
+`LLAMAFILE`, `LOCALAI` and `RAMALAMA` are enum members with `DEFAULT_CAPS` entries but **no
+`ProbeSpec`**: they are reachable only via `PRAISONAI_LOCAL_ENGINE`. Adding a row requires a
+discriminator verified on a live server. A `ProbeSpec` with `verified=False` is still probed —
+it is the *note* that is unproven, not the port.
+
+---
+
+## 8. `target.py` — `resolve()` and precedence
+
+```python
+DEFAULT_API_KEY: str = "local"
+ENV_BASE_URL: str = "PRAISONAI_LOCAL_BASE_URL"
+ENV_ENGINE:   str = "PRAISONAI_LOCAL_ENGINE"
+ENV_MODEL:    str = "PRAISONAI_LOCAL_MODEL"
+ENV_TTL:      str = "PRAISONAI_LOCAL_TTL"
+ENV_NEG_TTL:  str = "PRAISONAI_LOCAL_NEG_TTL"
+ENV_TIMEOUT:  str = "PRAISONAI_LOCAL_TIMEOUT"
+
+def resolve(spec=None, *, timeout=None, refresh=False, transport=None) -> LocalTarget: ...
+async def aresolve(...) -> LocalTarget: ...
+def resolve_or_none(spec=None, **kwargs) -> LocalTarget | None: ...
+async def aresolve_or_none(...) -> LocalTarget | None: ...
+def build_target(discovery, model_id, *, caps=None, caps_evidence=Evidence.TABLE,
+                 model_evidence=Evidence.SERVER) -> LocalTarget: ...   # pure
+def litellm_model_for(engine, model_id) -> str | None: ...             # pure
+def parse_spec(spec) -> tuple[LocalEngine | None, str | None, str | None]: ...
+def parse_ollama_host(value: str) -> str | None: ...
+def select_model(discovery, *, transport=None, timeout=0.4) -> str | None: ...
+def clear_cache() -> None: ...
+def cache_info() -> dict[str, int]: ...
+```
+
+`parse_ollama_host` applies Ollama's own rules: empty/whitespace -> `None`; contains `://` ->
+parsed as a URL where an absent port means **80 for http and 443 for https, not 11434**; all
+digits (`"11500"`) or a leading colon (`":11500"`) -> `http://127.0.0.1:11500`; otherwise
+`host[:port]` with default port 11434 and scheme http. IPv6 must be bracketed; an unbracketed
+IPv6 literal returns `None`.
+
+### 8.1 Resolution precedence
+
+Sources are consulted in this order. **Authoritative** means its failure raises;
+**inferential** means its failure falls through.
+
+1. **`spec` argument — authoritative.**
+   - `None` / `""` / `"local"` / `"auto"` -> contributes nothing; go to 2.
+   - `"<engine>/<model>"` -> pins `engine` and `model_id` (`Evidence.SPEC`); the base URL
+     still comes from 2-5, restricted via `probe_endpoint(expect=engine)`.
+   - a URL -> pins `base_url`; an optional `#model` fragment pins `model_id`. Probed for
+     identity; answering but matching no discriminator gives `engine=UNKNOWN`.
+   - anything else -> `InvalidLocalSpecError(f"Cannot parse local spec {spec!r}. Expected None, 'local', '<engine>/<model>', a base URL, or '<url>#<model>'.")`
+   - A pinned `base_url` that does not answer -> `EngineUnreachableError(source="spec")`.
+     **No fallback** — silently talking to a different server than the caller named is the
+     failure mode this package exists to prevent.
+2. **`PRAISONAI_LOCAL_BASE_URL` — authoritative.** `PRAISONAI_LOCAL_ENGINE`, if set to a valid
+   `LocalEngine` value, skips identity probing and pins the engine (`Evidence.ENV`); an
+   invalid value raises `InvalidLocalSpecError`.
+3. **`OLLAMA_HOST` — authoritative.** Via `parse_ollama_host()`, with `expect=OLLAMA`. This is
+   where the bare-host / `http://` asymmetry bites, which is why the error must print the
+   resolved URL.
+4. **`OPENAI_BASE_URL`, then `OPENAI_API_BASE` — inferential.** Used **only** if the host is
+   loopback (`127.0.0.0/8`, `::1`, `localhost`) or RFC1918/link-local. A public host is
+   ignored — it is normally a cloud proxy. Falls through to 5, recording the skip reason.
+5. **Probe-table scan — inferential.** `discover(host="127.0.0.1")` in table order, ports
+   concurrent, within `budget`. The first non-`blocked` `Discovery` in table order wins, so
+   Ollama on 11434 beats an unidentified server on 8000.
+6. **Nothing found.** If step 5 produced only `blocked` discoveries, raise
+   `HostHeaderRejectedError`. Otherwise `NoLocalEngineError`.
+
+### 8.2 Error message templates (exact)
+
+```
+No local model runtime found. Probed 127.0.0.1 ports 11434 (ollama), 8080 (llama_cpp, mlx_lm), 1234 (lm_studio), 8000 (vllm, transformers_serve) in 1.5s; nothing answered. Start one (e.g. `ollama serve`, then `ollama pull qwen3:0.6b`) or set PRAISONAI_LOCAL_BASE_URL to its address.
+```
+When step 4 was skipped for being non-local, append exactly:
+` Ignored OPENAI_BASE_URL='https://api.openai.com/v1': not a local address.`
+
+```
+Local runtime at http://127.0.0.1:80 did not answer (refused). It was named explicitly by OLLAMA_HOST='http://127.0.0.1', so no other port was probed. Note that OLLAMA_HOST with an explicit http:// scheme and no port means port 80, not 11434.
+```
+The trailing sentence appears only when `source == "OLLAMA_HOST"` and the parsed port is 80 or 443.
+
+```
+Local runtime at http://192.168.1.10:11434 returned HTTP 403 with an empty body. Ollama rejects any request whose Host header is not localhost or an IP address; set OLLAMA_HOST on the server to allow this origin.
+```
+
+```
+Model 'llama3.2' is not served by ollama at http://127.0.0.1:11434. Available: qwen3:0.6b, mervinpraison/praisonai-qwen3.5-9b-tamil-en2ta:latest. Pull it with `ollama pull llama3.2`.
+```
+
+### 8.3 `select_model()` — deterministic choice
+
+Applied only when no source pinned a model:
+
+1. `PRAISONAI_LOCAL_MODEL` if set — validated against the model list; a miss raises `ModelNotAvailableError`.
+2. If the engine has `Quirk.SINGLE_MODEL_PER_PROCESS` -> the single id reported, or `None`.
+3. If the list has exactly one entry -> that entry.
+4. Otherwise prefer entries whose reported capabilities include `tools` (Ollama's `/api/tags`
+   carries `capabilities` per entry — verified); tie-break newest `modified_at`; final
+   tie-break lexicographic ascending. **Never** guess a model not in the list.
+5. Empty list -> `None` (and `litellm_model` is `None`).
+
+### 8.4 Timeouts
+
+`timeout=None` -> `float(os.environ.get(ENV_TIMEOUT, "1.5"))`, clamped to `[0.05, 30.0]`; a
+non-numeric value falls back to 1.5 without raising. Per-request timeout is
+`min(0.4, total/3)`. `resolve()` must return or raise within `total + 0.2` s.
+
+---
+
+## 9. Caching
+
+| Question | Answer |
+|---|---|
+| **What is cached** | Two dicts in `target.py`: `_TARGETS: dict[str, tuple[float, int, LocalTarget]]` (deadline, pid, target) and `_NEGATIVES: dict[str, tuple[float, int, str, str]]` (deadline, pid, exception class name, message). Nothing else. |
+| **Cache key** | `"\x00".join((spec or "*", PRAISONAI_LOCAL_BASE_URL, PRAISONAI_LOCAL_ENGINE, PRAISONAI_LOCAL_MODEL, OLLAMA_HOST, OPENAI_BASE_URL, OPENAI_API_BASE, f"{timeout:.3f}"))`. Every input that can change the answer is in the key, so an env change is a natural miss rather than a stale hit. |
+| **TTL** | Positive 30.0 s (`PRAISONAI_LOCAL_TTL`); negative 5.0 s (`PRAISONAI_LOCAL_NEG_TTL`). `0` disables; negative or non-numeric falls back to the default without raising. Negatives are cached so "nothing running" does not cost 1.5 s on every `Agent()` in a loop. |
+| **Invalidation** | (a) deadline passed; (b) `refresh=True`; (c) `clear_cache()`; (d) key change; (e) `os.getpid()` differs from the stored pid — a forked child must re-probe rather than inherit the parent's view. |
+| **Where** | **Process-local only. Never on disk.** A disk cache goes stale across `ollama pull` / `ollama serve --port`, needs locking and per-user `/tmp` permissions, and is persistent mutable state — i.e. behaviour, which §2.2 forbids. |
+| **Thread safety** | One module-level `_CACHE_LOCK = threading.Lock()`, held **only** around dict reads and writes, **never** across I/O. Two threads missing at once both probe; the second write wins; both callers get an equally valid target. `LocalTarget` is frozen, so a shared instance cannot be mutated. `aresolve` runs `resolve` in an executor and shares the same dicts and lock — no second cache. |
+| **Re-raise** | A negative hit raises a **fresh** exception built from the stored class name and message — never a stored exception object, which would carry a stale traceback and references to dead frames. |
+
+---
+
+## 10. Failure semantics
+
+`probe_endpoint()` and `discover()` never raise for network conditions.
+
+| Condition | Transport result | `probe_endpoint` | `resolve()` |
+|---|---|---|---|
+| Connection refused | `HttpReply(0, b"", "refused")` | `None` | authoritative -> `EngineUnreachableError(reason="refused")`; inferential -> skip |
+| Timeout | `HttpReply(0, b"", "timeout")` | `None` | as above, `reason="timeout"` |
+| Reset / partial read | `HttpReply(0, b"", "reset")` | `None` | as above, `reason="reset"` |
+| DNS failure (`socket.gaierror`) | `HttpReply(0, b"", "refused")` | `None` | as above |
+| **Bodyless 403** (verified: Ollama, non-local Host header, `size_download=0`) | `HttpReply(403, b"", "http")` | `Discovery(blocked="host_header_rejected")` | skipped as a candidate; if it is the only one -> `HostHeaderRejectedError`; otherwise its reason is appended to `NoLocalEngineError`. **Never** silently reported as "nothing found". |
+| 401/403 **with** a body | `HttpReply(401\|403, body, "http")` | `Discovery(blocked="auth_required")` | same handling, different message clause |
+| Other 4xx/5xx | `HttpReply(status, body, "http")` | `None` unless an `ABSENT` rule wanted 404/405 | skip / `EngineUnreachableError(reason=f"http_{status}")` |
+| Malformed JSON | `HttpReply(200, junk, None)` | `JSON_KEY` rules fail; `ABSENT` rules **succeed**; a matched `BODY_PREFIX`/`STATUS_OK` identity still stands with `models=()` | target built with `caps=default_caps(engine)`, evidence `TABLE`. Never raises. |
+| Unknown runtime on a known port (200, no discriminator) | — | `Discovery(engine=UNKNOWN, api_style=OPENAI_CHAT if /v1/models parsed else OPENAI_COMPLETIONS, evidence=TABLE)` | `caps={CHAT, STREAMING}`, `quirks={CAPS_ASSUMED_ENGINE_UNIDENTIFIED}`, `litellm_model=f"openai/{model_id}"`. The quirk is the honest signal that everything here is a guess. |
+| Non-UTF-8 body | decoded with `errors="replace"` | per rule | — |
+| Reply larger than 1 MiB | truncated at 1 MiB | rules see truncated bytes | — |
+
+The default transport must catch `urllib.error.HTTPError` (a subclass of `URLError` **and** a
+response object — read its body, do not let it escape), `urllib.error.URLError`, `OSError`,
+`socket.timeout`, `TimeoutError`, `ValueError` (bad URL) and `http.client.HTTPException`. It
+must set `Host` implicitly (never override it) and send `Accept: application/json` and
+`User-Agent: praisonaiagents-local/1`.
+
+---
+
+## 11. `manage.py` and `embed.py`
+
+### 11.1 `manage.py` — remedy data, executes nothing
+
+```python
+class RemedyKind(str, Enum):
+    INSTALL = "install"            # engine not on PATH
+    START = "start"                # installed but not listening
+    PULL_MODEL = "pull_model"      # listening but model absent
+    ENABLE_TOOLS = "enable_tools"  # listening but launched without tool flags
+    SET_ENV = "set_env"            # reachable but an env var points elsewhere
+
+@dataclass(frozen=True, slots=True)
+class Remedy:
+    engine: LocalEngine
+    kind: RemedyKind
+    argv: tuple[str, ...]              # ("ollama", "pull", "qwen3:0.6b"); () for SET_ENV
+    env: tuple[tuple[str, str], ...]
+    docs_url: str
+    note: str
+
+def remedies(engine=None, *, kind=None, model_id=None) -> tuple[Remedy, ...]: ...  # pure
+def binary_name(engine) -> str | None: ...
+def binary_path(engine) -> str | None: ...            # shutil.which only
+def installed_engines() -> tuple[LocalEngine, ...]: ...
+
+@dataclass(frozen=True, slots=True)
+class LocalModel:
+    model_id: str
+    engine: LocalEngine
+    size_bytes: int | None
+    modified_at: str | None            # ISO-8601 verbatim as the server reports it
+    caps: frozenset[Cap]
+    family: str | None
+
+def installed_models(discovery, *, timeout=0.4, transport=None) -> tuple[LocalModel, ...]: ...
+async def ainstalled_models(...) -> tuple[LocalModel, ...]: ...
+```
+
+`manage.py` **never** imports `subprocess`, `os.system`, `os.popen` or `pty`, and never calls
+`os.exec*`. It emits `argv` tuples for a caller (a CLI, a doctor, an error message) to run or
+print. That is the line between data and behaviour, and it is a test.
+
+### 11.2 `embed.py`
+
+```python
+EMBED_DEFAULT_MODELS: Mapping[LocalEngine, str | None]   # OLLAMA -> "nomic-embed-text"
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingTarget:
+    engine: LocalEngine
+    base_url: str
+    endpoint: str                  # base_url + "/v1/embeddings", or the native path
+    model_id: str | None
+    dimensions: int | None         # from server metadata or a static table; None when unknown
+    litellm_model: str | None
+    api_key: str
+    evidence: tuple[tuple[str, Evidence], ...]
+    def as_dict(self) -> dict[str, object]: ...
+
+def embedding_target(target, *, model_id=None, timeout=0.4, transport=None) -> EmbeddingTarget:
+    """Model choice: model_id > PRAISONAI_LOCAL_EMBED_MODEL > EMBED_DEFAULT_MODELS > None.
+
+    Dimensions come from server metadata only: for Ollama, POST /api/show and read the
+    model_info key ending in ".embedding_length" (verified: qwen3.embedding_length == 1024).
+    """
+    # Raises LocalError when the target carries Quirk.NO_EMBEDDINGS_ENDPOINT or lacks
+    # Cap.EMBEDDINGS_ENDPOINT; ModelNotAvailableError when a named model is not served.
+
+async def aembedding_target(...) -> EmbeddingTarget: ...
+def default_embed_model(engine) -> str | None: ...
+```
+
+**`dimensions` is never obtained by embedding a probe string.** That would be an inference
+call — cost, model load, behaviour. `None` is the correct answer when metadata is silent.
+
+### 11.3 `__init__.py`
+
+Re-exports only; no logic, no `os.environ` reads, no lazy machinery (every submodule is
+stdlib-only, so eager import is cheap).
+
+```python
+__all__ = [
+    "LocalEngine", "ApiStyle", "Cap", "Evidence", "Severity", "Quirk",
+    "Discovery", "HttpReply", "ProbeSpec", "Rule", "RuleKind", "Transport",
+    "discover", "adiscover", "probe_endpoint", "probe_table", "models", "amodels",
+    "capabilities", "acapabilities", "default_caps",
+    "parse_ollama_capabilities", "parse_llama_cpp_props",
+    "parse_lm_studio_models", "parse_openai_models",
+    "QuirkNote", "note", "all_notes", "notes_for", "quirks_for", "silent_quirks",
+    "LocalTarget", "resolve", "aresolve", "resolve_or_none", "aresolve_or_none",
+    "build_target", "litellm_model_for", "parse_spec", "parse_ollama_host",
+    "select_model", "clear_cache", "cache_info",
+    "Remedy", "RemedyKind", "LocalModel", "remedies", "binary_name", "binary_path",
+    "installed_engines", "installed_models", "ainstalled_models",
+    "EmbeddingTarget", "embedding_target", "aembedding_target", "default_embed_model",
+    "LocalError", "NoLocalEngineError", "EngineUnreachableError",
+    "HostHeaderRejectedError", "ModelNotAvailableError", "InvalidLocalSpecError",
+]
+```
+
+---
+
+## 12. Tests
+
+All under `src/praisonai-agents/tests/unit/local/`. Every test carries
+`pytestmark = pytest.mark.unit`. The markers `network`, `local_service` and `provider_ollama`
+are **forbidden** in this directory — a test needing a live server belongs in
+`tests/integration/`, out of scope here.
+
+**Files:** `__init__.py`, `conftest.py`, `fixtures/`, `test_import_boundary.py`,
+`test_discover.py`, `test_capabilities.py`, `test_quirktable.py`, `test_target.py`,
+`test_cache.py`, `test_manage.py`, `test_embed.py`, `test_async_parity.py`.
+
+### 12.1 `conftest.py` provides exactly three things
+
+- **`no_sockets`** (autouse, session-scoped): monkeypatches `socket.socket.__init__` to
+  `raise AssertionError("tests/unit/local must not open a socket")`. This is *the* mechanism
+  that proves offline safety — a test that forgets to inject a transport fails loudly instead
+  of silently hitting a developer's live Ollama.
+- **`fake_transport(routes, *, default=HttpReply(0, b"", "refused"))`** — a `Transport`
+  callable that also records calls, so tests can assert "exactly one request was made" and
+  "no POST was issued".
+- **`recorded(name)`** — reads `fixtures/<name>` from disk. No network.
+
+### 12.2 `fixtures/` — byte-for-byte captures from this machine, 2026-09-03
+
+`ollama_root.txt`, `ollama_api_version.json`, `ollama_api_tags.json` (both models, with
+`capabilities` and `modified_at`), `ollama_api_show_qwen3_0_6b.json` (`capabilities`,
+`details`, `model_info` incl. `qwen3.context_length: 40960`, `qwen3.embedding_length: 1024`),
+`ollama_v1_models.json`, plus clearly-labelled hand-written-from-docs
+`llama_cpp_props.json`, `lm_studio_api_v0_models.json`, `vllm_version.json`, `malformed.txt`,
+`empty_403.bin`.
+
+### 12.3 Test inventory
+
+| File | Test | How it avoids the network |
+|---|---|---|
+| `test_import_boundary.py` | `test_only_stdlib_imports` | `ast.parse()` each `local/*.py`; every absolute import root must be in `sys.stdlib_module_names`. No import executed. |
+| | `test_no_praisonaiagents_import` | AST: no import whose module starts with `praisonaiagents`. |
+| | `test_no_parent_relative_imports` | AST: every `ImportFrom` has `level <= 1`. `level >= 2` is the escape hatch that breaks the sink. |
+| | `test_forbidden_distributions` | AST: import roots ∩ `{litellm, openai, pydantic, httpx, requests, aiohttp, anyio, rich, yaml, posthog, numpy}` is empty. |
+| | `test_loads_standalone_from_file_path` | `importlib.util.spec_from_file_location` loads `local/` **without** executing `praisonaiagents/__init__.py`, proving the sink property. Filesystem only. |
+| | `test_no_third_party_in_sys_modules` | After the standalone load, newly-added `sys.modules` contains no forbidden distribution. |
+| | `test_import_via_parent_package_also_works` | `import praisonaiagents.local` in a `subprocess -I`; asserts exit 0 and no `litellm`/`openai` in the printed module list. |
+| | `test_manage_has_no_subprocess` | AST of `manage.py`: no `subprocess`/`os.system`/`os.popen`/`pty` import, no `os.exec*` call. |
+| | `test_sloc_ceiling` | Counts non-blank, non-comment lines per file against §13. Filesystem only. |
+| | `test_public_api_is_frozen` | `__all__` equals a literal list held in the test, so an addition is a deliberate edit. |
+| `test_discover.py` | `test_ollama_identity_from_recorded_root` | `fake_transport` + recorded fixtures. |
+| | `test_ollama_not_matched_by_port_alone` | Transport returns 200 `"hello"` on 11434 → `UNKNOWN`, not `OLLAMA`. |
+| | `test_port_8080_collision_llama_cpp_vs_mlx` | `/props` yields `build_info` → `LLAMA_CPP`; `/props` 404 + `/health` 200 → `MLX_LM`. |
+| | `test_port_8000_collision_vllm_vs_transformers` | `/version` present → `VLLM`; `/version` 404 + `/health` 200 → `TRANSFORMERS_SERVE`. |
+| | `test_connection_refused_yields_no_candidate` | Default transport reply is `refused`; returns `()`, raises nothing. |
+| | `test_timeout_yields_no_candidate` | `HttpReply(0, b"", "timeout")`. |
+| | `test_bodyless_403_marks_blocked` | `HttpReply(403, b"", "http")`; asserts `blocked == "host_header_rejected"`. |
+| | `test_malformed_json_does_not_raise` | `malformed.txt`. |
+| | `test_probe_table_rows_are_wellformed` | Pure: unique engines, non-empty `identity`, methods in `{GET, POST}`, paths start with `/`, non-empty `note`. |
+| | `test_discover_respects_budget` | Transport counts, never `time.sleep`s; asserts request count ≤ ports × rules. |
+| | `test_models_uses_get_only` | Recorded call log has no `POST`. |
+| `test_capabilities.py` | `test_parse_ollama_capabilities_covers_recorded_payload` | Recorded show → `{COMPLETION, CHAT, TOOLS, THINKING}`. |
+| | `test_unknown_capability_string_is_ignored` | Pure `{"capabilities": ["teleportation"]}`. |
+| | `test_default_caps_exhaustive_over_engines` | Pure. |
+| | `test_default_caps_never_claim_tools_or_vision` | Pure. |
+| | `test_llama_cpp_props_modalities` | Recorded fixture. |
+| | `test_capabilities_degrades_to_table_on_failure` | Transport `refused` → `(default_caps(engine), Evidence.TABLE)`. |
+| | `test_pure_parsers_take_no_transport` | `inspect.signature` has no `transport` parameter. |
+| `test_quirktable.py` | `test_every_quirk_has_a_note` | Pure: `set(Quirk) == set(NOTES)`. |
+| | `test_every_note_is_self_consistent` | Pure: key matches `note.quirk`; `engines` non-empty; strings non-empty. |
+| | `test_ollama_openai_route_quirks` | Pure: contains `THINK_FIELD_IGNORED_ON_OPENAI_ROUTE` + `THINKING_WITH_TOOLS_YIELDS_EMPTY_TURN`, excludes `NATIVE_ROUTE_NEVER_SETS_TOOL_FINISH_REASON`. |
+| | `test_ollama_native_route_quirks` | Pure: the inverse. |
+| | `test_thinking_quirk_requires_both_caps` | Pure: absent when `TOOLS` not in `caps`. |
+| | `test_unknown_engine_gets_caps_assumed_quirk` | Pure. |
+| | `test_quirktable_reads_no_environment` | AST: no `os.environ`/`getenv`. |
+| `test_target.py` | `test_precedence_spec_url_wins_over_every_env` | All env set via `monkeypatch`; transport keyed to the spec URL only. |
+| | `test_precedence_env_base_url_beats_ollama_host` | `monkeypatch` + transport. |
+| | `test_ollama_host_bare_host_defaults_11434` | Pure. |
+| | `test_ollama_host_with_scheme_defaults_80` | Pure: `"http://127.0.0.1"` → `":80"`. |
+| | `test_ollama_host_bare_port_forms` | Pure: `"11500"` and `":11500"`. |
+| | `test_openai_base_url_ignored_when_not_local` | Asserts skip + appended message clause. |
+| | `test_openai_base_url_used_when_loopback` | Transport-backed. |
+| | `test_explicit_source_unreachable_raises_and_does_not_fall_through` | Transport refuses the pinned URL but would answer on 11434; asserts the raise **and** that 11434 was never requested. |
+| | `test_nothing_found_message_is_exact` | Empty transport; asserts the full string equals the §8.2 literal. |
+| | `test_blocked_only_raises_host_header_error` | 403-bodyless transport. |
+| | `test_model_selection_prefers_tools_then_recency` | Recorded tags → `qwen3:0.6b`. |
+| | `test_model_not_available_lists_alternatives` | `PRAISONAI_LOCAL_MODEL=llama3.2` + recorded tags. |
+| | `test_litellm_model_for_every_engine` | Pure, parametrised over all members. |
+| | `test_ollama_never_maps_to_ollama_chat` | Pure; guards the §4.4 decision. |
+| | `test_target_is_frozen_and_hashable` | Pure: `hash(t)` works; assignment raises `FrozenInstanceError`. |
+| | `test_as_dict_is_json_serialisable` | Pure: `json.dumps(t.as_dict())`. |
+| `test_cache.py` | `test_hit_does_not_reprobe` | Counting transport; second call adds zero. |
+| | `test_ttl_expiry_reprobes` | `monkeypatch target.time.time`; never sleeps. |
+| | `test_refresh_bypasses_cache` | Counting transport. |
+| | `test_env_change_changes_key` | `monkeypatch.setenv` between calls. |
+| | `test_negative_result_is_cached_and_reraised_fresh` | Asserts two distinct exception objects, identical messages, one probe round. |
+| | `test_pid_change_invalidates` | `monkeypatch target.os.getpid`. |
+| | `test_concurrent_resolve_is_consistent` | 16 threads, in-memory transport; all results equal, no exception. |
+| | `test_clear_cache_empties_both_dicts` | `cache_info()`. |
+| `test_manage.py` | `test_remedies_exist_for_every_engine` | Pure. |
+| | `test_remedy_argv_is_a_tuple_of_str` | Pure. |
+| | `test_binary_path_uses_shutil_which_only` | `monkeypatch shutil.which`; asserts no other probing, no execution. |
+| | `test_installed_engines_never_executes` | `monkeypatch subprocess` attributes to raise; asserts untouched. |
+| `test_embed.py` | `test_embedding_target_from_recorded_show` | Recorded fixture. |
+| | `test_dimensions_from_model_info_embedding_length` | Pure: `qwen3.embedding_length` → `1024`. |
+| | `test_context_length_lands_in_extra` | Pure: `40960`. |
+| | `test_mlx_lm_has_no_embeddings_endpoint` | Pure: raises per §11.2. |
+| | `test_embed_never_posts_an_inference_request` | Call log has no request to any `/embeddings` path. |
+| `test_async_parity.py` | `test_public_api_parity` | Reflection over `__all__`: every sync public callable has an `a`-twin with an identical signature. |
+| | `test_aresolve_matches_resolve` | `asyncio.run` + the same fake transport. |
+| | `test_aresolve_shares_the_cache` | Counting transport across one sync and one async call. |
+
+---
+
+## 13. LOC budget
+
+A prior extraction in this repo grew **55%** past its pre-split size in five months
+(`agent.py` split 8,915 → 5,030 on 2026-04-01; the two halves total 13,852 today). Budgets
+are therefore enforced by `test_sloc_ceiling` (non-blank, non-comment lines), not suggested.
+
+| Module | Estimate | Ceiling |
+|---|---|---|
+| `__init__.py` | 60 | 90 |
+| `capabilities.py` | 150 | 200 |
+| `quirktable.py` | 200 (mostly data) | 260 |
+| `discover.py` | 220 | 300 |
+| `target.py` | 180 | 240 |
+| `manage.py` | 120 | 160 |
+| `embed.py` | 90 | 120 |
+| **package total** | **1020** | **1150** |
+
+Per-file ceilings sum to 1370, but the **package** ceiling of 1150 binds first — one module
+may grow only if another shrinks. Raising a ceiling requires editing this document in the same
+commit. Exceeding it is a failing test, not a review comment.
+
+---
+
+## 14. Worked examples
+
+### (a) Only Ollama running — `Agent(llm="local")`
+
+```python
+from praisonaiagents import Agent
+agent = Agent(instructions="Summarise this", llm="local")
+# integration site calls: local.resolve("local")
+```
+
+Four loopback requests (~6 ms on this machine): `GET /` → `Ollama is running`;
+`GET /api/version`; `GET /api/tags`; `POST /api/show {"model":"qwen3:0.6b"}`.
+
+Model choice: two models present, so §8.3 rule 4 applies — `qwen3:0.6b` reports
+`["completion","tools","thinking"]` while the 9B tamil model reports
+`["tools","thinking","completion","vision"]`. Both have `tools`, so the tie-break is
+`modified_at` recency, which also selects `qwen3:0.6b`.
+
+```python
+LocalTarget(
+    engine=LocalEngine.OLLAMA,
+    base_url='http://127.0.0.1:11434',
+    openai_base_url='http://127.0.0.1:11434/v1',
+    api_style=ApiStyle.OPENAI_CHAT,
+    model_id='qwen3:0.6b',
+    caps=frozenset({Cap.CHAT, Cap.COMPLETION, Cap.TOOLS, Cap.THINKING,
+                    Cap.STREAMING, Cap.JSON_OBJECT, Cap.JSON_SCHEMA,
+                    Cap.EMBEDDINGS_ENDPOINT}),
+    quirks=frozenset({Quirk.FORMAT_AND_TOOLS_MUTUALLY_DESTRUCTIVE,
+                      Quirk.TOOL_SCHEMA_KEYWORDS_STRIPPED,
+                      Quirk.TOOL_PARAM_TYPE_MUST_BE_BARE_STRING,
+                      Quirk.UNKNOWN_OPTIONS_ACCEPTED_AND_IGNORED,
+                      Quirk.THINK_FIELD_IGNORED_ON_OPENAI_ROUTE,
+                      Quirk.THINKING_WITH_TOOLS_YIELDS_EMPTY_TURN,
+                      Quirk.TOOL_CALLS_ARRIVE_WHOLE_NOT_INCREMENTAL,
+                      Quirk.STREAM_ERROR_ENDS_WITHOUT_DONE,
+                      Quirk.SAMPLING_DEFAULTS_FORCED_TO_ONE,
+                      Quirk.CONTEXT_OPTION_CHANGE_RELOADS_MODEL,
+                      Quirk.KEEP_ALIVE_IS_GLOBAL_LAST_WRITER_WINS,
+                      Quirk.BODYLESS_403_ON_NON_LOCAL_HOST_HEADER}),
+    litellm_model='ollama/qwen3:0.6b',
+    api_key='local',
+    engine_version='0.33.2',
+    evidence=(('api_style', Evidence.TABLE), ('base_url', Evidence.SERVER),
+              ('caps', Evidence.SERVER), ('engine', Evidence.SERVER),
+              ('engine_version', Evidence.SERVER), ('model_id', Evidence.SERVER),
+              ('quirks', Evidence.TABLE)),
+    extra=(('context_length', '40960'), ('embedding_length', '1024'),
+           ('family', 'qwen3'), ('parameter_size', '751.63M'),
+           ('quantization_level', 'Q4_K_M')),
+    probed_at=1788439200.0,
+)
+```
+
+`NATIVE_ROUTE_NEVER_SETS_TOOL_FINISH_REASON` is **absent** — `api_style` is `OPENAI_CHAT` and
+that quirk is native-route-only. `Cap.VISION` is **absent** — `qwen3:0.6b` reports no vision
+(verified twice; vision belongs to the other installed model).
+`Cap.STREAMING_WITH_TOOLS` is absent because `TOOL_CALLS_ARRIVE_WHOLE_NOT_INCREMENTAL` is present.
+
+### (b) `Agent(llm="ollama/qwen3:0.6b")` with `OLLAMA_HOST=127.0.0.1`
+
+Step 1 pins `engine=OLLAMA` and `model_id` (`Evidence.SPEC`); step 3 supplies the base URL —
+`parse_ollama_host("127.0.0.1")` → `http://127.0.0.1:11434` (bare host ⇒ 11434). Three
+requests: `GET /`, `GET /api/version`, `POST /api/show`. `/api/tags` is **not** fetched
+because the model was named.
+
+Result identical to (a) except:
+```python
+evidence=(('api_style', Evidence.TABLE), ('base_url', Evidence.ENV),
+          ('caps', Evidence.SERVER), ('engine', Evidence.SPEC),
+          ('engine_version', Evidence.SERVER), ('model_id', Evidence.SPEC),
+          ('quirks', Evidence.TABLE)),
+```
+
+Had the user written `OLLAMA_HOST=http://127.0.0.1` (explicit scheme, no port ⇒ **port 80**),
+step 3 is authoritative and nothing answers on 80:
+
+```
+EngineUnreachableError: Local runtime at http://127.0.0.1:80 did not answer (refused). It was named explicitly by OLLAMA_HOST='http://127.0.0.1', so no other port was probed. Note that OLLAMA_HOST with an explicit http:// scheme and no port means port 80, not 11434.
+```
+
+It does **not** quietly fall back to 11434.
+
+### (c) Nothing running
+
+Six ports across four numbers probed concurrently; all refused within ~2 ms.
+
+```
+NoLocalEngineError: No local model runtime found. Probed 127.0.0.1 ports 11434 (ollama), 8080 (llama_cpp, mlx_lm), 1234 (lm_studio), 8000 (vllm, transformers_serve) in 1.5s; nothing answered. Start one (e.g. `ollama serve`, then `ollama pull qwen3:0.6b`) or set PRAISONAI_LOCAL_BASE_URL to its address.
+```
+
+The negative is cached for 5 s, so a loop constructing 100 agents pays the probe cost once.
+`local.resolve_or_none("local")` returns `None` instead. `local.remedies(kind=RemedyKind.INSTALL)`
+supplies the `argv` a CLI can print — `local/` neither runs it nor formats it for a terminal.
+
+---
+
+## 15. Integration points
+
+Named only. This document designs **no** changes to these sites; each is a separate work order
+with its own review. Line numbers are against `main` @ `2591aa405`.
+
+| # | Call site | What it reads from `LocalTarget` |
+|---|---|---|
+| 15.1 | `agent/agent.py:305-345` — `_PROVIDER_DEFAULT_MODELS` / `_resolve_default_model()` | `litellm_model`. Today hardcodes `("OLLAMA_HOST", "ollama/llama3.2")` — a model that need not be pulled. |
+| 15.2 | `agent/agent.py:2049-2112` — `base_url`/`api_key` plumbing | `openai_base_url`, `api_key`, `litellm_model` |
+| 15.3 | `agent/agent.py:373` — `_apply_default_llm` base_url path | `openai_base_url` |
+| 15.4 | `llm/llm.py:621` — `_detect_provider()` | `engine` (replaces prefix guessing) |
+| 15.5 | `llm/llm.py:701` — `_is_ollama_provider()` | `engine` |
+| 15.6 | `llm/adapters/__init__.py` — `get_provider_adapter()`, `OllamaAdapter` | `quirks`, `caps` |
+| 15.7 | `llm/adapters/__init__.py` — `OllamaAdapter.get_default_settings()` + `llm/llm.py:273` | `quirks` |
+| 15.8 | `llm/streaming_protocol.py:285-372` — `OllamaStreamingAdapter` | `TOOL_CALLS_ARRIVE_WHOLE_NOT_INCREMENTAL`, `STREAM_ERROR_ENDS_WITHOUT_DONE` |
+| 15.9 | `llm/model_capabilities.py:106/141/173/204` | `caps` — litellm's map has no entry for a local tag, so these fall to name heuristics today |
+| 15.10 | `llm/openai_client.py:645-660` — `_supports_responses_api` | `engine`, `api_style` |
+| 15.11 | `llm/model_providers.py:_BUILTINS["ollama"]` | `engine` |
+| 15.12 | `llm/sanitize.py`, `agent/chat_mixin.py:690-720` | `TOOL_SCHEMA_KEYWORDS_STRIPPED`, `TOOL_PARAM_TYPE_MUST_BE_BARE_STRING`, `FORMAT_AND_TOOLS_MUTUALLY_DESTRUCTIVE` |
+| 15.13 | `tools/call_executor.py:125,141,256,294,351,364` — the `is_ollama: bool` field | `engine` |
+| 15.14 | `embedding/embed.py:13` — `embedding()` | `EmbeddingTarget.litellm_model`, `.endpoint`, `.dimensions` |
+| 15.15 | `runtime/health_check.py`, `runtime/doctor_registry.py` | `LocalTarget.as_dict()`, `manage.remedies()` |
+| 15.16 | `llm/failover.py`, `llm/model_router.py` | `caps` — to avoid routing a tool call to a model without `Cap.TOOLS` |
+
+---
+
+## 16. Non-goals
+
+Each with the reason, so a later contributor does not "add the obvious missing feature".
+
+1. **Not an HTTP client for inference.** litellm and `openai` own that transport; a second one doubles the streaming bug surface.
+2. **No chat, completion or embedding inference calls.** Any request whose reply depends on model weights is out. Metadata only.
+3. **No process management.** Never starts, stops, restarts or pulls. Returns `argv` for someone else. Starting a server is a privileged side effect with no correct default.
+4. **No request mutation, no schema rewriting.** Stripping a `oneOf` for Ollama is behaviour and belongs in `llm/adapters/`; `local/` only says the stripping will happen.
+5. **No retries, no backoff, no circuit breaking.** `llm/retry_utils.py`, `llm/rate_limiter.py` and `llm/failover.py` exist; a second policy would silently compete.
+6. **No disk cache, no config file.** Persistent state goes stale across `ollama pull`, needs locking, and is behaviour.
+7. **No LAN or subnet scanning.** Loopback and explicitly-named hosts only. Sweeping a subnet is a security event, not a feature.
+8. **No credential handling.** `api_key` is the fixed placeholder `"local"`; a server behind real auth is named explicitly by the caller.
+9. **No model downloading, quantisation choice or VRAM estimation.** Hardware fit is a separate problem with a separate error surface.
+10. **No new dependency and no 18th extra.** See §3.
+11. **No cloud-provider detection.** `llm/model_providers.py` owns that; overlapping creates a second source of truth for provider ids.
+12. **No top-level export.** Reached as `praisonaiagents.local`; nothing added to `_LAZY_IMPORTS`, so the sink cannot be dragged into the package import graph by an `__init__` edit.
+13. **No `praisonaiagents.errors` inheritance.** Would import upward and break §2.1; wrapping is the integration layer's job.
+14. **No Pydantic models.** Would add a hard-dependency edge and drag validation behaviour into a data package. Frozen dataclasses only.
+15. **No support for engines lacking a verified discriminator.** `LLAMAFILE`, `LOCALAI`, `RAMALAMA` are reachable only via `PRAISONAI_LOCAL_ENGINE` until someone verifies an identity endpoint live. Guessing from port 8080 is the exact mistake this table is designed to avoid.

--- a/src/praisonai-agents/docs/local-model-layer/README.md
+++ b/src/praisonai-agents/docs/local-model-layer/README.md
@@ -26,7 +26,15 @@ work and execute it correctly, in isolation, without re-deriving the analysis.
 Each order is independently revertible by design and that property is worth more than
 convenience.
 
-> **A correction this ledger has already had to make.** Its first draft told an agent to "wire
+> **Two corrections this ledger has already had to make.** Both were caught by measuring rather
+> than reasoning, and both would have sent an agent down the wrong path.
+>
+> **The D7 root cause is not `provider_ollama`.** The audit blamed the per-file `provider_ollama`
+> tag. Measurement (`04-test-gating.md` §2) shows `not network` deselects all seven tests **on its
+> own**, because the plugin implies `network` from *any* provider marker and the file also matches
+> `provider_openai`. **Removing `not provider_ollama` from the workflows would change nothing.**
+> That is why order `04` touches no YAML at all — the fix is marker-side.
+> Its first draft told an agent to "wire
 > the twelve dead adapter methods". Measurement (`06-adapter-revival.md` §1) says the opposite:
 > **12 of 20 items should be deleted, only 3 wired.** Six of the dead methods have no inline
 > equivalent anywhere — they are speculative API, and an agent told to "wire them up" would
@@ -100,8 +108,8 @@ authority. Before starting, check that no in-flight PR owns your files.
 | `01-d1-default-model` | `agent/agent.py` (branch chain only) | `llm/llm.py`, `llm/adapters/` |
 | `02-d3-provider-detection` | `llm/llm.py` (`_detect_provider`, `_is_ollama_provider` only) | `agent/agent.py`, `llm/adapters/` |
 | `03-d2-base-url-routing` | `agent/agent.py` (base_url branch), root `README.md` | `llm/llm.py`, `llm/adapters/` |
-| `04-d7-test-gating` | `tests/_pytest_plugins/test_gating.py`, `.github/workflows/*` | any `praisonaiagents/` source |
-| `05-live-ci-job` | `.github/workflows/test-optimized.yml` | any `praisonaiagents/` source |
+| `04-test-gating` | `tests/_pytest_plugins/test_gating.py`, both `pytest.ini`, `tests/conftest.py`, `tests/integration/test_base_url_api_base_fix.py`, `tests/unit/cli/test_test_command.py` | any `praisonaiagents/` source; **`.github/workflows/**` — the `-m` expressions are not the bug** |
+| `05-live-ci-job` | `.github/workflows/test-optimized.yml`, `tests/integration/test_ollama_tool_calling_live.py` | any `praisonaiagents/` source; `test_gating.py` |
 | `06-adapter-revival` | `llm/adapters/__init__.py`, `llm/llm.py` (3 response paths) | `agent/agent.py` |
 | `07-local-package` | `praisonaiagents/local/**` (new), `src/praisonai/tests/unit/llm/local/**` (new), `pyproject.toml` extras | everything else |
 | `08-reachability` | `memory/`, `eval/`, `context/`, `lite/`, `telemetry/` | `llm/`, `agent/` |
@@ -110,7 +118,9 @@ authority. Before starting, check that no in-flight PR owns your files.
 
 - **`01` then `03`** — both edit `agent/agent.py`. Land `01` first.
 - **`02` then `06`** — both edit `llm/llm.py`. Land `02` first; it is far smaller.
-- **`04` and `07` are independent** of everything above and may run in parallel with them.
+- **`04` then `05`** — before `04`, `-m provider_ollama` selects 32 tests across 5 files (only 7
+  are Ollama tests), so `05` has no usable selector and is unbuildable.
+- **`04` and `07` are independent** of orders 01/02/03/06 and may run in parallel with them.
 - **`08` requires `07`** to have landed, because it consumes `local/`.
 
 ---
@@ -124,8 +134,8 @@ Update your row in the same commit as your change. One line only.
 | 01 | D1 — provider-prefixed default model never reaches litellm | `fix/d1-default-provider-model` | — | in progress |
 | 02 | D3 — provider over-detection from base_url | — | — | planned |
 | 03 | D2 — `OPENAI_BASE_URL` to a non-OpenAI host uses the wrong client | — | — | planned |
-| 04 | D7 — per-file provider marker deselects unrelated tests | — | — | planned |
-| 05 | Live local-model CI job | — | — | planned |
+| 04 | D7 — per-file provider marker deselects unrelated tests | — | — | **spec ready** |
+| 05 | Live local-model CI job | — | — | **spec ready** |
 | 06 | A1/A2 — make the provider adapter load-bearing (6 sub-steps) | — | — | **spec ready** |
 | 07 | `praisonaiagents/local/` — discovery and capability resolver | — | — | **spec ready** |
 | 08 | A3 — reachability for the modules that bypass the LLM layer | — | — | planned |

--- a/src/praisonai-agents/docs/local-model-layer/README.md
+++ b/src/praisonai-agents/docs/local-model-layer/README.md
@@ -1,0 +1,162 @@
+# Local Model Layer — implementation ledger
+
+**Status:** planning complete, implementation in progress
+**Owner workstream:** local model runtimes (Ollama, LM Studio, llama.cpp, vLLM, MLX, `transformers serve`)
+**Created:** 2026-09-03
+
+---
+
+## 0. How to use this document
+
+This directory is a **work-order ledger**. It exists so that any agent — including one
+with no memory of the conversation that produced it — can pick up exactly one unit of
+work and execute it correctly, in isolation, without re-deriving the analysis.
+
+**If you are an agent starting work here, do this in order:**
+
+1. Read [`00-ground-truth.md`](00-ground-truth.md). It records what was measured, how, and
+   when. Do not trust a claim in any work order that contradicts it; re-measure instead.
+2. Read §2 (Invariants) and §3 (File ownership) of this file. §3 is what stops two agents
+   corrupting each other's work.
+3. Open the single work order you were assigned. Execute only that one.
+4. Update the status row in §4 of this file in the same commit as your change. That row is
+   the only shared file content; keep the edit to one line to avoid conflicts.
+
+**Do not** expand scope, batch two work orders into one PR, or "fix while you're in there".
+Each order is independently revertible by design and that property is worth more than
+convenience.
+
+> **A correction this ledger has already had to make.** Its first draft told an agent to "wire
+> the twelve dead adapter methods". Measurement (`06-adapter-revival.md` §1) says the opposite:
+> **12 of 20 items should be deleted, only 3 wired.** Six of the dead methods have no inline
+> equivalent anywhere — they are speculative API, and an agent told to "wire them up" would
+> invent an implementation that no test could ever have failed against. Read the decision table
+> before touching `llm/adapters/`; do not act on the summary in §1 of this file.
+
+---
+
+## 1. Why this work exists
+
+Every local runtime worth supporting already speaks `POST /v1/chat/completions`, and
+`litellm` already handles that transport. So the problem is not calling local models — the
+SDK can already do that. The problems are:
+
+- **Discovery.** A user with a running daemon still hand-types a URL, a port and an exact
+  model tag; getting any one wrong produces `OPENAI_API_KEY environment variable is required`.
+- **Capability.** "Does this model support tools?" is answerable by asking the server
+  (`/api/show`, `/props`, `/server_info`). The SDK asks nothing and guesses from a name prefix.
+- **Quirks.** Local stacks fail silently with HTTP 200. The sharpest: sending `format` and
+  `tools` together to Ollama suppresses the tool call and the model fabricates an answer.
+
+The layer being built is therefore a **resolver, not a transport**: it returns data about
+what is running and what it will get wrong. Compensating behaviour stays in
+`llm/adapters/`, which already declares methods for exactly this purpose.
+
+---
+
+## 2. Invariants — never break these
+
+These come from `src/praisonai-agents/AGENTS.md` §4.6 plus the structural review in
+`00-ground-truth.md`. Every work order inherits them; none may waive them.
+
+| # | Invariant | Why it binds this work specifically |
+|---|-----------|--------------------------------------|
+| I1 | **Backward compatible.** Public API changes need a deprecation cycle. | Several fixes change which code path a given input takes. Each order carries an explicit list of inputs whose behaviour must not change. |
+| I2 | **Lazy imports.** Optional deps never imported at module level. | Discovery must not import `litellm` or any runtime SDK at import time. |
+| I3 | **Safe defaults.** New features are opt-in. | Discovery must not fire unless the model spec is `"local"` or unset. Never probe the network on a fully-specified config. |
+| I4 | **Deterministic tests.** No dependence on timing or external state. | Every test must pass with **no server running**. Live-server tests go behind an explicit marker and never run in the default suite. |
+| I5 | **Protocol-driven core.** No heavy implementations in core. | `local/` returns dataclasses. It performs no chat calls, no retry, no request mutation. |
+| I6 | **`local/` is a dependency sink.** | It may import the standard library and `httpx` only — nothing from `praisonaiagents`. Enforced by a test. See §5. |
+| I7 | **No second abstraction.** | `llm/adapters/` is the extension point. Do not add a parallel quirk/adapter registry beside it. |
+| I8 | **No new public knobs without a live consumer.** | Root `AGENTS.md`: do not add params, modules or exports that merely duplicate existing behaviour. |
+
+### I6 in detail — the import rule
+
+An AST pass over `praisonaiagents/` (595 files, 238,936 lines) found **65 subpackages, 212
+directed edges and 26 mutually-importing subpackage pairs**. `llm/` already imports upward
+into `agent/`, and 15 subpackages import `llm/` back. Consequently a shared helper placed in
+`llm/` **cannot** be adopted by `memory/` or `eval/` without deepening the existing cycles.
+
+`local/` is therefore specified as a leaf. That single property is what allows the 21
+modules which currently bypass the LLM layer to adopt it later. Treat any import of
+`praisonaiagents.*` from inside `local/` as a build break, not a style issue.
+
+`httpx` is permitted because it is already a **hard transitive dependency** of the required
+core dep `openai>=2.0.0` (`httpx<1,>=0.23.0`); verified present at 0.28.1. Using it adds no
+dependency and needs no new extra.
+
+---
+
+## 3. File ownership — collision avoidance
+
+Two work orders that touch the same file **must not run concurrently**. This table is the
+authority. Before starting, check that no in-flight PR owns your files.
+
+| Work order | Owns (may edit) | Must not edit |
+|---|---|---|
+| `01-d1-default-model` | `agent/agent.py` (branch chain only) | `llm/llm.py`, `llm/adapters/` |
+| `02-d3-provider-detection` | `llm/llm.py` (`_detect_provider`, `_is_ollama_provider` only) | `agent/agent.py`, `llm/adapters/` |
+| `03-d2-base-url-routing` | `agent/agent.py` (base_url branch), root `README.md` | `llm/llm.py`, `llm/adapters/` |
+| `04-d7-test-gating` | `tests/_pytest_plugins/test_gating.py`, `.github/workflows/*` | any `praisonaiagents/` source |
+| `05-live-ci-job` | `.github/workflows/test-optimized.yml` | any `praisonaiagents/` source |
+| `06-adapter-revival` | `llm/adapters/__init__.py`, `llm/llm.py` (3 response paths) | `agent/agent.py` |
+| `07-local-package` | `praisonaiagents/local/**` (new), `pyproject.toml` extras | everything else |
+| `08-reachability` | `memory/`, `eval/`, `context/`, `lite/`, `telemetry/` | `llm/`, `agent/` |
+
+### Enforced serialisation
+
+- **`01` then `03`** — both edit `agent/agent.py`. Land `01` first.
+- **`02` then `06`** — both edit `llm/llm.py`. Land `02` first; it is far smaller.
+- **`04` and `07` are independent** of everything above and may run in parallel with them.
+- **`08` requires `07`** to have landed, because it consumes `local/`.
+
+---
+
+## 4. Status
+
+Update your row in the same commit as your change. One line only.
+
+| Order | Title | Branch | PR | Status |
+|---|---|---|---|---|
+| 01 | D1 — provider-prefixed default model never reaches litellm | `fix/d1-default-provider-model` | — | in progress |
+| 02 | D3 — provider over-detection from base_url | — | — | planned |
+| 03 | D2 — `OPENAI_BASE_URL` to a non-OpenAI host uses the wrong client | — | — | planned |
+| 04 | D7 — per-file provider marker deselects unrelated tests | — | — | planned |
+| 05 | Live local-model CI job | — | — | planned |
+| 06 | A1/A2 — make the provider adapter load-bearing (6 sub-steps) | — | — | **spec ready** |
+| 07 | `praisonaiagents/local/` — discovery and capability resolver | — | — | **spec ready** |
+| 08 | A3 — reachability for the modules that bypass the LLM layer | — | — | planned |
+
+---
+
+## 5. The two tests that keep this work honest
+
+Both are cheap, both are anti-regression, and both should land with their respective orders.
+
+**Import boundary (`07`).** Asserts `local/` imports nothing from `praisonaiagents`. Without
+it, I6 decays silently and the leaf property — the whole reason the package can be adopted
+by `memory/` and `eval/` — is lost.
+
+**Adapter reachability (`06`).** Asserts every method on `DefaultAdapter` has at least one
+call site. This is the test whose absence allowed 11 of 17 adapter methods to become dead code
+while `llm.py` grew 145 hand-written Ollama references. Two limits, both real: it cannot detect
+an *unreachable* call site (proven by `should_skip_streaming_with_tools`, which a caller would
+have satisfied while the branch stayed dead), and **one call site satisfies it — so it does not
+detect the three-path divergence at all.** A floor, not a ceiling.
+
+---
+
+## 6. Deliberately out of scope
+
+Named here so that deferring them is a decision rather than an oversight. Do not let a work
+order quietly grow into one of these.
+
+| Deferred | Measured size | Why not now |
+|---|---|---|
+| Consolidating `LLM` and `OpenAIClient` behind one protocol | 7,160 + 2,691 lines, selected by one boolean at 6 sites | Neither is a superset of the other; the merge is larger than every order in this ledger combined. |
+| Decomposing `LLM.get_response` | 1,675 lines, 194 branch/loop/try nodes | Highest-risk file in the package. Order `06` must edit it surgically without reflowing it. |
+| Removing the sync/async divergence | ~1,628 duplicated lines across 10 pairs; `get_response` vs `_async` only 22.3% similar | Requires the consolidation above to be worth doing. |
+
+The one obligation this ledger accepts toward them: **do not make them worse.** No order may
+add a fifth copy of any compensation, and no order may add new logic inside `get_response`
+that is not a delegation to an adapter.

--- a/src/praisonai-agents/docs/local-model-layer/README.md
+++ b/src/praisonai-agents/docs/local-model-layer/README.md
@@ -66,7 +66,7 @@ These come from `src/praisonai-agents/AGENTS.md` §4.6 plus the structural revie
 | I3 | **Safe defaults.** New features are opt-in. | Discovery must not fire unless the model spec is `"local"` or unset. Never probe the network on a fully-specified config. |
 | I4 | **Deterministic tests.** No dependence on timing or external state. | Every test must pass with **no server running**. Live-server tests go behind an explicit marker and never run in the default suite. |
 | I5 | **Protocol-driven core.** No heavy implementations in core. | `local/` returns dataclasses. It performs no chat calls, no retry, no request mutation. |
-| I6 | **`local/` is a dependency sink.** | It may import the standard library and `httpx` only — nothing from `praisonaiagents`. Enforced by a test. See §5. |
+| I6 | **`local/` is a dependency sink.** | It may import the **standard library only** — nothing from `praisonaiagents`, and no third-party distribution (`httpx`/`requests`/`aiohttp` are forbidden; use `urllib.request`). Enforced by a test. See §5 and `07` §3. |
 | I7 | **No second abstraction.** | `llm/adapters/` is the extension point. Do not add a parallel quirk/adapter registry beside it. |
 | I8 | **No new public knobs without a live consumer.** | Root `AGENTS.md`: do not add params, modules or exports that merely duplicate existing behaviour. |
 
@@ -81,9 +81,12 @@ into `agent/`, and 15 subpackages import `llm/` back. Consequently a shared help
 modules which currently bypass the LLM layer to adopt it later. Treat any import of
 `praisonaiagents.*` from inside `local/` as a build break, not a style issue.
 
-`httpx` is permitted because it is already a **hard transitive dependency** of the required
-core dep `openai>=2.0.0` (`httpx<1,>=0.23.0`); verified present at 0.28.1. Using it adds no
-dependency and needs no new extra.
+The HTTP client is stdlib `urllib.request`, **not** `httpx`. An earlier draft of this ledger
+permitted `httpx` on the grounds that it is a transitive dependency of `openai>=2.0.0`. That
+was reversed in `07` §3: the edge is undeclared in `pyproject.toml`, so a future `openai`
+release that drops `httpx` would silently break the sink — precisely the class of failure this
+package exists to catalogue. The boundary test in §5 hard-forbids `httpx`/`requests`/`aiohttp`
+so the decision cannot drift.
 
 ---
 
@@ -100,7 +103,7 @@ authority. Before starting, check that no in-flight PR owns your files.
 | `04-d7-test-gating` | `tests/_pytest_plugins/test_gating.py`, `.github/workflows/*` | any `praisonaiagents/` source |
 | `05-live-ci-job` | `.github/workflows/test-optimized.yml` | any `praisonaiagents/` source |
 | `06-adapter-revival` | `llm/adapters/__init__.py`, `llm/llm.py` (3 response paths) | `agent/agent.py` |
-| `07-local-package` | `praisonaiagents/local/**` (new), `pyproject.toml` extras | everything else |
+| `07-local-package` | `praisonaiagents/local/**` (new), `src/praisonai/tests/unit/llm/local/**` (new), `pyproject.toml` extras | everything else |
 | `08-reachability` | `memory/`, `eval/`, `context/`, `lite/`, `telemetry/` | `llm/`, `agent/` |
 
 ### Enforced serialisation

--- a/src/praisonai-agents/docs/local-model-layer/README.md
+++ b/src/praisonai-agents/docs/local-model-layer/README.md
@@ -129,16 +129,20 @@ authority. Before starting, check that no in-flight PR owns your files.
 
 Update your row in the same commit as your change. One line only.
 
+Additional PRs not in the original order list, found while executing it:
+D4 (local route prefixes) #4798, D5 (local embedding dimensions) #4802,
+D6 (registry accepts local providers) #4800.
+
 | Order | Title | Branch | PR | Status |
 |---|---|---|---|---|
-| 01 | D1 — provider-prefixed default model never reaches litellm | `fix/d1-default-provider-model` | — | in progress |
-| 02 | D3 — provider over-detection from base_url | — | — | planned |
-| 03 | D2 — `OPENAI_BASE_URL` to a non-OpenAI host uses the wrong client | — | — | planned |
-| 04 | D7 — per-file provider marker deselects unrelated tests | — | — | **spec ready** |
-| 05 | Live local-model CI job | — | — | **spec ready** |
-| 06 | A1/A2 — make the provider adapter load-bearing (6 sub-steps) | — | — | **spec ready** |
-| 07 | `praisonaiagents/local/` — discovery and capability resolver | — | — | **spec ready** |
-| 08 | A3 — reachability for the modules that bypass the LLM layer | — | — | planned |
+| 01 | D1 — provider-prefixed default model never reaches litellm | `fix/d1-default-provider-model` | #4795 | PR open |
+| 02 | D3 — provider over-detection from base_url | `fix/d3-provider-detection` | #4797 | PR open |
+| 03 | D2 — README recipe + local-endpoint diagnostic | `fix/d2-base-url-routing` | #4799 | PR open |
+| 04 | D7 — per-file provider marker deselects unrelated tests | `fix/d7-per-test-provider-markers` | #4801 | PR open |
+| 05 | Live local-model CI job | `feat/ci-ollama-live-job` | #4803 | PR open |
+| 06 | A1/A2 — make the provider adapter load-bearing (6 sub-steps) | 6 branches, stacked | #4804 #4806 #4808 #4809 #4810 #4811 | **complete — KNOWN_DEAD empty** |
+| 07 | `praisonaiagents/local/` — discovery and capability resolver | `feat/local-model-resolver` | #4807 | PR open |
+| 08 | A3 — reachability for the modules that bypass the LLM layer | — | — | in progress |
 
 ---
 

--- a/src/praisonai-agents/docs/local-model-layer/README.md
+++ b/src/praisonai-agents/docs/local-model-layer/README.md
@@ -1,6 +1,6 @@
 # Local Model Layer — implementation ledger
 
-**Status:** planning complete, implementation in progress
+**Status:** every order below has an open PR. See §4.
 **Owner workstream:** local model runtimes (Ollama, LM Studio, llama.cpp, vLLM, MLX, `transformers serve`)
 **Created:** 2026-09-03
 
@@ -133,6 +133,23 @@ Additional PRs not in the original order list, found while executing it:
 D4 (local route prefixes) #4798, D5 (local embedding dimensions) #4802,
 D6 (registry accepts local providers) #4800.
 
+**Three claims in this ledger were corrected by executing it.** Each is marked
+inline where it appears, but they are collected here because a reader who trusts
+the summary would otherwise carry the wrong version:
+
+1. *"Wire the twelve dead adapter methods."* Measurement said the opposite:
+   **12 of 20 items should be deleted, only 3 wired** (`06` §1). Six had no
+   inline equivalent at all — an agent told to wire them would have invented
+   behaviour no test could fail against.
+2. *"`provider_ollama` deselects the mocked base_url suite."* It does not.
+   **`not network` deselects it on its own**, because the plugin implies
+   `network` from any provider marker (`04` §1). Editing the workflow `-m`
+   strings would have changed nothing.
+3. *"Running fully locally is unachievable, not merely unconfigured."* Not so:
+   litellm and the openai SDK both honour `OPENAI_BASE_URL`, so the bypass sites
+   **do** reach a local server. The blocker is the hardcoded model name they then
+   ask for (`00` §5, `08`).
+
 | Order | Title | Branch | PR | Status |
 |---|---|---|---|---|
 | 01 | D1 — provider-prefixed default model never reaches litellm | `fix/d1-default-provider-model` | #4795 | PR open |
@@ -142,7 +159,7 @@ D6 (registry accepts local providers) #4800.
 | 05 | Live local-model CI job | `feat/ci-ollama-live-job` | #4803 | PR open |
 | 06 | A1/A2 — make the provider adapter load-bearing (6 sub-steps) | 6 branches, stacked | #4804 #4806 #4808 #4809 #4810 #4811 | **complete — KNOWN_DEAD empty** |
 | 07 | `praisonaiagents/local/` — discovery and capability resolver | `feat/local-model-resolver` | #4807 | PR open |
-| 08 | A3 — reachability for the modules that bypass the LLM layer | — | — | in progress |
+| 08 | A3 — auxiliary-model fallback configurable everywhere | `fix/reachability-local-endpoint` | #4812 | PR open (model half; parameter half deferred) |
 
 ---
 


### PR DESCRIPTION
## What

Adds `src/praisonai-agents/docs/local-model-layer/` — a work-order ledger for the local-model workstream — plus a pointer to it from `src/praisonai-agents/AGENTS.md`.

**Docs only. No source or test changes.**

## Why

Local-model support is about to be changed across several areas (`agent/agent.py` routing, `llm/llm.py` provider detection, `llm/adapters/`, embeddings, CI gating). That work will be done as a series of small independent PRs, likely by different agents at different times. This ledger is what lets each unit be executed correctly in isolation:

- **`README.md`** — the invariants (I1–I8), a **file-ownership table** with enforced serialisation so two concurrent work orders cannot corrupt each other, a status table, and the two anti-regression tests that keep the work honest.
- **`00-ground-truth.md`** — every measurement with *how to re-verify it*, so no agent has to re-derive the analysis.
- **`06-adapter-revival.md`** — the A1/A2 work order: a WIRE/DELETE/LEAVE decision for all 20 adapter items, sequenced into 6 independently-revertible steps.
- **`07-local-package-spec.md`** — normative API spec for a new leaf package `praisonaiagents/local/`.

## Two findings that overturned an earlier framing

Both are recorded as explicit corrections inside the documents, so a reader who skims the summary is warned off the wrong version.

**1. The adapter extension point should mostly be *deleted*, not wired.** `DefaultAdapter` declares 17 methods; 11 have zero call sites, and with 3 module functions that is 12 dead items. Meanwhile `llm/llm.py` carries 145 lines of hand-written Ollama dispatch doing some of the same jobs.

The instinct is to wire them up. Measurement says otherwise — **six of the dead methods have no inline equivalent anywhere**. They are speculative API. An agent told to "wire up the adapter" would invent an implementation, and that invented code would have no test that could ever have failed. Only 3 items have a real inline duplicate worth collapsing.

**2. The three response paths do not merely diverge — they disagree.** At `temperature=0`, reproducibly, the same prompt and tool through the same model gives:

| path | tool calls | output |
|---|---|---|
| `get_response` (1,675 lines, 16 of 18 compensations) | 1 | `'{\n\n\n}'` |
| `get_response_async` (969 lines, 8 compensations) | 1 | `'Paris: 21C sunny'` |
| `get_response_stream` (443 lines, 0 compensations) | **10** | `''` |

The best-compensated path produces the worst answer, and the stream path invokes the tool ten times for a one-tool question and yields nothing. So the goal is not *more* compensation but *the same* compensation — which changes the shape of the work.

## Two traps recorded so they don't cost anyone a day

- **`src/praisonai-agents/tests/unit/` is run by no CI workflow.** Only `tests/smoke/test_subscription_auth.py` and `tests/unit/auth/test_agent_auth_wiring.py` run from that tree. `test_adapter_registry.py` (38 tests) and all 13 files in `tests/unit/llm/` run nowhere. New tests therefore go in `src/praisonai/tests/unit/llm/`.
- **`test_ollama_tool_reliability.py` tests a copy, not the product.** Its `MockLLM` re-implements the methods under test, so it cannot fail in response to any change in `llm.py`.

## Verification

Every load-bearing number was measured by script over this tree or executed against a live Ollama 0.33.2 daemon, not estimated. Claims that could not be verified live (LM Studio, vLLM — neither installed here) are explicitly marked unverified in the documents rather than presented as fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected documented local-model behavior for synchronous, asynchronous, and streaming responses.
  - Added guidance for evaluating and prioritizing local-model adapter capabilities.
  - Added a specification for planned local runtime discovery, capability resolution, caching, and failure handling.
  - Added contributor guidance and updated the local-model work-order status and findings.
  - Documented more precise test-selection rules, offline handling, and a planned live local-model CI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->