### PR TITLE
fix(agent): route provider-prefixed default models through LLM, not OpenAIClient

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -2246,14 +2246,25 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
         # Otherwise, fall back to OpenAI environment/name (cached for performance)
         else:
             model_name = llm or Agent._get_default_model()
-            if auth:
+            # A provider-prefixed model must be built as an LLM instance, which
+            # owns provider routing and the per-provider adapters. The
+            # `"/" in llm` branch above only inspects the explicit `llm=`
+            # argument, so a prefixed model that arrived from a credential env
+            # var (_PROVIDER_DEFAULT_MODELS) or from OPENAI_MODEL_NAME lands
+            # here instead and would otherwise fall through to the plain OpenAI
+            # client holding a model name OpenAI has never heard of. Re-check
+            # the *resolved* name so `llm="ollama/x"` and OLLAMA_HOST agree.
+            _has_provider_prefix = isinstance(model_name, str) and "/" in model_name
+            if auth or _has_provider_prefix:
                 # A subscription auth provider only takes effect inside LLM
                 # (which injects the resolved OAuth credentials), so a bare
                 # model name plus auth= must still build an LLM instance rather
                 # than falling through to the plain OpenAI client.
-                llm_params = {'model': model_name, 'auth': auth}
+                llm_params = {'model': model_name}
                 if api_key:
                     llm_params['api_key'] = api_key
+                if auth:
+                    llm_params['auth'] = auth
                 llm_params['metrics'] = metrics
                 llm_params['web_search'] = web_search
                 llm_params['web_fetch'] = web_fetch

--- a/src/praisonai/tests/unit/llm/test_default_model_routing.py
+++ b/src/praisonai/tests/unit/llm/test_default_model_routing.py
@@ -1,0 +1,148 @@
+"""A provider-prefixed default model must reach LLM (litellm), not OpenAIClient.
+
+`Agent._PROVIDER_DEFAULT_MODELS` maps a credential env var to a provider-prefixed
+default model, e.g. ``OLLAMA_HOST -> "ollama/llama3.2"``. The branch chain in
+``Agent.__init__`` that routes ``provider/model`` strings to ``LLM`` tests the
+*original* ``llm=`` argument, which is ``None`` when the model came from the
+environment. Such an agent therefore fell through to ``OpenAIClient`` and failed
+with "OPENAI_API_KEY environment variable is required" -- while holding a model
+name OpenAI has never heard of.
+
+These tests assert on constructed state only. They make no network call and need
+no server, so they are safe in the default suite.
+"""
+
+import pytest
+
+from praisonaiagents import Agent
+
+
+# Every credential env var the Agent scans, so a stray one in the developer's
+# environment cannot change which default is resolved.
+_CREDENTIAL_VARS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "COHERE_API_KEY",
+    "OLLAMA_HOST",
+    "OPENAI_MODEL_NAME",
+    "OPENAI_BASE_URL",
+    "OPENAI_API_BASE",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Remove every credential var, and reset Agent's cached default model."""
+    for var in _CREDENTIAL_VARS:
+        monkeypatch.delenv(var, raising=False)
+    # The default model is memoised on the class; without this the first test to
+    # run would pin the answer for every later one.
+    monkeypatch.setattr(Agent, "_default_model_checked", False, raising=False)
+    monkeypatch.setattr(Agent, "_default_model", None, raising=False)
+    yield
+    monkeypatch.setattr(Agent, "_default_model_checked", False, raising=False)
+    monkeypatch.setattr(Agent, "_default_model", None, raising=False)
+
+
+@pytest.mark.parametrize(
+    "env_var, env_value, expected_model",
+    [
+        ("OLLAMA_HOST", "http://localhost:11434", "ollama/llama3.2"),
+        ("ANTHROPIC_API_KEY", "sk-ant-test", "anthropic/claude-3-5-sonnet-latest"),
+        ("GEMINI_API_KEY", "test", "gemini/gemini-1.5-flash"),
+        ("GOOGLE_API_KEY", "test", "google/gemini-1.5-flash"),
+        ("GROQ_API_KEY", "test", "groq/llama-3.3-70b-versatile"),
+        ("COHERE_API_KEY", "test", "cohere/command-r"),
+    ],
+)
+def test_provider_prefixed_default_routes_to_llm(
+    clean_env, monkeypatch, env_var, env_value, expected_model
+):
+    """A credential env var alone must produce an agent wired to litellm.
+
+    Before the fix every one of these resolved the right model name and then
+    routed it to OpenAIClient, which has no provider adapters and demands an
+    OpenAI key.
+    """
+    monkeypatch.setenv(env_var, env_value)
+
+    agent = Agent(instructions="test")
+
+    assert agent.llm == expected_model
+    assert agent._using_custom_llm is True, (
+        f"{env_var} resolved {agent.llm!r} but left _using_custom_llm False, "
+        "so the agent routes to OpenAIClient instead of litellm"
+    )
+    assert agent._llm_init_params is not None
+    assert agent._llm_init_params["model"] == expected_model
+
+
+def test_openai_default_still_uses_openai_client(clean_env, monkeypatch):
+    """The OpenAI default has no provider prefix and must not change route.
+
+    This is the backward-compatibility anchor: existing OpenAI users keep the
+    plain openai-SDK path.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    agent = Agent(instructions="test")
+
+    assert agent.llm == "gpt-4o-mini"
+    assert agent._using_custom_llm is False
+    assert getattr(agent, "_llm_init_params", None) is None
+
+
+def test_explicit_bare_model_still_uses_openai_client(clean_env, monkeypatch):
+    """An explicit bare model name keeps its current route."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    agent = Agent(instructions="test", llm="gpt-4o")
+
+    assert agent.llm == "gpt-4o"
+    assert agent._using_custom_llm is False
+
+
+def test_openai_model_name_with_prefix_routes_to_llm(clean_env, monkeypatch):
+    """OPENAI_MODEL_NAME carrying a provider prefix behaves like llm=.
+
+    `Agent(llm="ollama/x")` already routes to litellm; the env-var form must not
+    disagree with it.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_MODEL_NAME", "ollama/llama3.2")
+
+    agent = Agent(instructions="test")
+
+    assert agent.llm == "ollama/llama3.2"
+    assert agent._using_custom_llm is True
+    assert agent._llm_init_params["model"] == "ollama/llama3.2"
+
+
+def test_env_default_matches_explicit_llm_routing(clean_env, monkeypatch):
+    """The same model must route identically whether given by env or by llm=."""
+    monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+    from_env = Agent(instructions="test")
+
+    for var in _CREDENTIAL_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(Agent, "_default_model_checked", False, raising=False)
+    explicit = Agent(instructions="test", llm="ollama/llama3.2")
+
+    assert from_env.llm == explicit.llm
+    assert from_env._using_custom_llm == explicit._using_custom_llm
+    assert from_env._llm_init_params["model"] == explicit._llm_init_params["model"]
+
+
+def test_non_string_llm_argument_does_not_raise(clean_env, monkeypatch):
+    """A dict without a "model" key falls into the same branch; guard the type.
+
+    The prefix check must not assume `model_name` is a string, or this raises.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    agent = Agent(instructions="test", llm={"temperature": 0.5})
+
+    assert agent._using_custom_llm is False


### PR DESCRIPTION
## Problem

`Agent._PROVIDER_DEFAULT_MODELS` ([agent.py:309-317](../blob/main/src/praisonai-agents/praisonaiagents/agent/agent.py#L309-L317)) maps a credential env var to a provider-appropriate default model — `OLLAMA_HOST → "ollama/llama3.2"`, `ANTHROPIC_API_KEY → "anthropic/claude-3-5-sonnet-latest"`, and so on.

The branch chain that routes `provider/model` strings to `LLM` tests the **original `llm=` argument**, which is `None` when the model came from the environment. So a resolved default with a provider prefix falls into the final `else`, which only sets `_using_custom_llm` when `auth=` was passed. The agent ends up on `OpenAIClient` — holding a model name OpenAI has never heard of, and demanding an OpenAI key.

**Six of the seven defaults were affected.** Only the OpenAI default works today, because it is the one with no provider prefix.

```
OLLAMA_HOST       -> llm='ollama/llama3.2'                _using_custom_llm=False
ANTHROPIC_API_KEY -> llm='anthropic/claude-3-5-sonnet…'   _using_custom_llm=False
GEMINI_API_KEY    -> llm='gemini/gemini-1.5-flash'        _using_custom_llm=False
GOOGLE_API_KEY    -> llm='google/gemini-1.5-flash'        _using_custom_llm=False
GROQ_API_KEY      -> llm='groq/llama-3.3-70b-versatile'   _using_custom_llm=False
COHERE_API_KEY    -> llm='cohere/command-r'               _using_custom_llm=False
```

The user-visible symptom is the opposite of helpful: the SDK correctly detects your provider, picks a sensible model for it, and then tells you to set `OPENAI_API_KEY`.

## Verified before and after

Same machine, same environment (`OLLAMA_HOST` + `OPENAI_MODEL_NAME=ollama/qwen3:0.6b`, no API keys), against a live Ollama 0.33.2:

**Before**
```
llm='ollama/qwen3:0.6b'  _using_custom_llm=False
ValueError: OPENAI_API_KEY environment variable is required for the default OpenAI service...
```

**After**
```
llm='ollama/qwen3:0.6b'  _using_custom_llm=True
"2+2 is 4."
```

## The change

13 lines in one branch. It re-checks the **resolved** model name for a provider prefix, so `Agent(llm="ollama/x")` and `OLLAMA_HOST` stop taking opposite code paths for the same model.

Two details worth noting in review:

- `isinstance(model_name, str)` guards the prefix check — a `dict` without a `"model"` key also reaches this branch, and `"/" in some_dict` would silently do a key lookup rather than a substring test.
- `auth` is now added to the params only when truthy. The old line was `{'model': model_name, 'auth': auth}`, which was fine when the branch was auth-only but would inject `auth=None` on the new path. This matches the explicit-`llm=` branch it mirrors.

I also checked whether the fix needed to replicate `if tools: self.tools = tools` from the sibling slash branch ([agent.py:2245](../blob/main/src/praisonai-agents/praisonaiagents/agent/agent.py#L2245)). It does not — `self.tools` is assigned unconditionally at :2280-2292 after the chain, so that line is redundant either way.

## Backward compatibility

Three of the eleven new tests exist purely to pin behaviour that must **not** change:

| input | route | why it must not move |
|---|---|---|
| `OPENAI_API_KEY` only → `gpt-4o-mini` | `OpenAIClient` | existing OpenAI users keep the plain SDK path |
| explicit `llm="gpt-4o"` | `OpenAIClient` | a bare model name is unchanged |
| `llm={"temperature": 0.5}` (no `"model"`) | `OpenAIClient`, no raise | the type guard |

One behaviour does change deliberately: `OPENAI_MODEL_NAME="ollama/x"` now routes to `LLM`, matching what `llm="ollama/x"` has always done. Those two disagreeing was the same bug wearing a different hat.

## Tests

`src/praisonai/tests/unit/llm/test_default_model_routing.py`, 11 tests. **Eight fail before this change**, three pass throughout (the compatibility anchors).

They live under `src/praisonai/tests/` rather than `src/praisonai-agents/tests/` because no CI workflow collects the latter — a test placed there would never run. They assert on constructed state only: no network, no server, no keys.

```
tests/unit/llm/test_default_model_routing.py ......... 11 passed
tests/unit/{llm,agent,adapters,doctor}/          264 passed, 4 subtests passed
```

The six collection errors in the wider `tests/unit/` tree (`sqlalchemy`, langflow, docker) reproduce identically with this change stashed — they are pre-existing local dependency gaps, not regressions.

## Context

First code change in the local-model workstream; the analysis and remaining work orders are in #4790. That PR's status row for this order will be updated once it merges — this PR deliberately touches no ledger file so the two can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider-prefixed model names from environment settings now route through the appropriate model provider.
  * Bare OpenAI model names continue using the standard OpenAI client.
  * Improved handling of non-string language model configuration values.

* **Tests**
  * Added coverage for environment-based and explicitly configured model routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->