### PR TITLE
fix(mobile): the Android status bar, navigation bar and keyboard reach the layout

### DIFF
--- a/src/praisonai-mobile/adapters/src/tauri/native-insets.test.ts
+++ b/src/praisonai-mobile/adapters/src/tauri/native-insets.test.ts
@@ -1,0 +1,210 @@
+/**
+ * The Android window-insets bridge.
+ *
+ * WHAT THIS IS FOR. `createTauriShell`'s comment on `keyboardHeightPx` says
+ * that reading `visualViewport` "works here and needs no native code" because
+ * "WKWebView and Android WebView both implement `visualViewport`". Half of that
+ * is false, and the half that is false is the half nobody could test without a
+ * phone. Measured on an Android 15 emulator with this app installed, the IME up
+ * (`dumpsys input_method` reporting `mInputShown=true`) and the composer's
+ * textarea focused:
+ *
+ *     window.innerHeight            915
+ *     visualViewport.height         915.05
+ *     virtualKeyboard.boundingRect  0x0
+ *     --keyboard-height             (unset)
+ *
+ * -- so `readKeyboardHeight` returned 0 and the composer was painted at the
+ * bottom of a viewport the keyboard was covering. `enableEdgeToEdge()` is why:
+ * the window is not resized by the IME, so there is nothing for a web API to
+ * observe. The same dispatch showed `env(safe-area-inset-*)` reporting the
+ * display cutout and nothing else -- 49px of cutout at the top and 0px for a
+ * 24px status bar, and in landscape 0px top with the status bar still there.
+ *
+ * MainActivity.kt reads `WindowInsetsCompat`, which has all of it, and calls
+ * the global asserted here. These cases are the seam: they run in node with a
+ * fake window, and the Kotlin half is pinned to the same string by
+ * `tools/shell-seam.test.mjs`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createTauriShell,
+  NATIVE_INSETS_GLOBAL,
+  type InsetSource,
+} from "./shell.ts";
+import type { SafeAreaInsets } from "../../../core/src/ports/shell.ts";
+import { INSET_VARIABLES } from "../../../core/src/ports/shell.ts";
+import type { TauriBridge } from "./bridge.ts";
+
+/** A bridge that records nothing and answers everything, so these cases are
+ *  about the global and not about Tauri's event plumbing. */
+function quietBridge(): { bridge: TauriBridge; emit(event: string, payload: unknown): void } {
+  const listeners = new Map<string, Set<(payload: unknown) => void>>();
+  return {
+    bridge: {
+      isPresent: () => true,
+      invoke: () => Promise.resolve(null),
+      invokeStrict: () => Promise.resolve(null),
+      listen(event: string, handler: (payload: unknown) => void) {
+        const set = listeners.get(event) ?? new Set();
+        set.add(handler);
+        listeners.set(event, set);
+        return Promise.resolve(() => void set.delete(handler));
+      },
+      openExternal: () => Promise.resolve(true),
+      haptic: () => Promise.resolve(true),
+      share: () => Promise.resolve(true),
+    },
+    emit(event, payload) {
+      for (const handler of [...(listeners.get(event) ?? [])]) handler(payload);
+    },
+  };
+}
+
+/** The four CSS variables, as a device with a notch and NO other inset
+ *  reports them through `env()` on Android: cutout only. */
+function cutoutOnlySource(topPx: number): InsetSource {
+  const map: Record<string, string> = {
+    [INSET_VARIABLES.top]: `${topPx}px`,
+    [INSET_VARIABLES.right]: "0px",
+    [INSET_VARIABLES.bottom]: "0px",
+    [INSET_VARIABLES.left]: "0px",
+  };
+  return { readCssVariable: (name: string) => map[name] ?? "" };
+}
+
+/** Just enough `Window` for the shell: no `visualViewport`, which is the
+ *  Android reality this bridge exists for. */
+function fakeView(): Window {
+  return {
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  } as unknown as Window;
+}
+
+interface Harness {
+  readonly view: Window;
+  readonly insets: SafeAreaInsets[];
+  readonly keyboards: number[];
+  push(payload: unknown): void;
+  emit(event: string, payload: unknown): void;
+  keyboardHeightPx(): number;
+  currentInsets(): SafeAreaInsets;
+}
+
+function harness(cutoutTopPx = 49): Harness {
+  const probe = quietBridge();
+  const view = fakeView();
+  const shell = createTauriShell({
+    bridge: probe.bridge,
+    insetSource: cutoutOnlySource(cutoutTopPx),
+    view,
+  });
+  const insets: SafeAreaInsets[] = [];
+  const keyboards: number[] = [];
+  shell.onInsetsChanged((i) => void insets.push(i));
+  shell.onKeyboardHeightChanged((px) => void keyboards.push(px));
+  return {
+    view,
+    insets,
+    keyboards,
+    push(payload) {
+      const fn = (view as unknown as Record<string, unknown>)[NATIVE_INSETS_GLOBAL];
+      assert.equal(typeof fn, "function", `the shell must install window.${NATIVE_INSETS_GLOBAL}`);
+      (fn as (p: unknown) => void)(payload);
+    },
+    emit: probe.emit,
+    keyboardHeightPx: () => shell.keyboardHeightPx,
+    currentInsets: () => shell.insets,
+  };
+}
+
+test("android: the shell installs the insets global the native side calls", () => {
+  const h = harness();
+  assert.equal(
+    typeof (h.view as unknown as Record<string, unknown>)[NATIVE_INSETS_GLOBAL],
+    "function",
+    "without this global MainActivity's evaluateJavascript is a no-op and nothing reports it",
+  );
+});
+
+test("android: a native keyboard height reaches the layout when no web API reports one", () => {
+  const h = harness();
+  // The state the emulator was actually in: viewport unchanged, IME up.
+  assert.equal(h.keyboardHeightPx(), 0, "nothing has reported a keyboard yet");
+  h.push({ top: 24, right: 0, bottom: 24, left: 0, keyboard: 336 });
+  assert.equal(
+    h.keyboardHeightPx(),
+    336,
+    "the composer is placed from this number; 0 puts it under the keyboard",
+  );
+  assert.deepEqual(h.keyboards, [336], "and the change is delivered, not just stored");
+});
+
+test("android: the system bars arrive, which env() never reported", () => {
+  const h = harness(49);
+  // Seeded from the CSS: the cutout, and zero for the three system-bar edges.
+  assert.deepEqual(h.currentInsets(), { top: 49, right: 0, bottom: 0, left: 0 });
+  h.push({ top: 49, right: 0, bottom: 24, left: 0, keyboard: 0 });
+  assert.equal(
+    h.currentInsets().bottom,
+    24,
+    "the navigation bar is a bottom inset; without it the composer sits under the gesture pill",
+  );
+});
+
+test("android: the keyboard is not added to the bottom inset twice", () => {
+  const h = harness();
+  h.push({ top: 24, right: 0, bottom: 24, left: 0, keyboard: 336 });
+  assert.equal(
+    h.currentInsets().bottom,
+    24,
+    "bottom is the system bars only -- ui/src/layout/insets.ts composes it with the keyboard " +
+      "using max(), so sending the keyboard on both channels is that sum by another route",
+  );
+});
+
+test("android: a later empty safe-area event does not wipe the native insets", () => {
+  const h = harness(49);
+  h.push({ top: 24, right: 0, bottom: 24, left: 0, keyboard: 0 });
+  assert.deepEqual(h.currentInsets(), { top: 24, right: 0, bottom: 24, left: 0 });
+  // What Rust emits on every resize: an empty payload meaning "re-read the
+  // CSS". On Android the CSS is the cutout only, so obeying it here would drop
+  // the status and navigation bars back to 0 on the first rotation.
+  h.emit("safe-area-changed", {});
+  assert.deepEqual(
+    h.currentInsets(),
+    { top: 24, right: 0, bottom: 24, left: 0 },
+    "a CSS re-read must not clobber the native insets once they are live",
+  );
+});
+
+test("android: a garbage payload cannot put NaN into the layout", () => {
+  const h = harness();
+  h.push({ top: "x", right: undefined, bottom: null, left: {}, keyboard: "nope" });
+  const insets = h.currentInsets();
+  for (const [edge, value] of Object.entries(insets)) {
+    assert.ok(Number.isFinite(value), `${edge} became ${String(value)}`);
+  }
+  assert.ok(Number.isFinite(h.keyboardHeightPx()), "a NaN keyboard height drops the declaration");
+});
+
+test("android: a non-object payload is ignored rather than zeroing the layout", () => {
+  const h = harness();
+  h.push({ top: 24, right: 0, bottom: 24, left: 0, keyboard: 336 });
+  h.push(null);
+  assert.equal(h.keyboardHeightPx(), 336, "a malformed call must not drop the composer");
+  assert.deepEqual(h.currentInsets(), { top: 24, right: 0, bottom: 24, left: 0 });
+});
+
+test("android: the keyboard going away is delivered, like any other height", () => {
+  const h = harness();
+  h.push({ top: 24, right: 0, bottom: 24, left: 0, keyboard: 336 });
+  h.push({ top: 24, right: 0, bottom: 24, left: 0, keyboard: 0 });
+  assert.deepEqual(
+    h.keyboards,
+    [336, 0],
+    "a hide that is not delivered leaves the composer floating over empty space",
+  );
+});

--- a/src/praisonai-mobile/adapters/src/tauri/shell.ts
+++ b/src/praisonai-mobile/adapters/src/tauri/shell.ts
@@ -184,6 +184,42 @@ function coercePhase(payload: unknown): LifecyclePhase | null {
   return LIFECYCLE_PHASES.find((phase) => phase === raw) ?? null;
 }
 
+/**
+ * The global the Android side calls, once per window-insets dispatch.
+ *
+ * WHY THIS EXISTS. `env(safe-area-inset-*)` in Chromium on Android reports the
+ * DISPLAY CUTOUT and nothing else -- not the status bar, not the navigation
+ * bar, and never the keyboard. Measured on an Android 15 emulator with the app
+ * running: `--safe-area-inset-top` read 49px, which is the 128px cutout at
+ * dpr 2.625, while the status bar is 63px (24 CSS px); rotated to landscape the
+ * SAME 49px moved to `--safe-area-inset-left` and top became 0px even though
+ * the status bar is still along the top edge. And the keyboard is worse than
+ * under-reported, it is invisible: with the IME shown (`mInputShown=true`) and
+ * the textarea focused, `window.innerHeight`, `visualViewport.height` and
+ * `navigator.virtualKeyboard.boundingRect` all still read the full 915px
+ * viewport, so `readKeyboardHeight` returned 0 and the composer was painted
+ * underneath the keyboard -- the exact bug the comment on `keyboardHeightPx`
+ * below says `visualViewport` fixed. It fixes it on iOS. On Android there was
+ * no source at all.
+ *
+ * `enableEdgeToEdge()` in MainActivity is why: with `decorFitsSystemWindows`
+ * false the window is never resized by the system bars or the IME, so there is
+ * nothing for a web API to observe. The values exist only in
+ * `WindowInsetsCompat`, which is native. MainActivity reads them and calls this.
+ */
+export const NATIVE_INSETS_GLOBAL = "__praisonaiNativeInsets";
+
+/** What the Android side sends. Every field is optional and every field is run
+ *  through `toPx`, because this crosses a `evaluateJavascript` string boundary
+ *  and a malformed number here would reach a style property as NaN. */
+export interface NativeInsetsPayload {
+  readonly top?: unknown;
+  readonly right?: unknown;
+  readonly bottom?: unknown;
+  readonly left?: unknown;
+  readonly keyboard?: unknown;
+}
+
 /** Keyboard height in px. 0 is a VALUE (hidden), not an absence -- an adapter
  *  that treats it as absent never reports the hide and the composer stays
  *  pushed up over empty space for the rest of the session. */
@@ -321,10 +357,19 @@ export function createTauriShell(deps: TauriShellDeps = {}): TauriShell {
    * shell became per-window -- noted here rather than discovered there.
    */
   attach(EVENTS.safeArea, (payload) => {
-    // A payload we cannot read is not a reason to skip the update: the CSS
-    // variables have already been recomputed by the time this fires, so
-    // re-reading them is strictly better than keeping a stale snapshot.
-    publishInsets(coerceInsets(payload) ?? readInsets(source));
+    const explicit = coerceInsets(payload);
+    if (explicit !== null) {
+      publishInsets(explicit);
+      return;
+    }
+    // An empty payload means "re-read the CSS", and the CSS has already been
+    // recomputed by the time this fires -- so re-reading is strictly better
+    // than keeping a stale snapshot. UNLESS the Android bridge is live: there
+    // `env()` is the display cutout only, and re-reading it would silently
+    // drop the status and navigation bars back to 0 on the first rotation
+    // after the keyboard had been used.
+    if (nativeInsetsSeen) return;
+    publishInsets(readInsets(source));
   });
 
   // The web path, live. `visualViewport` fires `resize` and `scroll` as the
@@ -332,19 +377,63 @@ export function createTauriShell(deps: TauriShellDeps = {}): TauriShell {
   // jump once at the end. Removed the moment a native height arrives, so the
   // two sources never fight -- native is authoritative where it exists.
   let viewportOff: Unsubscribe | null = null;
+
+  /** One writer for the keyboard height, so the "snapshot before notify" rule
+   *  and the no-op check are stated once for all three sources. */
+  const publishKeyboard = (height: number): void => {
+    if (height === keyboardHeightPx) return;
+    keyboardHeightPx = height;
+    for (const cb of keyboardSubs) cb(height);
+  };
+
   if (view?.visualViewport !== undefined && view.visualViewport !== null) {
     const viewport = view.visualViewport;
     const onViewport = (): void => {
-      const height = readKeyboardHeight(view);
-      if (height === keyboardHeightPx) return;
-      keyboardHeightPx = height;
-      for (const cb of keyboardSubs) cb(height);
+      publishKeyboard(readKeyboardHeight(view));
     };
     viewport.addEventListener("resize", onViewport);
     viewport.addEventListener("scroll", onViewport);
     viewportOff = () => {
       viewport.removeEventListener("resize", onViewport);
       viewport.removeEventListener("scroll", onViewport);
+    };
+  }
+
+  /**
+   * The Android window-insets bridge. See NATIVE_INSETS_GLOBAL above.
+   *
+   * Both halves of the payload are authoritative once it starts arriving:
+   *
+   *  - the insets, because the CSS `env()` values it replaces are the cutout
+   *    ONLY on Android, so re-reading them would drop the status and navigation
+   *    bars back to 0 on the next resize. `nativeInsetsSeen` is what stops the
+   *    `safe-area-changed` handler below from doing exactly that.
+   *  - the keyboard, for the same reason the native `keyboard-height` event is
+   *    authoritative: two writers would race, and `visualViewport` on Android
+   *    only ever reports 0.
+   *
+   * It is installed on `view`, not on `globalThis`, so a test drives it with a
+   * fake window and no phone.
+   */
+  let nativeInsetsSeen = false;
+  if (view !== undefined) {
+    (view as unknown as Record<string, unknown>)[NATIVE_INSETS_GLOBAL] = (
+      payload: NativeInsetsPayload,
+    ): void => {
+      if (typeof payload !== "object" || payload === null) return;
+      nativeInsetsSeen = true;
+      // The viewport listener is retired for the same reason a native
+      // `keyboard-height` retires it: the native source fires through the whole
+      // IME animation and cannot be raced by a viewport that never moves.
+      viewportOff?.();
+      viewportOff = null;
+      publishInsets({
+        top: toPx(payload.top),
+        right: toPx(payload.right),
+        bottom: toPx(payload.bottom),
+        left: toPx(payload.left),
+      });
+      publishKeyboard(toPx(payload.keyboard));
     };
   }
 
@@ -357,8 +446,11 @@ export function createTauriShell(deps: TauriShellDeps = {}): TauriShell {
     viewportOff = null;
     // Snapshot before notifying, per the port's ordering rule.
     keyboardHeightPx = height;
-    // Unconditional. Fires through the transition, not just at its end, and
-    // 0 is delivered like any other height.
+    // Unconditional, and NOT through `publishKeyboard`: this event's contract
+    // is that every height it carries is delivered, including a repeat. The
+    // other two sources poll (`visualViewport` on scroll, the Android bridge on
+    // every frame of the IME animation and again when it settles) and would
+    // otherwise relayout on values that have not changed.
     for (const cb of keyboardSubs) cb(height);
   });
 

--- a/src/praisonai-mobile/app/app.css
+++ b/src/praisonai-mobile/app/app.css
@@ -14,6 +14,27 @@
   --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
   --safe-area-inset-left: env(safe-area-inset-left, 0px);
 
+  /*
+   * The EFFECTIVE insets, and what every layout rule below consumes.
+   *
+   * The four above are a one-way mirror of `env()` for ShellPort to read; these
+   * are what the app lays out against, and app/src/main.ts overwrites them on
+   * `#root` from `shell.insets` as soon as it has them. The two differ on
+   * Android, where `env(safe-area-inset-*)` reports the DISPLAY CUTOUT and
+   * nothing else: measured on an Android 15 emulator with no cutout configured,
+   * `env(safe-area-inset-top)` was 0px against a 24px status bar and the
+   * topbar's title was painted straight through the clock; with a cutout it was
+   * 49px, the cutout, and the 24px status bar still contributed nothing.
+   * MainActivity.kt reads the real `WindowInsetsCompat` and feeds it in.
+   *
+   * The env() value is the fallback rather than a hard 0 so the FIRST paint --
+   * before any script has run -- is still inset on iOS, where env() is right.
+   */
+  --inset-top: var(--safe-area-inset-top);
+  --inset-right: var(--safe-area-inset-right);
+  --inset-bottom: var(--safe-area-inset-bottom);
+  --inset-left: var(--safe-area-inset-left);
+
   --ground: #ffffff;
   --panel: #f5f6f8;
   --ink: #14171c;
@@ -82,9 +103,9 @@ html, body {
   display: flex;
   align-items: center;
   gap: .5rem;
-  padding: calc(var(--safe-area-inset-top) + .5rem) 
-           calc(var(--safe-area-inset-right) + .75rem) .5rem
-           calc(var(--safe-area-inset-left) + .75rem);
+  padding: calc(var(--inset-top) + .5rem) 
+           calc(var(--inset-right) + .75rem) .5rem
+           calc(var(--inset-left) + .75rem);
   border-bottom: 1px solid var(--rule);
   background: var(--ground);
 }
@@ -95,8 +116,8 @@ html, body {
   min-height: 0;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: .75rem calc(var(--safe-area-inset-right) + .75rem) .75rem
-           calc(var(--safe-area-inset-left) + .75rem);
+  padding: .75rem calc(var(--inset-right) + .75rem) .75rem
+           calc(var(--inset-left) + .75rem);
   display: flex;
   flex-direction: column;
   gap: .6rem;
@@ -136,9 +157,9 @@ html, body {
   align-items: flex-end;
   border-top: 1px solid var(--rule);
   background: var(--ground);
-  padding: .5rem calc(var(--safe-area-inset-right) + .75rem)
-           calc(var(--safe-area-inset-bottom) + .5rem)
-           calc(var(--safe-area-inset-left) + .75rem);
+  padding: .5rem calc(var(--inset-right) + .75rem)
+           calc(var(--inset-bottom) + .5rem)
+           calc(var(--inset-left) + .75rem);
   /* main.ts sets this from the shell's live keyboard height. It is a padding
      rather than a transform so the transcript's scroll height shrinks with it
      and the last message stays reachable. */
@@ -182,11 +203,58 @@ button:disabled { opacity: .45; cursor: default; }
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .empty { margin: auto; color: var(--soft); text-align: center; padding: 2rem 1rem; }
-.chat-row { display: flex; align-items: center; gap: .5rem; width: 100%;
+/*
+ * A row in the chat list. `.row-chat` is the class `buildChatsScreen` emits;
+ * this block was written as `.chat-row`, which the app has never painted, so
+ * every row fell back to the bare `button` rule: a centre-aligned, auto-width
+ * pill instead of a full-width list row. The `.title` / `.when` children it
+ * also styled do not exist either -- the row's title is its own text node --
+ * so the truncation lives on the row itself, where a chat named from a long
+ * first message would otherwise wrap to as many lines as it liked.
+ */
+.row-chat { display: flex; align-items: center; gap: .5rem; width: 100%;
   border: 1px solid var(--rule); border-radius: var(--radius); padding: .6rem .75rem;
-  background: var(--panel); text-align: left; }
-.chat-row .title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.chat-row .when { color: var(--soft); font-size: .78rem; }
+  background: var(--panel); text-align: left;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.row-chat-unreadable { color: var(--warn); border-color: var(--warn); }
+
+/*
+ * Every screen that is NOT the chat screen.
+ *
+ * `.topbar` is the only rule in this file that consumes
+ * `--safe-area-inset-top`, and only the chat screen builds a `.topbar`
+ * (app/src/main.ts). `buildSettingsScreen` and `buildChatsScreen` emit a bare
+ * `<section class="screen screen-settings">` / `screen-chats` whose first child
+ * is an `<h2 class="screen-heading">` -- so on a device those two screens were
+ * laid out from y = 0 with no inset on any edge. Measured on an Android 15
+ * emulator (Pixel-class, 49px cutout inset): the "Settings" heading's box
+ * started at y = 20 with a 49px top inset, i.e. 29px of the title painted
+ * underneath the status-bar clock, and every heading sat at x = 0 -- inside the
+ * left cutout in landscape.
+ *
+ * `overflow-y: auto` is the second half. `.screen` is `flex: 1; min-height: 0`
+ * with the default `overflow: visible`, so a settings list taller than the
+ * viewport -- a longer registry, a large font scale, landscape -- overflowed
+ * with no way to scroll to the rows at the bottom. The chat screen never hit
+ * this because its scroller is the inner `.transcript`; these screens ARE their
+ * own scroller and have to say so.
+ *
+ * The gutter is added to the inset rather than replacing it, for the reason
+ * app/src/main.ts states about the composer: a device with no inset on a side
+ * must still keep its 12px gutter instead of going flush to the glass.
+ */
+.screen-settings,
+.screen-chats {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: calc(var(--inset-top) + .75rem)
+           calc(var(--inset-right) + .75rem)
+           calc(var(--inset-bottom) + .75rem)
+           calc(var(--inset-left) + .75rem);
+}
+/* The rows already carry `.row`'s own .75rem inline padding, so without this
+   they would be indented twice as far as the headings they sit under. */
+.screen-settings .row-setting { padding-inline: 0; }
 
 .setting { display: flex; flex-direction: column; gap: .25rem; padding: .6rem 0; border-bottom: 1px solid var(--rule); }
 .setting .label { font-weight: 550; }

--- a/src/praisonai-mobile/app/src/css.test.ts
+++ b/src/praisonai-mobile/app/src/css.test.ts
@@ -39,10 +39,17 @@ test("the composer does not add the bottom inset twice", () => {
   const keyboardDecls = declarations.filter((d) => d.includes("--keyboard-height"));
   assert.ok(keyboardDecls.length > 0, "the composer must follow the keyboard at all");
   for (const d of keyboardDecls) {
-    assert.ok(
-      !d.includes("--safe-area-inset-bottom"),
-      `--keyboard-height is already max(keyboard, inset); adding the inset double-counts it:${d}`,
-    );
+    // BOTH names. The stylesheet now lays out against `--inset-bottom` (the
+    // effective inset main.ts writes from `shell.insets`) rather than the
+    // `--safe-area-inset-bottom` env() mirror, so a test that only knew the old
+    // name would have gone quiet the moment the rename landed and let the
+    // double-count back in under the new one.
+    for (const name of ["--safe-area-inset-bottom", "--inset-bottom"]) {
+      assert.ok(
+        !d.includes(name),
+        `--keyboard-height is already max(keyboard, inset); adding ${name} double-counts it:${d}`,
+      );
+    }
   }
 });
 

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -432,12 +432,19 @@ test("the keyboard height and BOTH insets reach the layout", async () => {
   assert.ok(screen, "no screen element");
   const props = (screen as unknown as { style: { props: Record<string, string> } }).style.props;
   assert.equal(props["--keyboard-height"], "300px", "the keyboard height must reach the layout");
-  assert.equal(props["--inset-top"], `${PHONE_INSETS.top}px`, "the TOP inset must come from the top");
+  // The four insets go on ROOT, not on the chat screen: settings and chats are
+  // siblings of it, so an inset written on `screen` never reaches them -- which
+  // is what left their headings under the status bar.
+  const rootProps = (dom.root as unknown as { style: { props: Record<string, string> } }).style.props;
+  assert.equal(rootProps["--inset-top"], `${PHONE_INSETS.top}px`, "the TOP inset must come from the top");
   assert.notEqual(
-    props["--inset-top"],
+    rootProps["--inset-top"],
     `${PHONE_INSETS.bottom}px`,
     "reading the top inset from the bottom puts content under the notch",
   );
+  assert.equal(rootProps["--inset-bottom"], `${PHONE_INSETS.bottom}px`, "and the bottom from the bottom");
+  assert.equal(rootProps["--inset-left"], `${PHONE_INSETS.left}px`);
+  assert.equal(rootProps["--inset-right"], `${PHONE_INSETS.right}px`);
   app?.dispose();
 });
 
@@ -452,13 +459,12 @@ test("the layout keeps reacting after mount, not only on the first frame", async
     http: createFakeHttp(), time: nodeTime(), kind: "web",
   };
   const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
-  const screen = dom.find((n) => n.className === "screen");
-  assert.ok(screen, "no screen element");
-  const props = (screen as unknown as { style: { props: Record<string, string> } }).style.props;
+  const props = (dom.root as unknown as { style: { props: Record<string, string> } }).style.props;
 
   shell.setInsets({ top: 99, bottom: 12, left: 3, right: 4 });
   await settle(20);
   assert.equal(props["--inset-top"], "99px", "a rotation must reach the layout");
+  assert.equal(props["--inset-bottom"], "12px", "and every other edge with it");
   app?.dispose();
 });
 

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -720,7 +720,32 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     layout = withKeyboard(layout, platform.shell.keyboardHeightPx);
     const geometry = geometryOf(layout);
     screen.style.setProperty("--keyboard-height", `${geometry.composerBottomPx}px`);
-    screen.style.setProperty("--inset-top", `${geometry.scrollTopPx}px`);
+    // The four EFFECTIVE insets, on the container every screen lives in.
+    //
+    // app.css declares `--inset-*` as `var(--safe-area-inset-*)` so the first
+    // paint has something, and every layout rule consumes `--inset-*` rather
+    // than the env() mirror. This is why: on Android `env(safe-area-inset-*)`
+    // is the DISPLAY CUTOUT and nothing else -- measured on an Android 15
+    // emulator with no cutout configured, `--safe-area-inset-top` was 0px
+    // against a 24px status bar and 24px navigation bar, and the topbar's title
+    // was painted straight through the clock. `shell.insets` is the OS's own
+    // numbers (MainActivity.kt feeds them in through the bridge in
+    // adapters/src/tauri/shell.ts), so writing them here is what makes the
+    // stylesheet see a status bar at all.
+    //
+    // Written on `root`, not on `screen`: settings and chats are SIBLINGS of
+    // the chat screen, so anything set on `screen` never reaches them -- which
+    // is the shape the original `--inset-top` had, and it was consumed by no
+    // rule at all.
+    //
+    // The env() mirror is deliberately NOT overwritten. It is what
+    // `readInsets` reads, and writing our own value back into the variable we
+    // read from would make the shell echo itself instead of the device.
+    const insets = layout.insets;
+    root.style.setProperty("--inset-top", `${insets.top}px`);
+    root.style.setProperty("--inset-right", `${insets.right}px`);
+    root.style.setProperty("--inset-bottom", `${insets.bottom}px`);
+    root.style.setProperty("--inset-left", `${insets.left}px`);
     const logical = logicalInsets(bundle.direction, geometry.composerLeftPx, geometry.composerRightPx);
     // The GUTTER is added here, not left to the stylesheet. An inline style
     // beats `app.css`'s `calc(var(--safe-area-inset-left) + .75rem)`, so

--- a/src/praisonai-mobile/src-tauri/gen/android/app/src/main/java/ai/praison/mobile/MainActivity.kt
+++ b/src/praisonai-mobile/src-tauri/gen/android/app/src/main/java/ai/praison/mobile/MainActivity.kt
@@ -1,11 +1,142 @@
 package ai.praison.mobile
 
 import android.os.Bundle
+import android.webkit.WebView
 import androidx.activity.enableEdgeToEdge
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
 
+/**
+ * The Android host, and the only place the real window insets exist.
+ *
+ * `enableEdgeToEdge()` sets `decorFitsSystemWindows = false`, which is what
+ * lets the webview paint behind the status and navigation bars. The cost is
+ * that the window is then never resized -- not by the system bars and not by
+ * the IME -- so no web API can see either of them:
+ *
+ *   - `env(safe-area-inset-*)` in Chromium on Android reports the DISPLAY
+ *     CUTOUT alone. Measured on an Android 15 emulator running this app: with a
+ *     cutout configured, `--safe-area-inset-top` was 49px (the 128px cutout at
+ *     dpr 2.625) while the 63px status bar contributed nothing, and rotated to
+ *     landscape that same 49px moved to `--safe-area-inset-left` and top read
+ *     0px with the status bar still along the top edge. On the same emulator
+ *     with no cutout, every edge read 0px and the topbar's title was painted
+ *     straight through the status-bar clock.
+ *   - the keyboard is not merely under-reported but absent. With the IME shown
+ *     (`dumpsys input_method` reporting `mInputShown=true`) and the composer
+ *     focused, `window.innerHeight`, `visualViewport.height` and
+ *     `navigator.virtualKeyboard.boundingRect` all still reported the full
+ *     915px viewport, so the composer was laid out at the bottom of a viewport
+ *     the keyboard was covering and vanished underneath it.
+ *
+ * `WindowInsetsCompat` has all of it, so this reads it and hands it to the page
+ * through the one global `adapters/src/tauri/shell.ts` installs. `bottom` is
+ * the system bars, NOT the keyboard: the page composes the two with `max`, not
+ * `+` (ui/src/layout/insets.ts), and sending the keyboard on both channels
+ * would be that sum by another route.
+ *
+ * The animation callback is not decoration. `setOnApplyWindowInsetsListener`
+ * fires once at each END of the IME transition, so on its own the composer
+ * teleports the full height of the keyboard; `onProgress` runs every frame in
+ * between, which is what makes it slide with the keyboard instead.
+ */
 class MainActivity : TauriActivity() {
+  /** True once the page has answered a push. Until then the global does not
+   *  exist yet and every push is silently dropped -- see `retryUntilAcked`. */
+  private var acknowledged = false
+
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
+  }
+
+  override fun onWebViewCreate(webView: WebView) {
+    ViewCompat.setOnApplyWindowInsetsListener(webView) { view, insets ->
+      push(view as WebView, insets)
+      // Returned, not consumed: the webview is not the only view in the tree
+      // and swallowing the insets here would stop anything below it seeing a
+      // rotation.
+      insets
+    }
+
+    ViewCompat.setWindowInsetsAnimationCallback(
+      webView,
+      object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
+        override fun onProgress(
+          insets: WindowInsetsCompat,
+          runningAnimations: MutableList<WindowInsetsAnimationCompat>,
+        ): WindowInsetsCompat {
+          push(webView, insets)
+          return insets
+        }
+      },
+    )
+
+    ViewCompat.requestApplyInsets(webView)
+    retryUntilAcked(webView, 0)
+  }
+
+  /**
+   * Push the current insets until the page has actually taken one.
+   *
+   * This exists because of an ordering that produced a fix that worked on
+   * every later dispatch and did nothing at all on the one that matters.
+   * `onWebViewCreate` runs before the page has loaded, so the first
+   * `requestApplyInsets` evaluates `window.<global> && window.<global>(...)`
+   * against a document that has no global yet -- a legal no-op with no error
+   * anywhere. Android then has no reason to dispatch insets again, so the app
+   * sat at zero insets until the user rotated the phone or opened the keyboard:
+   * measured on the emulator as `#root` still carrying `--inset-top: 0px` with
+   * the OS reporting 48px, and the topbar title over the clock exactly as
+   * before the fix.
+   *
+   * Polling rather than a `@JavascriptInterface` handshake because the webview
+   * is Tauri's, created and navigated by Rust, and an interface added here is
+   * only injected into documents loaded AFTER the call -- which is the same
+   * race in a different place. This stops the moment the page answers.
+   */
+  private fun retryUntilAcked(webView: WebView, attempt: Int) {
+    if (acknowledged || attempt > MAX_PUSH_ATTEMPTS) return
+    ViewCompat.getRootWindowInsets(webView)?.let { push(webView, it) }
+    webView.postDelayed({ retryUntilAcked(webView, attempt + 1) }, PUSH_RETRY_MS)
+  }
+
+  private fun push(webView: WebView, insets: WindowInsetsCompat) {
+    val density = webView.resources.displayMetrics.density
+    // Guard the divide: a density of 0 is not something Android reports, but a
+    // NaN reaching a CSS length silently drops the whole declaration and drops
+    // the composer under the keyboard with nothing in any log.
+    if (density <= 0f) return
+    // A cutout is folded in with the system bars rather than sent separately:
+    // the page wants one "do not paint here" number per edge, and on a device
+    // whose cutout is deeper than its status bar (every emulator AVD with a
+    // punch hole, and such a phone in landscape) the bars alone are too small.
+    val bars = insets.getInsets(
+      WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+    )
+    val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+    fun css(value: Int): Int = (value / density).toInt().coerceAtLeast(0)
+    // Returns a boolean so the page's readiness is observable rather than
+    // assumed; `retryUntilAcked` is the only reader.
+    val js = "(function(){if(!window.$INSETS_GLOBAL)return false;window.$INSETS_GLOBAL({" +
+      "top:${css(bars.top)}," +
+      "right:${css(bars.right)}," +
+      "bottom:${css(bars.bottom)}," +
+      "left:${css(bars.left)}," +
+      "keyboard:${css(ime.bottom)}});return true;})()"
+    webView.evaluateJavascript(js) { result ->
+      if (result == "true") acknowledged = true
+    }
+  }
+
+  private companion object {
+    /** Must match NATIVE_INSETS_GLOBAL in adapters/src/tauri/shell.ts.
+     *  tools/shell-seam.test.mjs pins the two together. */
+    const val INSETS_GLOBAL = "__praisonaiNativeInsets"
+    const val PUSH_RETRY_MS = 120L
+    /** ~15s of retries. A page that has not booted by then has a worse problem
+     *  than its insets, and a retry loop with no bound is a battery bug. */
+    const val MAX_PUSH_ATTEMPTS = 125
   }
 }

--- a/src/praisonai-mobile/tools/screen-layout.test.mjs
+++ b/src/praisonai-mobile/tools/screen-layout.test.mjs
@@ -1,0 +1,301 @@
+/**
+ * What the non-chat screens actually LOOK like, measured in a real engine.
+ *
+ * app/src/css.test.ts reads `app.css` as text. That catches a declaration that
+ * is written wrong; it cannot catch a declaration that is not written at all,
+ * and it cannot catch a rule whose selector matches nothing the app emits.
+ * Both of those shipped:
+ *
+ *   - `.topbar` is the only rule in the stylesheet that consumes
+ *     `--safe-area-inset-top`, and only the chat screen builds a `.topbar`.
+ *     `buildSettingsScreen` / `buildChatsScreen` emit a bare
+ *     `<section class="screen screen-settings">`, so on an Android 15 emulator
+ *     the "Settings" heading's box started at y = 20 with a 49px inset -- 29px
+ *     of the title painted under the status-bar clock -- and every heading sat
+ *     at x = 0, which in landscape is inside the display cutout.
+ *   - those screens are `overflow: visible`, so a settings list taller than the
+ *     viewport had rows that could not be scrolled to at all.
+ *   - the chat-row block was written as `.chat-row`; main.ts emits `row-chat`.
+ *     The rule has therefore never painted, and rows fell back to the bare
+ *     `button` styling -- a centred, auto-width pill instead of a list row.
+ *
+ * So this file asserts COMPUTED GEOMETRY, never declaration text. A device with
+ * insets is simulated by overriding the four `--safe-area-inset-*` custom
+ * properties, which is the documented bridge between `env()` and the app
+ * (core/src/ports/shell.ts INSET_VARIABLES): everything downstream of that
+ * variable is the code under test.
+ */
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtemp, readFile, readdir, symlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, extname, join, normalize, resolve } from "node:path";
+import { chromium } from "playwright";
+
+const pkg = resolve(dirname(new URL(import.meta.url).pathname), "..");
+const ENGINE = "http://127.0.0.1:8765";
+
+/**
+ * Build into a PRIVATE dist, not the package's own.
+ *
+ * `tools/build-webview.mjs` starts with `rm -rf <root>/dist`, and it takes the
+ * root as its one argument. Two test files that both build and then serve
+ * `<pkg>/dist` therefore race: measured under a full `npm run check`, this
+ * file's server handed out a half-written `app.js` while `web-boot.test.mjs`
+ * was rebuilding, the app never booted, and the first case here sat on the
+ * boot wait for a full minute. A root of symlinks costs nothing and makes the
+ * two builds independent.
+ */
+async function buildPrivately() {
+  const root = await mkdtemp(join(tmpdir(), "praisonai-layout-"));
+  for (const entry of await readdir(pkg)) {
+    if (entry === "dist") continue;
+    await symlink(join(pkg, entry), join(root, entry));
+  }
+  const built = spawnSync(process.execPath, [join(pkg, "tools/build-webview.mjs"), root], {
+    encoding: "utf8",
+  });
+  assert.equal(built.status, 0, `the build must succeed first:\n${built.stdout}${built.stderr}`);
+  return join(root, "dist");
+}
+
+/** Deep enough to be unmistakable and different on every edge, so a fix that
+ *  wires one inset into all four sides fails here rather than passing. */
+const INSETS = { top: 44, right: 21, bottom: 34, left: 13 };
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".webmanifest": "application/manifest+json",
+  ".png": "image/png",
+};
+
+function serveDist(dist) {
+  const server = createServer(async (req, res) => {
+    let rel = new URL(req.url, "http://x").pathname.slice(1);
+    if (rel === "" || rel.endsWith("/")) rel += "index.html";
+    const file = normalize(join(dist, rel));
+    if (!file.startsWith(dist) || !existsSync(file)) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, {
+      "content-type": MIME[extname(file)] ?? "application/octet-stream",
+      "cache-control": "no-store",
+    });
+    res.end(await readFile(file));
+  });
+  return new Promise((ok) => server.listen(0, "127.0.0.1", () => ok(server)));
+}
+
+async function launch() {
+  try {
+    return await chromium.launch();
+  } catch (bundled) {
+    try {
+      return await chromium.launch({ channel: "chrome" });
+    } catch (system) {
+      throw new Error(
+        "no browser to measure the layout in: run `npx playwright install chromium` (or install Google Chrome).\n" +
+          `  bundled: ${bundled.message.split("\n")[0]}\n  system: ${system.message.split("\n")[0]}`,
+      );
+    }
+  }
+}
+
+/**
+ * Build, serve and launch ONCE for the whole file.
+ *
+ * Doing it per case built dist/ five times and started five Chromiums, and
+ * under the parallelism of a full `npm run check` that was slow enough to trip
+ * the boot wait -- a flake that says nothing about the layout.
+ */
+let shared = null;
+async function shell() {
+  if (shared !== null) return shared;
+  const server = await serveDist(await buildPrivately());
+  const browser = await launch();
+  shared = { server, browser };
+  return shared;
+}
+
+after(async () => {
+  if (shared === null) return;
+  await shared.browser.close();
+  shared.server.closeAllConnections?.();
+  await new Promise((ok) => shared.server.close(ok));
+});
+
+/** The built app on a phone-sized viewport, with the four inset variables
+ *  standing in for a notched device. Each case gets its OWN context, so one
+ *  case's injected stylesheet and appended nodes cannot reach the next. */
+async function openApp(t) {
+  const { server, browser } = await shell();
+
+  // `serviceWorkers: "block"` because this file is about layout and the service
+  // worker is a second, stateful source of the page's bytes: a context that
+  // keeps one alive serves the NEXT page from its cache, and a precache that
+  // has not finished leaves that page waiting on a fetch nothing will answer.
+  // Under the parallelism of a full `npm run check` that showed up as one case
+  // in five hanging on the boot wait for a full minute -- a flake that says
+  // nothing about any inset. tools/web-boot.test.mjs is where the worker is
+  // the subject and is tested properly.
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    serviceWorkers: "block",
+  });
+  t.after(() => context.close());
+  const page = await context.newPage();
+  await page.route((u) => u.href.startsWith(ENGINE), (route) => route.abort("connectionrefused"));
+  await page.goto(`http://127.0.0.1:${server.address().port}/`, { waitUntil: "load" });
+  await page.locator('textarea[aria-label="Message"]').waitFor({ timeout: 60_000 });
+  // AFTER load, so this beats app.css's `:root` block on order rather than
+  // relying on specificity.
+  await page.addStyleTag({
+    content:
+      `:root{--safe-area-inset-top:${INSETS.top}px;--safe-area-inset-right:${INSETS.right}px;` +
+      `--safe-area-inset-bottom:${INSETS.bottom}px;--safe-area-inset-left:${INSETS.left}px}`,
+  });
+  // Then a `resize`, which is what a browser fires on a rotation and what makes
+  // the shell re-read those variables and republish. Going through the shell
+  // rather than styling `#root` directly is the point: main.ts writes the
+  // EFFECTIVE `--inset-*` onto `#root` from `shell.insets`, so a test that set
+  // them itself would be asserting against its own value and would pass with
+  // the shell unplugged.
+  await page.evaluate(() => window.dispatchEvent(new Event("resize")));
+  await page.waitForFunction(
+    (top) => document.getElementById("root").style.getPropertyValue("--inset-top") === `${top}px`,
+    INSETS.top,
+    { timeout: 10_000 },
+  );
+  return page;
+}
+
+/** Navigate by tapping the affordance a user taps, so the test cannot pass
+ *  against a screen the app has no route to. */
+async function go(page, route) {
+  await page.locator(`button[data-action="navigate"][data-route="${route}"]`).click();
+  const screen = page.locator(`.screen-${route}`);
+  await screen.waitFor({ timeout: 10_000 });
+  return screen;
+}
+
+for (const route of ["settings", "chats"]) {
+  test(`the ${route} screen clears the safe area on every edge`, async (t) => {
+    const page = await openApp(t);
+    await go(page, route);
+
+    const box = await page.evaluate((r) => {
+      const screen = document.querySelector(`.screen-${r}`);
+      const heading = screen.querySelector(".screen-heading");
+      const h = heading.getBoundingClientRect();
+      return {
+        headingTop: h.top,
+        headingLeft: h.left,
+        headingRight: h.right,
+        viewportWidth: window.innerWidth,
+        // The screen fills the window, so its own padding is what has to hold
+        // the content off the edges.
+        screenBottom: screen.getBoundingClientRect().bottom,
+        padBottom: parseFloat(getComputedStyle(screen).paddingBottom),
+      };
+    }, route);
+
+    // The reported defect, as a number: the heading's own box must start below
+    // the status bar, not 29px inside it.
+    assert.ok(
+      box.headingTop >= INSETS.top,
+      `the ${route} heading starts at y=${box.headingTop}, inside the ${INSETS.top}px top inset`,
+    );
+    assert.ok(
+      box.headingLeft >= INSETS.left,
+      `the ${route} heading starts at x=${box.headingLeft}, inside the ${INSETS.left}px left inset`,
+    );
+    assert.ok(
+      box.headingRight <= box.viewportWidth - INSETS.right,
+      `the ${route} heading reaches x=${box.headingRight}, inside the ${INSETS.right}px right inset`,
+    );
+    assert.ok(
+      box.padBottom >= INSETS.bottom,
+      `the ${route} screen keeps ${box.padBottom}px below its last row, under a ${INSETS.bottom}px home indicator`,
+    );
+  });
+
+  test(`the ${route} screen can be scrolled when its content overflows`, async (t) => {
+    const page = await openApp(t);
+    await go(page, route);
+
+    const scrolled = await page.evaluate((r) => {
+      const screen = document.querySelector(`.screen-${r}`);
+      // Content taller than any phone, so the question is only whether the
+      // screen scrolls -- not how many settings happen to be registered today.
+      const filler = document.createElement("div");
+      filler.style.height = "3000px";
+      filler.style.flex = "none";
+      screen.append(filler);
+      const before = { scrollHeight: screen.scrollHeight, clientHeight: screen.clientHeight };
+      screen.scrollTop = 500;
+      return { ...before, scrollTop: screen.scrollTop };
+    }, route);
+
+    assert.ok(
+      scrolled.scrollHeight > scrolled.clientHeight,
+      `the ${route} screen did not even overflow, so this test proves nothing`,
+    );
+    assert.ok(
+      scrolled.scrollTop > 0,
+      `the ${route} screen will not scroll (scrollTop stayed ${scrolled.scrollTop}), ` +
+        "so every row past the fold is unreachable",
+    );
+  });
+}
+
+test("a chat row is a full-width list row, and a long title is truncated", async (t) => {
+  const page = await openApp(t);
+  const screen = await go(page, "chats");
+  await screen.waitFor();
+
+  // The class list `buildChatsScreen` builds, verbatim. app/src/main.test.ts
+  // holds the other half of this pair: that the builder emits these names.
+  const measured = await page.evaluate(() => {
+    const screen = document.querySelector(".screen-chats");
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "row row-chat row-chat-chat";
+    row.textContent = "A chat whose title came from a very long first message ".repeat(6);
+    screen.append(row);
+    const style = getComputedStyle(row);
+    const rect = row.getBoundingClientRect();
+    const content = screen.clientWidth
+      - parseFloat(getComputedStyle(screen).paddingLeft)
+      - parseFloat(getComputedStyle(screen).paddingRight);
+    return {
+      display: style.display,
+      textAlign: style.textAlign,
+      whiteSpace: style.whiteSpace,
+      textOverflow: style.textOverflow,
+      width: rect.width,
+      height: rect.height,
+      content,
+    };
+  });
+
+  assert.equal(measured.display, "flex", "a chat row is a list row, not an inline-block button");
+  assert.equal(measured.textAlign, "left", "a chat row's title reads from the leading edge");
+  assert.equal(measured.whiteSpace, "nowrap", "a long chat title must not wrap to many lines");
+  assert.equal(measured.textOverflow, "ellipsis", "a long chat title is ellipsised");
+  assert.ok(
+    Math.abs(measured.width - measured.content) < 1,
+    `a chat row is ${measured.width}px wide inside a ${measured.content}px column: it must fill it`,
+  );
+  // The truncation, as geometry rather than as a declaration: six repeats of
+  // that sentence cannot fit on one line of a 390px phone unless it is clipped.
+  assert.ok(
+    measured.height < 100,
+    `a long chat title grew the row to ${measured.height}px instead of staying one line`,
+  );
+});

--- a/src/praisonai-mobile/tools/shell-seam.test.mjs
+++ b/src/praisonai-mobile/tools/shell-seam.test.mjs
@@ -25,6 +25,10 @@ const pkg = join(here, "..");   // tools/ -> the package root
 
 const rust = readFileSync(join(pkg, "src-tauri/src/shell/mod.rs"), "utf8");
 const ts = readFileSync(join(pkg, "adapters/src/tauri/shell.ts"), "utf8");
+const kotlin = readFileSync(
+  join(pkg, "src-tauri/gen/android/app/src/main/java/ai/praison/mobile/MainActivity.kt"),
+  "utf8",
+);
 
 /** `pub const NAME: &str = "value";` */
 function rustConst(name) {
@@ -60,4 +64,36 @@ test("the comparison is real, not two lookups of the same file", () => {
   assert.notEqual(rust, ts);
   assert.ok(rust.includes("pub const"), "the Rust source was not read");
   assert.ok(ts.includes("const EVENTS"), "the TypeScript source was not read");
+});
+
+/**
+ * The Android insets bridge is a FIFTH string across the same seam, and it
+ * fails the same silent way: MainActivity's `evaluateJavascript` calls
+ * `window.<name> && window.<name>(...)`, so a name the shell does not install
+ * is not an error, it is a no-op -- and the app lays out as though the phone
+ * had no status bar, no navigation bar and no keyboard, which is precisely the
+ * state it was measured in on an Android 15 emulator before this existed.
+ */
+test("the Android insets global agrees across the Kotlin/TypeScript seam", () => {
+  const tsName = /NATIVE_INSETS_GLOBAL = "([^"]+)"/.exec(ts);
+  assert.ok(tsName, "NATIVE_INSETS_GLOBAL not found in the TypeScript adapter");
+  const ktName = /INSETS_GLOBAL = "([^"]+)"/.exec(kotlin);
+  assert.ok(ktName, "INSETS_GLOBAL not found in MainActivity.kt");
+  assert.equal(ktName[1], tsName[1]);
+  assert.notEqual(kotlin, ts, "two lookups of the same file would assert nothing");
+});
+
+test("MainActivity sends every edge, and the keyboard separately from them", () => {
+  // The payload is built as a string literal, so a dropped edge is a missing
+  // key the TypeScript reads as 0 -- silently flush against that edge.
+  const call = /INSETS_GLOBAL\(\{" \+([\s\S]*?)\}\)/.exec(kotlin);
+  assert.ok(call, "the insets payload literal was not found in MainActivity.kt");
+  for (const key of ["top", "right", "bottom", "left", "keyboard"]) {
+    assert.match(call[1], new RegExp(`\\b${key}:`), `MainActivity must send ${key}`);
+  }
+  // `bottom` must come from the system bars, not from the IME: the page
+  // composes the two with max(), so sending the keyboard on both channels is
+  // the double-count ui/src/layout/insets.ts warns about.
+  assert.match(call[1], /bottom:\$\{css\(bars\.bottom\)\}/, "bottom is the system bars");
+  assert.match(call[1], /keyboard:\$\{css\(ime\.bottom\)\}/, "keyboard is the IME inset");
 });


### PR DESCRIPTION
Audited on a real Android 15 emulator (Pixel-class, 1080x2400 @ 420dpi, gesture nav) with the app installed and its WebView driven over the Chrome DevTools Protocol, so every number here is measured on a device rather than reasoned about. The fix was rebuilt into an APK and re-verified on the same emulator.

## What was wrong

### 1. Settings and Chats ignored every safe-area inset, and could not scroll — the reported defect

`.topbar` is the only rule in `app.css` that consumes the top inset, and only the chat screen builds a `.topbar`. `buildSettingsScreen` / `buildChatsScreen` emit a bare `<section class="screen screen-settings">` whose first child is an `<h2 class="screen-heading">`.

Measured, portrait, 49px inset reported: the heading's box started at **y = 20** — 29px of "Settings" painted under the status-bar clock — and every heading sat at **x = 0**, which in landscape is inside the display cutout. Those screens were also `overflow: visible` with `flex: 1`, so a settings list taller than the viewport had rows nothing could scroll to.

### 2. `env(safe-area-inset-*)` on Android is the display cutout and nothing else

| state | `--safe-area-inset-*` | what the OS reported |
|---|---|---|
| portrait, cutout AVD | top 49px | cutout 128px ÷ 2.625 = 49; status bar 63px (24 CSS px) contributed **nothing** |
| landscape, cutout AVD | left 49px, **top 0px** | status bar still along the top edge |
| portrait, no cutout | **all four 0px** | 24px status bar, 24px navigation bar |

With no cutout even the chat topbar painted through the clock, and the composer sat under the gesture pill in every configuration. `enableEdgeToEdge()` is why: with `decorFitsSystemWindows` false the window is never resized, so there is nothing for a web API to observe.

### 3. The composer sat under the keyboard, and no web API reported one

With the IME shown (`dumpsys input_method` → `mInputShown=true`) and the composer's textarea focused:

```
window.innerHeight                     915
visualViewport.height                  915.05
navigator.virtualKeyboard.boundingRect 0x0
--keyboard-height                      (unset)
```

`readKeyboardHeight` returned 0 and the textarea and Send were painted entirely behind the keyboard. `adapters/src/tauri/shell.ts` says of `keyboardHeightPx` that `visualViewport` "works here and needs no native code" because "WKWebView and Android WebView both implement" it. It works on iOS. On Android there was no source at all, and nothing in the suite could have noticed.

### 4. `.chat-row` in `app.css` is a selector the app has never emitted

`buildChatsScreen` builds `row row-chat row-chat-<kind>`. The whole block, and its `.title` / `.when` children (which the markup does not have either), matched nothing — so chat rows fell back to the bare `button` rule, a centred auto-width pill, and a long title wrapped without limit.

## The fixes

- **`MainActivity.kt`** reads the real `WindowInsetsCompat` — system bars, display cutout and the IME — and pushes it to the page through one global. The keyboard travels on its own field: `ui/src/layout/insets.ts` composes it with the bottom inset using `max`, so sending it on both channels would be the `bottom + keyboard` sum that file calls "the single most recognisable 'web page in a box' tell there is". A `WindowInsetsAnimationCompat` callback pushes every frame, so the composer slides with the keyboard instead of teleporting. The first push retries until the page answers — it lands before the document exists, and `window.X && window.X(...)` against a page with no `X` is a legal no-op that left the app at zero insets until the user rotated the phone (observed, and fixed).
- **`app.css`** lays out against `--inset-*`, which `main.ts` writes on `#root` from `shell.insets`, with the `env()` mirror as the pre-script fallback so the first paint is still right on iOS. The mirror is deliberately not overwritten: it is what `readInsets` reads, and writing our own value into it would make the shell echo itself instead of the device.
- **Settings and Chats** get all four insets plus the gutter, and `overflow-y: auto`.
- **`.chat-row` → `.row-chat`**, with the truncation moved onto the row itself.

## Tests

Every one of these fails without its fix — verified by reverting each and watching a **named** test go red (the mutation script `assert`s its anchor, so a silent no-op mutation cannot report a false SURVIVED).

| test | mutation that kills it |
|---|---|
| `tools/screen-layout.test.mjs` — 5 cases | rename the `.screen-settings, .screen-chats` selector; drop the `--inset-top` write in `main.ts`; rename `.row-chat` back to `.chat-row` |
| `adapters/src/tauri/native-insets.test.ts` — 8 cases | stop installing the global |
| `tools/shell-seam.test.mjs` — 2 new cases | rename `INSETS_GLOBAL` in the Kotlin |
| `app/src/css.test.ts` double-count guard | put `--inset-bottom` back into the composer's keyboard padding |

`screen-layout.test.mjs` asserts **computed geometry**, never declaration text — this repo has already been bitten by a `/calc\(([^)]*)\)/` that cannot see past `calc(var(a) + var(b))`. It simulates a device through the CSS inset bridge and a `resize`, so the assertion runs through the shell rather than against a value the test set itself; it builds into a private `dist` (`build-webview.mjs` opens with `rm -rf dist`, which raced `web-boot.test.mjs` and made one case hang on boot for a full minute), and blocks service workers so the page's bytes come from one place.

`npm run check` exits **0** — confirmed by process exit code on two consecutive full runs, 1434 pass / 0 fail.

## Verified on device after the fix

`#root` carries `--inset-top: 48px; --inset-bottom: 24px` on first paint; the Settings heading starts at y = 80 with 12px gutters, `overflow-y: auto`, and `scrollTop` actually moves; the composer sits directly above the keyboard. Re-checked in portrait and landscape, light and dark (`cmd uimode night yes`), at `font_scale` 1.5, across a background/resume, and with Android Back (Settings → Chat → exit, which is correct).

## Found, not fixed

- **The user's own message never appears in the transcript.** Reproduced with a real tap on Send: only the engine's error row renders. `ui/src/transcript/view-model.ts` has no user row kind at all, so this is an unimplemented feature rather than a regression — it needs a new row kind and protocol event, which is outside a visual-defect fix and overlaps work in flight on `engines/src/`.
- **`.jump-latest` has no CSS.** It is `hidden` at rest so it was never seen misrendered, but when shown it is an unstyled full-width button in the flex column rather than a floating pill.
- At `font_scale` 1.5 the topbar's "Settings" label slightly overflows its own button box. It stays inside the viewport and remains tappable.
- **`--inset-top` was previously written on the chat screen element and consumed by no rule at all** — a live-looking variable with a passing test and no effect. It is now the effective inset and is on `#root`, where sibling screens can see it.

## Not verified

iOS. The `env()` bridge and the `visualViewport` keyboard path are untouched there and the new `--inset-*` fall back to `env()`, so the first paint and every subsequent frame should be unchanged, but I had no iOS device or simulator in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android handling of safe-area and keyboard insets, preventing incorrect spacing and double-counted keyboard height.
  - Ensured keyboard show and hide events update the layout reliably.
  - Improved layout behavior on devices with display cutouts and system bars.

- **UI Improvements**
  - Settings and Chats screens now account for device insets and remain scrollable when content overflows.
  - Chat rows now use full-width layouts with clearer truncation for long titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->