### PR TITLE
fix(llm): recognise ollama_chat/ and the OpenAI-compatible local prefixes

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/adapters/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/llm/adapters/__init__.py
@@ -203,6 +203,30 @@ Now provide your final answer using this result. Summarize the information natur
         }
 
 
+class LocalOpenAIAdapter(DefaultAdapter):
+    """Adapter for local servers that speak real OpenAI over HTTP.
+
+    Covers LM Studio, vLLM and llama.cpp's ``llama-server``. These differ from
+    Ollama in the way that matters most here: they implement the standard tool
+    protocol correctly, so tool results stay ``role: "tool"`` and streaming with
+    tools works. Inheriting ``DefaultAdapter``'s message handling is therefore
+    deliberate -- applying Ollama's natural-language ``role: "user"`` rewrite
+    would corrupt a conversation these servers handle properly.
+
+    What they share with Ollama is the model: locally-served weights are often
+    small and emit a malformed tool call now and then. So the one thing this
+    adapter adds is a repair budget.
+
+    ``force_tool_usage`` is deliberately NOT set. It injects prompts into every
+    conversation, and vLLM commonly serves large, highly capable models where
+    that is unwanted noise. ``max_tool_repairs`` costs nothing unless a tool
+    call actually arrives malformed.
+    """
+
+    def get_default_settings(self) -> Dict[str, Any]:
+        return {'max_tool_repairs': 2}
+
+
 class AnthropicAdapter(DefaultAdapter):
     """Anthropic/Claude provider adapter."""
     
@@ -273,6 +297,7 @@ _provider_adapters: Dict[str, LLMProviderAdapterProtocol] = {}
 _default_adapter = DefaultAdapter()
 _provider_adapters['default'] = _default_adapter
 _provider_adapters['ollama'] = OllamaAdapter()
+_provider_adapters['local'] = LocalOpenAIAdapter()
 _provider_adapters['anthropic'] = AnthropicAdapter()
 _provider_adapters['claude'] = AnthropicAdapter()  # Alias
 _provider_adapters['gemini'] = GeminiAdapter()
@@ -310,6 +335,8 @@ def get_provider_adapter(name: str) -> LLMProviderAdapterProtocol:
     # Provider prefixes or substrings
     if "ollama" in name_lower:
         return _provider_adapters["ollama"]
+    if name_lower in {"local", "lm_studio", "lmstudio", "vllm", "hosted_vllm", "llamacpp", "llama_cpp"}:
+        return _provider_adapters["local"]
     if "claude" in name_lower or "anthropic" in name_lower:
         return _provider_adapters["anthropic"]
     if "gemini" in name_lower:
@@ -331,6 +358,7 @@ def has_provider_adapter(name: str) -> bool:
 __all__ = [
     'DefaultAdapter',
     'OllamaAdapter', 
+    'LocalOpenAIAdapter',
     'AnthropicAdapter',
     'GeminiAdapter',
     'get_provider_adapter',

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -731,6 +731,17 @@ Respond with ONLY a valid JSON tool call in this format:
         
         return False
 
+    def _is_local_openai_provider(self) -> bool:
+        """Detect local OpenAI-compatible servers (LM Studio, vLLM, llama.cpp).
+
+        These speak the standard OpenAI protocol, so well-formed tool calls
+        arrive as ``message.tool_calls``. But after a tool-call *repair* prompt
+        the model is asked to reply with a bare JSON tool call as text content;
+        like Ollama, that text must be reconstructed into a dispatchable tool
+        call rather than returned as the final answer.
+        """
+        return self._detect_provider() == "local"
+
     def _is_qwen_provider(self) -> bool:
         """Detect if this is a Qwen provider"""
         if not self.model:
@@ -3474,8 +3485,11 @@ Respond with ONLY a valid JSON tool call in this format:
                     tool_calls = final_response["choices"][0]["message"].get("tool_calls")
                     
                     
-                    # For Ollama, parse tool calls from response text if not in tool_calls field
-                    if self._is_ollama_provider() and not tool_calls and response_text and formatted_tools:
+                    # For Ollama and local OpenAI-compatible servers, parse tool
+                    # calls from response text if not in the tool_calls field.
+                    # This is essential after a repair prompt, which asks the
+                    # model to reply with a bare JSON tool call as text content.
+                    if (self._is_ollama_provider() or self._is_local_openai_provider()) and not tool_calls and response_text and formatted_tools:
                         # Try to parse JSON tool call from response text
                         try:
                             response_json = json.loads(response_text.strip())

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -636,9 +636,18 @@ Respond with ONLY a valid JSON tool call in this format:
         # Parse route prefix for explicit provider routing
         provider_prefix = model_lower.split("/", 1)[0] if "/" in model_lower else None
         
-        # Explicit provider prefixes take priority
-        if provider_prefix == "ollama":
+        # Explicit provider prefixes take priority.
+        # "ollama_chat" is litellm's recommended prefix for Ollama tool calling
+        # and must not be treated as a different provider than "ollama".
+        if provider_prefix in {"ollama", "ollama_chat"}:
             return "ollama"
+        # Local servers that speak real OpenAI over HTTP. They keep the standard
+        # tool-message shape (unlike Ollama) but serve locally-hosted weights
+        # that benefit from a tool-call repair budget. "huggingface" is
+        # deliberately absent: that prefix is the hosted Inference API.
+        if provider_prefix in {"lm_studio", "lmstudio", "vllm", "hosted_vllm",
+                               "llamacpp", "llama_cpp"}:
+            return "local"
         if provider_prefix in {"anthropic", "claude"}:
             return "anthropic"
         if provider_prefix in {"gemini", "google"} and "gemini" in model_lower:

--- a/src/praisonai/tests/unit/llm/test_local_provider_prefixes.py
+++ b/src/praisonai/tests/unit/llm/test_local_provider_prefixes.py
@@ -141,3 +141,33 @@ def test_explicit_max_tool_repairs_wins():
     """A user-set value is never overridden by a provider default."""
     assert LLM(model="lm_studio/qwen", max_tool_repairs=5).max_tool_repairs == 5
     assert LLM(model="ollama_chat/llama3.2", max_tool_repairs=0).max_tool_repairs == 0
+
+
+# --- repair-response reconstruction (Greptile P1) -----------------------------
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "lm_studio/qwen2.5-7b-instruct",
+        "vllm/meta-llama/Llama-3.1-8B-Instruct",
+        "hosted_vllm/Qwen2.5-7B",
+        "llamacpp/qwen2.5",
+    ],
+)
+def test_local_openai_provider_flag(model):
+    """Local OpenAI-compatible routes report as local for text reconstruction."""
+    assert LLM(model=model)._is_local_openai_provider() is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-4o", "ollama/llama3.2", "ollama_chat/llama3.2", "claude-3-5-sonnet-latest"],
+)
+def test_non_local_providers_are_not_local_openai(model):
+    """Hosted OpenAI, Ollama and Anthropic must not be flagged as local OpenAI."""
+    assert LLM(model=model)._is_local_openai_provider() is False
+
+
+def test_huggingface_is_not_local_openai():
+    """`huggingface/` is the hosted Inference API, not a local server."""
+    assert LLM(model="huggingface/meta-llama/Llama-3.1-8B-Instruct")._is_local_openai_provider() is False

--- a/src/praisonai/tests/unit/llm/test_local_provider_prefixes.py
+++ b/src/praisonai/tests/unit/llm/test_local_provider_prefixes.py
@@ -1,0 +1,143 @@
+"""Local-server route prefixes must select an adapter that knows they are local.
+
+litellm resolves `ollama_chat/`, `lm_studio/`, `vllm/` and `hosted_vllm/`, but
+`LLM._detect_provider` recognised only the bare `ollama/` prefix, so every other
+local route fell through to "openai" and got `DefaultAdapter` with
+`max_tool_repairs=0` -- no tool-call repair at all, for exactly the small local
+models that need it most.
+
+`ollama_chat/` is the sharpest case: it is litellm's *recommended* prefix for
+Ollama tool calling, and it was the one form of Ollama the SDK did not detect.
+
+Constructed state only: no network, no server.
+"""
+
+import pytest
+
+from praisonaiagents.llm.llm import LLM
+from praisonaiagents.llm.adapters import (
+    DefaultAdapter,
+    LocalOpenAIAdapter,
+    OllamaAdapter,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in ("OPENAI_BASE_URL", "OPENAI_API_BASE", "OLLAMA_HOST"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+
+# --- ollama_chat/ is Ollama ---------------------------------------------------
+
+@pytest.mark.parametrize("model", ["ollama_chat/llama3.2", "ollama_chat/qwen3:0.6b"])
+def test_ollama_chat_prefix_is_ollama(model):
+    """litellm's recommended Ollama prefix must resolve to Ollama."""
+    llm = LLM(model=model)
+    assert llm._detect_provider() == "ollama"
+    assert isinstance(llm._provider_adapter, OllamaAdapter)
+    assert llm.max_tool_repairs == 2
+
+
+def test_ollama_chat_matches_ollama_prefix_behaviour():
+    """The two Ollama spellings must not disagree."""
+    chat = LLM(model="ollama_chat/llama3.2")
+    plain = LLM(model="ollama/llama3.2")
+    assert chat._detect_provider() == plain._detect_provider()
+    assert type(chat._provider_adapter) is type(plain._provider_adapter)
+    assert chat.max_tool_repairs == plain.max_tool_repairs
+
+
+# --- OpenAI-compatible local servers -----------------------------------------
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "lm_studio/qwen2.5-7b-instruct",
+        "vllm/meta-llama/Llama-3.1-8B-Instruct",
+        "hosted_vllm/Qwen2.5-7B",
+    ],
+)
+def test_local_openai_compatible_prefixes_get_repairs(model):
+    """A local OpenAI-compatible server gets tool-call repair, not zero."""
+    llm = LLM(model=model)
+    assert llm._detect_provider() == "local"
+    assert isinstance(llm._provider_adapter, LocalOpenAIAdapter)
+    assert llm.max_tool_repairs == 2
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "lm_studio/qwen2.5-7b-instruct",
+        "vllm/meta-llama/Llama-3.1-8B-Instruct",
+    ],
+)
+def test_local_openai_compatible_keeps_openai_message_shape(model):
+    """These servers speak real OpenAI, so tool results stay role:tool.
+
+    This is what separates them from Ollama, whose adapter rewrites a tool
+    result into a natural-language role:user turn. Applying that here would
+    corrupt a conversation with a server that handles the standard protocol
+    correctly.
+    """
+    llm = LLM(model=model)
+    msg = llm._provider_adapter.format_tool_result_message("get_weather", {"c": 21}, "call_1")
+    assert msg["role"] == "tool"
+    assert msg["tool_call_id"] == "call_1"
+
+
+def test_local_adapter_does_not_force_tool_usage():
+    """Repairs are a safety net; forced-tool prompting is not applied blind.
+
+    `max_tool_repairs` only fires on a malformed tool call, so it is safe for a
+    strong model. `force_tool_usage` injects prompts into every conversation,
+    and vLLM commonly serves large, capable models -- so it is deliberately not
+    part of the local default.
+    """
+    settings = LocalOpenAIAdapter().get_default_settings()
+    assert settings.get("max_tool_repairs") == 2
+    assert "force_tool_usage" not in settings
+
+
+def test_local_adapter_allows_streaming_with_tools():
+    """Unlike Ollama, these servers stream tool calls correctly."""
+    assert LocalOpenAIAdapter().supports_streaming_with_tools() is True
+
+
+# --- what must not change -----------------------------------------------------
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        ("gpt-4o", "openai"),
+        ("openai/gpt-4o", "openai"),
+        ("claude-3-5-sonnet-latest", "anthropic"),
+        ("anthropic/claude-3-5-sonnet-latest", "anthropic"),
+        ("gemini/gemini-1.5-flash", "gemini"),
+        ("groq/llama-3.3-70b-versatile", "openai"),
+    ],
+)
+def test_existing_providers_unchanged(model, expected):
+    assert LLM(model=model)._detect_provider() == expected
+
+
+def test_huggingface_is_not_treated_as_local():
+    """`huggingface/` is the hosted Inference API, not a local server."""
+    llm = LLM(model="huggingface/meta-llama/Llama-3.1-8B-Instruct")
+    assert llm._detect_provider() != "local"
+    assert isinstance(llm._provider_adapter, DefaultAdapter)
+    assert not isinstance(llm._provider_adapter, LocalOpenAIAdapter)
+    assert llm.max_tool_repairs == 0
+
+
+def test_openai_still_has_no_repairs():
+    """The repair default must not leak onto hosted OpenAI."""
+    assert LLM(model="gpt-4o").max_tool_repairs == 0
+
+
+def test_explicit_max_tool_repairs_wins():
+    """A user-set value is never overridden by a provider default."""
+    assert LLM(model="lm_studio/qwen", max_tool_repairs=5).max_tool_repairs == 5
+    assert LLM(model="ollama_chat/llama3.2", max_tool_repairs=0).max_tool_repairs == 0


### PR DESCRIPTION
## Problem

litellm resolves `ollama_chat/`, `lm_studio/`, `vllm/` and `hosted_vllm/`, but `LLM._detect_provider` matched only the bare `ollama/` prefix. Every other local route fell through to `"openai"` and got `DefaultAdapter` with `max_tool_repairs=0` — no tool-call repair at all, for exactly the small local models that need it most.

`ollama_chat/` is the sharpest case: it is litellm's **recommended** prefix for Ollama tool calling, and it was the one spelling of Ollama the SDK did not detect.

| model | before | after |
|---|---|---|
| `ollama_chat/llama3.2` | `openai` · DefaultAdapter · repairs=**0** | `ollama` · OllamaAdapter · repairs=2 |
| `lm_studio/qwen2.5-7b` | `openai` · DefaultAdapter · repairs=**0** | `local` · LocalOpenAIAdapter · repairs=2 |
| `vllm/Llama-3.1-8B` | `openai` · DefaultAdapter · repairs=**0** | `local` · LocalOpenAIAdapter · repairs=2 |
| `hosted_vllm/Qwen2.5` | `openai` · DefaultAdapter · repairs=**0** | `local` · LocalOpenAIAdapter · repairs=2 |
| `huggingface/Llama-3.1-8B` | `openai` · DefaultAdapter · repairs=0 | *unchanged* |
| `gpt-4o` | `openai` · DefaultAdapter · repairs=0 | *unchanged* |

## Why not just point them all at OllamaAdapter

That was the obvious fix and it is wrong. `OllamaAdapter` rewrites a tool result into a natural-language `role: "user"` turn and disables streaming-with-tools — compensations for Ollama's own protocol quirks.

**LM Studio, vLLM and llama-server implement the standard tool protocol correctly.** Applying Ollama's rewrite to them would corrupt a conversation those servers already handle properly.

So `ollama_chat/` maps to the existing `OllamaAdapter` — same server, same handling — while the OpenAI-compatible servers get a new `LocalOpenAIAdapter` that **inherits `DefaultAdapter`'s message handling** and adds exactly one thing: a repair budget, for locally-served weights that occasionally emit a malformed tool call.

`force_tool_usage` is deliberately **not** in that default, even though `OllamaAdapter` sets it. It injects prompts into every conversation, and vLLM commonly serves large, highly capable models where that is unwanted noise. `max_tool_repairs` costs nothing unless a tool call actually arrives malformed — a safety net, not a behaviour change.

`huggingface/` is deliberately excluded: that prefix is the hosted Inference API, not a local server.

## Tests

`src/praisonai/tests/unit/llm/test_local_provider_prefixes.py`, 19 tests. Beyond the routing itself, they pin the things that make this safe:

- hosted OpenAI keeps `repairs=0` — the default must not leak
- `huggingface/` is not treated as local
- an explicitly-passed `max_tool_repairs` is never overridden by a provider default
- `LocalOpenAIAdapter` keeps `role: "tool"` message shape and allows streaming-with-tools
- the two Ollama spellings produce identical provider, adapter and repair count

```
test_local_provider_prefixes.py                        19 passed
tests/unit/{llm,agent,adapters,doctor}/                272 passed, 4 subtests
praisonai-agents tests/unit/test_adapter_registry.py    38 passed
```

## Verification honesty

Verified end-to-end against a live Ollama 0.33.2 — `ollama_chat/qwen3:0.6b` selects `OllamaAdapter` with `repairs=2` and answers correctly.

**LM Studio and vLLM are not installed on this machine.** Their routing is asserted by unit test; their end-to-end behaviour is unverified here. That is why `LocalOpenAIAdapter` is deliberately minimal — it changes one number and inherits everything else, so the blast radius of an unverified assumption is as small as I could make it.

## Relationship to #4797

That PR fixes **over**-detection (a local `base_url` capturing `gpt-4o`); this one fixes **under**-detection. Both touch `_detect_provider`, so they will need a trivial rebase depending on merge order — the hunks are in different parts of the function and do not conflict semantically. Neither depends on the other.

Context and the wider plan: #4790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for local OpenAI-compatible servers, including LM Studio, vLLM, hosted vLLM, and llama.cpp.
  - Added provider routing for local server aliases and expanded Ollama compatibility with `ollama_chat`.
  - Local providers now support tool-enabled streaming and preserve tool results.

- **Bug Fixes**
  - Improved parsing of JSON tool calls from local providers after repair prompts.
  - Added automatic tool-call repair handling for local model integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->