### PR TITLE
fix(registry): accept the local provider forms the registry's own error recommends

### DIFF
--- a/src/praisonai/praisonai/llm/registry.py
+++ b/src/praisonai/praisonai/llm/registry.py
@@ -323,11 +323,24 @@ def _get_builtin_provider_loaders() -> Dict[str, Callable[[], ProviderType]]:
     # Build loader dict for the canonical PluginRegistry
     loaders: Dict[str, Callable[[], ProviderType]] = {}
     
-    # Cover the providers parse_model_string() already special-cases.
+    # Cover the providers parse_model_string() already special-cases, plus the
+    # local-server routes. All of these are resolved by litellm, which is what
+    # _make_litellm_factory wraps, so registering them costs nothing beyond the
+    # entry -- and without them `create_llm_provider("ollama/llama3")` raised
+    # "Unknown praisonai.llm_providers plugin: 'ollama'", which is the exact
+    # string parse_model_string() tells users to write a few lines below.
     for name, aliases in [
-        ("openai",    ("oai",)),
-        ("anthropic", ("claude",)),
-        ("google",    ("gemini", "google_genai")),
+        ("openai",      ("oai",)),
+        ("anthropic",   ("claude",)),
+        ("google",      ("gemini", "google_genai")),
+        # Local runtimes. "ollama_chat" is litellm's recommended prefix for
+        # Ollama tool calling; "hosted_vllm" is its name for an OpenAI-compatible
+        # vLLM server.
+        ("ollama",      ()),
+        ("ollama_chat", ()),
+        ("lm_studio",   ()),
+        ("vllm",        ()),
+        ("hosted_vllm", ()),
     ]:
         # Use local function to capture name correctly in closure
         def make_loader(provider_name):

--- a/src/praisonai/tests/unit/llm/test_registry_local_providers.py
+++ b/src/praisonai/tests/unit/llm/test_registry_local_providers.py
@@ -1,0 +1,78 @@
+"""The provider registry must accept the forms its own errors recommend.
+
+`parse_model_string` raises, for an un-inferable model:
+
+    Cannot infer provider from model 'llama3'. Use the 'provider/model' form,
+    e.g. 'ollama/llama3', 'bedrock/anthropic.claude-3-sonnet'.
+
+Following that advice then failed:
+
+    Unknown praisonai.llm_providers plugin: 'ollama'.
+    Available: ['anthropic', 'custom-gateway', 'google', 'litellm-proxy', ...]
+
+Only openai, anthropic and google had builtin loaders, even though every one of
+these routes is resolved by litellm, which is what the loaders wrap.
+"""
+
+import pytest
+
+from praisonai.llm.registry import create_llm_provider, parse_model_string
+
+
+LOCAL_MODELS = [
+    "ollama/llama3",
+    "ollama_chat/llama3",
+    "lm_studio/qwen2.5-7b-instruct",
+    "vllm/meta-llama/Llama-3.1-8B-Instruct",
+    "hosted_vllm/Qwen2.5-7B",
+]
+
+
+@pytest.mark.parametrize("model", LOCAL_MODELS)
+def test_local_provider_can_be_created(model):
+    """The provider/model form must produce a provider, not a ValueError."""
+    provider = create_llm_provider(model)
+    assert provider is not None
+
+
+@pytest.mark.parametrize("model", LOCAL_MODELS)
+def test_local_provider_keeps_the_full_model_string(model):
+    """litellm needs the prefix to route, so it must not be stripped."""
+    provider = create_llm_provider(model)
+    model_attr = getattr(provider, "model_id", None) or getattr(provider, "model", None)
+    assert model_attr is not None
+    assert model.split("/", 1)[1] in str(model_attr)
+
+
+def test_the_exact_example_from_the_error_message_works():
+    """`ollama/llama3` is the string parse_model_string tells users to write."""
+    assert create_llm_provider("ollama/llama3") is not None
+
+
+@pytest.mark.parametrize("model", LOCAL_MODELS)
+def test_parse_model_string_agrees_with_creation(model):
+    parsed = parse_model_string(model)
+    assert parsed["provider_id"] == model.split("/", 1)[0]
+    create_llm_provider(model)  # must not raise
+
+
+# --- unchanged behaviour ------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "model", ["openai/gpt-4o", "anthropic/claude-3-5-sonnet-latest", "google/gemini-1.5-flash"]
+)
+def test_existing_providers_still_work(model):
+    assert create_llm_provider(model) is not None
+
+
+def test_unknown_provider_still_raises():
+    """Adding local routes must not turn the registry into a silent accept-all."""
+    with pytest.raises(ValueError) as exc:
+        create_llm_provider("definitely-not-a-provider/some-model")
+    assert "definitely-not-a-provider" in str(exc.value)
+
+
+def test_uninferable_bare_model_still_raises():
+    with pytest.raises(ValueError) as exc:
+        parse_model_string("llama3")
+    assert "provider/model" in str(exc.value)

--- a/src/praisonai/tests/unit/llm/test_registry_local_providers.py
+++ b/src/praisonai/tests/unit/llm/test_registry_local_providers.py
@@ -37,11 +37,24 @@ def test_local_provider_can_be_created(model):
 
 @pytest.mark.parametrize("model", LOCAL_MODELS)
 def test_local_provider_keeps_the_full_model_string(model):
-    """litellm needs the prefix to route, so it must not be stripped."""
+    """litellm needs the prefix to route, so it must not be stripped.
+
+    The provider stores the prefix (in config["provider"]) and the suffix (in
+    model_id) separately, then reconstructs "provider/model" at request time.
+    Assert BOTH survive -- checking the suffix alone would let a regression that
+    drops the prefix pass here and only fail once litellm is actually called.
+    """
+    provider_id, model_suffix = model.split("/", 1)
+
     provider = create_llm_provider(model)
+
     model_attr = getattr(provider, "model_id", None) or getattr(provider, "model", None)
     assert model_attr is not None
-    assert model.split("/", 1)[1] in str(model_attr)
+    assert model_suffix in str(model_attr)
+
+    # The prefix must survive too, otherwise litellm cannot route the request.
+    prefix = getattr(provider, "config", {}).get("provider")
+    assert prefix == provider_id
 
 
 def test_the_exact_example_from_the_error_message_works():


### PR DESCRIPTION
## Problem

`parse_model_string` tells users, verbatim:

```
Cannot infer provider from model 'llama3'.
Use the 'provider/model' form, e.g. 'ollama/llama3', 'bedrock/anthropic.claude-3-sonnet'.
```

Following that advice failed a few lines later:

```
ValueError: Unknown praisonai.llm_providers plugin: 'ollama'.
Available: ['anthropic', 'custom-gateway', 'google', 'litellm-proxy', 'openai', 'openrouter', ...]
```

`parse_model_string` resolved `ollama/llama3` to `provider_id: 'ollama'` perfectly well. `create_llm_provider` then rejected it — because only `openai`, `anthropic` and `google` had builtin loaders.

## Change

Registers the local routes in the same table: `ollama`, `ollama_chat`, `lm_studio`, `vllm`, `hosted_vllm`.

All of them are resolved by litellm, which is exactly what the loader these entries reuse (`_make_litellm_factory`) wraps — so this costs nothing beyond the table entry. `ollama_chat` is litellm's recommended prefix for Ollama tool calling; `hosted_vllm` is its name for an OpenAI-compatible vLLM server.

| model | before | after |
|---|---|---|
| `ollama/llama3` | **ValueError: Unknown plugin** | `_LiteLLMProvider` |
| `ollama_chat/llama3` | **ValueError: Unknown plugin** | `_LiteLLMProvider` |
| `lm_studio/qwen` | **ValueError: Unknown plugin** | `_LiteLLMProvider` |
| `vllm/x` | **ValueError: Unknown plugin** | `_LiteLLMProvider` |
| `hosted_vllm/y` | **ValueError: Unknown plugin** | `_LiteLLMProvider` |
| `openai/gpt-4o` | `_LiteLLMProvider` | *unchanged* |
| `bogus/x` | ValueError | *unchanged — still raises* |

## Tests

`src/praisonai/tests/unit/llm/test_registry_local_providers.py`, 21 tests, **16 fail before this change**.

One asserts the literal example from the error message now works. Two exist specifically to stop this becoming a silent accept-all: an unknown provider still raises naming the offender, and a bare un-inferable model still raises with the `provider/model` advice intact.

```
test_registry_local_providers.py                       21 passed
tests/unit/{llm,agent,adapters,doctor}/                274 passed, 4 subtests
```

Independent of the other local-model PRs — different package (`praisonai` wrapper, not `praisonaiagents`), different file. Context: #4790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for local LiteLLM runtimes, including Ollama, LM Studio, vLLM, and hosted vLLM.
  * Local models such as `ollama/llama3` can now be created successfully.
  * Model provider prefixes and model names are preserved correctly.
  * Existing provider validation and errors for unknown or incomplete model names remain supported.

* **Tests**
  * Added coverage for local provider creation, model parsing, existing providers, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->