### PR TITLE
ci: add nightly live-Ollama job exercising a real local model

### DIFF
--- a/.github/workflows/test-optimized.yml
+++ b/.github/workflows/test-optimized.yml
@@ -760,6 +760,126 @@ jobs:
       run: echo "✅ Cohere tests skipped (no API key available)"
 
   # ============================================
+  # OLLAMA LIVE TESTS - Real local model, no API key
+  # Nightly / extended only. Installs Ollama on the runner and pulls a small
+  # tools-capable model. Unlike the other live jobs this one needs no secret,
+  # so its required step has no "|| echo" fallback: a failure here is a real
+  # regression in local-model tool calling, not a missing credential.
+  # ============================================
+  extended-ollama:
+    if: github.event_name == 'schedule' || github.event.inputs.tier == 'extended' || github.event.inputs.tier == 'nightly'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Bump deliberately: this is the version everything in this job was
+      # verified against. Latest at time of writing is v0.33.3.
+      OLLAMA_VERSION: v0.33.2
+      # 522 MB, capabilities: completion, tools, thinking.
+      OLLAMA_TEST_MODEL: qwen3:0.6b
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Cache pip packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-ollama-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Cache Ollama model blobs
+      uses: actions/cache@v4
+      with:
+        path: ~/.ollama/models
+        # No restore-keys on purpose: a partial hit from a different model would
+        # silently test something other than OLLAMA_TEST_MODEL.
+        key: ${{ runner.os }}-ollama-models-${{ env.OLLAMA_TEST_MODEL }}
+
+    - name: Install Ollama
+      shell: bash
+      run: |
+        set -euo pipefail
+        # The official installer, but VERSION-PINNED via OLLAMA_VERSION (which it
+        # honours) so this job cannot silently change what it tests. Fetching the
+        # release asset directly is not a workable alternative: since v0.33 the
+        # linux bundle ships as a 1.4 GB .tar.zst with GPU runtimes bundled in,
+        # and the installer already handles the zst/tgz split across versions.
+        sudo apt-get update -qq && sudo apt-get install -y -qq zstd
+        curl -fsSL https://ollama.com/install.sh | sh
+        ollama --version
+
+    - name: Start Ollama and pull model
+      shell: bash
+      run: |
+        set -euo pipefail
+        ollama serve > /tmp/ollama-serve.log 2>&1 &
+        for i in $(seq 1 30); do
+          if curl -sf http://127.0.0.1:11434/api/tags > /dev/null; then
+            echo "Ollama is up after ${i}s"
+            break
+          fi
+          sleep 1
+        done
+        curl -sf http://127.0.0.1:11434/api/tags > /dev/null
+        ollama pull "$OLLAMA_TEST_MODEL"
+        ollama list
+
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install pytest pytest-asyncio pytest-timeout
+    - uses: ./.github/actions/install-monorepo-packages
+      with:
+        agents-extras: ".[all]"
+
+    - name: Run Ollama minimum contract (required)
+      env:
+        PRAISONAI_TEST_TIER: extended
+        PRAISONAI_ALLOW_NETWORK: '1'
+        PRAISONAI_LIVE_TESTS: '1'
+        PRAISONAI_TEST_PROVIDERS: 'ollama'
+        PRAISONAI_TEST_OLLAMA: '1'
+        PRAISONAI_OLLAMA_TEST_MODEL: ${{ env.OLLAMA_TEST_MODEL }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd src/praisonai
+        # No "|| echo" here: no secret is involved, so a failure is a real
+        # regression rather than a missing credential.
+        python -m pytest tests/integration/test_ollama_tool_calling_live.py::TestOllamaCIMinimum \
+          -v --tb=short \
+          --timeout=120
+
+    - name: Run remaining Ollama live tests (informational)
+      if: always()
+      env:
+        PRAISONAI_TEST_TIER: extended
+        PRAISONAI_ALLOW_NETWORK: '1'
+        PRAISONAI_LIVE_TESTS: '1'
+        PRAISONAI_TEST_PROVIDERS: 'ollama'
+        PRAISONAI_TEST_OLLAMA: '1'
+        PRAISONAI_OLLAMA_TEST_MODEL: ${{ env.OLLAMA_TEST_MODEL }}
+      run: |
+        cd src/praisonai
+        python -m pytest tests/integration/test_ollama_tool_calling_live.py \
+          --deselect tests/integration/test_ollama_tool_calling_live.py::TestOllamaCIMinimum \
+          -v --tb=short \
+          --timeout=180 \
+          || echo "Ollama exploratory tests completed (small models are non-deterministic)"
+
+    - name: Ollama server log
+      if: failure()
+      run: tail -100 /tmp/ollama-serve.log
+
+  # ============================================
   # LEGACY UNIT TESTS - Post-C6 re-enabled suite
   # Nightly / extended tier only (~401 tests)
   # ============================================
@@ -836,7 +956,7 @@ jobs:
   # TEST SUMMARY
   # ============================================
   test-summary:
-    needs: [smoke, main]
+    needs: [smoke, main, extended-ollama]
     if: always()
     runs-on: ubuntu-latest
     

--- a/src/praisonai/tests/integration/test_ollama_tool_calling_live.py
+++ b/src/praisonai/tests/integration/test_ollama_tool_calling_live.py
@@ -3,7 +3,9 @@ Live integration tests for Ollama tool calling.
 
 These tests require:
 1. Ollama running locally (default: http://localhost:11434)
-2. olmo-3 model pulled: ollama pull olmo-3
+2. A tools-capable model pulled (default olmo-3; CI uses qwen3:0.6b)
+   Override with PRAISONAI_OLLAMA_TEST_MODEL, e.g.
+       export PRAISONAI_OLLAMA_TEST_MODEL=qwen3:0.6b
 3. Environment variable: PRAISONAI_TEST_OLLAMA=1
 
 Run with:
@@ -20,6 +22,11 @@ pytestmark = pytest.mark.skipif(
     not os.getenv("PRAISONAI_TEST_OLLAMA"),
     reason="Ollama live tests disabled. Set PRAISONAI_TEST_OLLAMA=1 to enable."
 )
+
+
+# CI overrides this with a small, fast model; local runs keep olmo-3 so an
+# existing developer workflow is unchanged.
+OLLAMA_MODEL = "ollama/" + os.getenv("PRAISONAI_OLLAMA_TEST_MODEL", "olmo-3")
 
 
 def calculator(a: int, b: int) -> int:
@@ -53,6 +60,47 @@ def ollama_available():
     return True
 
 
+class TestOllamaCIMinimum:
+    """The minimum contract a local model must satisfy: a tool call round-trips.
+
+    Deliberately narrow. Measured on qwen3:0.6b, this exact configuration
+    (forced tool usage, temperature 0, one arithmetic step) passed 6/6, while
+    the default configuration passed 3/4 and multi-step prompts were worse.
+    Those live in TestOllamaToolCallingLive, which CI runs informationally.
+
+    This is the class the required CI step runs, so it must not grow into a
+    general behaviour suite.
+    """
+
+    def test_tool_call_round_trips(self, ollama_available):
+        from praisonaiagents import Agent
+
+        invocations = []
+
+        def add(a: int, b: int) -> int:
+            """Add two integers together.
+
+            Args:
+                a: First number to add
+                b: Second number to add
+            """
+            invocations.append((a, b))
+            return a + b
+
+        agent = Agent(
+            name="CI Calculator",
+            llm={"model": OLLAMA_MODEL, "force_tool_usage": "always", "temperature": 0},
+            tools=[add],
+        )
+        result = agent.chat("Compute 17 + 25. You MUST use the calculator tool.")
+
+        # Both halves matter. qwen3:0.6b answers "17 + 25 = 42" correctly with no
+        # tools at all, so an answer-only assertion is satisfied by a model that
+        # ignores tools entirely.
+        assert invocations == [(17, 25)], f"tool was not invoked: {invocations!r}"
+        assert "42" in str(result), f"tool result did not round-trip: {result!r}"
+
+
 class TestOllamaToolCallingLive:
     """Live tests for Ollama tool calling with olmo-3."""
 
@@ -62,9 +110,8 @@ class TestOllamaToolCallingLive:
         
         agent = Agent(
             name="Calculator Agent",
-            llm="ollama/olmo-3",
-            tools=[calculator],
-            verbose=True
+            llm=OLLAMA_MODEL,
+            tools=[calculator]
         )
         
         result = agent.chat("Compute 17 + 25. You MUST use the calculator tool.")
@@ -79,10 +126,8 @@ class TestOllamaToolCallingLive:
         
         agent = Agent(
             name="Calculator Agent",
-            llm="ollama/olmo-3",
-            tools=[calculator],
-            force_tool_usage="always",
-            verbose=True
+            llm={"model": OLLAMA_MODEL, "force_tool_usage": "always"},
+            tools=[calculator]
         )
         
         result = agent.chat("What is 17 plus 25?")
@@ -97,9 +142,8 @@ class TestOllamaToolCallingLive:
         
         agent = Agent(
             name="Calculator Agent",
-            llm="ollama/olmo-3",
-            tools=[calculator],
-            verbose=True
+            llm=OLLAMA_MODEL,
+            tools=[calculator]
         )
         
         result = agent.chat(
@@ -115,9 +159,8 @@ class TestOllamaToolCallingLive:
         
         agent = Agent(
             name="Calculator Agent",
-            llm="ollama/olmo-3",
-            tools=[calculator],
-            verbose=True
+            llm=OLLAMA_MODEL,
+            tools=[calculator]
         )
         
         result = agent.chat(
@@ -135,10 +178,8 @@ class TestOllamaToolCallingLive:
         
         agent = Agent(
             name="Calculator Agent",
-            llm="ollama/olmo-3",
-            tools=[calculator],
-            max_tool_repairs=3,
-            verbose=True
+            llm={"model": OLLAMA_MODEL, "max_tool_repairs": 3},
+            tools=[calculator]
         )
         
         result = agent.chat("Calculate 100 + 200 using the calculator tool.")
@@ -152,9 +193,8 @@ class TestOllamaToolCallingLive:
         
         agent = Agent(
             name="Direct Agent",
-            llm="ollama/olmo-3",
+            llm=OLLAMA_MODEL,
             tools=[],  # No tools
-            verbose=True
         )
         
         result = agent.chat("What is 17 + 25?")
@@ -176,9 +216,8 @@ class TestOllamaToolCallingDebugLogging:
         with caplog.at_level(logging.DEBUG):
             agent = Agent(
                 name="Calculator Agent",
-                llm="ollama/olmo-3",
-                tools=[calculator],
-                verbose=True
+                llm=OLLAMA_MODEL,
+                tools=[calculator]
             )
             
             result = agent.chat("Compute 5 + 3 using the calculator tool.")
@@ -202,7 +241,7 @@ if __name__ == "__main__":
     if not check_ollama_available():
         print("ERROR: Ollama is not running at localhost:11434")
         print("Start Ollama with: ollama serve")
-        print("Pull model with: ollama pull olmo-3")
+        print("Pull model with: ollama pull $PRAISONAI_OLLAMA_TEST_MODEL")
         exit(1)
     
     print("Ollama is available. Running tests...")
@@ -213,9 +252,8 @@ if __name__ == "__main__":
     
     agent = Agent(
         name="Calculator Agent",
-        llm="ollama/olmo-3",
-        tools=[calculator],
-        verbose=True
+        llm=OLLAMA_MODEL,
+        tools=[calculator]
     )
     
     print("Test 1: Basic tool call")

--- a/src/praisonai/tests/integration/test_ollama_tool_calling_live.py
+++ b/src/praisonai/tests/integration/test_ollama_tool_calling_live.py
@@ -54,9 +54,21 @@ def check_ollama_available():
 
 @pytest.fixture(scope="module")
 def ollama_available():
-    """Fixture to check Ollama availability."""
+    """Fixture to check Ollama availability.
+
+    When PRAISONAI_TEST_OLLAMA=1 the caller has explicitly asked for these
+    tests to run against a server it is responsible for (the CI job starts and
+    pulls the model itself). In that mode an unreachable server is a real
+    failure, not a reason to skip: a skip would let the "required" CI step exit
+    successfully without ever exercising the tool-call contract. Only a plain
+    local invocation (env var unset — reached via -m or an explicit path) is
+    allowed to skip gracefully.
+    """
     if not check_ollama_available():
-        pytest.skip("Ollama is not running at localhost:11434")
+        message = "Ollama is not running at localhost:11434"
+        if os.getenv("PRAISONAI_TEST_OLLAMA"):
+            pytest.fail(message)
+        pytest.skip(message)
     return True
 
 
@@ -241,7 +253,7 @@ if __name__ == "__main__":
     if not check_ollama_available():
         print("ERROR: Ollama is not running at localhost:11434")
         print("Start Ollama with: ollama serve")
-        print("Pull model with: ollama pull $PRAISONAI_OLLAMA_TEST_MODEL")
+        print(f"Pull model with: ollama pull {OLLAMA_MODEL.split('/', 1)[1]}")
         exit(1)
     
     print("Ollama is available. Running tests...")


### PR DESCRIPTION
## Problem

Six providers have a live CI job in `test-optimized.yml` — openai, anthropic, google, groq, grok_xai, cohere. **Local models have none**, and no job has ever started a model server, so nothing has ever verified that a locally-served model can complete a tool call through `praisonaiagents`.

A suite for this **already exists** — `tests/integration/test_ollama_tool_calling_live.py`, 7 tests, gated on `PRAISONAI_TEST_OLLAMA=1`. It has never run anywhere, and it is **broken against `main`**:

```
Agent(name='C', llm='ollama/qwen3:0.6b', verbose=True)
  TypeError: Agent.__init__() got unexpected keyword argument(s): verbose
Agent(..., force_tool_usage="always")   -> TypeError
Agent(..., max_tool_repairs=3)          -> TypeError
```

All 7 tests use `verbose=True`; two use the other two. **Every test errored on construction.** So this PR is "fix a dead test file and wire it up", not "write a live suite".

## Change

**Test file** — `verbose=True` removed, `force_tool_usage` / `max_tool_repairs` moved into the `llm` dict (the form that works), and the hard-coded `olmo-3` replaced by `PRAISONAI_OLLAMA_TEST_MODEL`, defaulting to `olmo-3` so local developer workflow is unchanged.

**New `TestOllamaCIMinimum::test_tool_call_round_trips`** asserts *both* halves of the round trip:

```python
assert invocations == [(17, 25)]     # our function actually ran, with the right args
assert "42" in str(result)           # its return value reached the answer
```

The first half is the one that matters. `qwen3:0.6b` answers `17 + 25 = 42` correctly with `tools=[]` — measured — so an answer-only assertion is satisfied by a model that ignores tools entirely.

**New nightly `extended-ollama` job**, same `if:` as the other `extended-*` jobs, so it **never runs on a pull request** (asserted before pushing).

## Model choice, measured through `Agent` against a real server

| configuration | trials | tool invoked + correct | latency |
|---|---|---|---|
| default | 4 | 3/4 | 0.5–5.4 s |
| `force_tool_usage="always"` + `temperature=0` | 6 | **6/6** | 0.4–4.0 s |
| multi-step `(17+25)+(8+9)` | 2 | 0/2 (one hung >90 s) | — |

Hence a deliberately narrow **required** step. Running the full suite locally now gives **7 passed, 1 failed** — the failure being that same multi-step test, which is exactly why it sits in the **informational** step.

`qwen3:0.6b` is 522 MB with capabilities `completion, tools, thinking`. Rejected: `smollm2:135m` (**no `tools` capability** — disqualifying), `llama3.2:1b` (2.5× the cache for no measured gain), `qwen2.5:0.5b` (unmeasured, no reason to prefer over a verified model).

## Two deliberate departures from the sibling jobs

**The required step has no `|| echo` fallback.** Every existing live job ends that way, so it can never fail. That is defensible for a key-dependent job — a rotated secret should not page anyone — but Ollama needs no secret and the job controls its own server, so a failure here is a real regression. Exploratory tests run in a second, informational step that keeps the sibling style.

**Install is the official script with `OLLAMA_VERSION` pinned**, not a direct release asset. I tried the pinned-tarball approach first and it does not work: since v0.33 the linux bundle ships as a **1.4 GB `.tar.zst`** with GPU runtimes included, and `ollama-linux-amd64.tgz` 404s. The installer honours `OLLAMA_VERSION` (line 42 of `install.sh`) and already handles the zst/tgz split across versions, so pinning keeps the job reproducible without reimplementing that logic.

Model blobs are cached on the model tag with **no `restore-keys`** — a partial hit from a different model would silently test something other than `OLLAMA_TEST_MODEL`.

## Verification

```
6 consecutive runs of the required test against live Ollama 0.33.2:  6/6 passed
full suite:                                     7 passed, 1 failed (the known-flaky multi-step)
env var absent:                                 8 skipped  (gate holds)
yaml parses; extended-ollama `if:` contains no pull_request/push
```

## Depends on

#4801. Before it, `-m provider_ollama` selects 32 tests across 5 files (only 7 are Ollama tests). This job targets the file and class directly so it does not strictly require that marker, but the two belong together — merge #4801 first.

Context: #4790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added scheduled and on-demand live Ollama tool-calling coverage.
  - Added a required minimum-contract test that treats tool-calling failures as regressions.
  - Exploratory live tests remain informational.
  - Ollama test models can now be configured through an environment variable, with a default model provided.
  - Updated model-specific test settings and manual-run guidance.
  - Test summaries now include the extended Ollama validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->