### PR TITLE
refactor(llm): delete the adapter surface nothing calls

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/adapters/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/llm/adapters/__init__.py
@@ -9,8 +9,6 @@ and integrates with Gap 2 (parallel tool execution).
 """
 
 from ..protocols import LLMProviderAdapterProtocol
-from ..model_capabilities import GEMINI_INTERNAL_TOOLS
-from ..streaming_protocol import StreamingCapableAdapter, get_streaming_adapter
 from typing import Dict, Any, List, Optional
 
 
@@ -23,14 +21,8 @@ class DefaultAdapter:
     def should_summarize_tools(self, iter_count: int) -> bool:
         return iter_count >= 5  # Conservative default
     
-    def format_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        return tools  # No special formatting by default
     
-    def post_tool_iteration(self, state: Dict[str, Any]) -> None:
-        pass  # No post-processing by default
     
-    def supports_structured_output(self) -> bool:
-        return False  # Conservative default
     
     def supports_streaming(self) -> bool:
         return True  # Most providers support streaming
@@ -38,13 +30,7 @@ class DefaultAdapter:
     def supports_streaming_with_tools(self) -> bool:
         return True  # Most providers support streaming with tools
     
-    def get_streaming_adapter(self) -> StreamingCapableAdapter:
-        """Get the streaming adapter for this provider."""
-        # Default providers use the default streaming adapter
-        return get_streaming_adapter("default")
     
-    def get_max_iteration_threshold(self) -> int:
-        return 10  # Conservative default
     
     def format_tool_result_message(self, function_name: str, tool_result: Any, tool_call_id: Optional[str] = None) -> Dict[str, Any]:
         # Standard OpenAI-style tool result message
@@ -65,24 +51,12 @@ class DefaultAdapter:
     def get_default_settings(self) -> Dict[str, Any]:
         return {}  # No provider-specific defaults
     
-    def parse_tool_calls(self, raw_response: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
-        """Default tool call parsing - use OpenAI-style format."""
-        if "choices" in raw_response and len(raw_response["choices"]) > 0:
-            message = raw_response["choices"][0].get("message", {})
-            return message.get("tool_calls")
-        return None
     
-    def should_skip_streaming_with_tools(self) -> bool:
-        return False  # Most providers support streaming with tools
     
     def recover_tool_calls_from_text(self, response_text: str, tools: List[Dict[str, Any]]) -> Optional[List[Dict[str, Any]]]:
         return None  # No text recovery by default
     
-    def inject_cache_control(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        return messages  # No cache control by default
     
-    def extract_reasoning_tokens(self, response: Dict[str, Any]) -> int:
-        return 0  # No reasoning tokens by default
 
 
 class OllamaAdapter(DefaultAdapter):
@@ -105,12 +79,7 @@ class OllamaAdapter(DefaultAdapter):
         # Ollama doesn't reliably support streaming with tools
         return False
     
-    def get_streaming_adapter(self) -> StreamingCapableAdapter:
-        """Get Ollama-specific streaming adapter."""
-        return get_streaming_adapter("ollama")
     
-    def get_max_iteration_threshold(self) -> int:
-        return 1  # Ollama-specific threshold
     
     def format_tool_result_message(self, function_name: str, tool_result: Any, tool_call_id: Optional[str] = None) -> Dict[str, Any]:
         # Ollama uses natural language format for tool results.
@@ -188,13 +157,6 @@ Now provide your final answer using this result. Summarize the information natur
         
         return None
     
-    def post_tool_iteration(self, state: Dict[str, Any]) -> None:
-        # Replaces: Ollama-specific post-tool summary branches
-        if (not state.get('response_text', '').strip() and 
-            state.get('formatted_tools') and 
-            state.get('iteration_count') == 0):
-            # Add Ollama-specific summary logic here
-            state['needs_summary'] = True
     
     def get_default_settings(self) -> Dict[str, Any]:
         return {
@@ -209,8 +171,6 @@ class AnthropicAdapter(DefaultAdapter):
     def supports_prompt_caching(self) -> bool:
         return True  # Claude supports prompt caching
     
-    def supports_structured_output(self) -> bool:
-        return True
 
     def supports_streaming(self) -> bool:
         # litellm.acompletion with stream=True returns a ModelResponse (not async generator)
@@ -220,9 +180,6 @@ class AnthropicAdapter(DefaultAdapter):
     def supports_streaming_with_tools(self) -> bool:
         return False
     
-    def get_streaming_adapter(self) -> StreamingCapableAdapter:
-        """Get Anthropic-specific streaming adapter."""
-        return get_streaming_adapter("anthropic")
 
 
 class GeminiAdapter(DefaultAdapter):
@@ -235,35 +192,13 @@ class GeminiAdapter(DefaultAdapter):
     - Supports structured output
     """
     
-    def should_skip_streaming_with_tools(self) -> bool:
-        """Gemini should skip streaming when tools are present."""
-        return True
     
-    def supports_structured_output(self) -> bool:
-        return True
     
-    def format_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        # Replaces: gemini_internal_tools handling in llm.py
-        # Internal tool names match GEMINI_INTERNAL_TOOLS: {'googleSearch', 'urlContext', 'codeExecution'}
-        formatted = []
-        for tool in tools:
-            if tool.get('name') in GEMINI_INTERNAL_TOOLS:
-                # Convert to Gemini internal tool format
-                formatted.append({
-                    'type': 'function',
-                    'function': tool
-                })
-            else:
-                formatted.append(tool)
-        return formatted
     
     def supports_streaming_with_tools(self) -> bool:
         # Gemini has issues with streaming + tools
         return False
     
-    def get_streaming_adapter(self) -> StreamingCapableAdapter:
-        """Get Gemini-specific streaming adapter."""
-        return get_streaming_adapter("gemini")
 
 
 # Provider adapter registry - public for extension
@@ -318,16 +253,6 @@ def get_provider_adapter(name: str) -> LLMProviderAdapterProtocol:
     return _provider_adapters["default"]
 
 
-def list_provider_adapters() -> List[str]:
-    """List all registered provider adapter names."""
-    return sorted(_provider_adapters.keys())
-
-
-def has_provider_adapter(name: str) -> bool:
-    """Check if a provider adapter is registered."""
-    return name in _provider_adapters
-
-
 __all__ = [
     'DefaultAdapter',
     'OllamaAdapter', 
@@ -335,6 +260,4 @@ __all__ = [
     'GeminiAdapter',
     'get_provider_adapter',
     'add_provider_adapter',
-    'list_provider_adapters',
-    'has_provider_adapter',
 ]

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -3117,12 +3117,7 @@ Respond with ONLY a valid JSON tool call in this format:
                         if formatted_tools and not self._supports_streaming_tools():
                             # Provider doesn't support streaming with tools, use non-streaming
                             use_streaming = False
-                        
-                        # Gemini has issues with streaming + tools, disable streaming for Gemini when tools are present
-                        if use_streaming and formatted_tools and self._is_gemini_model():
-                            logging.debug("Disabling streaming for Gemini model with tools due to JSON parsing issues")
-                            use_streaming = False
-                        
+
                         # Track whether fallback was successful to avoid duplicate API calls
                         fallback_completed = False
                         

--- a/src/praisonai-agents/praisonaiagents/llm/protocols.py
+++ b/src/praisonai-agents/praisonaiagents/llm/protocols.py
@@ -271,15 +271,10 @@ class LLMProviderAdapterProtocol(Protocol):
                 return False
             
             def should_summarize_tools(self, iter_count: int) -> bool:
-                return iter_count >= 3  # Ollama-specific threshold
+                return iter_count >= 1  # Ollama-specific threshold
             
-            def format_tools(self, tools) -> list:
-                return tools  # No special formatting needed
-            
-            def post_tool_iteration(self, state) -> None:
-                if state.get('empty_response') and state.get('tools'):
-                    # Add Ollama-specific tool summary
-                    state['summary'] = "Tool results processed"
+            def supports_streaming_with_tools(self) -> bool:
+                return False  # Ollama doesn't reliably stream with tools
         ```
     """
     

--- a/src/praisonai-agents/praisonaiagents/llm/protocols.py
+++ b/src/praisonai-agents/praisonaiagents/llm/protocols.py
@@ -291,17 +291,8 @@ class LLMProviderAdapterProtocol(Protocol):
         """Check if tools should be summarized at this iteration count."""
         ...
     
-    def format_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Format tools for this provider's requirements."""
-        ...
     
-    def post_tool_iteration(self, state: Dict[str, Any]) -> None:
-        """Handle provider-specific post-tool processing."""
-        ...
     
-    def supports_structured_output(self) -> bool:
-        """Check if provider supports structured JSON output."""
-        ...
     
     def supports_streaming(self) -> bool:
         """Check if provider supports streaming responses."""
@@ -311,9 +302,6 @@ class LLMProviderAdapterProtocol(Protocol):
         """Check if provider supports streaming with tools enabled."""
         ...
     
-    def get_max_iteration_threshold(self) -> int:
-        """Get provider-specific maximum iteration count."""
-        ...
     
     def format_tool_result_message(self, function_name: str, tool_result: Any, tool_call_id: Optional[str] = None) -> Dict[str, Any]:
         """Format tool result message for this provider's requirements."""
@@ -327,25 +315,13 @@ class LLMProviderAdapterProtocol(Protocol):
         """Get provider-specific default settings."""
         ...
     
-    def parse_tool_calls(self, raw_response: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
-        """Parse tool calls from provider-specific response format."""
-        ...
     
-    def should_skip_streaming_with_tools(self) -> bool:
-        """Check if provider should skip streaming when tools are present."""
-        ...
     
     def recover_tool_calls_from_text(self, response_text: str, tools: List[Dict[str, Any]]) -> Optional[List[Dict[str, Any]]]:
         """Attempt to recover tool calls from response text for providers that don't format them properly."""
         ...
     
-    def inject_cache_control(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Inject provider-specific cache control headers."""
-        ...
     
-    def extract_reasoning_tokens(self, response: Dict[str, Any]) -> int:
-        """Extract reasoning token count from provider-specific response."""
-        ...
 
 
 @runtime_checkable  

--- a/src/praisonai-agents/tests/unit/test_adapter_registry.py
+++ b/src/praisonai-agents/tests/unit/test_adapter_registry.py
@@ -346,22 +346,6 @@ class TestLLMProviderAdapters:
         if threshold > 0:
             assert adapter.should_summarize_tools(threshold - 1) is False
 
-    def test_gemini_adapter_formats_internal_tools(self):
-        """GeminiAdapter must recognise the actual Gemini internal tool names."""
-        from praisonaiagents.llm.adapters import GeminiAdapter
-        from praisonaiagents.llm.model_capabilities import GEMINI_INTERNAL_TOOLS
-
-        adapter = GeminiAdapter()
-        tools = [{"name": name} for name in GEMINI_INTERNAL_TOOLS]
-        tools.append({"name": "regular_tool"})
-
-        formatted = adapter.format_tools(tools)
-        internal = [t for t in formatted if "function" in t]
-        regular = [t for t in formatted if "function" not in t]
-
-        assert len(internal) == len(GEMINI_INTERNAL_TOOLS)
-        assert len(regular) == 1
-        assert regular[0]["name"] == "regular_tool"
 
 
 class TestGetProviderAdapter:

--- a/src/praisonai/tests/unit/llm/test_llm_adapter_seam.py
+++ b/src/praisonai/tests/unit/llm/test_llm_adapter_seam.py
@@ -20,17 +20,8 @@ import pytest
 # adapter method with no consumer is the exact defect this file prevents
 # (root AGENTS.md: no exports without a live consumer).
 KNOWN_DEAD = frozenset({
-    "extract_reasoning_tokens",          # no override anywhere, no divergence to abstract
-    "format_tools",                      # inline behaviour in llm.py is the inverse
-    "get_max_iteration_threshold",       # duplicates should_summarize_tools
-    "get_streaming_adapter",             # speculative: no inline equivalent
     "handle_empty_response_with_tools",  # has an exact inline equivalent; wire it
-    "inject_cache_control",              # stub, no implementation anywhere
-    "parse_tool_calls",                  # signature cannot express litellm's ModelResponse
-    "post_tool_iteration",               # sets a flag nothing reads
     "recover_tool_calls_from_text",      # duplicated inline at llm.py:3468-3500; wire it
-    "should_skip_streaming_with_tools",  # subsumed by supports_streaming_with_tools
-    "supports_structured_output",        # model_capabilities already does this per-model
 })
 
 # Attribute-call receivers that denote a provider adapter. Restricting to these


### PR DESCRIPTION
> **Stacked on #4804.** Base is `test/adapter-reachability-ratchet`, so the diff shows only this change. Merge #4804 first; this will retarget to `main` automatically.

## Problem

`DefaultAdapter` declares 17 methods. **Eleven have zero call sites**, plus 2 dead module functions. The ratchet in #4804 now proves it.

## Why most of these are deleted rather than wired

This is the whole judgment call. The instinct is to wire them up — and for most, that would be **wrong**, in ways that only show up when you look for the inline equivalent:

**No inline equivalent anywhere — pure speculative API, nothing to move in:**
`get_streaming_adapter`, `inject_cache_control`, `extract_reasoning_tokens`, `list_provider_adapters`, `has_provider_adapter`

**Inline equivalent exists but is incompatible:**

| method | why wiring it would be a behaviour change |
|---|---|
| `format_tools` | the inline behaviour is the **inverse** of the adapter's — inline passes Gemini internal tools through unwrapped, the adapter wraps them |
| `parse_tool_calls` | its `Dict[str, Any]` signature cannot express the litellm `ModelResponse` object that `llm.py:4591` actually receives; wiring it means inventing API |
| `post_tool_iteration` | sets a state flag nothing reads; the real behaviour is *append a message and continue*, not expressible through a `None`-returning mutator |

**Strictly worse than what already exists:**

| method | what already does the job |
|---|---|
| `supports_structured_output` | `model_capabilities.supports_structured_outputs` — live, and per-**model** rather than per-**provider** |
| `get_max_iteration_threshold` | duplicates `should_summarize_tools`; wiring it would change the threshold from 1 to 10 for every non-Ollama provider |

**Provably unreachable:** `should_skip_streaming_with_tools` — `GeminiAdapter.supports_streaming_with_tools()` is already `False`, so the guard three lines above always fires first.

An agent told to "wire up the adapter" without this analysis would have invented implementations for five methods, with no test that could ever have failed against them.

## Also removed

The `llm.py` branch that shadowed the last one:

```python
if use_streaming and formatted_tools and self._is_gemini_model():   # can never be true
```

It sits immediately after `use_streaming` has already been set `False` for exactly that case. Verified: `get_provider_adapter('gemini').supports_streaming_with_tools()` is `False`.

`has_provider_adapter` carried a latent bug on its way out — no `.lower()`, so `has_provider_adapter("Ollama")` was `False` while `get_provider_adapter("Ollama")` succeeded. Untested dead code that disagreed with its own sibling.

## Result

`DefaultAdapter`: **17 methods → 8**. Six have live call sites. The two still in `KNOWN_DEAD` — `handle_empty_response_with_tools` and `recover_tool_calls_from_text` — each have an *exact inline duplicate* in `llm.py` and are wired in a follow-up rather than deleted.

`add_provider_adapter` is deliberately **kept** despite also having zero callers: it is the one name a third party would plausibly have found, and making it reachable is a change to `_detect_provider`, which belongs to a different work order.

## Safety

One test exercised a deleted surface and is removed with it (`test_gemini_adapter_formats_internal_tools`). A repo-wide scan found **two other name matches, both unrelated and untouched**: `OpenAIClient.format_tools`, and the module-level `get_streaming_adapter` in `streaming_protocol.py` imported directly by `test_architectural_fixes.py`.

That distinction is exactly why the ratchet matches on the **receiver** rather than the bare method name — a naive scan would have reported these deletions as breaking live code.

Nothing in `praisonaiagents.llm.adapters` is re-exported from `praisonaiagents` or `praisonaiagents.llm`, and none of these names appears in docs, so this is not a public-surface removal in practice.

```
tests/unit/{llm,agent,adapters,doctor}/     257 passed, 4 subtests
test_adapter_registry.py                     37 passed  (was 38, minus the removed test)
test_llm_adapter_seam.py                      4 passed  (KNOWN_DEAD 11 -> 2)
end-to-end ollama/qwen3:0.6b                 answers correctly
```

The two failures in `test_architectural_fixes.py` reproduce identically with this change stashed — they need a live OpenAI key.

Context: #4790 order 06, step 06.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
