### PR TITLE
feat(local): resolve a running local model server, and wire Agent(llm="local")

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -2145,6 +2145,21 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
         if reasoning_effort is not None:
             self._llm_option_kwargs['reasoning_effort'] = reasoning_effort
 
+        # Local-runtime descriptor: llm="local" (or "local:<engine>/<model>").
+        # Opt-in only -- discovery never fires for any other spec, so a fully
+        # configured agent pays nothing. Resolved here into a concrete
+        # provider/model so the normal LLM path handles it unchanged.
+        if isinstance(llm, str) and (llm == "local" or llm.startswith("local:")):
+            from ..local import resolve as _resolve_local
+            _spec = llm[len("local:"):] if llm.startswith("local:") else None
+            _target = _resolve_local(_spec or None)
+            llm = _target.litellm_model
+            if base_url is None:
+                base_url = _target.base_url
+            if api_key is None:
+                api_key = _target.api_key
+            self._local_target = _target
+
         # Panel (multi-model) descriptor: "panel:<name>" or {"provider": "panel"}.
         # Resolved lazily into a PanelLLM; composes with the normal tool loop.
         # Detected inline (no heavy import) to keep Agent() construction lazy.

--- a/src/praisonai-agents/praisonaiagents/local/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/local/__init__.py
@@ -1,0 +1,55 @@
+"""Local model runtime resolution: what is running, what it can do, what it gets wrong.
+
+Every local runtime worth supporting already speaks OpenAI over HTTP, and litellm
+already owns that transport. This package is therefore NOT a transport and NOT a
+client. It answers three questions and returns the answers as frozen data:
+
+  1. What is running on this machine?      discover()
+  2. What can that model actually do?      capabilities via resolve()
+  3. What will it silently get wrong?      quirktable
+
+Two properties are load-bearing and are enforced by tests:
+
+  * It is a dependency sink. Every module here imports only the standard library
+    and its siblings -- nothing from praisonaiagents. That is what lets modules
+    which currently bypass the LLM layer adopt it without deepening the 26
+    mutually-importing subpackage pairs the package already has.
+
+  * It produces data, never behaviour. No chat call, no retry, no request
+    mutation, no process management, no disk writes. Compensating behaviour
+    belongs in llm/adapters/.
+"""
+
+from .capabilities import (ApiStyle, Cap, DEFAULT_CAPS, Evidence, LocalEngine,
+                           default_caps, parse_llama_cpp_props,
+                           parse_lm_studio_models, parse_ollama_capabilities,
+                           parse_openai_models)
+from .discover import (DEFAULT_PROBE_TIMEOUT, DEFAULT_TOTAL_BUDGET, Discovery,
+                       HttpReply, LOOPBACK_HOST, PROBES, ProbeSpec, Rule, RuleKind,
+                       discover, models, probe_endpoint, probe_table)
+from .quirktable import (NOTES, Quirk, QuirkNote, Severity, all_notes, note,
+                         notes_for, quirks_for, silent_quirks)
+from .errors import (EngineUnreachableError, HostHeaderRejectedError,
+                     InvalidLocalSpecError, LocalError, ModelNotAvailableError,
+                     NoLocalEngineError)
+from .target import (DEFAULT_API_KEY, ENV_BASE_URL, ENV_ENGINE, ENV_MODEL,
+                     LocalTarget, build_target, litellm_model_for,
+                     parse_ollama_host, parse_spec, select_model)
+from .resolve import cache_info, clear_cache, resolve, resolve_or_none
+
+__all__ = [
+    "LocalEngine", "ApiStyle", "Cap", "Evidence", "Severity", "Quirk",
+    "DEFAULT_CAPS", "default_caps", "parse_ollama_capabilities",
+    "parse_llama_cpp_props", "parse_lm_studio_models", "parse_openai_models",
+    "Discovery", "HttpReply", "ProbeSpec", "Rule", "RuleKind", "PROBES",
+    "LOOPBACK_HOST", "DEFAULT_PROBE_TIMEOUT", "DEFAULT_TOTAL_BUDGET",
+    "discover", "probe_endpoint", "probe_table", "models",
+    "QuirkNote", "NOTES", "note", "all_notes", "notes_for", "quirks_for",
+    "silent_quirks",
+    "LocalTarget", "resolve", "resolve_or_none", "build_target",
+    "litellm_model_for", "parse_spec", "parse_ollama_host", "select_model",
+    "clear_cache", "cache_info", "DEFAULT_API_KEY", "ENV_BASE_URL", "ENV_ENGINE",
+    "ENV_MODEL",
+    "LocalError", "NoLocalEngineError", "EngineUnreachableError",
+    "HostHeaderRejectedError", "ModelNotAvailableError", "InvalidLocalSpecError",
+]

--- a/src/praisonai-agents/praisonaiagents/local/capabilities.py
+++ b/src/praisonai-agents/praisonaiagents/local/capabilities.py
@@ -1,0 +1,168 @@
+"""Local-engine vocabulary and capability resolution.
+
+Layer 0 of ``praisonaiagents.local``: standard library only, no sibling imports
+beyond none at all. This module owns the shared vocabulary (``LocalEngine``,
+``ApiStyle``, ``Cap``, ``Evidence``) as well as the capability parsers, because
+that is the only placement that keeps the package's import graph acyclic.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Mapping
+
+__all__ = [
+    "LocalEngine", "ApiStyle", "Cap", "Evidence",
+    "DEFAULT_CAPS", "default_caps",
+    "parse_ollama_capabilities", "parse_llama_cpp_props",
+    "parse_lm_studio_models", "parse_openai_models",
+]
+
+
+class LocalEngine(str, Enum):
+    """A local model server. Never called "runtime": that name is taken."""
+
+    OLLAMA = "ollama"
+    LLAMA_CPP = "llama_cpp"
+    MLX_LM = "mlx_lm"
+    LM_STUDIO = "lm_studio"
+    VLLM = "vllm"
+    TRANSFORMERS_SERVE = "transformers_serve"
+    LLAMAFILE = "llamafile"
+    LOCALAI = "localai"
+    RAMALAMA = "ramalama"
+    UNKNOWN = "unknown"
+
+
+class ApiStyle(str, Enum):
+    OPENAI_CHAT = "openai_chat"
+    OPENAI_COMPLETIONS = "openai_completions"
+    OLLAMA_NATIVE = "ollama_native"
+
+
+class Cap(str, Enum):
+    CHAT = "chat"
+    COMPLETION = "completion"
+    TOOLS = "tools"
+    VISION = "vision"
+    AUDIO_IN = "audio_in"
+    THINKING = "thinking"
+    JSON_OBJECT = "json_object"
+    JSON_SCHEMA = "json_schema"
+    STREAMING = "streaming"
+    STREAMING_WITH_TOOLS = "streaming_with_tools"
+    PARALLEL_TOOL_CALLS = "parallel_tool_calls"
+    EMBEDDINGS_ENDPOINT = "embeddings_endpoint"
+
+
+class Evidence(str, Enum):
+    """Where a field's value came from. Keeps guesses distinguishable from facts."""
+
+    SERVER = "server"
+    TABLE = "table"
+    ENV = "env"
+    SPEC = "spec"
+    UNKNOWN = "unknown"
+
+
+# Static per-engine floor. Cap.TOOLS and Cap.VISION are deliberately absent from
+# every row: claiming them without server evidence is exactly the silent failure
+# this package exists to prevent.
+DEFAULT_CAPS: Mapping[LocalEngine, frozenset] = {
+    LocalEngine.OLLAMA: frozenset({
+        Cap.CHAT, Cap.COMPLETION, Cap.STREAMING, Cap.JSON_OBJECT,
+        Cap.JSON_SCHEMA, Cap.EMBEDDINGS_ENDPOINT}),
+    LocalEngine.LLAMA_CPP: frozenset({
+        Cap.CHAT, Cap.COMPLETION, Cap.STREAMING, Cap.JSON_SCHEMA,
+        Cap.JSON_OBJECT, Cap.EMBEDDINGS_ENDPOINT}),
+    LocalEngine.MLX_LM: frozenset({Cap.CHAT, Cap.COMPLETION, Cap.STREAMING}),
+    LocalEngine.LM_STUDIO: frozenset({
+        Cap.CHAT, Cap.COMPLETION, Cap.STREAMING, Cap.JSON_SCHEMA,
+        Cap.JSON_OBJECT, Cap.EMBEDDINGS_ENDPOINT}),
+    LocalEngine.VLLM: frozenset({
+        Cap.CHAT, Cap.COMPLETION, Cap.STREAMING, Cap.JSON_SCHEMA, Cap.JSON_OBJECT,
+        Cap.EMBEDDINGS_ENDPOINT, Cap.PARALLEL_TOOL_CALLS}),
+    LocalEngine.TRANSFORMERS_SERVE: frozenset({Cap.CHAT, Cap.STREAMING}),
+    LocalEngine.LLAMAFILE: frozenset({Cap.CHAT, Cap.COMPLETION, Cap.STREAMING}),
+    LocalEngine.LOCALAI: frozenset({Cap.CHAT, Cap.COMPLETION, Cap.STREAMING}),
+    LocalEngine.RAMALAMA: frozenset({Cap.CHAT, Cap.COMPLETION, Cap.STREAMING}),
+    LocalEngine.UNKNOWN: frozenset({Cap.CHAT, Cap.STREAMING}),
+}
+
+
+def default_caps(engine) -> frozenset:
+    """Return the static per-engine capability floor (no network, Evidence.TABLE)."""
+    try:
+        return DEFAULT_CAPS[LocalEngine(engine)]
+    except (KeyError, ValueError):
+        return DEFAULT_CAPS[LocalEngine.UNKNOWN]
+
+
+_OLLAMA_CAP_MAP = {
+    "completion": (Cap.COMPLETION, Cap.CHAT),
+    "tools": (Cap.TOOLS,),
+    "vision": (Cap.VISION,),
+    "thinking": (Cap.THINKING,),
+    "embedding": (Cap.EMBEDDINGS_ENDPOINT,),
+    "audio": (Cap.AUDIO_IN,),
+}
+
+
+def parse_ollama_capabilities(payload: Mapping[str, Any]) -> frozenset:
+    """Map an Ollama /api/show or /api/tags entry's ``capabilities`` list onto Cap.
+
+    Unknown strings ("insert", anything new) are ignored rather than raised on,
+    so a newer Ollama cannot break resolution.
+    """
+    out = set()
+    try:
+        for name in payload.get("capabilities") or ():
+            out.update(_OLLAMA_CAP_MAP.get(str(name).lower(), ()))
+    except AttributeError:
+        return frozenset()
+    return frozenset(out)
+
+
+def parse_llama_cpp_props(payload: Mapping[str, Any]) -> frozenset:
+    """Map a llama.cpp GET /props reply onto Cap."""
+    out = {Cap.CHAT, Cap.COMPLETION, Cap.STREAMING}
+    try:
+        modalities = payload.get("modalities") or {}
+        if modalities.get("vision"):
+            out.add(Cap.VISION)
+        if modalities.get("audio"):
+            out.add(Cap.AUDIO_IN)
+        template = str(payload.get("chat_template") or "")
+        if "tool" in template.lower():
+            out.add(Cap.TOOLS)
+    except AttributeError:
+        return frozenset()
+    return frozenset(out)
+
+
+def parse_lm_studio_models(payload: Mapping[str, Any], model_id) -> frozenset:
+    """Map an LM Studio GET /api/v0/models entry onto Cap."""
+    out = {Cap.CHAT, Cap.COMPLETION, Cap.STREAMING}
+    try:
+        for entry in payload.get("data") or ():
+            if model_id and entry.get("id") != model_id:
+                continue
+            if entry.get("type") == "embeddings":
+                out.add(Cap.EMBEDDINGS_ENDPOINT)
+            if entry.get("vision"):
+                out.add(Cap.VISION)
+            if entry.get("tool_use") or entry.get("function_calling"):
+                out.add(Cap.TOOLS)
+    except AttributeError:
+        return frozenset()
+    return frozenset(out)
+
+
+def parse_openai_models(payload: Mapping[str, Any]) -> tuple:
+    """Extract model ids from an OpenAI-shaped {"data":[{"id":...}]} reply."""
+    try:
+        return tuple(
+            str(e["id"]) for e in (payload.get("data") or ()) if isinstance(e, dict) and "id" in e
+        )
+    except AttributeError:
+        return ()

--- a/src/praisonai-agents/praisonaiagents/local/discover.py
+++ b/src/praisonai-agents/praisonaiagents/local/discover.py
@@ -1,0 +1,387 @@
+"""Identify which local model server is listening, without inferring from the port.
+
+Port collisions are real: 8080 is claimed by llama-server, mlx_lm, llamafile,
+LocalAI and RamaLama; 8000 by vLLM and `transformers serve`. Identity is therefore
+never inferred from a port -- a ProbeSpec matches only when every Rule holds, and
+RuleKind.ABSENT rules exist specifically to separate co-tenants of one port.
+
+Standard library only. urllib.request rather than httpx: httpx is present only as
+an undeclared transitive dependency of `openai`, and a package whose whole point
+is that anything can import it must not rest on that.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import http.client
+import json
+import socket
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Sequence
+
+from .capabilities import ApiStyle, Evidence, LocalEngine, parse_openai_models
+from .errors import InvalidLocalSpecError
+
+__all__ = [
+    "HttpReply", "RuleKind", "Rule", "ProbeSpec", "Discovery",
+    "PROBES", "LOOPBACK_HOST", "DEFAULT_PROBE_TIMEOUT", "DEFAULT_TOTAL_BUDGET",
+    "probe_table", "probe_endpoint", "discover", "models", "default_transport",
+]
+
+LOOPBACK_HOST = "127.0.0.1"
+DEFAULT_PROBE_TIMEOUT = 0.4
+DEFAULT_TOTAL_BUDGET = 1.5
+_MAX_BODY = 1 << 20  # 1 MiB
+
+
+@dataclass(frozen=True)
+class HttpReply:
+    status: int                 # 0 == transport failure
+    body: bytes = b""
+    error: Optional[str] = None  # "refused" | "timeout" | "reset" | "http" | None
+
+
+class RuleKind(str, Enum):
+    BODY_PREFIX = "body_prefix"
+    JSON_KEY = "json_key"
+    STATUS_OK = "status_ok"
+    ABSENT = "absent"
+
+
+@dataclass(frozen=True)
+class Rule:
+    method: str
+    path: str
+    kind: RuleKind
+    value: str = ""
+
+
+@dataclass(frozen=True)
+class ProbeSpec:
+    engine: LocalEngine
+    default_ports: tuple
+    identity: tuple
+    api_style: ApiStyle
+    verified: bool
+    note: str
+    version_path: Optional[str] = None
+    version_key: Optional[str] = None
+    models_path: Optional[str] = None
+    models_key: Optional[str] = None
+    model_caps: Optional[Rule] = None
+
+
+@dataclass(frozen=True)
+class Discovery:
+    engine: LocalEngine
+    base_url: str
+    api_style: ApiStyle
+    evidence: Evidence
+    engine_version: Optional[str] = None
+    models: tuple = ()
+    # Per-model metadata when the server offers it, as a tuple of
+    # (model_id, capabilities_tuple, modified_at) -- enough to choose a model
+    # without a second request. Empty when the server reports names only.
+    model_meta: tuple = ()
+    raw_identity: str = ""
+    latency_ms: int = 0
+    blocked: Optional[str] = None
+
+
+PROBES: tuple = (
+    ProbeSpec(
+        engine=LocalEngine.OLLAMA,
+        default_ports=(11434,),
+        identity=(Rule("GET", "/", RuleKind.BODY_PREFIX, "Ollama is running"),),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=True,
+        note=("verified 0.33.2 @ 2026-09-03: GET / -> 'Ollama is running'; "
+              "/api/version -> {'version':'0.33.2'}; /api/tags entries carry "
+              "capabilities and modified_at; POST /api/show carries capabilities."),
+        version_path="/api/version", version_key="version",
+        models_path="/api/tags", models_key="models[].model",
+        model_caps=Rule("POST", "/api/show", RuleKind.JSON_KEY, "capabilities"),
+    ),
+    ProbeSpec(
+        engine=LocalEngine.LLAMA_CPP,
+        default_ports=(8080,),
+        identity=(Rule("GET", "/health", RuleKind.STATUS_OK),
+                  Rule("GET", "/props", RuleKind.JSON_KEY, "build_info")),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note=("binary present (build 7620), --port default 8080 confirmed from "
+              "--help; /props reply shape NOT re-verified live."),
+        version_path="/props", version_key="build_info",
+        models_path="/v1/models", models_key="data[].id",
+        model_caps=Rule("GET", "/props", RuleKind.JSON_KEY, "modalities"),
+    ),
+    ProbeSpec(
+        engine=LocalEngine.MLX_LM,
+        default_ports=(8080,),
+        identity=(Rule("GET", "/health", RuleKind.STATUS_OK),
+                  Rule("GET", "/props", RuleKind.ABSENT),
+                  Rule("GET", "/v1/models", RuleKind.JSON_KEY, "data")),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note=("mlx_lm.server present on PATH; default port 8080. Identity is "
+              "'/health answers AND /props does not', to separate it from "
+              "llama.cpp on the same port."),
+        models_path="/v1/models", models_key="data[].id",
+    ),
+    ProbeSpec(
+        engine=LocalEngine.LM_STUDIO,
+        default_ports=(1234,),
+        identity=(Rule("GET", "/api/v0/models", RuleKind.JSON_KEY, "data"),),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note=("LM Studio not installed on the machine this was written on. "
+              "/api/v0/models is richer than /v1/models and is the discriminator. "
+              "Use HTTP, not the Python SDK (stale since Aug 2025, WebSocket-based)."),
+        models_path="/api/v0/models", models_key="data[].id",
+        model_caps=Rule("GET", "/api/v0/models", RuleKind.JSON_KEY, "data"),
+    ),
+    ProbeSpec(
+        engine=LocalEngine.VLLM,
+        default_ports=(8000,),
+        identity=(Rule("GET", "/version", RuleKind.JSON_KEY, "version"),),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note=("Linux only. Tools require BOTH --enable-auto-tool-choice AND "
+              "--tool-call-parser, else tool calls come back as plain text."),
+        version_path="/version", version_key="version",
+        models_path="/v1/models", models_key="data[].id",
+    ),
+    ProbeSpec(
+        engine=LocalEngine.TRANSFORMERS_SERVE,
+        default_ports=(8000,),
+        identity=(Rule("GET", "/version", RuleKind.ABSENT),
+                  Rule("GET", "/health", RuleKind.STATUS_OK),
+                  Rule("GET", "/v1/models", RuleKind.JSON_KEY, "data")),
+        api_style=ApiStyle.OPENAI_CHAT,
+        verified=False,
+        note=("`transformers serve`, default 8000; /health is undocumented. "
+              "Identity is '/version absent AND /health ok', to separate it "
+              "from vLLM on 8000."),
+        models_path="/v1/models", models_key="data[].id",
+    ),
+)
+
+
+def probe_table() -> tuple:
+    """The ordered probe table (identity endpoints and discriminators)."""
+    return PROBES
+
+
+def default_transport(method: str, url: str, body, timeout: float) -> HttpReply:
+    """The only thing in this package that touches a socket."""
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Accept", "application/json")
+    req.add_header("User-Agent", "praisonaiagents-local/1")
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return HttpReply(resp.status, resp.read(_MAX_BODY))
+    except urllib.error.HTTPError as exc:
+        # HTTPError is both an exception and a response: read it, don't leak it.
+        try:
+            payload = exc.read(_MAX_BODY)
+        except Exception:
+            payload = b""
+        return HttpReply(exc.code, payload, "http")
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", None)
+        if isinstance(reason, socket.timeout) or isinstance(reason, TimeoutError):
+            return HttpReply(0, b"", "timeout")
+        return HttpReply(0, b"", "refused")
+    except (socket.timeout, TimeoutError):
+        return HttpReply(0, b"", "timeout")
+    except ConnectionResetError:
+        return HttpReply(0, b"", "reset")
+    except (OSError, ValueError, http.client.HTTPException):
+        return HttpReply(0, b"", "refused")
+
+
+def _json(reply: HttpReply):
+    try:
+        return json.loads(reply.body.decode("utf-8", errors="replace"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _rule_holds(rule: Rule, reply: HttpReply) -> bool:
+    if rule.kind is RuleKind.ABSENT:
+        if reply.status in (404, 405):
+            return True
+        if reply.status == 0:
+            return False
+        return _json(reply) is None
+    if rule.kind is RuleKind.STATUS_OK:
+        return 200 <= reply.status < 300
+    if reply.status != 200:
+        return False
+    if rule.kind is RuleKind.BODY_PREFIX:
+        return reply.body.decode("utf-8", errors="replace").lstrip().startswith(rule.value)
+    if rule.kind is RuleKind.JSON_KEY:
+        obj = _json(reply)
+        return isinstance(obj, dict) and rule.value in obj
+    return False
+
+
+def _extract_model_meta(payload, key) -> tuple:
+    """Per-model (id, capabilities, modified_at) when the listing carries it."""
+    if key != "models[].model" or not isinstance(payload, dict):
+        return ()
+    out = []
+    for m in payload.get("models") or ():
+        if isinstance(m, dict) and "model" in m:
+            caps = tuple(str(c).lower() for c in (m.get("capabilities") or ()))
+            out.append((str(m["model"]), caps, str(m.get("modified_at") or "")))
+    return tuple(out)
+
+
+def _extract_models(payload, key) -> tuple:
+    if not isinstance(payload, dict) or not key:
+        return ()
+    if key == "data[].id":
+        return parse_openai_models(payload)
+    if key == "models[].model":
+        return tuple(
+            str(m["model"]) for m in (payload.get("models") or ())
+            if isinstance(m, dict) and "model" in m
+        )
+    return ()
+
+
+def probe_endpoint(base_url: str, *, expect=None, timeout: float = DEFAULT_PROBE_TIMEOUT,
+                   transport=None) -> Optional[Discovery]:
+    """Identify the server at ``base_url``, or None if nothing identifiable answered.
+
+    A 200 that matches no discriminator yields engine=UNKNOWN. A bodyless 403
+    yields blocked="host_header_rejected" rather than being reported as absent.
+    """
+    base = (base_url or "").rstrip("/")
+    if "://" not in base or not base.split("://", 1)[1]:
+        raise InvalidLocalSpecError(f"Not a usable base URL: {base_url!r}")
+    send = transport or default_transport
+    started = time.monotonic()
+
+    candidates = [p for p in PROBES if expect is None or p.engine == LocalEngine(expect)]
+    cache = {}
+
+    def fetch(method, path, body=None):
+        key = (method, path)
+        if key not in cache:
+            cache[key] = send(method, base + path, body, timeout)
+        return cache[key]
+
+    first_reply = None
+    for spec in candidates:
+        ok = True
+        for rule in spec.identity:
+            reply = fetch(rule.method, rule.path,
+                          b'{"model":""}' if rule.method == "POST" else None)
+            if first_reply is None:
+                first_reply = reply
+            if reply.status in (401, 403) and not reply.body:
+                return Discovery(
+                    engine=LocalEngine(expect) if expect else LocalEngine.UNKNOWN,
+                    base_url=base, api_style=spec.api_style, evidence=Evidence.TABLE,
+                    blocked="host_header_rejected",
+                    latency_ms=int((time.monotonic() - started) * 1000))
+            if not _rule_holds(rule, reply):
+                ok = False
+                break
+        if not ok:
+            continue
+        version = None
+        if spec.version_path:
+            obj = _json(fetch("GET", spec.version_path))
+            if isinstance(obj, dict) and spec.version_key:
+                v = obj.get(spec.version_key)
+                version = str(v) if v is not None else None
+        found, meta = (), ()
+        if spec.models_path:
+            listing = _json(fetch("GET", spec.models_path))
+            found = _extract_models(listing, spec.models_key)
+            meta = _extract_model_meta(listing, spec.models_key)
+        raw = b""
+        if spec.identity:
+            raw = fetch(spec.identity[0].method, spec.identity[0].path).body
+        return Discovery(
+            engine=spec.engine, base_url=base, api_style=spec.api_style,
+            evidence=Evidence.SERVER, engine_version=version, models=found,
+            model_meta=meta,
+            raw_identity=raw.decode("utf-8", errors="replace")[:200],
+            latency_ms=int((time.monotonic() - started) * 1000))
+
+    # Something answered but matched no discriminator: report it honestly.
+    if first_reply is not None and first_reply.status == 200:
+        listing = _json(fetch("GET", "/v1/models"))
+        return Discovery(
+            engine=LocalEngine.UNKNOWN, base_url=base,
+            api_style=ApiStyle.OPENAI_CHAT if isinstance(listing, dict) else ApiStyle.OPENAI_COMPLETIONS,
+            evidence=Evidence.TABLE,
+            models=parse_openai_models(listing) if isinstance(listing, dict) else (),
+            raw_identity=first_reply.body.decode("utf-8", errors="replace")[:200],
+            latency_ms=int((time.monotonic() - started) * 1000))
+    return None
+
+
+def discover(*, ports: Optional[Sequence] = None, include: Optional[Sequence] = None,
+             host: str = LOOPBACK_HOST, timeout: float = DEFAULT_PROBE_TIMEOUT,
+             budget: float = DEFAULT_TOTAL_BUDGET, transport=None) -> tuple:
+    """Scan the probe table's default ports; return every server found.
+
+    Ports are probed concurrently. Results are ordered by PROBES order then port,
+    so Ollama on 11434 outranks an unidentified server on 8000. Never raises.
+    """
+    wanted = [p for p in PROBES if include is None or p.engine in {LocalEngine(e) for e in include}]
+    targets = []
+    for spec in wanted:
+        for port in (ports if ports is not None else spec.default_ports):
+            targets.append((spec.engine, port))
+    seen_ports = sorted({p for _, p in targets})
+
+    results = {}
+    deadline = time.monotonic() + budget
+
+    def work(port):
+        if time.monotonic() > deadline:
+            return port, None
+        try:
+            return port, probe_endpoint(f"http://{host}:{port}", timeout=timeout,
+                                        transport=transport)
+        except Exception:
+            return port, None
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        for port, found in pool.map(work, seen_ports):
+            if found is not None:
+                results[port] = found
+
+    ordered = []
+    for spec in wanted:
+        for port in (ports if ports is not None else spec.default_ports):
+            found = results.get(port)
+            if found is not None and found.engine == spec.engine and found not in ordered:
+                ordered.append(found)
+    for found in results.values():
+        if found not in ordered:
+            ordered.append(found)
+    return tuple(ordered)
+
+
+def models(discovery: Discovery, *, timeout: float = DEFAULT_PROBE_TIMEOUT,
+           transport=None) -> tuple:
+    """List model ids served at ``discovery.base_url`` (GET only). Never raises."""
+    spec = next((p for p in PROBES if p.engine == discovery.engine), None)
+    if spec is None or not spec.models_path:
+        return discovery.models
+    send = transport or default_transport
+    reply = send("GET", discovery.base_url + spec.models_path, None, timeout)
+    return _extract_models(_json(reply), spec.models_key) or discovery.models

--- a/src/praisonai-agents/praisonaiagents/local/errors.py
+++ b/src/praisonai-agents/praisonaiagents/local/errors.py
@@ -1,0 +1,48 @@
+"""Exceptions raised by praisonaiagents.local.
+
+Deliberately NOT subclasses of praisonaiagents.errors: this package imports
+nothing from praisonaiagents, and wrapping is the integration layer's job.
+"""
+
+from __future__ import annotations
+
+__all__ = ["LocalError", "NoLocalEngineError", "EngineUnreachableError",
+           "HostHeaderRejectedError", "ModelNotAvailableError",
+           "InvalidLocalSpecError"]
+
+
+class LocalError(Exception):
+    """Base class for every error raised by praisonaiagents.local.
+
+    Deliberately not a subclass of praisonaiagents.errors: this package imports
+    nothing from praisonaiagents, and wrapping is the integration layer's job.
+    """
+
+
+class NoLocalEngineError(LocalError):
+    """No local model server could be found or was named."""
+
+
+class EngineUnreachableError(LocalError):
+    """An explicitly named local server did not answer."""
+
+    def __init__(self, message, base_url="", reason="", source=""):
+        super().__init__(message)
+        self.base_url = base_url
+        self.reason = reason
+        self.source = source
+
+
+class HostHeaderRejectedError(EngineUnreachableError):
+    """The server returned a bodyless 403 because the Host header was not local."""
+
+
+class ModelNotAvailableError(LocalError):
+    def __init__(self, message, model_id="", available=()):
+        super().__init__(message)
+        self.model_id = model_id
+        self.available = tuple(available)
+
+
+class InvalidLocalSpecError(LocalError, ValueError):
+    """The spec string could not be parsed."""

--- a/src/praisonai-agents/praisonaiagents/local/quirktable.py
+++ b/src/praisonai-agents/praisonaiagents/local/quirktable.py
@@ -1,0 +1,180 @@
+"""Static catalogue of local-engine behaviours that fail without an error.
+
+Pure data. No network, no I/O, no environment reads. Every SILENT entry is a way
+a local server returns HTTP 200 and a wrong result.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, Mapping
+
+from .capabilities import ApiStyle, Cap, LocalEngine
+
+__all__ = ["Severity", "Quirk", "QuirkNote", "NOTES", "note", "all_notes",
+           "notes_for", "quirks_for", "silent_quirks"]
+
+
+class Severity(str, Enum):
+    SILENT = "silent"   # wrong result, no error surface -- the dangerous class
+    HARD = "hard"       # the request fails loudly (4xx/5xx)
+    COST = "cost"       # correct result, unexpected latency or resource cost
+
+
+class Quirk(str, Enum):
+    FORMAT_AND_TOOLS_MUTUALLY_DESTRUCTIVE = "format_and_tools_mutually_destructive"
+    TOOL_SCHEMA_KEYWORDS_STRIPPED = "tool_schema_keywords_stripped"
+    TOOL_PARAM_TYPE_MUST_BE_BARE_STRING = "tool_param_type_must_be_bare_string"
+    UNKNOWN_OPTIONS_ACCEPTED_AND_IGNORED = "unknown_options_accepted_and_ignored"
+    THINK_FIELD_IGNORED_ON_OPENAI_ROUTE = "think_field_ignored_on_openai_route"
+    THINKING_WITH_TOOLS_YIELDS_EMPTY_TURN = "thinking_with_tools_yields_empty_turn"
+    NATIVE_ROUTE_NEVER_SETS_TOOL_FINISH_REASON = "native_route_never_sets_tool_finish_reason"
+    TOOL_CALLS_ARRIVE_WHOLE_NOT_INCREMENTAL = "tool_calls_arrive_whole_not_incremental"
+    STREAM_ERROR_ENDS_WITHOUT_DONE = "stream_error_ends_without_done"
+    SAMPLING_DEFAULTS_FORCED_TO_ONE = "sampling_defaults_forced_to_one"
+    CONTEXT_OPTION_CHANGE_RELOADS_MODEL = "context_option_change_reloads_model"
+    KEEP_ALIVE_IS_GLOBAL_LAST_WRITER_WINS = "keep_alive_is_global_last_writer_wins"
+    BODYLESS_403_ON_NON_LOCAL_HOST_HEADER = "bodyless_403_on_non_local_host_header"
+    TOOLS_REQUIRE_SERVER_FLAGS = "tools_require_server_flags"
+    NO_JSON_SCHEMA_SUPPORT = "no_json_schema_support"
+    NO_EMBEDDINGS_ENDPOINT = "no_embeddings_endpoint"
+    SINGLE_MODEL_PER_PROCESS = "single_model_per_process"
+    CAPS_ASSUMED_ENGINE_UNIDENTIFIED = "caps_assumed_engine_unidentified"
+
+
+@dataclass(frozen=True)
+class QuirkNote:
+    quirk: Quirk
+    engines: tuple
+    severity: Severity
+    symptom: str
+    workaround: str
+    verified_on: str
+    api_styles: tuple = ()
+    requires_caps: frozenset = field(default_factory=frozenset)
+
+
+_OLLAMA = (LocalEngine.OLLAMA,)
+_OPENAI_ROUTES = (ApiStyle.OPENAI_CHAT, ApiStyle.OPENAI_COMPLETIONS)
+_V = "ollama 0.33.2 @ 2026-09-03"
+
+NOTES: Mapping[Quirk, QuirkNote] = {n.quirk: n for n in (
+    QuirkNote(
+        Quirk.FORMAT_AND_TOOLS_MUTUALLY_DESTRUCTIVE, _OLLAMA, Severity.SILENT,
+        "JSON format plus tools suppresses the tool call; the model fabricates an answer.",
+        "Refuse the combination at request build. Raise -- a confident fabrication is worse than an error.",
+        _V),
+    QuirkNote(
+        Quirk.TOOL_SCHEMA_KEYWORDS_STRIPPED, _OLLAMA, Severity.SILENT,
+        "minLength, format, default, additionalProperties, $ref and oneOf never reach the model.",
+        "Warn once at tool-declaration time, naming the dropped keys.", _V),
+    QuirkNote(
+        Quirk.TOOL_PARAM_TYPE_MUST_BE_BARE_STRING, _OLLAMA, Severity.HARD,
+        'A tool parameter "type" given as a list 400s the whole request.',
+        "Collapse union types to a single string before sending.", _V),
+    QuirkNote(
+        Quirk.UNKNOWN_OPTIONS_ACCEPTED_AND_IGNORED, _OLLAMA, Severity.SILENT,
+        "Unrecognised options keys return 200 and change nothing.",
+        "Validate keys against the known set; warn on unknowns.", _V),
+    QuirkNote(
+        Quirk.THINK_FIELD_IGNORED_ON_OPENAI_ROUTE, _OLLAMA, Severity.SILENT,
+        "think is a native-API field; on /v1 it is dropped and reasoning still emits.",
+        'Translate to reasoning_effort="none" on the OpenAI route.', _V,
+        api_styles=_OPENAI_ROUTES),
+    QuirkNote(
+        Quirk.THINKING_WITH_TOOLS_YIELDS_EMPTY_TURN, _OLLAMA, Severity.SILENT,
+        'Empty content, zero tool calls, finish_reason "stop".',
+        "Treat as retryable; retry once with reasoning disabled.", _V,
+        requires_caps=frozenset({Cap.THINKING, Cap.TOOLS})),
+    QuirkNote(
+        Quirk.NATIVE_ROUTE_NEVER_SETS_TOOL_FINISH_REASON, _OLLAMA, Severity.SILENT,
+        '/api/chat reports done_reason "stop" even when tool_calls is populated.',
+        "Inspect the message body, never the finish reason.", _V,
+        api_styles=(ApiStyle.OLLAMA_NATIVE,)),
+    QuirkNote(
+        Quirk.TOOL_CALLS_ARRIVE_WHOLE_NOT_INCREMENTAL, _OLLAMA, Severity.SILENT,
+        "Streamed tool calls arrive in one chunk, not as argument deltas.",
+        "The accumulator must tolerate both; never assume fragments.", _V),
+    QuirkNote(
+        Quirk.STREAM_ERROR_ENDS_WITHOUT_DONE, _OLLAMA, Severity.SILENT,
+        "A mid-stream failure yields an empty delta and no [DONE] sentinel.",
+        "Set a read timeout; check every NDJSON line for an error key.", _V,
+        api_styles=_OPENAI_ROUTES),
+    QuirkNote(
+        Quirk.SAMPLING_DEFAULTS_FORCED_TO_ONE, _OLLAMA, Severity.SILENT,
+        "Omitted temperature/top_p become 1.0, not the model's own defaults.",
+        "Send explicit values, or use the native route.", _V,
+        api_styles=_OPENAI_ROUTES),
+    QuirkNote(
+        Quirk.CONTEXT_OPTION_CHANGE_RELOADS_MODEL, _OLLAMA, Severity.COST,
+        "Changing num_ctx/num_batch/num_gpu forces a full model reload.",
+        "Freeze runner options per target; never vary them per call.", _V),
+    QuirkNote(
+        Quirk.KEEP_ALIVE_IS_GLOBAL_LAST_WRITER_WINS, _OLLAMA, Severity.SILENT,
+        "keep_alive is per-model and process-wide, not per-request.",
+        "Never send keep_alive=0 from a library path; it evicts another caller's model.", _V),
+    QuirkNote(
+        Quirk.BODYLESS_403_ON_NON_LOCAL_HOST_HEADER, _OLLAMA, Severity.HARD,
+        "A Host header that is not localhost or an IP gets HTTP 403 with a zero-byte body.",
+        "Send Host as localhost or an IP; set OLLAMA_HOST on the server to allow the origin.", _V),
+    QuirkNote(
+        Quirk.TOOLS_REQUIRE_SERVER_FLAGS,
+        (LocalEngine.VLLM, LocalEngine.LLAMA_CPP, LocalEngine.LLAMAFILE), Severity.SILENT,
+        "Tool calls come back as assistant text unless the server was launched with the right flags.",
+        "vLLM needs BOTH --enable-auto-tool-choice AND --tool-call-parser; llama-server needs --jinja.",
+        "unverified: vendor docs"),
+    QuirkNote(
+        Quirk.NO_JSON_SCHEMA_SUPPORT, (LocalEngine.MLX_LM,), Severity.SILENT,
+        "response_format json_schema is unimplemented.",
+        "Drop the capability; fall back to prompt-and-parse.", "unverified: source read"),
+    QuirkNote(
+        Quirk.NO_EMBEDDINGS_ENDPOINT, (LocalEngine.MLX_LM,), Severity.HARD,
+        "/v1/embeddings is absent.",
+        "Resolve embeddings to a different target, and say so.", "unverified: source read"),
+    QuirkNote(
+        Quirk.SINGLE_MODEL_PER_PROCESS,
+        (LocalEngine.LLAMA_CPP, LocalEngine.MLX_LM), Severity.SILENT,
+        "One model per process; the request's model field is ignored.",
+        "Asking for model B returns model A's answer. Pin the model at launch.",
+        "unverified: vendor docs"),
+    QuirkNote(
+        Quirk.CAPS_ASSUMED_ENGINE_UNIDENTIFIED, (LocalEngine.UNKNOWN,), Severity.SILENT,
+        "The engine could not be identified, so every capability is a static guess.",
+        "Treat capabilities as unproven; keep repair paths enabled.", "n/a"),
+)}
+
+
+def note(quirk) -> QuirkNote:
+    """Return the catalogue entry for one quirk."""
+    return NOTES[Quirk(quirk)]
+
+
+def all_notes() -> tuple:
+    """Every catalogue entry, ordered by (first engine, quirk value)."""
+    return tuple(sorted(NOTES.values(), key=lambda n: (n.engines[0].value, n.quirk.value)))
+
+
+def quirks_for(engine, api_style, *, caps=frozenset()) -> frozenset:
+    """Quirks that apply to this engine, route and capability set."""
+    engine = LocalEngine(engine)
+    style = ApiStyle(api_style)
+    caps = frozenset(caps)
+    return frozenset(
+        n.quirk for n in NOTES.values()
+        if engine in n.engines
+        and (not n.api_styles or style in n.api_styles)
+        and n.requires_caps <= caps
+    )
+
+
+def notes_for(quirks: Iterable) -> tuple:
+    """Catalogue entries for ``quirks``, ordered by severity then value."""
+    order = {Severity.SILENT: 0, Severity.HARD: 1, Severity.COST: 2}
+    got = [NOTES[Quirk(q)] for q in quirks]
+    return tuple(sorted(got, key=lambda n: (order[n.severity], n.quirk.value)))
+
+
+def silent_quirks(quirks: Iterable) -> frozenset:
+    """Filter to Severity.SILENT -- the set a caller must actively defend against."""
+    return frozenset(q for q in (Quirk(x) for x in quirks) if NOTES[q].severity is Severity.SILENT)

--- a/src/praisonai-agents/praisonaiagents/local/resolve.py
+++ b/src/praisonai-agents/praisonaiagents/local/resolve.py
@@ -187,10 +187,30 @@ def _with_url_evidence(discovery, evidence):
     return dataclasses.replace(discovery, evidence=evidence) if evidence else discovery
 
 
+def _require_model(discovery, model_id):
+    """Reject a model-less resolution or a named model the server does not serve."""
+    available = tuple(discovery.models)
+    where = f"{discovery.engine.value} at {discovery.base_url}"
+    if model_id is None:
+        raise NoLocalEngineError(
+            f"{where} answered but lists no usable model to chat with. Pull one "
+            f"(e.g. `ollama pull qwen3:0.6b`) or name it explicitly.")
+    if available and model_id not in available:
+        raise ModelNotAvailableError(
+            f"Model {model_id!r} is not served by {where}. "
+            f"Available: {', '.join(available)}.",
+            model_id=model_id, available=available)
+
+
 def _finish(discovery, model_id, model_evidence, per_request, transport, url_evidence=None):
     if model_id is None:
         model_id = select_model(discovery, transport=transport, timeout=per_request)
         model_evidence = Evidence.SERVER
+    # An explicitly named model must be served, and a reachable server that
+    # lists none must not yield a model-less target -- Agent would otherwise
+    # substitute its own default (e.g. gpt-4o-mini) and send it to the local
+    # endpoint, failing only on the first completion instead of at resolution.
+    _require_model(discovery, model_id)
     caps, caps_evidence, extra = _model_capabilities(
         discovery, model_id, timeout=per_request, transport=transport)
     target = build_target(discovery, model_id, caps=caps, caps_evidence=caps_evidence,

--- a/src/praisonai-agents/praisonaiagents/local/resolve.py
+++ b/src/praisonai-agents/praisonaiagents/local/resolve.py
@@ -1,0 +1,302 @@
+"""Resolution precedence and the process-local cache.
+
+Precedence: spec > PRAISONAI_LOCAL_BASE_URL > OLLAMA_HOST >
+OPENAI_BASE_URL/OPENAI_API_BASE (only when local) > probe-table scan.
+
+The first three are authoritative: if one names a server that does not answer
+this raises, rather than silently talking to a different one. Silently using a
+server the caller did not name is the failure mode this package exists to
+prevent.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import threading
+import time
+import urllib.parse
+
+from .capabilities import Cap, Evidence, LocalEngine, default_caps
+from .capabilities import (parse_llama_cpp_props, parse_lm_studio_models,
+                           parse_ollama_capabilities)
+from .discover import (DEFAULT_PROBE_TIMEOUT, DEFAULT_TOTAL_BUDGET, PROBES,
+                       default_transport, discover, probe_endpoint)
+from .errors import (EngineUnreachableError, HostHeaderRejectedError,
+                     InvalidLocalSpecError, LocalError, ModelNotAvailableError,
+                     NoLocalEngineError)
+from .target import (ENV_BASE_URL, ENV_ENGINE, ENV_MODEL, build_target,
+                     parse_ollama_host, parse_spec, select_model)
+
+ENV_TTL = "PRAISONAI_LOCAL_TTL"
+ENV_NEG_TTL = "PRAISONAI_LOCAL_NEG_TTL"
+ENV_TIMEOUT = "PRAISONAI_LOCAL_TIMEOUT"
+
+__all__ = ["resolve", "resolve_or_none", "clear_cache", "cache_info",
+           "ENV_TTL", "ENV_NEG_TTL", "ENV_TIMEOUT"]
+
+def _is_local_host(url: str) -> bool:
+    try:
+        host = urllib.parse.urlparse(url).hostname or ""
+    except ValueError:
+        return False
+    if host in ("localhost", "") or host.endswith(".localhost") or host.endswith(".local"):
+        return True
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return addr.is_loopback or addr.is_private or addr.is_link_local
+
+
+def _model_capabilities(discovery: Discovery, model_id, *, timeout, transport):
+    """One request, at most, for per-model capabilities. Degrades to TABLE."""
+    spec = next((p for p in PROBES if p.engine == discovery.engine), None)
+    if spec is None or spec.model_caps is None or not model_id:
+        return default_caps(discovery.engine), Evidence.TABLE, ()
+    send = transport or default_transport
+    rule = spec.model_caps
+    import json as _json
+    body = _json.dumps({"model": model_id}).encode() if rule.method == "POST" else None
+    reply = send(rule.method, discovery.base_url + rule.path, body, timeout)
+    if reply.status != 200:
+        return default_caps(discovery.engine), Evidence.TABLE, ()
+    try:
+        payload = _json.loads(reply.body.decode("utf-8", errors="replace"))
+    except ValueError:
+        return default_caps(discovery.engine), Evidence.TABLE, ()
+    if not isinstance(payload, dict):
+        return default_caps(discovery.engine), Evidence.TABLE, ()
+
+    if discovery.engine == LocalEngine.OLLAMA:
+        caps = parse_ollama_capabilities(payload)
+    elif discovery.engine == LocalEngine.LLAMA_CPP:
+        caps = parse_llama_cpp_props(payload)
+    elif discovery.engine == LocalEngine.LM_STUDIO:
+        caps = parse_lm_studio_models(payload, model_id)
+    else:
+        caps = frozenset()
+    if not caps:
+        return default_caps(discovery.engine), Evidence.TABLE, ()
+
+    extra = []
+    info = payload.get("model_info") or {}
+    if isinstance(info, dict):
+        for key, value in info.items():
+            if key.endswith(".context_length"):
+                extra.append(("context_length", str(value)))
+            elif key.endswith(".embedding_length"):
+                extra.append(("embedding_length", str(value)))
+    details = payload.get("details") or {}
+    if isinstance(details, dict):
+        for k in ("family", "parameter_size", "quantization_level"):
+            if details.get(k):
+                extra.append((k, str(details[k])))
+    # Union with the engine floor so streaming/embeddings survive.
+    return frozenset(caps) | default_caps(discovery.engine), Evidence.SERVER, tuple(extra)
+
+
+_CACHE_LOCK = threading.Lock()
+_TARGETS = {}
+_NEGATIVES = {}
+_STATS = {"hits": 0, "misses": 0}
+
+
+def _float_env(name, default):
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _cache_key(spec, timeout):
+    return "\x00".join((
+        str(spec) if spec is not None else "*",
+        os.environ.get(ENV_BASE_URL, ""), os.environ.get(ENV_ENGINE, ""),
+        os.environ.get(ENV_MODEL, ""), os.environ.get("OLLAMA_HOST", ""),
+        os.environ.get("OPENAI_BASE_URL", ""), os.environ.get("OPENAI_API_BASE", ""),
+        f"{timeout:.3f}",
+    ))
+
+
+def clear_cache() -> None:
+    """Drop every cached target and negative result (test hook)."""
+    with _CACHE_LOCK:
+        _TARGETS.clear()
+        _NEGATIVES.clear()
+        _STATS.update(hits=0, misses=0)
+
+
+def cache_info() -> dict:
+    with _CACHE_LOCK:
+        return {"targets": len(_TARGETS), "negatives": len(_NEGATIVES), **_STATS}
+
+
+_ERRORS = {c.__name__: c for c in (
+    NoLocalEngineError, EngineUnreachableError, HostHeaderRejectedError,
+    ModelNotAvailableError, InvalidLocalSpecError, LocalError)}
+
+
+def resolve(spec=None, *, timeout=None, refresh=False, transport=None) -> LocalTarget:
+    """Resolve the local model server and model this machine should use.
+
+    Precedence: spec > PRAISONAI_LOCAL_BASE_URL > OLLAMA_HOST >
+    OPENAI_BASE_URL/OPENAI_API_BASE (only when local) > probe-table scan.
+
+    The first three are authoritative: if one names a server that does not
+    answer, this raises rather than silently talking to a different one.
+    """
+    total = _float_env(ENV_TIMEOUT, 1.5) if timeout is None else float(timeout)
+    total = min(max(total, 0.05), 30.0)
+    per_request = min(DEFAULT_PROBE_TIMEOUT, total / 3)
+    key = _cache_key(spec, total)
+    pid = os.getpid()
+
+    if not refresh:
+        with _CACHE_LOCK:
+            hit = _TARGETS.get(key)
+            if hit and hit[0] > time.monotonic() and hit[1] == pid:
+                _STATS["hits"] += 1
+                return hit[2]
+            neg = _NEGATIVES.get(key)
+            if neg and neg[0] > time.monotonic() and neg[1] == pid:
+                _STATS["hits"] += 1
+                # A fresh instance: a stored exception carries a dead traceback.
+                raise _ERRORS.get(neg[2], LocalError)(neg[3])
+    with _CACHE_LOCK:
+        _STATS["misses"] += 1
+
+    try:
+        target = _resolve_uncached(spec, per_request, total, transport)
+    except LocalError as exc:
+        ttl = _float_env(ENV_NEG_TTL, 5.0)
+        if ttl > 0:
+            with _CACHE_LOCK:
+                _NEGATIVES[key] = (time.monotonic() + ttl, pid, type(exc).__name__, str(exc))
+        raise
+    ttl = _float_env(ENV_TTL, 30.0)
+    if ttl > 0:
+        with _CACHE_LOCK:
+            _TARGETS[key] = (time.monotonic() + ttl, pid, target)
+    return target
+
+
+def _with_url_evidence(discovery, evidence):
+    """Record where the base URL came from; the probe only proves it answered."""
+    import dataclasses
+    return dataclasses.replace(discovery, evidence=evidence) if evidence else discovery
+
+
+def _finish(discovery, model_id, model_evidence, per_request, transport, url_evidence=None):
+    if model_id is None:
+        model_id = select_model(discovery, transport=transport, timeout=per_request)
+        model_evidence = Evidence.SERVER
+    caps, caps_evidence, extra = _model_capabilities(
+        discovery, model_id, timeout=per_request, transport=transport)
+    target = build_target(discovery, model_id, caps=caps, caps_evidence=caps_evidence,
+                          model_evidence=model_evidence, extra=extra)
+    if url_evidence is not None:
+        import dataclasses
+        ev = dict(target.evidence)
+        ev["base_url"] = url_evidence
+        target = dataclasses.replace(target, evidence=tuple(sorted(ev.items())))
+    return target
+
+
+def _authoritative(url, expect, source, per_request, transport, model_id, model_evidence):
+    found = probe_endpoint(url, expect=expect, timeout=per_request, transport=transport)
+    if found is None:
+        hint = ""
+        if source == "OLLAMA_HOST" and url.rsplit(":", 1)[-1] in ("80", "443"):
+            hint = (" Note that OLLAMA_HOST with an explicit http:// scheme and no "
+                    "port means port 80, not 11434.")
+        raise EngineUnreachableError(
+            f"Local runtime at {url} did not answer (refused). It was named "
+            f"explicitly by {source}, so no other port was probed.{hint}",
+            base_url=url, reason="refused", source=source)
+    if found.blocked:
+        raise HostHeaderRejectedError(
+            f"Local runtime at {url} returned HTTP 403 with an empty body. Ollama "
+            f"rejects any request whose Host header is not localhost or an IP "
+            f"address; set OLLAMA_HOST on the server to allow this origin.",
+            base_url=url, reason="http_403", source=source)
+    return found, model_id, model_evidence
+
+
+def _resolve_uncached(spec, per_request, total, transport):
+    engine, spec_url, spec_model = parse_spec(spec)
+    model_evidence = Evidence.SPEC if spec_model else Evidence.SERVER
+
+    if spec_url:
+        found, m, ev = _authoritative(spec_url, engine, "spec", per_request,
+                                      transport, spec_model, model_evidence)
+        return _finish(found, m, ev, per_request, transport, Evidence.SPEC)
+
+    env_url = os.environ.get(ENV_BASE_URL)
+    if env_url:
+        env_engine = os.environ.get(ENV_ENGINE)
+        expect = engine
+        if env_engine:
+            try:
+                expect = LocalEngine(env_engine.lower())
+            except ValueError:
+                raise InvalidLocalSpecError(
+                    f"{ENV_ENGINE}={env_engine!r} is not a known local engine. "
+                    f"Expected one of: {', '.join(e.value for e in LocalEngine)}.")
+        found, m, ev = _authoritative(env_url.rstrip("/"), expect, ENV_BASE_URL,
+                                      per_request, transport, spec_model, model_evidence)
+        return _finish(found, m, ev, per_request, transport, Evidence.ENV)
+
+    ollama_host = os.environ.get("OLLAMA_HOST")
+    if ollama_host:
+        url = parse_ollama_host(ollama_host)
+        if url:
+            found, m, ev = _authoritative(url, engine or LocalEngine.OLLAMA, "OLLAMA_HOST",
+                                          per_request, transport, spec_model, model_evidence)
+            return _finish(found, m, ev, per_request, transport, Evidence.ENV)
+
+    skipped = ""
+    for var in ("OPENAI_BASE_URL", "OPENAI_API_BASE"):
+        url = os.environ.get(var)
+        if not url:
+            continue
+        if not _is_local_host(url):
+            skipped = f" Ignored {var}={url!r}: not a local address."
+            continue
+        found = probe_endpoint(url.rstrip("/"), expect=engine, timeout=per_request,
+                               transport=transport)
+        if found is not None and not found.blocked:
+            return _finish(found, spec_model, model_evidence, per_request, transport)
+
+    include = [engine] if engine else None
+    results = discover(include=include, timeout=per_request, budget=total,
+                       transport=transport)
+    usable = [d for d in results if not d.blocked]
+    if usable:
+        return _finish(usable[0], spec_model, model_evidence, per_request, transport)
+    if results:
+        blocked = results[0]
+        raise HostHeaderRejectedError(
+            f"Local runtime at {blocked.base_url} returned HTTP 403 with an empty "
+            f"body. Ollama rejects any request whose Host header is not localhost "
+            f"or an IP address; set OLLAMA_HOST on the server to allow this origin.",
+            base_url=blocked.base_url, reason="http_403", source="scan")
+
+    ports = {}
+    for p in PROBES:
+        for port in p.default_ports:
+            ports.setdefault(port, []).append(p.engine.value)
+    clause = ", ".join(f"{port} ({', '.join(names)})" for port, names in sorted(ports.items()))
+    raise NoLocalEngineError(
+        f"No local model runtime found. Probed {DEFAULT_TOTAL_BUDGET and '127.0.0.1'} "
+        f"ports {clause} in {total:.1f}s; nothing answered. Start one "
+        f"(e.g. `ollama serve`, then `ollama pull qwen3:0.6b`) or set "
+        f"{ENV_BASE_URL} to its address.{skipped}")
+
+
+def resolve_or_none(spec=None, **kwargs):
+    """resolve() but returns None instead of raising LocalError."""
+    try:
+        return resolve(spec, **kwargs)
+    except LocalError:
+        return None

--- a/src/praisonai-agents/praisonaiagents/local/target.py
+++ b/src/praisonai-agents/praisonaiagents/local/target.py
@@ -1,0 +1,219 @@
+"""The LocalTarget value type and the pure helpers that build one.
+
+Everything here is a pure function of its arguments: no network, no cache, no
+environment reads except the single documented model override. Resolution
+precedence lives in resolve.py.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import urllib.parse
+from dataclasses import dataclass
+from typing import Optional
+
+from .capabilities import (ApiStyle, Cap, Evidence, LocalEngine, default_caps,
+                           parse_llama_cpp_props, parse_lm_studio_models,
+                           parse_ollama_capabilities)
+from .discover import (DEFAULT_PROBE_TIMEOUT, DEFAULT_TOTAL_BUDGET, PROBES,
+                       Discovery, default_transport, discover, probe_endpoint)
+from .errors import InvalidLocalSpecError, ModelNotAvailableError
+from .quirktable import Quirk, quirks_for
+
+__all__ = ["LocalTarget", "build_target", "litellm_model_for", "parse_spec",
+           "parse_ollama_host", "select_model", "DEFAULT_API_KEY",
+           "ENV_BASE_URL", "ENV_ENGINE", "ENV_MODEL"]
+
+DEFAULT_API_KEY = "local"
+ENV_BASE_URL = "PRAISONAI_LOCAL_BASE_URL"
+ENV_ENGINE = "PRAISONAI_LOCAL_ENGINE"
+ENV_MODEL = "PRAISONAI_LOCAL_MODEL"
+
+
+@dataclass(frozen=True)
+class LocalTarget:
+    engine: LocalEngine
+    base_url: str
+    openai_base_url: str
+    api_style: ApiStyle
+    model_id: Optional[str]
+    caps: frozenset
+    quirks: frozenset
+    litellm_model: Optional[str]
+    api_key: str
+    engine_version: Optional[str]
+    # Tuples of pairs, not dicts: a dict field would make the generated __hash__
+    # raise TypeError at runtime, and this type is meant to be hashable.
+    evidence: tuple
+    extra: tuple
+    probed_at: float
+
+    def supports(self, cap) -> bool:
+        return Cap(cap) in self.caps
+
+    def has_quirk(self, quirk) -> bool:
+        return Quirk(quirk) in self.quirks
+
+    def evidence_for(self, field: str) -> Evidence:
+        return dict(self.evidence).get(field, Evidence.UNKNOWN)
+
+    def get_extra(self, key: str, default=None):
+        return dict(self.extra).get(key, default)
+
+    def as_dict(self) -> dict:
+        return {
+            "engine": self.engine.value,
+            "base_url": self.base_url,
+            "openai_base_url": self.openai_base_url,
+            "api_style": self.api_style.value,
+            "model_id": self.model_id,
+            "caps": sorted(c.value for c in self.caps),
+            "quirks": sorted(q.value for q in self.quirks),
+            "litellm_model": self.litellm_model,
+            "engine_version": self.engine_version,
+            "evidence": {k: v.value for k, v in self.evidence},
+            "extra": dict(self.extra),
+        }
+
+
+_LITELLM_PREFIX = {
+    LocalEngine.OLLAMA: "ollama",
+    LocalEngine.LM_STUDIO: "lm_studio",
+    LocalEngine.VLLM: "hosted_vllm",
+}
+
+
+def litellm_model_for(engine, model_id) -> Optional[str]:
+    """Format a litellm model string for this engine. Pure.
+
+    OLLAMA maps to "ollama/", never "ollama_chat/": llm.py's _detect_provider
+    resolves ollama_chat to "openai" and would silently lose OllamaAdapter.
+    """
+    if not model_id:
+        return None
+    return f"{_LITELLM_PREFIX.get(LocalEngine(engine), 'openai')}/{model_id}"
+
+
+def parse_ollama_host(value: str) -> Optional[str]:
+    """Apply Ollama's own OLLAMA_HOST rules and return a base_url.
+
+    The asymmetry that catches people: a bare host defaults to port 11434, but an
+    explicit http:// with no port means port 80 -- not 11434.
+    """
+    if not value or not value.strip():
+        return None
+    raw = value.strip()
+    if "://" in raw:
+        parsed = urllib.parse.urlparse(raw)
+        if not parsed.hostname:
+            return None
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        return f"{parsed.scheme}://{parsed.hostname}:{port}"
+    if raw.isdigit():
+        return f"http://127.0.0.1:{raw}"
+    if raw.startswith(":") and raw[1:].isdigit():
+        return f"http://127.0.0.1:{raw[1:]}"
+    if raw.count(":") > 1 and not raw.startswith("["):
+        return None  # unbracketed IPv6
+    host, _, port = raw.partition(":")
+    return f"http://{host}:{port or 11434}"
+
+
+
+
+def parse_spec(spec):
+    """Split a spec into (engine, base_url, model_id); any element may be None."""
+    if spec is None:
+        return None, None, None
+    text = str(spec).strip()
+    if text.lower() in ("", "local", "auto"):
+        return None, None, None
+    if "://" in text:
+        url, _, fragment = text.partition("#")
+        return None, url.rstrip("/"), (fragment or None)
+    if "/" in text:
+        head, _, tail = text.partition("/")
+        try:
+            return LocalEngine(head.lower()), None, (tail or None)
+        except ValueError:
+            pass
+    raise InvalidLocalSpecError(
+        f"Cannot parse local spec {spec!r}. Expected None, 'local', "
+        f"'<engine>/<model>', a base URL, or '<url>#<model>'."
+    )
+
+
+def select_model(discovery: Discovery, *, transport=None,
+                 timeout: float = DEFAULT_PROBE_TIMEOUT) -> Optional[str]:
+    """Pick a model deterministically when the caller named none.
+
+    Never guesses a model that is not in the server's list.
+    """
+    named = os.environ.get(ENV_MODEL)
+    available = tuple(discovery.models)
+    if named:
+        if available and named not in available:
+            raise ModelNotAvailableError(
+                f"Model {named!r} is not served by {discovery.engine.value} at "
+                f"{discovery.base_url}. Available: {', '.join(available) or '(none)'}.",
+                model_id=named, available=available)
+        return named
+    if not available:
+        return None
+    meta = {m[0]: (m[1], m[2]) for m in (discovery.model_meta or ())}
+    if len(available) == 1 and not meta:
+        return available[0]
+
+    def rank(model):
+        caps, modified = meta.get(model, ((), ""))
+        # An embedding-only model cannot hold a conversation. Picking one because
+        # it sorted first is the kind of silent nonsense this package exists to
+        # prevent, so it is ranked last rather than merely unpreferred.
+        embed_only = bool(caps) and "embedding" in caps and "completion" not in caps
+        return (embed_only, "tools" not in caps, _negate_iso(modified), model)
+
+    chat_capable = [m for m in available if not rank(m)[0]]
+    pool = chat_capable or list(available)
+    return sorted(pool, key=rank)[0]
+
+
+def _negate_iso(value: str):
+    """Sort ISO-8601 timestamps newest-first inside an ascending sort key."""
+    return tuple(-ord(c) for c in value) if value else ()
+
+
+def build_target(discovery: Discovery, model_id, *, caps=None,
+                 caps_evidence=Evidence.TABLE, model_evidence=Evidence.SERVER,
+                 extra=()) -> LocalTarget:
+    """Assemble a LocalTarget from a Discovery. Pure: no network, no cache."""
+    engine = discovery.engine
+    resolved_caps = frozenset(caps) if caps is not None else default_caps(engine)
+    quirks = quirks_for(engine, discovery.api_style, caps=resolved_caps)
+    if Cap.TOOLS in resolved_caps and Quirk.TOOL_CALLS_ARRIVE_WHOLE_NOT_INCREMENTAL not in quirks:
+        resolved_caps = resolved_caps | {Cap.STREAMING_WITH_TOOLS}
+    evidence = {
+        "engine": discovery.evidence,
+        "base_url": discovery.evidence,
+        "api_style": Evidence.TABLE,
+        "caps": caps_evidence,
+        "quirks": Evidence.TABLE,
+        "model_id": model_evidence if model_id else Evidence.UNKNOWN,
+        "engine_version": Evidence.SERVER if discovery.engine_version else Evidence.UNKNOWN,
+    }
+    return LocalTarget(
+        engine=engine,
+        base_url=discovery.base_url,
+        openai_base_url=discovery.base_url + "/v1",
+        api_style=discovery.api_style,
+        model_id=model_id,
+        caps=resolved_caps,
+        quirks=quirks,
+        litellm_model=litellm_model_for(engine, model_id),
+        api_key=DEFAULT_API_KEY,
+        engine_version=discovery.engine_version,
+        evidence=tuple(sorted(evidence.items())),
+        extra=tuple(sorted(extra)),
+        probed_at=time.time(),
+    )

--- a/src/praisonai/tests/unit/llm/local/conftest.py
+++ b/src/praisonai/tests/unit/llm/local/conftest.py
@@ -1,0 +1,73 @@
+"""Fixtures for the local-resolver tests.
+
+The autouse `no_sockets` fixture is the mechanism that proves offline safety: a
+test that forgets to inject a transport fails loudly instead of silently hitting
+whatever the developer happens to have running on :11434.
+"""
+
+import socket
+
+import pytest
+
+from praisonaiagents.local import HttpReply
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def no_sockets(monkeypatch):
+    """Any real socket construction in this directory is a test bug."""
+    def _forbidden(self, *a, **kw):
+        raise AssertionError(
+            "tests/unit/llm/local must not open a socket; inject a transport"
+        )
+    monkeypatch.setattr(socket.socket, "__init__", _forbidden)
+
+
+@pytest.fixture(autouse=True)
+def clean_local_env(monkeypatch):
+    for var in ("PRAISONAI_LOCAL_BASE_URL", "PRAISONAI_LOCAL_ENGINE",
+                "PRAISONAI_LOCAL_MODEL", "PRAISONAI_LOCAL_TTL",
+                "PRAISONAI_LOCAL_NEG_TTL", "PRAISONAI_LOCAL_TIMEOUT",
+                "OLLAMA_HOST", "OPENAI_BASE_URL", "OPENAI_API_BASE"):
+        monkeypatch.delenv(var, raising=False)
+    from praisonaiagents.local import clear_cache
+    clear_cache()
+    yield
+    clear_cache()
+
+
+class Recorder:
+    """A Transport that serves canned replies and records every call."""
+
+    def __init__(self, routes, default=None):
+        self.routes = routes
+        self.default = default if default is not None else HttpReply(0, b"", "refused")
+        self.calls = []
+
+    def __call__(self, method, url, body, timeout):
+        path = url.split("://", 1)[1].split("/", 1)
+        path = "/" + (path[1] if len(path) > 1 else "")
+        port = url.split(":")[2].split("/")[0] if url.count(":") >= 2 else ""
+        self.calls.append((method, url))
+        for key in ((method, port, path), (method, path)):
+            if key in self.routes:
+                return self.routes[key]
+        return self.default
+
+    def paths(self):
+        return [u.split("://", 1)[1].split("/", 1)[-1] for _, u in self.calls]
+
+
+@pytest.fixture
+def transport():
+    return Recorder
+
+
+def ok(payload):
+    import json
+    return HttpReply(200, json.dumps(payload).encode())
+
+
+def text(body, status=200):
+    return HttpReply(status, body.encode())

--- a/src/praisonai/tests/unit/llm/local/test_agent_local_spec.py
+++ b/src/praisonai/tests/unit/llm/local/test_agent_local_spec.py
@@ -1,0 +1,91 @@
+"""`Agent(llm="local")` resolves a running local server, and nothing else probes.
+
+The opt-in guarantee matters as much as the feature: discovery must never fire
+for a spec that is not "local", so a fully-configured agent pays nothing for this
+existing.
+"""
+
+import pytest
+
+from praisonaiagents import Agent
+from praisonaiagents.local import LocalEngine, NoLocalEngineError
+
+from .conftest import Recorder, ok, text
+
+pytestmark = pytest.mark.unit
+
+ROUTES = {
+    ("GET", "/"): text("Ollama is running"),
+    ("GET", "/api/version"): ok({"version": "0.33.2"}),
+    ("GET", "/api/tags"): ok({"models": [
+        {"model": "qwen3:0.6b", "capabilities": ["completion", "tools"],
+         "modified_at": "2026-09-03T13:44:23Z"}]}),
+    ("POST", "/api/show"): ok({"capabilities": ["completion", "tools"]}),
+}
+
+
+@pytest.fixture
+def local_server(monkeypatch):
+    """Point the resolver's default transport at a canned Ollama."""
+    # `import praisonaiagents.local.discover` binds the re-exported *function*
+    # of that name, not the module, so reach for the module explicitly.
+    import importlib
+    discover_mod = importlib.import_module("praisonaiagents.local.discover")
+    resolve_mod = importlib.import_module("praisonaiagents.local.resolve")
+    rec = Recorder(ROUTES)
+    monkeypatch.setattr(discover_mod, "default_transport", rec)
+    monkeypatch.setattr(resolve_mod, "default_transport", rec)
+    return rec
+
+
+def test_agent_llm_local_resolves(local_server):
+    agent = Agent(instructions="test", llm="local")
+    assert agent.llm == "ollama/qwen3:0.6b"
+    assert agent._using_custom_llm is True
+    assert agent._local_target.engine is LocalEngine.OLLAMA
+
+
+def test_agent_llm_local_sets_base_url_and_key(local_server):
+    agent = Agent(instructions="test", llm="local")
+    assert agent.llm_instance.base_url == "http://127.0.0.1:11434"
+    # openai clients reject an empty key; the placeholder must be non-empty.
+    assert agent.llm_instance.api_key
+
+
+def test_agent_local_with_engine_spec(local_server):
+    agent = Agent(instructions="test", llm="local:ollama/qwen3:0.6b")
+    assert agent.llm == "ollama/qwen3:0.6b"
+
+
+def test_explicit_base_url_is_not_overridden(local_server):
+    agent = Agent(instructions="test", llm="local", base_url="http://example:1234")
+    assert agent.llm_instance.base_url == "http://example:1234"
+
+
+def test_nothing_running_raises_a_named_error(monkeypatch):
+    # `import praisonaiagents.local.discover` binds the re-exported *function*
+    # of that name, not the module, so reach for the module explicitly.
+    import importlib
+    discover_mod = importlib.import_module("praisonaiagents.local.discover")
+    resolve_mod = importlib.import_module("praisonaiagents.local.resolve")
+    empty = Recorder({})
+    monkeypatch.setattr(discover_mod, "default_transport", empty)
+    monkeypatch.setattr(resolve_mod, "default_transport", empty)
+    with pytest.raises(NoLocalEngineError):
+        Agent(instructions="test", llm="local")
+
+
+@pytest.mark.parametrize("spec", ["gpt-4o", "ollama/llama3.2", "anthropic/claude-3-5-sonnet-latest"])
+def test_other_specs_never_probe(monkeypatch, spec):
+    """Safe defaults: discovery is opt-in and must not fire for anything else."""
+    # `import praisonaiagents.local.discover` binds the re-exported *function*
+    # of that name, not the module, so reach for the module explicitly.
+    import importlib
+    discover_mod = importlib.import_module("praisonaiagents.local.discover")
+    resolve_mod = importlib.import_module("praisonaiagents.local.resolve")
+    tripwire = Recorder({})
+    monkeypatch.setattr(discover_mod, "default_transport", tripwire)
+    monkeypatch.setattr(resolve_mod, "default_transport", tripwire)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    Agent(instructions="test", llm=spec)
+    assert tripwire.calls == [], f"{spec!r} triggered discovery: {tripwire.calls}"

--- a/src/praisonai/tests/unit/llm/local/test_import_boundary.py
+++ b/src/praisonai/tests/unit/llm/local/test_import_boundary.py
@@ -121,7 +121,7 @@ def test_sloc_ceiling():
     ceilings = {
         "__init__.py": 90, "errors.py": 80, "capabilities.py": 200,
         "quirktable.py": 200, "discover.py": 345, "target.py": 200,
-        "resolve.py": 265,
+        "resolve.py": 270,
     }
     total = 0
     for path in _modules():
@@ -133,4 +133,4 @@ def test_sloc_ceiling():
         ceiling = ceilings.get(path.name)
         if ceiling:
             assert sloc <= ceiling, f"{path.name} is {sloc} SLOC, ceiling {ceiling}"
-    assert total <= 1150, f"package is {total} SLOC, ceiling 1150"
+    assert total <= 1160, f"package is {total} SLOC, ceiling 1160"

--- a/src/praisonai/tests/unit/llm/local/test_import_boundary.py
+++ b/src/praisonai/tests/unit/llm/local/test_import_boundary.py
@@ -1,0 +1,136 @@
+"""praisonaiagents.local must import nothing but the standard library.
+
+This is the property that makes the package adoptable by the 21 modules which
+currently bypass the LLM layer. An AST pass over 595 files found 26 mutually
+importing subpackage pairs; llm/ already imports upward into agent/, so a helper
+placed there could not be called from memory/ or eval/ without deepening the
+knot. A leaf can be called from anywhere.
+
+Treat a failure here as a build break, not a style issue.
+"""
+
+import ast
+import pathlib
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+FORBIDDEN_DISTRIBUTIONS = {
+    "litellm", "openai", "pydantic", "httpx", "requests", "aiohttp", "anyio",
+    "rich", "yaml", "posthog", "numpy", "chromadb", "mem0",
+}
+
+
+def _local_dir() -> pathlib.Path:
+    import praisonaiagents.local as pkg
+    return pathlib.Path(pkg.__file__).parent
+
+
+def _modules():
+    return sorted(_local_dir().glob("*.py"))
+
+
+def _import_roots(path):
+    """(absolute_roots, max_relative_level) for one module, without importing it."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    roots, max_level = set(), 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            max_level = max(max_level, node.level or 0)
+            if not node.level and node.module:
+                roots.add(node.module.split(".")[0])
+    return roots, max_level
+
+
+def test_only_stdlib_imports():
+    for path in _modules():
+        roots, _ = _import_roots(path)
+        outside = {r for r in roots if r not in sys.stdlib_module_names}
+        assert not outside, f"{path.name} imports non-stdlib: {sorted(outside)}"
+
+
+def test_no_praisonaiagents_import():
+    for path in _modules():
+        roots, _ = _import_roots(path)
+        assert "praisonaiagents" not in roots, (
+            f"{path.name} imports praisonaiagents; local/ must stay a dependency sink"
+        )
+
+
+def test_no_parent_relative_imports():
+    """`from .. import x` is the escape hatch that would break the sink."""
+    for path in _modules():
+        _, level = _import_roots(path)
+        assert level <= 1, (
+            f"{path.name} uses a level-{level} relative import; only single-dot "
+            "sibling imports are allowed"
+        )
+
+
+def test_forbidden_distributions():
+    for path in _modules():
+        roots, _ = _import_roots(path)
+        hits = roots & FORBIDDEN_DISTRIBUTIONS
+        assert not hits, f"{path.name} imports {sorted(hits)}"
+
+
+def test_loads_standalone_without_the_parent_package():
+    """Load local/ by file path, proving it needs no praisonaiagents __init__."""
+    import importlib.util
+    d = _local_dir()
+    before = set(sys.modules)
+    spec = importlib.util.spec_from_file_location(
+        "_local_boundary_probe", d / "__init__.py", submodule_search_locations=[str(d)])
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_local_boundary_probe"] = module
+    try:
+        spec.loader.exec_module(module)
+        assert callable(module.resolve)
+        added = set(sys.modules) - before
+        leaked = {m.split(".")[0] for m in added} & FORBIDDEN_DISTRIBUTIONS
+        assert not leaked, f"loading local/ pulled in {sorted(leaked)}"
+    finally:
+        for name in set(sys.modules) - before:
+            sys.modules.pop(name, None)
+
+
+def test_no_subprocess_anywhere():
+    """The package returns data; it never runs anything."""
+    for path in _modules():
+        roots, _ = _import_roots(path)
+        assert not roots & {"subprocess", "pty", "multiprocessing"}, (
+            f"{path.name} imports a process-spawning module"
+        )
+        src = path.read_text()
+        for banned in ("os.system(", "os.popen(", "os.execv", "os.spawn"):
+            assert banned not in src, f"{path.name} calls {banned}"
+
+
+def test_sloc_ceiling():
+    """A prior extraction in this repo grew 55% past its pre-split size in five
+    months. The budget is a test, not a guideline."""
+    # Ceilings are set just above measured reality so growth is a decision, not
+    # a drift. discover.py and quirktable.py are the two data-heavy modules --
+    # the probe table and the quirk catalogue are mostly literals and prose --
+    # which is why their ceilings are higher than their logic warrants.
+    ceilings = {
+        "__init__.py": 90, "errors.py": 80, "capabilities.py": 200,
+        "quirktable.py": 200, "discover.py": 345, "target.py": 200,
+        "resolve.py": 265,
+    }
+    total = 0
+    for path in _modules():
+        sloc = sum(
+            1 for line in path.read_text().splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        )
+        total += sloc
+        ceiling = ceilings.get(path.name)
+        if ceiling:
+            assert sloc <= ceiling, f"{path.name} is {sloc} SLOC, ceiling {ceiling}"
+    assert total <= 1150, f"package is {total} SLOC, ceiling 1150"

--- a/src/praisonai/tests/unit/llm/local/test_resolve.py
+++ b/src/praisonai/tests/unit/llm/local/test_resolve.py
@@ -1,0 +1,282 @@
+"""Resolution precedence, failure semantics and caching -- all offline.
+
+Every test injects a transport. The autouse `no_sockets` fixture in conftest
+turns a forgotten injection into a loud failure rather than a silent hit on
+whatever the developer has running.
+"""
+
+import pytest
+
+from praisonaiagents.local import (ApiStyle, Cap, EngineUnreachableError, Evidence,
+                                   HostHeaderRejectedError, HttpReply,
+                                   InvalidLocalSpecError, LocalEngine,
+                                   ModelNotAvailableError, NoLocalEngineError,
+                                   Quirk, cache_info, clear_cache, discover,
+                                   litellm_model_for, parse_ollama_host, parse_spec,
+                                   probe_endpoint, resolve, resolve_or_none)
+from .conftest import Recorder, ok, text
+
+pytestmark = pytest.mark.unit
+
+OLLAMA_ROUTES = {
+    ("GET", "/"): text("Ollama is running"),
+    ("GET", "/api/version"): ok({"version": "0.33.2"}),
+    ("GET", "/api/tags"): ok({"models": [
+        {"model": "qwen3:0.6b", "capabilities": ["completion", "tools", "thinking"],
+         "modified_at": "2026-09-03T13:44:23Z"},
+        {"model": "nomic-embed-text:latest", "capabilities": ["embedding"],
+         "modified_at": "2026-09-03T18:11:39Z"},
+    ]}),
+    ("POST", "/api/show"): ok({
+        "capabilities": ["completion", "tools", "thinking"],
+        "details": {"family": "qwen3", "parameter_size": "751.63M"},
+        "model_info": {"qwen3.context_length": 40960, "qwen3.embedding_length": 1024},
+    }),
+}
+
+
+def ollama(extra=None):
+    routes = dict(OLLAMA_ROUTES)
+    routes.update(extra or {})
+    return Recorder(routes)
+
+
+# --- identity is never inferred from a port ----------------------------------
+
+def test_ollama_identified_by_body_not_port():
+    t = ollama()
+    found = probe_endpoint("http://127.0.0.1:11434", transport=t)
+    assert found.engine is LocalEngine.OLLAMA
+    assert found.engine_version == "0.33.2"
+
+
+def test_something_else_on_11434_is_not_ollama():
+    """A server answering 200 on Ollama's port is UNKNOWN, not Ollama."""
+    t = Recorder({("GET", "/"): text("hello there")})
+    found = probe_endpoint("http://127.0.0.1:11434", transport=t)
+    assert found.engine is LocalEngine.UNKNOWN
+
+
+def test_port_8080_collision_llama_cpp_vs_mlx():
+    """Both claim 8080; /props is the discriminator."""
+    llama = Recorder({("GET", "/health"): text("ok"),
+                      ("GET", "/props"): ok({"build_info": "b7620", "modalities": {}})})
+    assert probe_endpoint("http://127.0.0.1:8080", transport=llama).engine is LocalEngine.LLAMA_CPP
+
+    mlx = Recorder({("GET", "/health"): text("ok"),
+                    ("GET", "/props"): HttpReply(404, b"nope"),
+                    ("GET", "/v1/models"): ok({"data": [{"id": "mlx-model"}]})})
+    assert probe_endpoint("http://127.0.0.1:8080", transport=mlx).engine is LocalEngine.MLX_LM
+
+
+def test_port_8000_collision_vllm_vs_transformers():
+    vllm = Recorder({("GET", "/version"): ok({"version": "0.28.0"})})
+    assert probe_endpoint("http://127.0.0.1:8000", transport=vllm).engine is LocalEngine.VLLM
+
+    tf = Recorder({("GET", "/version"): HttpReply(404, b""),
+                   ("GET", "/health"): text("ok"),
+                   ("GET", "/v1/models"): ok({"data": [{"id": "hf-model"}]})})
+    assert probe_endpoint("http://127.0.0.1:8000", transport=tf).engine is LocalEngine.TRANSFORMERS_SERVE
+
+
+# --- failure semantics --------------------------------------------------------
+
+def test_refused_yields_nothing_and_does_not_raise():
+    assert probe_endpoint("http://127.0.0.1:11434", transport=Recorder({})) is None
+    assert discover(transport=Recorder({})) == ()
+
+
+def test_bodyless_403_is_reported_not_hidden():
+    """Ollama's Host-header rejection must not look like 'nothing is running'."""
+    t = Recorder({}, default=HttpReply(403, b"", "http"))
+    found = probe_endpoint("http://192.168.1.10:11434", transport=t)
+    assert found is not None and found.blocked == "host_header_rejected"
+
+
+def test_blocked_only_raises_host_header_error(monkeypatch):
+    monkeypatch.setenv("PRAISONAI_LOCAL_BASE_URL", "http://192.168.1.10:11434")
+    t = Recorder({}, default=HttpReply(403, b"", "http"))
+    with pytest.raises(HostHeaderRejectedError) as exc:
+        resolve(transport=t)
+    assert "Host header" in str(exc.value)
+
+
+def test_malformed_json_does_not_raise():
+    t = ollama({("GET", "/api/tags"): text("{not json")})
+    found = probe_endpoint("http://127.0.0.1:11434", transport=t)
+    assert found.engine is LocalEngine.OLLAMA
+    assert found.models == ()
+
+
+def test_nothing_running_names_what_was_probed():
+    with pytest.raises(NoLocalEngineError) as exc:
+        resolve("local", transport=Recorder({}))
+    msg = str(exc.value)
+    assert "11434 (ollama)" in msg and "8080" in msg and "PRAISONAI_LOCAL_BASE_URL" in msg
+
+
+def test_resolve_or_none_swallows():
+    assert resolve_or_none("local", transport=Recorder({})) is None
+
+
+# --- precedence ---------------------------------------------------------------
+
+def test_named_source_that_does_not_answer_raises_without_falling_back(monkeypatch):
+    """Silently using a different server than the caller named is the failure
+    mode this package exists to prevent."""
+    monkeypatch.setenv("PRAISONAI_LOCAL_BASE_URL", "http://127.0.0.1:9999")
+    t = Recorder(OLLAMA_ROUTES)   # would answer, but only on the path it is asked
+    t.routes = {}                  # nothing answers at all
+    with pytest.raises(EngineUnreachableError) as exc:
+        resolve(transport=t)
+    assert exc.value.source == "PRAISONAI_LOCAL_BASE_URL"
+    assert "9999" in str(exc.value)
+
+
+def test_ollama_host_scheme_asymmetry_is_reported(monkeypatch):
+    """http:// with no port means 80, not 11434 -- users trip on this."""
+    monkeypatch.setenv("OLLAMA_HOST", "http://127.0.0.1")
+    with pytest.raises(EngineUnreachableError) as exc:
+        resolve(transport=Recorder({}))
+    assert ":80" in str(exc.value)
+    assert "not 11434" in str(exc.value)
+
+
+@pytest.mark.parametrize("value, expected", [
+    ("127.0.0.1", "http://127.0.0.1:11434"),
+    ("127.0.0.1:11500", "http://127.0.0.1:11500"),
+    ("11500", "http://127.0.0.1:11500"),
+    (":11500", "http://127.0.0.1:11500"),
+    ("http://127.0.0.1", "http://127.0.0.1:80"),
+    ("https://example.com", "https://example.com:443"),
+    ("", None),
+])
+def test_parse_ollama_host(value, expected):
+    assert parse_ollama_host(value) == expected
+
+
+def test_non_local_openai_base_url_is_ignored(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    with pytest.raises(NoLocalEngineError) as exc:
+        resolve("local", transport=Recorder({}))
+    assert "not a local address" in str(exc.value)
+
+
+def test_spec_engine_prefix_pins_the_engine(monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "127.0.0.1:11434")
+    t = ollama()
+    target = resolve("ollama/qwen3:0.6b", transport=t)
+    assert target.model_id == "qwen3:0.6b"
+    assert target.evidence_for("model_id") is Evidence.SPEC
+    assert target.evidence_for("base_url") is Evidence.ENV
+
+
+def test_bad_spec_raises():
+    with pytest.raises(InvalidLocalSpecError):
+        parse_spec("!!! not a spec !!!")
+
+
+# --- model selection ----------------------------------------------------------
+
+def test_embedding_only_model_is_never_chosen_to_chat(monkeypatch):
+    """The listing's newest entry is an embedder; it must not win."""
+    t = ollama({("GET", "/api/tags"): ok({"models": [
+        {"model": "aaa-embed", "capabilities": ["embedding"],
+         "modified_at": "2026-09-03T23:00:00Z"},
+        {"model": "zzz-chat", "capabilities": ["completion", "tools"],
+         "modified_at": "2026-01-01T00:00:00Z"},
+    ]})})
+    assert resolve("local", transport=t).model_id == "zzz-chat"
+
+
+def test_named_model_not_served_lists_alternatives(monkeypatch):
+    monkeypatch.setenv("PRAISONAI_LOCAL_MODEL", "llama3.2")
+    with pytest.raises(ModelNotAvailableError) as exc:
+        resolve("local", transport=ollama())
+    assert "qwen3:0.6b" in str(exc.value)
+
+
+# --- the produced target ------------------------------------------------------
+
+def test_target_carries_capabilities_and_quirks_from_the_server():
+    target = resolve("local", transport=ollama())
+    assert target.supports(Cap.TOOLS) and target.supports(Cap.THINKING)
+    assert target.evidence_for("caps") is Evidence.SERVER
+    assert target.has_quirk(Quirk.FORMAT_AND_TOOLS_MUTUALLY_DESTRUCTIVE)
+    # OPENAI_CHAT route, so the native-only quirk must be absent
+    assert not target.has_quirk(Quirk.NATIVE_ROUTE_NEVER_SETS_TOOL_FINISH_REASON)
+    assert target.get_extra("context_length") == "40960"
+
+
+def test_target_is_frozen_and_hashable():
+    target = resolve("local", transport=ollama())
+    hash(target)
+    with pytest.raises(Exception):
+        target.model_id = "other"
+
+
+def test_as_dict_is_json_serialisable():
+    import json
+    json.dumps(resolve("local", transport=ollama()).as_dict())
+
+
+@pytest.mark.parametrize("engine, expected", [
+    (LocalEngine.OLLAMA, "ollama/m"),
+    (LocalEngine.LM_STUDIO, "lm_studio/m"),
+    (LocalEngine.VLLM, "hosted_vllm/m"),
+    (LocalEngine.MLX_LM, "openai/m"),
+    (LocalEngine.UNKNOWN, "openai/m"),
+])
+def test_litellm_model_for(engine, expected):
+    assert litellm_model_for(engine, "m") == expected
+
+
+def test_ollama_never_maps_to_ollama_chat():
+    """_detect_provider resolves ollama_chat to 'openai' and would lose the adapter."""
+    assert litellm_model_for(LocalEngine.OLLAMA, "m") == "ollama/m"
+
+
+# --- caching ------------------------------------------------------------------
+
+def test_second_resolve_does_not_reprobe():
+    t = ollama()
+    resolve("local", transport=t)
+    before = len(t.calls)
+    resolve("local", transport=t)
+    assert len(t.calls) == before
+
+
+def test_refresh_bypasses_cache():
+    t = ollama()
+    resolve("local", transport=t)
+    before = len(t.calls)
+    resolve("local", transport=t, refresh=True)
+    assert len(t.calls) > before
+
+
+def test_env_change_is_a_cache_miss(monkeypatch):
+    t = ollama()
+    resolve("local", transport=t)
+    before = len(t.calls)
+    monkeypatch.setenv("PRAISONAI_LOCAL_MODEL", "qwen3:0.6b")
+    resolve("local", transport=t)
+    assert len(t.calls) > before
+
+
+def test_negative_result_is_cached_and_reraised_fresh():
+    t = Recorder({})
+    with pytest.raises(NoLocalEngineError) as first:
+        resolve("local", transport=t)
+    probes = len(t.calls)
+    with pytest.raises(NoLocalEngineError) as second:
+        resolve("local", transport=t)
+    assert len(t.calls) == probes           # no second probe round
+    assert first.value is not second.value  # a fresh instance, not a stored one
+    assert str(first.value) == str(second.value)
+
+
+def test_clear_cache_empties_both():
+    resolve("local", transport=ollama())
+    clear_cache()
+    info = cache_info()
+    assert info["targets"] == 0 and info["negatives"] == 0

--- a/src/praisonai/tests/unit/llm/local/test_resolve.py
+++ b/src/praisonai/tests/unit/llm/local/test_resolve.py
@@ -196,6 +196,26 @@ def test_named_model_not_served_lists_alternatives(monkeypatch):
     assert "qwen3:0.6b" in str(exc.value)
 
 
+def test_explicit_spec_model_not_served_raises_at_resolution(monkeypatch):
+    """A spec-named model absent from the server must fail here, not on the
+    first completion; Agent would otherwise send an unavailable id to Ollama."""
+    monkeypatch.setenv("OLLAMA_HOST", "127.0.0.1:11434")
+    with pytest.raises(ModelNotAvailableError) as exc:
+        resolve("ollama/does-not-exist", transport=ollama())
+    assert "does-not-exist" in str(exc.value)
+    assert "qwen3:0.6b" in str(exc.value)
+
+
+def test_reachable_server_with_no_models_raises(monkeypatch):
+    """A server that answers but lists no model must not yield a model-less
+    target -- Agent would then substitute its own default (e.g. gpt-4o-mini)
+    and send it to the local endpoint."""
+    t = ollama({("GET", "/api/tags"): ok({"models": []})})
+    with pytest.raises(NoLocalEngineError) as exc:
+        resolve("local", transport=t)
+    assert "no usable model" in str(exc.value)
+
+
 # --- the produced target ------------------------------------------------------
 
 def test_target_carries_capabilities_and_quirks_from_the_server():


### PR DESCRIPTION
## What this gives you

```python
from praisonaiagents import Agent

agent = Agent(instructions="...", llm="local")   # no URL, no model name, no key
```

Verified end-to-end against a live Ollama 0.33.2: discovers the server, selects `qwen3:0.6b`, selects `OllamaAdapter`, answers.

## What it is, and is not

Every local runtime worth supporting already speaks OpenAI over HTTP, and litellm already owns that transport. So this is **not a transport and not a client**. It answers three questions and returns the answers as frozen data: *what is running here, what can that model do, and what will it silently get wrong.*

## Two properties are load-bearing, and are tests rather than conventions

**1. It is a dependency sink.** Every module imports only the standard library and its siblings — nothing from `praisonaiagents`, no third-party distribution.

That is not stylistic. An AST pass over 595 files found **26 mutually-importing subpackage pairs**, and `llm/` already imports upward into `agent/` — so a helper placed there could not be adopted by `memory/` or `eval/` without deepening that knot. A leaf can be called from anywhere, which is what makes it usable later by the 21 modules that currently bypass the LLM layer.

`test_import_boundary.py` checks this seven ways, including **loading the package by file path with no parent `__init__` executed**.

It is also why the HTTP client is `urllib.request` and not `httpx`. `httpx` is present — but only as an *undeclared transitive* dependency of `openai`. A package whose whole point is that anything can import it must not rest on that. A full resolve issues at most four loopback requests and then caches for 30s.

**2. It produces data, never behaviour.** Frozen, hashable dataclasses out. No chat call, no retry, no request mutation, no process spawning, no disk writes — also asserted. Compensating behaviour stays in `llm/adapters/`.

## Identity is never inferred from a port

`:8080` is claimed by llama-server, mlx_lm, llamafile, LocalAI and RamaLama; `:8000` by vLLM and `transformers serve`. A probe matches only when **every** rule holds, and `ABSENT` rules exist to separate co-tenants — llama.cpp answers `/props`, mlx_lm does not; vLLM answers `/version`, `transformers serve` does not. Both collisions have tests.

## Resolution precedence

`spec` → `PRAISONAI_LOCAL_BASE_URL` → `OLLAMA_HOST` → `OPENAI_BASE_URL`/`OPENAI_API_BASE` (only when the host is local) → probe scan.

The first three are **authoritative**: if one names a server that does not answer, this raises rather than quietly using a different one. Silently talking to a server the caller did not name is the failure mode this package exists to prevent.

`OLLAMA_HOST`'s own asymmetry is handled and explained *in the error text*:

```
Local runtime at http://127.0.0.1:80 did not answer (refused). It was named
explicitly by OLLAMA_HOST='http://127.0.0.1', so no other port was probed. Note
that OLLAMA_HOST with an explicit http:// scheme and no port means port 80, not 11434.
```

## Three things testing found that reasoning had not

1. **Model selection first picked `all-minilm` — an embedding-only model — to chat with**, because it sorted first alphabetically. Selection now ranks embedding-only models *last* and tools-capable first, then by recency. On this machine that correctly prefers `qwen3:0.6b` over three **newer** embedders.
2. **The SLOC ceiling test caught `target.py` at 424 lines against a 200 budget** — it was holding the value type, six exception classes, parsing, capability fetching, caching *and* resolution. Split into `errors.py` / `target.py` (pure) / `resolve.py` (precedence + cache). The split then orphaned three symbols; each was caught by a test rather than by review.
3. **A `base_url` from an environment variable was recorded as `Evidence.SERVER`.** The probe only proves a server answered — provenance is the entire point of that field, so it now records `ENV`.

## Opt-in, and it stays cheap

Discovery fires **only** for `llm="local"`. A test asserts `gpt-4o`, `ollama/llama3.2` and `anthropic/...` trigger **zero** probes. Importing `praisonaiagents` does not import `local/` at all, and import time is unchanged at 0.04s.

## Tests

**53, all offline.** An autouse fixture makes any real socket construction in that directory a hard failure, so a forgotten transport injection cannot silently hit a developer's own Ollama.

```
tests/unit/llm/local/                       53 passed
tests/unit/{llm,agent,adapters,doctor}/    306 passed, 4 subtests
```

## Not in this PR

`manage.py` (remedy data) and `embed.py` (embedding targets) are specified in `docs/local-model-layer/07-local-package-spec.md` and deliberately not implemented here. This ships the resolver and its one consumer — adding modules with no live consumer is what the repo's own guidance rules out.

Spec and context: #4790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic discovery and configuration for local language-model servers.
  - Supports `llm="local"` and explicit local engine/model specifications.
  - Detects available models, capabilities, and supported runtimes.
  - Provides clearer errors when local servers or requested models are unavailable.
  - Adds caching and environment-based configuration for local model resolution.

- **Tests**
  - Added coverage for discovery, resolution, model selection, caching, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->