### PR TITLE
fix(llm): filter Ollama tool arguments on the stream path too

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -4384,6 +4384,15 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                     self._tool_parse_error_message(function_name, tool_call_id)
                                 )
                                 continue
+                            # Validate and filter arguments for Ollama provider.
+                            # Pre-dispatch, so this is streaming-safe: nothing has
+                            # been yielded that would need retracting. Weak local
+                            # models routinely emit arguments belonging to a
+                            # different function, and dispatching those calls the
+                            # user's tool with parameters it never declared.
+                            if is_ollama and tools:
+                                arguments = self._validate_and_filter_ollama_arguments(
+                                    function_name, arguments, tools)
                             tool_calls_batch.append(ToolCall(
                                 function_name=function_name,
                                 arguments=arguments, 
@@ -4590,6 +4599,15 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 messages.append(
                                     self._tool_parse_error_message(function_name, tool_call_id))
                                 continue
+                            # Validate and filter arguments for Ollama provider.
+                            # Pre-dispatch, so this is streaming-safe: nothing has
+                            # been yielded that would need retracting. Weak local
+                            # models routinely emit arguments belonging to a
+                            # different function, and dispatching those calls the
+                            # user's tool with parameters it never declared.
+                            if is_ollama and tools:
+                                arguments = self._validate_and_filter_ollama_arguments(
+                                    function_name, arguments, tools)
                             try:
                                 tool_result = execute_tool_fn(function_name, arguments)
                             except Exception as tool_error:  # noqa: BLE001

--- a/src/praisonai/tests/unit/llm/test_stream_ollama_argument_filtering.py
+++ b/src/praisonai/tests/unit/llm/test_stream_ollama_argument_filtering.py
@@ -1,0 +1,104 @@
+"""The stream path now filters Ollama's tool arguments, like the other two.
+
+`_validate_and_filter_ollama_arguments` drops arguments that do not appear in the
+target function's signature. Weak local models routinely emit arguments belonging
+to a *different* function, and dispatching those calls the user's tool with
+parameters it never declared.
+
+It was applied on the sync and async paths and absent from both of the stream
+path's dispatch points. Porting it is safe there because it runs *before*
+`execute_tool_fn`, so nothing has been yielded that would need retracting -- which
+is what separates it from the repair-and-retry compensations that genuinely
+cannot work while streaming.
+"""
+
+import inspect
+
+import pytest
+
+from praisonaiagents.llm import llm as llm_module
+from praisonaiagents.llm.llm import LLM
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in ("OPENAI_BASE_URL", "OPENAI_API_BASE", "OLLAMA_HOST"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+
+def _source(name):
+    return inspect.getsource(getattr(LLM, name))
+
+
+def test_stream_path_now_filters_arguments():
+    """Both stream dispatch points guard before calling the tool."""
+    src = _source("get_response_stream")
+    assert src.count("_validate_and_filter_ollama_arguments") == 2, (
+        "expected the filter at both the streaming and fallback dispatch points"
+    )
+
+
+@pytest.mark.parametrize("method", ["get_response", "get_response_async", "get_response_stream"])
+def test_every_response_path_filters(method):
+    """The parity this step exists to create."""
+    assert "_validate_and_filter_ollama_arguments" in _source(method)
+
+
+def test_filter_runs_before_dispatch_in_the_stream_path():
+    """Pre-dispatch placement is what makes this streaming-safe."""
+    src = _source("get_response_stream")
+    first_filter = src.index("_validate_and_filter_ollama_arguments")
+    first_exec = src.index("execute_tool_fn(function_name, arguments)")
+    assert first_filter < first_exec
+
+
+# --- the filter's own behaviour ------------------------------------------------
+
+def make_llm():
+    return LLM(model="ollama/qwen3:0.6b")
+
+
+def get_weather(city: str) -> str:
+    """Get the weather.
+
+    Args:
+        city: the city
+    """
+    return f"{city}: sunny"
+
+
+def test_argument_from_another_function_is_dropped():
+    llm = make_llm()
+    filtered = llm._validate_and_filter_ollama_arguments(
+        "get_weather", {"city": "Paris", "stock_symbol": "AAPL"}, [get_weather])
+    assert filtered == {"city": "Paris"}
+
+
+def test_valid_arguments_survive_untouched():
+    llm = make_llm()
+    assert llm._validate_and_filter_ollama_arguments(
+        "get_weather", {"city": "Paris"}, [get_weather]) == {"city": "Paris"}
+
+
+def test_unknown_function_is_left_alone():
+    """If we cannot inspect the target, do not silently drop the user's data."""
+    llm = make_llm()
+    args = {"anything": 1}
+    assert llm._validate_and_filter_ollama_arguments("not_a_tool", args, [get_weather]) == args
+
+
+def test_no_tools_leaves_arguments_alone():
+    llm = make_llm()
+    args = {"city": "Paris"}
+    assert llm._validate_and_filter_ollama_arguments("get_weather", args, []) == args
+
+
+def test_guard_is_scoped_to_ollama():
+    """`if is_ollama and tools` keeps this a no-op for every other provider."""
+    src = _source("get_response_stream")
+    idx = src.index("_validate_and_filter_ollama_arguments")
+    window = src[max(0, idx - 400):idx]
+    assert "if is_ollama and tools:" in window


### PR DESCRIPTION
> **Stacked on #4810 → #4809 → #4808 → #4806 → #4804.** Merge in order. Last step of order 06.

## Problem

`_validate_and_filter_ollama_arguments` drops arguments that do not appear in the target function's signature. Weak local models routinely emit arguments belonging to a **different** function, and dispatching those calls **your tool with parameters it never declared**.

It was applied on the sync and async paths and **absent from both of the stream path's dispatch points**, so a streaming agent got no protection at all.

| compensation | sync | async | stream (before) | stream (after) |
|---|---|---|---|---|
| `_validate_and_filter_ollama_arguments` | ✓ | ✓ | **✗** | ✓ |

## Why this one is safe to port, when most are not

It runs **before** `execute_tool_fn`, so nothing has been yielded that would need retracting.

That is precisely what separates it from the repair-and-retry compensations, which genuinely **cannot** work while streaming: once a content delta has been yielded into the caller's `for` loop, it cannot be un-yielded. You can refuse to dispatch, you can yield more, you can raise — you cannot retract.

So this is the one A2 gap that belongs in a refactor-only order rather than a behaviour-changing follow-up.

Guarded by `if is_ollama and tools`, so it is a no-op for every other provider — and a test pins that guard rather than trusting the surrounding code.

## Scope discipline

Behaviour on this machine is **unchanged across all three paths**, including the stream path's pre-existing failure:

```
sync    calls=2   'Paris: 21C sunny. Paris: 21C sunny.'
async   calls=1   'Paris: 21C sunny'
stream  calls=10  ''            <- still broken, deliberately
```

The stream path invoking the tool ten times and yielding nothing is caused by the *absence of the summary compensations*, not this filter. Fixing it changes the stream contract — a turn that currently yields nothing would begin yielding synthesized text the model never produced — and that is a product decision needing its own order and its own review, not something to smuggle in here.

## Tests

10 in `test_stream_ollama_argument_filtering.py`, including that the filter runs *before* dispatch, that all three paths now apply it, and that an argument belonging to another function is dropped while valid ones survive untouched.

```
test_stream_ollama_argument_filtering.py   10 passed
tests/unit/{llm,agent,adapters,doctor}/   321 passed, 4 subtests
```

Context: #4790 order 06, step 06.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
