### PR TITLE
fix: make the auxiliary-model fallback configurable everywhere, not just half of it

### DIFF
--- a/src/praisonai-agents/praisonaiagents/context/compressor.py
+++ b/src/praisonai-agents/praisonaiagents/context/compressor.py
@@ -13,6 +13,7 @@ from datetime import datetime
 
 from ..llm.protocols import LLMProviderProtocol
 from .tokens import estimate_messages_tokens, get_estimator
+from ..llm.model_providers import default_auxiliary_model
 
 
 @dataclass
@@ -374,7 +375,7 @@ Provide a concise summary under {max_tokens} tokens that preserves the essential
                 # Try common OpenAI-compatible interface - check if async
                 if hasattr(self.llm.chat.completions, 'acreate'):
                     response = await self.llm.chat.completions.acreate(
-                        model=model or "gpt-4o-mini",
+                        model=default_auxiliary_model(model),
                         messages=[{"role": "user", "content": summary_prompt}],
                         max_tokens=max_tokens,
                         temperature=0.3,
@@ -382,7 +383,7 @@ Provide a concise summary under {max_tokens} tokens that preserves the essential
                 else:
                     # Fallback to sync create (blocking in async context)
                     response = self.llm.chat.completions.create(
-                        model=model or "gpt-4o-mini",
+                        model=default_auxiliary_model(model),
                         messages=[{"role": "user", "content": summary_prompt}],
                         max_tokens=max_tokens,
                         temperature=0.3,

--- a/src/praisonai-agents/praisonaiagents/context/optimizer.py
+++ b/src/praisonai-agents/praisonaiagents/context/optimizer.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from .models import ContextLedger, OptimizerStrategy, OptimizationResult
 from .tokens import estimate_messages_tokens, get_estimator
 from .compressor import ContextCompressor
+from ..llm.model_providers import default_auxiliary_model
 
 logger = logging.getLogger(__name__)
 
@@ -638,7 +639,7 @@ class LLMContextCompressorOptimizer(BaseOptimizer):
             use_accurate_tokenizer: Use model-specific tokenizer if available
         """
         self.llm_client = llm_client
-        self.auxiliary_model = auxiliary_model or "gpt-4o-mini"
+        self.auxiliary_model = default_auxiliary_model(auxiliary_model)
         self.protect_last_n_tokens = protect_last_n_tokens
         self.summary_target_tokens = summary_target_tokens
         

--- a/src/praisonai-agents/praisonaiagents/lite/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/lite/__init__.py
@@ -91,7 +91,7 @@ class LiteAgent:
             import openai
             client = openai.OpenAI()
             response = client.chat.completions.create(
-                model="gpt-4o-mini",
+                model=default_auxiliary_model(),
                 messages=messages
             )
             return response.choices[0].message.content
@@ -235,7 +235,7 @@ def create_openai_llm_fn(
         LLM function compatible with LiteAgent
         
     Example:
-        llm_fn = create_openai_llm_fn(model="gpt-4o-mini")
+        llm_fn = create_openai_llm_fn(model=default_auxiliary_model())
         agent = LiteAgent(llm_fn=llm_fn)
     """
     def llm_fn(messages: List[Dict]) -> str:
@@ -312,6 +312,7 @@ def create_anthropic_llm_fn(
 from ..tools.tools import Tools
 from ..tools.base import BaseTool, ToolResult
 from ..tools.decorator import tool
+from ..llm.model_providers import default_auxiliary_model
 
 
 __all__ = [

--- a/src/praisonai-agents/praisonaiagents/llm/model_providers.py
+++ b/src/praisonai-agents/praisonaiagents/llm/model_providers.py
@@ -74,6 +74,37 @@ def is_hosted_only_model(model_name: str) -> bool:
     return False
 
 
+# The small helper model used for internal auxiliary calls -- memory quality
+# scoring, context compaction, session titling, workflow routing. Historically
+# about a dozen sites resolved this from OPENAI_MODEL_NAME while about twenty
+# more hardcoded the same string, so half of them could not be pointed anywhere
+# else. That, not the endpoint, is what blocks running fully locally: litellm and
+# the openai SDK both honour OPENAI_BASE_URL, so those sites do reach a local
+# server -- and then ask it for a model no local server serves.
+DEFAULT_AUXILIARY_MODEL = "gpt-4o-mini"
+
+
+def default_auxiliary_model(explicit: Optional[str] = None) -> str:
+    """Resolve the model to use for an internal auxiliary LLM call.
+
+    Precedence: an explicit argument, then PRAISONAI_AUXILIARY_MODEL, then
+    OPENAI_MODEL_NAME, then DEFAULT_AUXILIARY_MODEL.
+
+    PRAISONAI_AUXILIARY_MODEL exists because a local setup often wants a
+    *smaller* model for helper calls than for the agent itself -- pointing
+    OPENAI_MODEL_NAME at a 70B local model should not make every internal
+    summarisation call use it.
+    """
+    if explicit:
+        return explicit
+    import os
+    for var in ("PRAISONAI_AUXILIARY_MODEL", "OPENAI_MODEL_NAME"):
+        value = (os.environ.get(var) or "").strip()
+        if value:
+            return value
+    return DEFAULT_AUXILIARY_MODEL
+
+
 def _entry_point_matchers():
     """Yield (provider_id, matcher) pairs registered by third-party plugins.
 

--- a/src/praisonai-agents/praisonaiagents/memory/learn/manager.py
+++ b/src/praisonai-agents/praisonaiagents/memory/learn/manager.py
@@ -19,6 +19,7 @@ from .stores import (
     ImprovementStore,
     LearnEntry,
 )
+from ...llm.model_providers import default_auxiliary_model
 
 
 class LearnManager:
@@ -555,7 +556,7 @@ Return empty arrays if nothing is found for a category."""
             from ...llm import LLM
             import json
             
-            model = llm or "gpt-4o-mini"
+            model = default_auxiliary_model(llm)
             llm_instance = LLM(model=model)
             response = llm_instance.get_response(
                 prompt=extraction_prompt,
@@ -659,7 +660,7 @@ Return empty arrays if nothing is found for a category."""
             import json
             import asyncio
             
-            model = llm or "gpt-4o-mini"
+            model = default_auxiliary_model(llm)
             llm_instance = LLM(model=model)
             
             # Run sync LLM call in executor for async compatibility

--- a/src/praisonai-agents/praisonaiagents/memory/memory.py
+++ b/src/praisonai-agents/praisonaiagents/memory/memory.py
@@ -2191,7 +2191,10 @@ class Memory(SearchMixin, MemoryCoreMixin):
                 # base_url supplied through config -- which is the shape the rest
                 # of the memory layer uses.
                 _client_kwargs = {}
-                _base_url = (self.config or {}).get("base_url") if hasattr(self, "config") else None
+                _cfg = getattr(self, "cfg", None) or {}
+                _base_url = _cfg.get("base_url")
+                if not _base_url and isinstance(_cfg.get("config"), dict):
+                    _base_url = _cfg["config"].get("base_url")
                 _base_url = _base_url or os.getenv("OPENAI_BASE_URL") or os.getenv("OPENAI_API_BASE")
                 if _base_url:
                     _client_kwargs["base_url"] = _base_url

--- a/src/praisonai-agents/praisonaiagents/memory/memory.py
+++ b/src/praisonai-agents/praisonaiagents/memory/memory.py
@@ -19,6 +19,7 @@ from .protocols import MemoryProtocol
 from .adapters import get_memory_adapter, get_first_available_memory_adapter
 from .adapters.sqlite_adapter import SqliteMemoryAdapter
 from .adapters.factories import sanitize_chroma_metadata
+from ..llm.model_providers import default_auxiliary_model
 
 # Disable litellm telemetry before any imports
 os.environ["LITELLM_TELEMETRY"] = "False"
@@ -2171,7 +2172,7 @@ class Memory(SearchMixin, MemoryCoreMixin):
                 import litellm
                 
                 # Convert model name if it's in litellm format
-                model_name = llm or "gpt-4o-mini"
+                model_name = default_auxiliary_model(llm)
                 
                 response = litellm.completion(
                     model=model_name,
@@ -2185,10 +2186,21 @@ class Memory(SearchMixin, MemoryCoreMixin):
             elif openai_available:
                 # Fallback to OpenAI client
                 from openai import OpenAI
-                client = OpenAI()
+                # Pass the endpoint explicitly. A bare OpenAI() happens to work
+                # when OPENAI_BASE_URL is exported, but silently ignores a
+                # base_url supplied through config -- which is the shape the rest
+                # of the memory layer uses.
+                _client_kwargs = {}
+                _base_url = (self.config or {}).get("base_url") if hasattr(self, "config") else None
+                _base_url = _base_url or os.getenv("OPENAI_BASE_URL") or os.getenv("OPENAI_API_BASE")
+                if _base_url:
+                    _client_kwargs["base_url"] = _base_url
+                    # Local servers reject an empty key; any non-empty value works.
+                    _client_kwargs["api_key"] = os.getenv("OPENAI_API_KEY") or "local"
+                client = OpenAI(**_client_kwargs)
                 
                 response = client.chat.completions.create(
-                    model=llm or "gpt-4o-mini",
+                    model=default_auxiliary_model(llm),
                     messages=[{
                         "role": "user", 
                         "content": custom_prompt or default_prompt

--- a/src/praisonai-agents/praisonaiagents/session/title.py
+++ b/src/praisonai-agents/praisonaiagents/session/title.py
@@ -11,8 +11,6 @@ from ..llm.model_providers import default_auxiliary_model
 
 __all__ = ["generate_title", "generate_title_async"]
 
-_DEFAULT_SMALL_MODEL = default_auxiliary_model()
-
 
 def _resolve_small_model(llm_model: Optional[str], primary_model: Optional[str]) -> str:
     """Resolve the auxiliary model for title generation.
@@ -20,18 +18,21 @@ def _resolve_small_model(llm_model: Optional[str], primary_model: Optional[str])
     An explicit ``llm_model`` always wins. Otherwise the configured
     ``defaults.small_model`` is used, falling back to the primary model and
     finally to the historical ``gpt-4o-mini`` default so existing behaviour is
-    preserved when nothing is configured.
+    preserved when nothing is configured. The default is resolved at call time
+    so ``PRAISONAI_AUXILIARY_MODEL`` / ``OPENAI_MODEL_NAME`` set after import
+    still take effect.
     """
     if llm_model:
         return llm_model
+    default_small_model = default_auxiliary_model()
     try:
         from ..config.loader import get_small_model
-        resolved = get_small_model(primary_model=primary_model, fallback=_DEFAULT_SMALL_MODEL)
+        resolved = get_small_model(primary_model=primary_model, fallback=default_small_model)
         if resolved:
             return resolved
     except Exception:
         pass
-    return primary_model or _DEFAULT_SMALL_MODEL
+    return primary_model or default_small_model
 
 
 def generate_title(

--- a/src/praisonai-agents/praisonaiagents/session/title.py
+++ b/src/praisonai-agents/praisonaiagents/session/title.py
@@ -7,10 +7,11 @@ exchange in a conversation. Uses a lightweight model for fast generation.
 
 import asyncio
 from typing import Optional
+from ..llm.model_providers import default_auxiliary_model
 
 __all__ = ["generate_title", "generate_title_async"]
 
-_DEFAULT_SMALL_MODEL = "gpt-4o-mini"
+_DEFAULT_SMALL_MODEL = default_auxiliary_model()
 
 
 def _resolve_small_model(llm_model: Optional[str], primary_model: Optional[str]) -> str:

--- a/src/praisonai-agents/praisonaiagents/task/task.py
+++ b/src/praisonai-agents/praisonaiagents/task/task.py
@@ -10,6 +10,7 @@ import os
 import time
 
 from .protocols import TaskStatus, TaskLifecycleManager
+from ..llm.model_providers import default_auxiliary_model
 
 # Set up logger
 logger = get_logger(__name__)
@@ -729,7 +730,7 @@ class Task:
                         if hasattr(self.agent.llm_instance, 'model'):
                             llm_model = self.agent.llm_instance.model
                         else:
-                            llm_model = "gpt-4o-mini"  # Default fallback
+                            llm_model = default_auxiliary_model()
                     elif hasattr(self.agent, 'llm') and self.agent.llm:
                         # For standard model strings
                         llm_model = self.agent.llm

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -36,6 +36,7 @@ from .workflow_configs import (
     TaskContextConfig, TaskOutputConfig, TaskExecutionConfig, TaskRoutingConfig,
 )
 from ..task.task import Task
+from ..llm.model_providers import default_auxiliary_model
 
 logger = get_logger(__name__)
 
@@ -1267,7 +1268,7 @@ class AgentFlow:
         self._validate_framework()
         
         # Use default LLM if not specified
-        model = llm or self.llm or "gpt-4o-mini"
+        model = default_auxiliary_model(llm or self.llm)
         logger.debug(f"Workflow using model: {model} (llm={llm}, default_llm={self.llm})")
 
         # Agents the flow builds itself already receive the default via

--- a/src/praisonai/tests/unit/llm/test_auxiliary_model_default.py
+++ b/src/praisonai/tests/unit/llm/test_auxiliary_model_default.py
@@ -1,0 +1,104 @@
+"""The auxiliary-model fallback must be configurable everywhere, not just in some places.
+
+Roughly a dozen sites resolved their small helper model as
+`os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini")`, and roughly twenty more
+hardcoded `"gpt-4o-mini"` directly. Same value, same purpose -- but only half of
+them could be pointed anywhere else.
+
+That is the real obstacle to running fully locally. It is NOT the endpoint:
+litellm and the openai SDK both honour OPENAI_BASE_URL from the environment
+(verified), so the bypass call sites do reach a local server. They then ask it
+for a model called "gpt-4o-mini", which no local server serves.
+"""
+
+import pytest
+
+from praisonaiagents.llm.model_providers import (DEFAULT_AUXILIARY_MODEL,
+                                                 default_auxiliary_model)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def clean(monkeypatch):
+    monkeypatch.delenv("OPENAI_MODEL_NAME", raising=False)
+    monkeypatch.delenv("PRAISONAI_AUXILIARY_MODEL", raising=False)
+
+
+def test_default_is_unchanged_when_nothing_is_set():
+    assert default_auxiliary_model() == DEFAULT_AUXILIARY_MODEL == "gpt-4o-mini"
+
+
+def test_openai_model_name_is_honoured(monkeypatch):
+    monkeypatch.setenv("OPENAI_MODEL_NAME", "ollama/llama3.2")
+    assert default_auxiliary_model() == "ollama/llama3.2"
+
+
+def test_dedicated_override_wins_over_the_general_one(monkeypatch):
+    """A local setup often wants a *smaller* model for helper calls than for the
+    agent itself, so the specific variable must beat the general one."""
+    monkeypatch.setenv("OPENAI_MODEL_NAME", "ollama/llama3.3:70b")
+    monkeypatch.setenv("PRAISONAI_AUXILIARY_MODEL", "ollama/qwen3:0.6b")
+    assert default_auxiliary_model() == "ollama/qwen3:0.6b"
+
+
+def test_explicit_argument_beats_every_environment_variable(monkeypatch):
+    monkeypatch.setenv("OPENAI_MODEL_NAME", "ollama/llama3.2")
+    assert default_auxiliary_model("gpt-4o") == "gpt-4o"
+
+
+def test_empty_environment_value_is_ignored(monkeypatch):
+    monkeypatch.setenv("OPENAI_MODEL_NAME", "   ")
+    assert default_auxiliary_model() == DEFAULT_AUXILIARY_MODEL
+
+
+def test_no_heavy_import(monkeypatch):
+    """These call sites are on hot paths; resolving a model name must stay cheap."""
+    import subprocess, sys, textwrap
+    code = textwrap.dedent("""
+        import sys
+        from praisonaiagents.llm.model_providers import default_auxiliary_model
+        default_auxiliary_model()
+        bad = [m for m in sys.modules if m.split('.')[0] in ('litellm', 'chromadb')]
+        print('HEAVY' if bad else 'CLEAN')
+    """)
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert "CLEAN" in out.stdout, out.stdout + out.stderr
+
+
+# --- the call sites ------------------------------------------------------------
+
+CALL_SITES = [
+    ("memory/memory.py", 2),
+    ("memory/learn/manager.py", 2),
+    ("context/compressor.py", 2),
+    ("context/optimizer.py", 1),
+    ("workflows/workflows.py", 1),
+    ("lite/__init__.py", 2),
+    ("task/task.py", 1),
+    ("session/title.py", 1),
+]
+
+
+@pytest.mark.parametrize("relative, expected", CALL_SITES)
+def test_call_site_uses_the_helper(relative, expected):
+    import pathlib
+    import praisonaiagents
+    path = pathlib.Path(praisonaiagents.__file__).parent / relative
+    source = path.read_text()
+    assert source.count("default_auxiliary_model") >= expected, (
+        f"{relative} still hardcodes its auxiliary model fallback"
+    )
+
+
+def test_memory_quality_scoring_does_not_construct_a_bare_openai_client():
+    """`OpenAI()` with no arguments ignores any configured endpoint.
+
+    It happens to work today because the SDK reads OPENAI_BASE_URL itself, but it
+    silently ignores a base_url passed through config, which is the shape the
+    rest of the memory layer uses.
+    """
+    import pathlib
+    import praisonaiagents
+    source = (pathlib.Path(praisonaiagents.__file__).parent / "memory/memory.py").read_text()
+    assert "client = OpenAI()" not in source


### PR DESCRIPTION
## A correction to my own earlier analysis

The ledger (#4790) states that nine modules "structurally cannot be pointed at a local server" because they contain no `api_base`/`base_url` parameter, and concludes that running fully locally is *"unachievable, not merely unconfigured"*.

**The parameter gap is real. The conclusion was wrong.** Measured:

```
litellm.completion  with OPENAI_BASE_URL=http://127.0.0.1:11434/v1  -> answers
openai SDK          with OPENAI_BASE_URL=http://127.0.0.1:11434/v1  -> answers
```

Both honour the environment variable, so those bypass call sites **do** reach a local server. They then ask it for a model called `gpt-4o-mini`, which no local server serves. **That** is the actual obstacle, and it is a different fix from the one the audit implied.

## The real defect: half-configurable

| | count |
|---|---|
| sites resolving `os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini")` | ~12 |
| sites hardcoding `"gpt-4o-mini"` instead | ~20 |

Same value, same purpose — but only half could be pointed anywhere else. So memory quality scoring, context compaction, session titling, workflow routing and the lite helpers all silently asked a local server for an OpenAI model.

## Change

Adds `default_auxiliary_model()` to `llm/model_providers.py` — the module already documented as *"the single source of truth for provider inference"* — and routes eight modules through it.

Precedence: **explicit argument** → `PRAISONAI_AUXILIARY_MODEL` → `OPENAI_MODEL_NAME` → `"gpt-4o-mini"` (unchanged).

`PRAISONAI_AUXILIARY_MODEL` exists because a local setup usually wants a **smaller** model for internal helper calls than for the agent itself. Pointing `OPENAI_MODEL_NAME` at a 70B local model should not make every internal summarisation call use it:

```
unset                                   -> gpt-4o-mini
OPENAI_MODEL_NAME=ollama/llama3.3:70b   -> ollama/llama3.3:70b
+ PRAISONAI_AUXILIARY_MODEL=qwen3:0.6b  -> ollama/qwen3:0.6b
```

Also replaces the bare `OpenAI()` in memory quality scoring. It happens to work when `OPENAI_BASE_URL` is exported, but silently ignores a `base_url` supplied through **config** — which is the shape the rest of the memory layer uses.

**Routed:** `memory/memory.py`, `memory/learn/manager.py`, `context/compressor.py`, `context/optimizer.py`, `workflows/workflows.py`, `lite/__init__.py`, `task/task.py`, `session/title.py`.

**Deliberately not routed:** cost tables (`utils/cost_utils.py`, `llm/_cost.py`) where the name selects a *price* not a model; docstring examples; and public dataclass field defaults, which are API surface rather than internal fallbacks.

## Tests

15 in `test_auxiliary_model_default.py`, **9 fail before this change**. They include the unchanged default when nothing is set, a **subprocess check that resolving a model name pulls in no heavy dependency** (these are hot paths), and a per-module assertion that each call site now uses the helper.

```
test_auxiliary_model_default.py                              15 passed
tests/unit/{llm,agent,adapters,doctor,knowledge}/           384 passed, 4 subtests
every touched module still imports                            8/8 ok
```

The 28 failures in the wider memory/context/workflow suites reproduce identically with this change stashed (28 vs 28).

## Scope

This closes the *model-name* half of the reachability problem, which is the half that actually blocked local use. The *parameter* half — giving those nine modules a real `base_url=` argument so they can be configured without environment variables — remains open and is a larger API change deserving its own design.

Context: #4790 order 08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized auxiliary model configuration with support for explicit settings and environment variables.
  * Auxiliary model selection now supports local and OpenAI-compatible endpoints.
  * Improved base URL handling for quality metrics.

* **Bug Fixes**
  * Updated workflows, memory, learning, context compression, session titles, and task processing to respect configured auxiliary models.

* **Tests**
  * Added coverage for model precedence, environment handling, defaults, call-site usage, and local endpoint support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->