### PR TITLE
fix(mobile): your own message never appeared in the chat

### DIFF
--- a/src/praisonai-mobile/app/app.css
+++ b/src/praisonai-mobile/app/app.css
@@ -124,6 +124,42 @@ html, body {
 }
 
 .row { border-radius: var(--radius); padding: .55rem .75rem; max-width: 100%; }
+
+/*
+ * The user's own message.
+ *
+ * `align-self` is the load-bearing declaration, not the background: the
+ * transcript is a flex COLUMN, so pulling this row to the end is what makes a
+ * conversation legible as a conversation at a glance. Colour alone would leave
+ * the two speakers distinguishable only to someone who can see the difference,
+ * which is the failure the whole transcript layer is written against -- so the
+ * row also carries `data-speaker="user"` and opens with a visually-hidden
+ * "You said:" (app/src/dom.ts).
+ *
+ * `max-width` short of 100% so a long message still shows the ragged left edge
+ * that says it is not full-width prose from the model.
+ *
+ * `dir`-agnostic on purpose: `flex-end` follows the writing direction, so on an
+ * Arabic device (`root[dir=rtl]`, set in main.ts) the user's side flips with
+ * the rest of the layout instead of being pinned to the right in a
+ * right-to-left column.
+ */
+.row-user {
+  align-self: flex-end;
+  max-width: 85%;
+  background: var(--accent);
+  color: var(--ground);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+/* Sent, and NOT in the stored conversation. A block of its own so it reads as a
+   separate statement about the message rather than as part of it. */
+.row-user .user-note {
+  display: block;
+  margin-top: .3rem;
+  font-size: .78rem;
+  opacity: .85;
+}
 .row-text { background: var(--panel); white-space: pre-wrap; overflow-wrap: anywhere; }
 .row-text.streaming::after {
   content: "▍";

--- a/src/praisonai-mobile/app/src/dom.test.ts
+++ b/src/praisonai-mobile/app/src/dom.test.ts
@@ -671,3 +671,67 @@ test("the visible status is repainted on update too", () => {
   const status = row?.children.find((c: any) => c.className === "tool-status");
   assert.equal(status?._text, en.toolStatus("ok"));
 });
+
+// ---- the user's own message -------------------------------------------------
+
+const userRow = (text: string, state: "sent" | "stored" | "unstored" = "sent"): Row =>
+  ({ kind: "user", id: "u0", text, state });
+
+test("a user's message is set as TEXT, never as markup", () => {
+  // The same guarantee as the assistant's rows, and it is NOT covered by them:
+  // this is a separate `paint` branch with its own assignments. A message can
+  // be pasted from anywhere, and a shared conversation is read by someone else.
+  const { host, created } = fakeDoc();
+  const payload = '<img src=x onerror="alert(1)">';
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: "u0", index: 0, row: userRow(payload) }]);
+
+  const row = created.find((el) => el.dataset.rowId === "u0");
+  assert.ok(row, "the user row element was not created");
+  assert.equal(row._html, "", "innerHTML must never be written");
+  const said = row.children.find((c: any) => c.className === "user-text");
+  assert.equal(said?._text, payload, "the payload must land as text");
+});
+
+test("a user row announces the speaker WITHOUT labelling away the message", () => {
+  // Two halves of one rule. An aria-label would replace the message in the
+  // accessibility tree and cost the reader word-by-word navigation of their own
+  // words (a11y/names.ts rule 3) -- so there must be none. But with none and
+  // nothing else, the only thing distinguishing the user's row from the model's
+  // is CSS alignment and a background colour, neither of which a screen reader
+  // can see -- so the speaker is rendered as visually-hidden CONTENT, first.
+  const { host, created } = fakeDoc();
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: "u0", index: 0, row: userRow("hello") }]);
+  const row = created.find((el) => el.dataset.rowId === "u0");
+
+  assert.equal(row.getAttribute("aria-label"), null, "a user row must not be labelled away");
+  const first = row.children[0];
+  assert.equal(first?.className, "sr-only", "the speaker must be the FIRST thing announced");
+  assert.match(first?._text ?? "", /you/i);
+  // And it must be in the tree at all -- `display: none` would remove it.
+  assert.equal(row.dataset.speaker, "user", "the row must say which side it is");
+});
+
+test("a message that was never stored SAYS so, once and only when true", () => {
+  // `end.userIndex` reported nothing, so the message is on screen and will not
+  // be in the conversation when it is reopened. Told in words and as an
+  // element, so it survives both a screen reader and a colour-blind glance.
+  const { host, created } = fakeDoc();
+  const nodes = emptyNodes();
+  applyOps(host, nodes, [{ kind: "insert", id: "u0", index: 0, row: userRow("hello", "sent") }]);
+  const row = created.find((el) => el.dataset.rowId === "u0");
+  assert.equal(row.children.some((c: any) => c.className === "user-note"), false,
+    "a live message must not be accused of being lost");
+
+  applyOps(host, nodes, [{ kind: "update", id: "u0", row: userRow("hello", "stored") }]);
+  assert.equal(row.children.some((c: any) => c.className === "user-note"), false);
+  assert.equal(row.dataset.state, "stored");
+
+  applyOps(host, nodes, [{ kind: "update", id: "u0", row: userRow("hello", "unstored") }]);
+  const note = row.children.find((c: any) => c.className === "user-note");
+  assert.ok(note, "a message the engine never wrote must say so");
+  assert.match(note._text, /not saved/i);
+  // Repainted in place, so the row cannot keep a stale note either.
+  applyOps(host, nodes, [{ kind: "update", id: "u0", row: userRow("hello", "stored") }]);
+  assert.equal(row.children.some((c: any) => c.className === "user-note"), false,
+    "a stale 'not saved' note survived the confirmation");
+});

--- a/src/praisonai-mobile/app/src/dom.ts
+++ b/src/praisonai-mobile/app/src/dom.ts
@@ -16,7 +16,7 @@
 import type { Op } from "../../ui/src/render/reconcile.ts";
 import type { Row } from "../../ui/src/transcript/view-model.ts";
 import { en, type Strings } from "../../ui/src/i18n/strings.ts";
-import { accessibleName } from "../../ui/src/a11y/names.ts";
+import { accessibleName, userRowNames } from "../../ui/src/a11y/names.ts";
 import { UNKNOWN } from "../../ui/src/format.ts";
 
 export interface RowNodes {
@@ -64,6 +64,37 @@ function paint(el: HTMLElement, row: Row, strings: Strings): void {
   else el.setAttribute("aria-label", name);
 
   switch (row.kind) {
+    case "user": {
+      // Three independent signals, only one of which is a colour: the row hugs
+      // the opposite edge (app.css), it carries `data-speaker="user"`, and it
+      // opens with a visually-hidden "You said:". A conversation whose two
+      // sides are told apart by background colour alone is one a screen-reader
+      // user hears as a single voice -- the defect a11y/names.ts exists for,
+      // with alignment standing in for hue.
+      el.dataset["speaker"] = "user";
+      el.dataset["state"] = row.state;
+      el.textContent = "";
+      const names = userRowNames(strings, row);
+      const speaker = el.ownerDocument.createElement("span");
+      // Content, NOT an aria-label. See a11y/names.ts: labelling the row would
+      // replace the message in the accessibility tree and cost the reader the
+      // ability to navigate their own words.
+      speaker.className = "sr-only";
+      speaker.textContent = names.speaker;
+      const said = el.ownerDocument.createElement("span");
+      said.className = "user-text";
+      said.textContent = row.text;
+      el.append(speaker, said);
+      if (names.note !== null) {
+        // Sent, and not on disk. Said in words and shown as an element, so it
+        // survives both a screen reader and a colour-blind glance.
+        const note = el.ownerDocument.createElement("span");
+        note.className = "user-note";
+        note.textContent = names.note;
+        el.append(note);
+      }
+      return;
+    }
     case "text":
       el.textContent = row.text;
       el.classList.toggle("streaming", row.streaming);

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -2367,3 +2367,158 @@ test("New chat clears the finished turns too, not just the live one", async () =
   );
   app?.dispose();
 });
+
+// ---- the transcript and the model's memory, held to each other ---------------
+//
+// Two "histories" meet in `mount` and they are NOT the same list. #4816 replays
+// `Session.current()` onto a fresh agent every turn -- only what `record()`
+// actually wrote. This PR keeps every finished turn on screen, written or not,
+// because a question you asked and the error that answered it both belong in
+// the transcript.
+//
+// So they can legitimately differ, and the danger is that they differ SILENTLY:
+// a turn rendered as though it were part of the conversation while the model
+// has never heard of it. These pin the agreement in both directions, and pin
+// the one divergence to the row that announces itself.
+
+/** An Agent that records the history it was restored with and fails one turn. */
+function agentFailingTurn(failOn: number, answers: readonly string[]): {
+  readonly module: unknown;
+  readonly histories: { role: string; content: string }[][];
+} {
+  const histories: { role: string; content: string }[][] = [];
+  let turn = 0;
+  class Flaky {
+    lastStopReason: "completed" | null = "completed";
+    private restored: { role: string; content: string }[] = [];
+    setHistory(messages: readonly { role: string; content: string }[]): void {
+      this.restored = messages.map((m) => ({ role: m.role, content: m.content }));
+    }
+    async *streamEvents(
+      _prompt: string,
+    ): AsyncGenerator<{ type: "text"; delta: string } | { type: "finish"; text: string }> {
+      histories.push(this.restored);
+      const mine = turn++;
+      if (mine === failOn) throw new Error("the provider dropped the connection");
+      const text = answers[mine] ?? "";
+      // The DELTA as well as the finish. An agent that only ever yields
+      // `finish` produces a turn with no text, which `finish()` in
+      // transcript.ts correctly turns into error{empty} -- so the transcript
+      // would be all error rows and the assertions below would be measuring
+      // the harness rather than the app.
+      yield { type: "text", delta: text } as const;
+      yield { type: "finish", text } as const;
+    }
+  }
+  return { module: Flaky, histories };
+}
+
+/** The user rows on screen, as `state|text`. */
+const userRowsOnScreen = (dom: ReturnType<typeof createFakeDom>): string[] => {
+  const transcript = dom.find((n) => n.className.includes("transcript"));
+  assert.ok(transcript, "no transcript");
+  return (transcript.children as { className: string; textContent: string; dataset: Record<string, string> }[])
+    .filter((c) => c.className.includes("row-user"))
+    .map((c) => `${c.dataset["state"]}|${c.textContent}`);
+};
+
+test("every turn the model is told about is on screen, in the same order", async () => {
+  // The agreeing direction. `Session.current()` is what the engine replays and
+  // what `historyRows` paints on reopen, so a stored turn cannot be in one and
+  // missing from the other -- and the promoted rows must not reorder it.
+  const { module, histories } = agentFailingTurn(-1, ["Paris.", "About 2.1 million."]);
+  const { dom, platform: web } = harness();
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+    loadAgent: async () => module as never,
+  });
+
+  submit(dom, "What is the capital of France?");
+  await settle(120);
+  submit(dom, "And its population?");
+  await settle(120);
+
+  // What the model was told on the second turn...
+  const told = histories[1] ?? [];
+  assert.deepEqual(
+    told,
+    [
+      { role: "user", content: "What is the capital of France?" },
+      { role: "assistant", content: "Paris." },
+    ],
+    "the follow-up must carry the exchange it follows",
+  );
+
+  // ...must all be on screen, in that order. Not "present somewhere": a
+  // transcript that shows the same turns in a different order than the model
+  // was given them is a conversation the two parties remember differently.
+  const shown = transcriptRows(dom);
+  let cursor = -1;
+  for (const message of told) {
+    const at = shown.findIndex((r, i) => i > cursor && r.includes(message.content));
+    assert.notEqual(at, -1, `the model was told "${message.content}" and the screen never showed it:\n${shown.join("\n")}`);
+    cursor = at;
+  }
+  // And every user row that claims to be stored is one the model has.
+  assert.deepEqual(
+    userRowsOnScreen(dom).filter((r) => r.startsWith("stored|")).map((r) => r.slice("stored|".length)),
+    ["You said:What is the capital of France?", "You said:And its population?"],
+    "a row claiming to be stored must be a turn that was really written",
+  );
+  await app?.dispose();
+});
+
+test("a turn the model was NEVER told about is the one row that says it was not saved", async () => {
+  // The diverging direction, and the reason the divergence is allowed. The
+  // second turn fails, so `record()` is never called and the model is never
+  // told -- but the question stays on screen above the error explaining what
+  // happened to it. What must NOT happen is that it looks like an ordinary,
+  // remembered message: the row is `unstored` and says so in words.
+  const { module, histories } = agentFailingTurn(1, ["Paris.", "", "Still here."]);
+  const { dom, platform: web } = harness();
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+    loadAgent: async () => module as never,
+  });
+
+  submit(dom, "remembered question");
+  await settle(120);
+  submit(dom, "LOST-QUESTION");
+  await settle(150);
+  submit(dom, "third question");
+  await settle(150);
+
+  // All three are on screen -- the failed one is not swept away.
+  const rows = userRowsOnScreen(dom);
+  assert.equal(rows.length, 3, `every question asked belongs on screen:\n${rows.join("\n")}`);
+  assert.match(rows[1] ?? "", /LOST-QUESTION/);
+
+  // The failed one, and ONLY the failed one, is marked not-saved.
+  assert.ok((rows[0] ?? "").startsWith("stored|"), `turn 1 was written and must say so: ${rows[0]}`);
+  assert.ok((rows[1] ?? "").startsWith("unstored|"), `turn 2 was never written: ${rows[1]}`);
+  assert.ok((rows[2] ?? "").startsWith("stored|"), `turn 3 was written: ${rows[2]}`);
+  assert.match(rows[1] ?? "", /not in the stored conversation/i);
+
+  // And the model, on the third turn, was told about turn 1 and NOT turn 2.
+  const told = histories[2] ?? [];
+  assert.deepEqual(
+    told,
+    [
+      { role: "user", content: "remembered question" },
+      { role: "assistant", content: "Paris." },
+    ],
+    `the model must be told exactly what was stored:\n${JSON.stringify(told)}`,
+  );
+  assert.equal(
+    JSON.stringify(told).includes("LOST-QUESTION"),
+    false,
+    "a turn that was never stored must not reach the model",
+  );
+  await app?.dispose();
+});

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -2042,3 +2042,223 @@ test("New chat starts the model with a blank memory, not the previous conversati
   assert.deepEqual(histories[1], [], `the new chat must start empty:\n${JSON.stringify(histories)}`);
   await app?.dispose();
 });
+
+// ---- your own message, on screen --------------------------------------------
+//
+// The plainest defect the app had: you typed, tapped Send, and only the reply
+// appeared. `ui/src/transcript/view-model.ts` defined seven row kinds and not
+// one of them was the user, so there was nothing for any renderer to draw.
+// These drive the whole composition root -- composer, controller, reducer, view
+// model, reconciler, DOM -- because every layer below was individually correct
+// and the conversation still came out with one side missing.
+
+/** The transcript's rows, in order, as `kind|text` so ORDER can be asserted. */
+const transcriptRows = (dom: ReturnType<typeof createFakeDom>): string[] => {
+  const transcript = dom.find((n) => n.className.includes("transcript"));
+  assert.ok(transcript, "no transcript");
+  return (transcript.children as { className: string; textContent: string }[]).map(
+    (c) => `${c.className}|${c.textContent}`,
+  );
+};
+
+test("your own message appears in the transcript, above the reply", async () => {
+  const { dom, http, platform } = harness();
+  http.on("/chat", () =>
+    sseResponse(
+      sse([
+        ["start", { msg_id: "m1", run_id: "r1" }],
+        ["delta", { msg_id: "m1", text: "Paris." }],
+        ["end", { msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 }],
+      ]),
+    ),
+  );
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  assert.notEqual(app, null);
+
+  submit(dom, "what is the capital of France");
+  await settle(120);
+
+  const rows = transcriptRows(dom);
+  const mine = rows.findIndex((r) => r.startsWith("row row-user"));
+  assert.notEqual(mine, -1, `the user's own message never rendered:\n${rows.join("\n")}`);
+  assert.match(rows[mine] ?? "", /what is the capital of France/);
+
+  // Above the answer, which is the only thing that says which reply belongs to
+  // which question once the conversation is longer than one turn.
+  const reply = rows.findIndex((r) => r.startsWith("row row-text") && r.includes("Paris."));
+  assert.notEqual(reply, -1, `the reply never rendered:\n${rows.join("\n")}`);
+  assert.ok(mine < reply, `the question must render above its answer:\n${rows.join("\n")}`);
+  app?.dispose();
+});
+
+test("a send the composer REFUSES leaves nothing on screen", async () => {
+  // The optimistic-vs-confirmed rule, end to end: a message that was never sent
+  // must not be sitting in the transcript looking sent. The composer refuses a
+  // second submit while a turn is in flight (composer.ts rule 1) and that
+  // refusal must be total -- the row is seeded when a run is ISSUED, so a
+  // refused submit produces no turn and therefore no row.
+  const { dom, http, platform } = harness();
+  // A stream held OPEN between frames, so the turn is genuinely still running
+  // when the second submit arrives. `sseResponse` delivers everything at once,
+  // which would let the first turn finish and make the second submit a
+  // perfectly ordinary send.
+  const frames = sse([
+    ["start", { msg_id: "m1", run_id: "r1" }],
+    ["delta", { msg_id: "m1", text: "first answer" }],
+    ["end", { msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 }],
+  ]).split(/(?<=\n\n)/).filter((f) => f !== "");
+  http.on("/chat", () => ({
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+    body: new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const next = frames.shift();
+        if (next === undefined) return controller.close();
+        await new Promise((r) => setTimeout(r, 150));
+        controller.enqueue(new TextEncoder().encode(next));
+      },
+    }),
+  }));
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  submit(dom, "the one I sent");
+  // Long enough for `start` to arrive and the button to become Stop.
+  await settle(250);
+  const stopping = dom.find((n) => n.dataset["action"] === "stop");
+  assert.ok(stopping, "the turn was not still running -- the refusal path is untested");
+  submit(dom, "REFUSED-while-busy");
+  await settle(500);
+
+  const all = transcriptRows(dom).join("\n");
+  assert.match(all, /the one I sent/, `the sent message must be on screen:\n${all}`);
+  assert.equal(
+    all.includes("REFUSED-while-busy"),
+    false,
+    `a message the composer refused was painted as though it had been sent:\n${all}`,
+  );
+  app?.dispose();
+});
+
+test("a turn that FAILED keeps the message on screen and says it was not saved", async () => {
+  // The other half of the same rule. The message WAS sent -- the engine got it
+  // and answered 401 -- so removing it would hide the question the error is
+  // about. But `end.userIndex` never arrived, so it is not in the stored
+  // conversation and the row must not imply that it is.
+  const { dom, http, platform } = harness();
+  http.on("/chat", () => ({ ok: false, status: 401, headers: {}, body: streamOf("nope") }));
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  submit(dom, "a question nobody answered");
+  await settle(150);
+
+  const rows = transcriptRows(dom);
+  const mine = rows.find((r) => r.startsWith("row row-user"));
+  assert.ok(mine, `a failed turn must still show what was asked:\n${rows.join("\n")}`);
+  assert.match(mine, /a question nobody answered/);
+  assert.match(mine, /not saved/i, `a message that reached no disk must say so:\n${mine}`);
+  app?.dispose();
+});
+
+test("a REOPENED conversation shows the user's messages as the USER's", async () => {
+  // `historyRows` mapped both roles to a `text` row -- the kind that means "the
+  // model said this" -- so a reopened conversation painted the user's questions
+  // in the assistant's clothes. The two sides were rendered identically and a
+  // screen reader heard one voice. The prompt is ALREADY on disk with its role;
+  // it was the role that was being discarded.
+  const { dom, platform } = harness();
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  await app!.session.record("what is the capital of France", "Paris");
+
+  dom.click(dom.find((n) => n.dataset["route"] === "chats") as never);
+  await settle();
+  dom.click(dom.find((n) => n.dataset["action"] === "open-chat") as never);
+  await settle();
+
+  const rows = transcriptRows(dom);
+  const mine = rows.findIndex((r) => r.startsWith("row row-user"));
+  assert.notEqual(mine, -1, `the reopened conversation showed no user message:\n${rows.join("\n")}`);
+  assert.match(rows[mine] ?? "", /what is the capital of France/);
+  // And the reply is still the assistant's, in order.
+  const reply = rows.findIndex((r) => r.startsWith("row row-text") && r.includes("Paris"));
+  assert.notEqual(reply, -1, `the stored answer was lost:\n${rows.join("\n")}`);
+  assert.ok(mine < reply, `a reopened conversation must read in order:\n${rows.join("\n")}`);
+  // The question must NOT be painted as model output.
+  assert.equal(
+    (rows[mine] ?? "").startsWith("row row-text"),
+    false,
+    "the user's stored message was rendered as the assistant's",
+  );
+  app?.dispose();
+});
+
+test("a finished turn stays on screen when the NEXT one begins", async () => {
+  // The controller publishes only the CURRENT turn and resets it per run, so
+  // the reconciler saw the previous turn's ids missing and removed every one of
+  // them. Measured on main: after a second Send the transcript contained the
+  // second answer and nothing else -- the first question and its reply gone
+  // from a conversation that was still open. Invisible while there were no user
+  // rows (one anonymous paragraph replacing another) and glaring with them.
+  const { dom, http, platform } = harness();
+  let n = 0;
+  http.on("/chat", () => {
+    n += 1;
+    const id = `m${n}`;
+    return sseResponse(
+      sse([
+        ["start", { msg_id: id, run_id: `r${n}` }],
+        ["delta", { msg_id: id, text: `ANSWER-${n}` }],
+        ["end", { msg_id: id, user_index: 2 * n - 2, assistant_index: 2 * n - 1, versions: 1, active: 0 }],
+      ]),
+    );
+  });
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+
+  submit(dom, "QUESTION-1");
+  await settle(150);
+  submit(dom, "QUESTION-2");
+  await settle(150);
+
+  const rows = transcriptRows(dom);
+  const at = (needle: string): number => {
+    const i = rows.findIndex((r) => r.includes(needle));
+    assert.notEqual(i, -1, `"${needle}" is not on screen:\n${rows.join("\n")}`);
+    return i;
+  };
+  // All four, in the order they happened.
+  assert.ok(at("QUESTION-1") < at("ANSWER-1"), `turn 1 is out of order:\n${rows.join("\n")}`);
+  assert.ok(at("ANSWER-1") < at("QUESTION-2"), `turn 1 was erased by turn 2:\n${rows.join("\n")}`);
+  assert.ok(at("QUESTION-2") < at("ANSWER-2"), `turn 2 is out of order:\n${rows.join("\n")}`);
+  // And nothing was drawn twice: promotion must move a turn, not copy it.
+  assert.equal(rows.filter((r) => r.includes("QUESTION-1")).length, 1, "the first question rendered twice");
+  app?.dispose();
+});
+
+test("New chat clears the finished turns too, not just the live one", async () => {
+  // The promotion above gives the screen a second place a previous
+  // conversation can hide in. `setChat` clears the controller's turn; it cannot
+  // know about rows the app promoted, so New chat has to drop those as well or
+  // the "fresh" chat opens on the last one.
+  const { dom, http, platform } = harness();
+  http.on("/chat", () =>
+    sseResponse(
+      sse([
+        ["start", { msg_id: "m1", run_id: "r1" }],
+        ["delta", { msg_id: "m1", text: "an answer" }],
+        ["end", { msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 }],
+      ]),
+    ),
+  );
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  submit(dom, "the old conversation");
+  await settle(150);
+  assert.match(transcriptRows(dom).join("\n"), /the old conversation/);
+
+  dom.click(dom.find((n) => n.dataset["action"] === "new-chat") as never);
+  await settle(60);
+  assert.equal(
+    transcriptRows(dom).join("\n").includes("the old conversation"),
+    false,
+    "a new chat opened on the previous conversation's messages",
+  );
+  app?.dispose();
+});

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -1111,6 +1111,89 @@ test("a turn sent AFTER reopening a chat lands below the history, not above it",
   app?.dispose();
 });
 
+test("opening another chat mid-run keeps that run's answer OUT of it", async () => {
+  // The cross-chat leak (greptile P1). New chat and deleting the open chat both
+  // stop the run in flight before reseeding the screen; Open chat did not. So a
+  // run still streaming in the conversation you LEFT kept going, and its
+  // terminal publish -- which the controller always emits, even on abort --
+  // reconciled the old chat's answer into the transcript just seeded with the
+  // chat you OPENED, where it was then promoted into history and reopened there.
+  //
+  // Two defences, both asserted here: Open chat now stops the previous run, and
+  // the app drops any publish arriving for a chat that has issued no turn of its
+  // own -- so even the guaranteed terminal frame paints nothing into the wrong
+  // conversation.
+  const { dom, http, platform } = harness();
+
+  // Chat A's run stays open: `start` and a `delta`, then the stream hangs until
+  // the test releases it -- exactly the shape of a reply still in flight.
+  let release: (() => void) | null = null;
+  http.on("/chat", () => ({
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        const enc = new TextEncoder();
+        controller.enqueue(enc.encode(sse([["start", { msg_id: "mA", run_id: "rA" }]])));
+        controller.enqueue(enc.encode(sse([["delta", { msg_id: "mA", text: "LEAKED-ANSWER-A" }]])));
+        release = () => {
+          controller.enqueue(
+            enc.encode(
+              sse([["end", { msg_id: "mA", user_index: 0, assistant_index: 1, versions: 1, active: 0 }]]),
+            ),
+          );
+          controller.close();
+        };
+      },
+    }),
+  }));
+
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  assert.notEqual(app, null);
+
+  // A second, stored conversation to open into. Recorded through the session so
+  // the chat list has a real row to tap.
+  await app!.session.record("chat B question", "chat B answer");
+
+  // Start chat A's run and let it stream the delta, but NOT the end.
+  submit(dom, "chat A question");
+  await settle(80);
+  assert.match(transcriptRows(dom).join("\n"), /LEAKED-ANSWER-A/, "chat A never started streaming");
+
+  // Open chat B WHILE chat A is still in flight.
+  dom.click(dom.find((n) => n.dataset["route"] === "chats") as never);
+  await settle();
+  dom.click(dom.find((n) => n.dataset["action"] === "open-chat") as never);
+  await settle();
+
+  // Now let chat A's run finish. Its terminal publish must not reach chat B.
+  release?.();
+  await settle(120);
+
+  // Chat B shows its OWN stored conversation and nothing else. With the leak
+  // present, chat A's terminated run publishes into B as a spurious error row
+  // (its turn was cleared by `setChat`, so its `end` lands on an idle turn and
+  // `finish` synthesises "the engine produced no output") plus a "before_start"
+  // dropped row -- both belonging to a run that was never chat B's.
+  const rows = transcriptRows(dom);
+  const joined = rows.join("\n");
+  assert.match(joined, /chat B question/, `chat B's own history was lost:\n${joined}`);
+  assert.match(joined, /chat B answer/, `chat B's own answer was lost:\n${joined}`);
+  assert.equal(
+    rows.some((r) => r.startsWith("row row-error") || r.startsWith("row row-dropped")),
+    false,
+    `the previous chat's terminated run leaked a row into the opened conversation:\n${joined}`,
+  );
+  assert.equal(
+    joined.includes("LEAKED-ANSWER-A") || joined.includes("chat A question"),
+    false,
+    `the previous chat's message leaked into the opened conversation:\n${joined}`,
+  );
+  // Exactly chat B's two rows -- nothing appended below them.
+  assert.equal(rows.length, 2, `chat B must show only its own turn:\n${joined}`);
+  app?.dispose();
+});
+
 test("a storage failure while the chat list loads stays LOCAL, not fatal", async () => {
   // The list load was a floating `void (async ...)()` with no rejection
   // handler. A StoragePort rejection -- SecurityError, QuotaExceeded -- reached

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -1127,7 +1127,29 @@ test("opening another chat mid-run keeps that run's answer OUT of it", async () 
 
   // Chat A's run stays open: `start` and a `delta`, then the stream hangs until
   // the test releases it -- exactly the shape of a reply still in flight.
+  //
+  // Released through a NAMED ACCESSOR rather than by calling `release?.()`, for
+  // two reasons that turn out to be the same reason.
+  //
+  // The compiler's: `release` is assigned only inside the stream's `start`
+  // callback, and TypeScript's control-flow analysis does not follow
+  // assignments made inside a callback. At the call site below it is therefore
+  // still narrowed to the `null` it was initialised with, `?.` short-circuits,
+  // and the call target is `never` -- TS2349, "Type 'never' has no call
+  // signatures".
+  //
+  // The test's: that narrowing is right about the risk. `release?.()` on a null
+  // releaser silently does NOTHING. Chat A's run would never terminate, no
+  // terminal publish would ever be emitted, and every assertion below -- all of
+  // which say chat B is free of chat A's rows -- would pass for the wrong
+  // reason, proving only that a leak that never happened did not happen. An
+  // optional call is the wrong tool for a value the test depends on. This one
+  // fails loudly instead.
   let release: (() => void) | null = null;
+  const releaseChatA = (): void => {
+    assert.ok(release !== null, "chat A's stream never opened, so there was nothing to release");
+    release();
+  };
   http.on("/chat", () => ({
     status: 200,
     headers: { "content-type": "text/event-stream" },
@@ -1167,7 +1189,7 @@ test("opening another chat mid-run keeps that run's answer OUT of it", async () 
   await settle();
 
   // Now let chat A's run finish. Its terminal publish must not reach chat B.
-  release?.();
+  releaseChatA();
   await settle(120);
 
   // Chat B shows its OWN stored conversation and nothing else. With the leak

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -764,14 +764,38 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   const nodes: RowNodes = emptyNodes();
   let announcer: AnnouncerState = initialAnnouncer;
 
-  // Everything ABOVE the turn now on screen: a reopened conversation's stored
-  // messages, plus every turn this session has already finished. The controller
-  // only ever publishes the CURRENT turn -- it resets to `beginTurn(prompt)` on
-  // each run -- so neither is in the RunView. Both are held here and PREPENDED
-  // to every reconcile, so a follow-up turn's rows land below them and a
-  // reconcile never emits `remove` for rows it did not know about. Empty for a
-  // fresh chat; cleared on New chat.
-  let history: readonly Row[] = [];
+  /**
+   * Everything ABOVE the turn now on screen: a reopened conversation's stored
+   * messages, plus every turn this session has already finished.
+   *
+   * The controller only ever publishes the CURRENT turn -- it resets to
+   * `beginTurn(prompt)` on each run -- so neither is in the RunView. Both are
+   * held here and PREPENDED to every reconcile, so a follow-up turn's rows land
+   * below them and a reconcile never emits `remove` for rows it did not know
+   * about. Empty for a fresh chat; cleared on New chat.
+   *
+   * `priorRows`, NOT `history`, and the distinction is worth the longer name.
+   * `history` in this file now means CONVERSATION MEMORY -- the
+   * `ConversationHistory` the in-process engine replays onto a fresh agent
+   * every turn, read from `Session.current()`. This is a list of RENDERED ROWS.
+   * The two are close but not equal, and calling both `history` shadowed one
+   * with the other inside `mount`:
+   *
+   *   - Conversation memory holds only what `record()` actually WROTE. A turn
+   *     that failed was never offered for persistence, so the model is never
+   *     told about it.
+   *   - These rows hold every finished turn, persisted or not, because a
+   *     question you asked and the error that answered it both belong on
+   *     screen -- removing them would hide the failure.
+   *
+   * That divergence is deliberate and it is SAID OUT LOUD rather than left to
+   * be discovered: a turn on screen that is not in the stored conversation
+   * renders its user row as `unstored`, which reads "Not saved -- this message
+   * is not in the stored conversation". `main.test.ts` asserts the agreement in
+   * both directions, so a change that starts feeding the model rows it never
+   * stored -- or drops a stored turn off the screen -- fails by name.
+   */
+  let priorRows: readonly Row[] = [];
 
   /**
    * The rows of the turn currently on screen, and the turn they belong to.
@@ -789,7 +813,8 @@ export async function mount(deps: MountDeps): Promise<App | null> {
    * is fixed here rather than left: a "your message" row that disappears the
    * next time you speak is not the feature.
    *
-   * So a turn that has ENDED is moved into `history` when the NEXT one begins.
+   * So a turn that has ENDED is moved into `priorRows` when the NEXT one
+   * begins.
    * Not when it ends: at that moment it is still the live turn, still carrying
    * its tool cards, its usage and its error row, and moving it early would
    * either duplicate those rows or drop them at the exact instant the answer
@@ -819,7 +844,7 @@ export async function mount(deps: MountDeps): Promise<App | null> {
    * see controller.ts) -- and that frame carries the OLD chat's turn. Left
    * ungated it reconciles the old answer or a "Stopped" row into the transcript
    * we have just seeded with the NEW chat's history, and it is then promoted
-   * into `history` and reopens there. `setChat` cannot help: by the time the
+   * into `priorRows` and reopens there. `setChat` cannot help: by the time the
    * late publish lands the controller already reports the new chat's id.
    *
    * So every chat switch sets this false -- from that point the only publishes
@@ -834,7 +859,7 @@ export async function mount(deps: MountDeps): Promise<App | null> {
    *  the chat that is open, because getting one of the three resets wrong is
    *  how a previous conversation's rows leak into the next one. */
   const clearTurns = (): void => {
-    history = [];
+    priorRows = [];
     liveRows = [];
     turnSeq = 0;
     turnEnded = false;
@@ -879,19 +904,19 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     // `liveRows` -- without this the answer above is removed by the very
     // reconcile that draws the new question.
     if (turnEnded && view.turn.phase !== "ended") {
-      history = [...history, ...liveRows];
+      priorRows = [...priorRows, ...liveRows];
       turnSeq += 1;
     }
     turnEnded = view.turn.phase === "ended";
 
     const built = buildTranscript(view.turn, view.approvals);
     liveRows = keyed(built.rows, turnSeq);
-    // History first, then the live turn. `history` is empty for a fresh chat
+    // Prior rows first, then the live turn. `priorRows` is empty for a fresh chat
     // that has not finished a turn yet, so this is a no-op there; otherwise it
     // keeps the restored conversation and every completed turn ABOVE the turn
     // now streaming and inside the render state, so the diff updates the live
     // rows without removing what is above them.
-    const rows = history.length === 0 ? liveRows : [...history, ...liveRows];
+    const rows = priorRows.length === 0 ? liveRows : [...priorRows, ...liveRows];
     const diff = reconcile(render, rows);
     applyOps(transcript, nodes, diff.ops, strings);
     render = diff.next;
@@ -1649,7 +1674,7 @@ export async function mount(deps: MountDeps): Promise<App | null> {
         // conversation being left keeps streaming, and its terminal `publish()`
         // reconciles the old chat's answer or error row into the transcript we
         // are about to seed with THIS chat's history -- where it is then promoted
-        // into `history` and reopens with the wrong conversation. `setChat`
+        // into `priorRows` and reopens with the wrong conversation. `setChat`
         // clears the controller's turn, but it cannot cancel a run the engine is
         // still driving; only `stop()` does.
         void app.controller.stop();
@@ -1675,8 +1700,8 @@ export async function mount(deps: MountDeps): Promise<App | null> {
         // that is mid-flight. Reopening a chat into another chat's rows is the
         // same leak `setChat` was added for, one layer up.
         clearTurns();
-        history = chat === null ? [] : historyRows(chat.messages);
-        const seeded = reconcile(render, history);
+        priorRows = chat === null ? [] : historyRows(chat.messages);
+        const seeded = reconcile(render, priorRows);
         applyOps(transcript, nodes, seeded.ops, strings);
         render = seeded.next;
         app.router.push({ name: "chat", chatId: intent.chatId });

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -590,14 +590,35 @@ export function stopNotice(stopped: boolean, strings: Strings): string | null {
  * (a re-open paints the same rows, not duplicates) and cannot collide with a
  * live turn's `text:N` ids -- a collision would make the first streamed
  * paragraph update a history row in place instead of appending after it.
+ *
+ * THE ROLE DECIDES THE ROW KIND, and this is the second half of the missing
+ * user message. `StoredMessage.role` has been `"user" | "assistant"` since the
+ * repository was written and this function threw it away, mapping both to a
+ * `text` row -- the kind that means "the model said this". So a reopened
+ * conversation did paint the user's questions, in the assistant's clothes: the
+ * two sides of the conversation were rendered identically, and a screen reader
+ * heard one voice. The prompt is ALREADY on disk, so there is no second source
+ * of truth to invent here -- only a role that had to stop being discarded.
+ *
+ * A stored message is `stored` by definition: it was read back off the disk it
+ * is asking about.
  */
 export function historyRows(messages: readonly StoredMessage[]): readonly Row[] {
-  return messages.map((message, index) => ({
-    kind: "text",
-    id: `history:${index}:${message.role}`,
-    text: message.content,
-    streaming: false,
-  }));
+  return messages.map((message, index) =>
+    message.role === "user"
+      ? {
+          kind: "user",
+          id: `history:${index}:user`,
+          text: message.content,
+          state: "stored",
+        }
+      : {
+          kind: "text",
+          id: `history:${index}:assistant`,
+          text: message.content,
+          streaming: false,
+        },
+  );
 }
 
 /** `createApp`, with a thrown failure turned into the same typed result the
@@ -743,13 +764,62 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   const nodes: RowNodes = emptyNodes();
   let announcer: AnnouncerState = initialAnnouncer;
 
-  // A reopened conversation's stored messages, as reconciler rows. The
-  // controller only ever publishes the CURRENT turn -- it resets to
-  // `initialTurn` on each run -- so history is not in the RunView. It is held
-  // here and PREPENDED to every reconcile, so a follow-up turn's rows land
-  // below it and a reconcile never emits `remove` for history it did not know
-  // about. Empty for a fresh chat; cleared on New chat.
+  // Everything ABOVE the turn now on screen: a reopened conversation's stored
+  // messages, plus every turn this session has already finished. The controller
+  // only ever publishes the CURRENT turn -- it resets to `beginTurn(prompt)` on
+  // each run -- so neither is in the RunView. Both are held here and PREPENDED
+  // to every reconcile, so a follow-up turn's rows land below them and a
+  // reconcile never emits `remove` for rows it did not know about. Empty for a
+  // fresh chat; cleared on New chat.
   let history: readonly Row[] = [];
+
+  /**
+   * The rows of the turn currently on screen, and the turn they belong to.
+   *
+   * A finished turn used to be ERASED by the next one. The controller publishes
+   * only the current turn, so the moment `runTurn` installed a fresh state the
+   * reconciler saw the previous turn's ids missing from the next row list and
+   * emitted `remove` for every one of them. Measured on main before this
+   * change, with two questions asked in one session: after the second Send the
+   * transcript contained the second answer AND NOTHING ELSE -- the first
+   * question and its reply were gone from a conversation that was still open.
+   *
+   * That is invisible while the transcript has no user rows (one anonymous
+   * paragraph replaces another) and glaring once it has them, which is why it
+   * is fixed here rather than left: a "your message" row that disappears the
+   * next time you speak is not the feature.
+   *
+   * So a turn that has ENDED is moved into `history` when the NEXT one begins.
+   * Not when it ends: at that moment it is still the live turn, still carrying
+   * its tool cards, its usage and its error row, and moving it early would
+   * either duplicate those rows or drop them at the exact instant the answer
+   * lands.
+   *
+   * Ids are namespaced per turn (`t0:`, `t1:`, ...) from the moment they are
+   * built, not rewritten at promotion time. Two turns both produce `text:0`,
+   * and a shared id is how a keyed renderer paints one row's content into
+   * another row's node. Keying up front also means promotion changes no id at
+   * all, so it emits no ops: the rows already on screen stay exactly where they
+   * are instead of being removed and rebuilt under the user.
+   */
+  let liveRows: readonly Row[] = [];
+  let turnSeq = 0;
+  let turnEnded = false;
+
+  /** A turn's rows, namespaced so no two turns can claim the same id. Both
+   *  turns of a two-turn chat produce `text:0`; see `liveRows`. */
+  const keyed = (rows: readonly Row[], seq: number): readonly Row[] =>
+    rows.map((row) => ({ ...row, id: `t${seq}:${row.id}` }));
+
+  /** Forget every turn on screen. Shared by New chat, Open chat and deleting
+   *  the chat that is open, because getting one of the three resets wrong is
+   *  how a previous conversation's rows leak into the next one. */
+  const clearTurns = (): void => {
+    history = [];
+    liveRows = [];
+    turnSeq = 0;
+    turnEnded = false;
+  };
 
   // ---- composer state (draft, key policy, autosize) ----------------------
   // The composer is data now, not just a <textarea>: a draft that survives a
@@ -775,12 +845,23 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   };
 
   const publish = (view: RunView): void => {
+    // A new turn has begun and the previous one had ended: keep it. See
+    // `liveRows` -- without this the answer above is removed by the very
+    // reconcile that draws the new question.
+    if (turnEnded && view.turn.phase !== "ended") {
+      history = [...history, ...liveRows];
+      turnSeq += 1;
+    }
+    turnEnded = view.turn.phase === "ended";
+
     const built = buildTranscript(view.turn, view.approvals);
-    // History first, then the live turn. `history` is empty for a fresh chat,
-    // so this is a no-op there; for a reopened chat it keeps the restored
-    // conversation ABOVE the turn now streaming and inside the render state, so
-    // the diff updates the live rows without removing the history.
-    const rows = history.length === 0 ? built.rows : [...history, ...built.rows];
+    liveRows = keyed(built.rows, turnSeq);
+    // History first, then the live turn. `history` is empty for a fresh chat
+    // that has not finished a turn yet, so this is a no-op there; otherwise it
+    // keeps the restored conversation and every completed turn ABOVE the turn
+    // now streaming and inside the render state, so the diff updates the live
+    // rows without removing what is above them.
+    const rows = history.length === 0 ? liveRows : [...history, ...liveRows];
     const diff = reconcile(render, rows);
     applyOps(transcript, nodes, diff.ops, strings);
     render = diff.next;
@@ -1353,8 +1434,9 @@ export async function mount(deps: MountDeps): Promise<App | null> {
         // the same id".
         app.controller.setChat(mintChatId());
         app.session.reset();
-        // A fresh chat has no history to keep above the next turn.
-        history = [];
+        // A fresh chat has no history to keep above the next turn, and no
+        // finished turn to promote into it.
+        clearTurns();
         render = emptyRender;
         nodes.nodes.clear();
         announcer = initialAnnouncer;
@@ -1458,7 +1540,7 @@ export async function mount(deps: MountDeps): Promise<App | null> {
           void app.controller.stop();
           app.controller.setChat(mintChatId());
           app.session.reset();
-          history = [];
+          clearTurns();
           render = emptyRender;
           nodes.nodes.clear();
           announcer = initialAnnouncer;
@@ -1550,6 +1632,10 @@ export async function mount(deps: MountDeps): Promise<App | null> {
         // `publish` keeps it in the same coordinate system the stream appends to
         // AND makes it survive the next turn's reconcile.
         const chat = app.session.current();
+        // The turns of the PREVIOUS conversation go with it -- including one
+        // that is mid-flight. Reopening a chat into another chat's rows is the
+        // same leak `setChat` was added for, one layer up.
+        clearTurns();
         history = chat === null ? [] : historyRows(chat.messages);
         const seeded = reconcile(render, history);
         applyOps(transcript, nodes, seeded.ops, strings);

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -811,6 +811,25 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   const keyed = (rows: readonly Row[], seq: number): readonly Row[] =>
     rows.map((row) => ({ ...row, id: `t${seq}:${row.id}` }));
 
+  /**
+   * Whether a publish from the controller belongs to the chat now on screen.
+   *
+   * Stopping the previous chat's run on a switch aborts it, but the abort still
+   * drives one FINAL publish (the controller always paints the terminal frame,
+   * see controller.ts) -- and that frame carries the OLD chat's turn. Left
+   * ungated it reconciles the old answer or a "Stopped" row into the transcript
+   * we have just seeded with the NEW chat's history, and it is then promoted
+   * into `history` and reopens there. `setChat` cannot help: by the time the
+   * late publish lands the controller already reports the new chat's id.
+   *
+   * So every chat switch sets this false -- from that point the only publishes
+   * worth painting are for a turn THIS chat issued -- and `submit` sets it true
+   * for the turn it is about to start. A stale terminal publish from the run we
+   * left arrives while false and is dropped; the new chat's own first frame
+   * (`beginTurn`, from inside `send`) arrives after `submit` re-armed it.
+   */
+  let expectingTurn = false;
+
   /** Forget every turn on screen. Shared by New chat, Open chat and deleting
    *  the chat that is open, because getting one of the three resets wrong is
    *  how a previous conversation's rows leak into the next one. */
@@ -819,6 +838,9 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     liveRows = [];
     turnSeq = 0;
     turnEnded = false;
+    // A switched-to chat has issued no turn yet, so any publish still arriving
+    // is the run we just left painting its last frame into the wrong chat.
+    expectingTurn = false;
   };
 
   // ---- composer state (draft, key policy, autosize) ----------------------
@@ -845,6 +867,14 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   };
 
   const publish = (view: RunView): void => {
+    // Drop a frame from the run we switched away from. A chat switch stops the
+    // previous run, but the abort still drives one terminal publish carrying
+    // the OLD chat's turn; painting it here reconciles that turn into the chat
+    // we just opened. `expectingTurn` is armed only by the turn THIS chat
+    // issued (see `submit`), so an idle, cleared chat drops the straggler and
+    // stays empty. See `expectingTurn`.
+    if (!expectingTurn) return;
+
     // A new turn has begun and the previous one had ended: keep it. See
     // `liveRows` -- without this the answer above is removed by the very
     // reconcile that draws the new question.
@@ -1614,6 +1644,15 @@ export async function mount(deps: MountDeps): Promise<App | null> {
         // list back into a stored transcript.
         const opened = await app.session.open(intent.chatId);
         if (!opened) return;
+        // Stop the previous chat's run FIRST, exactly as New chat and deleting
+        // the open chat already do. Without this, a run still in flight from the
+        // conversation being left keeps streaming, and its terminal `publish()`
+        // reconciles the old chat's answer or error row into the transcript we
+        // are about to seed with THIS chat's history -- where it is then promoted
+        // into `history` and reopens with the wrong conversation. `setChat`
+        // clears the controller's turn, but it cannot cancel a run the engine is
+        // still driving; only `stop()` does.
+        void app.controller.stop();
         app.controller.setChat(intent.chatId);
         render = emptyRender;
         nodes.nodes.clear();
@@ -1661,6 +1700,11 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     input.value = "";
     syncComposer();
     if (result.sent === null) return; // refused while a turn is in flight
+    // Arm the transcript for THIS chat's own turn. A switch left `expectingTurn`
+    // false so a straggling publish from the run we left is dropped; issuing a
+    // run here is the moment publishes become ours to paint again. Set before
+    // `send`, which publishes `beginTurn` synchronously on the way in.
+    expectingTurn = true;
     await app.controller.send(result.sent);
   };
 

--- a/src/praisonai-mobile/core/src/run/controller.test.ts
+++ b/src/praisonai-mobile/core/src/run/controller.test.ts
@@ -1501,3 +1501,51 @@ test("a finished turn leaves no timer running", async () => {
     `a turn that ended must stop its ticker; live intervals: ${JSON.stringify(time.intervalMs)}`,
   );
 });
+
+// ---- the prompt on the turn -------------------------------------------------
+
+test("the turn carries the prompt that was actually SENT", async () => {
+  // No engine reports the prompt back -- `start` carries ids and nothing else
+  // -- so the reducer can never learn it from the stream. The controller is the
+  // only place that has it, and this is the seam that hands it over. Without
+  // it the transcript layer has nothing to build a user row from and the
+  // conversation is drawn with one side missing.
+  const h = harness(SCRIPTS.happy);
+  await h.controller.send("what is the answer?");
+  assert.equal(h.last().turn.prompt, "what is the answer?");
+});
+
+test("a QUEUED prompt is not on the turn until its own run begins", async () => {
+  // The optimistic-vs-confirmed decision, at the layer that owns it. The row is
+  // seeded when a run is ISSUED, not when send() is called -- so a prompt still
+  // waiting behind another turn is not yet on screen claiming to have been
+  // asked, and the answer streaming above it is not captioned with the wrong
+  // question.
+  const h = harness(SCRIPTS.happy);
+  const first = h.controller.send("one");
+  const second = h.controller.send("two");
+
+  // The publish send() makes when "two" is ENQUEUED, which happens while "one"
+  // is still in flight and before any run for "two" has been issued.
+  const queued = h.views.find((v) => v.queue.items.some((i) => i.text === "two"));
+  assert.ok(queued !== undefined, "the second prompt was never queued");
+  assert.equal(queued.turn.prompt, "one", "a queued prompt must not caption the running turn");
+  // And no publish, at any point, showed "two" on a turn that had not begun.
+  const early = h.views.filter((v) => v.turn.prompt === "two" && v.turn.phase === "idle" && v.queue.items.length > 0);
+  assert.deepEqual(early, [], "a prompt still in the queue was put on the turn");
+
+  await Promise.all([first, second]);
+  assert.equal(h.last().turn.prompt, "two", "the queued prompt captions its own turn once it runs");
+});
+
+test("switching chats takes the previous conversation's prompt with it", async () => {
+  // `setChat` installs `initialTurn` precisely so a new conversation cannot
+  // inherit the last one's transcript. A prompt left behind would put the
+  // previous chat's question at the top of the next one -- the same leak that
+  // brought a pending approval back with live buttons.
+  const h = harness(SCRIPTS.happy);
+  await h.controller.send("one");
+  assert.equal(h.controller.view().turn.prompt, "one");
+  h.controller.setChat("another-chat");
+  assert.equal(h.controller.view().turn.prompt, "");
+});

--- a/src/praisonai-mobile/core/src/run/controller.ts
+++ b/src/praisonai-mobile/core/src/run/controller.ts
@@ -41,7 +41,7 @@ import {
   type PromptQueue,
   type QueuedPrompt,
 } from "./queue.ts";
-import { apply, finish, initialTurn, noteDropped, type TurnState } from "./transcript.ts";
+import { apply, beginTurn, finish, initialTurn, noteDropped, type TurnState } from "./transcript.ts";
 import type { DropSink } from "./drop-sink.ts";
 
 /** Everything a view needs, in one object. */
@@ -170,7 +170,14 @@ export function createRunController(deps: ControllerDeps): RunController {
     // blaming itself for its predecessor; and because `send()` publishes
     // before `runTurn` begins, a stale turn was painted into what the user
     // believed was a new conversation.
-    turn = initialTurn;
+    //
+    // And it is seeded with the PROMPT, which is the only moment the prompt is
+    // available to anything downstream: no engine reports it back, so a
+    // reducer over the event stream cannot recover it. Seeding it HERE rather
+    // than in `send()` is what ties the user's row to a run that was really
+    // issued -- a queued prompt has not been sent yet, and a prompt the
+    // composer refused was never handed over at all.
+    turn = beginTurn(prompt.text);
     publish();
 
     // The approval table is per TURN, not per app.

--- a/src/praisonai-mobile/core/src/run/transcript.test.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.test.ts
@@ -9,7 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { apply, finish, initialTurn, isPersisted, type TurnState, noteDropped } from "./transcript.ts";
+import { apply, beginTurn, finish, initialTurn, isPersisted, type TurnState, noteDropped } from "./transcript.ts";
 import type { RunEvent } from "../../../protocol/src/events.ts";
 
 const M = "m1";
@@ -526,4 +526,39 @@ test("a tool_result is matched by callId, never by tool NAME", () => {
   assert.deepEqual(first?.args, { cmd: "one" }, "and keep its own arguments");
   assert.equal(second?.status, "failed", "the resolved call takes the result");
   assert.equal(second?.output, "boom");
+});
+
+// ---- the prompt -------------------------------------------------------------
+
+test("the prompt SURVIVES the engine's start event", () => {
+  // `start` rebuilds the turn from `initialTurn`, whose prompt is "". Without
+  // carrying it the user's message is painted the instant the run is issued and
+  // erased by the engine's very first frame -- your own words appearing and
+  // then vanishing, which is the original defect with a stutter in front of it.
+  //
+  // The prompt is NOT in the event stream: `start` carries ids and nothing
+  // else, so once dropped here it cannot be recovered from anything.
+  const turn = apply(beginTurn("what is the capital of France"), start);
+  assert.equal(turn.prompt, "what is the capital of France");
+  assert.equal(turn.phase, "streaming");
+});
+
+test("the prompt survives a failure that arrives BEFORE start", () => {
+  // The common case on a phone -- 401, 403, offline, a wrong baseUrl -- reaches
+  // `apply` while the turn is still idle and is applied through the
+  // idle-and-error branch. The message was really sent, so it must still be on
+  // screen above the error explaining what happened to it.
+  const turn = apply(beginTurn("hello"), {
+    type: "error", msgId: M, kind: "auth", message: "invalid api key",
+  });
+  assert.equal(turn.prompt, "hello");
+  assert.equal(turn.outcome?.type, "error");
+});
+
+test("a turn nobody prompted has no prompt", () => {
+  // `initialTurn` is what `setChat` installs when the user switches
+  // conversations. A prompt left on it would put the previous chat's question
+  // at the top of the next one.
+  assert.equal(initialTurn.prompt, "");
+  assert.equal(run(start, delta("hi")).prompt, "");
 });

--- a/src/praisonai-mobile/core/src/run/transcript.ts
+++ b/src/praisonai-mobile/core/src/run/transcript.ts
@@ -78,6 +78,27 @@ export interface TurnState {
   readonly phase: "idle" | "streaming" | "ended";
   readonly msgId: string | null;
   readonly runId: string | null;
+  /**
+   * The user's message: what this turn is an answer TO.
+   *
+   * A turn used to be assistant-only, and that was a structural gap rather
+   * than an oversight -- chat/session.ts names it in as many words ("TurnState
+   * is assistant-only, StoredChat has both roles, and nothing owned the
+   * join"). The consequence was visible on a phone: you typed, tapped Send,
+   * and only the reply appeared. There was no row kind for your own words
+   * because there was no field to build one from.
+   *
+   * It is NOT an event. No engine reports the prompt back -- `start` carries
+   * only ids -- so a reducer over the event stream can never learn it. It is
+   * seeded by whoever issues the run (`beginTurn`), which is also what makes
+   * it honest: a turn that exists has been handed to an engine, so a prompt
+   * on screen is a prompt that was actually sent.
+   *
+   * "" for a turn nobody prompted -- `initialTurn`, and the cleared state
+   * `setChat` installs. The view model draws no user row for "", so an empty
+   * chat is empty rather than showing a blank bubble.
+   */
+  readonly prompt: string;
   readonly text: string;
   readonly reasoning: string;
   /** The name of a tool being drafted, or null. NEVER a row -- see below. */
@@ -112,6 +133,7 @@ export const initialTurn: TurnState = {
   phase: "idle",
   msgId: null,
   runId: null,
+  prompt: "",
   text: "",
   reasoning: "",
   drafting: null,
@@ -123,6 +145,23 @@ export const initialTurn: TurnState = {
   dropped: [],
   carry: [],
 };
+
+/**
+ * A fresh turn that already knows what it is answering.
+ *
+ * The one sanctioned way to put a prompt on a turn. Called when a run is
+ * actually ISSUED to an engine -- not when Send is tapped -- which is what
+ * makes the row it produces impossible to leave behind after a send that never
+ * happened: an empty composer, a double tap the composer refuses while a turn
+ * is in flight, and a prompt still sitting in the queue all produce no turn and
+ * therefore no row.
+ *
+ * `initialTurn` deliberately still exists and still has `prompt: ""`: switching
+ * chats installs it, and a conversation nobody has spoken in must show nothing.
+ */
+export function beginTurn(prompt: string): TurnState {
+  return { ...initialTurn, prompt };
+}
 
 const drop = (state: TurnState, reason: Dropped["reason"], detail: string): TurnState => {
   const d: Dropped = { reason, detail };
@@ -193,6 +232,14 @@ export function apply(state: TurnState, event: RunEvent): TurnState {
       // exists to undo.
       dropped: state.carry,
       carry: [],
+      // CARRIED, like `carry` above and for the same reason: `start` rebuilds
+      // the turn from `initialTurn`, and `initialTurn.prompt` is "". Without
+      // this line the user's message is painted the instant the run is issued
+      // and then ERASED by the engine's first frame -- a flicker that reads as
+      // "my message was there and then it wasn't", which is the original bug
+      // with a stutter in front of it. The prompt is not in the event stream
+      // and cannot be recovered once dropped.
+      prompt: state.prompt,
     };
   }
 

--- a/src/praisonai-mobile/ui/src/a11y/names.test.ts
+++ b/src/praisonai-mobile/ui/src/a11y/names.test.ts
@@ -19,12 +19,13 @@ import {
   chatRowName,
   routeTitle,
   toolRowName,
+  userRowNames,
 } from "./names.ts";
 import { en } from "../i18n/strings.ts";
 import { UNKNOWN } from "../format.ts";
 import { buildChatList } from "../chats/list-view-model.ts";
-import { buildTranscript, toolRowsOf, type ToolRowView } from "../transcript/view-model.ts";
-import { apply, initialTurn, type TurnState } from "../../../core/src/run/transcript.ts";
+import { buildTranscript, toolRowsOf, type ToolRowView, type UserRow } from "../transcript/view-model.ts";
+import { apply, beginTurn, initialTurn, type TurnState } from "../../../core/src/run/transcript.ts";
 import { add, choose, emptyApprovals } from "../../../core/src/run/approvals.ts";
 import type { RunEvent } from "../../../protocol/src/events.ts";
 
@@ -199,4 +200,52 @@ test("a titled chat row announces its title, and an untitled one says so", () =>
   assert.equal(chatRowName(en, { kind: "chat", id: "c1", title: "Quarterly plan" } as never), "Quarterly plan");
   assert.equal(chatRowName(en, { kind: "chat", id: "c1", title: "" } as never), en.untitled);
   assert.notEqual(chatRowName(en, { kind: "chat", id: "c1", title: "" } as never), "", "a row must never be nameless");
+});
+
+// ---- the user's own message -------------------------------------------------
+
+/** The user row of a turn seeded with a prompt. */
+const userRowOf = (prompt: string, ...events: readonly RunEvent[]): UserRow => {
+  const turn = events.reduce<TurnState>(apply, beginTurn(prompt));
+  const row = buildTranscript(turn).rows.find((r) => r.kind === "user");
+  assert.ok(row !== undefined && row.kind === "user", "no user row");
+  return row;
+};
+
+test("a user row is NOT given an aria-label, for the same reason a text row is not", () => {
+  // Rule 3 in this file's header, applied to the other speaker. An aria-label
+  // REPLACES the element's content in the accessibility tree, so labelling a
+  // message would cost the reader the ability to navigate their own words by
+  // word, sentence or character -- and hand them a summary of a thing they
+  // wrote instead of the thing. The speaker is announced as CONTENT instead.
+  assert.equal(accessibleName(en, userRowOf("what is the capital of France", start)), null);
+});
+
+test("a user row says WHO said it, so the two sides are not told apart by colour", () => {
+  // On screen a user row is distinguished by which edge it hugs and what colour
+  // it is. Both are CSS; neither is in the accessibility tree. Without a spoken
+  // speaker a screen-reader user hears an undifferentiated run of paragraphs
+  // and cannot tell their own question from the answer to it -- this file's
+  // founding defect, with alignment standing in for hue.
+  const names = userRowNames(en, userRowOf("hello", start));
+  assert.notEqual(names.speaker.trim(), "");
+  assert.match(names.speaker, /you/i, "the speaker must actually name the speaker");
+});
+
+test("only a message that is NOT stored is annotated as such", () => {
+  // A caveat on every message is a caveat nobody reads. The note appears when
+  // the turn ended and `end.userIndex` never arrived -- the message is on
+  // screen and will not be in the conversation when it is reopened -- and at no
+  // other time.
+  const streaming = userRowNames(en, userRowOf("q", start, { type: "delta", msgId: M, text: "a" }));
+  assert.equal(streaming.note, null, "a live turn must not be accused of losing anything");
+
+  const written = userRowNames(en, userRowOf("q", start, { type: "delta", msgId: M, text: "a" },
+    { type: "end", msgId: M, userIndex: 0, assistantIndex: 1, versions: 1, active: 0 }));
+  assert.equal(written.note, null);
+
+  const lost = userRowNames(en, userRowOf("q", start, { type: "delta", msgId: M, text: "a" },
+    { type: "end", msgId: M, userIndex: null, assistantIndex: null, versions: 1, active: 0 }));
+  assert.notEqual(lost.note, null, "a message the engine did not write must say so");
+  assert.match(String(lost.note), /not saved/i);
 });

--- a/src/praisonai-mobile/ui/src/a11y/names.ts
+++ b/src/praisonai-mobile/ui/src/a11y/names.ts
@@ -48,6 +48,7 @@ import type {
   NoticeRow,
   Row,
   ToolRowView,
+  UserRow,
 } from "../transcript/view-model.ts";
 import type { Strings } from "../i18n/strings.ts";
 
@@ -94,6 +95,46 @@ export function droppedRowName(strings: Strings, row: DroppedRow): string {
   return strings.droppedEvents(row.count, row.reasons);
 }
 
+/** The two things a user row says besides the message itself. */
+export interface UserRowNames {
+  /** Announced BEFORE the message, and hidden visually. */
+  readonly speaker: string;
+  /** A storage note, both spoken and seen, or null when there is nothing to
+   *  say -- which is the ordinary case. */
+  readonly note: string | null;
+}
+
+/**
+ * What a user row says beyond its own words.
+ *
+ * A user row is distinguished on screen by which edge it hugs and what colour
+ * it is. Both are CSS; neither reaches the accessibility tree. So without a
+ * spoken speaker a screen-reader user arrowing through a conversation hears an
+ * undifferentiated run of paragraphs and cannot tell their own question from
+ * the answer to it -- the same "conveyed exclusively by hue" defect this file
+ * was written against, with alignment standing in for hue.
+ *
+ * The speaker is NOT an `aria-label`, and `accessibleName` returns null for
+ * this kind on purpose (rule 3 in the header). A label would replace the
+ * message in the accessibility tree and cost the reader the ability to
+ * navigate their own words by word, sentence or character. It is rendered as
+ * visually-hidden text INSIDE the row, ahead of the message, so the speaker is
+ * announced and the message stays browsable.
+ *
+ * `note` is produced only for `unstored`: the turn ENDED and `end.userIndex`
+ * never arrived, so the message on screen will not be there when the
+ * conversation is reopened. `sent` is the ordinary streaming state and `stored`
+ * the ordinary finished one -- annotating either would hang a caveat on every
+ * message in the transcript, and a warning that is always on is a warning
+ * nobody reads.
+ */
+export function userRowNames(strings: Strings, row: UserRow): UserRowNames {
+  return {
+    speaker: strings.speakerUser,
+    note: row.state === "unstored" ? strings.userNotStored : null,
+  };
+}
+
 /**
  * The name for any row, or null when the row's own text is its name.
  *
@@ -101,6 +142,12 @@ export function droppedRowName(strings: Strings, row: DroppedRow): string {
  */
 export function accessibleName(strings: Strings, row: Row): string | null {
   switch (row.kind) {
+    case "user":
+      // Rule 3, applied to the OTHER speaker. A user row is prose exactly like
+      // a text row, and an aria-label on it would replace the message with a
+      // summary of the message. The speaker is announced instead by
+      // `userRowNames`, which is content and therefore additive.
+      return null;
     case "text":
     case "reasoning":
       return null;

--- a/src/praisonai-mobile/ui/src/i18n/strings.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.ts
@@ -168,6 +168,27 @@ export interface Strings {
   readonly durationHoursMinutes: (hours: string, minutes: string) => string;
 
   // ---- transcript --------------------------------------------------------
+  /**
+   * Who said it, for a reader who cannot see which side of the screen a row
+   * sits on.
+   *
+   * Rendered INSIDE the user's row as visually-hidden text rather than as an
+   * `aria-label` on it. An aria-label replaces the element's content in the
+   * accessibility tree, and a11y/names.ts rule 3 spells out what that costs on
+   * a row whose content is prose: the reader loses word, sentence and character
+   * navigation and gets one unbrowsable blob. That reasoning was written about
+   * the model's paragraphs and applies word for word to the user's own.
+   */
+  readonly speakerUser: string;
+  /**
+   * "Sent, and not stored."
+   *
+   * Shown only when the turn has FINISHED without the engine reporting an
+   * index -- cancelled, errored, or a write that failed. Not while streaming:
+   * a row that says "not saved" for the whole of a normal answer is crying
+   * wolf during the seconds it matters least.
+   */
+  readonly userNotStored: string;
   /** The turn was cancelled. */
   readonly stopped: string;
   readonly streaming: string;
@@ -369,6 +390,10 @@ export const en: Strings = {
   durationMinutesSeconds: (minutes, seconds) => `${minutes}m ${seconds}s`,
   durationHoursMinutes: (hours, minutes) => `${hours}h ${minutes}m`,
 
+  speakerUser: "You said:",
+  // Says what happened AND what it means, because "unsaved" alone leaves the
+  // user to guess whether reopening the chat will find it. It will not.
+  userNotStored: "Not saved — this message is not in the stored conversation",
   stopped: "Stopped",
   streaming: "Responding",
   reasoningLabel: "Reasoning",

--- a/src/praisonai-mobile/ui/src/render/reconcile.test.ts
+++ b/src/praisonai-mobile/ui/src/render/reconcile.test.ts
@@ -232,3 +232,25 @@ test("an unchanged approval row still produces nothing", () => {
   const first = reconcile(emptyRender, [row]);
   assert.deepEqual(reconcile(first.next, [row]).ops, []);
 });
+
+test("a user row whose storage state changed is UPDATED, not left stale", () => {
+  // `signatureOf` is how a row learns it changed. A `user` case that folded in
+  // only the text would leave the row saying whatever it said at insert time --
+  // so a message that ended up NOT stored would keep reading as an ordinary
+  // sent one, which is the failure-that-looks-like-success this package is
+  // written against, on the user's own words.
+  const sent = { kind: "user", id: "user", text: "hello", state: "sent" } as const;
+  const unstored = { ...sent, state: "unstored" } as const;
+
+  const first = reconcile(emptyRender, [sent]);
+  const second = reconcile(first.next, [unstored]);
+  assert.deepEqual(
+    second.ops,
+    [{ kind: "update", id: "user", row: unstored }],
+    "the confirmation must repaint the row",
+  );
+
+  // And the same text with the same state emits nothing: a row that "changed"
+  // on every publish is a node rebuilt on every token.
+  assert.deepEqual(reconcile(second.next, [unstored]).ops, []);
+});

--- a/src/praisonai-mobile/ui/src/render/reconcile.ts
+++ b/src/praisonai-mobile/ui/src/render/reconcile.ts
@@ -38,6 +38,10 @@ export type Op =
  */
 export function signatureOf(row: Row): string {
   switch (row.kind) {
+    case "user":
+      // `state` is in the signature, so the row is UPDATED in place when the
+      // engine confirms the write rather than left saying "sending" forever.
+      return `user|${row.state}|${row.text}`;
     case "text":
       return `text|${row.streaming ? 1 : 0}|${row.text}`;
     case "reasoning":

--- a/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
+++ b/src/praisonai-mobile/ui/src/transcript/view-model.test.ts
@@ -23,7 +23,7 @@ import {
   type ToolRowView,
 } from "./view-model.ts";
 import { UNKNOWN, formatElapsed } from "../format.ts";
-import { apply, initialTurn, noteDropped, type TurnState } from "../../../core/src/run/transcript.ts";
+import { apply, beginTurn, initialTurn, noteDropped, type TurnState } from "../../../core/src/run/transcript.ts";
 import { add, choose, emptyApprovals } from "../../../core/src/run/approvals.ts";
 import type { RunEvent } from "../../../protocol/src/events.ts";
 import { SCRIPTS } from "../../../testing/src/scripts.ts";
@@ -565,4 +565,92 @@ test("an empty text block never becomes a message bubble", () => {
     false,
     `an empty bubble was rendered: ${JSON.stringify(textRows.map((r) => r.kind === "text" && r.text))}`,
   );
+});
+
+// ---- the user's own message -------------------------------------------------
+//
+// This file defined seven row kinds and not one of them was the user. A grep
+// for "user" or "prompt" in view-model.ts returned nothing, so a real tap on
+// Send produced a transcript containing the reply and no question. The turn was
+// drawn with one side of the conversation missing.
+
+/** A turn seeded with a prompt, the way `runTurn` seeds one. */
+const asked = (prompt: string, ...events: readonly RunEvent[]): TurnState =>
+  events.reduce<TurnState>(apply, beginTurn(prompt));
+
+test("the user's own message is a row in the transcript", () => {
+  // The whole defect, at the layer that decides what is painted. Without a
+  // `user` row here there is nothing for any renderer to draw, on any platform.
+  const view = buildTranscript(asked("what is the capital of France", start, delta("Paris")));
+  const users = view.rows.filter((r) => r.kind === "user");
+  assert.equal(users.length, 1, `expected exactly one user row, got ${JSON.stringify(view.rows.map((r) => r.kind))}`);
+  assert.equal(users[0]?.kind === "user" && users[0].text, "what is the capital of France");
+});
+
+test("the user's message renders ABOVE the answer it prompted", () => {
+  // Position is the only thing that says which reply belongs to which prompt
+  // once a chat is more than one turn long. A question below its own answer is
+  // not a conversation, and reversing the two here is a mutation that changes
+  // no count and no text -- so the count assertion above cannot catch it.
+  const turn = asked(
+    "why",
+    start,
+    { type: "reasoning", msgId: M, text: "thinking" },
+    delta("because"),
+  );
+  const kinds = buildTranscript(turn).rows.map((r) => r.kind);
+  const user = kinds.indexOf("user");
+  assert.notEqual(user, -1, "no user row at all");
+  // Above the ANSWER and above the model's reasoning about it: the model
+  // cannot have started thinking before the question arrived.
+  assert.equal(user, 0, `the user's message must be the first row, got ${JSON.stringify(kinds)}`);
+  assert.ok(user < kinds.indexOf("reasoning"));
+  assert.ok(user < kinds.indexOf("text"));
+});
+
+test("a turn nobody prompted draws no user row", () => {
+  // `initialTurn` and the cleared state `setChat` installs both have prompt "".
+  // A blank bubble in a fresh chat is a message the user did not send -- the
+  // same failure `an empty text block never becomes a message bubble` forbids
+  // on the other side of the conversation.
+  assert.equal(
+    buildTranscript(run(start, delta("hello"))).rows.some((r) => r.kind === "user"),
+    false,
+  );
+  assert.equal(buildTranscript(initialTurn).rows.length, 0);
+});
+
+test("the user row says STORED only when end reported an index it wrote", () => {
+  // Optimistic vs confirmed, decided by `end.userIndex` and never by the fact
+  // that we sent something. `isPersisted` is the sanctioned reader of that
+  // index and the same predicate that decides Fork and Delete; a user row that
+  // announced "saved" off its own bat would promise a reopen that finds nothing.
+  const live = buildTranscript(asked("q", start, delta("a"))).rows[0];
+  assert.equal(live?.kind === "user" && live.state, "sent", "a streaming turn is not stored yet");
+
+  const written = buildTranscript(asked("q", start, delta("a"), endAt(4))).rows[0];
+  assert.equal(written?.kind === "user" && written.state, "stored");
+
+  // `userIndex: null` is the engine saying the write FAILED. The message is on
+  // screen and not on disk, and saying so is the whole point of the field.
+  const lost = buildTranscript(asked("q", start, delta("a"), endAt(null))).rows[0];
+  assert.equal(lost?.kind === "user" && lost.state, "unstored");
+
+  // A turn the user stopped was never offered for persistence at all.
+  const stopped = buildTranscript(asked("q", start, delta("a"), { type: "cancelled", msgId: M, runId: "r1" })).rows[0];
+  assert.equal(stopped?.kind === "user" && stopped.state, "unstored");
+});
+
+test("the user row keeps ONE id across the whole turn, so it cannot flicker", () => {
+  // The reconciler is keyed by id. If the row's id moved with the turn's
+  // progress -- an index, a msgId, anything derived from what has arrived --
+  // every publish would remove the row and insert a new node in its place: a
+  // visible flicker on every token, and the user's text selection dropped with
+  // it. Asserted across the states the row actually passes through.
+  const ids = [
+    buildTranscript(asked("q", start)).rows[0]?.id,
+    buildTranscript(asked("q", start, delta("a"))).rows[0]?.id,
+    buildTranscript(asked("q", start, delta("a"), endAt(0))).rows[0]?.id,
+  ];
+  assert.deepEqual(new Set(ids), new Set(["user"]), `the user row changed id mid-turn: ${JSON.stringify(ids)}`);
 });

--- a/src/praisonai-mobile/ui/src/transcript/view-model.ts
+++ b/src/praisonai-mobile/ui/src/transcript/view-model.ts
@@ -50,6 +50,48 @@ export type RowTone = "neutral" | "pending" | "success" | "failure" | "warning";
 /** What the user can do about an error. Chosen by `kind`, never by message. */
 export type Recovery = "retry" | "settings" | "none";
 
+/**
+ * Where the user's own message stands.
+ *
+ * Three states, not a boolean, because "not saved yet" and "finished and never
+ * saved" are different facts and only one of them is worth telling anyone
+ * about. A row that said `saved: false` for the whole of a normal streaming
+ * turn would be crying wolf for the several seconds that matter least.
+ *
+ * `sent` while the turn is live; `stored` once the engine reported the index it
+ * WROTE; `unstored` when the turn finished and no index came back.
+ */
+export type UserRowState = "sent" | "stored" | "unstored";
+
+/**
+ * The user's own message.
+ *
+ * The row kind this file did not have. There were seven -- text, reasoning,
+ * tool, approval, error, notice, dropped -- and every one of them describes
+ * something the ASSISTANT did, so a real tap on Send produced a transcript
+ * containing only the reply. The conversation was drawn with one side missing.
+ *
+ * It carries no `tone`. Tone is the vocabulary for "did this work", and
+ * whether a message was understood is the reply's business, not the message's.
+ * What the row DOES carry is `state`, which is about storage and nothing else.
+ */
+export interface UserRow {
+  readonly kind: "user";
+  readonly id: string;
+  readonly text: string;
+  /**
+   * Optimistic or confirmed, decided by `end.userIndex` and never by the fact
+   * that we sent something.
+   *
+   * `isPersisted` is the sanctioned reader of that index (transcript.ts) and it
+   * is the same predicate that decides whether Fork and Delete are offered. Two
+   * copies of that rule is one copy that gets it wrong, and here the wrong one
+   * would tell the user their message is filed away when a reopen will not find
+   * it.
+   */
+  readonly state: UserRowState;
+}
+
 export interface TextRow {
   readonly kind: "text";
   readonly id: string;
@@ -127,6 +169,7 @@ export interface DroppedRow {
 }
 
 export type Row =
+  | UserRow
   | ReasoningRow
   | TextRow
   | ToolRowView
@@ -275,6 +318,30 @@ export function buildTranscript(
 ): TranscriptView {
   const rows: Row[] = [];
   const streaming = turn.phase === "streaming";
+
+  // FIRST, above everything the assistant produced -- including `reasoning`,
+  // which is the model already thinking about it. A question that renders below
+  // its own answer is not a conversation, and position is the only thing that
+  // says which reply belongs to which prompt once a chat is more than one turn
+  // long.
+  //
+  // "" draws nothing rather than an empty bubble, for the same reason an empty
+  // text block draws nothing: `initialTurn` and the state `setChat` installs
+  // both have no prompt, and a blank row in a fresh chat is a message the user
+  // did not send.
+  if (turn.prompt !== "") {
+    rows.push({
+      kind: "user",
+      // A constant, not an index. There is exactly one prompt per turn, so the
+      // id is stable across every publish of that turn -- which is what lets
+      // the reconciler UPDATE the row when it goes from `sent` to `stored`
+      // rather than removing and re-inserting it. A remove/insert pair is the
+      // flicker, and it would also drop the user's text selection mid-stream.
+      id: "user",
+      text: turn.prompt,
+      state: turn.phase !== "ended" ? "sent" : isPersisted(turn) ? "stored" : "unstored",
+    });
+  }
 
   if (turn.reasoning !== "") {
     rows.push({ kind: "reasoning", id: "reasoning", text: turn.reasoning });


### PR DESCRIPTION
You type, tap Send, and only the reply renders.

`ui/src/transcript/view-model.ts` defined seven row kinds — `text`, `reasoning`, `tool`, `approval`, `error`, `notice`, `dropped` — and every one of them describes something the **assistant** did. A grep for `user` or `prompt` in that file returned nothing. The transcript modelled one side of the conversation. This was unimplemented rather than broken: nothing regressed, there was simply no field on a turn to build the row from.

## Where the text comes from

**A reopened chat: from disk, and it was already there.** `StoredMessage.role` has been `"user" | "assistant"` since `core/src/chat/repository.ts` was written, and `historyRows` in `app/src/main.ts` threw it away — mapping both roles to a `text` row, the kind that means "the model said this". So a reopened conversation *did* paint the user's questions, dressed as the assistant's answers: the two sides rendered identically and a screen reader heard one voice. No second source of truth was invented here; a role stopped being discarded.

**The live turn: from the controller.** No engine reports the prompt back — `start` carries ids and nothing else — so a reducer over the event stream can never learn it. `TurnState.prompt` is seeded by `beginTurn(prompt)` in `runTurn`, and carried explicitly across `start`, which otherwise rebuilds from `initialTurn`: without that line your message is painted the instant the run is issued and then erased by the engine's first frame.

## Optimistic vs confirmed — both, because they are different facts

The row appears when the run is **issued**, not when Send is tapped. A prompt the composer refuses while a turn is in flight, and a prompt still sitting in the queue, produce no turn and therefore no row — nothing that was never sent is ever on screen looking sent.

Confirmation is read from `end.userIndex`, through `isPersisted` — the same predicate that decides whether Fork and Delete are offered, rather than a second copy of that rule. It only ever **updates** the row: the id is the constant `user` for the whole turn, so the reconciler repaints in place and the row cannot flicker or duplicate when the confirmation lands. A turn that ends with no index renders "Not saved — this message is not in the stored conversation", because that message will not be there when the conversation is reopened. `sent` and `stored` are annotated with nothing: a caveat on every message is a caveat nobody reads.

## A finished turn no longer vanishes

Found while building this, and fixed here because it makes the feature meaningless otherwise. The controller publishes only the *current* turn and resets it per run, so the reconciler removed the previous turn's rows the moment the next one began.

Measured on `main`, two questions in one session:

```
AFTER TURN 1: ANSWER-1
AFTER TURN 2: ANSWER-2          <- the first question and its reply are gone
```

Invisible while one anonymous paragraph replaced another; glaring once the transcript has user rows — a "your message" row that disappears the next time you speak is not the feature. Finished turns are now promoted into the history prefix when the *next* turn begins (not when they end, while they still carry their tool cards, usage and error rows), with ids namespaced per turn so two turns cannot both claim `text:0`. Promotion changes no id, so it emits no ops and nothing is rebuilt under the user.

## Accessibility

`accessibleName` returns `null` for a user row, deliberately, for exactly the reason `ui/src/a11y/names.ts` already gives for a text row: an `aria-label` **replaces** the element's content in the accessibility tree, and a paragraph of prose then loses word, sentence and character navigation. On screen the two speakers are distinguished by alignment and colour, and neither reaches a screen reader — so the new `userRowNames` supplies a visually-hidden `"You said:"` rendered as **content** ahead of the message, plus the storage note when there is one. Three independent signals: edge, `data-speaker`, spoken speaker; only one of them is a colour.

## Verified on a real Android 35 emulator, against the real OpenAI API

| | |
|---|---|
| Send tapped | one `row-user` in the transcript, before any reply |
| Reply arrived | `row-user[data-state=stored]`, then `row-text` — confirmed, not guessed |
| Second message | all four rows present, in order; turn 1 survived |
| Force-stop, relaunch, reopen | all four rows still present, in order |
| Offline send | message kept, marked "Not saved", `row-error` below it |

Live computed geometry read over CDP rather than eyeballed:

```
row-user  left=167  aria-label=null  sr-only="You said:"  clip-path=inset(50%)  bg=rgb(31,122,99)
row-text  left=12   aria-label=null  sr-only=null                              bg=rgb(245,246,248)
```

## Gates

`npm run check` exits **0** on Node 22.18.0, 22.23.2 and 24.12.0 (run sequentially; exit code read from the command, not through a pipe): 1549 tests, 0 fail, 0 cancelled. 24 tests added.

Eight mutations, each **killed** by a named test:

| Mutation | Killed by |
|---|---|
| drop the user row from the view model | `the user's own message is a row in the transcript` (+7 more) |
| render it below the answer | `the user's own message is a row in the transcript`, `a finished turn stays on screen when the NEXT one begins` |
| seed the row on `send` instead of on run | `a QUEUED prompt is not on the turn until its own run begins` |
| omit the role when reopening | `a REOPENED conversation shows the user's messages as the USER's` |
| let `start` wipe the prompt | `the prompt SURVIVES the engine's start event` (+7 more) |
| claim a failed turn was saved | `the user row says STORED only when end reported an index it wrote` |
| let the next turn erase the finished one | `a finished turn stays on screen when the NEXT one begins` |
| silence the hidden speaker | `a user row announces the speaker WITHOUT labelling away the message` |

No new importer of any `*-contract.ts` was added from a sibling test file (#4813).

## Known, and not addressed here

The in-process engine sends only the current prompt, with no prior messages, so the model has no memory of the conversation — visible in the screenshots, where "And its population?" is answered with a request for clarification. That is a separate defect in the engine's request construction, not in the transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - User messages now appear above assistant responses with clear sending, saved, or unsaved status.
  - Completed turns remain visible, and reopened conversations display previously sent messages.
  - Improved accessibility identifies user messages with a spoken “You said:” label.

- **Bug Fixes**
  - Failed or interrupted sends retain the correct prompt and status.
  - Switching conversations or starting a new chat no longer allows content from the previous conversation to appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->