### PR TITLE
feat(mobile): give the model the conversation, not just the last message

### DIFF
--- a/src/praisonai-mobile/app/src/boot.test.ts
+++ b/src/praisonai-mobile/app/src/boot.test.ts
@@ -316,6 +316,46 @@ test("the engine writes through the SAME session the app hands out", async () =>
   await result.app.dispose();
 });
 
+test("the engine reads history from the SAME session the app hands out", async () => {
+  // The mirror of the case above, and the one that was missing entirely: the
+  // engine was handed somewhere to WRITE a turn and nowhere to READ one back,
+  // so every message reached the model as a fresh conversation. Both objects
+  // must project the same session, or the model remembers a conversation other
+  // than the one on screen.
+  const storage = createFakeStorage();
+  let handedHistory: { messages: () => readonly { role: string; content: string }[] } | null = null;
+  let handedPersistence: { record: (r: { prompt: string }, a: string) => Promise<unknown> } | null =
+    null;
+
+  const result = await createApp(deps({
+    storage,
+    engines: (persistence, history) => {
+      handedPersistence = persistence as typeof handedPersistence;
+      handedHistory = history as typeof handedHistory;
+      return [{ id: "scripted", create: () => engineWith({ id: "scripted" }) }];
+    },
+  }));
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  const persistence = handedPersistence as unknown as {
+    record: (r: { prompt: string }, a: string) => Promise<unknown>;
+  };
+  const history = handedHistory as unknown as {
+    messages: () => readonly { role: string; content: string }[];
+  };
+  assert.notEqual(history, null, "the engine factory must be handed a history");
+  assert.deepEqual(history.messages(), [], "a fresh app has nothing to remember");
+
+  await persistence.record({ prompt: "What is the capital of France?" }, "Paris.");
+
+  assert.deepEqual(history.messages(), [
+    { role: "user", content: "What is the capital of France?" },
+    { role: "assistant", content: "Paris." },
+  ]);
+  await result.app.dispose();
+});
+
 test("the engine list cannot be built before the session exists", () => {
   // Enforced by the type, not by a comment: `engines` is a factory taking the
   // persistence, so there is no way to obtain the list without being handed
@@ -349,7 +389,7 @@ test("the engine factory is handed the REAL settings, not a stub", async () => {
   const result = await createApp(deps({
     storage,
     settingDefs: [...DEFS, { key: "baseUrl", default: "http://127.0.0.1:8765" }],
-    engines: (_persistence, settings) => {
+    engines: (_persistence, _history, settings) => {
       seen = settings.get("baseUrl") as string;
       return [{ id: "scripted", create: () => engine }];
     },
@@ -416,7 +456,7 @@ test("a refusal the ENGINE reports reaches the app's transcript", async () => {
 
   const result = await createApp(deps({
     onPublish: (v) => views.push(v),
-    engines: (_persistence, _settings, onIgnored) => {
+    engines: (_persistence, _history, _settings, onIgnored) => {
       const engine: AgentEnginePort = {
         ...inner,
         id: "scripted",

--- a/src/praisonai-mobile/app/src/boot.ts
+++ b/src/praisonai-mobile/app/src/boot.ts
@@ -17,7 +17,7 @@ import type { ShellPort } from "../../core/src/ports/shell.ts";
 import type { StoragePort } from "../../core/src/ports/storage.ts";
 import type { SecretsPort } from "../../core/src/ports/secrets.ts";
 import type { TimePort } from "../../core/src/ports/time.ts";
-import { createSession, persistenceFor, type Session } from "../../core/src/chat/session.ts";
+import { createSession, historyFor, persistenceFor, type Session } from "../../core/src/chat/session.ts";
 import {
   createSettingsStore,
   facadeFor,
@@ -30,7 +30,7 @@ import { attachBackGesture, createRouter, type Router } from "../../ui/src/route
 import { selectEngine, type EngineChoice } from "./engines.ts";
 import { createDropSink } from "../../core/src/run/drop-sink.ts";
 import type { IgnoredReason } from "../../protocol/src/decode.ts";
-import type { RunPersistence } from "../../engines/src/praisonai-ts/engine.ts";
+import type { ConversationHistory, RunPersistence } from "../../engines/src/praisonai-ts/engine.ts";
 
 export interface AppDeps {
   readonly storage: StoragePort;
@@ -45,9 +45,14 @@ export interface AppDeps {
    * never ran in a real turn and no conversation was ever saved. Taking a
    * factory makes that impossible to express: there is no way to obtain the
    * engine list without being handed the thing engines write through.
+   *
+   * It now hands over the READ side too. The same argument applies twice: an
+   * engine list obtainable without a history is an engine list whose engines
+   * can be built with no memory of the chat they are answering in.
    */
   readonly engines: (
     persistence: RunPersistence,
+    history: ConversationHistory,
     settings: SettingsFacade,
     onIgnored: (reason: IgnoredReason, detail: string) => void,
   ) => readonly EngineChoice[];
@@ -160,7 +165,11 @@ export async function createApp(deps: AppDeps): Promise<BootResult> {
 
   const selection = await selectEngine(
     chosenEngineId,
-    deps.engines(persistenceFor(session), settings, dropSink.note),
+    // Both halves of the same store, from the same session. Passing a
+    // persistence built here and a history built anywhere else is the failure
+    // this single expression exists to make unspellable: the model would
+    // remember a conversation other than the one the UI is showing.
+    deps.engines(persistenceFor(session), historyFor(session), settings, dropSink.note),
   );
   if (!selection.ok) {
     // Includes a health-probe refusal: a remote that answered 200 with

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -77,12 +77,14 @@ test("the real composition root offers the in-process engine", async () => {
       return { userIndex: 0, assistantIndex: 1, versions: 1, active: 0 };
     },
   };
+  const conversation = { messages: () => [] };
 
   const ids = appEngines({
     settings,
     http: createFakeHttp(),
     secrets,
     persistence,
+    history: conversation,
     onIgnored: () => {},
   }).map((c) => c.id);
 
@@ -112,12 +114,14 @@ test("the in-process engine, when its chunk cannot load, fails RECOVERABLY", asy
       return { userIndex: 0, assistantIndex: 1, versions: 1, active: 0 };
     },
   };
+  const conversation = { messages: () => [] };
 
   const inProcess = appEngines({
     settings,
     http: createFakeHttp(),
     secrets,
     persistence,
+    history: conversation,
     onIgnored: () => {},
     loadAgent: async () => {
       throw new Error("chunk-XXXXXXXX.js: failed to fetch");
@@ -1318,6 +1322,7 @@ test("on a device with nothing configured, the first message reaches the in-proc
     constructor(config: { instructions: string; llm?: string }) {
       configs.push(config);
     }
+    setHistory() {}
     async *streamEvents(prompt: string) {
       prompts.push(prompt);
       yield { type: "text", delta: "The capital of France is Paris." } as const;
@@ -1836,6 +1841,11 @@ test("END TO END: a key entered in Settings authenticates the very next message"
     constructor(config: { instructions: string; llm?: string; apiKey?: string }) {
       configs.push(config);
     }
+    // Present because the engine CALLS it on every turn, and this class is
+    // handed in through `loadAgent` as `never` -- so a missing member is not a
+    // typecheck failure, it is "agent.setHistory is not a function" rendered
+    // into the transcript where the answer should be.
+    setHistory() {}
     async *streamEvents() {
       yield { type: "text", delta: "Paris." } as const;
       yield { type: "finish", text: "Paris." } as const;
@@ -1881,5 +1891,154 @@ test("END TO END: a key entered in Settings authenticates the very next message"
   assert.equal(dom.find((n) => n.className.includes("row-error")), null, "and nothing must fail on the way");
   // And the key is still not anywhere on the page.
   assert.equal(dom.text().includes("sk-end-to-end"), false, dom.text());
+  await app?.dispose();
+});
+
+// ---- conversation memory, through the shipping composition root -------------
+//
+// engine.test.ts proves the engine restores whatever history it is handed;
+// session.test.ts proves the session projects one. Neither proves the two are
+// connected in the app that ships, and "both halves built, nothing joining
+// them" is exactly how this package lost `record()` once already. These drive
+// the real mount, the real controller, the real session and the real in-process
+// engine -- only the Agent class is scripted, through the seam appEngines
+// exposes for it.
+
+/** An Agent class that records the conversation it was restored with, per turn. */
+function rememberingAgentClass(answers: readonly string[]): {
+  readonly module: unknown;
+  readonly histories: { role: string; content: string }[][];
+  readonly prompts: string[];
+} {
+  const histories: { role: string; content: string }[][] = [];
+  const prompts: string[] = [];
+  let turn = 0;
+  class Remembering {
+    lastStopReason: "completed" | null = "completed";
+    private restored: { role: string; content: string }[] = [];
+    setHistory(messages: readonly { role: string; content: string }[]) {
+      this.restored = messages.map((m) => ({ role: m.role, content: m.content }));
+    }
+    async *streamEvents(prompt: string) {
+      histories.push(this.restored);
+      prompts.push(prompt);
+      const text = answers[Math.min(turn++, answers.length - 1)] ?? "";
+      yield { type: "finish", text } as const;
+    }
+  }
+  return { module: Remembering, histories, prompts };
+}
+
+test("ACCEPTANCE: a follow-up question reaches the model WITH the turn before it", async () => {
+  // The defect, stated as the user experiences it: ask for the capital of
+  // France, get "Paris", ask "And its population?" -- and the second question
+  // used to arrive at the provider with no subject at all, so the honest reply
+  // was a request for clarification rather than a number.
+  const { module, histories, prompts } = rememberingAgentClass([
+    "Paris.",
+    "About 2.1 million.",
+  ]);
+  const { dom, platform: web } = harness();
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+    loadAgent: async () => module as never,
+  });
+  assert.equal(app?.engine.id, ENGINE_PRAISONAI_TS);
+
+  submit(dom, "What is the capital of France?");
+  await settle(120);
+  submit(dom, "And its population?");
+  await settle(120);
+
+  assert.deepEqual(prompts, ["What is the capital of France?", "And its population?"]);
+  assert.deepEqual(histories[0], [], "the first question has nothing behind it");
+  assert.deepEqual(
+    histories[1],
+    [
+      { role: "user", content: "What is the capital of France?" },
+      { role: "assistant", content: "Paris." },
+    ],
+    "the follow-up must carry the exchange it follows",
+  );
+  await app?.dispose();
+});
+
+test("ACCEPTANCE: a conversation REOPENED after a relaunch still has its memory", async () => {
+  // Force-stop, relaunch, reopen from the chat list, ask a follow-up. A
+  // history assembled from turns seen in the current process passes the case
+  // above and fails this one -- and this is the case a phone hits every day,
+  // because a phone kills backgrounded apps.
+  const storage = createFakeStorage();
+
+  const first = rememberingAgentClass(["Paris."]);
+  const one = harness({ storage });
+  const app1 = await mount({
+    root: one.dom.root as never,
+    platform: { ...one.platform, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+    loadAgent: async () => first.module as never,
+  });
+  submit(one.dom, "What is the capital of France?");
+  await settle(120);
+  await app1?.dispose();
+
+  // A second launch over the same disk. Nothing survives in memory.
+  const second = rememberingAgentClass(["About 2.1 million."]);
+  const two = harness({ storage });
+  const app2 = await mount({
+    root: two.dom.root as never,
+    platform: { ...two.platform, kind: "tauri" },
+    now: () => 2,
+    newChatId: () => "c-fresh",
+    loadAgent: async () => second.module as never,
+  });
+
+  two.dom.click(two.dom.find((n) => n.dataset["route"] === "chats") as never);
+  await settle();
+  const row = two.dom.find((n) => n.dataset["action"] === "open-chat");
+  assert.ok(row, `the stored chat must be listed:\n${two.dom.text()}`);
+  two.dom.click(row as never);
+  await settle();
+
+  submit(two.dom, "And its population?");
+  await settle(120);
+
+  assert.deepEqual(second.prompts, ["And its population?"]);
+  assert.deepEqual(
+    second.histories[0],
+    [
+      { role: "user", content: "What is the capital of France?" },
+      { role: "assistant", content: "Paris." },
+    ],
+    "a reopened conversation must contribute its stored history",
+  );
+  await app2?.dispose();
+});
+
+test("New chat starts the model with a blank memory, not the previous conversation", async () => {
+  // The pair. A history that is merely "everything ever recorded" would leak
+  // the abandoned conversation into a chat the user believes is empty.
+  const { module, histories } = rememberingAgentClass(["Paris.", "second answer"]);
+  const { dom, platform: web } = harness();
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+    loadAgent: async () => module as never,
+  });
+
+  submit(dom, "What is the capital of France?");
+  await settle(120);
+  dom.click(dom.find((n) => n.dataset["action"] === "new-chat") as never);
+  await settle();
+  submit(dom, "an unrelated question");
+  await settle(120);
+
+  assert.deepEqual(histories[1], [], `the new chat must start empty:\n${JSON.stringify(histories)}`);
   await app?.dispose();
 });

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -70,7 +70,11 @@ import {
 } from "../../ui/src/transcript/scroll.ts";
 import type { EngineChoice } from "./engines.ts";
 import type { AgentEnginePort } from "../../core/src/ports/agent-engine.ts";
-import { createPraisonTsEngine, type RunPersistence } from "../../engines/src/praisonai-ts/engine.ts";
+import {
+  createPraisonTsEngine,
+  type ConversationHistory,
+  type RunPersistence,
+} from "../../engines/src/praisonai-ts/engine.ts";
 import { loadPraisonAgent, type PraisonAgentModule } from "../../engines/src/praisonai-ts/load-agent.ts";
 import type { PraisonAgent } from "../../engines/src/praisonai-ts/agent-api.ts";
 import { secretRefOf, type SettingDef, type SettingsFacade } from "../../core/src/settings/store.ts";
@@ -97,6 +101,7 @@ import type { HttpPort } from "../../core/src/ports/http.ts";
  */
 async function createInProcessEngine(
   persistence: RunPersistence,
+  history: ConversationHistory,
   settings: SettingsFacade,
   secrets: SecretsPort,
   loadAgent: () => Promise<PraisonAgentModule>,
@@ -107,6 +112,12 @@ async function createInProcessEngine(
   };
   return createPraisonTsEngine({
     persistence,
+    // The read side of the same store `persistence` writes to. The engine
+    // builds a fresh Agent per turn -- the model and the key come from
+    // settings and can change between messages -- so upstream's own
+    // accumulation dies with each agent and the conversation has to be
+    // restored explicitly on every turn.
+    history,
     createAgent: async (): Promise<PraisonAgent> => {
       // The chunk is fetched here, on the first turn, not at create(): a
       // fetch that fails then surfaces through engine.ts's run loop as a
@@ -166,6 +177,10 @@ export function appEngines(deps: {
    */
   readonly secrets: SecretsPort;
   readonly persistence: RunPersistence;
+  /** Where prior turns come from. Required for the same reason `secrets` is:
+   *  an optional one builds an engine that answers every message as though it
+   *  were the first. */
+  readonly history: ConversationHistory;
   readonly onIgnored: (reason: IgnoredReason, detail: string) => void;
   /** How the in-process engine's `Agent` class is fetched. Defaults to the
    *  real chunk loader. A test injects a rejecting one to drive the failure
@@ -177,9 +192,10 @@ export function appEngines(deps: {
     settings: deps.settings,
     http: deps.http,
     persistence: deps.persistence,
+    history: deps.history,
     onIgnored: deps.onIgnored,
-    createInProcess: (persistence) =>
-      createInProcessEngine(persistence, deps.settings, deps.secrets, loadAgent),
+    createInProcess: (persistence, history) =>
+      createInProcessEngine(persistence, history, deps.settings, deps.secrets, loadAgent),
   });
 }
 
@@ -838,7 +854,7 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     // them. This used to be a stub whose `get` returned undefined, captured by
     // the engine at boot and never replaced -- so the engine address the user
     // set was read, stored, and thrown away in favour of the hardcoded default.
-    engines: (persistence, settings, onIgnored) =>
+    engines: (persistence, history, settings, onIgnored) =>
       appEngines({
         settings,
         http: platform.http,
@@ -848,6 +864,11 @@ export async function mount(deps: MountDeps): Promise<App | null> {
         // the one file allowed to name a concrete adapter.
         secrets: platform.secrets,
         persistence,
+        // Read side and write side, both from the session `createApp` just
+        // built. A turn is recorded through one and replayed through the
+        // other, so the model's memory and the transcript on screen cannot
+        // drift apart.
+        history,
         onIgnored,
         ...(deps.loadAgent === undefined ? {} : { loadAgent: deps.loadAgent }),
       }),

--- a/src/praisonai-mobile/app/src/registry.test.ts
+++ b/src/praisonai-mobile/app/src/registry.test.ts
@@ -40,12 +40,25 @@ const build = async () => {
   // A RunPersistence that records nothing: these cases are about WHICH
   // engines are offered, not about what a turn writes.
   const persistence = { async record() { return { userIndex: 0, assistantIndex: 1, versions: 1, active: 0 }; } };
-  return { store, secrets, settings: facadeFor(store, secrets), http: createFakeHttp(), storage, persistence };
+  // Likewise a ConversationHistory with nothing in it: what a turn REMEMBERS is
+  // engine.test.ts's subject. Required rather than defaulted, for the reason
+  // RegistryDeps gives -- an engine built without one answers every message as
+  // though it were the first.
+  const history = { messages: () => [] };
+  return {
+    store,
+    secrets,
+    settings: facadeFor(store, secrets),
+    http: createFakeHttp(),
+    storage,
+    persistence,
+    history,
+  };
 };
 
 test("the remote engine is always offered, because it needs nothing injected", async () => {
-  const { settings, http, persistence } = await build();
-  const ids = enginesFor({ settings, http, persistence }).map((c) => c.id);
+  const { settings, http, persistence, history } = await build();
+  const ids = enginesFor({ settings, http, persistence, history }).map((c) => c.id);
   assert.deepEqual(ids, [ENGINE_REMOTE_HTTP]);
 });
 
@@ -54,18 +67,19 @@ test("the in-process engine is omitted when no factory is supplied", async () =>
   // factory is how main.ts supplies the engine (RegistryDeps says why it is
   // injected); without one there is nothing behind the id, so offering it
   // would be a lie.
-  const { settings, http, persistence } = await build();
-  assert.equal(enginesFor({ settings, http, persistence }).some((c) => c.id === ENGINE_PRAISONAI_TS), false);
+  const { settings, http, persistence, history } = await build();
+  assert.equal(enginesFor({ settings, http, persistence, history }).some((c) => c.id === ENGINE_PRAISONAI_TS), false);
 });
 
 test("the in-process engine appears once a factory is supplied", async () => {
   // The pair: without it, "never offer it" would satisfy the test above and
   // the engine could never be selected at all.
-  const { settings, http, persistence } = await build();
+  const { settings, http, persistence, history } = await build();
   const choices = enginesFor({
     settings,
     http,
       persistence,
+      history,
     createInProcess: () => createScriptedEngine({ id: ENGINE_PRAISONAI_TS, script: SCRIPTS.happy }),
   });
   assert.deepEqual(choices.map((c) => c.id), [ENGINE_REMOTE_HTTP, ENGINE_PRAISONAI_TS]);
@@ -73,8 +87,8 @@ test("the in-process engine appears once a factory is supplied", async () => {
 
 test("every offered engine actually constructs", async () => {
   // The registry's whole job. An id that cannot be built is worse than absent.
-  const { settings, http, persistence } = await build();
-  for (const choice of enginesFor({ settings, http, persistence })) {
+  const { settings, http, persistence, history } = await build();
+  for (const choice of enginesFor({ settings, http, persistence, history })) {
     const engine = await choice.create();
     assert.equal(engine.id, choice.id, "an engine must report the id it is registered under");
     await engine.dispose();
@@ -84,9 +98,9 @@ test("every offered engine actually constructs", async () => {
 test("the engine address comes from settings and loses a trailing slash", async () => {
   // `${baseUrl}/v1/run` against "http://host/" produces a double slash, which
   // some servers 404 and others silently redirect -- losing the POST body.
-  const { store, settings, http, persistence } = await build();
+  const { store, settings, http, persistence, history } = await build();
   await store.set("baseUrl", "http://example.test:9000///");
-  const engine = await enginesFor({ settings, http, persistence })[0]!.create();
+  const engine = await enginesFor({ settings, http, persistence, history })[0]!.create();
   assert.ok(engine);
   await engine.dispose();
 });
@@ -115,8 +129,8 @@ test("the engine setting offers exactly the engines the SHIPPING build can make"
   // disagree in a way it could see. It now compares against what `appEngines`
   // -- the composition main.ts actually mounts -- offers, which is the only
   // comparison that can fail.
-  const { settings, http, secrets, persistence } = await build();
-  const buildable = appEngines({ settings, http, secrets, persistence, onIgnored: () => {} }).map((c) => c.id);
+  const { settings, http, secrets, persistence, history } = await build();
+  const buildable = appEngines({ settings, http, secrets, persistence, history, onIgnored: () => {} }).map((c) => c.id);
 
   const def = SETTING_DEFS.find((d) => d.key === "engineId");
   assert.deepEqual(
@@ -293,11 +307,11 @@ test("enginesFor wires a health probe that refuses an engine answering 200 with 
   // the choice `enginesFor` builds must carry a probe that runs the shipping
   // `/health` classifier. A 200 with `{"ok": false}` is the engine saying it is
   // NOT ready, and the probe must report exactly that.
-  const { settings, persistence } = await build();
+  const { settings, persistence, history } = await build();
   const http = createFakeHttp();
   http.on("/health", () => jsonResponse(200, { ok: false }));
 
-  const choice = enginesFor({ settings, http, persistence }).find((c) => c.id === ENGINE_REMOTE_HTTP);
+  const choice = enginesFor({ settings, http, persistence, history }).find((c) => c.id === ENGINE_REMOTE_HTTP);
   assert.ok(choice?.probe, "the remote engine must carry a readiness probe");
 
   const verdict = await choice.probe();
@@ -307,11 +321,11 @@ test("enginesFor wires a health probe that refuses an engine answering 200 with 
 
 test("enginesFor's probe lets a healthy engine through -- the pair", async () => {
   // Without this, a probe hard-wired to refuse would satisfy the case above.
-  const { settings, persistence } = await build();
+  const { settings, persistence, history } = await build();
   const http = createFakeHttp();
   http.on("/health", () => jsonResponse(200, { ok: true, version: PROTOCOL_VERSION }));
 
-  const choice = enginesFor({ settings, http, persistence }).find((c) => c.id === ENGINE_REMOTE_HTTP);
+  const choice = enginesFor({ settings, http, persistence, history }).find((c) => c.id === ENGINE_REMOTE_HTTP);
   const verdict = await choice!.probe!();
   assert.equal(verdict.ready, true);
 });
@@ -320,12 +334,12 @@ test("enginesFor's probe targets the configured engine address", async () => {
   // The probe must reach the address the user set, not a hardcoded default:
   // otherwise a healthy default masks a broken configured engine, or the
   // reverse. The trailing slash is stripped so `${baseUrl}/health` is clean.
-  const { store, settings, persistence } = await build();
+  const { store, settings, persistence, history } = await build();
   await store.set("baseUrl", "http://configured.test:9000/");
   const http = createFakeHttp();
   http.on("/health", () => jsonResponse(200, { ok: true, version: PROTOCOL_VERSION }));
 
-  const choice = enginesFor({ settings, http, persistence }).find((c) => c.id === ENGINE_REMOTE_HTTP);
+  const choice = enginesFor({ settings, http, persistence, history }).find((c) => c.id === ENGINE_REMOTE_HTTP);
   await choice!.probe!();
   assert.equal(http.sent.at(-1)?.url, "http://configured.test:9000/health");
 });
@@ -338,7 +352,7 @@ test("enginesFor hands the refusal callback to the engine it builds", async () =
   // so it never exercises the real one. A callback the composition root
   // creates and the registry quietly declines to pass on is the same
   // mechanism-connected-to-nothing this channel exists to undo.
-  const { settings, persistence } = await build();
+  const { settings, persistence, history } = await build();
   const http = createFakeHttp();
   const refused: { reason: string; detail: string }[] = [];
 
@@ -356,6 +370,7 @@ test("enginesFor hands the refusal callback to the engine it builds", async () =
   const choice = enginesFor({
     settings,
     http,
+    history,
     persistence,
     onIgnored: (reason, detail) => refused.push({ reason, detail }),
   }).find((c) => c.id === ENGINE_REMOTE_HTTP);
@@ -374,7 +389,7 @@ test("enginesFor hands the refusal callback to the engine it builds", async () =
 
 test("a clean stream through the same engine reports no refusal", async () => {
   // The pair: a registry that invented a refusal would satisfy the above.
-  const { settings, persistence } = await build();
+  const { settings, persistence, history } = await build();
   const http = createFakeHttp();
   const refused: unknown[] = [];
   http.on("/chat", () =>
@@ -387,7 +402,7 @@ test("a clean stream through the same engine reports no refusal", async () => {
   );
 
   const choice = enginesFor({
-    settings, http, persistence,
+    settings, http, persistence, history,
     onIgnored: (...args) => refused.push(args),
   }).find((c) => c.id === ENGINE_REMOTE_HTTP);
   const engine = await choice!.create();
@@ -450,13 +465,13 @@ async function drain(engine: { run: (r: typeof A_RUN, s: AbortSignal) => AsyncIt
 }
 
 test("a turn goes to the address the user set AFTER the engine was built", async () => {
-  const { store, settings, persistence } = await build();
+  const { store, settings, persistence, history } = await build();
   const http = createFakeHttp();
   http.on("/chat", () => sseResponse(""));
 
   // Built first, exactly as boot.ts does: the engine exists before the user
   // ever reaches Settings.
-  const engine = await enginesFor({ settings, http, persistence })[0]!.create();
+  const engine = await enginesFor({ settings, http, persistence, history })[0]!.create();
   await store.set("baseUrl", "http://10.0.0.7:9000");
   await drain(engine as never);
 
@@ -471,11 +486,11 @@ test("a turn goes to the address the user set AFTER the engine was built", async
 test("an untouched setting still reaches the address the engine was built with", async () => {
   // The pair. Reading the setting late must not mean reading it wrongly: with
   // nothing changed, the default is still where a turn goes.
-  const { settings, persistence } = await build();
+  const { settings, persistence, history } = await build();
   const http = createFakeHttp();
   http.on("/chat", () => sseResponse(""));
 
-  const engine = await enginesFor({ settings, http, persistence })[0]!.create();
+  const engine = await enginesFor({ settings, http, persistence, history })[0]!.create();
   await drain(engine as never);
 
   assert.equal(http.sent.at(-1)?.url, "http://127.0.0.1:8765/chat");
@@ -487,11 +502,11 @@ test("a corrected address is re-read by the health probe too", async () => {
   // produces the "not answering" warning the user is trying to clear. Probing
   // the OLD address after the address was fixed reports a failure about a
   // machine nobody is talking to any more.
-  const { store, settings, persistence } = await build();
+  const { store, settings, persistence, history } = await build();
   const http = createFakeHttp();
   http.on("/health", () => jsonResponse(200, { ok: true, version: PROTOCOL_VERSION }));
 
-  const choice = enginesFor({ settings, http, persistence }).find((c) => c.id === ENGINE_REMOTE_HTTP);
+  const choice = enginesFor({ settings, http, persistence, history }).find((c) => c.id === ENGINE_REMOTE_HTTP);
   await store.set("baseUrl", "http://10.0.0.7:9000/");
   await choice!.probe!();
 
@@ -549,12 +564,12 @@ async function runOneTurn(
 }
 
 test("the stored key is handed to the agent the in-process engine builds", async () => {
-  const { settings, http, secrets, store, persistence } = await build();
+  const { settings, http, secrets, store, persistence, history } = await build();
   await store.setSecret({ slot: "openai", account: "default" }, "sk-live-key");
 
   const { module, configs } = recordingAgentClass();
   await runOneTurn({
-    settings, http, secrets, persistence, onIgnored: () => {}, loadAgent: async () => module,
+    settings, http, secrets, persistence, history, onIgnored: () => {}, loadAgent: async () => module,
   });
 
   assert.deepEqual(configs.map((c) => c.apiKey), ["sk-live-key"]);
@@ -567,10 +582,10 @@ test("with no key stored the field is ABSENT, not an empty string", async () => 
   // build an Authorization header out of nothing and turn a missing-credential
   // error into an authentication one, which reads as a bad key rather than as
   // no key.
-  const { settings, http, secrets, persistence } = await build();
+  const { settings, http, secrets, persistence, history } = await build();
   const { module, configs } = recordingAgentClass();
   await runOneTurn({
-    settings, http, secrets, persistence, onIgnored: () => {}, loadAgent: async () => module,
+    settings, http, secrets, persistence, history, onIgnored: () => {}, loadAgent: async () => module,
   });
   assert.equal(configs.length, 1);
   assert.equal("apiKey" in configs[0]!, false, "an unset key must not appear in the agent config at all");
@@ -582,10 +597,10 @@ test("a key pasted AFTER the engine was built works on the very next message", a
   // work until they force-quit the app -- and the error they would see is the
   // same one they were trying to clear, so the app appears to have ignored
   // them. `enginesFor` learned this with `baseUrl`; a credential is worse.
-  const { settings, http, secrets, store, persistence } = await build();
+  const { settings, http, secrets, store, persistence, history } = await build();
   const { module, configs } = recordingAgentClass();
   const deps = {
-    settings, http, secrets, persistence, onIgnored: () => {}, loadAgent: async () => module,
+    settings, http, secrets, persistence, history, onIgnored: () => {}, loadAgent: async () => module,
   };
 
   const choice = appEngines(deps).find((c) => c.id === ENGINE_PRAISONAI_TS);
@@ -603,10 +618,10 @@ test("a key pasted AFTER the engine was built works on the very next message", a
 test("a replaced key replaces itself on the next turn", async () => {
   // The other half of "read per turn": rotating a key must not need a relaunch
   // either.
-  const { settings, http, secrets, store, persistence } = await build();
+  const { settings, http, secrets, store, persistence, history } = await build();
   const { module, configs } = recordingAgentClass();
   const deps = {
-    settings, http, secrets, persistence, onIgnored: () => {}, loadAgent: async () => module,
+    settings, http, secrets, persistence, history, onIgnored: () => {}, loadAgent: async () => module,
   };
   const engine = await appEngines(deps).find((c) => c.id === ENGINE_PRAISONAI_TS)!.create();
 
@@ -623,11 +638,11 @@ test("the secret never reaches the plain settings file on the way through", asyn
   // Rule 1 of ports/secrets.ts, asserted at the composition level rather than
   // only in the store's own unit test: the whole path from `setSecret` to the
   // agent must leave nothing behind in StoragePort.
-  const { settings, http, secrets, store, storage, persistence } = await build();
+  const { settings, http, secrets, store, storage, persistence, history } = await build();
   await store.setSecret({ slot: "openai", account: "default" }, "sk-do-not-leak");
   const { module } = recordingAgentClass();
   await runOneTurn({
-    settings, http, secrets, persistence, onIgnored: () => {}, loadAgent: async () => module,
+    settings, http, secrets, persistence, history, onIgnored: () => {}, loadAgent: async () => module,
   });
   const contents: string[] = [];
   for (const key of storage.writes) {

--- a/src/praisonai-mobile/app/src/registry.ts
+++ b/src/praisonai-mobile/app/src/registry.ts
@@ -19,7 +19,7 @@ import { readSecretSetting, type SettingDef, type SettingsFacade } from "../../c
 import type { Platform } from "./platform.ts";
 import { createRemoteHttpEngine, probeHealth } from "../../engines/src/remote-http/engine.ts";
 import type { EngineChoice } from "./engines.ts";
-import type { RunPersistence } from "../../engines/src/praisonai-ts/engine.ts";
+import type { ConversationHistory, RunPersistence } from "../../engines/src/praisonai-ts/engine.ts";
 
 export const ENGINE_REMOTE_HTTP = "remote-http";
 export const ENGINE_PRAISONAI_TS = "praisonai-ts";
@@ -195,7 +195,10 @@ export interface RegistryDeps {
    * ships as a lazy chunk and main.ts supplies the factory; the injection
    * stays because the boundary does.
    */
-  readonly createInProcess?: (persistence: RunPersistence) => AgentEnginePort | Promise<AgentEnginePort>;
+  readonly createInProcess?: (
+    persistence: RunPersistence,
+    history: ConversationHistory,
+  ) => AgentEnginePort | Promise<AgentEnginePort>;
   /**
    * Where a completed turn is written.
    *
@@ -210,6 +213,20 @@ export interface RegistryDeps {
    * store. Two engines, two owners of the write, one honest `userIndex`.
    */
   readonly persistence: RunPersistence;
+  /**
+   * Where the conversation so far is READ from.
+   *
+   * The counterpart of `persistence`, and it goes to exactly the same engines
+   * for exactly the same reason. The in-process engine owns its store, so it
+   * must replay it or the model has no memory of a chat the app is displaying.
+   * The remote engine deliberately does not take it: the server it talks to
+   * keeps its own history against the `chat_id` every request carries, so
+   * sending the client's copy as well would send every prior turn twice.
+   *
+   * Two engines, two owners of the conversation -- the same split this file
+   * already draws for the write, drawn once for the read.
+   */
+  readonly history: ConversationHistory;
   /** Called for every frame an engine's decoder refuses. Supplied by the
    *  composition root, which owns the transcript those refusals land on. */
   readonly onIgnored?: (reason: IgnoredReason, detail: string) => void;
@@ -272,7 +289,7 @@ export function enginesFor(deps: RegistryDeps): readonly EngineChoice[] {
 
   if (deps.createInProcess !== undefined) {
     const build = deps.createInProcess;
-    choices.push({ id: ENGINE_PRAISONAI_TS, create: () => build(deps.persistence) });
+    choices.push({ id: ENGINE_PRAISONAI_TS, create: () => build(deps.persistence, deps.history) });
   }
   return choices;
 }

--- a/src/praisonai-mobile/core/src/chat/history.test.ts
+++ b/src/praisonai-mobile/core/src/chat/history.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The truncation rule, and the shape of the answer when it fires.
+ *
+ * `truncateHistory` is the only place in this package that decides what a
+ * model is allowed to remember, so every clause of the rule in history.ts
+ * gets a case here that fails if the clause is removed.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  HISTORY_CHAR_BUDGET,
+  truncateHistory,
+  type HistoryMessage,
+} from "./history.ts";
+
+const turn = (role: "user" | "assistant", content: string): HistoryMessage => ({ role, content });
+
+test("a conversation inside the budget passes through unchanged, in order", async () => {
+  const messages = [
+    turn("user", "What is the capital of France?"),
+    turn("assistant", "Paris."),
+    turn("user", "And its population?"),
+  ];
+
+  const bounded = truncateHistory(messages, HISTORY_CHAR_BUDGET);
+
+  assert.deepEqual(bounded.messages, messages);
+  assert.equal(bounded.dropped, 0);
+});
+
+test("over the budget, the RECENT end is what survives", async () => {
+  // The direction is the whole point: "and its population?" is answerable from
+  // the last two turns and unanswerable from the first two.
+  const bounded = truncateHistory(
+    [turn("user", "aaaa"), turn("assistant", "bbbb"), turn("user", "cccc"), turn("assistant", "dddd")],
+    8,
+  );
+
+  assert.deepEqual(bounded.messages.map((m) => m.content), ["cccc", "dddd"]);
+  assert.equal(bounded.dropped, 2);
+});
+
+test("a history that would BEGIN with an assistant message drops that message", async () => {
+  // 4 characters of room reaches only "dddd", an answer with no question above
+  // it. Keeping it hands the model something it appears to have volunteered.
+  const bounded = truncateHistory(
+    [turn("user", "aaaa"), turn("assistant", "bbbb"), turn("user", "cccc"), turn("assistant", "dddd")],
+    4,
+  );
+
+  assert.deepEqual(bounded.messages, []);
+  assert.equal(bounded.dropped, 4);
+});
+
+test("a message too large to fit STOPS the walk rather than being skipped over", async () => {
+  // Skipping the oversized message to fit older, smaller ones would reorder the
+  // conversation around a hole: the model would read a follow-up whose subject
+  // was removed.
+  const bounded = truncateHistory(
+    [turn("user", "short"), turn("assistant", "x".repeat(50)), turn("user", "tail")],
+    10,
+  );
+
+  assert.deepEqual(bounded.messages.map((m) => m.content), ["tail"]);
+});
+
+test("a conversation that exactly fills the budget still fits", async () => {
+  // `>` and not `>=`. An off-by-one here silently drops the oldest turn of
+  // every conversation that lands on the boundary.
+  const bounded = truncateHistory([turn("user", "12345"), turn("assistant", "67890")], 10);
+
+  assert.equal(bounded.messages.length, 2);
+  assert.equal(bounded.dropped, 0);
+});
+
+test("an empty conversation truncates to an empty conversation, not to a throw", async () => {
+  const bounded = truncateHistory([], HISTORY_CHAR_BUDGET);
+
+  assert.deepEqual(bounded.messages, []);
+  assert.equal(bounded.dropped, 0);
+});
+
+test("the default budget is large enough for an ordinary conversation", async () => {
+  // A budget accidentally set to a small number would truncate every chat and
+  // look exactly like the bug this change removes. 200 turns of 100 characters
+  // is a long conversation by phone standards and must survive whole.
+  const messages: HistoryMessage[] = [];
+  for (let i = 0; i < 200; i++) {
+    messages.push(turn(i % 2 === 0 ? "user" : "assistant", "x".repeat(100)));
+  }
+
+  assert.equal(truncateHistory(messages).dropped, 0);
+});

--- a/src/praisonai-mobile/core/src/chat/history.ts
+++ b/src/praisonai-mobile/core/src/chat/history.ts
@@ -1,0 +1,114 @@
+/**
+ * The conversation as the MODEL sees it.
+ *
+ * `repository.ts` owns how a chat is stored and `session.ts` owns which chat
+ * is open. Neither answers the question this file exists for: what does the
+ * next turn get to remember?
+ *
+ * Until this module existed, the answer was "nothing". The engine was handed
+ * `request.prompt` and only `request.prompt`, so the app stored a
+ * conversation, rendered it, and showed the model none of it -- "What is the
+ * capital of France?" followed by "And its population?" reached the provider
+ * as a question about no subject, and the honest reply was a request for
+ * clarification. A chat app that cannot hold a conversation is the defect;
+ * this is the shape the fix is built on.
+ *
+ * TWO ROLES, NOT FOUR. `StoredMessage.role` is `"user" | "assistant"` and this
+ * mirrors it exactly rather than widening to the provider's four. A `tool`
+ * message restored without the `tool_calls` entry it answers is rejected by
+ * every provider, and this package has never persisted one -- so a wider type
+ * here would be a promise the store cannot keep. If tool turns are persisted
+ * later, `repository.ts` bumps its schema and this widens with it.
+ */
+
+/** One prior turn, as handed to an engine. Deliberately without `at`: an
+ *  engine has no business with wall-clock time, and including it would make
+ *  the type a second copy of `StoredMessage` rather than a projection of it. */
+export interface HistoryMessage {
+  readonly role: "user" | "assistant";
+  readonly content: string;
+}
+
+/**
+ * How much prior conversation may travel with a turn, in CHARACTERS.
+ *
+ * Characters, not tokens: this package cannot tokenize without pulling a
+ * model-specific tokenizer into a webview bundle, and a character budget is
+ * both cheap and conservative -- English averages ~4 characters per token, so
+ * 24,000 characters is roughly 6,000 tokens. Against the 128k context of the
+ * default `gpt-4o-mini` that leaves the instructions, the current prompt, any
+ * tool traffic and the answer itself an order of magnitude more room than they
+ * need, which is the point: the budget is here to make the failure IMPOSSIBLE,
+ * not to use the window efficiently.
+ *
+ * Deliberately a plain constant rather than a setting. A setting invites a
+ * value that is wrong for whichever model the user later picks, and the
+ * failure it produces -- a provider 400 in the middle of an answer -- is
+ * exactly what this is meant to prevent.
+ */
+export const HISTORY_CHAR_BUDGET = 24_000;
+
+export interface BoundedHistory {
+  /** What the engine may send, oldest first. */
+  readonly messages: readonly HistoryMessage[];
+  /** How many messages were left out. Zero for every conversation that fits,
+   *  which is almost all of them. Returned rather than logged so a caller can
+   *  say something about it; see the note on visibility below. */
+  readonly dropped: number;
+}
+
+/**
+ * Bound a conversation to `budget` characters, keeping the RECENT end.
+ *
+ * A long conversation eventually exceeds any context window, and the question
+ * "what happens then" has to have an answer written down somewhere. Letting
+ * the provider answer it is the option this rejects: the user's next message
+ * would fail with a 400 whose text names a token count, mid-answer, with no
+ * way forward except deleting the chat.
+ *
+ * The rule:
+ *
+ *  - Walk from the NEWEST message backwards, taking messages while they fit.
+ *    The recent end is the end that makes "and its population?" answerable;
+ *    dropping it to keep the opening pleasantries would be exactly backwards.
+ *  - Stop at the first message that does not fit, and do not resume. Skipping
+ *    a large message to fit a smaller older one would reorder the conversation
+ *    around a hole and hand the model a non-sequitur.
+ *  - Then, if the kept history would BEGIN with an assistant message, drop
+ *    that too. An answer with no question above it reads to the model as
+ *    something it asserted unprompted, and the whole reason to keep history is
+ *    that the model reasons about what was actually said.
+ *
+ * A budget too small for even the last message yields an empty history, which
+ * is the honest result: this turn has no memory rather than a corrupted one.
+ *
+ * WHAT THE USER SEES when this fires: the transcript on screen is unchanged --
+ * nothing is deleted, and scrolling back still shows every message -- but the
+ * model stops being able to refer to the oldest turns. There is no protocol
+ * event for "context was trimmed" in v2, so this is not surfaced in the UI
+ * today; adding one is a protocol bump and is recorded in docs/gaps.md rather
+ * than left implied.
+ */
+export function truncateHistory(
+  messages: readonly HistoryMessage[],
+  budget: number = HISTORY_CHAR_BUDGET,
+): BoundedHistory {
+  const kept: HistoryMessage[] = [];
+  let used = 0;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]!;
+    const cost = message.content.length;
+    // `>` not `>=`: a conversation that exactly fills the budget fits.
+    if (used + cost > budget) break;
+    used += cost;
+    kept.push(message);
+  }
+
+  kept.reverse();
+
+  // A leading assistant message is dropped, never re-ordered around.
+  if (kept.length > 0 && kept[0]!.role === "assistant") kept.shift();
+
+  return { messages: kept, dropped: messages.length - kept.length };
+}

--- a/src/praisonai-mobile/core/src/chat/session.test.ts
+++ b/src/praisonai-mobile/core/src/chat/session.test.ts
@@ -9,7 +9,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createSession, persistenceFor, titleFrom } from "./session.ts";
+import { createSession, historyFor, persistenceFor, titleFrom } from "./session.ts";
 import { createFakeStorage } from "../../../testing/src/fake-storage.ts";
 
 const build = (over: Partial<Parameters<typeof createSession>[0]> = {}) => {
@@ -278,4 +278,90 @@ test("a title at exactly the limit is not elided -- the pair", () => {
   // Without this, a titleFrom that always elided would pass above.
   const sixty = "a".repeat(60);
   assert.equal(titleFrom(sixty), sixty);
+});
+
+// ---- the session as the engine's MEMORY ------------------------------------
+//
+// `persistenceFor` is how a turn gets written; `historyFor` is how it gets
+// remembered. The second did not exist, so the model was shown none of a
+// conversation the app was storing and rendering.
+
+test("historyFor reports the completed turns of the open chat, oldest first", async () => {
+  const { session } = build();
+  await session.record("What is the capital of France?", "Paris.");
+  await session.record("And its population?", "About 2.1 million.");
+
+  assert.deepEqual(historyFor(session).messages(), [
+    { role: "user", content: "What is the capital of France?" },
+    { role: "assistant", content: "Paris." },
+    { role: "user", content: "And its population?" },
+    { role: "assistant", content: "About 2.1 million." },
+  ]);
+});
+
+test("a REOPENED conversation reports its stored history, not an empty one", async () => {
+  // The force-stop case, and the one a session-scoped in-memory history would
+  // fail: the app is relaunched, the chat is opened from the list, and the
+  // model must still know what was said. A `historyFor` reading anything other
+  // than `current()` -- a buffer filled by `record`, say -- returns nothing
+  // here while the transcript on screen is full.
+  const storage = createFakeStorage();
+  let clock = 1000;
+  const first = createSession({
+    storage,
+    engineId: "scripted",
+    now: () => ++clock,
+    newChatId: () => "c1",
+  });
+  await first.record("What is the capital of France?", "Paris.");
+
+  // A different Session over the same storage: a new process, same disk.
+  const relaunched = createSession({
+    storage,
+    engineId: "scripted",
+    now: () => ++clock,
+    newChatId: () => "c-never-used",
+  });
+  assert.deepEqual(historyFor(relaunched).messages(), [], "nothing is open yet");
+
+  assert.equal(await relaunched.open("c1"), true);
+  assert.deepEqual(historyFor(relaunched).messages(), [
+    { role: "user", content: "What is the capital of France?" },
+    { role: "assistant", content: "Paris." },
+  ]);
+});
+
+test("history is re-read on every call, so the turn just recorded is in the next one", async () => {
+  // Captured once, this returns the empty array forever and every conversation
+  // is one question long from the model's point of view.
+  const { session } = build();
+  const history = historyFor(session);
+  assert.deepEqual(history.messages(), []);
+
+  await session.record("one", "first answer");
+
+  assert.equal(history.messages().length, 2);
+});
+
+test("a new chat has no history, and starting one clears what was there", async () => {
+  // `reset()` is what New chat calls. A history that survived it would leak the
+  // previous conversation into a chat the user believes is empty -- the same
+  // class of defect as the transcript that used to survive New chat.
+  const { session } = build();
+  await session.record("secret question", "secret answer");
+  assert.equal(historyFor(session).messages().length, 2);
+
+  session.reset();
+
+  assert.deepEqual(historyFor(session).messages(), []);
+});
+
+test("history carries roles, not just text", async () => {
+  // A projection that dropped `role` would still produce the right sentences in
+  // the right order and be useless: the model could not tell its own previous
+  // answers from the user's questions.
+  const { session } = build();
+  await session.record("q", "a");
+
+  assert.deepEqual(historyFor(session).messages().map((m) => m.role), ["user", "assistant"]);
 });

--- a/src/praisonai-mobile/core/src/chat/session.ts
+++ b/src/praisonai-mobile/core/src/chat/session.ts
@@ -21,6 +21,7 @@
  */
 import type { StoragePort } from "../ports/storage.ts";
 import { createChatRepository, type ChatRepository, type StoredChat, type StoredMessage } from "./repository.ts";
+import type { HistoryMessage } from "./history.ts";
 
 /** What the engine ports call. Mirrors the engine-side interface exactly. */
 export interface RecordedIndices {
@@ -157,5 +158,37 @@ export function persistenceFor(session: Session): {
 } {
   return {
     record: (request, answer) => session.record(request.prompt, answer),
+  };
+}
+
+/**
+ * A `Session` seen as the engine's conversation MEMORY.
+ *
+ * The mirror image of `persistenceFor`, and it exists for the same reason: the
+ * two halves were designed apart. `Session` knows the whole `StoredChat`;
+ * an engine wants prior turns and nothing else -- no ids, no titles, no
+ * timestamps, no engineId. This is the projection, named rather than inlined
+ * so the one place the two vocabularies meet stays findable.
+ *
+ * READ FROM `current()`, exactly as `record` WRITES to it. That is what makes a
+ * REOPENED conversation carry its history: `open(chatId)` loads the stored
+ * chat into `current`, so the messages a user scrolls back through and the
+ * messages the next turn remembers are the same array. A history assembled
+ * from turns seen in this process instead would have given a fresh launch a
+ * model with amnesia and a screen full of transcript -- which is the original
+ * defect surviving a force-stop.
+ *
+ * It does NOT include the prompt currently being sent. `record` runs after a
+ * turn succeeds, so `current()` holds completed turns only; the engine adds
+ * the live prompt itself. Including it here would send the question twice --
+ * once as history and once as the prompt -- and a model asked the same
+ * question twice in one request answers the wrong one about half the time.
+ */
+export function historyFor(session: Session): {
+  messages(): readonly HistoryMessage[];
+} {
+  return {
+    messages: () =>
+      (session.current()?.messages ?? []).map((m) => ({ role: m.role, content: m.content })),
   };
 }

--- a/src/praisonai-mobile/docs/gaps.md
+++ b/src/praisonai-mobile/docs/gaps.md
@@ -489,3 +489,55 @@ already ended owns its drops; only a `before_start` drop, recorded while
 `idle`, belongs to the turn now opening. Fixed by clearing `dropped` on a
 `start` that replaces an ended turn, pinned at both hops: reverting it fails
 one reducer test and one controller test.
+
+
+## Conversation memory, and the one thing it deliberately does not do
+
+**Closed.** `engines/src/praisonai-ts/engine.ts` sent `request.prompt` and only
+`request.prompt`. Nothing in `engines/src` assembled prior messages, so the app
+stored a conversation, rendered it, and showed the model none of it. Measured on
+an Android emulator against the real provider: "What is the capital of France?"
+→ "Paris.", then "And its population?" → a request for clarification, because
+the second question arrived with no subject.
+
+The fix is `Agent.setHistory`, upstream's documented answer to exactly this
+("Restore a previously saved conversation so the model regains its memory of
+it"). The engine builds a **fresh agent per turn** — the model and the key come
+from settings and can change between messages — so upstream's own accumulation
+across `streamEvents` calls dies with each agent and the conversation has to be
+restored explicitly, every turn.
+
+**Where the layering fell out.** Conversation memory is an *engine-level*
+responsibility, owned by whoever owns the store, and it is NOT on
+`AgentEnginePort`. Widening `RunRequest` with a `history` field would hand the
+conversation to `remote-http` as well — and that engine POSTs `chat_id` to a
+server that keeps its own history for that id, so every prior turn would arrive
+twice, once from the client and once from the server's store. A doubled
+conversation is worse than a missing one: silent, growing, and it makes the
+model contradict itself. This is the same split `RegistryDeps.persistence`
+already draws for the WRITE, drawn once more for the READ: two engines, two
+owners of the conversation.
+
+### Truncation: what happens, and what a user sees
+
+`core/src/chat/history.ts` bounds a turn's history to
+`HISTORY_CHAR_BUDGET` (24,000 characters, ≈6,000 tokens) by keeping the
+**recent** end, stopping at the first message that does not fit, and dropping a
+leading assistant message so the history never begins with an answer to a
+question the model cannot see. Characters rather than tokens because tokenizing
+would pull a model-specific tokenizer into a webview bundle; the budget is
+deliberately an order of magnitude under the default model's window, because it
+exists to make the failure impossible rather than to use the window efficiently.
+
+**Still open, and stated rather than implied:** truncation is *not surfaced in
+the UI*. When it fires, the transcript on screen is unchanged — nothing is
+deleted, scrolling back still shows every message — but the model stops being
+able to refer to the oldest turns, and the user is not told. Protocol v2 has no
+event for "context was trimmed" and adding one is a protocol bump, so this is
+recorded here instead of being half-done. `truncateHistory` already returns
+`dropped`, so the value a notice would carry exists; nothing consumes it yet.
+
+**Also still open:** `remote-http` conversations remain server-owned end to end,
+so a chat answered by the default remote engine leaves the local session empty
+and has no local history to restore. That is the same scope note Gap 4 carries
+and it is unchanged by this.

--- a/src/praisonai-mobile/engines/src/praisonai-ts/agent-api.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/agent-api.ts
@@ -58,14 +58,52 @@ export interface PraisonStreamOptions {
 }
 
 /**
+ * One prior turn, as `setHistory` accepts it.
+ *
+ * Upstream's `AgentMessage` has four roles (`system`, `user`, `assistant`,
+ * `tool`), a nullable `content`, and optional `tool_calls` / `tool_call_id` /
+ * `name`. This declares the SUBSET this engine actually restores, which is the
+ * house rule of this file -- "the exact slice, and nothing more".
+ *
+ * Narrower is safe and wider would not be. Method parameters are checked
+ * bivariantly, so the real `Agent` still satisfies this and
+ * `check-upstream-parity` still catches a rename or a signature change. But
+ * `core/src/chat/repository.ts` persists two roles and no tool context, so a
+ * `tool` message here would be a shape this app can never produce -- and an
+ * unpaired tool result is a 400 from every provider, which is why upstream's
+ * own `setHistory` rejects one.
+ */
+export interface PraisonHistoryMessage {
+  readonly role: "user" | "assistant";
+  readonly content: string;
+}
+
+/**
  * The structural contract the real `Agent` satisfies.
  *
  * `lastStopReason` is a mutable field upstream, read AFTER the stream ends.
  * That ordering matters: read before, it is the previous turn's value.
+ *
+ * `setHistory` is what makes the app a conversation rather than a sequence of
+ * unrelated questions. Upstream's `Agent` accumulates turns in a private
+ * `messages` array and sends the whole array on every call -- but this engine
+ * builds a FRESH agent per turn (the model and the key come from settings,
+ * which can change between messages), so that array starts empty every time
+ * and the accumulated memory is thrown away with the agent. `setHistory` is
+ * upstream's documented answer to exactly this: "Restore a previously saved
+ * conversation so the model regains its memory of it."
+ *
+ * REQUIRED, not optional. An optional member is a composition that can forget
+ * it and still typecheck -- and what it builds is the amnesiac engine this
+ * change exists to remove.
  */
 export interface PraisonAgent {
   streamEvents(prompt: string, opts?: PraisonStreamOptions): AsyncIterable<PraisonAgentEvent>;
   readonly lastStopReason: PraisonStopReason | null;
+  /** Replaces the agent's conversation, oldest first. Throws on a malformed
+   *  history: upstream validates because the input comes from disk, and disk
+   *  outlives the code that wrote it. */
+  setHistory(messages: readonly PraisonHistoryMessage[]): void;
 }
 
 /** How the engine obtains an agent. A factory, not an instance: the model and

--- a/src/praisonai-mobile/engines/src/praisonai-ts/conformance.test.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/conformance.test.ts
@@ -95,6 +95,12 @@ function agentFor(scenario: ScenarioName): PraisonAgent {
   }
   return {
     lastStopReason: script.stop,
+    // The contract says nothing about history -- it is an engine-level
+    // concern, not a port-level one (see ConversationHistory in engine.ts) --
+    // so the scenarios do not exercise it. It is still REQUIRED on the
+    // interface, so the fake has to answer it: an optional member is one a
+    // real composition can forget.
+    setHistory() {},
     async *streamEvents(_prompt, opts) {
       for (const event of script.events) {
         if (opts?.signal?.aborted) return;
@@ -116,6 +122,7 @@ describeEngineContract({
           return { userIndex: 0, assistantIndex: 1, versions: 1, active: 0 };
         },
       },
+      history: { messages: () => [] },
       newMsgId: () => `m${++counter}`,
     }),
   unsupported: {

--- a/src/praisonai-mobile/engines/src/praisonai-ts/engine.test.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/engine.test.ts
@@ -10,8 +10,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createPraisonTsEngine, PRAISONAI_TS_CAPABILITIES, type RunPersistence } from "./engine.ts";
-import type { PraisonAgent, PraisonAgentEvent, PraisonStopReason } from "./agent-api.ts";
+import {
+  createPraisonTsEngine,
+  PRAISONAI_TS_CAPABILITIES,
+  type ConversationHistory,
+  type RunPersistence,
+} from "./engine.ts";
+import type {
+  PraisonAgent,
+  PraisonAgentEvent,
+  PraisonHistoryMessage,
+  PraisonStopReason,
+} from "./agent-api.ts";
+import type { HistoryMessage } from "../../../core/src/chat/history.ts";
 import type { RunEvent } from "../../../protocol/src/events.ts";
 import { isTerminal } from "../../../protocol/src/events.ts";
 import type { RunRequest } from "../../../core/src/ports/agent-engine.ts";
@@ -26,16 +37,38 @@ const request = (over: Partial<RunRequest> = {}): RunRequest => ({
   ...over,
 });
 
+/**
+ * What the agent was actually told, per turn.
+ *
+ * Recorded rather than asserted inline because the whole conversation-memory
+ * question is "what reached the model", and a fake that only yields events can
+ * answer questions about the OUTPUT of a turn and nothing about its input.
+ */
+interface AgentCalls {
+  /** One entry per `setHistory` call, in order. A turn that never called it
+   *  leaves the array shorter, which is what a dropped call looks like. */
+  readonly histories: (readonly PraisonHistoryMessage[])[];
+  /** The prompt string handed to `streamEvents`, per turn. */
+  readonly prompts: string[];
+}
+
 /** A scripted PraisonAgent. `stop` is read only after the stream ends, exactly
  *  as the real field behaves. */
 function fakeAgent(
   script: readonly PraisonAgentEvent[],
   stop: PraisonStopReason | null = "completed",
   onSignal?: (signal: AbortSignal | undefined) => void,
+  calls?: AgentCalls,
 ): PraisonAgent {
   return {
     lastStopReason: stop,
-    async *streamEvents(_prompt, opts) {
+    setHistory(messages) {
+      // Copied: the engine hands over an array it built, and a test that held
+      // the live reference would pass even if the engine later mutated it.
+      calls?.histories.push(messages.map((m) => ({ ...m })));
+    },
+    async *streamEvents(prompt, opts) {
+      calls?.prompts.push(prompt);
       onSignal?.(opts?.signal);
       for (const event of script) {
         if (opts?.signal?.aborted) return;
@@ -44,6 +77,15 @@ function fakeAgent(
     },
   };
 }
+
+const noCalls = (): AgentCalls => ({ histories: [], prompts: [] });
+
+/** A fixed conversation, as the session would report it. */
+const historyOf = (...messages: readonly HistoryMessage[]): ConversationHistory => ({
+  messages: () => messages,
+});
+
+const NO_HISTORY: ConversationHistory = { messages: () => [] };
 
 const recorded: RunRequest[] = [];
 const persistence = (indices: Awaited<ReturnType<RunPersistence["record"]>> = {
@@ -58,12 +100,19 @@ const persistence = (indices: Awaited<ReturnType<RunPersistence["record"]>> = {
   },
 });
 
-const build = (agent: PraisonAgent, p: RunPersistence = persistence()) => {
+const build = (
+  agent: PraisonAgent,
+  p: RunPersistence = persistence(),
+  history: ConversationHistory = NO_HISTORY,
+  historyBudget?: number,
+) => {
   let n = 0;
   return createPraisonTsEngine({
     createAgent: () => agent,
     persistence: p,
+    history,
     newMsgId: () => `m${++n}`,
+    ...(historyBudget === undefined ? {} : { historyBudget }),
   });
 };
 
@@ -438,4 +487,166 @@ test("a run with a live signal still streams, so the abort test is not vacuous",
   }
   assert.ok(events.some((e) => e.type === "delta"));
   assert.deepEqual(p.writes.map((w) => w.answer), ["kept"]);
+});
+
+// ---- conversation memory ---------------------------------------------------
+//
+// The engine sent `request.prompt` and only `request.prompt`, so the app stored
+// a conversation, rendered it, and showed the model none of it. Measured on a
+// device: "What is the capital of France?" -> "Paris", then "And its
+// population?" -> a request for clarification. These cases are the gates on
+// that, and each one is written to die under a specific way of half-doing it.
+
+test("the prior conversation is restored onto the agent before the prompt is sent", async () => {
+  // The whole defect in one assertion. Removing the `setHistory` call -- the
+  // state this file was written against -- leaves `histories` empty here.
+  const calls = noCalls();
+  const engine = build(
+    fakeAgent([{ type: "finish", text: "About 2.1 million." }], "completed", undefined, calls),
+    persistence(),
+    historyOf(
+      { role: "user", content: "What is the capital of France?" },
+      { role: "assistant", content: "Paris." },
+    ),
+  );
+
+  await collect(engine, new AbortController().signal, request({ prompt: "And its population?" }));
+
+  assert.equal(calls.histories.length, 1, "setHistory must be called exactly once per turn");
+  assert.deepEqual(calls.histories[0], [
+    { role: "user", content: "What is the capital of France?" },
+    { role: "assistant", content: "Paris." },
+  ]);
+});
+
+test("the restored conversation keeps its ORDER, oldest first", async () => {
+  // Reversing the array is the cheapest way to look like this works while
+  // handing the model a conversation that runs backwards -- the answer before
+  // the question, the follow-up before what it follows.
+  const calls = noCalls();
+  const engine = build(
+    fakeAgent([{ type: "finish", text: "ok" }], "completed", undefined, calls),
+    persistence(),
+    historyOf(
+      { role: "user", content: "first" },
+      { role: "assistant", content: "second" },
+      { role: "user", content: "third" },
+      { role: "assistant", content: "fourth" },
+    ),
+  );
+
+  await collect(engine);
+
+  assert.deepEqual(
+    calls.histories[0]?.map((m) => m.content),
+    ["first", "second", "third", "fourth"],
+    "history must arrive in the order it was said",
+  );
+});
+
+test("the restored conversation keeps its ROLES", async () => {
+  // A history whose roles are all "user" reads to the model as one person
+  // talking to themselves, and it will happily answer a question it already
+  // answered. Content-only assertions cannot see this.
+  const calls = noCalls();
+  const engine = build(
+    fakeAgent([{ type: "finish", text: "ok" }], "completed", undefined, calls),
+    persistence(),
+    historyOf(
+      { role: "user", content: "q1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "q2" },
+      { role: "assistant", content: "a2" },
+    ),
+  );
+
+  await collect(engine);
+
+  assert.deepEqual(
+    calls.histories[0]?.map((m) => m.role),
+    ["user", "assistant", "user", "assistant"],
+  );
+});
+
+test("the prompt of the turn being run is NOT also in its history", async () => {
+  // The other half of the seam. `session.record` writes a turn only after it
+  // succeeds, so the live prompt is genuinely absent from the store -- but an
+  // engine that appended `request.prompt` to the history "to be safe" would
+  // ask the model the same question twice in one request, and the passing
+  // tests above would not notice.
+  const calls = noCalls();
+  const engine = build(
+    fakeAgent([{ type: "finish", text: "ok" }], "completed", undefined, calls),
+    persistence(),
+    historyOf({ role: "user", content: "earlier" }, { role: "assistant", content: "reply" }),
+  );
+
+  await collect(engine, new AbortController().signal, request({ prompt: "the live question" }));
+
+  assert.deepEqual(calls.prompts, ["the live question"], "the prompt still travels as the prompt");
+  assert.equal(
+    calls.histories[0]?.some((m) => m.content === "the live question"),
+    false,
+    "the live prompt must not also appear in the history",
+  );
+});
+
+test("history is read PER TURN, so a turn sees what the turn before it recorded", async () => {
+  // The engine is built once and held for the session, so a history captured
+  // at construction would freeze at whatever was on disk when the app booted --
+  // which for a fresh launch is the empty conversation, and for a reopened one
+  // is correct until the first reply and wrong forever after.
+  const calls = noCalls();
+  const conversation: HistoryMessage[] = [];
+  const engine = build(
+    fakeAgent([{ type: "finish", text: "an answer" }], "completed", undefined, calls),
+    persistence(),
+    { messages: () => conversation },
+  );
+
+  await collect(engine, new AbortController().signal, request({ prompt: "one", runId: "r1" }));
+  conversation.push({ role: "user", content: "one" }, { role: "assistant", content: "an answer" });
+  await collect(engine, new AbortController().signal, request({ prompt: "two", runId: "r2" }));
+
+  assert.deepEqual(calls.histories[0], [], "the first turn has nothing to remember");
+  assert.deepEqual(calls.histories[1], [
+    { role: "user", content: "one" },
+    { role: "assistant", content: "an answer" },
+  ]);
+});
+
+test("a first turn calls setHistory with an empty conversation rather than skipping it", async () => {
+  // Unconditional on purpose: a guard would make the first turn of every
+  // conversation the one path that does not go through the restore, and that
+  // is the path least likely to be exercised by any other test here.
+  const calls = noCalls();
+  const engine = build(
+    fakeAgent([{ type: "finish", text: "hi" }], "completed", undefined, calls),
+  );
+
+  await collect(engine);
+
+  assert.deepEqual(calls.histories, [[]]);
+});
+
+test("history over the budget is truncated to the RECENT end, not the oldest", async () => {
+  // The turn must still run. Letting the provider answer "what happens when
+  // the context is full" means a 400 mid-answer with no way forward.
+  const calls = noCalls();
+  const engine = build(
+    fakeAgent([{ type: "finish", text: "ok" }], "completed", undefined, calls),
+    persistence(),
+    historyOf(
+      { role: "user", content: "aaaa" },
+      { role: "assistant", content: "bbbb" },
+      { role: "user", content: "cccc" },
+      { role: "assistant", content: "dddd" },
+    ),
+    8, // room for the last two messages only
+  );
+
+  const events = await collect(engine);
+
+  assert.deepEqual(calls.histories[0]?.map((m) => m.content), ["cccc", "dddd"]);
+  assert.equal(events.at(-1)?.type, "end", "a truncated history must not fail the turn");
 });

--- a/src/praisonai-mobile/engines/src/praisonai-ts/engine.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/engine.ts
@@ -32,6 +32,11 @@ import type { ApprovalChoice, RunEvent } from "../../../protocol/src/events.ts";
 import { PROTOCOL_VERSION } from "../../../protocol/src/version.ts";
 import { classifyError } from "./classify.ts";
 import type { PraisonAgentFactory } from "./agent-api.ts";
+import {
+  truncateHistory,
+  HISTORY_CHAR_BUDGET,
+  type HistoryMessage,
+} from "../../../core/src/chat/history.ts";
 
 export const PRAISONAI_TS_ENGINE_ID = "praisonai-ts";
 
@@ -47,6 +52,36 @@ export interface RunPersistence {
   /** Returns null when the turn could NOT be written. Null is a real value
    *  here: it is what makes `end.userIndex === null` mean "not on disk". */
   record(request: RunRequest, answer: string): Promise<PersistedIndices | null>;
+}
+
+/**
+ * Where the conversation so far comes from.
+ *
+ * WHY THE ENGINE ASSEMBLES IT, and not the controller or the port.
+ *
+ * The obvious move is to widen `RunRequest` with a `history` field, so every
+ * engine is handed the conversation and the controller owns the assembly. That
+ * is the wrong seam here, and `remote-http/engine.ts` is the reason: it POSTs
+ * `chat_id` to a server that keeps its OWN history for that id -- boot.ts says
+ * so in as many words ("against an engine keying server-side history by
+ * chat_id, every user's first chat was one shared thread"). Sending history
+ * from the client to that engine would send every prior turn TWICE, once from
+ * the client and once from the server's store, and a doubled conversation is a
+ * far worse failure than a missing one: it is silent, it grows, and it makes
+ * the model contradict itself.
+ *
+ * So conversation memory is an ENGINE-LEVEL responsibility, owned by whoever
+ * owns the store. `RegistryDeps.persistence` already reasons this way about
+ * the WRITE -- "the remote engine deliberately does not take it: the server it
+ * talks to persists" -- and this is the same split applied to the READ. Two
+ * engines, two owners of the conversation, one shape for the port.
+ */
+export interface ConversationHistory {
+  /** Prior COMPLETED turns of the open conversation, oldest first. Never
+   *  includes the prompt of the turn being run: that arrives as
+   *  `RunRequest.prompt` and sending it in both places asks the model the same
+   *  question twice. */
+  messages(): readonly HistoryMessage[];
 }
 
 /** Capabilities, stated against what the engine can REPORT. */
@@ -66,8 +101,22 @@ export const PRAISONAI_TS_CAPABILITIES: EngineCapabilities = {
 export interface PraisonEngineOptions {
   readonly createAgent: PraisonAgentFactory;
   readonly persistence: RunPersistence;
+  /**
+   * The conversation this engine's turns continue.
+   *
+   * REQUIRED, alongside `persistence`, and paired with it on purpose: the
+   * thing that records a turn and the thing that replays it must be the same
+   * store, or the model remembers a different conversation from the one on
+   * screen. An optional field would let a composition supply one and forget
+   * the other and still build.
+   */
+  readonly history: ConversationHistory;
   /** Injected so tests are deterministic. */
   readonly newMsgId: () => string;
+  /** Characters of prior conversation a turn may carry. Injected only so a
+   *  test can drive the truncation path without building a 24,000-character
+   *  chat; production uses the constant. */
+  readonly historyBudget?: number;
 }
 
 export function createPraisonTsEngine(options: PraisonEngineOptions): AgentEnginePort {
@@ -104,6 +153,23 @@ export function createPraisonTsEngine(options: PraisonEngineOptions): AgentEngin
 
     try {
       const agent = await options.createAgent();
+
+      // THE CONVERSATION, restored before the prompt is sent.
+      //
+      // A fresh agent is built per turn, so upstream's own accumulation across
+      // `streamEvents` calls never survives one -- see agent-api.ts. Without
+      // this line the model is handed a single sentence with no antecedent and
+      // "And its population?" is unanswerable, which is exactly what a device
+      // reported: a request for clarification instead of a number.
+      //
+      // Called UNCONDITIONALLY, including with an empty history. A guard would
+      // make the empty case a different code path from the ordinary one, and
+      // the empty case is the first turn of every conversation -- the one path
+      // that must not diverge.
+      agent.setHistory(
+        truncateHistory(options.history.messages(), options.historyBudget ?? HISTORY_CHAR_BUDGET)
+          .messages,
+      );
 
       for await (const event of agent.streamEvents(request.prompt, { signal: controller.signal })) {
         if (event.type === "text") {


### PR DESCRIPTION
## The gap

`engines/src/praisonai-ts/engine.ts:108` streamed `request.prompt` and nothing
else, and a grep across `engines/src` for anything assembling prior messages
found nothing. So the app stored a conversation, rendered it, and showed the
model none of it.

Measured on an Android 15 emulator against the real provider, before this
change: "What is the capital of France?" → "Paris.", then "And its
population?" → a request for clarification, because the second question
arrived at the provider with no subject.

## What carries the conversation

Upstream's `Agent.setHistory`, which is documented for exactly this: *"Restore
a previously saved conversation so the model regains its memory of it."* It was
found by reading `src/praisonai-ts/src/agent/simple.ts`, not assumed — upstream
accumulates turns in a private `messages` array and `getHistory`/`setHistory`
is the supported round-trip, tool context included.

The engine builds a **fresh agent per turn** (the model and the API key come
from settings and can change between messages), so upstream's own accumulation
dies with each agent. The restore therefore happens every turn, and
unconditionally — including on the first turn, so the empty conversation is not
a separate code path from the ordinary one.

## Where history comes from

`Session.current()` — the same object `record` writes to, projected through a
new `historyFor(session)` that mirrors the existing `persistenceFor(session)`.

That is what makes a **reopened** conversation carry its memory: `open(chatId)`
loads the stored chat, so the messages a user scrolls back through and the
messages the next turn remembers are one array. A history buffered in-process
would pass the multi-turn case and fail every relaunch — which is the case a
phone hits daily, because a phone kills backgrounded apps. Both are asserted.

## Who assembles it — and why not the port

**Not `RunRequest`.** Widening the port looked obvious and is wrong here.
`remote-http` POSTs `chat_id` to a server that keeps its own history for that
id — `boot.ts` already says so in as many words ("against an engine keying
server-side history by chat_id, every user's first chat was one shared
thread"). Sending client-side history to that engine would send every prior
turn **twice**, once from the client and once from the server's store. A
doubled conversation is worse than a missing one: silent, growing, and it makes
the model contradict itself.

So conversation memory is engine-level, owned by whoever owns the store. This
is the same split `RegistryDeps.persistence` already draws for the *write*,
drawn once more for the *read*: two engines, two owners of the conversation,
one unchanged `AgentEnginePort`. `ConversationHistory` is **required** beside
`persistence` at every hop (`PraisonEngineOptions`, `RegistryDeps`,
`appEngines`, `AppDeps.engines`), so a composition cannot supply one and forget
the other and still build.

The engine conformance contract and its assertion ledger are untouched: the
port did not change, and no new importer of a `*-contract.ts` was added
(issue #4813).

## Truncation — decided, not deferred

`core/src/chat/history.ts` bounds a turn's history to `HISTORY_CHAR_BUDGET`
(24,000 characters, ≈6,000 tokens) by:

- keeping the **recent** end — the end that makes "and its population?"
  answerable;
- **stopping** at the first message that does not fit rather than skipping over
  it, so the conversation is never reordered around a hole;
- dropping a **leading assistant message**, so the history never begins with an
  answer to a question the model cannot see.

Characters rather than tokens because tokenizing means shipping a
model-specific tokenizer into a webview; the budget is deliberately an order of
magnitude under the default model's window, because it exists to make the
failure impossible rather than to use the window efficiently.

**What a user sees when it fires, stated rather than left undefined:** the
transcript on screen is unchanged and complete — nothing is deleted, scrolling
back still shows every message — but the model stops being able to refer to the
oldest turns, and **the user is not told**. Protocol v2 has no event for
"context was trimmed" and adding one is a protocol bump, so it is recorded in
`docs/gaps.md` instead of half-done. `truncateHistory` already returns
`dropped`, so the value such a notice would carry exists; nothing consumes it
yet.

Also unchanged and restated in gaps.md: `remote-http` conversations stay
server-owned end to end, so a chat answered by the default remote engine has no
local history to restore.

## Gates

`npm run check` from `src/praisonai-mobile`, exit code read from the command
itself, run sequentially:

```
node v22.18.0 → FINAL_CHECK_EXIT=0   ℹ tests 1548  ℹ pass 1548  ℹ fail 0
node v24.12.0 → CHECK_24_EXIT=0      ℹ tests 1548  ℹ pass 1548  ℹ fail 0
```

`npm run check:upstream` also passes: *"the real Agent still satisfies
PraisonAgent"* — the structural `setHistory` added to `agent-api.ts` is checked
against the real upstream class, so a rename or signature change upstream is a
typecheck failure here rather than a runtime one on a device.

### Mutation ledger — 9 applied, 9 KILLED

Every mutation asserted its anchor appeared exactly once before replacing it, so
a silent no-op cannot report a false SURVIVED.

| Mutation | Result | Killed by (named) |
|---|---|---|
| send only the latest prompt (`setHistory([])`) | KILLED | `the prior conversation is restored onto the agent before the prompt is sent` + 6 more |
| history in the wrong order (reversed) | KILLED | `the restored conversation keeps its ORDER, oldest first` + 6 more |
| roles dropped (all `"user"`) | KILLED | `history carries roles, not just text`, `the restored conversation keeps its ROLES` + 4 more |
| current prompt included twice | KILLED | `the prompt of the turn being run is NOT also in its history` + 9 more |
| history captured once, so a reopened chat contributes nothing | KILLED | `history is re-read on every call…`, `ACCEPTANCE: a conversation REOPENED after a relaunch still has its memory` + 2 more |
| `open()` loads a chat with no messages | KILLED | `a REOPENED conversation reports its stored history, not an empty one` + 7 more |
| truncation removed | KILLED | `over the budget, the RECENT end is what survives` + 3 more |
| leading assistant message kept | KILLED | `a history that would BEGIN with an assistant message drops that message` |
| budget boundary off by one (`>` → `>=`) | KILLED | `a conversation that exactly fills the budget still fits` + 2 more |

## Verified on a real Android emulator

Android 15 (`google_apis/arm64-v8a`), debug APK built from this exact
tree with **no mutation applied**, driven over CDP against the real
`praisonai-ts` in-process engine (`Engine: praisonai-ts`) and a real
`OPENAI_API_KEY` entered once in Settings. Transcript read from the live DOM:

```
> What is the capital of France?
  The capital of France is **Paris**.

> And its population?
  As of the latest estimates in 2023, the population of Paris is
  approximately **2.1 million** people within the city limits. However, the
  larger metropolitan area of Paris has a population of about **12 million**.
```

An answer *about Paris*, with no clarifying question.

Then `am force-stop ai.praison.mobile`, relaunch, open the conversation from
the chat list, and ask a follow-up that only works with the earlier context:

```
> And which river runs through it?
  The river that runs through Paris is the **Seine**.
```

The shipped webview bundle was checked to contain the call
(`dist/app.js`: `setHistory(Or(e.history.messages(), …24e3).m…`), so the APK
under test is the fixed one and not a stale build.

## Files

- **new** `core/src/chat/history.ts` — `HistoryMessage`, `HISTORY_CHAR_BUDGET`,
  `truncateHistory` (+ `history.test.ts`)
- `core/src/chat/session.ts` — `historyFor(session)`
- `engines/src/praisonai-ts/agent-api.ts` — `setHistory` on the structural
  `PraisonAgent`, narrowed to the two roles this app persists
- `engines/src/praisonai-ts/engine.ts` — `ConversationHistory`, the restore
- `app/src/{registry,boot,main}.ts` — the read side threaded beside the write
- `docs/gaps.md` — the layering argument and the truncation decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation memory is now restored for follow-up messages.
  * Reopened chats retain their previous conversation history.
  * Starting a new chat begins with a blank memory.
  * Long conversations are automatically limited to the most recent context that fits the available budget.

* **Bug Fixes**
  * Conversation history now stays synchronized with persisted chat messages across turns and app relaunches.

* **Documentation**
  * Added documentation describing conversation memory behavior and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->