### PR TITLE
fix(ci): use GitHub MCP get_* tool names in merge gate assess

### DIFF
--- a/.github/actions/claude-code-action/action.yml
+++ b/.github/actions/claude-code-action/action.yml
@@ -288,7 +288,7 @@ runs:
         fi
         
         # Add allowed tools (include GitHub tools by default)
-        TOOLS="mcp__github__issue_read,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__add_issue_comment,mcp__github__pull_request_read,Read,Write,Edit,Bash"
+        TOOLS="mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__add_issue_comment,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,Read,Write,Edit,Bash"
         if [[ -n "$INPUT_ALLOWED_TOOLS" ]]; then
           TOOLS="$TOOLS,$INPUT_ALLOWED_TOOLS"
         fi

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -319,8 +319,11 @@ jobs:
             Replace
           allowed_tools: |
             mcp__github__add_issue_comment
-            mcp__github__pull_request_read
-            mcp__github__issue_read
+            mcp__github__get_pull_request
+            mcp__github__get_pull_request_files
+            mcp__github__get_pull_request_reviews
+            mcp__github__get_pull_request_status
+            mcp__github__get_issue
             mcp__github__get_issue_comments
             Glob
             Grep


### PR DESCRIPTION
## Summary
- Align merge gate `allowed_tools` and `claude-code-action` defaults with the GitHub MCP server's actual tool names (`get_pull_request`, `get_pull_request_status`, etc.).
- Opus assess was failing closed with BLOCK on merge-ready PRs because `pull_request_read` / `issue_read` are not exposed by the MCP server, so CI/reviews/labels could not be read.

## Test plan
- [ ] Merge this PR to `main`
- [ ] Re-dispatch merge gate on #4797, #4801, #4802
- [ ] Confirm assess logs show successful `get_pull_request*` / `get_pull_request_status` calls
- [ ] Confirm `MERGE_GATE_VERDICT: APPROVE` posts where gates pass and auto-merge runs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review and merge-gate tooling to use current, more granular GitHub read-only capabilities.
  * Improved access coverage for pull request details, changed files, reviews, statuses, and issue information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->