### PR TITLE
fix(mobile): Back on Settings no longer leaves the app

### DIFF
--- a/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
+++ b/src/praisonai-mobile/adapters/src/conformance/contracts.test.ts
@@ -1183,6 +1183,56 @@ test("the back gesture is always answered, because silence reads as consumed", a
   });
 });
 
+test("the shell tells Rust in advance whether the app can go back", async () => {
+  // The answer to a press is not fast enough to be the only signal: measured on
+  // an Android 15 emulator, the same press was answered in 0.7 s and then in
+  // 5.4 s, both past the 400 ms watchdog -- which then handed the press to
+  // Android and took a live app away from the user mid-navigation. The standing
+  // declaration is what the watchdog reads instead of that silence, so it has
+  // to actually cross the bridge.
+  const probe = probeBridge();
+  const shell = createTauriShell({ bridge: probe.bridge, insetSource: cssSource({}) });
+
+  shell.setCanGoBack(true);
+  assert.deepEqual(probe.invocations.at(-1), {
+    command: "back_gesture_can_go_back",
+    args: { canGoBack: true },
+  });
+
+  shell.setCanGoBack(false);
+  assert.deepEqual(probe.invocations.at(-1), {
+    command: "back_gesture_can_go_back",
+    args: { canGoBack: false },
+  });
+});
+
+test("the first declaration is sent even when it agrees with the default", async () => {
+  // Rust starts at false, so `false` looks like a value worth skipping. It is
+  // not: after a reload the native side is holding whatever the PREVIOUS page
+  // declared, and a shell that stays quiet because it agrees with a default is
+  // a shell that says nothing at all.
+  const probe = probeBridge();
+  const shell = createTauriShell({ bridge: probe.bridge, insetSource: cssSource({}) });
+  const before = probe.invocations.length;
+  shell.setCanGoBack(false);
+  assert.deepEqual(probe.invocations.slice(before), [
+    { command: "back_gesture_can_go_back", args: { canGoBack: false } },
+  ]);
+});
+
+test("re-declaring the same answer costs nothing", async () => {
+  // The router declares on EVERY stack change, and moving between two chats
+  // does not change the answer. Forwarding those would put an IPC round trip on
+  // a navigation that needs none.
+  const probe = probeBridge();
+  const shell = createTauriShell({ bridge: probe.bridge, insetSource: cssSource({}) });
+  shell.setCanGoBack(true);
+  const after = probe.invocations.length;
+  shell.setCanGoBack(true);
+  shell.setCanGoBack(true);
+  assert.equal(probe.invocations.length, after, "a repeated declaration was re-sent");
+});
+
 test("the shell refuses to hand a javascript: URL to the OS", async () => {
   // openExternal inside a webview is script execution in the app's own origin
   // with the user's session, from whatever produced the link -- a model, a tool

--- a/src/praisonai-mobile/adapters/src/tauri/shell.ts
+++ b/src/praisonai-mobile/adapters/src/tauri/shell.ts
@@ -251,6 +251,11 @@ const EVENTS = {
  *  back gesture. Answering `false` is what lets Android exit the app. */
 const BACK_RESULT_COMMAND = "back_gesture_result";
 
+/** The command that carries the app's STANDING answer -- can it go back at all
+ *  -- sent whenever that changes rather than in reply to a press. Rust reads it
+ *  when the reply above is too slow to arrive; see ShellPort.setCanGoBack. */
+const BACK_CAN_GO_BACK_COMMAND = "back_gesture_can_go_back";
+
 export interface TauriShellDeps {
   /** Defaults to the real bridge. Injected in tests so the event paths run
    *  without a device -- an adapter whose events only work on a phone has no
@@ -460,6 +465,10 @@ export function createTauriShell(deps: TauriShellDeps = {}): TauriShell {
     for (const cb of lifecycleSubs) cb(phase);
   });
 
+  // The last value handed to `setCanGoBack`, or null before the app has said
+  // anything. See the method below for why null and not false.
+  let declaredCanGoBack: boolean | null = null;
+
   attach(EVENTS.back, () => {
     let handled = false;
     // Last registered gets first refusal; the first to consume it wins and
@@ -502,6 +511,23 @@ export function createTauriShell(deps: TauriShellDeps = {}): TauriShell {
         const at = backSubs.lastIndexOf(cb);
         if (at !== -1) backSubs.splice(at, 1);
       };
+    },
+
+    setCanGoBack(canGoBack) {
+      // Sent on CHANGE only. The router declares on every stack change, and a
+      // chat-to-chat move does not alter the answer; forwarding those anyway
+      // would put an IPC call on a navigation that needs none.
+      //
+      // `declaredCanGoBack` starts as null rather than false so the first
+      // declaration always crosses, even when it is `false`: Rust's default
+      // agrees, but a shell that stayed silent because it AGREED with a default
+      // is one that says nothing at all after a reload.
+      if (declaredCanGoBack === canGoBack) return;
+      declaredCanGoBack = canGoBack;
+      // void, like the answer above: this is fire-and-forget state. A rejected
+      // invoke leaves Rust on its previous value, which is the same failure as
+      // a lost event and is covered by the watchdog either way.
+      void bridge.invoke(BACK_CAN_GO_BACK_COMMAND, { canGoBack });
     },
 
     haptic(kind: HapticKind) {

--- a/src/praisonai-mobile/adapters/src/web/shell.ts
+++ b/src/praisonai-mobile/adapters/src/web/shell.ts
@@ -174,6 +174,15 @@ export function createWebShell(view: Window = window): WebShell {
       };
     },
 
+    setCanGoBack(_canGoBack: boolean) {
+      // Nothing to tell. A browser answers `popstate` SYNCHRONOUSLY -- the
+      // handler runs in the page, its return value is acted on in the same
+      // task, and there is no bridge to be slow and no watchdog to lose a race
+      // with. The declaration exists for the native shells, where the answer to
+      // a press has to cross a thread boundary before the OS decides what the
+      // press meant; recording it here would be state nothing reads.
+    },
+
     haptic(_kind: HapticKind) {
       // No haptic engine. Silence is the honest behaviour.
     },

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -1029,6 +1029,58 @@ test("a route change MOVES focus to the new heading, and Back restores it", asyn
   app?.dispose();
 });
 
+test("opening Settings tells the shell there is a route to come back to", async () => {
+  // The whole point, end to end, on the path the user walks. On a device the
+  // app's ANSWER to the back press was measured arriving 5.4 s after it -- long
+  // past the 400 ms the native side waits -- so Android acted on the press
+  // itself and the app left the screen the user was on. What stops that is the
+  // declaration made when the route is PUSHED, before any press exists.
+  const shell = createFakeShell(PHONE_INSETS);
+  const dom = createFakeDom();
+  const platform: Platform = {
+    shell, storage: createFakeStorage(), secrets: createFakeSecrets(),
+    http: createFakeHttp(), time: nodeTime(), kind: "web",
+  };
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  assert.notEqual(app, null);
+  assert.equal(shell.canGoBack(), false, "the chat the app opens on is the root");
+
+  dom.click(dom.find((n) => n.dataset["route"] === "settings") as never);
+  await settle();
+  assert.equal(shell.canGoBack(), true, "Settings must be declared as a route back");
+
+  shell.pressBack();
+  await settle();
+  assert.equal(shell.canGoBack(), false, "and popped back to the root");
+  assert.equal(shell.pressBack(), false, "the root still lets the OS act");
+  app?.dispose();
+});
+
+test("the crash screen stops claiming there is a route to go back to", async () => {
+  // The fatal screen has no routes. If the last thing declared was `true`, the
+  // native side keeps waiting on a webview that will never answer again, and
+  // back on a dead app does nothing at all -- the one outcome that is worse
+  // than exiting.
+  const shell = createFakeShell(PHONE_INSETS);
+  const dom = createFakeDom();
+  const platform: Platform = {
+    shell, storage: createFakeStorage(), secrets: createFakeSecrets(),
+    http: createFakeHttp(), time: nodeTime(), kind: "web",
+  };
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  assert.notEqual(app, null);
+  dom.click(dom.find((n) => n.dataset["route"] === "settings") as never);
+  await settle();
+  assert.equal(shell.canGoBack(), true);
+
+  // A real crash, through the real handler: an uncaught error at the window.
+  dom.view.dispatch("error", { error: new Error("the webview fell over") });
+  await settle();
+  assert.match(dom.text(), /Something went wrong/, "the crash screen did not paint");
+  assert.equal(shell.canGoBack(), false, "a crashed app must not swallow the back gesture");
+  app?.dispose();
+});
+
 test("the chat list is painted from the session, and a chat reopens", async () => {
   // `session.list()` had no app caller and the chat list no way to be reached,
   // so a conversation, once left, could never be reopened. The chats route must

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -19,6 +19,7 @@ import { enginesFor, apiKeyFor, defaultEngineIdFor, settingDefsFor } from "./reg
 import { intentFrom, type Actionable, type Intent } from "./intents.ts";
 import { applyOps, emptyNodes, type RowNodes } from "./dom.ts";
 import { installCrashHandler } from "./crash.ts";
+import type { ShellPort } from "../../core/src/ports/shell.ts";
 import { emptyRender, reconcile, type RenderState } from "../../ui/src/render/reconcile.ts";
 import { buildTranscript, type Row } from "../../ui/src/transcript/view-model.ts";
 import type { RunView } from "../../core/src/run/controller.ts";
@@ -648,12 +649,27 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   // completely empty: a blank white page, no crash screen, on a device nobody
   // can attach a debugger to.
   const owner = doc.defaultView;
+  // Known only after `detectPlatform()` below, which is AFTER the handler is
+  // installed -- deliberately, since detecting can itself throw. A crash before
+  // then has no shell to tell, and nothing to correct: nothing has declared a
+  // route stack yet either.
+  let crashedShell: ShellPort | null = null;
   installCrashHandler({
     ...(owner === null ? {} : { view: owner }),
-    onCrash: () => renderFatal(root, strings.crashed),
+    onCrash: () => {
+      // The fatal screen has no routes, so the last thing the router declared
+      // is now a lie. Left standing, the native side keeps handing every back
+      // press to a webview that is not going to answer -- and back on a dead
+      // app would do nothing at all, which is the one outcome ShellPort's
+      // `setCanGoBack` doc forbids. Said BEFORE the repaint, because the
+      // repaint is the part that can throw.
+      crashedShell?.setCanGoBack(false);
+      renderFatal(root, strings.crashed);
+    },
   });
 
   const platform = deps.platform ?? detectPlatform();
+  crashedShell = platform.shell;
 
   /**
    * The WALL clock, and it comes from the port.

--- a/src/praisonai-mobile/core/src/ports/ports.test.ts
+++ b/src/praisonai-mobile/core/src/ports/ports.test.ts
@@ -62,6 +62,7 @@ test("the shell port is implementable", () => {
     onKeyboardHeightChanged: noop,
     onLifecycleChanged: noop,
     onBackGesture: noop,
+    setCanGoBack() {},
     haptic() {},
     async share() {},
     async openExternal() {},

--- a/src/praisonai-mobile/core/src/ports/shell.ts
+++ b/src/praisonai-mobile/core/src/ports/shell.ts
@@ -121,6 +121,30 @@ export interface ShellPort {
    */
   onBackGesture(cb: () => boolean): Unsubscribe;
 
+  /**
+   * Say, IN ADVANCE, whether the app would consume the next back gesture.
+   *
+   * `onBackGesture` answers a press that has already happened, and on Android
+   * that answer has to cross the native bridge before the OS decides what the
+   * press meant. That crossing is not bounded by anything the app controls: the
+   * event reaches the webview on the platform's UI thread and the handler runs
+   * on the thread that is painting. Measured on an Android 15 emulator, the
+   * same press was answered in 0.7 s once and 5.4 s the next time -- both past
+   * the native watchdog, which then handed the press to the OS and took the app
+   * away from a user who was mid-navigation.
+   *
+   * So the app also declares its state whenever the route stack changes, and
+   * the native side reads THAT when an answer is late rather than reading
+   * silence as "the app does not want this press". `attachBackGesture` in
+   * ui/src/router.ts is the one caller; it declares on attach, on every stack
+   * change, and `false` on detach.
+   *
+   * FALSE IS THE SAFE DEFAULT and shells must behave as though it had been
+   * declared until told otherwise: an app that never declares anything is one
+   * that never loaded, and back must still be able to leave it.
+   */
+  setCanGoBack(canGoBack: boolean): void;
+
   haptic(kind: HapticKind): void;
 
   share(payload: SharePayload): Promise<void>;

--- a/src/praisonai-mobile/src-tauri/plugins/back-gesture/android/src/main/java/ai/praison/mobile/backgesture/BackGesturePlugin.kt
+++ b/src/praisonai-mobile/src-tauri/plugins/back-gesture/android/src/main/java/ai/praison/mobile/backgesture/BackGesturePlugin.kt
@@ -19,6 +19,10 @@ import app.tauri.plugin.Plugin
  * listener -- Rust setup failed, or the channel is gone -- the press falls
  * through immediately, so a broken bridge degrades to a normal back button
  * rather than a dead one.
+ *
+ * What "falling through" means depends on where the app is: see `defer` -- at
+ * the task root the app is BACKGROUNDED, and anywhere else the press is
+ * re-dispatched to whatever is beneath this callback.
  */
 @TauriPlugin
 class BackGesturePlugin(private val activity: Activity) : Plugin(activity) {
@@ -56,16 +60,41 @@ class BackGesturePlugin(private val activity: Activity) : Plugin(activity) {
   }
 
   /**
-   * Re-dispatch with this callback disabled, so the next one runs: Tauri's
-   * AppPlugin (webview history, if any), then the system default. On Android
-   * 12+ the default moves the task to the back rather than destroying the
-   * activity, which preserves warm start. `finish()` would destroy it and
-   * `exitProcess` would kill the process; both are worse.
+   * Let something else have the press.
+   *
+   * Two paths, because the "system default" is not one thing.
+   *
+   * Above the task root -- a second activity, or webview history -- the press
+   * is RE-DISPATCHED with this callback disabled, so whatever sits beneath it
+   * runs: Tauri's AppPlugin, then the platform.
+   *
+   * At the task root it is not re-dispatched, and that difference is the whole
+   * point of this function. Android 12+ backgrounds a root activity instead of
+   * finishing it, but only on the press the SYSTEM dispatches; calling
+   * `onBackPressedDispatcher.onBackPressed()` ourselves walks the app-level
+   * path, which ends in `Activity.onBackPressed` -> `finishAfterTransition()`.
+   * Measured on an Android 15 emulator: back on the root chat produced
+   * `WIN DEATH` for MainActivity and `pidof` came back empty -- the process was
+   * gone, so returning to the app was a cold start with the transcript and the
+   * live run lost. `moveTaskToBack(true)` is the behaviour the comment above
+   * used to claim: the task goes behind the launcher, the process stays warm,
+   * and the app is one tap away in Recents.
+   *
+   * `finish()` would destroy the activity and `exitProcess` would kill the
+   * process; both are worse than either path here.
    */
   private fun defer() {
+    val host = activity as AppCompatActivity
+    if (host.isTaskRoot) {
+      // Ignore the return: `false` means the task was not moved (it is not the
+      // one in front any more), and there is nothing better to do about that
+      // than leave the app where it is.
+      host.moveTaskToBack(true)
+      return
+    }
     callback.isEnabled = false
     try {
-      (activity as AppCompatActivity).onBackPressedDispatcher.onBackPressed()
+      host.onBackPressedDispatcher.onBackPressed()
     } finally {
       callback.isEnabled = true
     }

--- a/src/praisonai-mobile/src-tauri/src/commands.rs
+++ b/src/praisonai-mobile/src-tauri/src/commands.rs
@@ -64,6 +64,23 @@ fn watchdog<R: Runtime>(app: AppHandle<R>) {
     });
 }
 
+/// The webview's standing declaration: has it a route to pop?
+///
+/// Pushed on every route change, not in response to a press, because the answer
+/// to a press cannot be waited for -- the round trip was measured at 0.7 s and
+/// then 5.4 s on one Android 15 emulator, against a 400 ms watchdog. This is
+/// what the watchdog consults instead of reading silence as "the app does not
+/// want it" and taking a live app away from the user mid-navigation.
+#[tauri::command]
+pub fn back_gesture_can_go_back<R: Runtime>(app: AppHandle<R>, can_go_back: bool) {
+    transition(&app, |gate| {
+        gate.declare_can_go_back(can_go_back);
+        // Nothing to do now: a declaration is state, not an event. It is read
+        // by `Gate::timed_out` the next time a press goes unanswered.
+        Action::Ignore
+    });
+}
+
 /// The webview's answer to a back gesture.
 ///
 /// Answering at all is mandatory on the TypeScript side, and it is fire and

--- a/src/praisonai-mobile/src-tauri/src/lib.rs
+++ b/src/praisonai-mobile/src-tauri/src/lib.rs
@@ -12,7 +12,9 @@
 //!  - `shell::on_window_event` — `lifecycle` on suspend/resume/focus, and
 //!    `safe-area-changed` on resize and scale change.
 //!  - `tauri_plugin_back_gesture` + `commands::on_back_pressed` — `back-gesture`
-//!    on Android's system back, answered through `back_gesture_result`.
+//!    on Android's system back, answered through `back_gesture_result` and
+//!    pre-empted by `back_gesture_can_go_back`, the standing declaration the
+//!    watchdog reads when that answer is too slow to arrive.
 //!  - `keyboard-height` — NOT emitted by anything here. The TypeScript reads
 //!    `visualViewport`, which WKWebView and Android WebView both implement,
 //!    and treats a native event as an override if one ever arrives.
@@ -106,6 +108,7 @@ pub fn configure<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::Builde
         .manage(shell::LifecycleState::default())
         .invoke_handler(tauri::generate_handler![
             commands::back_gesture_result,
+            commands::back_gesture_can_go_back,
             store::storage_read,
             store::storage_write,
             store::storage_remove,

--- a/src/praisonai-mobile/src-tauri/src/shell/back.rs
+++ b/src/praisonai-mobile/src-tauri/src/shell/back.rs
@@ -3,7 +3,7 @@
 //! Android presses back. Rust asks the webview whether it wants it. The webview
 //! answers, and if it says no, Rust lets the system act.
 //!
-//! Three things make this harder than it sounds, and all three are failure
+//! Four things make this harder than it sounds, and all four are failure
 //! modes rather than edge cases:
 //!
 //!  1. **The answer may never come.** `bridge.invoke` on the TypeScript side
@@ -20,6 +20,18 @@
 //!  3. **A late answer must not act twice.** If the watchdog already fired and
 //!     fell back, an answer arriving afterwards has to be ignored, or the app
 //!     falls back twice for one press.
+//!  4. **Slow is not dead.** The round trip is not bounded by anything this
+//!     crate controls: the emit reaches the webview on the platform's UI
+//!     thread, and the handler runs on the thread that is painting. On an
+//!     Android 15 emulator the same press was answered in 0.7 s once and 5.4 s
+//!     the next time, both far past the watchdog. Treating that silence as
+//!     "the app does not want this press" sent an app the user was actively
+//!     using to the background -- back on the Settings screen left the app
+//!     entirely, while its own router had already popped back to the chat.
+//!     So the webview DECLARES, in advance and out of band, whether it can go
+//!     back ([`Gate::declare_can_go_back`]), and the watchdog only lets the
+//!     platform act when the app has said it cannot. A press it said it can
+//!     take is left to it, however late the answer is.
 //!
 //! The logic is pure and the platform is injected, so all of that is tested on
 //! a laptop rather than discovered on a device.
@@ -42,14 +54,38 @@ pub enum Action {
 }
 
 /// One press in flight at a time. See the header for why there cannot be more.
+///
+/// `can_go_back` is the webview's standing answer to "would you take the next
+/// press", pushed whenever its route stack changes. It defaults to FALSE, which
+/// is the safe default in the one case that matters: a webview that never
+/// loaded has declared nothing, and back must still leave the app rather than
+/// do nothing forever.
 #[derive(Debug, Default)]
 pub struct Gate {
     pending: bool,
+    can_go_back: bool,
 }
 
 impl Gate {
     pub fn new() -> Self {
-        Self { pending: false }
+        Self {
+            pending: false,
+            can_go_back: false,
+        }
+    }
+
+    /// The webview's standing declaration: is there a route to pop?
+    ///
+    /// Out of band, and that is the point -- it is known LONG before the press
+    /// arrives, so the decision that follows one does not depend on a round
+    /// trip that this crate cannot bound.
+    pub fn declare_can_go_back(&mut self, can_go_back: bool) {
+        self.can_go_back = can_go_back;
+    }
+
+    /// What the webview last declared. False until it says otherwise.
+    pub fn can_go_back(&self) -> bool {
+        self.can_go_back
     }
 
     /// The user pressed back.
@@ -77,6 +113,17 @@ impl Gate {
     }
 
     /// The answer never came.
+    ///
+    /// Silence means one of two things and they need opposite treatment. If the
+    /// webview said it has nowhere to go back to, silence is a dead bundle and
+    /// the platform must act -- a back button that does nothing forever is
+    /// worse than one that leaves. If it said it CAN go back, silence is a
+    /// webview that is merely slow, and letting the platform act would take the
+    /// app away from a user who is still in it. Measured on a device: 5.4 s
+    /// from emit to answer, against a 400 ms watchdog.
+    ///
+    /// The press is dropped either way -- `pending` is cleared, so the next one
+    /// is asked afresh.
     pub fn timed_out(&mut self) -> Action {
         if !self.pending {
             // It arrived between the timer firing and this running. Not a
@@ -84,6 +131,9 @@ impl Gate {
             return Action::Ignore;
         }
         self.pending = false;
+        if self.can_go_back {
+            return Action::Ignore;
+        }
         Action::FallBack
     }
 

--- a/src/praisonai-mobile/src-tauri/src/shell/mod.rs
+++ b/src/praisonai-mobile/src-tauri/src/shell/mod.rs
@@ -1,4 +1,4 @@
-//! The four things the native shell tells the webview, and the one thing it asks.
+//! The four things the native shell tells the webview, and the two it is told.
 //!
 //! These names are a CONTRACT with `adapters/src/tauri/shell.ts`, which
 //! subscribes to them by string. A rename on either side is silent: the
@@ -46,6 +46,15 @@ pub const EVT_BACK: &str = "back-gesture";
 
 /// What the webview calls to answer a back gesture.
 pub const CMD_BACK_RESULT: &str = "back_gesture_result";
+
+/// What the webview calls whenever its route stack changes, to say whether it
+/// could take the NEXT back press.
+///
+/// Out of band on purpose. The answer to a press cannot be waited for -- the
+/// round trip was measured at 0.7 s and then 5.4 s on the same device -- so the
+/// watchdog decides from this standing declaration instead of from silence.
+/// See `shell::back` for what each value means when the answer never comes.
+pub const CMD_BACK_CAN_GO_BACK: &str = "back_gesture_can_go_back";
 
 /// The lifecycle tracker, managed as Tauri state so `on_window_event` — a
 /// plain `Fn` with no captures — can reach it through the window.

--- a/src/praisonai-mobile/src-tauri/tests/back_gesture.rs
+++ b/src/praisonai-mobile/src-tauri/tests/back_gesture.rs
@@ -64,6 +64,62 @@ fn silence_falls_back_rather_than_leaving_a_dead_button() {
 }
 
 #[test]
+fn silence_does_not_take_the_app_away_when_it_said_it_can_go_back() {
+    // The device bug this whole declaration exists for. Back on the Settings
+    // screen: the webview HAD consumed the press and popped, but its answer
+    // took 5.4 s to cross the bridge, the 400 ms watchdog fired first, and the
+    // app was handed to the platform -- which left it. The app said it could go
+    // back, so silence is a slow webview, not one that declined.
+    let mut gate = Gate::new();
+    gate.declare_can_go_back(true);
+    gate.press();
+    assert_eq!(gate.timed_out(), Action::Ignore);
+    assert!(!gate.is_pending(), "the press is spent either way");
+}
+
+#[test]
+fn silence_still_falls_back_when_the_app_says_it_cannot_go_back() {
+    // The other half, and the reason the declaration is not simply "never fall
+    // back on silence": at the root there is nothing to pop, so a webview that
+    // never answers must not leave the back button dead.
+    let mut gate = Gate::new();
+    gate.declare_can_go_back(false);
+    gate.press();
+    assert_eq!(gate.timed_out(), Action::FallBack);
+}
+
+#[test]
+fn a_gate_that_was_told_nothing_assumes_it_cannot_go_back() {
+    // A bundle that failed to load declares nothing at all. Defaulting to "it
+    // can go back" would swallow every press on an app that cannot even paint.
+    let gate = Gate::new();
+    assert!(!gate.can_go_back());
+    assert!(!Gate::default().can_go_back());
+}
+
+#[test]
+fn an_explicit_no_falls_back_even_from_a_screen_that_could_go_back() {
+    // The declaration only speaks for silence. An answer is the app's own word
+    // about THIS press and outranks it -- otherwise a route the app decided not
+    // to pop would leave the back button doing nothing.
+    let mut gate = Gate::new();
+    gate.declare_can_go_back(true);
+    gate.press();
+    assert_eq!(gate.answered(false), Action::FallBack);
+}
+
+#[test]
+fn going_back_to_the_root_re_arms_the_fall_back() {
+    // The declaration is a mirror of a stack that moves both ways. Popping the
+    // last route has to clear it, or the app is one that can never be left.
+    let mut gate = Gate::new();
+    gate.declare_can_go_back(true);
+    gate.declare_can_go_back(false);
+    gate.press();
+    assert_eq!(gate.timed_out(), Action::FallBack);
+}
+
+#[test]
 fn a_late_answer_after_a_timeout_does_not_fall_back_twice() {
     // The bug this design is most likely to ship: the watchdog fires, the app
     // goes to the background, and the webview's answer arrives afterwards and

--- a/src/praisonai-mobile/src-tauri/tests/contract.rs
+++ b/src/praisonai-mobile/src-tauri/tests/contract.rs
@@ -5,7 +5,9 @@
 //! as though the phone had no notch, no keyboard and no lifecycle. Nothing
 //! throws, so nothing is reported.
 
-use praisonai_mobile_lib::shell::{CMD_BACK_RESULT, EVT_BACK, EVT_KEYBOARD, EVT_LIFECYCLE, EVT_SAFE_AREA};
+use praisonai_mobile_lib::shell::{
+    CMD_BACK_CAN_GO_BACK, CMD_BACK_RESULT, EVT_BACK, EVT_KEYBOARD, EVT_LIFECYCLE, EVT_SAFE_AREA,
+};
 
 #[test]
 fn event_names_match_the_typescript_adapter() {
@@ -20,6 +22,15 @@ fn event_names_match_the_typescript_adapter() {
 #[test]
 fn the_command_name_matches() {
     assert_eq!(CMD_BACK_RESULT, "back_gesture_result");
+}
+
+#[test]
+fn the_can_go_back_command_name_matches() {
+    // The webview invokes this by string on every route change. A rename here
+    // alone is silent: Tauri rejects the unknown command, the TypeScript's
+    // `invoke` swallows the rejection, and the gate keeps its default -- so the
+    // app exits on a slow back press again, with every test still green.
+    assert_eq!(CMD_BACK_CAN_GO_BACK, "back_gesture_can_go_back");
 }
 
 #[test]

--- a/src/praisonai-mobile/src-tauri/tests/wiring.rs
+++ b/src/praisonai-mobile/src-tauri/tests/wiring.rs
@@ -159,6 +159,7 @@ fn run_registers_the_window_event_handler() {
         ".manage(shell::LifecycleState::default())",
         ".manage(commands::BackState::default())",
         "tauri_plugin_back_gesture::init(commands::on_back_pressed)",
+        "commands::back_gesture_can_go_back",
     ] {
         assert!(
             LIB_RS.contains(required),

--- a/src/praisonai-mobile/testing/src/fake-shell.ts
+++ b/src/praisonai-mobile/testing/src/fake-shell.ts
@@ -30,6 +30,13 @@ export interface FakeShell extends ShellPort {
   setLifecycle(phase: LifecyclePhase): void;
   /** Returns what the app answered, so a test can assert the OS would act. */
   pressBack(): boolean;
+  /** The app's standing declaration, as the native side would hold it. False
+   *  until the app says otherwise, which is what a shell must assume of an app
+   *  that never loaded. */
+  readonly canGoBack: () => boolean;
+  /** Every value the app declared, in order: a test can prove the declaration
+   *  tracks the stack rather than being sent once at startup. */
+  readonly declared: readonly boolean[];
 
   // ---- observe what the app asked for ----
   readonly haptics: readonly HapticKind[];
@@ -51,6 +58,11 @@ export function createFakeShell(initial: SafeAreaInsets = NO_INSETS): FakeShell 
   // registered gets first refusal. A Set has no defined order, so a modal
   // would not reliably consume the gesture ahead of the route beneath it.
   const backSubs: Array<() => boolean> = [];
+
+  // False, exactly as the Rust gate defaults: an app that has declared nothing
+  // is one that never loaded, and back must still be able to leave it.
+  let canGoBack = false;
+  const declared: boolean[] = [];
 
   const haptics: HapticKind[] = [];
   const shared: SharePayload[] = [];
@@ -85,6 +97,11 @@ export function createFakeShell(initial: SafeAreaInsets = NO_INSETS): FakeShell 
       };
     },
 
+    setCanGoBack(next) {
+      canGoBack = next;
+      declared.push(next);
+    },
+
     haptic: (kind) => void haptics.push(kind),
 
     async share(payload) {
@@ -110,6 +127,9 @@ export function createFakeShell(initial: SafeAreaInsets = NO_INSETS): FakeShell 
     },
 
     // ---- test controls ----
+    canGoBack: () => canGoBack,
+    declared,
+
     setInsets(next) {
       insets = next;
       for (const cb of insetSubs) cb(next);

--- a/src/praisonai-mobile/tools/shell-seam.test.mjs
+++ b/src/praisonai-mobile/tools/shell-seam.test.mjs
@@ -57,6 +57,34 @@ test("the back-result command name agrees", () => {
   assert.equal(rustConst("CMD_BACK_RESULT"), m[1]);
 });
 
+test("the can-go-back command name agrees", () => {
+  // The webview invokes this by string whenever its route stack changes, and a
+  // rename on either side is silent in the worst way: Tauri rejects the unknown
+  // command, the TypeScript's `invoke` swallows the rejection into null, and
+  // the Rust gate keeps its default of "cannot go back" -- so a slow answer on
+  // the Settings screen sends the app to the background again, with both test
+  // suites still green.
+  const m = /BACK_CAN_GO_BACK_COMMAND = "([^"]+)"/.exec(ts);
+  assert.ok(m, "BACK_CAN_GO_BACK_COMMAND not found in the TypeScript adapter");
+  assert.equal(rustConst("CMD_BACK_CAN_GO_BACK"), m[1]);
+});
+
+test("the command the webview invokes is one the app actually registers", () => {
+  // The other half of the same silence: a command named identically on both
+  // sides but missing from `generate_handler!` is unreachable, and rejects
+  // exactly like a misspelt one.
+  const lib = readFileSync(join(pkg, "src-tauri/src/lib.rs"), "utf8");
+  const handler = /invoke_handler\(tauri::generate_handler!\[([\s\S]*?)\]\)/.exec(lib);
+  assert.ok(handler, "the invoke_handler list was not found in lib.rs");
+  for (const command of ["back_gesture_result", "back_gesture_can_go_back"]) {
+    assert.match(
+      handler[1],
+      new RegExp(`commands::${command}\\b`),
+      `lib.rs does not register ${command}, so the webview's invoke would reject`,
+    );
+  }
+});
+
 test("the comparison is real, not two lookups of the same file", () => {
   // The way this test could quietly stop working: if both helpers read the
   // same source, every assertion above passes forever. Assert the two files

--- a/src/praisonai-mobile/tools/shell-seam.test.mjs
+++ b/src/praisonai-mobile/tools/shell-seam.test.mjs
@@ -85,6 +85,27 @@ test("the command the webview invokes is one the app actually registers", () => 
   }
 });
 
+test("a declined press at the task root backgrounds the app instead of finishing it", () => {
+  // Kotlin has no test harness in this package, and this is the one line no
+  // other gate can reach: `onBackPressedDispatcher.onBackPressed()` called by
+  // the APP walks the app-level path, which ends in `finishAfterTransition()`
+  // even on Android 12+. Measured on an Android 15 emulator, back on the root
+  // chat logged `WIN DEATH` and left `pidof` empty -- the process was gone and
+  // returning was a cold start. `moveTaskToBack` is what keeps it warm.
+  const plugin = readFileSync(
+    join(pkg, "src-tauri/plugins/back-gesture/android/src/main/java/ai/praison/mobile/backgesture/BackGesturePlugin.kt"),
+    "utf8",
+  );
+  const defer = /private fun defer\(\) \{([\s\S]*?)\n  \}/.exec(plugin);
+  assert.ok(defer, "defer() was not found in BackGesturePlugin.kt");
+  assert.match(defer[1], /isTaskRoot/, "defer() must tell the task root from anything above it");
+  assert.match(defer[1], /moveTaskToBack\(true\)/, "the root must be backgrounded, not finished");
+  assert.doesNotMatch(defer[1], /\bfinish\(\)|exitProcess/, "the root must not be destroyed");
+  // And the other path is still there: above the root, the press belongs to
+  // whatever sits beneath this callback.
+  assert.match(defer[1], /onBackPressedDispatcher\.onBackPressed\(\)/);
+});
+
 test("the comparison is real, not two lookups of the same file", () => {
   // The way this test could quietly stop working: if both helpers read the
   // same source, every assertion above passes forever. Assert the two files

--- a/src/praisonai-mobile/ui/src/router.test.ts
+++ b/src/praisonai-mobile/ui/src/router.test.ts
@@ -111,6 +111,68 @@ test("detaching the back gesture leaves no listener behind", () => {
   assert.equal(shell.pressBack(), false, "a detached router must not consume the gesture");
 });
 
+test("attaching declares whether there is anywhere to go back to", () => {
+  // The device bug this exists for: on Settings the app HAD consumed the press
+  // and popped, but its answer took seconds to cross the native bridge, the
+  // watchdog read the silence as "the app does not want it", and Android took
+  // the app away. The native side can only be right about a late answer if it
+  // was told the stack IN ADVANCE, so the declaration goes out on attach and on
+  // every change -- not in reply to a press.
+  const shell = createFakeShell();
+  const router = createRouter(CHATS);
+  const detach = attachBackGesture(shell, router);
+
+  assert.equal(shell.canGoBack(), false, "the root has nothing to pop");
+
+  router.push(SETTINGS);
+  assert.equal(shell.canGoBack(), true, "Settings is a route back must keep");
+
+  router.pop();
+  assert.equal(shell.canGoBack(), false, "back at the root again");
+
+  // Every change, not just the first: a declaration sent once at startup would
+  // be right exactly until the user navigated.
+  assert.deepEqual(shell.declared, [false, true, false]);
+  detach();
+});
+
+test("detaching declares that there is nothing to go back to", () => {
+  // A torn-down view's router speaks for nothing. A native side left holding
+  // `true` would treat every unanswered press as "the app is just slow" and
+  // swallow it -- a back button that does nothing, forever.
+  const shell = createFakeShell();
+  const router = createRouter(CHATS);
+  const detach = attachBackGesture(shell, router);
+  router.push(SETTINGS);
+  assert.equal(shell.canGoBack(), true);
+
+  detach();
+  assert.equal(shell.canGoBack(), false, "a detached router must declare nothing to pop");
+
+  router.push(chat("c1"));
+  assert.equal(shell.canGoBack(), false, "a detached router must stop declaring at all");
+});
+
+test("the declaration says the same thing the handler will answer", () => {
+  // Two sources of truth for one question is the failure this is written
+  // against: a declaration that says "I can go back" while the handler answers
+  // false gets the press swallowed, and the opposite exits the app mid-screen.
+  const shell = createFakeShell();
+  const router = createRouter(CHATS);
+  attachBackGesture(shell, router);
+
+  for (const route of [SETTINGS, chat("c1"), SETTINGS]) {
+    router.push(route);
+    assert.equal(shell.canGoBack(), true);
+  }
+  while (router.stack.length > 1) {
+    const declared = shell.canGoBack();
+    assert.equal(shell.pressBack(), declared, "the answer contradicted the declaration");
+  }
+  assert.equal(shell.canGoBack(), false);
+  assert.equal(shell.pressBack(), false, "the root must let the OS act");
+});
+
 test("the most recently attached handler gets the gesture first", () => {
   // A modal must consume back ahead of the route beneath it, or dismissing it
   // also navigates.

--- a/src/praisonai-mobile/ui/src/router.ts
+++ b/src/praisonai-mobile/ui/src/router.ts
@@ -134,10 +134,39 @@ export function createRouter(root: Route): Router {
 /**
  * Wire the router to the OS gesture.
  *
+ * Two directions, and the second one is what makes Back work on a device.
+ *
+ * The handler answers a press that has already happened. On Android that answer
+ * has to reach Rust before the OS decides what the press meant, and it does not
+ * always get there in time: measured on an Android 15 emulator, one press was
+ * answered in 0.7 s and the next in 5.4 s, against a 400 ms watchdog. The app
+ * had consumed both -- the stack popped Settings and the chat was back on
+ * screen -- and the watchdog handed the press to Android anyway, which took the
+ * app away from the user. That is the "Back on Settings quits the app" report.
+ *
+ * So the stack is also DECLARED, out of band: on attach, on every change, and
+ * `false` on detach. A declaration is state the native side already has when a
+ * press arrives, so nothing has to be waited for. False on detach because a
+ * torn-down view's router speaks for nothing, and a native side still holding
+ * `true` would swallow every press afterwards.
+ *
  * Returns the unsubscribe, and returning it is not a formality: a leaked
  * handler keeps popping a router belonging to a torn-down view on every back
  * press, which reads to the user as the button doing nothing.
  */
 export function attachBackGesture(shell: ShellPort, router: Router): Unsubscribe {
-  return shell.onBackGesture(() => router.handleBack());
+  const declare = (stack: readonly Route[]): void =>
+    // The same pure decision the handler will make, so the declaration and the
+    // answer can never disagree about what the stack means.
+    shell.setCanGoBack(backDecision(stack).consumed);
+
+  declare(router.stack);
+  const stopDeclaring = router.subscribe(declare);
+  const stopHandling = shell.onBackGesture(() => router.handleBack());
+
+  return () => {
+    stopDeclaring();
+    stopHandling();
+    declare([]);
+  };
 }


### PR DESCRIPTION
## The defect

Pressing Back on the Settings screen exits to the Android launcher instead of returning to the chat. Reproduced on an Android 15 emulator (Pixel 6, 1080x2400) against `main`.

## What was actually wrong

Not the wiring — all of it ran. An instrumented build logged the whole press:

```
12:19:15.032  kotlin handleOnBackPressed hasListener=true
12:19:15.061  rust on_back_pressed / emitting back-gesture
12:19:15.506  rust watchdog timeout          <-- 400 ms is up
12:19:15.572  rust fall_back                 <-- the press is handed to Android
12:19:15.579  kotlin fallBack / defer isTaskRoot=true
12:19:20.920  rust back_gesture_result handled=true   <-- the app's answer, 5.4 s late
              router handleBack before=[chat, settings] consumed=true
```

The webview **had** consumed the press: the router popped Settings and the chat was back on screen. Its answer just could not cross the bridge inside `ANSWER_TIMEOUT_MS` (400 ms). The same press was answered in 0.7 s on one run and 5.4 s on the next — the emit reaches the webview on the platform's UI thread and the handler runs on the thread that is painting, so the round trip is not bounded by anything the app controls. `Gate::timed_out` read that silence as "the app does not want this press" and let the OS act, which took the app away from a user standing on a screen their own router had already left.

Nothing in either suite could see it: every TypeScript test answers the gesture synchronously, and the Rust gate's tests assert exactly the timeout behaviour that is wrong on a device.

## The fix

**Remove the race rather than lengthen it.** The webview now *declares* whether it can go back — on attach, on every stack change, and `false` on detach — through a new `ShellPort.setCanGoBack` and the `back_gesture_can_go_back` command. That state is already in Rust when a press arrives, so a late answer no longer decides anything: silence falls back only when the app has said it has nowhere to go.

- An explicit answer still outranks the declaration (`answered(false)` still falls back).
- The declaration defaults to `false`, so a bundle that never loaded is still an app Back can leave — no dead button.
- The crash screen declares `false` too: a dead webview must not swallow the gesture.
- The web shell implements it as a documented no-op (`popstate` is answered synchronously in the same task; there is no bridge to lose a race with).

**Second commit — Back at the root.** With the first fix in, Back on the root chat was measured ending in `WIN DEATH` and an empty `pidof`: the process was gone and returning was a cold start. The plugin's comment claimed Android 12+ backgrounds a root activity, but that is true only of the press the *system* dispatches — calling `onBackPressedDispatcher.onBackPressed()` ourselves ends in `finishAfterTransition()`. `defer()` now backgrounds the task root with `moveTaskToBack(true)` and re-dispatches everywhere else.

## Verified on a device

Android 15 emulator, release of the exact reported reproduction:

| case | result |
|---|---|
| Back on **Settings** | returns to the chat; `pidof` keeps its PID; MainActivity still resumed |
| Back on **Chats** | returns to the chat; process alive |
| Back on the **root chat** | launcher comes forward, **process stays alive**, returning is warm — a draft typed in the composer was still there |
| Back **twice** from Settings | chat, then background; returning shows the chat with the draft intact |
| an uncommitted Settings edit + Back | committed, not discarded — reopening Settings reads the edited address back |

## Gates

`npm run check` exits 0 on Node 22.18.0 and 24.12.0 (1586 tests, run sequentially, exit code read from the command). `cargo test` exits 0.

Every gate was mutation-tested; each mutation was killed by a NAMED test:

| mutation | killed by |
|---|---|
| back handler ignores the Settings route | `opening Settings tells the shell there is a route to come back to` (+9) |
| the answer always reports "not handled" | `the back gesture is always answered, because silence reads as consumed` (+3) |
| pop past the root | `at the root the back gesture is refused so the OS can exit the app` (+7) |
| the router never declares | `attaching declares whether there is anywhere to go back to` (+4) |
| the router declares once, at attach | same (+2) |
| detach leaves the declaration standing | `detaching declares that there is nothing to go back to` |
| the Tauri shell drops the declaration | `the shell tells Rust in advance whether the app can go back` (+1) |
| the crash screen keeps the declaration | `the crash screen stops claiming there is a route to go back to` |
| the command renamed on the TypeScript side | `the can-go-back command name agrees` (+2) |
| the command missing from `generate_handler!` | `the command the webview invokes is one the app actually registers`, `run_registers_the_window_event_handler` |
| the timeout always falls back (the bug, restored) | `silence_does_not_take_the_app_away_when_it_said_it_can_go_back` |
| the timeout never falls back | `silence_falls_back_rather_than_leaving_a_dead_button` (+3) |
| the declaration defaults to true | `a_gate_that_was_told_nothing_assumes_it_cannot_go_back` (+2) |

Each mutation asserts its anchor text was found before writing, so a silent no-op cannot report a false SURVIVED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved mobile back-gesture handling by keeping the native shell informed when in-app back navigation is available.
  - Back presses now avoid triggering platform fallback actions when the app can handle navigation, including during slow responses.
  - Settings and other navigable screens return to the previous view, while the root screen and crash screen allow normal platform handling.
  - Android root activities are moved to the background when backing out, while nested activities retain existing navigation behavior.

- **Bug Fixes**
  - Prevented back gestures from being incorrectly passed to the platform when the app has an available route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->