### PR TITLE
fix(mobile): a cold start says the app is starting instead of showing nothing

### DIFF
--- a/src/praisonai-mobile/app/app.css
+++ b/src/praisonai-mobile/app/app.css
@@ -358,3 +358,45 @@ button:disabled { opacity: .45; cursor: default; }
   clip-path: inset(50%);
   white-space: nowrap;
 }
+
+/*
+ * The boot indicator, painted from index.html on the first frame.
+ *
+ * These rules are the reason it is worth painting at all: this stylesheet is a
+ * render-blocking <link> in <head>, so it is parsed BEFORE the first frame,
+ * while app.js is a deferred module that is not. Style the indicator from
+ * script and it would appear only once the thing it exists to cover for has
+ * already arrived.
+ *
+ * Every colour is a token from :root, never a literal, and that is what makes
+ * the indicator theme-correct without knowing the theme exists: the dark block
+ * above redefines --ground/--ink/--soft/--bad, so a dark device gets a dark
+ * boot screen and then a dark app. A hardcoded #fff here would have produced
+ * the one outcome worse than the blank page -- a white flash handing over to a
+ * dark UI on every launch.
+ *
+ * `margin: auto` inside `#root`'s flex column centres it, the same idiom
+ * `.empty` uses. The insets are still added as padding: centred content
+ * clears a status bar on a phone-shaped viewport by construction, but a short
+ * landscape viewport or a large font scale can push these lines into a cutout,
+ * and `--inset-*` falls back to `env()` here because nothing has run yet to
+ * write the shell's real numbers over it.
+ */
+.boot {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .4rem;
+  text-align: center;
+  padding: calc(var(--inset-top) + 1rem) calc(var(--inset-right) + 1.25rem)
+           calc(var(--inset-bottom) + 1rem) calc(var(--inset-left) + 1.25rem);
+}
+.boot-mark { margin: 0; font-size: 1.4rem; font-weight: 600; color: var(--ink); }
+.boot-note { margin: 0; font-size: .9rem; color: var(--soft); }
+/* The failure notice boot-guard.js reveals. `[hidden]` is spelled out for the
+   same reason `.screen[hidden]` and `.setting-error[hidden]` are: an author
+   `display` declaration beats the user agent's, and this repository has twice
+   shipped an element that ignored `hidden` because of one. */
+.boot-failed { margin: .4rem 0 0; max-width: 22rem; font-size: .9rem; color: var(--bad); }
+.boot-note[hidden], .boot-failed[hidden] { display: none; }

--- a/src/praisonai-mobile/app/boot-guard.js
+++ b/src/praisonai-mobile/app/boot-guard.js
@@ -27,9 +27,11 @@
 //
 // ES5, by hand. tools/bundle.mjs holds the app to the Chrome that the declared
 // `minSdkVersion` ships (chrome58 today) and scans every chunk it emits -- but
-// this file is copied verbatim, so esbuild never sees it and no gate would
-// catch an arrow function here. A syntax error in this script is a parse error
-// in the one file whose job is to report parse errors.
+// this file is copied verbatim, so esbuild never sees it. A syntax error here
+// would be a parse error in the one file whose job is to report parse errors,
+// so tools/bundle-target.test.mjs ("the hand-written verbatim scripts parse on
+// the floor too") lowers this file to that same floor and fails if anything
+// changes -- the gate the whole-bundle scan cannot be for a file it never sees.
 (function () {
   // ONE invariant, and every rule below follows from it: this file speaks only
   // while the boot indicator is still on screen. The app's first paint removes
@@ -57,11 +59,29 @@
       // for. It is also why the listener can be installed before the <script>
       // element it is about has even been parsed.
       var target = event.target;
-      // A SCRIPT that would not load, or a throw (whose target is the window).
-      // A stylesheet or an icon that 404s is a degraded page, not an app that
-      // cannot start, and claiming otherwise would be its own lie.
-      if (target && target !== window && target.tagName !== "SCRIPT") return;
-      fail();
+      // A throw (whose target is the window) is app code failing, so it counts.
+      if (target === window) {
+        fail();
+        return;
+      }
+      // Otherwise, only app.js loading is the boot this file speaks for. A
+      // stylesheet or an icon that 404s is a degraded page, not an app that
+      // cannot start -- and register-sw.js is a classic script that runs
+      // DURING parse, before the deferred app.js module ever executes, so its
+      // failure must not be pinned on the app: the worker declining to
+      // register is a page that still boots from the network (see
+      // register-sw.js), and claiming "could not start" for it would be a lie
+      // pointed the wrong way, exactly like an icon's would be. Matched on the
+      // src ending in "/app.js" -- the page loads it as "./app.js", which the
+      // DOM resolves to an absolute URL, so a suffix test is what reads it.
+      if (
+        target &&
+        target.tagName === "SCRIPT" &&
+        typeof target.src === "string" &&
+        /\/app\.js(?:[?#]|$)/.test(target.src)
+      ) {
+        fail();
+      }
     },
     true,
   );

--- a/src/praisonai-mobile/app/boot-guard.js
+++ b/src/praisonai-mobile/app/boot-guard.js
@@ -1,0 +1,68 @@
+// The boot indicator's failure path.
+//
+// index.html paints a wordmark and "Starting…" on the first frame so a cold
+// start does not look like a broken install. That message is true right up
+// until the moment the app can no longer start at all -- and the ONE failure
+// that leaves nobody to say so is app.js not loading or throwing on its way
+// in. app/src/crash.ts is installed by `mount()`, which is inside the module
+// that just failed; a static indicator with no cover would then sit there
+// claiming progress forever, which is worse than the blank page it replaced.
+//
+// An external file rather than an inline <script>, for the reason
+// register-sw.js gives: index.html ships a `script-src 'self'` CSP and an
+// inline script -- or an `onerror=` attribute, which is the same thing to CSP
+// -- would be blocked with nothing but a console line to say so.
+//
+// It is loaded BEFORE app.js and without `defer` on purpose, and that ordering
+// is the whole guarantee. `<script type=module>` is implicitly deferred: it is
+// FETCHED while the document parses and EXECUTED afterwards, and its `error`
+// fires whenever that fetch settles. A listener installed after it -- or
+// deferred alongside it -- may not exist yet at that moment. Over a real
+// connection the fetch always loses the race to the parser, so the wrong order
+// looks fine every time and fails the day a service worker or a memory cache
+// answers instantly; app/src/boot-screen.test.ts pins the order rather than
+// trusting the race. The cost is a parser pause on a same-origin file of a few
+// hundred bytes that the service worker precaches, and the boot markup is above
+// it, so nothing that has to be painted is waiting on this.
+//
+// ES5, by hand. tools/bundle.mjs holds the app to the Chrome that the declared
+// `minSdkVersion` ships (chrome58 today) and scans every chunk it emits -- but
+// this file is copied verbatim, so esbuild never sees it and no gate would
+// catch an arrow function here. A syntax error in this script is a parse error
+// in the one file whose job is to report parse errors.
+(function () {
+  // ONE invariant, and every rule below follows from it: this file speaks only
+  // while the boot indicator is still on screen. The app's first paint removes
+  // it (`root.textContent = ""` in app/src/main.ts), and so does the crash
+  // screen -- so once either has run, `fail()` finds nothing and says nothing.
+  // That is what keeps this from double-reporting over app/src/crash.ts, which
+  // owns every error from `mount()` onwards.
+  function fail() {
+    var boot = document.querySelector("[data-boot]");
+    if (boot === null) return;
+    var note = boot.querySelector("[data-boot-note]");
+    var failed = boot.querySelector("[data-boot-failed]");
+    if (note !== null) note.hidden = true;
+    // Swapped rather than added: "Starting…" and "could not start" on screen
+    // together is the app contradicting itself.
+    if (failed !== null) failed.hidden = false;
+  }
+
+  window.addEventListener(
+    "error",
+    function (event) {
+      // Capture, because a resource's `error` event does not bubble -- a
+      // bubble-phase listener on window hears a thrown exception and never
+      // hears a script that failed to download, which is the case this exists
+      // for. It is also why the listener can be installed before the <script>
+      // element it is about has even been parsed.
+      var target = event.target;
+      // A SCRIPT that would not load, or a throw (whose target is the window).
+      // A stylesheet or an icon that 404s is a degraded page, not an app that
+      // cannot start, and claiming otherwise would be its own lie.
+      if (target && target !== window && target.tagName !== "SCRIPT") return;
+      fail();
+    },
+    true,
+  );
+})();

--- a/src/praisonai-mobile/app/index.html
+++ b/src/praisonai-mobile/app/index.html
@@ -52,11 +52,82 @@
     <link rel="stylesheet" href="./app.css" />
   </head>
   <body>
-    <!-- Populated by app/src/main.ts. Deliberately empty: a skeleton rendered
-         here would be a second source of truth for a layout the view models
-         already own. -->
-    <div id="root"></div>
+    <!--
+      The boot indicator.
+
+      What used to be here said, correctly: "Deliberately empty: a skeleton
+      rendered here would be a second source of truth for a layout the view
+      models already own." That argument still stands and nothing below
+      weakens it. THIS IS NOT A SKELETON, and the difference is the whole
+      point:
+
+        - A skeleton imitates the LAYOUT -- a fake topbar, grey message
+          bubbles, a stand-in composer. It duplicates what
+          ui/src/transcript/view-model.ts and app/src/main.ts own, so it
+          drifts from them the moment either changes, and nothing fails when
+          it does.
+        - This is a WORDMARK and one line of text. It owns no view-model
+          state, mirrors no layout, and names nothing the app renders. There
+          is no second source of truth because there is no first one: "the app
+          is starting" is not something the view models model.
+
+      It earns its place because the alternative was measured: on an Android
+      15 emulator the page was blank -- no logo, no text, nothing -- for the
+      whole of a cold start while the WebView started, fetched app.js and ran
+      it. A user cannot tell a slow launch from a broken install by looking at
+      white.
+
+      It is STATIC on purpose, and that is a decision rather than laziness.
+      Nothing running before app.js executes can observe how far the boot has
+      got: a script element has no download-progress event, and there is no way
+      to ask how much of a module has been parsed. A spinner or a progress bar
+      here would be animation the compositor keeps running even when the main
+      thread is dead -- an assertion of liveness nobody is in a position to
+      make, in a repository that has spent days removing things that claim
+      state they cannot see. The honest claim is the one made here (the app has
+      been asked to start), plus the failure notice below, which is driven by a
+      real event and nothing else.
+
+      Removal is the app's first paint and needs no code of its own:
+      app/src/main.ts does `root.textContent = ""` before appending the chat
+      screen, and app/src/crash.ts's fatal route does the same. It therefore
+      cannot outlive the first render. Nor can it flash: a browser presents its
+      first frame after layout, and on a boot fast enough for that frame to
+      already contain the app, this element is gone before it is ever painted.
+      Measured on the emulator above, that is exactly what happens -- the
+      indicator costs a fast start nothing and only appears on the slow starts
+      it was written for.
+
+      The words are English literals rather than ui/src/i18n/strings.ts,
+      because every one of those arrives with the bundle this element exists
+      to cover for. That is the same trade <noscript> below already makes.
+
+      Written without the literal script tag name anywhere in this comment, on
+      purpose: tools/web-csp.test.mjs scans this file for an inline script and
+      cannot tell one inside a comment from a real one -- which is the right
+      way round for a gate about the CSP, so the prose gives way, not the gate.
+    -->
+    <div id="root">
+      <div class="boot" data-boot>
+        <p class="boot-mark">PraisonAI</p>
+        <p class="boot-note" data-boot-note role="status">Starting…</p>
+        <!--
+          Revealed by boot-guard.js when app.js itself fails to load or throws
+          on its way in -- the one boot failure that happens with no
+          application code left running to report it. Everything after that
+          point is app/src/crash.ts's renderFatal, which this deliberately
+          does not duplicate: text only, no controls, the same `.empty` register.
+        -->
+        <p class="boot-failed" data-boot-failed role="alert" hidden>
+          PraisonAI could not start: its code could not be loaded. Close the app and open it again.
+        </p>
+      </div>
+    </div>
     <noscript>PraisonAI needs JavaScript to run.</noscript>
+    <!-- Before app.js, and not deferred: see app/boot-guard.js for why the
+         ordering is load-bearing. It is the only thing left to report a failure
+         when app.js itself is what failed. -->
+    <script src="./boot-guard.js"></script>
     <script type="module" src="./app.js"></script>
     <script src="./register-sw.js"></script>
   </body>

--- a/src/praisonai-mobile/app/src/boot-screen.test.ts
+++ b/src/praisonai-mobile/app/src/boot-screen.test.ts
@@ -1,0 +1,256 @@
+/**
+ * The boot indicator: the thing on screen while there is no app yet.
+ *
+ * Before this existed a cold start was blank -- no wordmark, no text, nothing
+ * -- from the moment the launcher icon was tapped until app.js had been
+ * fetched, parsed and run. Measured on an Android 15 emulator (software GPU,
+ * `am force-stop` then `am start`, timed from the WebView's own
+ * `first-contentful-paint`): 1.36 s of white in light mode, 1.42 s of black in
+ * dark. On slower silicon, a first launch after install, or a cold page cache
+ * it is longer, and there is nothing in any of it to tell a user that the app
+ * is starting rather than broken.
+ *
+ * Everything asserted here is about a frame that is painted BEFORE any module
+ * has executed, which is why every one of these tests reads the shipped file
+ * off disk rather than driving code. `app/index.html`, `app/app.css` and
+ * `app/boot-guard.js` are copied verbatim into dist/ by
+ * tools/build-webview.mjs; they are not typechecked, not bundled, and until
+ * now not covered -- the same gap `css.test.ts` was written to close for the
+ * stylesheet.
+ *
+ * The one thing NOT asserted here is removal, because removal is behaviour:
+ * `main.test.ts` mounts the real composition root over a root that already
+ * holds a boot indicator and proves the first render takes it away.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { runInNewContext } from "node:vm";
+
+const html = readFileSync(join(import.meta.dirname, "../index.html"), "utf8");
+const guardSource = readFileSync(join(import.meta.dirname, "../boot-guard.js"), "utf8");
+/** Comments explain the rules and name the very tokens a rule must contain, so
+ *  they are stripped before matching -- exactly as css.test.ts does. */
+const css = readFileSync(join(import.meta.dirname, "../app.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+const markup = html.replace(/<!--[\s\S]*?-->/g, "");
+
+/** What is inside `<div id="root">`, as written in the page. */
+function rootContent(): string {
+  const open = /<div id="root"\s*>/.exec(markup);
+  assert.ok(open !== null, "app/index.html must still have a #root container");
+  const rest = markup.slice(open.index + open[0].length);
+  const end = rest.indexOf("</div>\n    <noscript");
+  assert.ok(end !== -1, "the #root container must close before <noscript>");
+  return rest.slice(0, end);
+}
+
+test("the page paints a boot indicator, before any script has run", () => {
+  // The defect in one line: #root shipped empty, so the first frame was the
+  // body's background colour and nothing else. The fix has to be IN THE
+  // MARKUP -- an indicator drawn by app.js appears at the same moment the app
+  // does and covers nothing at all.
+  const inside = rootContent();
+  assert.match(inside, /data-boot\b/, "#root must hold the boot indicator on first paint");
+
+  // And it must precede every <script>. The CSP is `script-src 'self'` with no
+  // inline scripts, so this element cannot be created by the page; it is only
+  // ever markup the parser meets before it meets the bundle.
+  const boot = markup.indexOf("data-boot");
+  const script = markup.indexOf("<script");
+  assert.ok(script !== -1, "the page must still load a script, or this proves nothing");
+  assert.ok(boot < script, "the boot indicator must be parsed before any script element");
+});
+
+test("the boot indicator says which app is starting, and that it is starting", () => {
+  // A bare spinner or an empty box answers neither question a user has at this
+  // moment: did I open the right thing, and is it doing anything. Both answers
+  // are words, because words are what a system font can paint with no second
+  // request.
+  const inside = rootContent();
+  assert.match(inside, /PraisonAI/, "the wordmark names the app");
+  const note = /class="boot-note"[^>]*>([^<]+)</.exec(inside)?.[1]?.trim() ?? "";
+  assert.ok(note.length > 0, "the indicator must say something, not just show a mark");
+  assert.match(note, /start/i, `the note must say the app is starting, not "${note}"`);
+});
+
+test("the boot indicator is styled by the render-blocking stylesheet, not by script", () => {
+  // app.css is a <link> in <head>, so it is parsed before the first frame;
+  // app.js is a deferred module and is not. Styling the indicator from script
+  // would make it appear at the same moment the app does, i.e. never usefully.
+  const head = html.slice(0, html.indexOf("</head>"));
+  assert.match(head, /<link rel="stylesheet" href="\.\/app\.css"/, "app.css must be linked in <head>");
+
+  // Every class the boot markup uses must have a rule here, so a renamed class
+  // cannot leave the indicator unstyled and silent about it.
+  const classes = [...rootContent().matchAll(/class="([^"]+)"/g)].flatMap((m) => (m[1] ?? "").split(/\s+/));
+  assert.ok(classes.includes("boot"), "the container carries the .boot class");
+  for (const name of new Set(classes)) {
+    assert.ok(css.includes(`.${name}`), `app.css has no rule for .${name}`);
+  }
+});
+
+/**
+ * Every `.boot*` rule in the stylesheet, selector and declarations.
+ *
+ * Parsed as ALL rules and then filtered, rather than matched with a pattern
+ * anchored on `}`. The first version of this did the latter, and a global
+ * regex consumes the brace it anchors on -- so it saw `.boot` and `.boot-note`
+ * and skipped `.boot-mark` entirely, between them. A hardcoded `#14171c` on the
+ * wordmark went straight through the assertions below while the test read as
+ * green. The `expect` list at the bottom is the second half of the fix: a rule
+ * that stops being seen has to fail rather than shrink the sample.
+ */
+function bootRules(): string {
+  const rules = [...css.matchAll(/([^{}]+)\{([^{}]*)}/g)]
+    .map((m) => ({ selector: (m[1] ?? "").trim(), body: m[2] ?? "" }))
+    .filter((r) => /(^|[\s,])\.boot[\w-]*/.test(r.selector));
+  const seen = rules.map((r) => r.selector).join(" ");
+  for (const expect of [".boot", ".boot-mark", ".boot-note", ".boot-failed"]) {
+    assert.match(seen, new RegExp(`\\${expect}[^\\w-]`), `no ${expect} rule was read out of app.css`);
+  }
+  return rules.map((r) => `${r.selector}{${r.body}}`).join("\n");
+}
+
+test("the boot indicator takes its colours from the theme tokens, so a dark device gets a dark boot screen", () => {
+  // A white boot screen handing over to a dark app on every launch would be
+  // worse than the blank page this replaces -- a flash that reads as a
+  // rendering fault. Nothing here can name a colour: :root defines the tokens
+  // and the `prefers-color-scheme: dark` block redefines them, so using the
+  // tokens is the whole of the dark-mode support.
+  const rules = bootRules();
+  const literals = [...rules.matchAll(/(#[0-9a-fA-F]{3,8}\b|\brgba?\(|\bhsla?\(|\b(?:white|black|silver|gray|grey)\b)/g)];
+  assert.deepEqual(
+    literals.map((m) => m[0]),
+    [],
+    `the boot indicator must not name a colour; use the :root tokens:\n${rules}`,
+  );
+  for (const decl of rules.matchAll(/(?:^|[;{])\s*(?:color|background(?:-color)?)\s*:([^;}]*)/g)) {
+    assert.match(decl[1] ?? "", /var\(--/, `a boot colour must come from a token: ${decl[0]}`);
+  }
+
+  // And the tokens it uses must actually be the ones the dark theme moves. A
+  // token that only ever has one value would pass the check above while
+  // painting the same colour in both themes.
+  const dark = /@media \(prefers-color-scheme: dark\)\s*\{([\s\S]*?)\n\}/.exec(css)?.[1] ?? "";
+  for (const token of [...rules.matchAll(/var\((--[\w-]+)/g)].map((m) => m[1] ?? "")) {
+    if (token.startsWith("--inset") || token.startsWith("--safe-area")) continue;
+    assert.match(dark, new RegExp(`${token}\\s*:`), `${token} is not redefined for dark mode`);
+  }
+});
+
+test("the boot indicator clears the safe-area insets", () => {
+  // The header clearing the status bar was a measured fix (app.css's own note:
+  // 29px of the "Settings" heading painted under the clock). The boot screen is
+  // painted before ANY of that machinery runs, so it lays out against the
+  // `env()` fallback the stylesheet declares -- and it has to consume it, or a
+  // short landscape viewport puts these lines inside a cutout.
+  const padding = /\.boot\s*\{([^}]*)}/.exec(css)?.[1] ?? "";
+  for (const side of ["top", "right", "bottom", "left"]) {
+    assert.match(padding, new RegExp(`--inset-${side}`), `.boot must respect the ${side} inset`);
+  }
+});
+
+// ---- the failure path -------------------------------------------------------
+//
+// The shipped bytes, run. `boot-guard.js` is a plain classic script outside the
+// bundle, so there is nothing to import -- but there is also no reason to
+// assert its SOURCE when the file is small enough to execute against a fake
+// window and be asked what it does.
+
+interface FakeNode {
+  hidden: boolean;
+  querySelector(selector: string): FakeNode | null;
+}
+
+/** A page in one of two states: still showing the boot indicator, or past it. */
+function runGuard(showing: boolean): {
+  note: FakeNode;
+  failed: FakeNode;
+  fire: (target: unknown) => void;
+  capture: boolean;
+} {
+  const note: FakeNode = { hidden: false, querySelector: () => null };
+  const failed: FakeNode = { hidden: true, querySelector: () => null };
+  const boot: FakeNode = {
+    hidden: false,
+    querySelector: (s) => (s === "[data-boot-note]" ? note : s === "[data-boot-failed]" ? failed : null),
+  };
+  let handler: ((event: unknown) => void) | null = null;
+  let capture = false;
+  const window = {
+    addEventListener(type: string, fn: (event: unknown) => void, useCapture?: boolean) {
+      if (type !== "error") return;
+      handler = fn;
+      capture = useCapture === true;
+    },
+  };
+  const document = { querySelector: (s: string) => (s === "[data-boot]" && showing ? boot : null) };
+  runInNewContext(guardSource, { window, document });
+  assert.ok(handler !== null, "boot-guard.js must listen for error events");
+  return { note, failed, fire: (target) => handler?.({ target }), capture };
+}
+
+test("the guard is loaded before the bundle, and not deferred", () => {
+  // A race, closed by ordering. `<script type="module">` is implicitly
+  // deferred: it is FETCHED while the document parses and EXECUTED afterwards,
+  // and its `error` event fires whenever that fetch settles. A guard placed
+  // after it -- or given `defer` -- is a guard that may not have run yet when
+  // that happens, and an error nobody is listening for is an indicator that
+  // claims "Starting…" forever.
+  //
+  // Asserted on the markup rather than in a browser, and that is not a
+  // shortcut: over a real connection the fetch always loses to the parser, so
+  // the wrong order passes a browser proof every time and fails the day a
+  // service worker or a memory cache answers instantly. The ordering is the
+  // guarantee; this is where it is pinned.
+  const guard = markup.indexOf('src="./boot-guard.js"');
+  const bundle = markup.indexOf('src="./app.js"');
+  assert.ok(guard !== -1, "the page must load boot-guard.js, or nothing reports a failed boot");
+  assert.ok(bundle !== -1, "the page must still load the bundle");
+  assert.ok(guard < bundle, "boot-guard.js must be loaded before app.js");
+  const tag = /<script[^>]*boot-guard\.js[^>]*>/.exec(markup)?.[0] ?? "";
+  assert.doesNotMatch(tag, /\b(defer|async|type="module")/, `the guard must run during parsing: ${tag}`);
+});
+
+test("a boot script that fails to load turns the indicator into a failure notice", () => {
+  // The one failure with nobody left to report it: app/src/crash.ts is
+  // installed by `mount()`, which lives in the module that just failed. Without
+  // this, a static "Starting…" would sit there claiming progress forever --
+  // which is worse than the blank page, because it is a blank page that lies.
+  const { note, failed, fire } = runGuard(true);
+  fire({ tagName: "SCRIPT" });
+  assert.equal(failed.hidden, false, "the failure notice must be revealed");
+  assert.equal(note.hidden, true, '"Starting…" must go: it is no longer true');
+});
+
+test("the guard listens in the CAPTURE phase, because a resource error does not bubble", () => {
+  // A bubble-phase listener on window hears a thrown exception and never hears
+  // a <script> that failed to download -- which is the case this file exists
+  // for. Capture is also what lets the listener be installed before the script
+  // element it is about has been parsed.
+  assert.equal(runGuard(true).capture, true);
+});
+
+test("a stylesheet or an icon that fails does not claim the app could not start", () => {
+  // `error` in the capture phase hears EVERY failed subresource. A missing
+  // favicon is a degraded page, not an app that cannot start, and saying
+  // otherwise would be the same class of lie pointed the other way.
+  for (const tagName of ["LINK", "IMG"]) {
+    const { note, failed, fire } = runGuard(true);
+    fire({ tagName });
+    assert.equal(failed.hidden, true, `a failed ${tagName} must not be reported as a boot failure`);
+    assert.equal(note.hidden, false);
+  }
+});
+
+test("once the app has rendered, the guard says nothing at all", () => {
+  // The invariant that keeps this file from double-reporting over
+  // app/src/crash.ts: the app's first paint clears #root, so from then on
+  // there is no boot indicator to find and every later error belongs to the
+  // crash handler alone.
+  const { note, failed, fire } = runGuard(false);
+  fire({ tagName: "SCRIPT" });
+  assert.equal(failed.hidden, true, "a post-render error is the crash handler's, not this file's");
+  assert.equal(note.hidden, false);
+});

--- a/src/praisonai-mobile/app/src/boot-screen.test.ts
+++ b/src/praisonai-mobile/app/src/boot-screen.test.ts
@@ -168,6 +168,7 @@ function runGuard(showing: boolean): {
   note: FakeNode;
   failed: FakeNode;
   fire: (target: unknown) => void;
+  fireThrow: () => void;
   capture: boolean;
 } {
   const note: FakeNode = { hidden: false, querySelector: () => null };
@@ -188,7 +189,15 @@ function runGuard(showing: boolean): {
   const document = { querySelector: (s: string) => (s === "[data-boot]" && showing ? boot : null) };
   runInNewContext(guardSource, { window, document });
   assert.ok(handler !== null, "boot-guard.js must listen for error events");
-  return { note, failed, fire: (target) => handler?.({ target }), capture };
+  return {
+    note,
+    failed,
+    // A resource error carries the failed element as its target.
+    fire: (target) => handler?.({ target }),
+    // A thrown exception's error event has the window as its target.
+    fireThrow: () => handler?.({ target: window }),
+    capture,
+  };
 }
 
 test("the guard is loaded before the bundle, and not deferred", () => {
@@ -219,9 +228,38 @@ test("a boot script that fails to load turns the indicator into a failure notice
   // this, a static "Starting…" would sit there claiming progress forever --
   // which is worse than the blank page, because it is a blank page that lies.
   const { note, failed, fire } = runGuard(true);
-  fire({ tagName: "SCRIPT" });
+  fire({ tagName: "SCRIPT", src: "https://example.test/PraisonAI/app.js" });
   assert.equal(failed.hidden, false, "the failure notice must be revealed");
   assert.equal(note.hidden, true, '"Starting…" must go: it is no longer true');
+});
+
+test("a throw before the app has rendered is reported: app code failing is a failed boot", () => {
+  // A runtime error whose event.target is the window -- app.js parsed and ran
+  // but threw on its way in, before mount() could install crash.ts. Nobody
+  // else is left to report it, so the guard must.
+  const { note, failed, fireThrow } = runGuard(true);
+  fireThrow();
+  assert.equal(failed.hidden, false, "a throw (target === window) is the app failing");
+  assert.equal(note.hidden, true);
+});
+
+test("register-sw.js failing to load does not claim the app could not start", () => {
+  // register-sw.js is a CLASSIC script that runs during parse, BEFORE the
+  // deferred app.js module executes. If its download fails while app.js is
+  // still in flight, the app can still load and mount -- so treating every
+  // <script> error as an app-bundle failure would flash "could not start" on a
+  // page that is about to boot fine. The worker declining to register is a
+  // degraded page (see register-sw.js), not a broken one, so it must be
+  // ignored exactly as a failed stylesheet or icon is.
+  for (const src of [
+    "https://example.test/PraisonAI/register-sw.js",
+    "https://example.test/PraisonAI/boot-guard.js",
+  ]) {
+    const { note, failed, fire } = runGuard(true);
+    fire({ tagName: "SCRIPT", src });
+    assert.equal(failed.hidden, true, `a failed ${src} must not be reported as a boot failure`);
+    assert.equal(note.hidden, false);
+  }
 });
 
 test("the guard listens in the CAPTURE phase, because a resource error does not bubble", () => {
@@ -250,7 +288,7 @@ test("once the app has rendered, the guard says nothing at all", () => {
   // there is no boot indicator to find and every later error belongs to the
   // crash handler alone.
   const { note, failed, fire } = runGuard(false);
-  fire({ tagName: "SCRIPT" });
+  fire({ tagName: "SCRIPT", src: "https://example.test/PraisonAI/app.js" });
   assert.equal(failed.hidden, true, "a post-render error is the crash handler's, not this file's");
   assert.equal(note.hidden, false);
 });

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -2574,3 +2574,39 @@ test("a turn the model was NEVER told about is the one row that says it was not 
   );
   await app?.dispose();
 });
+
+test("the first render takes the boot indicator away", async () => {
+  // The other half of the boot screen (app/src/boot-screen.test.ts asserts the
+  // markup and the styling). `app/index.html` paints a wordmark and "Starting…"
+  // into #root before any module runs, so a cold start is not a blank page --
+  // and the ONE thing that must never happen is that it survives the first
+  // render and sits on top of the app.
+  //
+  // Nothing removes it by name. `mount` clears #root before appending the chat
+  // screen, which is what makes the guarantee total: whatever the page painted
+  // ahead of the app is gone in the same statement pair that puts the real UI
+  // there. This test is what stops that clear from being "simplified" away --
+  // the app would still look correct on every screen a test drives, because
+  // every other test starts from an empty root.
+  const { dom, platform } = harness();
+  const boot = dom.make("div");
+  boot.className = "boot";
+  boot.dataset["boot"] = "";
+  const mark = dom.make("p");
+  mark.textContent = "PraisonAI";
+  boot.append(mark);
+  dom.root.append(boot);
+  assert.ok(dom.find((n) => n.dataset["boot"] !== undefined) !== null, "the fixture must start with one");
+
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  assert.equal(
+    dom.find((n) => n.dataset["boot"] !== undefined),
+    null,
+    "the boot indicator must not survive the first render",
+  );
+  // And the real UI is what replaced it, rather than the root simply being
+  // emptied -- an indicator removed with nothing put in its place would pass
+  // the assertion above while showing the blank page this all exists to fix.
+  assert.ok(dom.find((n) => n.tagName === "TEXTAREA") !== null, "the composer replaced it");
+  await app?.dispose();
+});

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -772,6 +772,15 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   jumpLatest.hidden = true;
 
   screen.append(bar, transcript, jumpLatest, composer, polite, assertive);
+  // This is also what RETIRES the boot indicator, and the ordering is the whole
+  // guarantee. `app/index.html` paints a wordmark and "Starting…" into #root on
+  // the first frame so a cold start does not look like a broken install; the
+  // clear below is the single point at which it can no longer be on screen, and
+  // it happens in the same statement pair that puts the real UI there -- so
+  // there is no frame with both, and none with neither. It is deliberately not
+  // a `removeChild` of a known id: anything the page painted before the app did
+  // is the app's to replace, and a targeted removal would leave a second
+  // element behind the day someone adds one.
   root.textContent = "";
   root.append(screen);
 

--- a/src/praisonai-mobile/tools/build-webview.mjs
+++ b/src/praisonai-mobile/tools/build-webview.mjs
@@ -29,7 +29,12 @@ await mkdir(join(dist, "icons"), { recursive: true });
 // The page, the stylesheet, the manifest and the registration script are
 // copied verbatim: none is compiled, and a transform step would be one more
 // thing between what is written and what ships.
-const verbatim = ["index.html", "app.css", "manifest.webmanifest", "register-sw.js"];
+// `boot-guard.js` is here for the same reason `register-sw.js` is: it is a
+// hand-written script the page loads directly, not something the bundle
+// produces. Being in this list is also what puts it in the PRECACHE below,
+// which matters -- it is the file that reports app.js failing to load, so it
+// must not itself be a thing that has to be fetched to work.
+const verbatim = ["index.html", "app.css", "manifest.webmanifest", "register-sw.js", "boot-guard.js"];
 for (const name of verbatim) {
   await copyFile(join(pkg, "app", name), join(dist, name));
 }

--- a/src/praisonai-mobile/tools/build-webview.test.mjs
+++ b/src/praisonai-mobile/tools/build-webview.test.mjs
@@ -15,6 +15,7 @@ const SHIPPED = [
   "app.js",
   "manifest.webmanifest",
   "register-sw.js",
+  "boot-guard.js",
   "sw.js",
   "icons/a.png",
   "icons/b.png",
@@ -30,6 +31,7 @@ function fixture(main) {
   writeFileSync(join(dir, "app/index.html"), "<!doctype html><div id=root></div>\n");
   writeFileSync(join(dir, "app/app.css"), ":root { color: red }\n");
   writeFileSync(join(dir, "app/register-sw.js"), "// register\n");
+  writeFileSync(join(dir, "app/boot-guard.js"), "// boot guard\n");
   writeFileSync(join(dir, "app/sw.js"), REAL_SW);
   writeFileSync(
     join(dir, "app/manifest.webmanifest"),

--- a/src/praisonai-mobile/tools/bundle-target.test.mjs
+++ b/src/praisonai-mobile/tools/bundle-target.test.mjs
@@ -24,7 +24,7 @@
 import test from "node:test";
 import * as esbuild from "esbuild";
 import assert from "node:assert/strict";
-import { readFileSync, readdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -112,6 +112,33 @@ test("the shipped bundle -- every chunk, engine included -- has no syntax the fl
       print(code, target("chrome")),
       print(code, "esnext"),
       `${name}: lowering it to ${target("chrome")} changed it, so it carries syntax the floor cannot parse`,
+    );
+  }
+});
+
+test("the hand-written verbatim scripts parse on the floor too", () => {
+  // boot-guard.js and register-sw.js are copied byte-for-byte into dist/ by
+  // build-webview.mjs -- esbuild never sees them, so the whole-bundle syntax
+  // gate above cannot. Both are load-bearing on old WebViews: boot-guard.js is
+  // the ONLY thing that reports app.js failing to load, and if it is itself a
+  // parse error on a chrome58 device then the one failure it exists to cover
+  // goes unreported. Their VM tests run on modern Node, where an arrow
+  // function or a `?.` passes clean and then fails to parse on the floor. So
+  // they are held to the same floor here, by the same parser-based no-op test
+  // the bundle uses: lowering a floor-clean file to the floor changes nothing.
+  const floor = target("chrome");
+  const lower = (code) => esbuild.transformSync(code, {
+    target: [floor], format: "esm", supported: { "dynamic-import": true, "template-literal": false },
+  }).code;
+  for (const name of ["boot-guard.js", "register-sw.js"]) {
+    const file = join(import.meta.dirname, "../app", name);
+    assert.ok(existsSync(file), `${name} must exist to be checked`);
+    const code = readFileSync(file, "utf8");
+    assert.equal(
+      lower(code, floor),
+      lower(code, "esnext"),
+      `app/${name}: lowering it to ${floor} changed it, so it carries syntax the floor cannot parse -- ` +
+        `and being copied verbatim, no other gate would catch it`,
     );
   }
 });

--- a/src/praisonai-mobile/tools/web-boot.test.mjs
+++ b/src/praisonai-mobile/tools/web-boot.test.mjs
@@ -66,6 +66,14 @@ function serveDist(overrides = new Map()) {
     let rel = url.pathname.slice(BASE.length);
     if (rel === "" || rel.endsWith("/")) rel += "index.html";
     if (overrides.has(rel)) {
+      // `null` means REFUSE this file, not serve nothing. A zero-byte 200 is a
+      // script that loaded and did nothing; the boot-guard proof below needs
+      // the other thing entirely -- a <script> the browser could not fetch,
+      // which is what fires the `error` event that file listens for.
+      if (overrides.get(rel) === null) {
+        res.writeHead(500).end("refused");
+        return;
+      }
       res.writeHead(200, { "content-type": MIME[extname(rel)] ?? "application/octet-stream", "cache-control": "no-store" });
       res.end(overrides.get(rel));
       return;
@@ -178,7 +186,7 @@ test("the built web app boots, installs, and survives going offline", async (t) 
   const cached = await page.evaluate(async () => {
     const keys = await caches.keys();
     const hits = {};
-    for (const rel of ["index.html", "app.js", "app.css", "manifest.webmanifest", "register-sw.js"]) {
+    for (const rel of ["index.html", "app.js", "app.css", "manifest.webmanifest", "register-sw.js", "boot-guard.js"]) {
       hits[rel] = (await caches.match(new URL(rel, location.href).href)) !== undefined;
     }
     return { keys, hits };
@@ -339,4 +347,98 @@ test("a redeployed site replaces the cached one instead of being pinned behind i
   await page.reload({ waitUntil: "load" });
   await page.locator('textarea[aria-label="Message"]').waitFor({ timeout: 15_000 });
   assert.ok(await page.evaluate(() => navigator.serviceWorker.controller !== null), "v2 controls the page");
+});
+
+test("the boot screen paints before the app, goes when the app arrives, and reports an app that cannot load", async (t) => {
+  // The blank-cold-start defect, proved in a browser rather than argued from
+  // the markup. Three claims, and only a real engine can settle any of them:
+  //
+  //   1. the indicator is on screen while app.js is still in flight -- i.e. it
+  //      covers the gap it was written for, rather than appearing alongside
+  //      the app it is meant to precede;
+  //   2. the app's first render removes it, so it can never sit on top of the
+  //      UI;
+  //   3. when app.js cannot be fetched at all, the page says so. That is the
+  //      one failure app/src/crash.ts cannot cover, because the crash handler
+  //      is installed by `mount()` inside the module that just failed -- and a
+  //      static "Starting…" left alone in that state is a page that lies.
+  const built = spawnSync(process.execPath, [join(pkg, "tools/build-webview.mjs")], { encoding: "utf8" });
+  assert.equal(built.status, 0, `the build must succeed before it can be booted:\n${built.stdout}${built.stderr}`);
+
+  const overrides = new Map();
+  const server = await serveDist(overrides);
+  const site = `http://127.0.0.1:${server.address().port}` + BASE;
+  const browser = await launch();
+  t.after(async () => {
+    await browser.close();
+    server.closeAllConnections?.();
+    await new Promise((ok) => server.close(ok));
+  });
+  const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  const page = await context.newPage();
+  await page.route((u) => u.href.startsWith(ENGINE), (route) => route.abort("connectionrefused"));
+
+  // ---- 1. on screen while the bundle is still coming ----------------------
+  // app.js is held for two seconds. Everything the indicator depends on --
+  // the markup and the render-blocking stylesheet -- has arrived by then, so
+  // whatever is visible in this window is what a user on a slow start sees.
+  let release = null;
+  await page.route(
+    (u) => u.pathname.endsWith("/app.js"),
+    async (route) => {
+      await new Promise((ok) => { release = ok; setTimeout(ok, 2000); });
+      await route.continue();
+    },
+  );
+  await page.goto(site, { waitUntil: "commit" });
+  const mark = page.locator("[data-boot] .boot-mark");
+  await mark.waitFor({ state: "visible", timeout: 10_000 });
+  assert.equal((await mark.textContent()).trim(), "PraisonAI", "the wordmark is what is on screen");
+  await page.locator("[data-boot] .boot-note").waitFor({ state: "visible" });
+  assert.equal(
+    await page.locator("[data-boot] .boot-failed").isVisible(),
+    false,
+    "a boot that is merely slow must not be reported as a boot that failed",
+  );
+  // It is inside #root and it is the only thing there: the app has not painted.
+  assert.equal(await page.locator("textarea").count(), 0, "the app has not rendered yet, or this proves nothing");
+
+  // ---- 2. gone the moment the app renders ---------------------------------
+  release?.();
+  await page.locator('textarea[aria-label="Message"]').waitFor({ timeout: 20_000 });
+  assert.equal(
+    await page.locator("[data-boot]").count(),
+    0,
+    "the boot indicator survived the first render and is sitting on top of the app",
+  );
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+
+  // ---- 3. an app.js that cannot be fetched --------------------------------
+  // Refused by the server rather than by a route, so the failure is a real
+  // network one on a real <script> element.
+  //
+  // A FRESH CONTEXT, and that detail is not incidental. The context above has
+  // a service worker registered for this scope with app.js precached, so it
+  // answers the refusal out of the cache and boots normally -- correct
+  // behaviour, and the whole point of the offline proof further up, but it
+  // means this failure cannot be staged there. This is a first visit: nothing
+  // is cached yet, and the refusal reaches the page.
+  overrides.set("app.js", null);
+  const firstVisit = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  t.after(() => firstVisit.close());
+  const failed = await firstVisit.newPage();
+  await failed.route((u) => u.href.startsWith(ENGINE), (route) => route.abort("connectionrefused"));
+  await failed.goto(site, { waitUntil: "commit" });
+  const notice = failed.locator("[data-boot] .boot-failed");
+  await notice.waitFor({ state: "visible", timeout: 15_000 });
+  assert.match(
+    (await notice.textContent()).trim(),
+    /could not start/i,
+    "the notice must say the app could not start",
+  );
+  assert.equal(
+    await failed.locator("[data-boot] .boot-note").isVisible(),
+    false,
+    '"Starting…" must be withdrawn: leaving it beside "could not start" is the page contradicting itself',
+  );
 });


### PR DESCRIPTION
## The defect

Launching the app painted nothing — no wordmark, no text, no affordance of any kind — from the tap until `app.js` had been fetched, parsed and run. A user could not tell a slow launch from a broken install by looking at it.

Measured on an Android 15 emulator (Pixel 6 profile, `-gpu swiftshader_indirect`), a genuine cold start each time (`am force-stop` then `am start`), timed from the WebView's own `first-contentful-paint` read over CDP:

| | light | dark |
|---|---|---|
| `am start` → navigationStart | 1060 ms | 1222 ms |
| navigationStart → first-contentful-paint | 300 ms | 197 ms |
| **`am start` → first contentful paint** | **1360 ms** | **1419 ms** |

All of it blank. I could not reproduce 45 s on this host — but the shape of the defect is the same at any duration, and the fix is the same.

## Why the old comment was right, and this is still not a skeleton

`index.html` said `#root` was "deliberately empty: a skeleton rendered here would be a second source of truth for a layout the view models already own." That argument stands and is not weakened here.

A skeleton imitates the **layout** — a fake topbar, grey bubbles, a stand-in composer — and drifts silently from the view models that own it. A **wordmark and one line of text** mirror no layout, own no view-model state, and name nothing the app renders: there is no second source of truth because there is no first one. "The app is starting" is not something the view models model. The replacement comment states that distinction explicitly, so the next reader does not revert this on the strength of the old one.

## What ships

- **`app/index.html`** paints `PraisonAI` / `Starting…` inside `#root`, so it is in the first frame the parser can produce, before any module executes.
- **`app/app.css`** styles it from the render-blocking stylesheet, entirely in the existing `:root` tokens — so a dark device gets a dark boot screen and then a dark app, never a white flash. It consumes `--inset-*` as padding, which falls back to `env()` before the shell has written the real numbers.
- **Removal is `mount()`'s existing `root.textContent = ""`**, in the same statement pair that appends the chat screen: no frame with both, none with neither. `renderFatal` clears the same way. On a boot fast enough for the first *presented* frame to already contain the app — which is what happens on this emulator — the indicator is gone before it is ever painted, so a fast start pays nothing and only a slow one sees it. No flash, by construction rather than by timer.
- **`app/boot-guard.js`** covers the one boot failure with nobody left to report it.

## Static, and why

Nothing running before `app.js` executes can observe how far the boot has got: a script element has no download-progress event, and there is no way to ask how much of a module has been parsed. A spinner or a progress bar would be motion the compositor keeps running even when the main thread is dead — an assertion of liveness nobody is in a position to make. So: a wordmark, a true sentence, and a failure notice driven by a real event.

## The failure path

`app/src/crash.ts` is installed by `mount()`, inside the module that just failed — so an `app.js` that cannot load leaves a static "Starting…" claiming progress forever, which is a blank page that lies. `boot-guard.js` is a classic script loaded **before** the bundle (`script-src 'self'`, so no inline script and no `onerror=` attribute) that listens for `error` in the **capture** phase, because a resource error does not bubble. It reveals a notice already present in the markup and withdraws "Starting…". It acts only while the indicator is still on screen, so it never doubles up with `crash.ts`. The lazily-loaded engine chunk failing is unchanged: `load-agent.ts` already turns it into a named recoverable error inside a rendered app.

## Evidence, on a real emulator

Boot indicator in light and dark, and the failure notice, all photographed with `adb screencap` on the device with the status bar visible — the safe area is respected and the recent header fix is not regressed:

| light | dark | app.js refused |
|---|---|---|
| `PraisonAI` / `Starting…` on the theme's ground, FCP **80 ms** | same, dark tokens, FCP **60 ms** | `PraisonAI could not start: its code could not be loaded.` with "Starting…" withdrawn |

## A separate finding: the 1.4 MB engine chunk is not on the critical path

Read off the WebView's own `PerformanceResourceTiming` during a cold start, the whole boot fetches `app.css`, `boot-guard.js`, `app.js`, `register-sw.js`, one 1.9 kB eager chunk and the icon — nothing else. The in-process engine's chunk is `import()`ed at first use and is never touched at launch. It is not what the blank window was made of.

What the window is actually made of is the other way round: **~80 % of it is before the WebView exists at all** (1060–1222 ms of `am start` → navigationStart, against 197–300 ms of navigationStart → paint). Nothing in the web layer can cover that; only an Android window background or splash on `MainActivity`'s theme reaches it. Out of scope here, and recorded rather than papered over.

## Gates

`npm run check` exits 0 on Node 22.18.0 and Node 24.12.0, 1598 tests, read from the command's own exit code.

Bundle budgets untouched — `boot-guard.js` is copied verbatim like `register-sw.js`, not bundled: shell **82.6 kB / 400 kB**, lazy **1497.4 kB / 1600 kB**, byte-identical to before.

Twelve mutations, each killed by a NAMED test (every anchor asserted present before applying, and no APK built while one was applied):

| mutation | killed by |
|---|---|
| remove the indicator | `the page paints a boot indicator, before any script has run` |
| build it from script instead of markup | same, + `…styled by the render-blocking stylesheet, not by script` |
| leave it on screen after the first render | `the first render takes the boot indicator away` |
| blank its text | `the boot indicator says which app is starting, and that it is starting` |
| hardcode its colours | `…takes its colours from the theme tokens, so a dark device gets a dark boot screen` |
| drop the safe-area insets | `the boot indicator clears the safe-area insets` |
| silence the guard | `a boot script that fails to load turns the indicator into a failure notice` |
| move the guard to the bubble phase | `the guard listens in the CAPTURE phase, because a resource error does not bubble` |
| let a failed icon claim a failed boot | `a stylesheet or an icon that fails does not claim the app could not start` |
| drop the guard's presence check | `once the app has rendered, the guard says nothing at all` |
| load the guard after `app.js` | `the guard is loaded before the bundle, and not deferred` |
| leave the guard out of the build | `a shippable app builds…`, `the service worker precaches exactly what was built…`, `the boot screen paints before the app…` |

One of those mutations earned its keep immediately: `hardcode its colours` **survived** the first version of the colour test, because a global regex anchored on `}` consumes the brace it anchors on and had silently skipped the `.boot-mark` rule between `.boot` and `.boot-note`. The test now parses all rules and asserts the specific selectors it must have read, so a rule that stops being seen fails instead of shrinking the sample.

Rebased onto #4842, which merged during this work; the gate was re-run green on both Node versions after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an immediate startup screen displaying the PraisonAI wordmark and loading status while the app initializes.
  - Added a clear failure message when the application cannot start.

- **Bug Fixes**
  - Improved startup behavior so the loading screen is replaced cleanly by the app interface once loading completes.
  - Improved handling of application bundle-load failures with an actionable startup notice.

- **Style**
  - Added theme-aware, dark-mode-compatible styling with safe-area support for mobile devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->