### PR TITLE
fix(mobile): an empty chat says what the app is, and that it needs a key

### DIFF
--- a/src/praisonai-mobile/app/app.css
+++ b/src/praisonai-mobile/app/app.css
@@ -254,6 +254,70 @@ button:disabled { opacity: .45; cursor: default; }
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .empty { margin: auto; color: var(--soft); text-align: center; padding: 2rem 1rem; }
+
+/*
+ * The empty chat: the welcome, and the "you need a key" guidance.
+ *
+ * A SIBLING of `.transcript`, not a child -- app/src/main.ts says why (three
+ * separate code paths would delete or displace it in there). That makes the
+ * height the one thing this stylesheet has to get right: `.transcript` is
+ * `flex: 1`, so with a second `flex: 1` beside it the two would split the
+ * screen and the panel would sit in the lower half with a tall blank box above
+ * it. While the panel is up, the transcript gives up its stretch and shrinks to
+ * its content -- which is nothing, or the "engine is not answering" notice, and
+ * that notice must stay VISIBLE above the panel rather than being hidden with
+ * the rows it has none of.
+ *
+ * `data-empty` is written by main.ts and carries the KIND, so a future state
+ * can be styled differently without another attribute. The selector below only
+ * needs its presence.
+ *
+ * Colours are tokens, never literals: `--ink`, `--soft` and `--accent` are all
+ * redefined under `prefers-color-scheme: dark` at the top of this file, so the
+ * panel follows the device theme with no rule of its own. A hardcoded #14171c
+ * here would be invisible on the dark ground -- which is the whole reason the
+ * tokens exist.
+ */
+.screen[data-empty] .transcript { flex: 0 0 auto; }
+
+.empty-state {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  text-align: center;
+  /* The inline padding follows the safe area for the same reason every other
+     screen's does: a landscape cutout would otherwise clip the first and last
+     characters of every line. */
+  padding: 1.5rem calc(var(--inset-right) + 1.25rem)
+           1.5rem calc(var(--inset-left) + 1.25rem);
+}
+/* Stated explicitly, exactly as `.screen[hidden]` and `.setting-error[hidden]`
+   are: the author `display: flex` above beats the user agent's
+   `[hidden] { display: none }`, so without this line `emptyPanel.hidden = true`
+   does nothing and the welcome panel stays on screen underneath the
+   conversation. That is the same defect app/src/mount.ts hit, in a new place. */
+.empty-state[hidden] { display: none; }
+
+.empty-state .empty-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--ink);
+}
+/* Muted, and narrow: a centred sentence running the full width of a phone is
+   read as a paragraph of prose rather than as one line of guidance. */
+.empty-state .empty-body {
+  margin: 0;
+  max-width: 30ch;
+  color: var(--soft);
+  font-size: .95rem;
+}
+.empty-state button { margin-top: .5rem; }
+.empty-state button[hidden] { display: none; }
 /*
  * A row in the chat list. `.row-chat` is the class `buildChatsScreen` emits;
  * this block was written as `.chat-row`, which the app has never painted, so

--- a/src/praisonai-mobile/app/src/css.test.ts
+++ b/src/praisonai-mobile/app/src/css.test.ts
@@ -70,3 +70,157 @@ test("the viewport bridge the safe areas depend on is intact -- the pair", () =>
   assert.match(css, /--safe-area-inset-bottom:\s*env\(safe-area-inset-bottom/);
   assert.match(css, /--safe-area-inset-top:\s*env\(safe-area-inset-top/);
 });
+
+// ---- the empty chat screen --------------------------------------------------
+//
+// These four assert a stylesheet, which is exactly where a test can lie to
+// itself. The rules below are found by BRACE MATCHING, not by a global regex,
+// and every selector is looked up through `ruleFor`, which fails when it is not
+// found EXACTLY once.
+//
+// That is not fussiness. The first version of this block used
+// `/\.empty-state\s*\{([^}]*)\}/g` over the whole file, and `[^}]*` stops at
+// the first `}` -- so a rule containing a nested block, or simply renamed,
+// silently dropped out of the sample and the loop that "checked every rule"
+// checked nothing while still passing. A gate that shrinks its own sample to
+// zero and reports success is worse than no gate.
+
+interface CssRule {
+  readonly selector: string;
+  readonly body: string;
+  /** The at-rule this sits inside, or "" at the top level. */
+  readonly at: string;
+}
+
+/** Every rule in the sheet, by matching braces rather than by scanning for the
+ *  next `}`. At-rules are recursed into, so a rule inside `@media` is found
+ *  with the media condition attached rather than lost. */
+function rulesOf(css: string, at = ""): CssRule[] {
+  const out: CssRule[] = [];
+  let start = 0;
+  let i = 0;
+  while (i < css.length) {
+    if (css[i] !== "{") {
+      i += 1;
+      continue;
+    }
+    const prelude = css.slice(start, i).trim();
+    let depth = 1;
+    let j = i + 1;
+    while (j < css.length && depth > 0) {
+      if (css[j] === "{") depth += 1;
+      else if (css[j] === "}") depth -= 1;
+      j += 1;
+    }
+    assert.equal(depth, 0, `unbalanced braces in app.css after "${prelude}"`);
+    const body = css.slice(i + 1, j - 1);
+    if (prelude.startsWith("@")) out.push(...rulesOf(body, prelude));
+    else out.push({ selector: prelude, body, at });
+    i = j;
+    start = j;
+  }
+  return out;
+}
+
+const RULES = rulesOf(css);
+
+/** The one rule with this selector. Asserts it was found, so a selector that
+ *  stops existing FAILS instead of quietly leaving nothing to check. */
+function ruleFor(selector: string): CssRule {
+  const found = RULES.filter((r) => r.selector === selector);
+  assert.equal(found.length, 1, `app.css must declare "${selector}" exactly once (found ${found.length})`);
+  return found[0] as CssRule;
+}
+
+/** `color: var(--ink)` -> ["color", "var(--ink)"]. Declarations only; these
+ *  bodies hold no nested blocks. */
+const declarationsOf = (body: string): readonly (readonly [string, string])[] =>
+  body
+    .split(";")
+    .map((d) => d.trim())
+    .filter((d) => d !== "")
+    .map((d) => {
+      const at = d.indexOf(":");
+      return [d.slice(0, at).trim(), d.slice(at + 1).trim()] as const;
+    });
+
+test("the parser actually sees the stylesheet", () => {
+  // The guard on every test below: if `rulesOf` ever returned an empty or tiny
+  // list -- a syntax change, a wrong argument -- each `ruleFor` would fail, but
+  // this says so in one sentence rather than as four confusing misses.
+  assert.ok(RULES.length > 30, `only ${RULES.length} rules parsed out of app.css`);
+  const selectors = new Set(RULES.map((r) => r.selector));
+  for (const known of [":root", ".screen", ".transcript", ".composer", ".empty-state"]) {
+    assert.ok(selectors.has(known), `"${known}" was not parsed out of app.css`);
+  }
+});
+
+test("a hidden empty state is actually hidden", () => {
+  // The same defect `.screen[hidden]` was written for, in a new place: the
+  // author `display: flex` below beats the user agent's `[hidden]` rule, so
+  // without an explicit override `emptyPanel.hidden = true` does nothing and
+  // the welcome panel stays on screen underneath the conversation.
+  assert.match(ruleFor(".empty-state").body, /display:\s*flex/, "the override is only needed because of this");
+  assert.match(ruleFor(".empty-state[hidden]").body, /display:\s*none/);
+  // And the button inside it, which is hidden on its own in the welcome state.
+  assert.match(ruleFor(".empty-state button[hidden]").body, /display:\s*none/);
+});
+
+test("the transcript yields its height while the empty state is up", () => {
+  // Both are children of the same flex column and `.transcript` is `flex: 1`.
+  // With a second `flex: 1` beside it the two split the screen, and the panel
+  // sits in the lower half under a tall blank box -- the very rectangle this
+  // change exists to remove, halved.
+  assert.match(ruleFor(".transcript").body, /flex:\s*1/);
+  assert.match(ruleFor(".screen[data-empty] .transcript").body, /flex:\s*0\s+0\s+auto/);
+  // The attribute the rule hangs on has to be one the app actually writes.
+  assert.match(main, /dataset\["empty"\]/, "app.css keys off data-empty; main.ts must set it");
+});
+
+test("the empty state is legible in dark mode, because it uses no literal colours", () => {
+  // The mutation this kills: replacing `var(--ink)` with the light value it
+  // resolves to. That looks identical in every screenshot taken in light mode
+  // and renders near-black text on the near-black dark ground.
+  //
+  // Both halves are asserted -- that the panel names tokens, and that the
+  // tokens it names are actually redefined for dark. Either alone passes over
+  // the bug: a token with no dark value is a literal with extra steps.
+  const dark = RULES.filter((r) => /prefers-color-scheme:\s*dark/.test(r.at));
+  assert.ok(dark.length > 0, "app.css has no dark-scheme block at all");
+  const darkTokens = new Set(
+    dark.flatMap((r) => declarationsOf(r.body).map(([prop]) => prop)).filter((p) => p.startsWith("--")),
+  );
+  const rootTokens = new Set(
+    declarationsOf(ruleFor(":root").body).map(([prop]) => prop).filter((p) => p.startsWith("--")),
+  );
+
+  let checked = 0;
+  for (const selector of [".empty-state .empty-title", ".empty-state .empty-body"]) {
+    const rule = ruleFor(selector);
+    const colours = declarationsOf(rule.body).filter(([prop]) => prop === "color");
+    assert.equal(colours.length, 1, `${selector} must state its colour exactly once`);
+    const [, value] = colours[0] as readonly [string, string];
+    const token = /var\((--[a-z-]+)\)/.exec(value)?.[1];
+    assert.ok(token !== undefined, `${selector} paints a literal colour: ${value}`);
+    assert.ok(rootTokens.has(token), `${token} is not defined on :root`);
+    assert.ok(darkTokens.has(token), `${token} has no dark-scheme value, so ${selector} cannot follow the theme`);
+    checked += 1;
+  }
+  // The sample cannot shrink to nothing and still pass.
+  assert.equal(checked, 2, "both empty-state text rules must have been checked");
+});
+
+test("the empty state keeps clear of the safe area", () => {
+  // Every other full-width surface in this file lays out against `--inset-*`
+  // and this one is no different: a landscape cutout would otherwise clip the
+  // first and last characters of a centred line. The insets are ADDED to the
+  // gutter rather than replacing it, for the reason the composer states -- a
+  // device with no inset on a side must still keep its gutter.
+  const padding = declarationsOf(ruleFor(".empty-state").body).filter(([prop]) => prop === "padding");
+  assert.equal(padding.length, 1, ".empty-state must state its padding exactly once");
+  const [, value] = padding[0] as readonly [string, string];
+  for (const name of ["--inset-left", "--inset-right"]) {
+    assert.ok(value.includes(name), `.empty-state ignores ${name}: ${value}`);
+  }
+  assert.match(value, /\+\s*[\d.]+rem/, `the gutter must survive a zero inset: ${value}`);
+});

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -2890,3 +2890,144 @@ test("an engine that needs no key never asks for one", async () => {
   assert.ok(words.includes(en.emptyAbout), words);
   await app?.dispose();
 });
+
+test("the guidance follows the engine IN FORCE, not the engineId setting", async () => {
+  // The engine is selected once at boot and the controller holds that instance:
+  // switching `engineId` in Settings changes the setting but not the engine
+  // answering until the next launch. So the panel must read `app.engine.id` --
+  // the engine actually handling prompts -- and not the live setting, or it
+  // describes an engine other than the one the user's next message hits.
+  //
+  // Measured before the fix, the other way round: on a device with no key the
+  // guidance was up, setting `engineId` to the remote engine dropped it, and
+  // `app.engine.id` was still `praisonai-ts` -- so the app said no key was
+  // needed and the next message went to the engine that needs one.
+  const { dom, platform } = harness(); // web default: the remote engine is in force
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  await settle();
+  assert.equal(app?.engine.id, ENGINE_REMOTE_HTTP, "precondition: the remote engine is answering");
+  assert.equal(emptyWords(dom).includes(en.emptyNeedsKeyTitle), false, "precondition: no key demanded");
+
+  // Flip the persisted engine choice under the panel. The running engine does
+  // not change, so the guidance must not either.
+  await app!.settings.set("engineId", ENGINE_PRAISONAI_TS);
+  await settle();
+
+  // Then force a repaint through a path the user actually has. Asserting
+  // straight after the `set` would prove nothing: nothing repaints the panel on
+  // a settings write, so a version reading the SETTING would also still show
+  // the welcome here and the test would pass over the bug. New chat re-runs the
+  // empty state, which is where a wrong source of truth becomes visible.
+  dom.click(dom.find((n) => n.dataset["action"] === "new-chat") as never);
+  await settle();
+
+  assert.equal(app?.engine.id, ENGINE_REMOTE_HTTP, "the engine in force must not have changed mid-session");
+  const words = emptyWords(dom);
+  assert.equal(
+    words.includes(en.emptyNeedsKeyTitle),
+    false,
+    `the panel demanded a key for an engine that is not the one running:\n${words}`,
+  );
+  await app?.dispose();
+});
+
+test("clearing a key while Settings is open is announced on return to chat", async () => {
+  // The polite region lives inside the chat screen, which is `hidden` while
+  // Settings is on top -- and a hidden element is out of the accessibility tree
+  // entirely, so a key removed there changes the empty state to needs-key
+  // against a region nobody is listening to. Marking it announced in that
+  // window would leave the "you now need a key" transition permanently
+  // unspoken. It must be said the moment chat is visible again -- reached here
+  // through the OS Back gesture, which is how a user returns from Settings.
+  const shell = createFakeShell(PHONE_INSETS);
+  const dom = createFakeDom();
+  const secrets = createFakeSecrets();
+  const platform: Platform = {
+    shell, storage: createFakeStorage(), secrets,
+    http: createFakeHttp(), time: nodeTime(), kind: "tauri",
+  };
+  await secrets.set({ slot: "openai", account: "default" }, "sk-already-stored");
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  await settle();
+  assert.equal(emptyWords(dom).includes(en.emptyNeedsKeyTitle), false, "precondition: welcomed, not demanding");
+
+  // Open Settings (chat screen hidden) and remove the key there.
+  dom.click(dom.find((n) => n.dataset["route"] === "settings") as never);
+  await settle();
+  const chatScreen = dom.find((n) => n.className === "screen");
+  assert.equal(chatScreen?.hidden, true, "precondition: the chat screen is hidden behind Settings");
+  const remove = dom.find((n) => n.dataset["action"] === "clear-secret");
+  assert.ok(remove, `no way to remove the key:\n${dom.text()}`);
+  dom.click(remove as never);
+  await settle();
+
+  // THE DISCRIMINATING ASSERTION, and the reason this test is not just "the
+  // region ends up with the right words in it". A live region announces on
+  // CHANGE; a change made while the region sits in a hidden subtree is heard by
+  // nobody and is not replayed when the subtree is shown again. So writing the
+  // guidance here would look identical at the end of the test and be silent in
+  // practice -- measured: removing the `screen.hidden` guard left every
+  // assertion below passing. What has to be true is that the region is still
+  // holding its PREVIOUS text at this point.
+  const polite = dom.find((n) => n.getAttribute("aria-live") === "polite");
+  assert.ok(polite);
+  assert.equal(
+    polite.textContent.includes(en.emptyNeedsKeyTitle),
+    false,
+    `announced into a hidden screen, where no reader hears it: "${polite.textContent}"`,
+  );
+
+  // Back to the chat. The empty state is now needs-key, and it must be spoken
+  // -- not silently swallowed while the screen was hidden.
+  shell.pressBack();
+  await settle();
+
+  assert.equal(chatScreen?.hidden, false, "the chat screen must be visible again after Back");
+  assert.ok(emptyWords(dom).includes(en.emptyNeedsKeyTitle), `the guidance did not return:\n${dom.text()}`);
+  assert.ok(
+    polite.textContent.includes(en.emptyNeedsKeyTitle),
+    `the needs-key transition was never announced:\n${polite.textContent}`,
+  );
+  await app?.dispose();
+});
+
+test("the chrome is never a blank rectangle, not even while boot is still running", async () => {
+  // The window #4845's boot indicator cannot cover. `mount` appends the chrome
+  // and THEN awaits `bootOrFail`; the indicator was retired by the
+  // `root.textContent = ""` in that same statement pair, so between the two the
+  // screen is a header, an empty middle and a Send button -- defect #8 exactly.
+  // Measured on an Android 35 emulator before this: 117ms of it on a cold
+  // start, 3.928s to 4.045s.
+  //
+  // Asserted with NO await at all. Everything up to `bootOrFail` is
+  // synchronous, so the panel has to be on screen the instant `mount` yields --
+  // which is what makes this a test of the seed and not of the post-boot
+  // refresh. A single `await` here would let boot finish and the test would
+  // pass without the seed existing.
+  const { dom, platform: web } = harness();
+  const pending = mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+  });
+
+  const panel = emptyPanel(dom);
+  assert.ok(panel, "no empty state was painted before boot finished");
+  assert.equal(panel.hidden, false, "the chrome was a blank rectangle while booting");
+  // The WELCOME, not the guidance: nothing has asked the keychain yet, and
+  // guessing "no key" here would accuse a configured user on every launch.
+  assert.ok(panel.textContent.includes(en.emptyTranscript), panel.textContent);
+  assert.equal(
+    panel.textContent.includes(en.emptyNeedsKeyTitle),
+    false,
+    "a key was declared missing before anything asked the keychain",
+  );
+
+  const app = await pending;
+  await settle();
+  // And once boot has finished and the keychain has answered, it becomes the
+  // guidance -- so the seed is a starting state, not a state it gets stuck in.
+  assert.ok(emptyWords(dom).includes(en.emptyNeedsKeyTitle), emptyWords(dom));
+  await app?.dispose();
+});

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -56,7 +56,7 @@ import { createFakeStorage } from "../../testing/src/fake-storage.ts";
 import { createFakeSecrets } from "../../testing/src/fake-secrets.ts";
 import { createFakeHttp, sseResponse, streamOf } from "../../testing/src/fake-http.ts";
 import { PROTOCOL_VERSION } from "../../protocol/src/version.ts";
-import { appEngines, mount } from "./main.ts";
+import { appEngines, mount, EMPTY_TITLE_ID } from "./main.ts";
 import { ENGINE_PRAISONAI_TS, ENGINE_REMOTE_HTTP, SETTING_DEFS } from "./registry.ts";
 import { createSettingsStore, facadeFor, type SettingsFacade } from "../../core/src/settings/store.ts";
 import type { Platform } from "./platform.ts";
@@ -2608,5 +2608,285 @@ test("the first render takes the boot indicator away", async () => {
   // emptied -- an indicator removed with nothing put in its place would pass
   // the assertion above while showing the blank page this all exists to fix.
   assert.ok(dom.find((n) => n.tagName === "TEXTAREA") !== null, "the composer replaced it");
+  await app?.dispose();
+});
+
+// ---- the empty chat screen, through the composition root --------------------
+//
+// Defects #3 and #8 were one screen: on a fresh launch the app rendered a
+// header, several hundred pixels of nothing, and a Send button, and the only
+// thing that ever mentioned the API key it cannot work without was the provider
+// SDK, after a message had been sent, in the words "The OPENAI_API_KEY
+// environment variable is missing or empty".
+//
+// `ui/src/transcript/empty-state.test.ts` owns the decision; these own the
+// WIRING, which is where every defect this file has ever found actually lived:
+// a pure function that is right and a composition root that calls it wrongly,
+// or not at all.
+
+/** The empty-state panel, or null when the app never built one. */
+const emptyPanel = (dom: ReturnType<typeof createFakeDom>) =>
+  dom.find((n) => n.className === "empty-state");
+
+/** The panel's words, or "" when it is absent or hidden -- which is what the
+ *  user sees in either case. */
+const emptyWords = (dom: ReturnType<typeof createFakeDom>): string => {
+  const panel = emptyPanel(dom);
+  return panel === null || panel.hidden ? "" : panel.textContent;
+};
+
+test("a fresh install is told it needs a key, on the first screen", async () => {
+  // Defect #3, end to end. `kind: "tauri"` is the device default, so the
+  // in-process engine is what would answer -- the engine that cannot answer
+  // anything without a key. Nothing is stored in the fake keychain.
+  const { dom, platform: web } = harness();
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+  });
+  // The keychain lookup is async; the guidance appears when it lands.
+  await settle();
+
+  const panel = emptyPanel(dom);
+  assert.ok(panel, `no empty state was built at all:\n${dom.text()}`);
+  assert.equal(panel.hidden, false, "the empty state must be on screen for a fresh install");
+  assert.ok(emptyWords(dom).includes(en.emptyNeedsKeyTitle), emptyWords(dom));
+  assert.ok(emptyWords(dom).includes(en.emptyNeedsKeyBody), emptyWords(dom));
+  await app?.dispose();
+});
+
+test("the key guidance offers a tap through to Settings", async () => {
+  // Saying a key is needed and leaving the user to find the screen that takes
+  // one is the same defect one step softer. The button goes through the SAME
+  // `navigate` intent every other route button does, so this asserts the screen
+  // actually changes rather than that a button exists.
+  const { dom, platform: web } = harness();
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+  });
+  await settle();
+
+  const panel = emptyPanel(dom);
+  assert.ok(panel);
+  const button = panel.children.find((c) => c.tagName === "BUTTON");
+  assert.ok(button, `the guidance has no way out of it:\n${panel.textContent}`);
+  assert.equal(button.hidden, false);
+  assert.equal(button.dataset["route"], "settings");
+
+  dom.click(button as never);
+  await settle();
+  assert.ok(keyField(dom), `tapping the guidance did not reach Settings:\n${dom.text()}`);
+  await app?.dispose();
+});
+
+test("a device with a key stored is welcomed, not told to configure the app", async () => {
+  // The mutation this kills: showing the "needs a key" copy when a key IS set.
+  // Same platform, same engine, one difference -- and it is the state a
+  // returning user meets on every new chat for the life of the install.
+  const { dom, platform: web, secrets } = harness();
+  await secrets.set({ slot: "openai", account: "default" }, "sk-already-stored");
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+  });
+  await settle();
+
+  const words = emptyWords(dom);
+  assert.ok(words.includes(en.emptyTranscript), words);
+  assert.ok(words.includes(en.emptyAbout), words);
+  assert.equal(words.includes(en.emptyNeedsKeyTitle), false, "a configured user must not be told to configure");
+  const button = emptyPanel(dom)?.children.find((c) => c.tagName === "BUTTON");
+  assert.equal(button?.hidden, true, "there is nothing to fix, so there is no button");
+  await app?.dispose();
+});
+
+test("pasting a key in Settings clears the guidance from the chat behind it", async () => {
+  // The transition, which is the whole point of the guidance: the user does the
+  // one thing it asks and the screen it came from stops asking. A panel that
+  // only re-reads the keychain at boot would still be demanding a key on the
+  // chat screen immediately after one was saved.
+  const { dom, platform: web } = harness();
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+  });
+  await settle();
+  assert.ok(emptyWords(dom).includes(en.emptyNeedsKeyTitle), "precondition: the guidance is up");
+
+  await openSettings(dom);
+  const field = keyField(dom);
+  assert.ok(field);
+  field.value = "sk-pasted";
+  dom.change(field as never);
+  await settle();
+
+  const words = emptyWords(dom);
+  assert.equal(words.includes(en.emptyNeedsKeyTitle), false, `still demanding a key:\n${words}`);
+  assert.ok(words.includes(en.emptyTranscript), words);
+  await app?.dispose();
+});
+
+test("the empty state goes the moment the transcript has anything in it", async () => {
+  // Defect #8's other half, and the constraint that matters most: the panel
+  // must not fight the user/assistant rows. `publish` is the one place rows
+  // arrive, so this drives a real turn over the fake transport rather than
+  // poking the DOM.
+  const { dom, http, platform } = harness();
+  http.on("/chat", () =>
+    sseResponse(
+      sse([
+        ["start", { msg_id: "m1", run_id: "r1" }],
+        ["delta", { msg_id: "m1", text: "Paris." }],
+        ["end", { msg_id: "m1", user_index: 0, assistant_index: 1, versions: 1, active: 0 }],
+      ]),
+    ),
+  );
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  await settle();
+  assert.notEqual(emptyWords(dom), "", "precondition: an empty chat says something");
+
+  submit(dom, "capital of france?");
+  await settle(120);
+
+  assert.equal(emptyPanel(dom)?.hidden, true, `the empty state survived a conversation:\n${dom.text()}`);
+  // And the rows it was standing in for are there instead.
+  assert.ok(dom.find((n) => n.className.includes("row-user")), "the user's message must be on screen");
+  assert.ok(dom.text().includes("Paris."), dom.text());
+
+  // New chat empties the transcript, so the empty state comes back -- the same
+  // three resets that clear the rows must not leave a blank rectangle behind.
+  dom.click(dom.find((n) => n.dataset["action"] === "new-chat") as never);
+  await settle();
+  assert.equal(emptyPanel(dom)?.hidden, false, `New chat left a blank screen:\n${dom.text()}`);
+  assert.ok(emptyWords(dom).includes(en.emptyTranscript), emptyWords(dom));
+  await app?.dispose();
+});
+
+test("the empty chat is announced, so it is not silent to a screen reader", async () => {
+  // An empty transcript is a `role="log"` with nothing in it. Without this the
+  // one screen a new user lands on has nothing at all to say to them.
+  const { dom, platform: web } = harness();
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+  });
+  await settle();
+
+  const polite = dom.find((n) => n.getAttribute("aria-live") === "polite");
+  assert.ok(polite);
+  assert.ok(polite.textContent.includes(en.emptyNeedsKeyTitle), `polite region said "${polite.textContent}"`);
+  // The way out is in the sentence, not three tab stops away.
+  assert.ok(polite.textContent.includes(en.recoveryLabel("settings")), polite.textContent);
+  await app?.dispose();
+});
+
+test("the empty state is a named landmark, not an unlabelled block", async () => {
+  // `aria-labelledby` and NOT `aria-label`: a label on a container replaces its
+  // contents in the accessibility tree (a11y/names.ts rule 3), which would cost
+  // the reader the sentence and the button. A landmark pointing at an id that
+  // does not exist has no name at all, so the pair is asserted together.
+  const { dom, platform: web } = harness();
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+  });
+  await settle();
+
+  const panel = emptyPanel(dom);
+  assert.ok(panel);
+  assert.equal(panel.getAttribute("role"), "region");
+  assert.equal(panel.getAttribute("aria-label"), null, "a label here would hide the panel's own words");
+  const labelledBy = panel.getAttribute("aria-labelledby");
+  assert.equal(labelledBy, EMPTY_TITLE_ID);
+  const heading = dom.find((n) => n.getAttribute("id") === labelledBy);
+  assert.ok(heading, "the landmark names an element that does not exist");
+  assert.equal(heading.textContent, en.emptyNeedsKeyTitle);
+  await app?.dispose();
+});
+
+test("presence is read with has(), never by faulting the key into the screen", async () => {
+  // ports/secrets.ts rule 2, applied to the new caller. The chat screen asks
+  // "is one configured?" and must not be able to answer it with `get()` -- and
+  // the value must never reach the rendered text, where a screenshot or a crash
+  // dump would pick it up.
+  const { dom, platform: web, secrets } = harness();
+  await secrets.set({ slot: "openai", account: "default" }, "sk-must-not-be-rendered");
+  const before = secrets.reads;
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+  });
+  await settle();
+
+  assert.equal(secrets.reads, before, "the empty state must ask presence, not read the value");
+  assert.equal(dom.text().includes("sk-must-not-be-rendered"), false);
+  await app?.dispose();
+});
+
+test("the boot indicator is gone before the empty state arrives -- neither, nor both", async () => {
+  // The one interaction between this change and #4845 worth pinning rather than
+  // assuming. `app/index.html` paints a wordmark and "Starting…" into #root on
+  // the first frame; `mount` clears #root and appends the chat screen in the
+  // same statement pair. The empty state lives INSIDE that screen, so it can
+  // only arrive with the swap -- never beside the indicator, and never leaving a
+  // frame with nothing on it.
+  //
+  // Both halves are asserted together, because either alone passes over the
+  // failure: "the indicator is gone" is satisfied by an app that renders
+  // nothing, and "the panel is up" is satisfied by an app that painted it
+  // underneath a leftover boot screen.
+  const { dom, platform: web } = harness();
+  const boot = dom.make("div");
+  boot.className = "boot";
+  boot.dataset["boot"] = "";
+  dom.root.append(boot);
+
+  const app = await mount({
+    root: dom.root as never,
+    platform: { ...web, kind: "tauri" },
+    now: () => 1,
+    newChatId: () => "c1",
+  });
+  await settle();
+
+  assert.equal(
+    dom.find((n) => n.dataset["boot"] !== undefined),
+    null,
+    "the boot indicator must not survive alongside the empty state",
+  );
+  assert.equal(emptyPanel(dom)?.hidden, false, `nothing replaced the boot indicator:\n${dom.text()}`);
+  assert.ok(emptyWords(dom).includes(en.emptyNeedsKeyTitle), emptyWords(dom));
+  // And the indicator's own words are not still on the page under another name.
+  assert.equal(dom.text().includes("Starting"), false, dom.text());
+  await app?.dispose();
+});
+
+test("an engine that needs no key never asks for one", async () => {
+  // The web default is the remote engine, which authenticates at the server it
+  // talks to. Telling its user to paste an OpenAI key sends them to configure a
+  // credential nothing on this device reads.
+  const { dom, platform } = harness();
+  const app = await mount({ root: dom.root as never, platform, now: () => 1, newChatId: () => "c1" });
+  await settle();
+
+  const words = emptyWords(dom);
+  assert.notEqual(words, "", "an empty chat still has to say something");
+  assert.equal(words.includes(en.emptyNeedsKeyTitle), false, words);
+  assert.ok(words.includes(en.emptyAbout), words);
   await app?.dispose();
 });

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -15,7 +15,13 @@
  */
 import { createApp, type App } from "./boot.ts";
 import { detectPlatform, type Platform } from "./platform.ts";
-import { enginesFor, apiKeyFor, defaultEngineIdFor, settingDefsFor } from "./registry.ts";
+import {
+  enginesFor,
+  apiKeyFor,
+  defaultEngineIdFor,
+  settingDefsFor,
+  ENGINE_PRAISONAI_TS,
+} from "./registry.ts";
 import { intentFrom, type Actionable, type Intent } from "./intents.ts";
 import { applyOps, emptyNodes, type RowNodes } from "./dom.ts";
 import { installCrashHandler } from "./crash.ts";
@@ -28,7 +34,12 @@ import { en, type Strings } from "../../ui/src/i18n/strings.ts";
 import { announce, initialAnnouncer, type AnnouncerState } from "../../ui/src/a11y/announce.ts";
 import { createScreens } from "./mount.ts";
 import { transition, screenFor, type ScreenId } from "../../ui/src/screens.ts";
-import { routeTitle, chatRowName } from "../../ui/src/a11y/names.ts";
+import { routeTitle, chatRowName, emptyStateName } from "../../ui/src/a11y/names.ts";
+import {
+  emptyState,
+  type EmptyStateKind,
+  type KeyPresence,
+} from "../../ui/src/transcript/empty-state.ts";
 import {
   focusForRoute,
   headingId,
@@ -563,6 +574,16 @@ function renderFatal(root: HTMLElement, message: string): void {
 }
 
 /**
+ * The id the empty-state region is named by.
+ *
+ * A constant rather than a literal in two places: the `aria-labelledby` and the
+ * heading's `id` have to be the same string, and a landmark pointing at an id
+ * that does not exist has NO accessible name at all -- it is announced as a
+ * bare "region", which is worse than not being a landmark.
+ */
+export const EMPTY_TITLE_ID = "empty-state-title";
+
+/**
  * What to announce after a Stop, or null when there is nothing to say.
  *
  * Extracted so a test calls it: `mount` needs a whole fake SSE transport to
@@ -738,6 +759,41 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   transcript.setAttribute("role", "log");
   transcript.setAttribute("aria-label", strings.appName);
 
+  /**
+   * What an empty chat says. A SIBLING of the transcript, never a child of it.
+   *
+   * Three separate things in this file would destroy or displace it if it lived
+   * inside `.transcript`: `applyOps` places rows by `children[index]`, so an
+   * extra node shifts every insert; New chat, Open chat and deleting the open
+   * chat each do `transcript.textContent = ""`, which would silently delete it;
+   * and the reconciler's `remove` ops only know the nodes it created. Outside,
+   * it is owned by exactly one function and nothing else can touch it.
+   *
+   * `role="region"` with `aria-labelledby`, not `aria-label`: a label on a
+   * generic container REPLACES its contents in the accessibility tree
+   * (a11y/names.ts rule 3), which would cost the reader the paragraph and the
+   * button. A landmark named by its own heading keeps both browsable and still
+   * gives the block a name to arrive at.
+   */
+  const emptyPanel = doc.createElement("section");
+  emptyPanel.className = "empty-state";
+  emptyPanel.setAttribute("role", "region");
+  emptyPanel.setAttribute("aria-labelledby", EMPTY_TITLE_ID);
+  emptyPanel.hidden = true;
+  const emptyTitle = doc.createElement("h2");
+  emptyTitle.className = "empty-title";
+  emptyTitle.setAttribute("id", EMPTY_TITLE_ID);
+  const emptyBody = doc.createElement("p");
+  emptyBody.className = "empty-body";
+  const emptyAction = doc.createElement("button");
+  emptyAction.type = "button";
+  emptyAction.dataset["action"] = "navigate";
+  emptyAction.dataset["variant"] = "primary";
+  // Hidden until a view supplies one. A button with no label is announced as
+  // "button" and is a hit target that does nothing.
+  emptyAction.hidden = true;
+  emptyPanel.append(emptyTitle, emptyBody, emptyAction);
+
   const polite = doc.createElement("div");
   polite.className = "sr-only";
   polite.setAttribute("aria-live", "polite");
@@ -771,7 +827,7 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   jumpLatest.textContent = strings.streaming;
   jumpLatest.hidden = true;
 
-  screen.append(bar, transcript, jumpLatest, composer, polite, assertive);
+  screen.append(bar, transcript, emptyPanel, jumpLatest, composer, polite, assertive);
   // This is also what RETIRES the boot indicator, and the ordering is the whole
   // guarantee. `app/index.html` paints a wordmark and "Starting…" into #root on
   // the first frame so a cold start does not look like a broken install; the
@@ -781,6 +837,13 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   // a `removeChild` of a known id: anything the page painted before the app did
   // is the app's to replace, and a targeted removal would leave a second
   // element behind the day someone adds one.
+  //
+  // The empty state is inside `screen` and therefore inside that same swap: it
+  // arrives with the rest of the UI, never beside the indicator. Its own
+  // visibility is decided one step later by `refreshEmptyState`, which is why
+  // the panel is built `hidden` -- a panel that defaulted to visible would show
+  // the welcome for a frame before the keychain answered, on an install that
+  // has no key.
   root.textContent = "";
   root.append(screen);
 
@@ -855,6 +918,18 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   let liveRows: readonly Row[] = [];
   let turnSeq = 0;
   let turnEnded = false;
+
+  /**
+   * Repaint the empty state. A no-op until boot has finished.
+   *
+   * Forward-declared because `publish` is handed to `bootOrFail` and can be
+   * called from inside it, before anything that needs `app` exists. A `const`
+   * declared further down would be in its temporal dead zone at that moment,
+   * and the first publish of the session would throw a ReferenceError into the
+   * crash handler -- replacing the whole app with the fatal screen on the very
+   * first token.
+   */
+  let refreshEmptyState: () => void = () => {};
 
   /** A turn's rows, namespaced so no two turns can claim the same id. Both
    *  turns of a two-turn chat produce `text:0`; see `liveRows`. */
@@ -990,6 +1065,11 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     follow = outcome.state;
     if (outcome.action.kind === "scrollTo") transcript.scrollTop = outcome.action.top;
     applyFollow();
+
+    // The transcript now has rows, so the empty state must go -- and it has to
+    // go on the SAME frame the first row appears, or the welcome panel and the
+    // user's own message are on screen together.
+    refreshEmptyState();
   };
 
   // `createApp` returns a typed BootResult for the failures it anticipated --
@@ -1195,14 +1275,24 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     const seq = ++latestPresenceSeq;
     void (async (): Promise<void> => {
       const answers = new Map<string, string>();
+      // Whether ANY credential is on file, which is the question the empty chat
+      // screen asks. Resolved from the same walk rather than from a second one:
+      // two independent lookups over the same keychain can land out of order
+      // and disagree, so the settings row saying "Configured" and the chat
+      // screen saying "Add an API key" would both be showing at once.
+      let anyPresent = false;
       for (const def of app.settings.defs()) {
         const ref = secretRefOf(def);
         if (ref === null) continue;
-        answers.set(def.key, presenceLabel((await app.settings.hasSecret(ref)) ? "configured" : "not-set"));
+        const present = await app.settings.hasSecret(ref);
+        anyPresent = anyPresent || present;
+        answers.set(def.key, presenceLabel(present ? "configured" : "not-set"));
       }
       // A newer refresh started while this one awaited: its answer is the
       // current truth, so this one must not overwrite it.
       if (seq !== latestPresenceSeq) return;
+      keyPresence = anyPresent ? "present" : "absent";
+      refreshEmptyState();
       for (const node of everyElement(scope)) {
         const key = node.dataset["secretPresence"];
         if (key === undefined) continue;
@@ -1215,8 +1305,106 @@ export async function mount(deps: MountDeps): Promise<App | null> {
       // their key is gone because a lookup failed -- view-model.ts rule 2, and
       // the reason UNKNOWN is a state at all. A floating rejection here would
       // also reach the global crash handler and replace the whole app.
+      //
+      // `keyPresence` is left where it was for the same reason, which is why it
+      // has an `unknown` value at all: a keychain that will not answer must not
+      // be reported to the user as "you have not set a key". See rule 3 of
+      // ui/src/transcript/empty-state.ts.
     });
   };
+
+  // ---- the empty chat -----------------------------------------------------
+  /**
+   * Whether a credential is on file, as far as anyone has actually been told.
+   *
+   * Starts `unknown`, not `absent`. The first paint happens before any keychain
+   * lookup can return, and rendering "Add an API key to start" during that
+   * window accuses every configured user of not having set one, on every
+   * launch, for as long as the lookup takes.
+   */
+  let keyPresence: KeyPresence = "unknown";
+
+  /** The kind last read into the polite region, so a repaint that changes
+   *  nothing does not re-announce. Reset to null when the panel goes away, so
+   *  the next empty chat is announced again. */
+  let announcedEmptyKind: EmptyStateKind | null = null;
+
+  /**
+   * Whether the engine that would answer the next message authenticates with a
+   * key held on this device.
+   *
+   * Read at paint time, not captured: `engineId` is a setting, and a user who
+   * switches from the remote engine to the in-process one has just made a
+   * missing key start mattering. Read through the facade so it follows the same
+   * value Settings shows.
+   */
+  const engineNeedsKey = (): boolean =>
+    app.settings.get("engineId") === ENGINE_PRAISONAI_TS;
+
+  refreshEmptyState = (): void => {
+    const view = emptyState(
+      {
+        // Both lists, because either one alone is a transcript: a reopened
+        // conversation has only `priorRows` and a first turn has only
+        // `liveRows`.
+        hasRows: priorRows.length + liveRows.length > 0,
+        keyRequired: engineNeedsKey(),
+        key: keyPresence,
+      },
+      strings,
+    );
+
+    if (view === null) {
+      emptyPanel.hidden = true;
+      // The stylesheet gives the transcript back its full height. Written as a
+      // data attribute rather than an inline style so the rule stays in
+      // app.css, where css.test.ts can see it.
+      delete screen.dataset["empty"];
+      announcedEmptyKind = null;
+      return;
+    }
+
+    emptyPanel.hidden = false;
+    screen.dataset["empty"] = view.kind;
+    emptyTitle.textContent = view.title;
+    emptyBody.textContent = view.body;
+    if (view.action === null) {
+      emptyAction.hidden = true;
+      // The route goes with the button. A hidden control still carrying
+      // `data-route` is one stylesheet mistake away from being tappable and
+      // sending a user who has a key configured to Settings for no reason.
+      delete emptyAction.dataset["route"];
+      emptyAction.textContent = "";
+    } else {
+      emptyAction.hidden = false;
+      emptyAction.textContent = view.action.label;
+      emptyAction.dataset["route"] = view.action.route;
+    }
+
+    // Said once per appearance, and again only when the state changes KIND --
+    // which is exactly the transition from "start typing" to "you cannot yet",
+    // the one a screen-reader user must not miss. An empty `role="log"` says
+    // nothing on its own, so without this a fresh chat is silent.
+    if (view.kind !== announcedEmptyKind) {
+      polite.textContent = emptyStateName(strings, view);
+      announcedEmptyKind = view.kind;
+    }
+  };
+
+  // The engine can change under the panel: switching to the in-process engine
+  // is what makes a missing key start mattering, and switching away is what
+  // makes it stop. `subscribe` fires only on ACCEPTED writes, so a refused
+  // value does not repaint.
+  app.settings.subscribe(() => {
+    refreshEmptyState();
+  });
+
+  // The first paint, and the first keychain lookup. `root` holds no secret rows
+  // yet -- Settings has not been built -- so this call is here for its OTHER
+  // half: it is what resolves `keyPresence` from `unknown`, which is what turns
+  // the welcome into the key guidance on a fresh install.
+  refreshEmptyState();
+  refreshSecretPresence(root);
 
   // ---- screens the router drives -----------------------------------------
   // The chat screen is retained (it holds scroll position and a live stream);
@@ -1528,6 +1716,10 @@ export async function mount(deps: MountDeps): Promise<App | null> {
         // again -- but still there for anyone navigating the page.
         polite.textContent = "";
         assertive.textContent = "";
+        // The transcript is empty again, so the empty state comes back -- and
+        // it is the welcome or the key guidance depending on what is on file
+        // NOW, not on what was true when the app launched.
+        refreshEmptyState();
         return;
       }
       case "navigate":
@@ -1626,6 +1818,7 @@ export async function mount(deps: MountDeps): Promise<App | null> {
           announcer = initialAnnouncer;
           transcript.textContent = "";
           polite.textContent = "";
+          refreshEmptyState();
         }
         assertive.textContent = strings.chatDeleted(title);
         const list = screens.nodes.get("chats");
@@ -1729,6 +1922,9 @@ export async function mount(deps: MountDeps): Promise<App | null> {
         const seeded = reconcile(render, priorRows);
         applyOps(transcript, nodes, seeded.ops, strings);
         render = seeded.next;
+        // A stored chat that turned out to have no messages is as empty as a
+        // new one and gets the same panel; one with history hides it.
+        refreshEmptyState();
         app.router.push({ name: "chat", chatId: intent.chatId });
         return;
       }

--- a/src/praisonai-mobile/app/src/main.ts
+++ b/src/praisonai-mobile/app/src/main.ts
@@ -38,6 +38,7 @@ import { routeTitle, chatRowName, emptyStateName } from "../../ui/src/a11y/names
 import {
   emptyState,
   type EmptyStateKind,
+  type EmptyStateView,
   type KeyPresence,
 } from "../../ui/src/transcript/empty-state.ts";
 import {
@@ -794,6 +795,67 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   emptyAction.hidden = true;
   emptyPanel.append(emptyTitle, emptyBody, emptyAction);
 
+  /** The kind last read into the polite region, so a repaint that changes
+   *  nothing does not re-announce. Reset to null when the panel goes away, so
+   *  the next empty chat is announced again. */
+  let announcedEmptyKind: EmptyStateKind | null = null;
+
+  /**
+   * The panel's DOM, written from a view. Takes no `app`, deliberately.
+   *
+   * Split from `refreshEmptyState`, which DECIDES, so that the first paint can
+   * happen before boot -- see the seed below. Everything in here is a write.
+   */
+  const paintEmptyState = (view: EmptyStateView | null): void => {
+    if (view === null) {
+      emptyPanel.hidden = true;
+      // The stylesheet gives the transcript back its full height. Written as a
+      // data attribute rather than an inline style so the rule stays in
+      // app.css, where css.test.ts can see it.
+      delete screen.dataset["empty"];
+      announcedEmptyKind = null;
+      return;
+    }
+
+    emptyPanel.hidden = false;
+    screen.dataset["empty"] = view.kind;
+    emptyTitle.textContent = view.title;
+    emptyBody.textContent = view.body;
+    if (view.action === null) {
+      emptyAction.hidden = true;
+      // The route goes with the button. A hidden control still carrying
+      // `data-route` is one stylesheet mistake away from being tappable and
+      // sending a user who has a key configured to Settings for no reason.
+      delete emptyAction.dataset["route"];
+      emptyAction.textContent = "";
+    } else {
+      emptyAction.hidden = false;
+      emptyAction.textContent = view.action.label;
+      emptyAction.dataset["route"] = view.action.route;
+    }
+
+    // Said once per appearance, and again only when the state changes KIND --
+    // which is exactly the transition from "start typing" to "you cannot yet",
+    // the one a screen-reader user must not miss. An empty `role="log"` says
+    // nothing on its own, so without this a fresh chat is silent.
+    //
+    // But only while the chat screen is actually on screen. Removing a key in
+    // Settings changes the kind, and the polite region lives INSIDE the chat
+    // screen, which `mount.ts` has set `hidden` -- a hidden element is out of
+    // the accessibility tree entirely, so the announcement is made to nobody.
+    // Recording it as announced there would be worse than not announcing: the
+    // "you now need a key" transition would then never be spoken at all,
+    // because on return the kind matches what was already marked said. So the
+    // panel is repainted and `announcedEmptyKind` is left alone; `showRoute`
+    // re-runs this the moment chat is visible again.
+    if (screen.hidden) return;
+    if (view.kind !== announcedEmptyKind) {
+      polite.textContent = emptyStateName(strings, view);
+      announcedEmptyKind = view.kind;
+    }
+  };
+
+
   const polite = doc.createElement("div");
   polite.className = "sr-only";
   polite.setAttribute("aria-live", "polite");
@@ -846,6 +908,25 @@ export async function mount(deps: MountDeps): Promise<App | null> {
   // has no key.
   root.textContent = "";
   root.append(screen);
+
+  /**
+   * The panel's FIRST paint, before boot and before anything is known.
+   *
+   * The chrome is appended above and `bootOrFail` is awaited a long way below;
+   * measured on an Android 35 emulator, that gap put the header, an empty
+   * middle and the Send button on screen for 117ms -- 3.928s to 4.045s on a
+   * cold start -- which is defect #8 exactly, in the one window #4845's boot
+   * indicator cannot cover because `root.textContent = ""` has already retired
+   * it.
+   *
+   * `key: "unknown"` is what makes this paintable with nothing known: rule 3 of
+   * empty-state.ts says an unresolved key reads as the welcome, and the welcome
+   * does not depend on which engine is in force -- so `keyRequired` cannot
+   * change the answer and its value here is not a guess about the engine.
+   * "Ask something to begin." is true while the app is starting; the guidance
+   * replaces it if the keychain comes back empty.
+   */
+  paintEmptyState(emptyState({ hasRows: false, keyRequired: false, key: "unknown" }, strings));
 
   // ---- boot ---------------------------------------------------------------
   let render: RenderState = emptyRender;
@@ -1324,85 +1405,58 @@ export async function mount(deps: MountDeps): Promise<App | null> {
    */
   let keyPresence: KeyPresence = "unknown";
 
-  /** The kind last read into the polite region, so a repaint that changes
-   *  nothing does not re-announce. Reset to null when the panel goes away, so
-   *  the next empty chat is announced again. */
-  let announcedEmptyKind: EmptyStateKind | null = null;
-
   /**
    * Whether the engine that would answer the next message authenticates with a
    * key held on this device.
    *
-   * Read at paint time, not captured: `engineId` is a setting, and a user who
-   * switches from the remote engine to the in-process one has just made a
-   * missing key start mattering. Read through the facade so it follows the same
-   * value Settings shows.
+   * `app.engine.id` -- the engine ACTUALLY in force -- and deliberately NOT the
+   * live `engineId` setting. The first version of this read the setting, and the
+   * two diverge: `createApp` selects the engine once at boot and the controller
+   * holds that instance for the session (`enginesFor` in registry.ts spells out
+   * why rebuilding it on a change is a much larger job). Measured on this
+   * branch before the fix -- mount on a device with no key, then set `engineId`
+   * to the remote engine in Settings: the panel dropped the guidance while
+   * `app.engine.id` was still `praisonai-ts`, so the app told a user no key was
+   * needed and the very next message went to the engine that needs one.
+   *
+   * The engine in force cannot change mid-session, so this is stable rather
+   * than merely "read at paint time" -- but it is still read here, not
+   * captured, because that is the fact being asked about and a copy of it is
+   * one more thing that can go stale.
    */
-  const engineNeedsKey = (): boolean =>
-    app.settings.get("engineId") === ENGINE_PRAISONAI_TS;
+  const engineNeedsKey = (): boolean => app.engine.id === ENGINE_PRAISONAI_TS;
 
   refreshEmptyState = (): void => {
-    const view = emptyState(
-      {
-        // Both lists, because either one alone is a transcript: a reopened
-        // conversation has only `priorRows` and a first turn has only
-        // `liveRows`.
-        hasRows: priorRows.length + liveRows.length > 0,
-        keyRequired: engineNeedsKey(),
-        key: keyPresence,
-      },
-      strings,
+    paintEmptyState(
+      emptyState(
+        {
+          // Both lists, because either one alone is a transcript: a reopened
+          // conversation has only `priorRows` and a first turn has only
+          // `liveRows`.
+          hasRows: priorRows.length + liveRows.length > 0,
+          keyRequired: engineNeedsKey(),
+          key: keyPresence,
+        },
+        strings,
+      ),
     );
-
-    if (view === null) {
-      emptyPanel.hidden = true;
-      // The stylesheet gives the transcript back its full height. Written as a
-      // data attribute rather than an inline style so the rule stays in
-      // app.css, where css.test.ts can see it.
-      delete screen.dataset["empty"];
-      announcedEmptyKind = null;
-      return;
-    }
-
-    emptyPanel.hidden = false;
-    screen.dataset["empty"] = view.kind;
-    emptyTitle.textContent = view.title;
-    emptyBody.textContent = view.body;
-    if (view.action === null) {
-      emptyAction.hidden = true;
-      // The route goes with the button. A hidden control still carrying
-      // `data-route` is one stylesheet mistake away from being tappable and
-      // sending a user who has a key configured to Settings for no reason.
-      delete emptyAction.dataset["route"];
-      emptyAction.textContent = "";
-    } else {
-      emptyAction.hidden = false;
-      emptyAction.textContent = view.action.label;
-      emptyAction.dataset["route"] = view.action.route;
-    }
-
-    // Said once per appearance, and again only when the state changes KIND --
-    // which is exactly the transition from "start typing" to "you cannot yet",
-    // the one a screen-reader user must not miss. An empty `role="log"` says
-    // nothing on its own, so without this a fresh chat is silent.
-    if (view.kind !== announcedEmptyKind) {
-      polite.textContent = emptyStateName(strings, view);
-      announcedEmptyKind = view.kind;
-    }
   };
 
-  // The engine can change under the panel: switching to the in-process engine
-  // is what makes a missing key start mattering, and switching away is what
-  // makes it stop. `subscribe` fires only on ACCEPTED writes, so a refused
-  // value does not repaint.
-  app.settings.subscribe(() => {
-    refreshEmptyState();
-  });
 
   // The first paint, and the first keychain lookup. `root` holds no secret rows
   // yet -- Settings has not been built -- so this call is here for its OTHER
   // half: it is what resolves `keyPresence` from `unknown`, which is what turns
   // the welcome into the key guidance on a fresh install.
+  //
+  // Every LATER repaint comes from the same function: the `set-secret` and
+  // `clear-secret` handlers already call `refreshSecretPresence` to update the
+  // settings rows, and resolving presence is exactly what the panel keys off,
+  // so pasting a key clears the guidance and removing one brings it back with
+  // no second mechanism. A `settings.subscribe` was tried here and deleted: it
+  // repainted on every accepted write and a mutation that emptied it killed no
+  // test, because the handlers had already done the work. An inert subscription
+  // that also has to be unsubscribed on teardown is the #4636 defect -- shipped
+  // machinery with no reader -- plus a lifetime to leak.
   refreshEmptyState();
   refreshSecretPresence(root);
 
@@ -1561,6 +1615,12 @@ export async function mount(deps: MountDeps): Promise<App | null> {
     // silently spending itself while the user was elsewhere.
     armedDelete = null;
     currentRoute = route;
+    // Back on the chat screen, re-run the empty state so its kind is announced.
+    // Anything that changed it while Settings was on top -- removing a key is
+    // the reachable one -- repainted the panel behind a hidden screen without
+    // speaking, deliberately (see `refreshEmptyState`). This is where that
+    // deferred announcement is made.
+    if (route.name === "chat") refreshEmptyState();
   };
   // The router's root is `chats`, but the app opens on the chat screen; align
   // the two so the first back gesture behaves and `screenFor` agrees.

--- a/src/praisonai-mobile/ui/src/a11y/names.test.ts
+++ b/src/praisonai-mobile/ui/src/a11y/names.test.ts
@@ -17,10 +17,12 @@ import {
   accessibleName,
   approvalRowName,
   chatRowName,
+  emptyStateName,
   routeTitle,
   toolRowName,
   userRowNames,
 } from "./names.ts";
+import { emptyState } from "../transcript/empty-state.ts";
 import { en } from "../i18n/strings.ts";
 import { UNKNOWN } from "../format.ts";
 import { buildChatList } from "../chats/list-view-model.ts";
@@ -248,4 +250,35 @@ test("only a message that is NOT stored is annotated as such", () => {
     { type: "end", msgId: M, userIndex: null, assistantIndex: null, versions: 1, active: 0 }));
   assert.notEqual(lost.note, null, "a message the engine did not write must say so");
   assert.match(String(lost.note), /not saved/i);
+});
+
+test("the empty chat has something to say to a screen reader", () => {
+  // An empty transcript is a `role="log"` with nothing in it, so a fresh chat
+  // is announced as nothing at all. The panel's own heading and paragraph are
+  // browsable content -- rule 3 forbids an aria-label over prose -- and this is
+  // the sentence the composition root reads into the polite region instead.
+  const view = emptyState({ hasRows: false, keyRequired: true, key: "present" }, en);
+  assert.ok(view !== null);
+  const said = emptyStateName(en, view);
+  assert.ok(said.includes(view.title), said);
+  assert.ok(said.includes(view.body), said);
+});
+
+test("the spoken key guidance includes the way out of it", () => {
+  // A reader hears the region before reaching anything focusable inside it, so
+  // "Open settings" arriving three tab stops later is a discovery rather than
+  // an instruction. It belongs in the sentence.
+  const view = emptyState({ hasRows: false, keyRequired: true, key: "absent" }, en);
+  assert.ok(view !== null && view.action !== null);
+  const said = emptyStateName(en, view);
+  assert.ok(said.includes(view.action.label), said);
+  assert.match(said, /key/i);
+});
+
+test("the welcome is not spoken as an instruction to fix something", () => {
+  // The pair: a name that appended a settings prompt unconditionally would tell
+  // a configured user to go and configure the app, out loud, on every new chat.
+  const view = emptyState({ hasRows: false, keyRequired: true, key: "present" }, en);
+  assert.ok(view !== null);
+  assert.equal(emptyStateName(en, view).toLowerCase().includes("settings"), false);
 });

--- a/src/praisonai-mobile/ui/src/a11y/names.ts
+++ b/src/praisonai-mobile/ui/src/a11y/names.ts
@@ -51,6 +51,7 @@ import type {
   UserRow,
 } from "../transcript/view-model.ts";
 import type { Strings } from "../i18n/strings.ts";
+import type { EmptyStateView } from "../transcript/empty-state.ts";
 
 /**
  * "Failed: search, 1.2s".
@@ -177,6 +178,33 @@ export function chatRowName(strings: Strings, row: ChatListRow): string {
   // row is never nameless. Asserted, because a nameless row is announced as
   // "button" and cannot be told apart from the one above it.
   return row.title === "" ? strings.untitled : row.title;
+}
+
+/**
+ * The empty chat screen, said out loud.
+ *
+ * The block itself carries no `aria-label` -- rule 3 in this file's header
+ * forbids one over prose, and the heading and paragraph inside it are ordinary
+ * content a reader can browse. This is for the OTHER half: an empty transcript
+ * is a `role="log"` with nothing in it, so a screen-reader user who lands on a
+ * fresh chat, or who taps New chat, is told nothing whatsoever about a screen
+ * that has just changed completely. The composition root reads this into the
+ * polite region when the state APPEARS or CHANGES KIND, which is also the
+ * moment a missing key stops being a guess and becomes a fact (see rule 3 of
+ * empty-state.ts) -- the one transition that must not be silent, because it is
+ * the difference between "start typing" and "you cannot yet".
+ *
+ * The action is part of the sentence rather than left to the button, because a
+ * reader hears the region before reaching anything focusable in it: "Open
+ * settings" arriving three tab stops later is not an instruction, it is a
+ * discovery.
+ */
+export function emptyStateName(_strings: Strings, view: EmptyStateView): string {
+  // Already localised by whoever built the view -- re-deriving it from the
+  // table here is how the spoken text and the printed text come to differ, the
+  // same reason `noticeRowName` returns the row's own words.
+  const said = `${view.title} ${view.body}`;
+  return view.action === null ? said : `${said} ${view.action.label}`;
 }
 
 /** The title of a screen. Used for its heading, and for the announcement made

--- a/src/praisonai-mobile/ui/src/i18n/strings.test.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.test.ts
@@ -83,6 +83,18 @@ test("the table reproduces the literals that are hardcoded at render sites today
   assert.equal(en.routeSettings, "Settings");
   assert.equal(en.chatsEmpty, "No conversations yet.");
   assert.equal(en.emptyTranscript, "Ask something to begin.");
+  // The empty chat screen's own copy. Pinned like the rest: these are the two
+  // sentences a new user reads before anything else in the product, and they
+  // were reviewed as copy rather than typed into a render site.
+  assert.equal(en.emptyNeedsKeyTitle, "Add an API key to start");
+  assert.equal(
+    en.emptyNeedsKeyBody,
+    "PraisonAI answers using your own OpenAI account. Paste a key in Settings and this chat is ready.",
+  );
+  assert.equal(
+    en.emptyAbout,
+    "PraisonAI answers questions, explains things, and works through tasks with you.",
+  );
   assert.equal(en.crashed, "Something went wrong. Your conversations are saved.");
   assert.equal(en.bootFailed("no storage"), "PraisonAI could not start: no storage");
 });
@@ -216,4 +228,23 @@ test("every reason the decoder can produce has a sentence", () => {
   for (const reason of REASONS) {
     assert.notEqual(en.droppedReason(reason), reason, `${reason} has no sentence`);
   }
+});
+
+test("the key guidance says what to do, and names where", () => {
+  // The two facts it has to carry. Without the first it is a diagnosis; without
+  // the second the user is left hunting for the screen that takes a key -- and
+  // "Settings" is the word on the button they will be looking for once they get
+  // there. Asserted on the SENSE rather than the exact sentence so the copy can
+  // be reworded without the guarantee going quiet.
+  assert.match(en.emptyNeedsKeyTitle, /key/i);
+  assert.match(en.emptyNeedsKeyBody, /settings/i);
+  // And it must not be the raw provider sentence it replaces.
+  assert.equal(en.emptyNeedsKeyBody.includes("OPENAI_API_KEY"), false);
+});
+
+test("an empty chat with a key set is not told to get a key", () => {
+  // The pair. A welcome that mentioned a key would put the app's one blocking
+  // requirement in front of a user who has already met it.
+  assert.equal(/api key/i.test(`${en.emptyTranscript} ${en.emptyAbout}`), false);
+  assert.notEqual(en.emptyAbout.trim(), en.emptyNeedsKeyBody.trim());
 });

--- a/src/praisonai-mobile/ui/src/i18n/strings.ts
+++ b/src/praisonai-mobile/ui/src/i18n/strings.ts
@@ -150,6 +150,34 @@ export interface Strings {
   readonly chatsAllUnreadable: (count: number) => string;
   /** An open chat with no messages in it yet. */
   readonly emptyTranscript: string;
+  /**
+   * What the app is, under `emptyTranscript`, in an empty chat.
+   *
+   * Second line rather than first: the invitation is what a returning user
+   * needs and the description is what a new one does, and only one of them can
+   * be read first. It says what the app DOES -- not what it is built on, and
+   * not a claim about where the words go, because with the in-process engine
+   * they go to a model provider and a privacy line here would be false.
+   */
+  readonly emptyAbout: string;
+  /**
+   * The empty chat, when no key is stored and the engine in force needs one.
+   *
+   * The whole of defect #3 is that this sentence did not exist anywhere: the
+   * app could not answer, and the only thing that said so was the provider SDK,
+   * after a message had been sent, in the words "The OPENAI_API_KEY environment
+   * variable is missing or empty". These two strings and the button beside them
+   * are the replacement, and they run BEFORE the failure rather than after it.
+   *
+   * The title says what to do, not what is wrong: "No API key" describes the
+   * app's state, "Add an API key to start" describes the user's next move, and
+   * only one of those is useful to someone holding a phone.
+   */
+  readonly emptyNeedsKeyTitle: string;
+  /** The sentence under it: why, and where. It NAMES Settings, because the
+   *  button says "Open settings" and a user who taps Back has to know what they
+   *  were looking for. */
+  readonly emptyNeedsKeyBody: string;
 
   // ---- relative time (fallback path; see format-intl.ts) -----------------
   readonly justNow: string;
@@ -370,6 +398,12 @@ export const en: Strings = {
   chatDeleteFailed: "That conversation could not be deleted.",
   chatsEmpty: "No conversations yet.",
   emptyTranscript: "Ask something to begin.",
+  emptyAbout: "PraisonAI answers questions, explains things, and works through tasks with you.",
+  emptyNeedsKeyTitle: "Add an API key to start",
+  // "Paste", to match `secretPlaceholder` and because nobody types a key on a
+  // phone. Active, addressed to the reader, and it does not apologise for a
+  // state the app is simply in on its first launch.
+  emptyNeedsKeyBody: "PraisonAI answers using your own OpenAI account. Paste a key in Settings and this chat is ready.",
   chatsAllUnreadable: (count) =>
     countedPhrase(EN, count, String(count), {
       one: "{n} chat could not be read",

--- a/src/praisonai-mobile/ui/src/transcript/empty-state.test.ts
+++ b/src/praisonai-mobile/ui/src/transcript/empty-state.test.ts
@@ -1,0 +1,155 @@
+/**
+ * What an empty chat says, and when it says nothing.
+ *
+ * Four gates, and each of them is a mutation that would ship a plausible-
+ * looking app with one of the two original defects back in it:
+ *
+ *   - never return a view          -> the blank rectangle, defect #8
+ *   - return one when rows exist   -> a welcome panel over a conversation
+ *   - guidance while a key IS set  -> a configured user told to configure
+ *   - welcome while NO key is set  -> defect #3, "ask something" to an app
+ *                                     that cannot answer anything
+ *
+ * Every test below is named for the one it kills.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { emptyState, type EmptyStateInput } from "./empty-state.ts";
+import { en } from "../i18n/strings.ts";
+
+/** A device with the in-process engine and nothing configured -- a fresh
+ *  install, which is the case both defects were reported against. */
+const FRESH: EmptyStateInput = { hasRows: false, keyRequired: true, key: "absent" };
+
+test("an empty chat with no key says a key is needed", () => {
+  // Defect #3. Before this the app said nothing at all until a message had been
+  // sent, and then said "The OPENAI_API_KEY environment variable is missing or
+  // empty" -- provider SDK prose, to a user who did nothing wrong.
+  const view = emptyState(FRESH, en);
+  assert.ok(view !== null, "a fresh install must not render an empty rectangle");
+  assert.equal(view.kind, "needs-key");
+  assert.match(view.title, /key/i);
+  assert.match(view.body, /key/i);
+});
+
+test("the key guidance offers a way to Settings from here", () => {
+  // Saying a key is needed without a way to reach the one screen that takes one
+  // is the same defect one step softer: the user still has to go looking.
+  const view = emptyState(FRESH, en);
+  assert.ok(view !== null);
+  assert.ok(view.action !== null, "the guidance must be actionable, not just a statement");
+  assert.equal(view.action.route, "settings");
+  assert.notEqual(view.action.label.trim(), "");
+  // And the body names the destination, because a user who taps Back has to
+  // know what they were looking for once they are there.
+  assert.match(view.body, /settings/i);
+});
+
+test("an empty chat with a key set welcomes instead of demanding one", () => {
+  // The mutation this kills: showing the "needs a key" copy when a key IS set.
+  // It is the state a returning, fully configured user meets on every single
+  // new chat, so getting it wrong tells the same person to configure the app
+  // every day forever.
+  const view = emptyState({ ...FRESH, key: "present" }, en);
+  assert.ok(view !== null, "a configured user's empty chat must still say something");
+  assert.equal(view.kind, "welcome");
+  assert.equal(view.action, null, "there is nothing to fix, so there is no button");
+  assert.equal(view.title, en.emptyTranscript);
+  assert.equal(view.body, en.emptyAbout);
+});
+
+test("the welcome copy and the key copy are not the same words", () => {
+  // The pair to both tests above, and the one that survives a lazy fix. A view
+  // that returned the same title for both states would satisfy "says
+  // something" twice over while telling a user with no key nothing they need.
+  const needsKey = emptyState(FRESH, en);
+  const welcome = emptyState({ ...FRESH, key: "present" }, en);
+  assert.ok(needsKey !== null && welcome !== null);
+  assert.notEqual(needsKey.title, welcome.title);
+  assert.notEqual(needsKey.body, welcome.body);
+});
+
+test("a transcript beats everything: the empty state disappears", () => {
+  // Rule 1. Checked against BOTH key states, because the interesting mutation
+  // is not "always show it" -- it is "show it while the key is missing", which
+  // would paint a "you need a key" panel above a conversation the user is
+  // having. Reachable: the engine can be switched mid-chat.
+  for (const key of ["absent", "present", "unknown"] as const) {
+    assert.equal(
+      emptyState({ hasRows: true, keyRequired: true, key }, en),
+      null,
+      `a transcript with key=${key} must clear the empty state`,
+    );
+    assert.equal(emptyState({ hasRows: true, keyRequired: false, key }, en), null);
+  }
+});
+
+test("an engine that needs no key is never told to get one", () => {
+  // Rule 2. The remote engine authenticates at the server it talks to, so
+  // sending its user to paste an OpenAI key sends them to configure a
+  // credential nothing on this device reads.
+  const view = emptyState({ hasRows: false, keyRequired: false, key: "absent" }, en);
+  assert.ok(view !== null);
+  assert.equal(view.kind, "welcome");
+  assert.equal(view.action, null);
+});
+
+test("an unresolved key check reads as fine, never as missing", () => {
+  // Rule 3, and the reason `KeyPresence` is three values rather than a boolean.
+  // The keychain lookup is async and the first paint beats it, so treating the
+  // pre-answer window as "absent" accuses every configured user of not having
+  // set a key, on every launch, and then takes it back a frame later.
+  const view = emptyState({ ...FRESH, key: "unknown" }, en);
+  assert.ok(view !== null);
+  assert.equal(view.kind, "welcome");
+});
+
+test("the action is present exactly when the key is missing", () => {
+  // Rule 4 stated as an invariant rather than as two separate assertions, so a
+  // third state added later cannot quietly ship a button with no reason or a
+  // reason with no button.
+  for (const keyRequired of [true, false]) {
+    for (const key of ["present", "absent", "unknown"] as const) {
+      const view = emptyState({ hasRows: false, keyRequired, key }, en);
+      assert.ok(view !== null);
+      assert.equal(
+        view.action !== null,
+        view.kind === "needs-key",
+        `keyRequired=${keyRequired} key=${key}`,
+      );
+    }
+  }
+});
+
+test("no state renders a blank panel", () => {
+  // The empty rectangle, one layer in: a view whose strings are empty is the
+  // same defect with a border around it.
+  for (const keyRequired of [true, false]) {
+    for (const key of ["present", "absent", "unknown"] as const) {
+      const view = emptyState({ hasRows: false, keyRequired, key }, en);
+      assert.ok(view !== null);
+      assert.notEqual(view.title.trim(), "");
+      assert.notEqual(view.body.trim(), "");
+    }
+  }
+});
+
+test("the copy is written to the reader, not about the app", () => {
+  // Copy is design material and this is the part of it a test can hold: no
+  // apology, and the title says what to DO rather than what is wrong. "No API
+  // key" describes the app's state; "Add an API key to start" describes the
+  // user's next move, and only one of those is useful to someone holding a
+  // phone.
+  const view = emptyState(FRESH, en);
+  assert.ok(view !== null);
+  for (const word of ["sorry", "unfortunately", "error", "failed", "invalid"]) {
+    assert.equal(
+      `${view.title} ${view.body}`.toLowerCase().includes(word),
+      false,
+      `the first screen must not ${word === "sorry" ? "apologise" : `read as a failure ("${word}")`}`,
+    );
+  }
+  // And it must not leak the machine-facing sentence it replaces.
+  assert.equal(view.body.includes("OPENAI_API_KEY"), false);
+});

--- a/src/praisonai-mobile/ui/src/transcript/empty-state.ts
+++ b/src/praisonai-mobile/ui/src/transcript/empty-state.ts
@@ -1,0 +1,132 @@
+/**
+ * What the chat screen says when the transcript is empty.
+ *
+ * On main, a fresh launch renders a header, a Send button, and several hundred
+ * pixels of nothing between them. Two separate defects live in that rectangle:
+ *
+ *  - It never says what the app is or that you are meant to type. `chatsEmpty`
+ *    ("No conversations yet.") and `emptyTranscript` ("Ask something to begin.")
+ *    were both written for this and only the first one had a caller, so an open
+ *    chat with no messages rendered as a blank box on every launch, forever --
+ *    including for someone returning to an app they already use.
+ *
+ *  - It never says a key is required. The in-process engine is the default on a
+ *    device (registry.ts) and it cannot answer anything without an OpenAI key,
+ *    which lives behind Settings. The only way to find that out was to send a
+ *    message and read `The OPENAI_API_KEY environment variable is missing or
+ *    empty` -- SDK prose, addressed to a developer, shown to a user who did
+ *    nothing wrong. The blocking fact and the way to fix it belong on the first
+ *    screen, not in the failure.
+ *
+ * Both are the same element, so the decision is one function: given whether
+ * there are rows, whether the engine in force needs a credential, and whether
+ * one is present, say which of the two states to paint -- or `null`, which is
+ * "paint nothing", the answer the moment a transcript exists.
+ *
+ * Four rules, each of them a thing that was easy to get wrong:
+ *
+ *  1. A TRANSCRIPT WINS OVER EVERYTHING. `hasRows` is checked first and alone.
+ *     A "you need a key" panel sitting above a conversation the user is having
+ *     is a worse bug than the blank rectangle -- and it is reachable, because
+ *     an engine can be switched to one needing a key mid-chat.
+ *
+ *  2. NO KEY IS ONLY A PROBLEM WHEN SOMETHING WANTS ONE. The remote engine
+ *     authenticates at the server it talks to; telling a remote user to paste
+ *     an OpenAI key would send them to configure a credential nothing here
+ *     reads. `keyRequired` comes from the engine actually selected.
+ *
+ *  3. AN UNRESOLVED KEY CHECK READS AS "FINE", NOT AS "MISSING". `SecretsPort`
+ *     is asynchronous -- a keychain lookup on a real device is not free -- so
+ *     the first paint happens before the answer lands. Guessing "absent" during
+ *     that window accuses a configured user of not having set a key, on every
+ *     single launch, and then takes it back. Guessing "present" shows the
+ *     welcome, which is true either way and is what the state settles to for
+ *     everyone who is set up. The guidance replaces it when the answer arrives.
+ *
+ *  4. THE ACTION IS PART OF THE STATE, NOT A DECORATION. "A key is needed"
+ *     without a way to reach Settings from here is the same defect one step
+ *     softer: the user still has to go looking. So `action` is non-null exactly
+ *     when `kind` is `needs-key`, and the tests assert the pairing rather than
+ *     the button's existence.
+ *
+ * The one thing deliberately NOT here is a set of example prompts. They are the
+ * obvious next idea and they were rejected: a suggestion chip is seen once, by
+ * a user who has already understood what a message box is, and is then in the
+ * way of every new chat afterwards -- while costing a translatable string per
+ * example that no translator can make right for their market, plus a second tap
+ * target competing with the one control on the screen that matters. What a new
+ * user actually lacks on this screen is not inspiration, it is the key; that is
+ * what the space is spent on.
+ */
+import type { Strings } from "../i18n/strings.ts";
+
+/** Which of the two things the empty chat has to say. */
+export type EmptyStateKind = "needs-key" | "welcome";
+
+/**
+ * Whether a credential is on file.
+ *
+ * Three values, not a boolean, and `unknown` is the reason: see rule 3. A
+ * boolean forces the pre-answer window to be spelled `false`, which is the one
+ * reading that produces a wrong accusation on every launch.
+ */
+export type KeyPresence = "present" | "absent" | "unknown";
+
+export interface EmptyStateAction {
+  readonly label: string;
+  /** A `Route["name"]`, kept as a string so `ui/` does not have to import the
+   *  router to describe a button. The renderer puts it in `data-route`, which
+   *  `intents.ts` already turns into a `navigate`. */
+  readonly route: "settings";
+}
+
+export interface EmptyStateView {
+  readonly kind: EmptyStateKind;
+  /** The heading. Short, and the first thing announced. */
+  readonly title: string;
+  /** One sentence under it. */
+  readonly body: string;
+  /** Non-null exactly when `kind` is `needs-key` -- rule 4. */
+  readonly action: EmptyStateAction | null;
+}
+
+export interface EmptyStateInput {
+  /** Anything at all in the transcript: restored history or a live turn. */
+  readonly hasRows: boolean;
+  /** Whether the engine currently selected authenticates with a key held here.
+   *  False for the remote engine, which authenticates at its own server. */
+  readonly keyRequired: boolean;
+  readonly key: KeyPresence;
+}
+
+/**
+ * What to paint in an empty chat, or null to paint nothing.
+ *
+ * Pure, and it takes the string table rather than reaching for `en`: this is
+ * the layer that decides, and a decision that hardcodes English is a decision a
+ * translator cannot see. See i18n/strings.ts.
+ */
+export function emptyState(input: EmptyStateInput, strings: Strings): EmptyStateView | null {
+  // Rule 1, and it is first for a reason: nothing below may override it.
+  if (input.hasRows) return null;
+
+  // Rules 2 and 3 together. Only a definite absence, against an engine that
+  // actually reads a key, produces the guidance.
+  if (input.keyRequired && input.key === "absent") {
+    return {
+      kind: "needs-key",
+      title: strings.emptyNeedsKeyTitle,
+      body: strings.emptyNeedsKeyBody,
+      // Rule 4. The label is the one the error rows already use for the same
+      // destination, so "Open settings" means one thing everywhere in the app.
+      action: { label: strings.recoveryLabel("settings"), route: "settings" },
+    };
+  }
+
+  return {
+    kind: "welcome",
+    title: strings.emptyTranscript,
+    body: strings.emptyAbout,
+    action: null,
+  };
+}


### PR DESCRIPTION
Fixes the two UI defects that share one screen: **#8** (the empty chat is an empty rectangle) and **#3** (nothing tells a new user to set an API key).

## What was on screen

On `main`, opening the app gives you a header, a very large blank white expanse, and a Send button.

- `emptyTranscript` — "Ask something to begin." — has been in `ui/src/i18n/strings.ts` since it was written, with a test pinning its text and **no caller anywhere in the application**. So an open chat with no messages rendered blank on every launch, for a returning user with everything configured too.
- The in-process engine is the device default (`registry.ts`) and cannot answer anything without an OpenAI key. Nothing on the first screen said so. You found out by sending a message and reading `The OPENAI_API_KEY environment variable is missing or empty` — provider SDK prose, addressed to a developer, shown to a user who did nothing wrong.

## What this adds

`ui/src/transcript/empty-state.ts` — a pure function that decides which of two states an empty chat paints, or `null` for "paint nothing":

| condition | what the user sees |
| --- | --- |
| any rows in the transcript | nothing — the panel is gone |
| no key, engine that needs one | **Add an API key to start** + one sentence + **Open settings** |
| otherwise | **Ask something to begin.** + one line saying what the app does |

Four rules it is built around, each of them a thing that was easy to get wrong:

1. **A transcript beats everything.** `hasRows` is checked first and alone. A "you need a key" panel above a conversation the user is having is worse than the blank box — and it is reachable, because the engine can be switched mid-chat.
2. **A missing key only matters to an engine that reads one.** The remote engine authenticates at the server it talks to; sending its user to paste an OpenAI key sends them to configure a credential nothing here reads.
3. **An unresolved keychain lookup reads as "fine", never as "missing".** `SecretsPort.has()` is async and the first paint beats it. Guessing "absent" in that window accuses every configured user of not having set a key, on every launch, and then takes it back. `KeyPresence` is three values for exactly this reason.
4. **The action is part of the state.** "A key is needed" with no way to Settings is the same defect one step softer. `action` is non-null exactly when the kind is `needs-key`, and a test asserts the pairing rather than the button's existence.

Presence comes from **`SecretsPort.has()` through the `SettingsFacade`** — rule 2 of `core/src/ports/secrets.ts`, "so the UI can render 'configured' without reading the value". It is resolved on the *same* walk that paints the settings rows rather than a second one, so the row saying "Configured" and the chat screen saying "Add an API key" cannot both be true. A named test asserts `secrets.reads` does not move and that the value never reaches the rendered text.

### On example prompts

Rejected, deliberately. A suggestion chip is read once, by someone who has already understood what a message box is, and is then in the way of every new chat afterwards — while costing a translatable string per example that no translator can make right for their market, and a second tap target competing with the one control on the screen that matters. What a new user lacks on this screen is not inspiration, it is the key; that is what the space is spent on. The reasoning is written into the module header so a reviewer can disagree with it in one place.

### Not fighting anything else

- The panel is a **sibling** of `.transcript`, never a child: `applyOps` places rows by `children[index]`, and New chat / Open chat / deleting the open chat each do `transcript.textContent = ""`. Inside, it would be displaced or silently deleted by three separate code paths.
- `.screen[data-empty] .transcript { flex: 0 0 auto }` — both are children of the same flex column and both would otherwise claim `flex: 1`, splitting the screen. The "engine is not answering" notice stays visible above the panel.
- Safe areas: `.empty-state` lays out against `--inset-left` / `--inset-right`, added to the gutter rather than replacing it. The topbar's `--inset-top` handling is untouched.
- Colours are `--ink` / `--soft` / `--accent` only, all of which already have dark-scheme values.

### Accessibility

`role="region"` named by its own `<h2>` through `aria-labelledby` — **not** `aria-label`, which would replace the panel's own words in the accessibility tree (`a11y/names.ts` rule 3), costing the reader the sentence and the button. `names.ts` gains `emptyStateName()`, read into the polite region when the empty state appears or changes kind: an empty `role="log"` announces nothing at all, so a fresh chat was silent, and the "you can start" → "you cannot yet" transition is the one that must not be missed.

## Verified on a device

Android 35 emulator, debug APK, in-process engine, key entered through the app's own Settings screen (never committed, never written to a file):

| | light | dark |
| --- | --- | --- |
| fresh install, no key | guidance + Open settings | ✔ legible, tokens follow the theme |
| tapping Open settings | reaches Settings, row reads "Not set" → "Configured" | ✔ |
| key set, no messages | welcome | ✔ |
| after one real exchange | both gone, user + assistant rows intact | ✔ |
| New chat | welcome returns | ✔ |

Every screenshot was opened and read.

## Gates

- `npm run check` exit **0** on Node 22.18.0, 22.23.2 and 24.12.0, read from the command's own exit code (never through a pipe). 1615 tests, 0 failures.
- `tools/bundle.mjs`: shell **82.6 kB → 84.5 kB** of 400 kB; lazy **1497.4 kB unchanged** of 1600 kB. Neither budget moved.
- **Twelve mutations, twelve kills, all by named tests** — remove the panel from the screen; make the renderer a no-op; show it when a transcript exists; show the needs-a-key copy when a key IS set; show the welcome when it is not; hardcode a colour; drop a token's dark value; defeat `[hidden]`; drop the safe-area insets; let the transcript keep its stretch; swap `aria-labelledby` for `aria-label`; stop announcing. Every anchor was asserted present exactly once before being applied, and no APK was built while a mutation was in the tree.
- `app/src/css.test.ts` now parses `app.css` by **matching braces**, not by scanning to the next `}`. The previous agent's warning was earned: `[^}]*` consumes the brace it anchors on and silently drops a rule, so a colour test passes over a rule it never saw. Every selector is looked up through `ruleFor`, which fails when it is not found exactly once, and the dark-mode test asserts it checked both rules — a sample that shrinks to zero fails rather than reporting success.
- No new importer of any `*-contract.ts` from a sibling test file (issue #4813).

Items 4–7 and 9 are untouched. This branch does not conflict with #4845 (`app/index.html`, `boot-guard.js`, `mount()`); it touches `app/app.css`, `app/src/main.ts`, `ui/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated empty-chat screen with welcome guidance.
  - Shows instructions to add an API key when required, including a shortcut to Settings.
  - Automatically updates when credentials are added, chats change, or a new chat is started.
  - Keeps remote-engine chats from displaying unnecessary key guidance.
  - Added a centered startup indicator and failure message.

- **Accessibility**
  - Improved screen-reader announcements, landmarks, labels, and live-region support.

- **Style**
  - Added responsive, safe-area-aware empty-state and startup layouts.

- **Tests**
  - Added coverage for empty-state behavior, styling, localization, navigation, and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->