### PR TITLE
fix(rag): honour --chunking and --chunk-size, and stop calling an empty index a success

### DIFF
--- a/src/praisonai/praisonai/cli/commands/rag.py
+++ b/src/praisonai/praisonai/cli/commands/rag.py
@@ -75,7 +75,15 @@ def rag_index(
                         "collection_name": collection,
                         "path": f"./.praison/knowledge/{collection}",
                     }
-                }
+                },
+                # --chunking and --chunk-size were declared, shown in this
+                # command's own example, and never read: knowledge_config
+                # carried only vector_store, so Knowledge used its defaults
+                # (recursive / 512) whatever the user asked for.
+                "chunker": {
+                    "type": chunking,
+                    "chunk_size": chunk_size,
+                },
             }
             
             # Load config file if provided
@@ -88,6 +96,7 @@ def rag_index(
             
             # Initialize Knowledge
             knowledge = Knowledge(config=knowledge_config, verbose=verbose)
+            failed = []
             
             # Index sources
             with Progress(
@@ -101,11 +110,30 @@ def rag_index(
                     try:
                         result = knowledge.add(source)
                         count = len(result.get("results", [])) if isinstance(result, dict) else 0
-                        console.print(f"[green]✓[/green] Indexed {source}: {count} chunks")
+                        if count:
+                            console.print(f"[green]✓[/green] Indexed {source}: {count} chunks")
+                        else:
+                            # Zero chunks is not success. Knowledge swallows per-file
+                            # failures, so this is the only place a user can be told
+                            # nothing was actually stored.
+                            failed.append(source)
+                            console.print(
+                                f"[yellow]![/yellow] Indexed nothing from {source} "
+                                "(no supported files, or every file failed)"
+                            )
                     except Exception as e:
+                        failed.append(source)
                         console.print(f"[red]✗[/red] Failed to index {source}: {e}")
                     progress.remove_task(task)
             
+            if failed:
+                # "Indexing complete!" printed unconditionally, so a run in
+                # which every source failed still ended green, exit 0.
+                console.print(
+                    f"\n[bold red]Indexing finished with {len(failed)} "
+                    f"failed source(s)[/bold red] Collection: {collection}"
+                )
+                raise typer.Exit(1)
             console.print(f"\n[bold green]Indexing complete![/bold green] Collection: {collection}")
             if profile_data:
                 profile_data["command"] = "rag index"

--- a/src/praisonai/praisonai/cli/commands/rag.py
+++ b/src/praisonai/praisonai/cli/commands/rag.py
@@ -92,7 +92,17 @@ def rag_index(
                 with open(config) as f:
                     file_config = yaml.safe_load(f)
                     if "knowledge" in file_config:
-                        knowledge_config.update(file_config["knowledge"])
+                        file_knowledge = file_config["knowledge"] or {}
+                        # A shallow update would let a file's "chunker" replace the
+                        # whole dict, silently dropping the explicit --chunking /
+                        # --chunk-size the user passed. Merge chunker key-by-key so
+                        # the file only overrides the fields it actually sets.
+                        cli_chunker = dict(knowledge_config["chunker"])
+                        file_chunker = file_knowledge.get("chunker")
+                        knowledge_config.update(file_knowledge)
+                        if isinstance(file_chunker, dict):
+                            cli_chunker.update(file_chunker)
+                            knowledge_config["chunker"] = cli_chunker
             
             # Initialize Knowledge
             knowledge = Knowledge(config=knowledge_config, verbose=verbose)
@@ -144,6 +154,10 @@ def rag_index(
             console.print(f"[red]Error:[/red] Missing dependency: {e}")
             console.print("Install with: pip install 'praisonaiagents[knowledge]'")
             raise typer.Exit(1)
+        except typer.Exit:
+            # The failed-source summary above already raised typer.Exit(1);
+            # let it through so we don't print a second, misleading "Error:" line.
+            raise
         except Exception as e:
             console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1)

--- a/src/praisonai/tests/unit/cli/test_rag_index_flags.py
+++ b/src/praisonai/tests/unit/cli/test_rag_index_flags.py
@@ -1,0 +1,112 @@
+"""`praisonai rag index` must honour --chunking and --chunk-size.
+
+Both were declared as typer options and shown in the command's own docstring
+example:
+
+    praisonai rag index ./data --chunking semantic --chunk-size 256
+
+and then never read. `knowledge_config` was built with a `vector_store` key
+only, so Knowledge fell back to its defaults (recursive / 512) whatever the
+user asked for. The one place in the codebase that documents the flags is the
+help text of the command that ignores them.
+
+The second half is the reporting: the loop counted chunks, printed a green
+tick regardless, and ended with "Indexing complete!" unconditionally — so a
+run in which every source indexed nothing still finished green and exited 0.
+"""
+import os
+import tempfile
+
+import pytest
+from typer.testing import CliRunner
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+import praisonaiagents.knowledge as knowledge_module
+import praisonai.cli.commands.rag as rag
+
+
+@pytest.fixture
+def src_dir():
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "x.md"), "w", encoding="utf-8") as fh:
+            fh.write("Authentication uses bcrypt.\n")
+        yield d
+
+
+@pytest.fixture
+def fake_knowledge(monkeypatch):
+    """Replace Knowledge, and record the config it was handed."""
+    seen = {}
+
+    def make(results):
+        class _K:
+            def __init__(self, config=None, verbose=False):
+                seen["config"] = config
+
+            def add(self, source):
+                return {"results": list(results)}
+        return _K
+
+    def install(results):
+        monkeypatch.setattr(knowledge_module, "Knowledge", make(results))
+        return seen
+
+    return install
+
+
+class TestChunkingFlagsReachKnowledge:
+
+    def test_chunking_strategy_is_passed_through(self, src_dir, fake_knowledge):
+        seen = fake_knowledge(["a"])
+        CliRunner().invoke(rag.app, ["index", src_dir, "--chunking", "semantic"])
+        assert seen["config"].get("chunker", {}).get("type") == "semantic"
+
+    def test_chunk_size_is_passed_through(self, src_dir, fake_knowledge):
+        seen = fake_knowledge(["a"])
+        CliRunner().invoke(rag.app, ["index", src_dir, "--chunk-size", "256"])
+        assert seen["config"].get("chunker", {}).get("chunk_size") == 256
+
+    def test_the_documented_example_works(self, src_dir, fake_knowledge):
+        """The exact line from the command's own docstring."""
+        seen = fake_knowledge(["a"])
+        CliRunner().invoke(rag.app, [
+            "index", src_dir, "--chunking", "semantic", "--chunk-size", "256"])
+        assert seen["config"]["chunker"] == {"type": "semantic", "chunk_size": 256}
+
+    def test_defaults_are_still_sent(self, src_dir, fake_knowledge):
+        seen = fake_knowledge(["a"])
+        CliRunner().invoke(rag.app, ["index", src_dir])
+        assert seen["config"]["chunker"]["type"] == "recursive"
+        assert seen["config"]["chunker"]["chunk_size"] == 512
+
+    def test_the_vector_store_config_is_untouched(self, src_dir, fake_knowledge):
+        seen = fake_knowledge(["a"])
+        CliRunner().invoke(rag.app, ["index", src_dir, "--collection", "research"])
+        vs = seen["config"]["vector_store"]["config"]
+        assert vs["collection_name"] == "research"
+
+
+class TestIndexingNothingIsNotSuccess:
+
+    def test_exit_code_is_nonzero_when_nothing_was_indexed(self, src_dir, fake_knowledge):
+        fake_knowledge([])
+        result = CliRunner().invoke(rag.app, ["index", src_dir])
+        assert result.exit_code != 0, (
+            "a run that stored nothing still reported success"
+        )
+
+    def test_it_does_not_claim_completion(self, src_dir, fake_knowledge):
+        fake_knowledge([])
+        result = CliRunner().invoke(rag.app, ["index", src_dir])
+        assert "Indexing complete" not in result.output
+
+    def test_a_real_success_still_exits_zero(self, src_dir, fake_knowledge):
+        fake_knowledge(["a", "b"])
+        result = CliRunner().invoke(rag.app, ["index", src_dir])
+        assert result.exit_code == 0
+        assert "Indexing complete" in result.output
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/praisonai/tests/unit/cli/test_rag_index_flags.py
+++ b/src/praisonai/tests/unit/cli/test_rag_index_flags.py
@@ -87,6 +87,34 @@ class TestChunkingFlagsReachKnowledge:
         assert vs["collection_name"] == "research"
 
 
+class TestConfigFileDoesNotSilentlyDropCliChunker:
+    """A --config file that sets its own chunker must not wipe the explicit
+    --chunking / --chunk-size the user typed on the same command line."""
+
+    def _write_config(self, d, body):
+        path = os.path.join(d, "cfg.yaml")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(body)
+        return path
+
+    def test_explicit_flags_survive_a_config_without_a_chunker(self, src_dir, fake_knowledge):
+        seen = fake_knowledge(["a"])
+        cfg = self._write_config(src_dir, "knowledge:\n  vector_store:\n    provider: chroma\n")
+        CliRunner().invoke(rag.app, [
+            "index", src_dir, "--chunking", "semantic", "--chunk-size", "256",
+            "--config", cfg])
+        assert seen["config"]["chunker"] == {"type": "semantic", "chunk_size": 256}
+
+    def test_config_chunker_field_overrides_only_that_field(self, src_dir, fake_knowledge):
+        seen = fake_knowledge(["a"])
+        cfg = self._write_config(src_dir, "knowledge:\n  chunker:\n    type: token\n")
+        CliRunner().invoke(rag.app, [
+            "index", src_dir, "--chunking", "semantic", "--chunk-size", "256",
+            "--config", cfg])
+        assert seen["config"]["chunker"]["type"] == "token"
+        assert seen["config"]["chunker"]["chunk_size"] == 256
+
+
 class TestIndexingNothingIsNotSuccess:
 
     def test_exit_code_is_nonzero_when_nothing_was_indexed(self, src_dir, fake_knowledge):
@@ -100,6 +128,11 @@ class TestIndexingNothingIsNotSuccess:
         fake_knowledge([])
         result = CliRunner().invoke(rag.app, ["index", src_dir])
         assert "Indexing complete" not in result.output
+
+    def test_intentional_exit_does_not_print_a_redundant_error(self, src_dir, fake_knowledge):
+        fake_knowledge([])
+        result = CliRunner().invoke(rag.app, ["index", src_dir])
+        assert "Error:" not in result.output
 
     def test_a_real_success_still_exits_zero(self, src_dir, fake_knowledge):
         fake_knowledge(["a", "b"])


### PR DESCRIPTION
Two defects in `praisonai rag index`.

## 1. The chunking flags were never read

`--chunking` and `--chunk-size` are declared as typer options and shown in the command's **own docstring example**:

```
praisonai rag index ./data --chunking semantic --chunk-size 256
```

`knowledge_config` was then built with a `vector_store` key only, so `Knowledge` fell back to its defaults (`recursive` / 512) whatever the user asked for. Grepping the file, both names appear exactly twice: in their own declaration, and in that example.

The only place in the codebase documenting these flags was the help text of the command that ignores them.

## 2. An empty index reported success

The loop printed a green tick for every source regardless of what came back, and `"Indexing complete!"` printed unconditionally. So a run where **every** source indexed nothing — an unreadable directory, a broken embedding backend, a glob matching no supported file — finished green and exited 0.

Zero chunks now reports the source as failed; a run with any failed source ends red and exits 1.

## Verified by driving the real CLI, with Knowledge faked

```
chunker config passed through : {'type': 'semantic', 'chunk_size': 256}
exit code (all succeeded)     : 0
exit code (indexed nothing)   : 1   <- was 0
says "Indexing complete"      : False
```

## Scope

Edits are confined to `rag_index`. The same `Knowledge(config=knowledge_config, ...)` line appears in **four other subcommands** in this file; none is touched. I found that only after a first attempt matched all five, which is why the change is applied by line range rather than by string.

8 tests; both mutations killed (dropping the chunker config, and treating an empty result as success). 28 existing rag tests pass.

Related: #4831 fixed the chunker being bypassed inside `Knowledge` itself — this fixes the caller that never asked for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `rag index` now honors selected chunking strategies and chunk sizes.
  - Configuration files can selectively override chunking options without discarding CLI settings.
  - Indexing reports sources that fail or produce no chunks and exits with an error status when any source fails.
  - Successful indexing continues to report completion.

- **Bug Fixes**
  - Prevented failed or empty indexing operations from being reported as successful.

- **Tests**
  - Added coverage for chunking options, configuration overrides, defaults, vector-store settings, and success/failure outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->