### PR TITLE
fix(local): stop a local agent sending documents to OpenAI, and five more gaps

### DIFF
--- a/src/praisonai-agents/docs/local-model-layer/07-local-package-spec.md
+++ b/src/praisonai-agents/docs/local-model-layer/07-local-package-spec.md
@@ -958,9 +958,15 @@ are therefore enforced by `test_sloc_ceiling` (non-blank, non-comment lines), no
 | `target.py` | 180 | 240 |
 | `manage.py` | 120 | 160 |
 | `embed.py` | 90 | 120 |
-| **package total** | **1020** | **1150** |
+| `embed.py` (local embedder selection) | 100 | 140 |
+| **package total** | **1120** | **1300** |
 
-Per-file ceilings sum to 1370, but the **package** ceiling of 1150 binds first — one module
+**Raised 2026-09-05 (1150 -> 1300)** to admit `embed.py`. It closes a data leak: a local
+agent embedded against OpenAI, sending the user's documents and queries off the machine.
+The ceiling test failed on the addition, which is the mechanism working -- the budget was
+raised deliberately here rather than absorbed silently.
+
+Per-file ceilings sum to 1510, but the **package** ceiling of 1300 binds first — one module
 may grow only if another shrinks. Raising a ceiling requires editing this document in the same
 commit. Exceeding it is a failing test, not a review comment.
 

--- a/src/praisonai-agents/docs/local-model-layer/07-local-package-spec.md
+++ b/src/praisonai-agents/docs/local-model-layer/07-local-package-spec.md
@@ -957,7 +957,6 @@ are therefore enforced by `test_sloc_ceiling` (non-blank, non-comment lines), no
 | `discover.py` | 220 | 300 |
 | `target.py` | 180 | 240 |
 | `manage.py` | 120 | 160 |
-| `embed.py` | 90 | 120 |
 | `embed.py` (local embedder selection) | 100 | 140 |
 | **package total** | **1120** | **1300** |
 

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -308,6 +308,15 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
                     cls._env_output_checked = True
         return cls._env_output_mode
     
+    @staticmethod
+    def _local_discovery(target):
+        """Re-read the discovery for a resolved local target (cached upstream)."""
+        try:
+            from ..local import probe_endpoint
+            return probe_endpoint(target.base_url, expect=target.engine)
+        except Exception:
+            return None
+
     # Ordered (credential env-var, provider-appropriate default model). The
     # first provider whose credential is present wins. OpenAI is first so
     # existing OpenAI users keep their default; any other single configured
@@ -2191,6 +2200,35 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
             if api_key is None:
                 api_key = _target.api_key
             self._local_target = _target
+
+            # Keep a local agent local end to end. Without this, chat went to
+            # the local server while knowledge/memory embedded against OpenAI --
+            # sending the user's documents AND their queries off the machine
+            # with no warning, which defeats the entire point of asking for a
+            # local model. Only fills a gap: an explicit embedder always wins.
+            _wants_embeddings = (retrieval_config is not None
+                                 or embedder_config is not None
+                                 or memory not in (None, False))
+            if _wants_embeddings and not embedder_config and not (
+                    retrieval_config or {}).get('embedder_config'):
+                from ..local import (local_embedder_config as _local_embedder,
+                                     select_embedding_model as _select_embed)
+                _embed_model = _select_embed(
+                    getattr(_d, 'models', ()) if (_d := Agent._local_discovery(_target)) else (),
+                    getattr(_d, 'model_meta', ()) if _d else ())
+                if _embed_model:
+                    embedder_config = _local_embedder(
+                        _target.engine, _target.base_url, _embed_model)
+                    if retrieval_config is not None:
+                        retrieval_config.setdefault('embedder_config', embedder_config)
+                else:
+                    logging.warning(
+                        "llm=%r resolved a local model, but %s serves no embedding "
+                        "model, so knowledge/memory would embed against a remote "
+                        "provider -- sending your documents off this machine. "
+                        "Pull one (e.g. `ollama pull nomic-embed-text`) or set an "
+                        "explicit embedder to silence this.",
+                        llm, _target.base_url)
 
         # Panel (multi-model) descriptor: "panel:<name>" or {"provider": "panel"}.
         # Resolved lazily into a PanelLLM; composes with the normal tool loop.

--- a/src/praisonai-agents/praisonaiagents/knowledge/adapters/factories.py
+++ b/src/praisonai-agents/praisonaiagents/knowledge/adapters/factories.py
@@ -135,6 +135,11 @@ class ChromaKnowledgeAdapter:
         config = kwargs.get("config", {})
         vector_config = config.get("vector_store", {}).get("config", {})
         
+        # The configured embedder. Reading only OPENAI_EMBEDDING_MODEL here meant
+        # an agent that had explicitly selected a local embedder still sent every
+        # document and query to OpenAI -- silently, and with a 200 back.
+        self._embedder = config.get("embedder") or {}
+
         collection_name = vector_config.get("collection_name", "praisonai_knowledge")
         persist_dir = vector_config.get("path") or _default_chroma_path()
         os.makedirs(persist_dir, exist_ok=True)
@@ -169,6 +174,34 @@ class ChromaKnowledgeAdapter:
                 metadata={"hnsw:space": "cosine"}
             )
     
+    def _embedding_call(self):
+        """Resolve (model, kwargs) for the configured embedder.
+
+        Precedence: the embedder block the agent configured > the
+        OPENAI_EMBEDDING_MODEL env var > OpenAI's default. Returns kwargs
+        carrying api_base when the embedder points at a local server, so the
+        request cannot escape to a remote provider.
+        """
+        block = self._embedder or {}
+        provider = (block.get("provider") or "").strip().lower()
+        cfg = block.get("config") or {}
+        model = cfg.get("model")
+        if not model:
+            return os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small"), {}
+
+        extra = {}
+        base = (cfg.get("ollama_base_url") or cfg.get("openai_base_url")
+                or cfg.get("api_base") or cfg.get("base_url"))
+        if provider == "ollama":
+            if not model.startswith("ollama/"):
+                model = f"ollama/{model}"
+            if base:
+                extra["api_base"] = base.rstrip("/")
+        elif base:
+            extra["api_base"] = base.rstrip("/")
+            extra.setdefault("api_key", cfg.get("api_key") or "local")
+        return model, extra
+
     def search(self, query: str, *, user_id: Optional[str] = None, agent_id: Optional[str] = None,
                run_id: Optional[str] = None, limit: int = 10, filters: Optional[Dict[str, Any]] = None,
                **kwargs: Any):
@@ -176,10 +209,10 @@ class ChromaKnowledgeAdapter:
         from ..models import SearchResult, SearchResultItem
         
         # Get embedding for query
-        embedding_model = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+        embedding_model, embedding_kwargs = self._embedding_call()
         try:
             from praisonaiagents.embedding import embedding
-            result = embedding(query, model=embedding_model)
+            result = embedding(query, model=embedding_model, **embedding_kwargs)
             query_embedding = result.embeddings[0] if result.embeddings else None
         except Exception as e:
             logger.warning(
@@ -257,11 +290,11 @@ class ChromaKnowledgeAdapter:
         content_str = str(content)
         
         # Get embedding
-        embedding_model = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+        embedding_model, embedding_kwargs = self._embedding_call()
         embedding_error = None
         try:
             from praisonaiagents.embedding import embedding
-            result = embedding(content_str, model=embedding_model)
+            result = embedding(content_str, model=embedding_model, **embedding_kwargs)
             content_embedding = result.embeddings[0] if result.embeddings else None
         except Exception as e:
             logger.warning(

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -250,6 +250,14 @@ class LLM:
         "results already gathered."
     )
     STEP_LIMIT_FALLBACK_MESSAGE = "Reached the step limit before finishing this task."
+
+    # Stalled-tool-loop finalisation: used when a provider re-emits an
+    # identical tool call with no prose, so the loop cannot make progress.
+    TOOL_LOOP_STALL_PROMPT = (
+        "The tools have already been called and their results are above. "
+        "Do not call any tools. Answer the original question now using "
+        "those results."
+    )
     
     # Force tool usage prompt template (used when model ignores tools)
     FORCE_TOOL_USAGE_PROMPT = """You MUST use one of the available tools to answer this question.
@@ -2094,7 +2102,8 @@ Respond with ONLY a valid JSON tool call in this format:
             logging.debug("Deferred registration skipped (non-fatal): %s", e)
 
     def _finalise_on_limit(self, messages: List[Dict], response_text: str,
-                           temperature: float = 0.2, **kwargs) -> str:
+                           temperature: float = 0.2,
+                           wrap_up_prompt: Optional[str] = None, **kwargs) -> str:
         """
         Force a final tools-disabled answer when the tool-calling loop hits max_iter.
 
@@ -2114,7 +2123,8 @@ Respond with ONLY a valid JSON tool call in this format:
         Returns:
             The synthesised final answer, or a safe fallback string.
         """
-        wrap_up = {"role": "user", "content": self.STEP_LIMIT_WRAP_UP_PROMPT}
+        wrap_up = {"role": "user",
+                   "content": wrap_up_prompt or self.STEP_LIMIT_WRAP_UP_PROMPT}
         try:
             safe_kwargs = {k: v for k, v in kwargs.items() if k != 'reasoning_steps'}
             final_params = self._build_completion_params(
@@ -4581,6 +4591,8 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     is_ollama = self._is_ollama_provider()
                     fallback_iterations = 0
                     tool_call_count = 0
+                    last_tool_call_fingerprint = None
+                    stall_reason = None
                     max_fallback_iterations = kwargs.pop("max_iterations", self.max_iter)
                     while fallback_iterations < max_fallback_iterations:
                         fallback_iterations += 1
@@ -4605,11 +4617,28 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
 
                         if not tool_calls or not execute_tool_fn:
                             # Nothing to dispatch: emit whatever prose we have.
-                            # An answer with no content AND no tool calls is the
-                            # provider's business, not ours to invent.
                             if content:
                                 yield content
+                            elif tool_call_count:
+                                # Tools ran, but the provider ended the turn
+                                # without writing an answer.
+                                stall_reason = "empty final answer"
                             break
+
+                        # A provider that re-emits the identical tool call with
+                        # no prose is not making progress: those results are
+                        # already in `messages`, so running the tool again
+                        # cannot add information. Stop before dispatching.
+                        fingerprint = self._tool_call_fingerprint(tool_calls, is_ollama)
+                        if (not content and tool_call_count
+                                and fingerprint == last_tool_call_fingerprint):
+                            logging.warning(
+                                "Provider repeated the same tool call with no answer at "
+                                f"fallback iteration {fallback_iterations}; finalising "
+                                "with tools disabled.")
+                            stall_reason = "repeated tool call"
+                            break
+                        last_tool_call_fingerprint = fingerprint
 
                         # Record the assistant turn before the tool replies, so
                         # the follow-up request is a valid conversation.
@@ -4634,6 +4663,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             logging.warning(
                                 f"Tool call limit reached ({max_tool_calls_per_turn}). "
                                 "Stopping to prevent infinite loop.")
+                            stall_reason = "tool call limit"
                             break
                         if tool_call_count + len(tool_calls) > max_tool_calls_per_turn:
                             remaining_calls = max_tool_calls_per_turn - tool_call_count
@@ -4685,8 +4715,28 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         # Loop: ask again now the results are in the messages.
                     else:
                         logging.warning(
-                            f"Tool call limit reached ({max_fallback_iterations}) on the "
+                            f"Iteration limit reached ({max_fallback_iterations}) on the "
                             "non-streaming fallback.")
+                        stall_reason = "iteration limit"
+
+                    # The loop ended without the provider ever writing an answer,
+                    # but every tool result is in `messages`. Ask once more with
+                    # tools disabled: the provider cannot emit another tool call,
+                    # so it has to answer. This is the same bounded finalisation
+                    # get_response and get_response_async already perform -- the
+                    # stream path was the only one that skipped it.
+                    if stall_reason and tool_call_count:
+                        final_text = self._finalise_on_limit(
+                            messages, "", temperature=temperature,
+                            wrap_up_prompt=self.TOOL_LOOP_STALL_PROMPT,
+                            **kwargs)
+                        if (final_text and final_text.strip()
+                                and final_text != self.STEP_LIMIT_FALLBACK_MESSAGE):
+                            yield final_text
+                        else:
+                            raise LLMResponseError(
+                                f"Provider produced no answer after {tool_call_count} "
+                                f"tool call(s) on the streaming path ({stall_reason}).")
 
                 except Exception as e:
                     logging.error(f"Non-streaming fallback failed: {e}")
@@ -5958,7 +6008,17 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         bare model under subscription auth does not reach LiteLLM unprefixed.
         """
         model = self.model
-        if not isinstance(model, str) or "/" in model:
+        if not isinstance(model, str):
+            return model
+        # llama.cpp's llama-server speaks OpenAI, but litellm knows no
+        # "llama_cpp/" provider -- it raised "LLM Provider NOT provided" and
+        # then retried four times before returning None. We accept the prefix
+        # because it names a real local engine, so we must also make it
+        # routable: strip it and let the OpenAI client handle the base_url.
+        for _local_prefix in ("llama_cpp/", "llamacpp/"):
+            if model.startswith(_local_prefix):
+                return f"openai/{model[len(_local_prefix):]}"
+        if "/" in model:
             return model
         effective_base_url = self.base_url
         if not effective_base_url:
@@ -6832,6 +6892,25 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     }
                 })
         return serializable_tool_calls
+
+    def _tool_call_fingerprint(self, tool_calls, is_ollama: bool = False) -> tuple:
+        """Stable identity for a batch of tool calls, ignoring provider call ids.
+
+        Two consecutive batches with the same fingerprint and no prose between
+        them mean the provider is repeating itself, not making progress. Call
+        ids are excluded deliberately: Ollama mints a fresh one every turn, so
+        an id-sensitive comparison would never match.
+        """
+        fingerprint = []
+        for tool_call in tool_calls:
+            function_name, arguments, _ = self._extract_tool_call_info(
+                tool_call, is_ollama)
+            try:
+                rendered = json.dumps(arguments, sort_keys=True, default=str)
+            except (TypeError, ValueError):
+                rendered = str(arguments)
+            fingerprint.append((function_name, rendered))
+        return tuple(fingerprint)
 
     def _extract_tool_call_info(self, tool_call, is_ollama: bool = False) -> tuple:
         """Extract function name, arguments, and tool_call_id from a tool call.

--- a/src/praisonai-agents/praisonaiagents/local/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/local/__init__.py
@@ -32,12 +32,22 @@ from .quirktable import (NOTES, Quirk, QuirkNote, Severity, all_notes, note,
 from .errors import (EngineUnreachableError, HostHeaderRejectedError,
                      InvalidLocalSpecError, LocalError, ModelNotAvailableError,
                      NoLocalEngineError)
+from .embed import (
+    ENV_EMBED_MODEL,
+    PREFERRED_EMBED_MODELS,
+    local_embedder_config,
+    select_embedding_model,
+)
 from .target import (DEFAULT_API_KEY, ENV_BASE_URL, ENV_ENGINE, ENV_MODEL,
                      LocalTarget, build_target, litellm_model_for,
                      parse_ollama_host, parse_spec, select_model)
 from .resolve import cache_info, clear_cache, resolve, resolve_or_none
 
 __all__ = [
+    "ENV_EMBED_MODEL",
+    "PREFERRED_EMBED_MODELS",
+    "local_embedder_config",
+    "select_embedding_model",
     "LocalEngine", "ApiStyle", "Cap", "Evidence", "Severity", "Quirk",
     "DEFAULT_CAPS", "default_caps", "parse_ollama_capabilities",
     "parse_llama_cpp_props", "parse_lm_studio_models", "parse_openai_models",

--- a/src/praisonai-agents/praisonaiagents/local/discover.py
+++ b/src/praisonai-agents/praisonaiagents/local/discover.py
@@ -319,14 +319,34 @@ def probe_endpoint(base_url: str, *, expect=None, timeout: float = DEFAULT_PROBE
             raw_identity=raw.decode("utf-8", errors="replace")[:200],
             latency_ms=int((time.monotonic() - started) * 1000))
 
-    # Something answered but matched no discriminator: report it honestly.
-    if first_reply is not None and first_reply.status == 200:
-        listing = _json(fetch("GET", "/v1/models"))
+    # No discriminator matched. Before declaring the host absent, ask the one
+    # question every OpenAI-compatible server answers. Gating this on the first
+    # probe's status was wrong: that probe is Ollama's `GET /`, which a generic
+    # OpenAI-compatible server 404s -- so a healthy llama-server, LM Studio or
+    # vLLM was reported as "did not answer (refused)" while it was serving.
+    # It also makes the pinned-engine path reachable: an engine named by
+    # PRAISONAI_LOCAL_ENGINE that has no ProbeSpec (llamafile, localai,
+    # ramalama) produced an empty candidate list and could never resolve.
+    models_reply = fetch("GET", "/v1/models")
+    if 200 <= models_reply.status < 300:
+        listing = _json(models_reply)
+        pinned = LocalEngine(expect) if expect else None
         return Discovery(
-            engine=LocalEngine.UNKNOWN, base_url=base,
+            engine=pinned or LocalEngine.UNKNOWN, base_url=base,
             api_style=ApiStyle.OPENAI_CHAT if isinstance(listing, dict) else ApiStyle.OPENAI_COMPLETIONS,
-            evidence=Evidence.TABLE,
+            # A pinned engine is asserted by the environment, not observed.
+            evidence=Evidence.ENV if pinned else Evidence.TABLE,
             models=parse_openai_models(listing) if isinstance(listing, dict) else (),
+            raw_identity=models_reply.body.decode("utf-8", errors="replace")[:200],
+            latency_ms=int((time.monotonic() - started) * 1000))
+
+    # Some servers expose no model listing at all. If anything answered with a
+    # 2xx we still know a server is there; only a transport failure means absent.
+    if first_reply is not None and 200 <= first_reply.status < 300:
+        return Discovery(
+            engine=LocalEngine(expect) if expect else LocalEngine.UNKNOWN,
+            base_url=base, api_style=ApiStyle.OPENAI_CHAT,
+            evidence=Evidence.ENV if expect else Evidence.TABLE,
             raw_identity=first_reply.body.decode("utf-8", errors="replace")[:200],
             latency_ms=int((time.monotonic() - started) * 1000))
     return None

--- a/src/praisonai-agents/praisonaiagents/local/discover.py
+++ b/src/praisonai-agents/praisonaiagents/local/discover.py
@@ -327,7 +327,9 @@ def probe_endpoint(base_url: str, *, expect=None, timeout: float = DEFAULT_PROBE
     # It also makes the pinned-engine path reachable: an engine named by
     # PRAISONAI_LOCAL_ENGINE that has no ProbeSpec (llamafile, localai,
     # ramalama) produced an empty candidate list and could never resolve.
-    models_reply = fetch("GET", "/v1/models")
+    # A base the user pasted from LM Studio or vLLM already ends in /v1; adding
+    # another produced /v1/v1/models and a 404, so a healthy server looked absent.
+    models_reply = fetch("GET", "/models" if base.endswith("/v1") else "/v1/models")
     if 200 <= models_reply.status < 300:
         listing = _json(models_reply)
         pinned = LocalEngine(expect) if expect else None

--- a/src/praisonai-agents/praisonaiagents/local/embed.py
+++ b/src/praisonai-agents/praisonaiagents/local/embed.py
@@ -1,0 +1,99 @@
+"""Resolve a local embedding model, so a local agent stays local end to end.
+
+The gap this closes: `Agent(llm="local", knowledge=[...])` routed chat to the
+local server and embeddings to OpenAI, sending both the user's documents and
+their queries off the machine with no warning. Ollama already serves
+`nomic-embed-text` and friends; nothing asked it.
+
+Data only, per the package contract: this returns a model name and an endpoint.
+It never embeds anything.
+"""
+
+import os
+from typing import Optional, Sequence, Tuple
+
+from .capabilities import LocalEngine
+
+__all__ = ["ENV_EMBED_MODEL", "PREFERRED_EMBED_MODELS",
+           "select_embedding_model", "local_embedder_config"]
+
+ENV_EMBED_MODEL = "PRAISONAI_LOCAL_EMBED_MODEL"
+
+# Preference order when the caller names nothing. These are the embedders people
+# actually pull for Ollama; the first one present wins. Order is quality-biased,
+# not alphabetical: nomic-embed-text is the common default and outranks the
+# smaller all-minilm.
+PREFERRED_EMBED_MODELS = (
+    "nomic-embed-text",
+    "mxbai-embed-large",
+    "bge-m3",
+    "snowflake-arctic-embed",
+    "all-minilm",
+)
+
+
+def _is_embedding_model(name: str, capabilities: Sequence[str]) -> bool:
+    """True when a listed model can serve embeddings.
+
+    Prefers the server's own capability list; falls back to the name for
+    servers that report no capabilities at all.
+    """
+    if capabilities:
+        return "embedding" in capabilities
+    lowered = name.lower()
+    return "embed" in lowered or lowered.startswith("bge-")
+
+
+def select_embedding_model(
+    models: Sequence[str],
+    model_meta: Sequence[Tuple[str, Tuple[str, ...], Optional[str]]] = (),
+) -> Optional[str]:
+    """Pick an embedding model from what the server actually serves.
+
+    Precedence: PRAISONAI_LOCAL_EMBED_MODEL (validated against the list) >
+    PREFERRED_EMBED_MODELS order > any remaining embedding-capable model.
+    Returns None when the server serves no embedding model -- callers must
+    treat that as "cannot embed locally", never as "fall back to a cloud
+    default".
+    """
+    caps_by_name = {name: caps for name, caps, _ in (model_meta or ())}
+    embedders = [m for m in models
+                 if _is_embedding_model(m, caps_by_name.get(m, ()))]
+    if not embedders:
+        return None
+
+    named = (os.environ.get(ENV_EMBED_MODEL) or "").strip()
+    if named:
+        # Accept an exact id or a bare name the server tags (":latest").
+        for candidate in embedders:
+            if candidate == named or candidate.split(":", 1)[0] == named:
+                return candidate
+        return None
+
+    for preferred in PREFERRED_EMBED_MODELS:
+        for candidate in embedders:
+            if candidate.split(":", 1)[0] == preferred:
+                return candidate
+    return embedders[0]
+
+
+def local_embedder_config(engine: LocalEngine, base_url: str,
+                          model: str) -> dict:
+    """Build the embedder config block for a local engine.
+
+    Shaped for the knowledge/memory layer (mem0-style provider + config).
+    """
+    if engine is LocalEngine.OLLAMA:
+        return {
+            "provider": "ollama",
+            "config": {"model": model, "ollama_base_url": base_url},
+        }
+    # Everything else speaks OpenAI over HTTP.
+    trimmed = base_url.rstrip("/")
+    return {
+        "provider": "openai",
+        "config": {
+            "model": model,
+            "openai_base_url": trimmed if trimmed.endswith("/v1") else trimmed + "/v1",
+        },
+    }

--- a/src/praisonai-agents/praisonaiagents/local/target.py
+++ b/src/praisonai-agents/praisonaiagents/local/target.py
@@ -110,7 +110,11 @@ def parse_ollama_host(value: str) -> Optional[str]:
         if not parsed.hostname:
             return None
         port = parsed.port or (443 if parsed.scheme == "https" else 80)
-        return f"{parsed.scheme}://{parsed.hostname}:{port}"
+        # Keep any path prefix. A reverse proxy commonly mounts the server under
+        # one (http://gateway:8000/ollama); rebuilding from host+port alone
+        # silently rewrote the URL and sent every request to the proxy root.
+        path = parsed.path.rstrip("/")
+        return f"{parsed.scheme}://{parsed.hostname}:{port}{path}"
     if raw.isdigit():
         return f"http://127.0.0.1:{raw}"
     if raw.startswith(":") and raw[1:].isdigit():
@@ -184,6 +188,16 @@ def _negate_iso(value: str):
     return tuple(-ord(c) for c in value) if value else ()
 
 
+def _openai_base(base_url: str) -> str:
+    """Return the OpenAI-compatible root for a base URL, without doubling /v1.
+
+    Users routinely paste the URL their server prints, which for LM Studio and
+    vLLM already ends in /v1. Appending unconditionally produced /v1/v1.
+    """
+    trimmed = base_url.rstrip("/")
+    return trimmed if trimmed.endswith("/v1") else trimmed + "/v1"
+
+
 def build_target(discovery: Discovery, model_id, *, caps=None,
                  caps_evidence=Evidence.TABLE, model_evidence=Evidence.SERVER,
                  extra=()) -> LocalTarget:
@@ -205,7 +219,7 @@ def build_target(discovery: Discovery, model_id, *, caps=None,
     return LocalTarget(
         engine=engine,
         base_url=discovery.base_url,
-        openai_base_url=discovery.base_url + "/v1",
+        openai_base_url=_openai_base(discovery.base_url),
         api_style=discovery.api_style,
         model_id=model_id,
         caps=resolved_caps,

--- a/src/praisonai-agents/tests/unit/llm/test_stream_tools_reach_the_model.py
+++ b/src/praisonai-agents/tests/unit/llm/test_stream_tools_reach_the_model.py
@@ -138,12 +138,24 @@ class TestNonStreamingFallbackRunsTools:
         assert "".join(out).strip()
 
     def test_it_stops_at_max_tool_calls_per_turn(self):
-        """The fallback must honour the same per-turn guardrail as the other loops."""
+        """The fallback must honour the same per-turn guardrail as the other loops.
+
+        The provider asks for a DIFFERENT city each round, so this is a genuine
+        multi-step chain and only the guardrail can stop it. (An identical
+        repeated call is a stall and is stopped sooner -- see the test below.)
+        """
         llm = LLM(model="anthropic/claude-sonnet-4-20250514")
         state = {"ran": 0}
 
         def always_calls(**kwargs):
-            message = types.SimpleNamespace(content=None, tool_calls=[_tool_call()])
+            # The tools-disabled finalisation request the loop makes once it
+            # stops. _finalise_on_limit reads the response by subscript, as a
+            # litellm ModelResponse supports, so the fake answers in kind.
+            if not kwargs.get("tools"):
+                return {"choices": [{"message": {"content": "Done.", "tool_calls": None}}]}
+            city = f"City{state['ran']}"
+            message = types.SimpleNamespace(
+                content=None, tool_calls=[_tool_call(args='{"city":"%s"}' % city)])
             return types.SimpleNamespace(
                 choices=[types.SimpleNamespace(message=message, finish_reason="tool_calls")])
 
@@ -157,6 +169,37 @@ class TestNonStreamingFallbackRunsTools:
                                      max_tool_calls_per_turn=3))
         assert state["ran"] == 3, (
             "the fallback ran tools past max_tool_calls_per_turn")
+
+    def test_an_identical_repeated_tool_call_is_stopped_as_a_stall(self):
+        """A provider re-emitting the same call with no prose makes no progress.
+
+        Before this guard the loop ran the user's tool ten times for one
+        question and then yielded nothing at all.
+        """
+        llm = LLM(model="anthropic/claude-sonnet-4-20250514")
+        state = {"ran": 0}
+
+        def same_call_forever(**kwargs):
+            # A request with no tools is the tools-disabled finalisation.
+            # _finalise_on_limit reads it by subscript, as a litellm
+            # ModelResponse supports, so the fake answers in kind.
+            if not kwargs.get("tools"):
+                return {"choices": [{"message": {"content": "It is sunny.",
+                                                 "tool_calls": None}}]}
+            message = types.SimpleNamespace(content=None, tool_calls=[_tool_call()])
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=message, finish_reason="stop")])
+
+        def execute(name, args, *a, **kw):
+            state["ran"] += 1
+            return get_weather(**args)
+
+        llm._completion_with_retry = same_call_forever
+        out = "".join(str(c) for c in llm.get_response_stream(
+            prompt="weather?", system_prompt="x", tools=[get_weather],
+            execute_tool_fn=execute, max_tool_calls_per_turn=10))
+        assert state["ran"] == 1, f"the identical call was dispatched {state['ran']} times"
+        assert "sunny" in out, "the stalled turn yielded nothing"
 
 
 if __name__ == "__main__":

--- a/src/praisonai/README.md
+++ b/src/praisonai/README.md
@@ -1120,8 +1120,11 @@ ollama pull llama3.2
 ```python
 from praisonaiagents import Agent
 
-agent = Agent(instructions="You are a helpful assistant", llm="ollama/llama3.2")
-agent.start("Why is the sky blue?")
+# Simplest: let PraisonAI find the running server and pick a model.
+Agent(instructions="You are a helpful assistant", llm="local").start("Hello!")
+
+# Or name the model yourself.
+Agent(instructions="You are a helpful assistant", llm="ollama/llama3.2").start("Why is the sky blue?")
 ```
 
 The `ollama/` prefix is what selects Ollama's handling — tool-call repair,

--- a/src/praisonai/examples/python/recipes_background/example_background.py
+++ b/src/praisonai/examples/python/recipes_background/example_background.py
@@ -31,7 +31,7 @@ async def main():
     agent = Agent(
         name="Research Assistant",
         instructions="You are a helpful research assistant. Provide concise answers.",
-        verbose=True
+        output='verbose'
     )
     
     # Create background runner

--- a/src/praisonai/examples/python/recipes_scheduler/example_scheduler.py
+++ b/src/praisonai/examples/python/recipes_scheduler/example_scheduler.py
@@ -31,7 +31,7 @@ def main():
     agent = Agent(
         name="News Monitor",
         instructions="You are a news monitoring assistant. Provide brief updates.",
-        verbose=True
+        output='verbose'
     )
     
     # Create scheduler

--- a/src/praisonai/tests/unit/llm/local/test_import_boundary.py
+++ b/src/praisonai/tests/unit/llm/local/test_import_boundary.py
@@ -133,4 +133,4 @@ def test_sloc_ceiling():
         ceiling = ceilings.get(path.name)
         if ceiling:
             assert sloc <= ceiling, f"{path.name} is {sloc} SLOC, ceiling {ceiling}"
-    assert total <= 1160, f"package is {total} SLOC, ceiling 1160"
+    assert total <= 1300, f"package is {total} SLOC, ceiling 1300"

--- a/src/praisonai/tests/unit/llm/test_local_gap_fixes.py
+++ b/src/praisonai/tests/unit/llm/test_local_gap_fixes.py
@@ -1,0 +1,158 @@
+"""Regressions for gaps found by auditing the merged local-model work.
+
+Each test names the defect it guards. All are offline: they use a fake HTTP
+transport or pure functions, so they pass with no server and no keys.
+"""
+
+import pytest
+
+from praisonaiagents import local
+from praisonaiagents.local.capabilities import ApiStyle, Evidence, LocalEngine
+from praisonaiagents.local.discover import Discovery, HttpReply
+
+
+def _transport(routes, default=HttpReply(0, b"", "refused")):
+    """Fake Transport: routes is {(method, path): HttpReply}."""
+    def send(method, url, body, timeout):
+        path = url.split("://", 1)[1].split("/", 1)
+        path = "/" + path[1] if len(path) > 1 else "/"
+        return routes.get((method, path), default)
+    return send
+
+
+class TestDiscoveryFallback:
+    """S2: a live OpenAI-compatible server that 404s '/' was reported absent."""
+
+    OPENAI_ONLY = {
+        ("GET", "/v1/models"): HttpReply(200, b'{"object":"list","data":[{"id":"m1"}]}', None),
+    }
+
+    def test_a_server_that_only_answers_v1_models_is_found(self):
+        d = local.probe_endpoint("http://127.0.0.1:9", transport=_transport(
+            self.OPENAI_ONLY, default=HttpReply(404, b"{}", "http")))
+        assert d is not None, "a live OpenAI-compatible server was reported absent"
+        assert d.engine is LocalEngine.UNKNOWN
+        assert d.models == ("m1",)
+
+    def test_a_genuinely_dead_host_is_still_absent(self):
+        # The fallback must not turn a transport failure into a discovery.
+        assert local.probe_endpoint("http://127.0.0.1:9", transport=_transport({})) is None
+
+
+class TestEnginePin:
+    """S3: PRAISONAI_LOCAL_ENGINE only ever filtered, so engines with no
+    ProbeSpec (llamafile, localai, ramalama) were reachable by no route."""
+
+    @pytest.mark.parametrize("engine", ["llamafile", "localai", "ramalama"])
+    def test_an_engine_without_a_probe_spec_can_still_be_pinned(self, engine):
+        d = local.probe_endpoint(
+            "http://127.0.0.1:9", expect=engine,
+            transport=_transport({("GET", "/v1/models"): HttpReply(
+                200, b'{"data":[{"id":"m1"}]}', None)},
+                default=HttpReply(404, b"{}", "http")))
+        assert d is not None, f"{engine} pinned by env was unreachable"
+        assert d.engine is LocalEngine(engine)
+        assert d.evidence is Evidence.ENV, "a pinned engine is asserted, not observed"
+
+
+class TestUrlHandling:
+    def test_a_path_prefix_survives(self):
+        """A reverse proxy commonly mounts the server under a path."""
+        assert local.parse_ollama_host("http://gateway:8000/ollama") == "http://gateway:8000/ollama"
+
+    def test_a_bare_host_still_defaults_to_11434(self):
+        assert local.parse_ollama_host("127.0.0.1") == "http://127.0.0.1:11434"
+
+    def test_an_explicit_scheme_without_a_port_still_means_80(self):
+        assert local.parse_ollama_host("http://127.0.0.1") == "http://127.0.0.1:80"
+
+    def test_v1_is_not_doubled(self):
+        """Users paste the URL their server prints, which often ends in /v1."""
+        from praisonaiagents.local.target import _openai_base
+        assert _openai_base("http://h:1234/v1") == "http://h:1234/v1"
+        assert _openai_base("http://h:11434") == "http://h:11434/v1"
+
+
+class TestLocalEmbedderSelection:
+    """S1: a local agent embedded against OpenAI, sending documents off-machine."""
+
+    META = (
+        ("qwen3:0.6b", ("completion", "tools"), "2026-09-03T10:00:00Z"),
+        ("all-minilm:latest", ("embedding",), "2026-09-03T10:00:00Z"),
+        ("nomic-embed-text:latest", ("embedding",), "2026-09-03T10:00:00Z"),
+    )
+    NAMES = tuple(m[0] for m in META)
+
+    def test_an_embedding_model_is_preferred_over_a_chat_model(self):
+        assert local.select_embedding_model(self.NAMES, self.META) == "nomic-embed-text:latest"
+
+    def test_none_when_the_server_serves_no_embedder(self):
+        """Must be None, never a cloud default -- that was the leak."""
+        chat_only = (("qwen3:0.6b", ("completion",), None),)
+        assert local.select_embedding_model(("qwen3:0.6b",), chat_only) is None
+
+    def test_an_explicit_choice_wins(self, monkeypatch):
+        monkeypatch.setenv("PRAISONAI_LOCAL_EMBED_MODEL", "all-minilm")
+        assert local.select_embedding_model(self.NAMES, self.META) == "all-minilm:latest"
+
+    def test_ollama_embedder_config_carries_the_endpoint(self):
+        cfg = local.local_embedder_config(
+            LocalEngine.OLLAMA, "http://127.0.0.1:11434", "nomic-embed-text")
+        assert cfg["provider"] == "ollama"
+        assert cfg["config"]["ollama_base_url"] == "http://127.0.0.1:11434"
+
+    def test_openai_shaped_engines_get_a_v1_endpoint(self):
+        cfg = local.local_embedder_config(
+            LocalEngine.LM_STUDIO, "http://127.0.0.1:1234", "text-embed")
+        assert cfg["config"]["openai_base_url"].endswith("/v1")
+
+
+class TestChromaAdapterHonoursTheEmbedder:
+    """S1 root cause: the adapter read only OPENAI_EMBEDDING_MODEL, so a
+    configured local embedder was silently discarded."""
+
+    def _adapter(self, embedder):
+        from praisonaiagents.knowledge.adapters.factories import ChromaKnowledgeAdapter
+        a = ChromaKnowledgeAdapter.__new__(ChromaKnowledgeAdapter)
+        a._embedder = embedder
+        return a
+
+    def test_a_configured_ollama_embedder_is_used_with_its_endpoint(self):
+        model, kwargs = self._adapter({
+            "provider": "ollama",
+            "config": {"model": "nomic-embed-text", "ollama_base_url": "http://127.0.0.1:11434"},
+        })._embedding_call()
+        assert model == "ollama/nomic-embed-text"
+        assert kwargs["api_base"] == "http://127.0.0.1:11434"
+
+    def test_no_embedder_configured_falls_back_to_the_previous_default(self):
+        model, kwargs = self._adapter({})._embedding_call()
+        assert model == "text-embedding-3-small"
+        assert kwargs == {}, "an unconfigured call must be byte-identical to before"
+
+
+class TestLlamaCppPrefixIsRoutable:
+    """A prefix we accept must be one litellm can route, or the request dies
+    after four retries with 'LLM Provider NOT provided'."""
+
+    @pytest.mark.parametrize("prefix", ["llama_cpp", "llamacpp"])
+    def test_llama_cpp_is_rewritten_for_litellm(self, prefix, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "x")
+        from praisonaiagents.llm.llm import LLM
+        llm = LLM(model=f"{prefix}/qwen3", base_url="http://127.0.0.1:8080/v1")
+        assert llm._resolve_openai_compatible_model() == "openai/qwen3"
+
+    def test_it_still_selects_the_local_adapter(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "x")
+        from praisonaiagents.llm.adapters import LocalOpenAIAdapter
+        from praisonaiagents.llm.llm import LLM
+        llm = LLM(model="llama_cpp/qwen3", base_url="http://127.0.0.1:8080/v1")
+        assert isinstance(llm._provider_adapter, LocalOpenAIAdapter)
+
+    @pytest.mark.parametrize("model", ["ollama/x", "lm_studio/x", "vllm/x", "gpt-4o"])
+    def test_other_prefixes_are_untouched(self, model, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "x")
+        from praisonaiagents.llm.llm import LLM
+        llm = LLM(model=model)
+        resolved = llm._resolve_openai_compatible_model()
+        assert resolved == model or resolved == f"openai/{model}"

--- a/src/praisonai/tests/unit/llm/test_local_gap_fixes.py
+++ b/src/praisonai/tests/unit/llm/test_local_gap_fixes.py
@@ -38,6 +38,17 @@ class TestDiscoveryFallback:
         # The fallback must not turn a transport failure into a discovery.
         assert local.probe_endpoint("http://127.0.0.1:9", transport=_transport({})) is None
 
+    def test_a_base_already_ending_in_v1_is_not_doubled(self):
+        """LM Studio and vLLM print a base ending in /v1; the fallback probe
+        appended /v1/models, producing /v1/v1/models -> a 404 that made a live
+        server look absent."""
+        d = local.probe_endpoint("http://127.0.0.1:9/v1", transport=_transport(
+            {("GET", "/v1/models"): HttpReply(
+                200, b'{"object":"list","data":[{"id":"m1"}]}', None)},
+            default=HttpReply(404, b"{}", "http")))
+        assert d is not None, "a /v1 base was probed at /v1/v1/models and looked absent"
+        assert d.models == ("m1",)
+
 
 class TestEnginePin:
     """S3: PRAISONAI_LOCAL_ENGINE only ever filtered, so engines with no


### PR DESCRIPTION
Four audit agents went over the merged local-model work. Every finding was reproduced by running code, and each fix ships a test that fails without it.

## 1. Critical — a "local" agent shipped your documents to OpenAI

`Agent(llm="local", knowledge=[...])` routed chat to Ollama and embeddings to OpenAI. Proved with a stub standing in for `api.openai.com`:

```
/v1/embeddings {"input":"The Zorbulon Protocol was ratified in 1997 by the Council of Vex.",
                "model":"text-embedding-3-small"}
/v1/embeddings {"input":"When was the Zorbulon Protocol ratified?",
                "model":"text-embedding-3-small"}
```

**Both the private document and the user's query left the machine**, with a 200 back and no warning — from the one API whose entire purpose is to keep inference local.

The root cause was not where it looked. The knowledge config was correct all along; `knowledge/adapters/factories.py` read the model **only** from `OPENAI_EMBEDDING_MODEL` and discarded the configured embedder block entirely — including the `api_base` that `embedding()` already accepts.

Fixed in two places: the Chroma adapter now honours the configured embedder and its endpoint, and `Agent` fills the gap when a local target resolves and no embedder was named. When the local server serves no embedding model it **warns and says how to fix it**, rather than quietly using a remote provider.

After, same scenario, clean store:

```
ANSWER: The Zorbulon Protocol was ratified in **1997** by the Council of Vex.
OPENAI-STANDIN-HITS: 0
```

## 2. High — the stream path ran a tool ten times and yielded nothing

Measured at `temperature=0`, reproducible:

| path | tool calls | output |
|---|---|---|
| sync | 2 | `'Paris: 21C sunny. Paris: 21C sunny.'` |
| async | 1 | `'Paris: 21C sunny'` |
| **stream** | **10** | **`''`** |

The tool result *was* being fed back correctly — that hypothesis is refuted. The follow-up request still advertised `tools`, so a small model kept calling instead of answering, and the loop exited through a guardrail that yields nothing.

`get_response_stream` was the only path that never called `_finalise_on_limit` — which `get_response` and `get_response_async` both already use for exactly this. So the fix wires in an existing, tested helper rather than adding machinery: stop before dispatching a repeated identical call, then ask once with tools disabled.

```
stream calls=1  out='Paris is currently sunny with a temperature of 21°C.'
```

One call instead of ten, and a real model-written sentence. **Sync and async are byte-identical**, deliberately — changing them is a separate decision with its own baseline.

Worth knowing for that follow-up: the sync and async outputs above are **not model-written**. They are `str(tool_result)` from `_generate_ollama_tool_summary`, and sync duplicates it. After this PR the stream path produces a better answer than either.

## 3. High — a healthy local server reported as "did not answer (refused)"

`probe_endpoint` gated its OpenAI-compatible fallback on the **first** probe's status — which is Ollama's `GET /`, a 404 for every other server. llama.cpp, LM Studio and vLLM were misdiagnosed as network failures while actively serving.

## 4. High — `PRAISONAI_LOCAL_ENGINE` could only ever reject

It was passed as a probe *filter*, so engines with no `ProbeSpec` (`llamafile`, `localai`, `ramalama`) were reachable by **no route at all** — despite the spec saying that variable is precisely how you reach them.

## 5. Medium — `llama_cpp/` accepted and unroutable

A regression this workstream introduced. `_detect_provider` claimed the prefix; litellm knows no such provider, so the request retried four times and returned `None`. The prefix names a real engine, so it is now rewritten to `openai/` rather than dropped.

## 6. Medium — two URL bugs

A path prefix was silently dropped, so a reverse proxy at `/ollama` had every request rewritten to the root. And `/v1` was appended unconditionally, so a URL that already ended in `/v1` — which is what LM Studio and vLLM print — became `/v1/v1`.

## Also

- **`src/praisonai/README.md` still shipped the recipe the root README documents as broken.** It sets `OPENAI_BASE_URL`, names no model, and a local server answers `model 'gpt-4o-mini' not found`. That file is the **PyPI long description**.
- Two examples passed `verbose=True` to `Agent()`, which raises `TypeError` on construction.

## The SLOC ceiling did its job

`local/embed.py` pushed the package past its budget and the ceiling test failed. Per the spec, raising a ceiling requires editing the spec in the same commit — so it is raised there, with the reason, rather than absorbed silently.

## Verification

```
agents package                     201 passed
praisonai unit (llm/agent/adapters/doctor/knowledge/rag)   670 passed
new regression tests                23 passed
integration selection    194/291 (97 deselected)  — unchanged
```

Live Ollama end-to-end: `Agent(llm="local")` answers; knowledge answers from local embeddings with zero remote requests; sync/async baselines byte-identical.

## Not in this PR

A fourth audit found the leak is wider than the knowledge path: **14 of 26 socket-instrumented probes** reach `api.openai.com` with a fully local agent — `eval/`, `memory/` quality scoring, `workflows/`, `lite/`, `context/` each hold their own direct provider call with no endpoint parameter. That needs four separate PRs and one new public parameter on five `eval/` constructors; it is specified rather than rushed.

Two further findings recorded for follow-up: the order-08 memory repair sits on an `elif openai_available:` branch that never runs when litellm is installed (which is every documented install), and `context/compressor.py`'s two adopted call sites are in provably unreachable code — so a passing anti-regression test is satisfied entirely by dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local model setups can automatically discover embedding models and keep knowledge and memory processing local.
  - Embedding selection supports configured preferences and improved Ollama and OpenAI-compatible server compatibility.
  - Tool-calling responses recover from repeated or stalled requests and produce a final answer when possible.

- **Bug Fixes**
  - Improved local server detection, URL handling, and support for path-prefixed endpoints.
  - Configured knowledge-base embedders are now respected.
  - Improved routing for llama.cpp-compatible model names.

- **Documentation**
  - Updated local Ollama setup guidance and examples for current output configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->