### PR TITLE
fix(mcp): exchange the authorization code instead of storing a fake token

### DIFF
--- a/src/praisonai-mcp/praisonai_mcp/cli/commands/mcp.py
+++ b/src/praisonai-mcp/praisonai_mcp/cli/commands/mcp.py
@@ -691,9 +691,40 @@ def mcp_auth(
         # forever, so the fabricated entry permanently shadowed any real
         # OAuth attempt. MCPOAuthProvider already implements the whole flow,
         # including the code-for-token exchange this command never did.
+        from praisonaiagents.mcp import MCPAuthStorage
         from praisonaiagents.mcp.oauth_provider import MCPOAuthProvider
 
-        provider = MCPOAuthProvider(mcp_name=name, server_url=server.url)
+        storage = MCPAuthStorage()
+
+        # Purge any credential left by the old hand-rolled flow. Those entries
+        # held `f"oauth_{code[:20]}..."` with no expires_at, so is_token_expired()
+        # reported them permanently valid and the provider would return the fake
+        # token instead of running a real exchange. Only the placeholder shape is
+        # removed; genuine (possibly non-expiring) OAuth tokens are preserved.
+        entry = storage.get(name)
+        if entry:
+            access_token = (entry.get("tokens") or {}).get("access_token") or ""
+            if access_token.startswith("oauth_") and access_token.endswith("..."):
+                storage.remove(name)
+
+        provider = MCPOAuthProvider(
+            mcp_name=name, server_url=server.url, storage=storage
+        )
+
+        # Carry a pre-registered client from config into storage so servers
+        # without dynamic registration still authenticate. The provider reads
+        # client_info from storage in _ensure_client(); without this it would
+        # fail with "no registration_endpoint" for pre-registered clients.
+        if server.oauth and server.oauth.client_id:
+            existing = storage.get_for_url(name, server.url) or {}
+            if not (existing.get("client_info") or {}).get("client_id"):
+                client_info = {"client_id": server.oauth.client_id}
+                if server.oauth.client_secret:
+                    client_info["client_secret"] = server.oauth.client_secret
+                storage.set_client_info(
+                    name, client_info, server_url=server.url
+                )
+
         token = provider.ensure_authenticated(timeout=timeout)
         if not token:
             output.print_error(f"Authentication with {name} returned no token")

--- a/src/praisonai-mcp/praisonai_mcp/cli/commands/mcp.py
+++ b/src/praisonai-mcp/praisonai_mcp/cli/commands/mcp.py
@@ -646,11 +646,10 @@ def mcp_auth(
     name: str = typer.Argument(..., help="Server name to authenticate"),
     timeout: float = typer.Option(300.0, "--timeout", "-t", help="Timeout for OAuth flow in seconds"),
 ):
-    """[EXPERIMENTAL] Authenticate with an OAuth-enabled MCP server.
+    """Authenticate with an OAuth-enabled MCP server.
     
-    WARNING: OAuth implementation is currently experimental and stores
-    placeholder tokens only. Real token exchange is not yet implemented.
-    Use headers/API key authentication for production use.
+    Runs the OAuth 2.1 authorization-code flow with PKCE and exchanges the
+    returned code for real tokens at the server's token endpoint.
     
     This command initiates the OAuth 2.1 authorization flow for a remote
     MCP server. It will open your browser for authentication and wait
@@ -685,82 +684,26 @@ def mcp_auth(
     output.print(f"  URL: {server.url}")
     
     try:
-        from praisonaiagents.mcp import (
-            MCPAuthStorage,
-            OAuthCallbackHandler,
-            generate_state,
-            generate_code_verifier,
-            generate_code_challenge,
-            get_redirect_url,
-        )
-        import webbrowser
-        
-        # Initialize auth storage and callback handler
-        auth_storage = MCPAuthStorage()
-        callback_handler = OAuthCallbackHandler()
-        
-        # Generate PKCE parameters
-        state = generate_state()
-        code_verifier = generate_code_verifier()
-        code_challenge = generate_code_challenge(code_verifier)
-        
-        # Store state and verifier
-        auth_storage.set_oauth_state(name, state)
-        auth_storage.set_code_verifier(name, code_verifier)
-        
-        # Build authorization URL
-        # Note: In a real implementation, we'd discover the auth endpoint
-        # For now, we'll use a simple pattern
-        redirect_uri = get_redirect_url()
-        
-        # Get OAuth config
-        client_id = server.oauth.client_id if server.oauth else None
-        scopes = " ".join(server.oauth.scopes) if server.oauth and server.oauth.scopes else ""
-        
-        # Build auth URL (simplified - real impl would use OIDC discovery)
-        auth_url = f"{server.url}/oauth/authorize"
-        auth_url += "?response_type=code"
-        auth_url += f"&state={state}"
-        auth_url += f"&redirect_uri={redirect_uri}"
-        auth_url += f"&code_challenge={code_challenge}"
-        auth_url += "&code_challenge_method=S256"
-        if client_id:
-            auth_url += f"&client_id={client_id}"
-        if scopes:
-            auth_url += f"&scope={scopes}"
-        
-        output.print_info("Opening browser for authentication...")
-        output.print(f"  If browser doesn't open, visit: {auth_url}")
-        
-        # Open browser
-        webbrowser.open(auth_url)
-        
-        output.print_info(f"Waiting for callback (timeout: {timeout}s)...")
-        
-        # Wait for callback
-        try:
-            code = callback_handler.wait_for_callback(state, timeout=timeout)
-            
-            # Store a placeholder token (real impl would exchange code for tokens)
-            auth_storage.set_tokens(name, {
-                "access_token": f"oauth_{code[:20]}...",
-                "refresh_token": None,
-            }, server_url=server.url)
-            
-            if output.is_json_mode:
-                output.print_json({"name": name, "status": "authenticated"})
-            else:
-                output.print_success(f"Successfully authenticated with {name}")
-                
-        except TimeoutError:
-            output.print_error(f"Authentication timed out after {timeout} seconds")
+        # The hand-rolled flow that used to live here stopped at the callback
+        # and stored `f"oauth_{code[:20]}..."` -- a truncated authorization
+        # code, not a token -- then printed "Successfully authenticated".
+        # Because it wrote no expires_at, is_token_expired() returned False
+        # forever, so the fabricated entry permanently shadowed any real
+        # OAuth attempt. MCPOAuthProvider already implements the whole flow,
+        # including the code-for-token exchange this command never did.
+        from praisonaiagents.mcp.oauth_provider import MCPOAuthProvider
+
+        provider = MCPOAuthProvider(mcp_name=name, server_url=server.url)
+        token = provider.ensure_authenticated(timeout=timeout)
+        if not token:
+            output.print_error(f"Authentication with {name} returned no token")
             raise typer.Exit(1)
-        finally:
-            # Always clear temporary OAuth state, regardless of success,
-            # timeout, or interruption.
-            auth_storage.clear_oauth_state(name)
-            auth_storage.clear_code_verifier(name)
-            
+
+        if output.is_json_mode:
+            output.print_json({"name": name, "status": "authenticated"})
+        else:
+            output.print_success(f"Successfully authenticated with {name}")
+
     except ImportError as e:
         output.print_error(f"MCP auth modules not available: {e}")
         output.print("Install with: pip install praisonaiagents[mcp]")

--- a/src/praisonai-mcp/tests/unit/test_mcp_auth_exchanges_code.py
+++ b/src/praisonai-mcp/tests/unit/test_mcp_auth_exchanges_code.py
@@ -22,6 +22,8 @@ MCPOAuthProvider already implemented the whole flow including the exchange
 """
 import ast
 import inspect
+import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -83,6 +85,142 @@ class TestTheProviderReallyExchanges:
             "expiry handling changed; re-check that a token with no expires_at "
             "cannot shadow re-authentication indefinitely"
         )
+
+
+class TestExpiryStorageBehaviour:
+    """Exercise the real storage, not its source, for the shadow property."""
+
+    def test_legacy_entry_without_expires_at_reports_not_expired(self, tmp_path):
+        """This is the exact state that made the fake token unrecoverable."""
+        from praisonaiagents.mcp.mcp_auth_storage import MCPAuthStorage
+
+        storage = MCPAuthStorage(filepath=str(tmp_path / "auth.json"))
+        storage.set_tokens(
+            "srv",
+            {"access_token": "oauth_ABCDEFGHIJKLMNOPQRST...", "refresh_token": None},
+            server_url="https://srv.example/mcp",
+        )
+        # No expires_at -> is_token_expired() is False, i.e. "looks valid".
+        assert storage.is_token_expired("srv") is False
+
+    def test_expired_token_reports_expired(self, tmp_path):
+        from praisonaiagents.mcp.mcp_auth_storage import MCPAuthStorage
+
+        storage = MCPAuthStorage(filepath=str(tmp_path / "auth.json"))
+        storage.set_tokens(
+            "srv",
+            {"access_token": "real", "expires_at": time.time() - 1},
+            server_url="https://srv.example/mcp",
+        )
+        assert storage.is_token_expired("srv") is True
+
+
+def _run_auth(remote_config, storage, provider, monkeypatch_targets):
+    """Invoke mcp_auth with storage/provider/config/output all mocked."""
+    from praisonai_mcp.cli.commands import mcp as mcp_cli
+
+    loader = MagicMock()
+    config = MagicMock()
+    config.mcp.servers = {"srv": remote_config}
+    loader.load.return_value = config
+
+    schema = MagicMock()
+    schema.MCPRemoteConfig = type(remote_config)
+
+    with patch.object(mcp_cli, "_require_code", lambda: None), \
+         patch.object(mcp_cli, "get_config_loader", return_value=loader), \
+         patch.object(mcp_cli, "get_output_controller", return_value=MagicMock(is_json_mode=False)), \
+         patch.object(mcp_cli, "configuration_schema", return_value=schema), \
+         patch("praisonaiagents.mcp.MCPAuthStorage", return_value=storage), \
+         patch(
+             "praisonaiagents.mcp.oauth_provider.MCPOAuthProvider",
+             return_value=provider,
+         ):
+        mcp_cli.mcp_auth("srv", timeout=1.0)
+
+
+class TestLegacyCredentialPurge:
+    """Seed the legacy fake entry and prove a real flow replaces it."""
+
+    def _remote(self, oauth=None):
+        from praisonai_code.cli.configuration.schema import (
+            MCPRemoteConfig,
+        )
+        return MCPRemoteConfig(url="https://srv.example/mcp", oauth=oauth)
+
+    def test_legacy_placeholder_is_removed_before_delegating(self, tmp_path):
+        from praisonaiagents.mcp.mcp_auth_storage import MCPAuthStorage
+
+        storage = MCPAuthStorage(filepath=str(tmp_path / "auth.json"))
+        storage.set_tokens(
+            "srv",
+            {"access_token": "oauth_ABCDEFGHIJKLMNOPQRST...", "refresh_token": None},
+            server_url="https://srv.example/mcp",
+        )
+
+        provider = MagicMock()
+        provider.ensure_authenticated.return_value = "real-access-token"
+
+        _run_auth(self._remote(), storage, provider, None)
+
+        # The provider ran a real exchange...
+        provider.ensure_authenticated.assert_called_once()
+        # ...and the fabricated entry was cleared before delegation.
+        entry = storage.get("srv")
+        if entry:
+            access = (entry.get("tokens") or {}).get("access_token") or ""
+            assert not (access.startswith("oauth_") and access.endswith("..."))
+
+    def test_genuine_token_is_not_purged(self, tmp_path):
+        from praisonaiagents.mcp.mcp_auth_storage import MCPAuthStorage
+
+        storage = MCPAuthStorage(filepath=str(tmp_path / "auth.json"))
+        storage.set_tokens(
+            "srv",
+            {"access_token": "gho_real_looking_token", "refresh_token": "r"},
+            server_url="https://srv.example/mcp",
+        )
+
+        provider = MagicMock()
+        provider.ensure_authenticated.return_value = "gho_real_looking_token"
+
+        _run_auth(self._remote(), storage, provider, None)
+
+        entry = storage.get("srv")
+        assert entry is not None
+        assert entry["tokens"]["access_token"] == "gho_real_looking_token"
+
+
+class TestConfiguredClientIsCarried:
+    """A pre-registered client_id from config must reach the provider."""
+
+    def _remote_with_oauth(self):
+        from praisonai_code.cli.configuration.schema import (
+            MCPRemoteConfig,
+            MCPOAuthConfig,
+        )
+        oauth = MCPOAuthConfig(
+            client_id="preregistered-id",
+            client_secret="s3cr3t",
+            scopes=["read", "write"],
+        )
+        return MCPRemoteConfig(url="https://srv.example/mcp", oauth=oauth)
+
+    def test_configured_client_id_is_seeded_into_storage(self, tmp_path):
+        from praisonaiagents.mcp.mcp_auth_storage import MCPAuthStorage
+
+        storage = MCPAuthStorage(filepath=str(tmp_path / "auth.json"))
+
+        provider = MagicMock()
+        provider.ensure_authenticated.return_value = "real-access-token"
+
+        _run_auth(self._remote_with_oauth(), storage, provider, None)
+
+        entry = storage.get_for_url("srv", "https://srv.example/mcp")
+        assert entry is not None
+        client_info = entry.get("client_info") or {}
+        assert client_info.get("client_id") == "preregistered-id"
+        assert client_info.get("client_secret") == "s3cr3t"
 
 
 if __name__ == "__main__":

--- a/src/praisonai-mcp/tests/unit/test_mcp_auth_exchanges_code.py
+++ b/src/praisonai-mcp/tests/unit/test_mcp_auth_exchanges_code.py
@@ -1,0 +1,89 @@
+"""`praisonai mcp auth` must not store a token it never obtained.
+
+The command ran the first half of an OAuth 2.1 flow -- discovery, browser,
+loopback callback -- and then, instead of exchanging the authorization code
+at the token endpoint, stored:
+
+    auth_storage.set_tokens(name, {
+        "access_token": f"oauth_{code[:20]}...",
+        "refresh_token": None,
+    }, server_url=server.url)
+
+That value is a truncated authorization code with a literal "..." appended:
+not a token, and useless as a bearer credential. It then printed
+"Successfully authenticated with {name}".
+
+Because no expires_at was written, MCPAuthStorage.is_token_expired() returns
+False for it, so the fabricated entry looked permanently valid and shadowed
+every later attempt at real OAuth -- the failure could not clear itself.
+
+MCPOAuthProvider already implemented the whole flow including the exchange
+(_exchange_code, grant_type=authorization_code). The command now calls it.
+"""
+import ast
+import inspect
+
+import pytest
+
+
+def _auth_source():
+    from praisonai_mcp.cli.commands import mcp as mcp_cli
+    return inspect.getsource(mcp_cli.mcp_auth), mcp_cli
+
+
+class TestNoFabricatedToken:
+
+    def test_no_synthesised_access_token_literal(self):
+        """Walk the AST: no f-string in this module builds an 'oauth_...' value."""
+        _, mcp_cli = _auth_source()
+        tree = ast.parse(inspect.getsource(mcp_cli))
+        offenders = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.JoinedStr):
+                parts = [v.value for v in node.values
+                         if isinstance(v, ast.Constant) and isinstance(v.value, str)]
+                if any(p.startswith("oauth_") for p in parts):
+                    offenders.append(parts)
+        assert not offenders, f"a token value is being synthesised: {offenders}"
+
+    def test_the_command_does_not_write_tokens_itself(self):
+        """Storing is the provider's job, after a real exchange."""
+        src, _ = _auth_source()
+        code = "\n".join(l for l in src.splitlines() if not l.strip().startswith("#"))
+        assert "set_tokens(" not in code
+
+    def test_it_delegates_to_the_oauth_provider(self):
+        src, _ = _auth_source()
+        assert "MCPOAuthProvider" in src
+        assert "ensure_authenticated" in src
+
+    def test_the_docstring_no_longer_promises_placeholders(self):
+        _, mcp_cli = _auth_source()
+        doc = mcp_cli.mcp_auth.__doc__ or ""
+        assert "placeholder tokens only" not in doc
+
+
+class TestTheProviderReallyExchanges:
+
+    def test_provider_has_a_code_exchange(self):
+        from praisonaiagents.mcp.oauth_provider import MCPOAuthProvider
+        assert hasattr(MCPOAuthProvider, "_exchange_code")
+
+    def test_the_exchange_uses_the_authorization_code_grant(self):
+        from praisonaiagents.mcp import oauth_provider
+        src = inspect.getsource(oauth_provider.MCPOAuthProvider._exchange_code)
+        assert '"grant_type": "authorization_code"' in src
+        assert "token_endpoint" in src
+
+    def test_a_token_without_expiry_is_not_treated_as_fresh_forever(self):
+        """The property that made the fabricated entry unrecoverable."""
+        from praisonaiagents.mcp.mcp_auth_storage import MCPAuthStorage
+        src = inspect.getsource(MCPAuthStorage.is_token_expired)
+        assert "expires_at" in src, (
+            "expiry handling changed; re-check that a token with no expires_at "
+            "cannot shadow re-authentication indefinitely"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
`praisonai mcp auth` ran the first half of an OAuth 2.1 flow — discovery, browser, loopback callback — and then, instead of exchanging the code at the token endpoint, stored this:

```python
auth_storage.set_tokens(name, {
    "access_token": f"oauth_{code[:20]}...",
    "refresh_token": None,
}, server_url=server.url)
```

That value is a **truncated authorization code with a literal `...` appended** — not a token, and useless as a bearer credential. The command then printed `✅ Successfully authenticated with {name}` and exited 0.

## What was and wasn't disclosed

In fairness to the original: the docstring *did* warn it stored "placeholder tokens only", so this was visible in `--help`.

What was **not** disclosed is the consequence. No `expires_at` was written, so `MCPAuthStorage.is_token_expired()` returns `False` for the entry — the fabricated credential looks **permanently valid**. It shadows every later attempt at real OAuth, and the failure cannot clear itself: the user has to know to delete the store by hand.

## The fix

`MCPOAuthProvider` already implemented the entire flow, including the code-for-token exchange this command never performed (`_exchange_code`, `grant_type=authorization_code` against the discovered `token_endpoint`). The command now calls `ensure_authenticated()` and lets the provider store what it actually received.

Nothing in the command writes tokens any more. The docstring's placeholder warning is removed, since it is no longer true.

## Verification

7 tests, including an **AST walk** asserting no f-string in the module synthesises an `oauth_...` value.

That detail matters: my first version of the test did a plain string search, which matched the *comment* explaining the old behaviour and reported the bug still present. The AST check is immune to that. Restoring the fabrication turns the tests red. 206 mcp tests pass.

## Related, not fixed here

The same sweep found that `praisonai mcp add` cannot create a remote server at all (it writes no `type`/`url`), so this command is unreachable from the CLI without hand-editing `~/.praisonai/config.toml`. That is a separate defect and wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `mcp auth` command now completes the OAuth 2.1 authorization flow and exchanges authorization codes for real access tokens.
  * Authentication supports token expiration handling and re-authentication when needed.
  * Authentication can use pre-registered client credentials when dynamic registration is unavailable.

* **Bug Fixes**
  * Prevented incomplete authorization codes from being saved as authentication tokens.
  * Legacy placeholder credentials are cleared during authentication without affecting valid tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->