### PR TITLE
feat(ts): the team runner actually runs the Task engine, closing 28 options

### DIFF
--- a/src/praisonai-ts/BEHAVIOUR_PARITY.md
+++ b/src/praisonai-ts/BEHAVIOUR_PARITY.md
@@ -22,8 +22,8 @@ needs a test proving the option changes what the code does.
 | Surface | Options not yet acted on |
 |---|---|
 | `AgentTeam.__init__` | 8 |
-| `Task.__init__` | 32 |
-| **Total** | **40** |
+| `Task.__init__` | 4 |
+| **Total** | **12** |
 
 Plus 17 options that work for some inputs and announce themselves for the rest.
 
@@ -43,40 +43,12 @@ add a test proving the option changes what the code does, and regenerate.
 - `learn`
 - `toolsRunOn`
 
-### `Task.__init__` (32)
+### `Task.__init__` (4)
 
-- `asyncExecution`
-- `config`
-- `outputPydantic`
-- `images`
-- `nextTasks`
-- `condition`
-- `isStart`
-- `loopState`
-- `memory`
-- `inputFile`
-- `rerun`
-- `retainFullContext`
-- `agentConfig`
-- `skipOnFailure`
-- `retryDelay`
-- `handler`
-- `loopOver`
-- `loopVar`
-- `execution`
-- `routing`
-- `outputConfig`
-- `when`
-- `thenTask`
-- `elseTask`
 - `autonomy`
-- `knowledge`
 - `web`
 - `reflection`
 - `planning`
-- `hooks`
-- `caching`
-- `failOnMemoryError`
 
 ## Partial
 

--- a/src/praisonai-ts/SIGNATURE_PARITY.md
+++ b/src/praisonai-ts/SIGNATURE_PARITY.md
@@ -100,7 +100,7 @@ TS-only members: `config`, `pretty`?, `fetch`?, `outputSchema`?, `outputSchemaNa
 ### `AgentTeam.__init__`
 
 - Python: `src/praisonai-agents/praisonaiagents/agents/agents.py:648`
-- TypeScript: `src/praisonai-ts/src/agent/team.ts:78` (ctor `src/praisonai-ts/src/agent/team.ts:342`)
+- TypeScript: `src/praisonai-ts/src/agent/team.ts:91` (ctor `src/praisonai-ts/src/agent/team.ts:377`)
 - Python aliases: PraisonAIAgents, Agents
 - Counts: 23 python params: 20 exact, 3 camelCase, 0 alias, 0 flattened, 0 missing; 1 mismatches; 1 waived; 3 TS-only of 26
 
@@ -246,7 +246,7 @@ TS-only members: `previousResult`?, `options`?
 ### `AgentTeam.start`
 
 - Python: `src/praisonai-agents/praisonaiagents/agents/agents.py:2007`
-- TypeScript: `src/praisonai-ts/src/agent/team.ts:770`
+- TypeScript: `src/praisonai-ts/src/agent/team.ts:1076`
 - Counts: 3 python params: 2 exact, 1 camelCase, 0 alias, 0 flattened, 0 missing; 0 mismatches; 0 waived; 1 TS-only of 4
 
 | Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |

--- a/src/praisonai-ts/behaviour-parity.json
+++ b/src/praisonai-ts/behaviour-parity.json
@@ -98,39 +98,11 @@
       "web"
     ],
     "Task.__init__": [
-      "agentConfig",
-      "asyncExecution",
       "autonomy",
-      "caching",
-      "condition",
-      "config",
-      "elseTask",
-      "execution",
-      "failOnMemoryError",
-      "handler",
-      "hooks",
-      "images",
-      "inputFile",
-      "isStart",
-      "knowledge",
-      "loopOver",
-      "loopState",
-      "loopVar",
-      "memory",
-      "nextTasks",
-      "outputConfig",
-      "outputPydantic",
       "planning",
       "reflection",
-      "rerun",
-      "retainFullContext",
-      "retryDelay",
-      "routing",
-      "skipOnFailure",
-      "thenTask",
-      "web",
-      "when"
+      "web"
     ]
   },
-  "total": 40
+  "total": 12
 }

--- a/src/praisonai-ts/signature-parity.json
+++ b/src/praisonai-ts/signature-parity.json
@@ -2741,8 +2741,8 @@
       ],
       "ts_only_required": [],
       "typescript": {
-        "ctor_location": "src/praisonai-ts/src/agent/team.ts:342",
-        "location": "src/praisonai-ts/src/agent/team.ts:78",
+        "ctor_location": "src/praisonai-ts/src/agent/team.ts:377",
+        "location": "src/praisonai-ts/src/agent/team.ts:91",
         "options_parameters": [
           "configOrAgents"
         ]
@@ -2859,7 +2859,7 @@
       ],
       "ts_only_required": [],
       "typescript": {
-        "location": "src/praisonai-ts/src/agent/team.ts:770",
+        "location": "src/praisonai-ts/src/agent/team.ts:1076",
         "options_interfaces": [
           "options: AgentTeamStartOptions"
         ],

--- a/src/praisonai-ts/src/agent/team-runner.ts
+++ b/src/praisonai-ts/src/agent/team-runner.ts
@@ -1,0 +1,192 @@
+/**
+ * The glue between {@link AgentTeam}'s run loop and the Task execution engine
+ * (`agent/engine/`).
+ *
+ * The engine implements the behaviour behind the Task options that only mean
+ * something to the loop that *runs* tasks — batching, routing, fan-out — but it
+ * deliberately knows nothing about `AgentTeam`. This module is the adapter: it
+ * turns a team's task list into the shapes the engine's list-level functions
+ * expect, and turns their answers back into indices into that list.
+ *
+ * ## Why the imports are narrow
+ *
+ * `agent/engine/index.ts` re-exports every engine module, and two of them
+ * (`task-input-file`, `task-messages`) import `fs` and `path` at module scope.
+ * `agent/simple.ts` re-exports `AgentTeam`, so `team.ts` — and therefore this
+ * file — sits on the graph that `scripts/webview-gate.mjs` bundles for a
+ * browser. Importing the engine barrel here drags `fs`, `path` and the rest of
+ * `src/config` onto that graph and fails the gate (verified with esbuild before
+ * this module was written). Everything below therefore imports the specific
+ * engine modules it needs, all of which are builtin-free.
+ *
+ * The per-task engine behaviour is reached through `Task`'s own methods
+ * (`needsRun`, `buildContext`, `runHandler`, `routeAfter`, ...), which costs
+ * this module no runtime import of `agent/types.ts` at all.
+ */
+
+import type { Task } from './types';
+import { planTaskBatches, type SchedulableTask } from './engine/task-schedule';
+import { hasWhenRouting, linkPreviousTasks, startTaskOf } from './engine/task-routing';
+
+/** The part of a team's normalised task entry this module needs to see. */
+export interface RunnerEntry {
+  /** The originating Task, when the team was given one rather than a prompt string. */
+  task?: Task;
+}
+
+/** One step of a team's run plan, as indices into the team's task list. */
+export interface RunStep {
+  /** True when every index in `indices` may run concurrently (`asyncExecution`). */
+  parallel: boolean;
+  indices: number[];
+}
+
+/** A schedulable stand-in for one entry, so a prompt-string task can be planned too. */
+interface EntryPlan extends SchedulableTask {
+  index: number;
+  asyncExecution: boolean;
+  dependencies: EntryPlan[];
+}
+
+/**
+ * Group a team's task list into the steps the runner should execute in order.
+ *
+ * Python parity: `Agents.arun_all_tasks` — consecutive `async_execution` tasks
+ * are gathered as one batch, and the batch is flushed before a synchronous task
+ * runs or when a queued task's dependency is still pending
+ * (`Agents._depends_on_pending`).
+ *
+ * The engine's `planTaskBatches` compares dependencies by identity, so the
+ * stand-ins here point at each other rather than at the `Task`s: an entry built
+ * from a prompt string has no Task to compare, and would otherwise never match.
+ */
+export function planRunSteps(entries: readonly RunnerEntry[]): RunStep[] {
+  const plans: EntryPlan[] = entries.map((entry, index) => ({
+    index,
+    asyncExecution: entry.task?.asyncExecution ?? false,
+    dependencies: [],
+  }));
+
+  const byTask = new Map<Task, EntryPlan>();
+  entries.forEach((entry, i) => { if (entry.task) byTask.set(entry.task, plans[i]); });
+  entries.forEach((entry, i) => {
+    if (!entry.task) return;
+    for (const dependency of entry.task.dependencies) {
+      const plan = byTask.get(dependency);
+      if (plan) plans[i].dependencies.push(plan);
+    }
+  });
+
+  return planTaskBatches(plans).map((batch) => ({
+    parallel: batch.parallel,
+    indices: batch.tasks.map((plan) => plan.index),
+  }));
+}
+
+/**
+ * Expand one Task into the tasks that actually run.
+ *
+ * Python parity: `Process._create_loop_subtasks` (`input_file`) and
+ * `Workflows._run_step_loop` (`loop_over` / `loop_var` / `loop_state`). Both
+ * fan a template task out into one child per row or item; `input_file` wins when
+ * a task somehow declares both, matching the order Python evaluates them in.
+ *
+ * A task that expands to nothing — no `inputFile`, no `loopOver`, an empty file,
+ * or a `loopOver` naming a variable that is missing or not a list — comes back
+ * as itself, which is Python's "run the step once" fallback.
+ */
+export function expandTask(task: Task, variables: Record<string, unknown>): Task[] {
+  if (task.inputFile) {
+    try {
+      const rows = task.expandFromInputFile();
+      if (rows.length > 0) return rows;
+    } catch (err) {
+      // Python wraps the whole of _create_loop_subtasks in a bare `except` that
+      // only logs, and the workflow proceeds as if the loop had no rows.
+      task.nonFatalErrors.push(`input_file: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  if (task.loopOver) {
+    const items = task.expandLoop(variables);
+    if (items.length > 0) return items;
+  }
+  return [task];
+}
+
+/**
+ * Whether this task list actually declares a workflow graph.
+ *
+ * A team whose tasks name no edges, no start task and no conditions is a plain
+ * list, and Python's `process="workflow"` then walks it in order — which is what
+ * the TypeScript team did before routing existed. Consulting the router for such
+ * a list would stop after the first task, so the runner asks this first.
+ */
+export function declaresRouting(entries: readonly RunnerEntry[]): boolean {
+  return entries.some((entry) => {
+    const task = entry.task;
+    if (!task) return false;
+    return task.isStart
+      || task.nextTasks.length > 0
+      || Object.keys(task.condition).length > 0
+      || hasWhenRouting(task);
+  });
+}
+
+/** Where a workflow run starts: the index of `startTaskOf`'s pick, else 0. */
+export function startIndexOf(entries: readonly RunnerEntry[]): number {
+  const tasks = entries.map((e) => e.task).filter((t): t is Task => t !== undefined);
+  if (tasks.length === 0) return 0;
+  const start = startTaskOf(tasks);
+  if (!start) return 0;
+  const index = entries.findIndex((e) => e.task === start);
+  return index >= 0 ? index : 0;
+}
+
+/**
+ * Fill every task's `previousTasks` from the `nextTasks` edges of the others,
+ * as Python does at the top of `process.workflow()`. Entries without a Task are
+ * ignored.
+ */
+export function linkEntries(entries: readonly RunnerEntry[]): void {
+  linkPreviousTasks(entries.map((e) => e.task).filter((t): t is Task => t !== undefined));
+}
+
+/** Index the entries by every name routing can address them with. */
+export function indexByName(entries: ReadonlyArray<RunnerEntry & { name: string }>): Map<string, number> {
+  const byName = new Map<string, number>();
+  entries.forEach((entry, index) => {
+    // The Task's own name is what `nextTasks` / `condition` targets refer to;
+    // the entry name (which falls back to `task_<n>`) is registered too so a
+    // routing target can name an unnamed task the way results are keyed.
+    if (!byName.has(entry.name)) byName.set(entry.name, index);
+    const taskName = entry.task?.name;
+    if (taskName && !byName.has(taskName)) byName.set(taskName, index);
+  });
+  return byName;
+}
+
+/**
+ * The `decision` a `decision`/`loop` task's answer carries.
+ *
+ * Python reads `result.pydantic.decision` and falls back to the lowercased raw
+ * text (`process.py`); here a JSON answer with a `decision` field is read the
+ * same way, and anything else is the raw text.
+ */
+export function decisionFrom(raw: string): string {
+  const text = raw.trim();
+  if (text.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      const decision = parsed.decision;
+      if (typeof decision === 'string') return decision.toLowerCase().trim();
+    } catch {
+      // Not JSON: the raw text is the decision.
+    }
+  }
+  return text.toLowerCase();
+}
+
+/** True when one of the task's declared dependencies ended the run failed. */
+export function dependenciesFailed(task: Task): boolean {
+  return task.dependencies.some((dependency) => dependency.status === 'failed');
+}

--- a/src/praisonai-ts/src/agent/team-runner.ts
+++ b/src/praisonai-ts/src/agent/team-runner.ts
@@ -27,6 +27,7 @@
 import type { Task } from './types';
 import { planTaskBatches, type SchedulableTask } from './engine/task-schedule';
 import { hasWhenRouting, linkPreviousTasks, startTaskOf } from './engine/task-routing';
+import { cleanJsonOutput } from './engine/task-output';
 
 /** The part of a team's normalised task entry this module needs to see. */
 export interface RunnerEntry {
@@ -169,11 +170,14 @@ export function indexByName(entries: ReadonlyArray<RunnerEntry & { name: string 
  * The `decision` a `decision`/`loop` task's answer carries.
  *
  * Python reads `result.pydantic.decision` and falls back to the lowercased raw
- * text (`process.py`); here a JSON answer with a `decision` field is read the
- * same way, and anything else is the raw text.
+ * text (`process.py`). The structured answer is what a `decision` task is asked
+ * to produce, and the model routinely wraps JSON in a ```json fence, so the
+ * fence is stripped first (Python `clean_json_output`) before a `decision`
+ * field is read the same way. Anything that is not such an object is the raw
+ * text.
  */
 export function decisionFrom(raw: string): string {
-  const text = raw.trim();
+  const text = cleanJsonOutput(raw);
   if (text.startsWith('{')) {
     try {
       const parsed = JSON.parse(text) as Record<string, unknown>;
@@ -183,7 +187,7 @@ export function decisionFrom(raw: string): string {
       // Not JSON: the raw text is the decision.
     }
   }
-  return text.toLowerCase();
+  return raw.trim().toLowerCase();
 }
 
 /** True when one of the task's declared dependencies ended the run failed. */

--- a/src/praisonai-ts/src/agent/team.ts
+++ b/src/praisonai-ts/src/agent/team.ts
@@ -33,6 +33,19 @@ import {
   type TeamPlanningInput,
   type TeamPlanningSettings,
 } from './team-planning';
+import {
+  declaresRouting,
+  decisionFrom,
+  dependenciesFailed,
+  expandTask,
+  indexByName,
+  linkEntries,
+  planRunSteps,
+  startIndexOf,
+} from './team-runner';
+import { cacheKey } from './engine/task-features';
+import type { PreviousOutput } from './engine/task-context';
+import type { RoutingContext } from './engine/task-routing';
 
 /**
  * How an AgentTeam runs its tasks. `workflow` runs like `sequential`;
@@ -220,6 +233,17 @@ interface TeamTask {
   assignedAgent?: Agent;
 }
 
+/** True when `value` is an Agent-shaped object, i.e. something a task can run on. */
+function isAgentLike(value: unknown): value is Agent {
+  return !!value && typeof (value as Agent).start === 'function';
+}
+
+/** The raw text of a Task's stored result, in either of the shapes it can take. */
+function rawOfResult(result: TaskOutput | string | null | undefined): string | undefined {
+  if (result === null || result === undefined) return undefined;
+  return typeof result === 'string' ? result : result.raw;
+}
+
 function looksLikeJsonSchema(value: unknown): value is Record<string, any> {
   return !!value && typeof value === 'object'
     && ('type' in value || 'properties' in value || '$schema' in value || 'anyOf' in value || 'oneOf' in value);
@@ -323,6 +347,17 @@ export class AgentTeam {
   /** Python parity: auto_approve_plan. */
   readonly autoApprovePlan: boolean;
 
+  /**
+   * Variables published by a task `handler` during the run (Python
+   * `StepResult.variables`). They join the team's own for `{{placeholder}}`
+   * substitution and for evaluating a later task's `when` condition.
+   */
+  private runVariables: Record<string, unknown> = {};
+  /** Set when a handler returned `stopWorkflow`: the run ends after that task. */
+  private stopRequested = false;
+  /** The `content` the current run was started with, handed to task handlers. */
+  private runContent?: string;
+
   private readonly planningSettings: TeamPlanningSettings;
   /** Python parity: _current_plan. Set once a planning run has produced a plan. */
   private currentPlan?: Plan;
@@ -421,9 +456,12 @@ export class AgentTeam {
       }
     }
 
-    // Auto-generate tasks if not provided
+    // Auto-generate tasks if not provided. `loopOver` and `inputFile` fan a
+    // template task out into one task per item or row BEFORE the run starts, so
+    // batching, routing and the results array all see the expanded list
+    // (Python: Process._create_loop_subtasks / Workflows._run_step_loop).
     this.tasks = config.tasks
-      ? config.tasks.map((task, i) => this.normaliseTask(task, i))
+      ? this.expandTasks(config.tasks).map((task, i) => this.normaliseTask(task, i))
       : this.generateTasks();
 
     // The shared context starts from what the members are for, so a task that
@@ -471,12 +509,32 @@ export class AgentTeam {
   private defaultCompletionChecker = (_task: TeamTaskRef, agentOutput: string): boolean =>
     agentOutput.trim().length > 0;
 
+  /**
+   * Apply the engine's plan-time fan-out to every Task in the list: a task with
+   * an `inputFile` becomes one task per row, a task with `loopOver` becomes one
+   * task per item. Everything else passes through untouched.
+   */
+  private expandTasks(tasks: (string | Task)[]): (string | Task)[] {
+    const scope: Record<string, unknown> = { ...(this.variables ?? {}) };
+    const expanded: (string | Task)[] = [];
+    for (const task of tasks) {
+      if (typeof task === 'string') { expanded.push(task); continue; }
+      expanded.push(...expandTask(task, scope));
+    }
+    return expanded;
+  }
+
   /** Turn a prompt string or Task object into a TeamTask, applying `variables`. */
   private normaliseTask(task: string | Task, index: number): TeamTask {
     if (typeof task === 'string') {
       return { name: `task_${index + 1}`, prompt: this.substituteVariables(task), status: 'not started' };
     }
-    let prompt = this.substituteVariables(task.description ?? '');
+    // A Task's own `variables` are applied first -- they carry the bound
+    // `loopVar` of a `loopOver` fan-out child -- and the team's afterwards.
+    const described = Object.keys(task.variables ?? {}).length > 0
+      ? task.renderDescription()
+      : (task.description ?? '');
+    let prompt = this.substituteVariables(described);
     if (task.expected_output) {
       prompt += `\n\nExpected output: ${this.substituteVariables(task.expected_output)}`;
     }
@@ -519,10 +577,40 @@ export class AgentTeam {
    * Python parity: `run_task` -- the on_task_start hook, the retry loop bounded
    * by `max_retries` and driven by `completion_checker`, the shared-memory
    * context and write-back, and the on_task_complete hook.
+   *
+   * This is also where the per-task half of the execution engine
+   * (`agent/engine/`) is applied, in the order Python applies it: the `rerun`
+   * gate and the dependency-failure gate before anything runs, then the task's
+   * own start hook, its `handler` in place of the model, its memory and
+   * knowledge folded into the prompt, its `images` carried on the call, its
+   * cache consulted around the call, the engine's TaskOutput built from the
+   * answer, and its memory written back.
    */
   private async runTask(entry: TeamTask, agent: Agent, prompt: string, previousResult?: string): Promise<string> {
     const index = this.tasks.indexOf(entry);
-    entry.task?.markStarted();
+    const task = entry.task;
+
+    // `rerun`: a task that already completed is not executed again unless it
+    // asked to be (engine `needsRun`; Python TaskExecutionConfig.rerun).
+    if (task && !task.needsRun()) {
+      entry.status = 'completed';
+      entry.result = entry.result ?? rawOfResult(task.result) ?? '';
+      await Logger.debug(`Task ${entry.name}: already completed and rerun is off; skipping.`);
+      return entry.result;
+    }
+
+    // `skipOnFailure` / `onError`: a task whose dependency failed is failed with
+    // it unless it opted into running degraded
+    // (Python `Agents._should_continue_on_dep_failure`).
+    if (task && dependenciesFailed(task) && !task.continuesOnDependencyFailure()) {
+      entry.status = 'failed';
+      entry.result = '';
+      task.markFailed();
+      await Logger.debug(`Task ${entry.name}: a dependency failed and it did not opt into continuing; skipping.`);
+      return '';
+    }
+
+    task?.markStarted();
     entry.status = 'in progress';
 
     if (this.onTaskStart) {
@@ -532,58 +620,129 @@ export class AgentTeam {
         await Logger.error(`Error in onTaskStart callback: ${(error as Error)?.message ?? String(error)}`);
       }
     }
+    // `hooks`: the task's own onTaskStart fires after the team's.
+    if (task) await task.notifyStart(index < 0 ? 0 : index);
 
+    // `handler`: the task's own function runs INSTEAD of the model, and its
+    // return value is the task's result (Python `Workflows._run_step`).
+    let handled: string | undefined;
+    if (task?.handler) {
+      const outcome = await task.runHandler({
+        input: this.runContent,
+        previousResult,
+        currentStep: entry.name,
+        variables: { ...this.variables, ...this.runVariables },
+        task,
+      });
+      if (outcome) {
+        if (outcome.variables) Object.assign(this.runVariables, outcome.variables);
+        if (outcome.stop) this.stopRequested = true;
+        if (!outcome.success) {
+          entry.status = 'failed';
+          entry.result = '';
+          task.markFailed();
+          await Logger.error(`Task ${entry.name}: handler failed: ${outcome.error ?? 'unknown error'}`);
+          return '';
+        }
+        handled = outcome.output ?? '';
+      }
+    }
+
+    // `memory` / `knowledge`: what the task itself recalls and knows is folded
+    // into the prompt (Python `_prepare_task_prompt`'s memory branch).
+    let finalPrompt = prompt;
+    if (task) {
+      const recalled = await task.memoryContext(prompt);
+      if (recalled) finalPrompt = `${finalPrompt}\n\n${recalled}`;
+      const known = await task.knowledgeContext(prompt);
+      if (known) finalPrompt = `${finalPrompt}\n\n${known}`;
+    }
     // Shared memory is context, not history: what it recalls is appended to the
     // prompt exactly as Python appends it, as bare bullet lines.
-    let finalPrompt = prompt;
     if (this.sharedMemory) {
       const recalled = await this.sharedMemory.recall(prompt);
-      if (recalled) finalPrompt = `${prompt}\n\n${recalled}`;
+      if (recalled) finalPrompt = `${finalPrompt}\n\n${recalled}`;
     }
+
+    // `images`: the model call carries the pictures alongside the text, as the
+    // OpenAI multimodal content list (Python `get_multimodal_message`).
+    let options = entry.options;
+    if (task && task.images.length > 0) {
+      options = { ...(options ?? {}), attachments: [...task.images] };
+    }
+
+    // `caching`: a repeat of the same agent + prompt is answered from the task's
+    // own cache instead of the model.
+    const key = task?.cache ? cacheKey(agent.name, finalPrompt) : undefined;
 
     let result = '';
     let completed = false;
-    const attempts = Math.max(1, this.maxRetries);
-    for (let attempt = 0; attempt < attempts; attempt++) {
-      try {
-        result = await agent.start(finalPrompt, previousResult, undefined, undefined, undefined, entry.options);
-      } catch (error) {
-        entry.status = 'failed';
-        entry.task?.markFailed();
-        throw error;
+    const cached = key && task?.cache ? task.cache.get(key) : undefined;
+    const passes = (raw: string): boolean => this.completionChecker(this.refFor(entry, agent), raw);
+
+    if (handled !== undefined) {
+      // A handler already answered. There is nothing to retry: re-running a
+      // deterministic function would produce the same answer.
+      result = handled;
+      completed = passes(result);
+    } else if (cached !== undefined) {
+      // `caching`: this agent has answered this exact prompt before. The lookup
+      // is outside the retry loop deliberately -- serving the cached answer to a
+      // retry would make the retry pointless.
+      await Logger.debug(`Task ${entry.name}: answered from the task's cache.`);
+      result = cached;
+      completed = passes(result);
+    } else {
+      const attempts = Math.max(1, this.maxRetries);
+      for (let attempt = 0; attempt < attempts; attempt++) {
+        try {
+          result = await agent.start(finalPrompt, previousResult, undefined, undefined, undefined, options);
+        } catch (error) {
+          entry.status = 'failed';
+          task?.markFailed();
+          throw error;
+        }
+        if (passes(result)) {
+          completed = true;
+          break;
+        }
+        await Logger.debug(`Task ${entry.name}: completion check failed (attempt ${attempt + 1}/${attempts})`);
+        // `retryDelay`: Python waits min(delay * 2**attempt, 300) seconds before
+        // the next attempt. The default of 0 never waits, which is what makes
+        // the option observable at all.
+        if (task && attempt < attempts - 1) await task.waitBeforeRetry(attempt);
       }
-      if (this.completionChecker(this.refFor(entry, agent), result)) {
-        completed = true;
-        break;
-      }
-      await Logger.debug(`Task ${entry.name}: completion check failed (attempt ${attempt + 1}/${attempts})`);
+      if (completed && key && task?.cache) task.cache.set(key, result);
     }
 
     entry.result = result;
     entry.status = completed ? 'completed' : 'failed';
 
-    const output: TaskOutput = {
-      description: entry.task?.description ?? entry.prompt,
-      raw: result,
-      agent: agent.name,
-      outputFormat: 'RAW',
-    };
-    if (entry.options?.outputJson || entry.options?.outputPydantic) {
+    // `memory` / `failOnMemoryError`: the answer goes into the task's own store.
+    // A store that throws is a degraded run, unless the task asked for it to be
+    // a failed one.
+    if (task) {
       try {
-        const parsed = JSON.parse(result);
-        if (entry.options.outputJson) { output.outputJson = parsed; output.outputFormat = 'JSON'; }
-        else { output.outputPydantic = parsed; output.outputFormat = 'Pydantic'; }
-      } catch {
-        // Not JSON: the raw text stands.
+        await task.storeInMemory(result, agent.name);
+      } catch (error) {
+        entry.status = 'failed';
+        task.markFailed();
+        throw error;
       }
     }
 
-    if (entry.task) {
+    // `outputPydantic` / `outputConfig`: the engine builds the TaskOutput and
+    // parses the structured payload the task asked for.
+    const output: TaskOutput = task
+      ? task.buildOutput(result, agent.name)
+      : this.rawOutput(entry, result, agent.name);
+
+    if (task) {
       if (completed) {
-        entry.task.markCompleted(output);
-        await entry.task.notifyComplete(output);
+        task.markCompleted(output);
+        await task.notifyComplete(output);
       } else {
-        entry.task.markFailed();
+        task.markFailed();
       }
     }
 
@@ -604,10 +763,34 @@ export class AgentTeam {
     return result;
   }
 
+  /**
+   * The TaskOutput for an entry that came from a prompt string rather than a
+   * Task: there is no Task to ask, so the shape the team always built stands.
+   */
+  private rawOutput(entry: TeamTask, result: string, agentName: string): TaskOutput {
+    const output: TaskOutput = {
+      description: entry.prompt,
+      raw: result,
+      agent: agentName,
+      outputFormat: 'RAW',
+    };
+    if (entry.options?.outputJson || entry.options?.outputPydantic) {
+      try {
+        const parsed = JSON.parse(result);
+        if (entry.options.outputJson) { output.outputJson = parsed; output.outputFormat = 'JSON'; }
+        else { output.outputPydantic = parsed; output.outputFormat = 'Pydantic'; }
+      } catch {
+        // Not JSON: the raw text stands.
+      }
+    }
+    return output;
+  }
+
   private substituteVariables(text: string): string {
-    if (!this.variables) return text;
+    const scope: Record<string, unknown> = { ...this.variables, ...this.runVariables };
+    if (Object.keys(scope).length === 0) return text;
     return text.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (match, key: string) => {
-      const value = this.variables![key];
+      const value = scope[key];
       return value === undefined ? match : String(value);
     });
   }
@@ -621,9 +804,72 @@ export class AgentTeam {
     });
   }
 
-  /** The agent that runs task `i`: a manager's pick, the Task's own agent, else the i-th (or last) member. */
-  private agentFor(task: TeamTask, index: number): Agent {
-    return task.assignedAgent ?? task.agent ?? this.agents[Math.min(index, this.agents.length - 1)];
+  /**
+   * The agent that runs task `i`: a manager's pick, the Task's own agent, an
+   * agent built from its `agentConfig`, else the i-th (or last) member.
+   *
+   * Python parity: `Agents._create_agent_from_config` -- a task that names no
+   * agent but carries an `agentConfig` gets one constructed from it, and the
+   * constructed agent is assigned back onto the task.
+   */
+  private agentFor(entry: TeamTask, index: number): Agent {
+    if (entry.assignedAgent) return entry.assignedAgent;
+    const fallback = entry.agent ?? this.agents[Math.min(index, this.agents.length - 1)];
+    if (!entry.task) return fallback;
+    // `agentConfig`: resolveAgent returns the task's own agent when it has one,
+    // builds one from `agentConfig` when it does not, and otherwise hands back
+    // the default -- so this covers all three cases in one call.
+    const resolved = entry.task.resolveAgent({
+      defaultAgent: fallback,
+      defaultLlm: this.llm,
+      memory: this.getSharedMemory(),
+    });
+    return isAgentLike(resolved) ? resolved : fallback;
+  }
+
+  /**
+   * Run the task at `index`, assembling its prompt first.
+   *
+   * @param isFirst - the first task to execute in this run gets no "input so
+   *   far" block, exactly as the plain sequential loop always behaved.
+   */
+  private async runOne(
+    index: number,
+    isFirst: boolean,
+    content: string | undefined,
+    previousResult: string | undefined,
+    previousOutputs: readonly PreviousOutput[],
+  ): Promise<string> {
+    const entry = this.tasks[index];
+    const agent = this.agentFor(entry, index);
+    await Logger.debug(`Running agent ${index + 1}: ${agent?.name}`);
+    await Logger.debug(`Task: ${entry.prompt}`);
+    const prompt = this.promptFor(entry, isFirst, content, previousResult, previousOutputs);
+    return this.runTask(entry, agent, prompt, previousResult);
+  }
+
+  /**
+   * The prompt one task runs.
+   *
+   * `retainFullContext` is the switch: with it the upstream block is the
+   * engine's, which folds in EVERY earlier result; without it the team's
+   * long-standing "here is the input" line carries only the most recent one
+   * (Python `Process._build_task_context`).
+   */
+  private promptFor(
+    entry: TeamTask,
+    isFirst: boolean,
+    content?: string,
+    previousResult?: string,
+    previousOutputs: readonly PreviousOutput[] = [],
+  ): string {
+    const base = this.withContent(this.substituteVariables(entry.prompt), content);
+    if (entry.task?.retainFullContext) {
+      const block = entry.task.buildContext(previousOutputs);
+      return block ? `${base}\n${block}` : base;
+    }
+    const input = this.inputSoFar(previousResult);
+    return isFirst || !input ? base : `${base}\n\nHere is the input: ${input}`;
   }
 
   /** `content` (Python parity) is added to every task's context. */
@@ -645,28 +891,87 @@ export class AgentTeam {
     return produced.length > 0 ? produced.join('\n\n') : undefined;
   }
 
+  /**
+   * Run the tasks in order.
+   *
+   * `asyncExecution` is what makes this more than a for-loop: the engine plans
+   * the list into steps, collapsing a run of async tasks into one parallel
+   * batch and flushing that batch before a synchronous task or an in-batch
+   * dependency (Python `Agents.arun_all_tasks` / `_depends_on_pending`).
+   */
   private async executeSequential(content?: string): Promise<string[]> {
-    const results: string[] = [];
+    const previousOutputs: PreviousOutput[] = [];
     let previousResult: string | undefined;
+    let isFirst = true;
 
-    for (let i = 0; i < this.tasks.length; i++) {
-      const task = this.tasks[i];
-      const agent = this.agentFor(task, i);
-
-      await Logger.debug(`Running agent ${i + 1}: ${agent.name}`);
-      await Logger.debug(`Task: ${task.prompt}`);
-
-      // For first agent, use task directly
-      // For subsequent agents, append the input so far to their instructions
-      const base = this.withContent(task.prompt, content);
-      const input = this.inputSoFar(previousResult);
-      const prompt = i === 0 || !input ? base : `${base}\n\nHere is the input: ${input}`;
-      const result = await this.runTask(task, agent, prompt, previousResult);
-      results.push(result);
-      previousResult = result;
+    for (const step of planRunSteps(this.tasks)) {
+      if (this.stopRequested) break;
+      if (step.parallel && step.indices.length > 1) {
+        // Every task in a batch sees the same upstream state: they are running
+        // at the same time, so none of them can see another's answer.
+        const carried = previousResult;
+        const snapshot = [...previousOutputs];
+        const first = isFirst;
+        const raws = await Promise.all(
+          step.indices.map((index) => this.runOne(index, first, content, carried, snapshot)),
+        );
+        step.indices.forEach((index, k) => previousOutputs.push({ name: this.tasks[index].name, raw: raws[k] }));
+        previousResult = raws[raws.length - 1];
+      } else {
+        const index = step.indices[0];
+        const raw = await this.runOne(index, isFirst, content, previousResult, previousOutputs);
+        previousOutputs.push({ name: this.tasks[index].name, raw });
+        previousResult = raw;
+      }
+      isFirst = false;
     }
 
-    return results;
+    return this.tasks.map((task) => task.result ?? '');
+  }
+
+  /**
+   * Follow the workflow graph instead of the list order.
+   *
+   * Python parity: `process.workflow()` -- `isStart` (or the task nothing points
+   * at) is the entry point, and each finished task's `condition`/`routing`
+   * table, `when`/`thenTask`/`elseTask` pair or `nextTasks` picks the next one.
+   * `exit`, an unroutable name, or no route at all ends the run, and `maxIter`
+   * bounds it so a cycle cannot spin forever.
+   */
+  private async executeWorkflow(content?: string): Promise<string[]> {
+    const byName = indexByName(this.tasks);
+    const previousOutputs: PreviousOutput[] = [];
+    let previousResult: string | undefined;
+    let isFirst = true;
+    let current: number | undefined = startIndexOf(this.tasks);
+
+    for (let iteration = 0; current !== undefined && iteration < this.maxIter; iteration++) {
+      const entry = this.tasks[current];
+      const raw = await this.runOne(current, isFirst, content, previousResult, previousOutputs);
+      isFirst = false;
+      previousOutputs.push({ name: entry.name, raw });
+      previousResult = raw;
+      if (this.stopRequested) break;
+
+      const task = entry.task;
+      if (!task) break;
+      const context: RoutingContext = {
+        ...this.variables,
+        ...this.runVariables,
+        previous_output: raw,
+        decision: decisionFrom(raw),
+      };
+      const route = task.routeAfter(context);
+      if (route.kind !== 'task') break;
+      const next = byName.get(route.name);
+      if (next === undefined) {
+        await Logger.warn(`Task ${entry.name} routed to "${route.name}", which is not a task on this team.`);
+        break;
+      }
+      current = next;
+    }
+
+    return this.tasks.map((task) => task.result ?? '');
   }
 
   /**
@@ -695,12 +1000,13 @@ export class AgentTeam {
         if (picked) this.tasks[taskId].assignedAgent = picked;
       },
       runTask: async (taskId) => {
-        const entry = this.tasks[taskId];
-        const agent = this.agentFor(entry, taskId);
-        const base = this.withContent(entry.prompt, content);
-        const input = this.inputSoFar(taskId > 0 ? this.tasks[taskId - 1].result : undefined);
-        const prompt = input ? `${base}\n\nHere is the input: ${input}` : base;
-        await this.runTask(entry, agent, prompt);
+        const previous = taskId > 0 ? this.tasks[taskId - 1].result : undefined;
+        const produced = this.tasks
+          .filter((entry) => entry.result !== undefined)
+          .map((entry) => ({ name: entry.name, raw: entry.result as string }));
+        // Never "first": the manager's pick is handed whatever the team has
+        // produced so far, as it always was.
+        await this.runOne(taskId, false, content, previous, produced);
       },
     });
 
@@ -780,10 +1086,17 @@ export class AgentTeam {
 
     // Fresh run: clear stale status/results so a reused team does not skip
     // already-"completed" tasks, and scope the shared context to this run so a
-    // task is handed only what this run has produced.
+    // task is handed only what this run has produced. Per-run engine state --
+    // the variables a handler publishes and the stop flag -- starts clean too,
+    // and `nextTasks` edges become each task's `previousTasks` before anything
+    // runs (Python does this at the top of process.workflow()).
     const savedTasks = this.tasks;
     this.resetTaskState();
     this.contextRunOffset = this.contextManager?.getByRole('assistant').length ?? 0;
+    this.runContent = content;
+    this.runVariables = {};
+    this.stopRequested = false;
+    linkEntries(this.tasks);
 
     try {
       if (this.planningSettings.enabled) {
@@ -794,13 +1107,17 @@ export class AgentTeam {
       let results: string[];
 
       if (this.process === 'parallel') {
-        // Run all tasks in parallel
-        const promises = this.tasks.map((task, i) => this.runTask(task, this.agentFor(task, i), this.withContent(task.prompt, content)));
-        results = await Promise.all(promises);
+        // Run all tasks in parallel: none of them can see another's answer, so
+        // every one is handed the run's starting state.
+        results = await Promise.all(this.tasks.map((_, i) => this.runOne(i, true, content, undefined, [])));
       } else if (this.process === 'hierarchical') {
         results = await this.executeHierarchical(content);
+      } else if (this.process === 'workflow' && declaresRouting(this.tasks)) {
+        // `workflow` follows the graph only when the tasks actually declare one;
+        // a workflow team whose tasks name no edges runs in order, as before.
+        results = await this.executeWorkflow(content);
       } else {
-        // sequential (default) and workflow run in order
+        // sequential (default), and workflow over a list with no edges
         results = await this.executeSequential(content);
       }
 

--- a/src/praisonai-ts/src/agent/types.ts
+++ b/src/praisonai-ts/src/agent/types.ts
@@ -476,7 +476,11 @@ export class Task {
         for (const option of ENGINE_LEVEL_OPTIONS) {
             if (config[option] !== undefined) notYetHonoured('Task', option);
         }
-        if (config.taskType !== undefined && config.taskType !== 'task') notYetHonoured('Task', 'taskType');
+        // 'decision' is honoured: the runner reads it to drive the routing table
+        // (see team-runner.ts). Anything else still has no meaning here.
+        if (config.taskType !== undefined && config.taskType !== 'task' && config.taskType !== 'decision') {
+            notYetHonoured('Task', 'taskType');
+        }
         if (typeof this.guardrail === 'string') {
             notYetHonoured('Task', 'guardrails', 'String guardrails need an LLM judge; callable guardrails run via runGuardrail().');
         }

--- a/src/praisonai-ts/src/utils/parity-notice.ts
+++ b/src/praisonai-ts/src/utils/parity-notice.ts
@@ -37,11 +37,7 @@ export const UNHONOURED_OPTIONS: Readonly<Record<string, readonly string[]>> = {
     'autonomy', 'knowledge', 'guardrails', 'web', 'reflection', 'caching', 'learn', 'toolsRunOn',
   ],
   'Task.__init__': [
-    'asyncExecution', 'config', 'outputPydantic', 'images', 'nextTasks', 'condition', 'isStart',
-    'loopState', 'memory', 'inputFile', 'rerun', 'retainFullContext', 'agentConfig', 'skipOnFailure',
-    'retryDelay', 'handler', 'loopOver', 'loopVar', 'execution', 'routing', 'outputConfig', 'when',
-    'thenTask', 'elseTask', 'autonomy', 'knowledge', 'web', 'reflection', 'planning', 'hooks',
-    'caching', 'failOnMemoryError',
+    'autonomy', 'web', 'reflection', 'planning',
   ],
 } as const;
 

--- a/src/praisonai-ts/tests/unit/agent/parity-task-runner.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/parity-task-runner.test.ts
@@ -721,6 +721,30 @@ describe('Task workflow routing', () => {
 
     expect(prompts().map((p) => p.split('\n')[0])).toEqual(['approve or reject', 'ship it']);
   });
+
+  it('routes on a decision wrapped in a ```json fence', async () => {
+    const gate = new Task({ name: 'gate', description: 'approve or reject', isStart: true, taskType: 'decision', condition: { approve: ['ship'] } });
+    const ship = new Task({ name: 'ship', description: 'ship it' });
+    // The model routinely fences JSON; Python strips the fence before reading
+    // `decision`, so the `approve` route must still be taken.
+    mockLlm.responder = (_model, prompt) =>
+      (prompt.includes('approve or reject') ? '```json\n{"decision":"approve"}\n```' : undefined);
+
+    await new AgentTeam({ agents: [member()], tasks: [gate, ship], process: 'workflow', ...quiet }).start();
+
+    expect(prompts().map((p) => p.split('\n')[0])).toEqual(['approve or reject', 'ship it']);
+  });
+
+  it('control: a fenced decision that does not match the table ends the run', async () => {
+    const gate = new Task({ name: 'gate', description: 'approve or reject', isStart: true, taskType: 'decision', condition: { approve: ['ship'] } });
+    const ship = new Task({ name: 'ship', description: 'ship it' });
+    mockLlm.responder = (_model, prompt) =>
+      (prompt.includes('approve or reject') ? '```json\n{"decision":"reject"}\n```' : undefined);
+
+    await new AgentTeam({ agents: [member()], tasks: [gate, ship], process: 'workflow', ...quiet }).start();
+
+    expect(prompts().map((p) => p.split('\n')[0])).toEqual(['approve or reject']);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/praisonai-ts/tests/unit/agent/parity-task-runner.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/parity-task-runner.test.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { Agent, AgentTeam } from '../../../src/agent/simple';
+import { Agent, AgentTeam } from '../../../src/agent';
 import { Task } from '../../../src/agent/types';
 import { resetParityNotices } from '../../../src/utils/parity-notice';
 

--- a/src/praisonai-ts/tests/unit/agent/parity-task-runner.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/parity-task-runner.test.ts
@@ -1,0 +1,804 @@
+/**
+ * Behaviour parity for the `Task` options whose behaviour lives in the run
+ * loop rather than in `Task` itself.
+ *
+ * The execution engine under `src/agent/engine/` already had unit tests: they
+ * prove `planTaskBatches` batches, `resolveNextTask` routes and `runTaskHandler`
+ * runs a handler. What they could not prove is that anything CALLS them --
+ * and for a while nothing did, so a `Task` could be handed `handler`,
+ * `loopOver` or `rerun` and the team would run exactly as if it had not been.
+ *
+ * Every test here therefore drives the option through the public API: build an
+ * `AgentTeam` with real `Task` objects, call `team.start()`, and assert the
+ * observable difference -- which prompts reached the model, which tasks ran,
+ * what the callbacks saw. Each is paired with a control showing the same team
+ * behaves differently when the option is absent. The model is stubbed;
+ * nothing touches the network or an API key.
+ */
+process.env.PRAISONAI_PARITY_SILENT = '1';
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { Agent, AgentTeam } from '../../../src/agent/simple';
+import { Task } from '../../../src/agent/types';
+import { resetParityNotices } from '../../../src/utils/parity-notice';
+
+/**
+ * One stub for every OpenAIService the run creates. `content` is kept exactly
+ * as the Agent sent it, because a multimodal call sends an array rather than a
+ * string and that difference is the whole `images` test.
+ *
+ * `delayMs` plus the in-flight counters are how `asyncExecution` is proved:
+ * two calls overlapping in time is a fact no prompt assertion can show.
+ */
+const mockLlm = {
+  calls: [] as Array<{ model: string; content: unknown }>,
+  responder: null as null | ((model: string, prompt: string) => string | undefined),
+  delayMs: 0,
+  inFlight: 0,
+  maxInFlight: 0,
+};
+
+/** The text of a message whether it was sent as a string or as content parts. */
+const textOf = (content: unknown): string => {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((part: any) => part?.type === 'text')
+      .map((part: any) => part.text)
+      .join('\n');
+  }
+  return String(content ?? '');
+};
+
+const answer = async (model: string, content: unknown): Promise<string> => {
+  mockLlm.calls.push({ model, content });
+  mockLlm.inFlight += 1;
+  mockLlm.maxInFlight = Math.max(mockLlm.maxInFlight, mockLlm.inFlight);
+  if (mockLlm.delayMs > 0) await new Promise((resolve) => setTimeout(resolve, mockLlm.delayMs));
+  mockLlm.inFlight -= 1;
+  return mockLlm.responder?.(model, textOf(content)) ?? `reply(${textOf(content)})`;
+};
+
+const lastContent = (messages: any[]): unknown => messages[messages.length - 1]?.content;
+
+jest.mock('../../../src/llm/openai', () => ({
+  OpenAIService: jest.fn().mockImplementation((model: string) => ({
+    model,
+    generateText: jest.fn(async (prompt: string) => answer(model, prompt)),
+    generateChat: jest.fn(async (messages: any[]) => ({ content: await answer(model, lastContent(messages)), role: 'assistant' })),
+    streamChat: jest.fn(async (messages: any[]) => answer(model, lastContent(messages))),
+    streamChatWithTools: jest.fn(async (messages: any[]) => ({ content: await answer(model, lastContent(messages)), role: 'assistant' })),
+  })),
+}));
+
+const quiet = { verbose: false, stream: false } as const;
+const member = (name = 'member', llm = 'member-model') => new Agent({ name, instructions: 'help', llm, ...quiet });
+/** Every prompt the model was asked, as text. */
+const prompts = (): string[] => mockLlm.calls.map((call) => textOf(call.content));
+
+beforeEach(() => {
+  resetParityNotices();
+  mockLlm.calls = [];
+  mockLlm.responder = null;
+  mockLlm.delayMs = 0;
+  mockLlm.inFlight = 0;
+  mockLlm.maxInFlight = 0;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// handler
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task handler', () => {
+  it('runs the task s own function instead of the model', async () => {
+    const handler = jest.fn(() => 'computed without an LLM');
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'compute', description: 'add the numbers', handler })],
+      ...quiet,
+    });
+
+    const results = await team.start();
+
+    expect(results).toEqual(['computed without an LLM']);
+    expect(handler).toHaveBeenCalledTimes(1);
+    // The handler was given the workflow context, not the bare prompt.
+    expect((handler.mock.calls[0] as any[])[0]).toMatchObject({ currentStep: 'compute' });
+    // The point of a handler: the model is never asked.
+    expect(mockLlm.calls).toHaveLength(0);
+  });
+
+  it('control: without a handler the same task calls the model', async () => {
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'compute', description: 'add the numbers' })],
+      ...quiet,
+    });
+
+    const results = await team.start();
+
+    expect(mockLlm.calls).toHaveLength(1);
+    expect(results[0]).toContain('reply(add the numbers');
+  });
+
+  it('publishes the handler s variables into the run, so a later prompt sees them', async () => {
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [
+        new Task({ name: 'gather', description: 'gather', handler: () => ({ output: 'raw data', variables: { topic: 'whales' } }) }),
+        new Task({ name: 'write', description: 'write about {{topic}}' }),
+      ],
+      ...quiet,
+    });
+
+    await team.start();
+
+    expect(prompts()[0]).toContain('write about whales');
+  });
+
+  it('control: a handler returning a plain string publishes nothing', async () => {
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [
+        new Task({ name: 'gather', description: 'gather', handler: () => 'raw data' }),
+        new Task({ name: 'write', description: 'write about {{topic}}' }),
+      ],
+      ...quiet,
+    });
+
+    await team.start();
+
+    expect(prompts()[0]).toContain('write about {{topic}}');
+  });
+
+  it('stopWorkflow ends the run, so the following task never starts', async () => {
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [
+        new Task({ name: 'halt', description: 'halt', handler: () => ({ output: 'stopping', stopWorkflow: true }) }),
+        new Task({ name: 'after', description: 'after' }),
+      ],
+      ...quiet,
+    });
+
+    const results = await team.start();
+
+    expect(mockLlm.calls).toHaveLength(0);
+    expect(results).toEqual(['stopping', '']);
+  });
+
+  it('a throwing handler fails its task without failing the run', async () => {
+    const failing = new Task({ name: 'boom', description: 'boom', handler: () => { throw new Error('handler exploded'); } });
+    const team = new AgentTeam({ agents: [member()], tasks: [failing, new Task({ name: 'after', description: 'after' })], ...quiet });
+
+    const results = await team.start();
+
+    expect(failing.status).toBe('failed');
+    expect(results[0]).toBe('');
+    // The unrelated task still ran.
+    expect(prompts()).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// rerun / caching / execution
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task rerun', () => {
+  const teamFor = (task: Task) => new AgentTeam({ agents: [member()], tasks: [task, task], ...quiet });
+
+  it('re-runs a task the team reaches a second time', async () => {
+    await teamFor(new Task({ name: 'poll', description: 'poll the queue', rerun: true })).start();
+    expect(mockLlm.calls).toHaveLength(2);
+  });
+
+  it('control: without rerun the second visit is skipped', async () => {
+    await teamFor(new Task({ name: 'poll', description: 'poll the queue' })).start();
+    expect(mockLlm.calls).toHaveLength(1);
+  });
+
+  it('execution: { rerun } reaches the same switch', async () => {
+    await teamFor(new Task({ name: 'poll', description: 'poll the queue', execution: { rerun: true } })).start();
+    expect(mockLlm.calls).toHaveLength(2);
+
+    mockLlm.calls = [];
+    await teamFor(new Task({ name: 'poll', description: 'poll the queue', execution: { rerun: false } })).start();
+    expect(mockLlm.calls).toHaveLength(1);
+  });
+});
+
+describe('Task caching', () => {
+  const teamFor = (task: Task) => new AgentTeam({ agents: [member()], tasks: [task], ...quiet });
+
+  it('answers a repeated prompt from the cache instead of the model', async () => {
+    const task = new Task({ name: 'quote', description: 'quote the price', rerun: true, caching: true });
+    const team = teamFor(task);
+
+    const first = await team.start();
+    const second = await team.start();
+
+    expect(second).toEqual(first);
+    expect(mockLlm.calls).toHaveLength(1);
+  });
+
+  it('control: without caching the second run asks the model again', async () => {
+    const team = teamFor(new Task({ name: 'quote', description: 'quote the price', rerun: true }));
+
+    await team.start();
+    await team.start();
+
+    expect(mockLlm.calls).toHaveLength(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// agentConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task agentConfig', () => {
+  it('builds the executing agent from the config when the task names none', async () => {
+    const task = new Task({
+      name: 'research',
+      description: 'research whales',
+      agentConfig: { llm: 'config-model', instructions: 'be brief', stream: false, verbose: false },
+    });
+    const team = new AgentTeam({ agents: [member()], tasks: [task], ...quiet });
+
+    await team.start();
+
+    expect(mockLlm.calls.map((call) => call.model)).toEqual(['config-model']);
+    // Python assigns the constructed agent back onto the task; so does this.
+    expect((task.agent as Agent).name).toBe('researchAgent');
+  });
+
+  it('control: without agentConfig the task runs on the team member', async () => {
+    const task = new Task({ name: 'research', description: 'research whales' });
+    const team = new AgentTeam({ agents: [member()], tasks: [task], ...quiet });
+
+    await team.start();
+
+    expect(mockLlm.calls.map((call) => call.model)).toEqual(['member-model']);
+    expect(task.agent).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// retainFullContext
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task retainFullContext', () => {
+  const teamFor = (retainFullContext: boolean) => new AgentTeam({
+    agents: [member()],
+    tasks: [
+      'find the first fact',
+      'find the second fact',
+      new Task({ name: 'summary', description: 'summarise', retainFullContext }),
+    ],
+    ...quiet,
+  });
+
+  it('hands the task every earlier result, not only the most recent one', async () => {
+    await teamFor(true).start();
+
+    const summaryPrompt = prompts()[2];
+    expect(summaryPrompt).toContain('Input data from previous tasks:');
+    // Both upstream results, each labelled with the task that produced it.
+    expect(summaryPrompt).toContain('\ntask_1: reply(find the first fact)');
+    expect(summaryPrompt).toContain('\ntask_2: reply(find the second fact');
+  });
+
+  it('control: without it only the most recent result is carried', async () => {
+    await teamFor(false).start();
+
+    const summaryPrompt = prompts()[2];
+    expect(summaryPrompt).toContain('Here is the input:');
+    // No engine block, and no per-task labels: only the previous answer is carried.
+    expect(summaryPrompt).not.toContain('Input data from previous tasks:');
+    expect(summaryPrompt).not.toContain('\ntask_1: ');
+    expect(summaryPrompt).not.toContain('\ntask_2: ');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// memory / failOnMemoryError / config
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task memory', () => {
+  const store = () => ({
+    add: jest.fn(async (_content: string, _role: string, _metadata?: Record<string, unknown>) => undefined),
+    search: jest.fn(async (_query: string, _limit?: number) => [{ entry: { content: 'whales migrate in winter' }, score: 1 }]),
+  });
+
+  it('recalls into the prompt and writes the answer back', async () => {
+    const memory = store();
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'summarise', description: 'summarise whales', memory })],
+      ...quiet,
+    });
+
+    const results = await team.start();
+
+    expect(prompts()[0]).toContain('whales migrate in winter');
+    expect(memory.search).toHaveBeenCalledTimes(1);
+    expect(memory.add).toHaveBeenCalledTimes(1);
+    expect(memory.add.mock.calls[0][0]).toBe(results[0]);
+  });
+
+  it('control: an unattached store is neither searched nor written', async () => {
+    const memory = store();
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'summarise', description: 'summarise whales' })],
+      ...quiet,
+    });
+
+    await team.start();
+
+    expect(prompts()[0]).not.toContain('whales migrate in winter');
+    expect(memory.search).not.toHaveBeenCalled();
+    expect(memory.add).not.toHaveBeenCalled();
+  });
+
+  it('failOnMemoryError turns a broken store into a failed run', async () => {
+    const broken = {
+      add: jest.fn(async () => { throw new Error('memory backend unreachable'); }),
+      search: jest.fn(async () => []),
+    };
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'summarise', description: 'summarise whales', memory: broken, failOnMemoryError: true })],
+      ...quiet,
+    });
+
+    await expect(team.start()).rejects.toThrow('memory backend unreachable');
+  });
+
+  it('control: the same broken store is a degraded run without the flag', async () => {
+    const broken = {
+      add: jest.fn(async () => { throw new Error('memory backend unreachable'); }),
+      search: jest.fn(async () => []),
+    };
+    const task = new Task({ name: 'summarise', description: 'summarise whales', memory: broken });
+    const team = new AgentTeam({ agents: [member()], tasks: [task], ...quiet });
+
+    const results = await team.start();
+
+    expect(results[0]).toContain('reply(');
+    expect(task.nonFatalErrors).toContain('store_in_memory: memory backend unreachable');
+  });
+});
+
+describe('Task config', () => {
+  it('config.memory_config gives the task a store, and the run fills it', async () => {
+    const task = new Task({ name: 'note', description: 'note the finding', config: { memory_config: { maxEntries: 5 } } });
+    const team = new AgentTeam({ agents: [member()], tasks: [task], ...quiet });
+
+    const results = await team.start();
+
+    const created = task.memory as { getAll(): Array<{ content: string }> };
+    expect(created).toBeDefined();
+    expect(created.getAll().map((entry) => entry.content)).toEqual([results[0]]);
+  });
+
+  it('control: without config the task never acquires a store', async () => {
+    const task = new Task({ name: 'note', description: 'note the finding' });
+    const team = new AgentTeam({ agents: [member()], tasks: [task], ...quiet });
+
+    await team.start();
+
+    expect(task.memory).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// knowledge
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task knowledge', () => {
+  it('folds the task s knowledge into its prompt', async () => {
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'brief', description: 'brief me', knowledge: 'penguins cannot fly' })],
+      ...quiet,
+    });
+
+    await team.start();
+
+    expect(prompts()[0]).toContain('penguins cannot fly');
+  });
+
+  it('searches a knowledge base and folds in what it matched', async () => {
+    const base = { search: jest.fn(async (_q: string, _l?: number) => [{ document: { content: 'the launch slipped to March' } }]) };
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'brief', description: 'brief me', knowledge: base })],
+      ...quiet,
+    });
+
+    await team.start();
+
+    expect(base.search).toHaveBeenCalledTimes(1);
+    expect(prompts()[0]).toContain('the launch slipped to March');
+  });
+
+  it('control: without knowledge nothing is added', async () => {
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'brief', description: 'brief me' })],
+      ...quiet,
+    });
+
+    await team.start();
+
+    expect(prompts()[0]).not.toContain('penguins cannot fly');
+    expect(prompts()[0].trim()).toContain('brief me');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// images
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task images', () => {
+  it('sends the pictures alongside the text as multimodal content', async () => {
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'describe', description: 'describe the picture', images: ['https://example.com/cat.png'] })],
+      ...quiet,
+    });
+
+    await team.start();
+
+    const content = mockLlm.calls[0].content as any[];
+    expect(Array.isArray(content)).toBe(true);
+    expect(content.filter((part) => part.type === 'image_url')).toEqual([
+      { type: 'image_url', image_url: { url: 'https://example.com/cat.png' } },
+    ]);
+    expect(textOf(content)).toContain('describe the picture');
+  });
+
+  it('control: without images the call carries plain text', async () => {
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'describe', description: 'describe the picture' })],
+      ...quiet,
+    });
+
+    await team.start();
+
+    expect(typeof mockLlm.calls[0].content).toBe('string');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// outputPydantic / outputConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task structured output', () => {
+  const schema = { type: 'object', properties: { title: { type: 'string' } } };
+
+  const runWith = async (config: Record<string, unknown>) => {
+    const seen: any[] = [];
+    mockLlm.responder = () => '```json\n{"title":"Whales"}\n```';
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'shape', description: 'shape it', onTaskComplete: (output) => { seen.push(output); }, ...config })],
+      ...quiet,
+    });
+    await team.start();
+    return seen[0];
+  };
+
+  it('outputPydantic parses the answer onto the TaskOutput', async () => {
+    const output = await runWith({ outputPydantic: schema });
+    expect(output.outputFormat).toBe('Pydantic');
+    expect(output.outputPydantic).toEqual({ title: 'Whales' });
+  });
+
+  it('outputConfig reaches the same parsing through its own field', async () => {
+    const output = await runWith({ outputConfig: { pydanticModel: schema } });
+    expect(output.outputFormat).toBe('Pydantic');
+    expect(output.outputPydantic).toEqual({ title: 'Whales' });
+  });
+
+  it('control: neither option leaves the output raw', async () => {
+    const output = await runWith({});
+    expect(output.outputFormat).toBe('RAW');
+    expect(output.outputPydantic).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// asyncExecution
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task asyncExecution', () => {
+  const twoTasks = (asyncExecution: boolean) => new AgentTeam({
+    agents: [member()],
+    tasks: [
+      new Task({ name: 'alpha', description: 'alpha', asyncExecution }),
+      new Task({ name: 'beta', description: 'beta', asyncExecution }),
+    ],
+    ...quiet,
+  });
+
+  it('runs consecutive async tasks as one batch, at the same time', async () => {
+    mockLlm.delayMs = 10;
+    await twoTasks(true).start();
+
+    expect(mockLlm.maxInFlight).toBe(2);
+    // Running together, neither can have seen the other's answer.
+    expect(prompts()[1]).not.toContain('Here is the input:');
+  });
+
+  it('control: without asyncExecution they run one after the other', async () => {
+    mockLlm.delayMs = 10;
+    await twoTasks(false).start();
+
+    expect(mockLlm.maxInFlight).toBe(1);
+    expect(prompts()[1]).toContain('Here is the input: reply(alpha');
+  });
+
+  it('flushes the batch when a queued task depends on one already in it', async () => {
+    mockLlm.delayMs = 10;
+    const alpha = new Task({ name: 'alpha', description: 'alpha', asyncExecution: true });
+    const beta = new Task({ name: 'beta', description: 'beta', asyncExecution: true });
+    const gamma = new Task({ name: 'gamma', description: 'gamma', asyncExecution: true, dependsOn: [beta] });
+
+    await new AgentTeam({ agents: [member()], tasks: [alpha, beta, gamma], ...quiet }).start();
+
+    // alpha+beta overlap; gamma waits, because its dependency was still pending.
+    expect(mockLlm.maxInFlight).toBe(2);
+    expect(prompts()[2]).toContain('Here is the input: reply(beta');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// skipOnFailure
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task skipOnFailure', () => {
+  const teamWith = (skipOnFailure: boolean) => {
+    const upstream = new Task({ name: 'fetch', description: 'fetch', handler: () => { throw new Error('upstream is down'); } });
+    const downstream = new Task({ name: 'report', description: 'report', dependsOn: [upstream], skipOnFailure });
+    return { downstream, team: new AgentTeam({ agents: [member()], tasks: [upstream, downstream], ...quiet }) };
+  };
+
+  it('runs the dependent task anyway when it opted in', async () => {
+    const { downstream, team } = teamWith(true);
+    await team.start();
+
+    expect(prompts()).toHaveLength(1);
+    expect(prompts()[0]).toContain('report');
+    expect(downstream.status).toBe('completed');
+  });
+
+  it('control: without it the dependent task is failed with its dependency', async () => {
+    const { downstream, team } = teamWith(false);
+    await team.start();
+
+    expect(mockLlm.calls).toHaveLength(0);
+    expect(downstream.status).toBe('failed');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// retryDelay
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task retryDelay', () => {
+  const neverSatisfied = { completionChecker: () => false };
+
+  const elapsedFor = async (retryDelay: number): Promise<number> => {
+    const team = new AgentTeam({
+      agents: [member()],
+      tasks: [new Task({ name: 'flaky', description: 'flaky', retryDelay })],
+      hooks: neverSatisfied,
+      execution: { maxRetries: 3 },
+      ...quiet,
+    });
+    const started = Date.now();
+    await team.start();
+    return Date.now() - started;
+  };
+
+  it('waits between attempts, doubling the delay each time', async () => {
+    const elapsed = await elapsedFor(0.05);
+    // Three attempts means two waits: 0.05s then 0.10s.
+    expect(mockLlm.calls).toHaveLength(3);
+    expect(elapsed).toBeGreaterThanOrEqual(120);
+  });
+
+  it('control: the default of 0 retries without waiting', async () => {
+    const elapsed = await elapsedFor(0);
+    expect(mockLlm.calls).toHaveLength(3);
+    expect(elapsed).toBeLessThan(100);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// hooks
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task hooks', () => {
+  it('fires the task s own onTaskStart and onTaskComplete', async () => {
+    const onTaskStart = jest.fn();
+    const onTaskComplete = jest.fn();
+    const task = new Task({ name: 'watched', description: 'watched', hooks: { onTaskStart, onTaskComplete } });
+
+    await new AgentTeam({ agents: [member()], tasks: [task], ...quiet }).start();
+
+    expect(onTaskStart).toHaveBeenCalledTimes(1);
+    expect(onTaskStart.mock.calls[0][0]).toBe(task);
+    expect(onTaskStart.mock.calls[0][1]).toBe(0);
+    expect(onTaskComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('control: a task without hooks fires nothing', async () => {
+    const onTaskStart = jest.fn();
+    await new AgentTeam({ agents: [member()], tasks: [new Task({ name: 'watched', description: 'watched' })], ...quiet }).start();
+    expect(onTaskStart).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// workflow routing: isStart / nextTasks / condition / routing / when
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task workflow routing', () => {
+  it('isStart picks the entry point and nextTasks picks what follows', async () => {
+    const one = new Task({ name: 'one', description: 'step one', isStart: true, nextTasks: ['three'] });
+    const two = new Task({ name: 'two', description: 'step two' });
+    const three = new Task({ name: 'three', description: 'step three' });
+
+    await new AgentTeam({ agents: [member()], tasks: [two, one, three], process: 'workflow', ...quiet }).start();
+
+    // `two` is first in the list and is never run: the graph, not the order, decides.
+    expect(prompts().map((p) => p.split('\n')[0])).toEqual(['step one', 'step three']);
+    expect(two.status).toBe('not started');
+    // The edges are also linked back, as Python does before the loop starts.
+    expect(three.previousTasks).toEqual(['one']);
+    expect(two.previousTasks).toEqual([]);
+  });
+
+  it('control: the same tasks run in list order under sequential', async () => {
+    const one = new Task({ name: 'one', description: 'step one', isStart: true, nextTasks: ['three'] });
+    const two = new Task({ name: 'two', description: 'step two' });
+    const three = new Task({ name: 'three', description: 'step three' });
+
+    await new AgentTeam({ agents: [member()], tasks: [two, one, three], process: 'sequential', ...quiet }).start();
+
+    expect(prompts().map((p) => p.split('\n')[0])).toEqual(['step two', 'step one', 'step three']);
+  });
+
+  it('when / thenTask / elseTask send control down the branch the answer chose', async () => {
+    const branchFor = async (verdict: string) => {
+      const triage = new Task({
+        name: 'triage',
+        description: 'triage the ticket',
+        isStart: true,
+        when: '{{previous_output}} contains urgent',
+        thenTask: 'escalate',
+        elseTask: 'archive',
+      });
+      const escalate = new Task({ name: 'escalate', description: 'escalate it' });
+      const archive = new Task({ name: 'archive', description: 'archive it' });
+      mockLlm.responder = (_model, prompt) => (prompt.includes('triage the ticket') ? verdict : undefined);
+      await new AgentTeam({ agents: [member()], tasks: [archive, escalate, triage], process: 'workflow', ...quiet }).start();
+      return prompts().map((p) => p.split('\n')[0]);
+    };
+
+    expect(await branchFor('this is urgent')).toEqual(['triage the ticket', 'escalate it']);
+    mockLlm.calls = [];
+    expect(await branchFor('nothing special')).toEqual(['triage the ticket', 'archive it']);
+  });
+
+  it('a decision task s routing table picks the next task, and "exit" ends the run', async () => {
+    const runWith = async (decision: string, table: Record<string, string[]>) => {
+      const gate = new Task({ name: 'gate', description: 'approve or reject', isStart: true, taskType: 'decision', routing: table });
+      const ship = new Task({ name: 'ship', description: 'ship it' });
+      mockLlm.responder = (_model, prompt) => (prompt.includes('approve or reject') ? `{"decision":"${decision}"}` : undefined);
+      await new AgentTeam({ agents: [member()], tasks: [gate, ship], process: 'workflow', ...quiet }).start();
+      return prompts().map((p) => p.split('\n')[0]);
+    };
+
+    const table = { approve: ['ship'], reject: ['exit'] };
+    expect(await runWith('approve', table)).toEqual(['approve or reject', 'ship it']);
+    mockLlm.calls = [];
+    expect(await runWith('reject', table)).toEqual(['approve or reject']);
+  });
+
+  it('condition is the same table under its older name', async () => {
+    const gate = new Task({ name: 'gate', description: 'approve or reject', isStart: true, taskType: 'decision', condition: { approve: ['ship'] } });
+    const ship = new Task({ name: 'ship', description: 'ship it' });
+    mockLlm.responder = (_model, prompt) => (prompt.includes('approve or reject') ? '{"decision":"approve"}' : undefined);
+
+    await new AgentTeam({ agents: [member()], tasks: [gate, ship], process: 'workflow', ...quiet }).start();
+
+    expect(prompts().map((p) => p.split('\n')[0])).toEqual(['approve or reject', 'ship it']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// loopOver / loopVar / loopState
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task loopOver', () => {
+  it('runs the task once per item, binding loopVar and recording loopState', async () => {
+    const states: unknown[] = [];
+    const task = new Task({
+      name: 'greet',
+      description: 'greet {{name}}',
+      loopOver: 'people',
+      loopVar: 'name',
+      onTaskComplete: (_output, metadata) => { states.push(metadata?.loopState); },
+    });
+
+    await new AgentTeam({ agents: [member()], tasks: [task], variables: { people: ['ada', 'bob'] }, ...quiet }).start();
+
+    expect(prompts().map((p) => p.split('\n')[0])).toEqual(['greet ada', 'greet bob']);
+    expect(states).toEqual([
+      { name: 'ada', index: 0, total: 2 },
+      { name: 'bob', index: 1, total: 2 },
+    ]);
+  });
+
+  it('loopVar defaults to "item"', async () => {
+    const task = new Task({ name: 'greet', description: 'greet {{item}}', loopOver: 'people' });
+
+    await new AgentTeam({ agents: [member()], tasks: [task], variables: { people: ['ada', 'bob'] }, ...quiet }).start();
+
+    expect(prompts().map((p) => p.split('\n')[0])).toEqual(['greet ada', 'greet bob']);
+  });
+
+  it('control: without loopOver the task runs once with the placeholder unfilled', async () => {
+    const task = new Task({ name: 'greet', description: 'greet {{name}}' });
+
+    await new AgentTeam({ agents: [member()], tasks: [task], variables: { people: ['ada', 'bob'] }, ...quiet }).start();
+
+    expect(prompts()).toHaveLength(1);
+    expect(prompts()[0]).toContain('greet {{name}}');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// inputFile
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Task inputFile', () => {
+  let directory: string;
+  let csv: string;
+
+  beforeAll(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'praison-task-inputfile-'));
+    csv = path.join(directory, 'rows.csv');
+    fs.writeFileSync(csv, 'Where is Paris?,France\nWhere is Rome?,Italy\n', 'utf8');
+  });
+
+  afterAll(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it('fans the task out into one subtask per row of the file', async () => {
+    const task = new Task({ name: 'quiz', description: 'Check the answer', inputFile: csv });
+
+    const results = await new AgentTeam({ agents: [member()], tasks: [task], ...quiet }).start();
+
+    expect(results).toHaveLength(2);
+    expect(prompts()[0]).toContain('Question: Where is Paris?\nAnswer: France');
+    expect(prompts()[1]).toContain('Question: Where is Rome?\nAnswer: Italy');
+  });
+
+  it('control: without inputFile the task runs once, on its own description', async () => {
+    const task = new Task({ name: 'quiz', description: 'Check the answer' });
+
+    const results = await new AgentTeam({ agents: [member()], tasks: [task], ...quiet }).start();
+
+    expect(results).toHaveLength(1);
+    expect(prompts()[0]).not.toContain('Where is Paris?');
+  });
+});


### PR DESCRIPTION
**Behaviour parity: 48 → 20.**

## Why this is a separate change

#4838 built the Task engine — real, unit-tested implementations behind 28 Task options — and deliberately **did not** shrink the ledger, because nothing called it:

```
runHandler: 0   expandLoop: 0   needsRun: 0   planTaskRun: 0
resolveAgent: 0 buildOutput: 0  storeInMemory: 0     ← call sites outside the engine
```

Passing `handler` or `loopOver` to a Task still did nothing. A count must not fall while the behaviour is inert — that is the one move the ratchet cannot detect. This is the change that makes them real.

## What the runner now does

A plan phase (loop and input-file fan-out, back-links, async batching), a routing loop, and a per-task path applying the engine in Python's order: rerun gate → dependency-failure gate → task hooks → `agentConfig` resolution → **handler before the model** → context assembly → memory and knowledge recall → images → cache → retry backoff → memory write → output shaping in place of the inline literal.

## How it is proved

All 28 options are driven through **`team.start()`**, not by calling an engine method directly — calling the engine was never the question. **48 tests**, each paired with a control.

## Two notes

- `taskType: 'decision'` now genuinely changes behaviour, so its notice is narrowed to the values that still mean nothing rather than left to cry wolf.
- **The engine barrel could not be imported.** `simple.ts` re-exports `AgentTeam`, so `team.ts` is on the graph the webview gate bundles for a browser, and the barrel re-exports two modules importing `fs`/`path` at module scope. Verified with esbuild *before* writing any code; `team-runner.ts` imports the three builtin-free engine modules directly. Gate: zero failures.

## Still open on this surface

`autonomy`, `web`, `reflection`, `planning` — no engine implementation exists to call. Closing them means writing new modules, not wiring existing ones.

## Verification

`tsc` clean · **2,278 tests passing** · webview gate 0 failures · all three parity gates OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved task execution with dependencies, retries, caching, reruns, handlers, memory, knowledge, images, and structured outputs.
  - Added sequential and parallel scheduling with asynchronous execution.
  - Added workflow routing with conditional branches and iteration limits.
  - Added task expansion for looped inputs and input files.
  - Added support for decision-based tasks and failure-handling options.
  - Improved handling of structured decisions, including JSON-formatted responses.

- **Bug Fixes**
  - Improved task state and run isolation between executions.
  - Tasks with failed dependencies are now handled according to configured failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->