### PR TITLE
fix(mobile): say what went wrong, not what the SDK said

### DIFF
--- a/src/praisonai-mobile/app/app.css
+++ b/src/praisonai-mobile/app/app.css
@@ -184,6 +184,14 @@ html, body {
 .row-approval { border: 1px solid var(--warn); display: flex; flex-wrap: wrap; gap: .4rem; align-items: center; }
 .row-approval p { margin: 0 0 .3rem; width: 100%; }
 .row-error { border: 1px solid var(--bad); color: var(--bad); }
+/* An error row is a TITLE chosen by kind and, under it, the provider's prose.
+   `display: block` is the whole rule and it is required rather than cosmetic:
+   both are spans inside one row, so without it they run together and the row
+   reads "Sign-in problemThe OPENAI_API_KEY environment variable...". No colour
+   is stated here on purpose -- `.row-error` above already sets one and both
+   spans inherit it, so this adds no token for the dark-scheme gate to check
+   and nothing for a palette pass to have to keep in step. */
+.row-error .error-title { display: block; font-weight: 600; }
 .row-notice { color: var(--soft); font-size: .88rem; text-align: center; }
 .row-dropped { color: var(--warn); font-size: .8rem; }
 

--- a/src/praisonai-mobile/app/src/dom.test.ts
+++ b/src/praisonai-mobile/app/src/dom.test.ts
@@ -618,6 +618,53 @@ test("an error row is named with its TITLE, not only the provider's prose", () =
   assert.equal(el?.getAttribute("aria-label"), en.errorRowName("auth", "401 unauthorized"));
 });
 
+test("an error row SHOWS its title too, not only announces it", () => {
+  // The test above asserts the `aria-label`, and that is all that was ever
+  // repaired: `strings.errorTitle` had no renderer anywhere in the app, so a
+  // screen-reader user heard "Sign-in problem. ..." while a sighted user got
+  // the provider's sentence alone with nothing to say what kind of failure it
+  // was. Two audiences, two different accounts of one event.
+  //
+  // Reproduced on an Android 35 emulator: a fresh install with no key rendered
+  // the whole of the SDK's sentence -- an environment variable and a JavaScript
+  // constructor -- as the entire visible content of the row.
+  const { host, created } = fakeDoc();
+  const row: Row = {
+    kind: "error", id: "error", errorKind: "auth",
+    message: "The OPENAI_API_KEY environment variable is missing or empty",
+    recovery: "settings", tone: "failure",
+  } as Row;
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: "error", index: 0, row }]);
+  const el = created.find((n) => n.dataset.rowId === "error");
+  assert.ok(el !== undefined, "the error row must exist");
+  const title = el.children.find((c: any) => c.className === "error-title");
+  assert.ok(title !== undefined, "the error row must SHOW a title, not only announce one");
+  assert.equal(title.textContent, en.errorTitle("auth"));
+  // And the provider's prose is kept, in full and unparsed -- it is what a
+  // support engineer searches for. Dropping it would trade one defect for a
+  // worse one.
+  const message = el.children.find((c: any) => c.className === "error-message");
+  assert.equal(message?.textContent, "The OPENAI_API_KEY environment variable is missing or empty");
+});
+
+test("the title an error row shows is chosen by KIND, not by the prose", () => {
+  // The pair. Hard-coding one title, or deriving it from the message, would
+  // pass the test above and mislabel every other failure -- which is the rule
+  // strings.ts states at `errorRowName`: a provider's message may say anything
+  // at all, so the kind is the only dependable part.
+  for (const kind of ["auth", "rate_limit", "transport", "internal"] as const) {
+    const { host, created } = fakeDoc();
+    const row: Row = {
+      kind: "error", id: "error", errorKind: kind, message: "same prose every time",
+      recovery: "none", tone: "failure",
+    } as Row;
+    applyOps(host, emptyNodes(), [{ kind: "insert", id: "error", index: 0, row }]);
+    const el = created.find((n) => n.dataset.rowId === "error");
+    const title = el?.children.find((c: any) => c.className === "error-title");
+    assert.equal(title?.textContent, en.errorTitle(kind), `the ${kind} title`);
+  }
+});
+
 test("a text row is left UNLABELLED, so its own words are read", () => {
   // `accessibleName` returns null here and null is a real answer: labelling a
   // paragraph replaces the answer with a summary of it. Writing "" instead of
@@ -734,4 +781,31 @@ test("a message that was never stored SAYS so, once and only when true", () => {
   applyOps(host, nodes, [{ kind: "update", id: "u0", row: userRow("hello", "stored") }]);
   assert.equal(row.children.some((c: any) => c.className === "user-note"), false,
     "a stale 'not saved' note survived the confirmation");
+});
+
+test("a reasoning row SAYS it is reasoning, not only looks like it", () => {
+  // `.row-reasoning` is a left rule, a softer colour and a smaller font. All
+  // three are CSS and none reaches the accessibility tree, so the model's
+  // private working and its actual answer were one undifferentiated run of
+  // paragraphs to a screen reader -- the "conveyed exclusively by hue" defect
+  // a11y/names.ts was written against, which the user row already fixed the
+  // same way. `strings.reasoningLabel` existed for this and had no caller.
+  //
+  // Content, NOT an aria-label: `accessibleName` returns null for this kind on
+  // purpose, because labelling prose replaces the prose in the tree and costs
+  // the reader the ability to navigate it.
+  const { host, created } = fakeDoc();
+  const row: Row = { kind: "reasoning", id: "reasoning", text: "weighing the options" };
+  applyOps(host, emptyNodes(), [{ kind: "insert", id: "reasoning", index: 0, row }]);
+  const el = created.find((n) => n.dataset.rowId === "reasoning");
+  assert.ok(el !== undefined, "the reasoning row must exist");
+  assert.equal(el.getAttribute("aria-label"), null, "a label would replace the prose it labels");
+  const label = el.children.find((c: any) => c.className === "sr-only");
+  assert.ok(label !== undefined, "the row must carry a visually-hidden word saying what it is");
+  assert.equal(label.textContent, en.reasoningLabel);
+  // And the reasoning itself survives, as text and never as markup: it is
+  // model output like any other.
+  const said = el.children.find((c: any) => c.className !== "sr-only");
+  assert.equal(said?.textContent, "weighing the options");
+  assert.equal(said?._html, "", "innerHTML must never be written");
 });

--- a/src/praisonai-mobile/app/src/dom.ts
+++ b/src/praisonai-mobile/app/src/dom.ts
@@ -99,18 +99,73 @@ function paint(el: HTMLElement, row: Row, strings: Strings): void {
       el.textContent = row.text;
       el.classList.toggle("streaming", row.streaming);
       return;
-    case "reasoning":
-      el.textContent = row.text;
+    case "reasoning": {
+      // A reasoning block is the model THINKING, not the model answering, and
+      // the difference reached the screen by styling alone: app.css gives
+      // `.row-reasoning` a left rule, a softer colour and a smaller font, and
+      // nothing else anywhere said which it was. `accessibleName` returns null
+      // for this kind (correctly -- rule 3: a label on prose replaces the prose),
+      // so a screen-reader user arrowing through a transcript heard the model's
+      // private working and its actual answer in one undifferentiated run.
+      //
+      // That is the same "conveyed exclusively by hue" defect a11y/names.ts was
+      // written against, and the user row already has the remedy: a
+      // visually-hidden word INSIDE the row, ahead of the text, which is
+      // content and therefore additive rather than replacing. `reasoningLabel`
+      // was written for exactly this and had no caller anywhere in the app.
+      el.textContent = "";
+      const label = el.ownerDocument.createElement("span");
+      label.className = "sr-only";
+      label.textContent = strings.reasoningLabel;
+      const said = el.ownerDocument.createElement("span");
+      said.textContent = row.text;
+      el.append(label, said);
       return;
+    }
     case "notice":
       el.textContent = row.text;
       el.dataset["tone"] = row.tone;
       return;
-    case "error":
-      el.textContent = row.message;
+    case "error": {
       el.dataset["tone"] = row.tone;
       el.dataset["recovery"] = row.recovery;
+      el.textContent = "";
+      // The kind IN WORDS, in front of the provider's prose -- the same repair
+      // the tool row below got, and for the same reason.
+      //
+      // The `aria-label` set at the top of this function has carried
+      // `errorRowName` (title + message) since a11y/names.ts was wired up, and
+      // the docstring of this file already claims the defect fixed: "an error
+      // row read as bare provider prose with no `errorTitle` in front of it".
+      // Only the ANNOUNCEMENT was repaired. What a sighted user saw was still
+      // `row.message` alone, so `strings.errorTitle` had no renderer anywhere
+      // in the application and the two audiences were told different things
+      // about the same failure.
+      //
+      // Measured on an Android 35 emulator: the first message of a fresh
+      // install with no key rendered, in full and as the entire content of the
+      // row, "The OPENAI_API_KEY environment variable is missing or empty;
+      // either provide it, or instantiate the OpenAI client with an apiKey
+      // option, like new OpenAI({ apiKey: 'My API Key' })." That is SDK prose
+      // addressed to a developer -- it names an environment variable and a
+      // JavaScript constructor, neither of which a phone has -- shown to a user
+      // who did nothing wrong. `ui/src/transcript/empty-state.ts` quotes that
+      // same sentence as the thing a user should never have had to read.
+      //
+      // The title is chosen by KIND and never by parsing the message, which is
+      // the rule strings.ts states at `errorRowName`: the prose is whatever a
+      // provider decided to say and may say anything at all, so the kind is the
+      // only dependable part. The message is kept, in full and unparsed,
+      // underneath -- it is what a support engineer searches for.
+      const title = el.ownerDocument.createElement("span");
+      title.className = "error-title";
+      title.textContent = strings.errorTitle(row.errorKind);
+      const message = el.ownerDocument.createElement("span");
+      message.className = "error-message";
+      message.textContent = row.message;
+      el.append(title, message);
       return;
+    }
     case "dropped":
       // Was a hand-rolled `event`/`events`, which is wrong in most languages --
       // Polish has three plural categories, Welsh six, Arabic a `zero`. The

--- a/src/praisonai-mobile/app/src/main.test.ts
+++ b/src/praisonai-mobile/app/src/main.test.ts
@@ -3265,10 +3265,14 @@ test("a setting's help and inactive note are ASSOCIATED with the control, not ju
   const describedBy = (address?.getAttribute("aria-describedby") ?? "").split(" ").filter(Boolean);
   const help = dom.find((n) => n.className === "setting-help" && n.id === "setting-help-baseUrl");
   const inactive = dom.find((n) => n.dataset["settingInactive"] === "baseUrl");
-  assert.ok(help !== undefined && help.id !== "", "the help note needs a stable id to be pointed at");
-  assert.ok(describedBy.includes(help!.id), "the address must describe itself with its help");
+  // `null`, not `undefined`: `dom.find` returns `FakeNode | null`, so the
+  // original `help !== undefined` was true for a help note that was NOT found
+  // and the assertion only failed one line later, by dereferencing null.
+  assert.ok(help !== null && help.id !== "", "the help note needs a stable id to be pointed at");
+  assert.ok(inactive !== null, "the inactive sentence must exist to be pointed at");
+  assert.ok(describedBy.includes(help.id), "the address must describe itself with its help");
   assert.ok(
-    describedBy.includes(inactive!.id),
+    describedBy.includes(inactive.id),
     "and, while it is off, with the sentence that turns it on",
   );
 

--- a/src/praisonai-mobile/engines/src/praisonai-ts/classify.test.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/classify.test.ts
@@ -91,3 +91,58 @@ test("a 403 is an auth failure even when its message says nothing useful", () =>
   assert.equal(classifyError({ status: 403, message: "nope" } as never), "auth");
   assert.equal(classifyError({ status: 401, message: "nope" } as never), "auth");
 });
+
+/**
+ * The message a fresh install actually gets, byte for byte.
+ *
+ * This is the app's most likely failure by a wide margin -- it is what the very
+ * first message of a new install does, before anyone has been to Settings --
+ * and it classified as `internal`, whose recovery is `none`. The one error
+ * whose entire answer is "open Settings and paste a key" offered no route to
+ * settings, which is the outcome the docstring at the top of classify.ts says
+ * the function exists to prevent.
+ *
+ * Reproduced on an Android 35 emulator before the fix: a fresh install, no key,
+ * one message, and the transcript rendered this sentence and nothing else.
+ *
+ * It reaches none of the older alternatives, which is why it was missed --
+ * `unauthor`, `forbidden` and `authentication` do not occur in it; `no api key`
+ * does not either (it says "is missing or empty", and the only "no" nearby is
+ * inside neither phrase); and `api key not` needs "not" straight after "key".
+ */
+const MISSING_OPENAI_KEY =
+  "The OPENAI_API_KEY environment variable is missing or empty; either provide it, " +
+  "or instantiate the OpenAI client with an apiKey option, like new OpenAI({ apiKey: 'My API Key' }).";
+
+test("a key that was never SET is an auth failure, not an internal one", () => {
+  assert.equal(classifyError(new Error(MISSING_OPENAI_KEY)), "auth");
+});
+
+test("the other providers' ways of saying the same thing are auth too", () => {
+  assert.equal(
+    classifyError(new Error("The ANTHROPIC_API_KEY environment variable is missing or empty")),
+    "auth",
+  );
+  assert.equal(
+    classifyError(new Error("GOOGLE_GENERATIVE_AI_API_KEY environment variable is not set")),
+    "auth",
+  );
+  assert.equal(classifyError(new Error("API key is missing")), "auth");
+  assert.equal(classifyError(new Error("Missing credentials")), "auth");
+});
+
+test("the missing-key patterns do not swallow unrelated failures -- the pair", () => {
+  // Without this, a regex broad enough to catch the sentence above would be
+  // free to catch everything, and every `retry`/`none` recovery in the app
+  // would quietly become "open settings". The gap between "api key" and the
+  // word that qualifies it is bounded by `[^.;]`, and each of these either has
+  // no key phrase at all or puts a sentence boundary in between.
+  assert.equal(classifyError(new Error("The server had an error while processing your request")), "internal");
+  assert.equal(classifyError(new Error("something went sideways")), "internal");
+  assert.equal(classifyError(new Error("fetch failed")), "transport");
+  assert.equal(classifyError(new Error("429 Rate limit reached for gpt-4o")), "rate_limit");
+  // The one that matters most: the model answered nothing. Its recovery is
+  // `retry`, and sending that user to Settings to check a key that is fine
+  // would be the same defect pointing the other way.
+  assert.equal(classifyError(new Error("The model produced an empty response")), "internal");
+});

--- a/src/praisonai-mobile/engines/src/praisonai-ts/classify.ts
+++ b/src/praisonai-mobile/engines/src/praisonai-ts/classify.ts
@@ -41,6 +41,33 @@ export function classifyError(error: unknown): ErrorKind {
   if (/\b(401|403)\b/.test(text) || /(unauthor|forbidden|authentication|invalid[ _-]?x?-?api[ _-]?key|incorrect api key|no api key|api key not)/.test(text)) {
     return "auth";
   }
+  // A key that was never SET, which is a different sentence from a key that was
+  // rejected and was reaching none of the patterns above.
+  //
+  // This is the single most likely failure the app has -- it is what a fresh
+  // install does on its very first message -- and it was classified `internal`,
+  // whose recovery is `none`. So the one error whose entire answer is "open
+  // Settings and paste a key" offered no route to settings at all, while the
+  // docstring at the top of this file describes exactly that outcome as the
+  // thing the function exists to prevent.
+  //
+  // The message it misses is not hypothetical: `The OPENAI_API_KEY environment
+  // variable is missing or empty` is quoted verbatim in
+  // ui/src/transcript/empty-state.ts as the prose a user was left to read, and
+  // none of `unauthor`, `forbidden`, `authentication`, `no api key` or
+  // `api key not` appears anywhere in it.
+  //
+  // Bounded by `[^.;]` rather than `.`: the same sentence goes on, after a
+  // semicolon, to suggest `instantiate the OpenAI client with an apiKey
+  // option`, and a greedy gap would let any later "missing" in an unrelated
+  // clause pull an unrelated failure into `auth`.
+  if (
+    /(?:[a-z0-9]+_)?api[_ -]?key\b[^.;]{0,80}\b(?:missing|not set|unset|empty|required|not provided)\b/.test(text) ||
+    /\b(?:missing|no|empty)\b[^.;]{0,40}\bapi[_ -]?key\b/.test(text) ||
+    /\bmissing credentials?\b/.test(text)
+  ) {
+    return "auth";
+  }
   if (/\b(429|rate.?limit|too many requests|quota|overloaded|capacity)\b/.test(text)) {
     return "rate_limit";
   }

--- a/src/praisonai-mobile/testing/src/fake-dom.test.ts
+++ b/src/praisonai-mobile/testing/src/fake-dom.test.ts
@@ -179,3 +179,33 @@ test("getAttribute reads back what setAttribute wrote, and null otherwise", () =
   assert.equal(el.getAttribute("aria-live"), "polite");
   assert.equal(el.getAttribute("aria-label"), null);
 });
+
+test("`id` is reflected onto the attribute, in BOTH directions", () => {
+  // The fifth lying fixture this file was written to catch. `id` was not on
+  // FakeNode at all: the app's `note.id = helpId(key)` landed on the object
+  // anyway -- a plain JS object takes any key -- so the tests reading `n.id`
+  // got the right answer at runtime while `tsc` rejected the same line, and
+  // `npm run typecheck` exited 2 on main from #4847 until it was added.
+  //
+  // Reflection is the part worth pinning rather than the field. The app sets an
+  // id both ways (`note.id = ...` for a settings help note,
+  // `setAttribute("id", ...)` for the empty panel's heading) and the pointers
+  // that make either worth having -- `aria-describedby`, `aria-labelledby` --
+  // are read back through `getAttribute`. A fake storing the two independently
+  // would let a test assert a description pointing at an id no element answers
+  // to, which is precisely the bug those attributes exist to have caught.
+  const dom = createFakeDom();
+  const el = tagged(dom, "a");
+  assert.equal(el.id, "", 'an element with no id reports "", as HTMLElement.id does');
+  assert.equal(el.getAttribute("id"), null);
+
+  el.id = "setting-help-baseUrl";
+  assert.equal(el.getAttribute("id"), "setting-help-baseUrl", "the property must reach the attribute");
+
+  const other = tagged(dom, "b");
+  other.setAttribute("id", "empty-state-title");
+  assert.equal(other.id, "empty-state-title", "and the attribute must reach the property");
+
+  other.removeAttribute("id");
+  assert.equal(other.id, "", "removing the attribute clears the property too");
+});

--- a/src/praisonai-mobile/testing/src/fake-dom.ts
+++ b/src/praisonai-mobile/testing/src/fake-dom.ts
@@ -22,6 +22,22 @@
 interface FakeNode {
   tagName: string;
   className: string;
+  /**
+   * REFLECTED onto the `id` attribute, both ways, as the real DOM reflects it.
+   *
+   * The app writes an id both ways -- `note.id = helpId(key)` for a settings
+   * help note, `emptyTitle.setAttribute("id", EMPTY_TITLE_ID)` for the empty
+   * panel's heading -- and the pointers that make either one worth having,
+   * `aria-describedby` and `aria-labelledby`, are read back through
+   * `getAttribute`. A fake that stored the two independently would let a test
+   * assert a description pointing at an id no element answers to.
+   *
+   * It was missing entirely, and the property assignment landed on the object
+   * anyway because a plain JS object takes any key. So `main.test.ts` read
+   * `n.id` at runtime and got the right answer, while `tsc` rejected the same
+   * line: `npm run typecheck` exited 2 on `main` from #4847 until here.
+   */
+  id: string;
   dataset: Record<string, string>;
   hidden: boolean;
   disabled: boolean;
@@ -157,6 +173,15 @@ export function createFakeDom(): FakeDom {
     Object.defineProperty(el, "innerHTML", {
       get: () => el._html,
       set: (v: string) => { el._html = v; },
+    });
+    // Backed by `attrs`, so `el.id = x` and `setAttribute("id", x)` are the
+    // same write and `getAttribute("id")` sees both -- which is what makes an
+    // `aria-describedby`/`aria-labelledby` assertion mean anything. `""` for an
+    // element with no id, exactly as `HTMLElement.id` reports it, so a test can
+    // tell "no id" from "an id" without reaching for null.
+    Object.defineProperty(el, "id", {
+      get: () => el.attrs["id"] ?? "",
+      set: (v: string) => { el.attrs["id"] = String(v); },
     });
 
     el.setAttribute = (n: string, v: string): void => { el.attrs[n] = v; };


### PR DESCRIPTION
An audit of the mobile app on `main` for what the last eight UI fixes missed. Four defects, all the same shape the recurring family predicts: something built, tested, and connected to nothing.

## The one a user hits first

A fresh install with no key, one message. This is what the transcript said, in full, as the entire content of the row — measured on an Android 35 emulator:

> The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option, like new OpenAI({ apiKey: 'My API Key' }).

An environment variable and a JavaScript constructor, on a phone, to a user who did nothing wrong. `ui/src/transcript/empty-state.ts` quotes that exact sentence as the thing a user should never have had to read.

Two independent defects put it there.

**1. `strings.errorTitle` had no renderer anywhere in the app.** It maps an `ErrorKind` onto six plain-English titles. Only the `aria-label` ever carried it, via `errorRowName` — so a screen-reader user heard "Sign-in problem. …" while a sighted user got the provider's sentence alone with nothing to say what kind of failure it was. Two audiences, two different accounts of one event. `app/src/dom.ts`'s own docstring already lists this as fixed ("an error row read as bare provider prose with no `errorTitle` in front of it"); only the announcement ever was.

**2. That message classified as `internal`, not `auth`.** `recoveryFor` maps `internal` → `none` and `auth` → `settings`, so the one failure whose entire answer is "open Settings and paste a key" was the one offering no route to settings. That is the exact outcome `classify.ts`'s docstring says the function exists to prevent. None of `unauthor`, `forbidden`, `authentication`, `no api key` or `api key not` occurs in the message. It is the most likely failure the app has — it is what every new install does first.

Both fixed, and the screenshot is the proof of both: the row now reads **Sign-in problem** above the provider's sentence, and "Sign-in problem" rather than "Something went wrong" is what shows the reclassification landed.

## And two more of the same shape

**3. A reasoning row was told apart from an answer by styling alone** — a left rule, a softer colour, a smaller font, none of which reaches the accessibility tree. `strings.reasoningLabel` was written for this and had no caller, so the model's private working and its actual answer were one undifferentiated run of paragraphs to a screen reader. That is the "conveyed exclusively by hue" defect `a11y/names.ts` was written against, and the user row already has the remedy: a visually-hidden word *inside* the row, which is content and therefore additive — never an `aria-label` over prose, which would replace it. Reachable through the remote engine (`reasoning: true`); proven by test rather than on device, because the default in-process engine declares `reasoning: false`.

**4. `npm run typecheck` exited 2 on `main`.** #4847 added a test reading `n.id` off the fake DOM, which has no `id` at all. The property assignment landed on the object anyway — a plain JS object takes any key — so the test passed at runtime while `tsc` rejected the same line. `id` now reflects onto the attribute in **both** directions, as a real element does, which is what makes an `aria-describedby` assertion mean anything: a fake storing the two independently would let a test assert a description pointing at an id no element answers to.

## Verification

- **On a real Android 35 emulator** (`gap_avd`, port 5582, fresh install confirmed by `lastUpdateTime`), end to end: cold start → empty state asking for a key → first message → the error above → key entered through Settings → Back → real turn → conversation memory → background/resume → force-stop → cold reopen → chats list → reopened history → a further turn on top of restored history. All clean. Every screenshot was opened and read.
- `npm run check` exits **0** on Node 22.18 and Node 24.12, exit code read from the command itself.
- **Every test was mutation-checked**: eight mutations, each asserting its anchor was found exactly once before being applied, each turning a *named* test red, each restored before any APK was built. All eight killed.
- No new importer of any `*-contract.ts` from a sibling test file (#4813).

## Ruled out — clean, and worth recording

- **CSS classes the app never paints**: none. Every class selector in `app.css` is referenced by `app/` or `ui/`, checked with a probe validated against a known-absent control.
- **Port methods with no caller**: `shell.haptic`, `shell.share` and `shell.openExternal` are implemented on both adapters and contract-tested, and have zero callers. Left alone deliberately — the transcript renders no anchors at all, so these are unbuilt features rather than broken controls, and wiring them is a feature decision, not a defect fix.
- **The back-gesture, boot-indicator, empty-state, keychain and Settings work all hold up** under the seams between them.

## Reported, not fixed

- **`sendsFromNative` is a rule that was never built.** `core/src/ports/http.ts` documents that "the composition root refuses to hand a hardware-backed secret to an engine" when it is false. Verified by exhaustive grep: the flag is declared, set by every adapter and fake, and asserted about itself — and read by no production code. There is also no Tauri HTTP adapter, so it is `false` on every platform; implementing the refusal today would stop any key reaching the engine on Android too. Needs a native HTTP adapter first, so it is a design gap rather than a patch.
- **iOS, read only (no Xcode on this machine).** Two things the Android inset work plausibly disturbed: layout now consumes `--inset-*`, which `main.ts` pins inline on `#root` from `shell.insets`, overriding the `env()` fallback that used to be iOS's live source — so a zero read during WKWebView's startup window would stick, and the only refresh is a Rust `Resized` event the listener likely misses at startup and does not see again until a rotation. Separately, `createTauriShell` has no DOM `resize`/`orientationchange` listener (only `createWebShell` does), and the test that appears to cover this drives the *web* shell. Also: on iOS the back-gesture plugin is inert by design and Settings has no in-app Back control, so entering an API key looks like a one-way trip. All unverifiable here; reported rather than guessed at.
- **Unrendered strings that are unbuilt features, not defects**: `actionCopy` / `actionFork` / `actionRetry` (no turn-action UI exists), `usageChars` / `usageElapsed` / `usageTimeToFirstToken`, and the error row's `data-recovery`, which nothing styles or reads. Worth noting that `empty-state.ts` claims "the label is the one the error rows already use for the same destination" — the error rows do not use it. Wiring a recovery action into the row is a real gap, but it is a new control and a layout change while a visual-design pass is in flight, so it is flagged rather than taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now display a clear, localized title separately from the provider’s detailed message.
  * Missing or invalid API credentials are correctly identified as authentication issues, guiding recovery instead of showing an internal error.
  * Reasoning content now includes an accessible label for screen readers and safely displays text.
  * Improved accessibility support for settings descriptions and error-row presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->