### PR TITLE
perf(ts): stop shipping three AI SDK providers to the phone

### DIFF
--- a/src/praisonai-mobile/tools/bundle.mjs
+++ b/src/praisonai-mobile/tools/bundle.mjs
@@ -289,14 +289,44 @@ export function bundledPackages(metafile) {
  * embeddings through the same registry removed them, and this list is what
  * stops them coming back one literal at a time.
  *
- * NOT the whole `@ai-sdk/*` namespace: `ai` statically imports
- * `@ai-sdk/provider`, `@ai-sdk/provider-utils` and `@ai-sdk/gateway`, which are
- * parts of `ai` itself rather than pluggable providers, and belong in the
- * bundle for exactly as long as `ai` does.
+ * A hand-kept list of four packages was the wrong shape: praisonai-ts's
+ * registry (`llm/providers/ai-sdk/types.ts`) names ~50 `@ai-sdk/*` providers,
+ * so a literal `import('@ai-sdk/mistral')` -- or groq, deepseek, any of the
+ * others -- would sail past a gate that only looked for openai/google/cohere/
+ * anthropic and cost 100-170kB in silence until the budget tripped. So the
+ * gate is a NAMESPACE rule now: every `@ai-sdk/*` package is host-loaded and
+ * must not ship, and a new provider is covered the day it is added upstream,
+ * with no second edit here.
+ *
+ * The exceptions are the packages `ai` is BUILT FROM, not providers it can
+ * load: `ai` statically imports `@ai-sdk/provider`, `@ai-sdk/provider-utils`
+ * and `@ai-sdk/gateway`, so they belong in the bundle for exactly as long as
+ * `ai` does. They are named individually -- an allowlist, not a prefix -- so a
+ * provider that happened to share a prefix could never hide behind them.
  */
-export const HOST_LOADED_AI_SDK_PROVIDERS = [
-  "@ai-sdk/openai", "@ai-sdk/google", "@ai-sdk/cohere", "@ai-sdk/anthropic",
+export const AI_INTERNAL_AI_SDK_PACKAGES = [
+  "@ai-sdk/provider", "@ai-sdk/provider-utils", "@ai-sdk/gateway",
 ];
+
+/**
+ * Whether `pkg` is an AI SDK PROVIDER a phone can never load (as opposed to one
+ * of `ai`'s own internals). The `@ai-sdk/` namespace minus {@link
+ * AI_INTERNAL_AI_SDK_PACKAGES}. Kept as a predicate, not a fixed list, so the
+ * whole provider registry is covered without enumerating it here.
+ */
+export function isHostLoadedAISDKProvider(pkg) {
+  return pkg.startsWith("@ai-sdk/") && !AI_INTERNAL_AI_SDK_PACKAGES.includes(pkg);
+}
+
+/**
+ * The host-loaded providers actually present in a shipped bundle: every
+ * `@ai-sdk/*` package `bundledPackages` found that is not one of `ai`'s
+ * internals. Empty is the healthy state; anything here is pure weight on a code
+ * path a webview cannot take.
+ */
+export function bundledHostLoadedProviders(metafile) {
+  return bundledPackages(metafile).filter(isHostLoadedAISDKProvider);
+}
 
 /**
  * The chunks a browser fetches BEFORE the entry's body runs: the entry itself

--- a/src/praisonai-mobile/tools/bundle.mjs
+++ b/src/praisonai-mobile/tools/bundle.mjs
@@ -248,6 +248,57 @@ export function chunkSizes(metafile) {
 }
 
 /**
+ * Every npm package whose source esbuild actually pulled INTO the bundle,
+ * by package name.
+ *
+ * Read off `metafile.inputs` -- the files that were compiled in -- so it says
+ * what SHIPPED rather than what was imported somewhere. An import esbuild left
+ * external is not here; `classifyBareImports` is the function for those.
+ *
+ * Exported so a test can ask "is package X in the bundle?" by calling this
+ * rather than re-deriving the node_modules path arithmetic inline, which is
+ * the sort of predicate that keeps passing after the thing it checked moved.
+ */
+export function bundledPackages(metafile) {
+  const found = new Set();
+  for (const path of Object.keys(metafile.inputs ?? {})) {
+    const at = path.lastIndexOf("node_modules/");
+    if (at === -1) continue;
+    const parts = path.slice(at + "node_modules/".length).split("/");
+    found.add(parts[0].startsWith("@") ? `${parts[0]}/${parts[1]}` : parts[0]);
+  }
+  return [...found].sort();
+}
+
+/**
+ * AI SDK PROVIDER packages a phone can never load, and must therefore never be
+ * charged for.
+ *
+ * praisonai-ts reaches every chat provider through the registry in
+ * `llm/providers/ai-sdk/provider-map.ts`, which does
+ * `await import(providerInfo.package)` -- a computed specifier no bundler can
+ * follow, so the package is the HOST's to supply at runtime. A webview has no
+ * host resolver and no import map, so that import cannot succeed whatever the
+ * bundle contains.
+ *
+ * `praisonai-ts`'s `llm/embeddings.ts` used to be the exception: three LITERAL
+ * `import()` calls naming `@ai-sdk/openai`, `@ai-sdk/google` and
+ * `@ai-sdk/cohere`. A literal is a BUNDLER instruction, so esbuild emitted all
+ * three as chunks -- 326.7kB, measured, charged to the lazy budget -- on a
+ * code path a phone has no way to reach and no reason to take. Routing
+ * embeddings through the same registry removed them, and this list is what
+ * stops them coming back one literal at a time.
+ *
+ * NOT the whole `@ai-sdk/*` namespace: `ai` statically imports
+ * `@ai-sdk/provider`, `@ai-sdk/provider-utils` and `@ai-sdk/gateway`, which are
+ * parts of `ai` itself rather than pluggable providers, and belong in the
+ * bundle for exactly as long as `ai` does.
+ */
+export const HOST_LOADED_AI_SDK_PROVIDERS = [
+  "@ai-sdk/openai", "@ai-sdk/google", "@ai-sdk/cohere", "@ai-sdk/anthropic",
+];
+
+/**
  * The chunks a browser fetches BEFORE the entry's body runs: the entry itself
  * plus the transitive closure of its STATIC imports.
  *

--- a/src/praisonai-mobile/tools/bundle.test.mjs
+++ b/src/praisonai-mobile/tools/bundle.test.mjs
@@ -10,17 +10,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
   bundle,
+  bundledPackages,
   forbiddenAmong,
   topLevelProcessReads,
   unresolvedBareImports,
   classifyBareImports,
   FORBIDDEN_BUILTINS,
+  HOST_LOADED_AI_SDK_PROVIDERS,
   SHELL_BUDGET_BYTES,
   LAZY_BUDGET_BYTES,
   isShippable,
@@ -325,6 +327,66 @@ test("the shipping bundle resolves everything it imports", async () => {
 
   assert.deepEqual(report.unresolved, [], `the shipped bundle must resolve everything: ${report.unresolved}`);
   assert.equal(isShippable(report), true, report.problems.join("\n"));
+});
+
+// ---- provider packages are the HOST's, not the bundle's ---------------------
+
+test("no AI SDK provider package is bundled into the shipping app", async () => {
+  // The headroom this asserts was reclaimed, not granted. `llm/embeddings.ts`
+  // named `@ai-sdk/openai`, `@ai-sdk/google` and `@ai-sdk/cohere` in three
+  // LITERAL `import()` calls, so esbuild emitted all three as chunks: 326.7kB
+  // of the 1600kB lazy budget, for an embedding path no mobile screen calls and
+  // that could not have loaded a provider anyway -- every OTHER provider goes
+  // through provider-map.ts's computed `import(providerInfo.package)`, which a
+  // webview has no resolver for.
+  //
+  // Without this test the next literal `import('@ai-sdk/anything')` upstream
+  // costs 100-170kB in silence until the budget trips, at which point the
+  // cheapest-looking fix is to raise the budget rather than find the import.
+  const outdir = mkdtempSync(join(tmpdir(), "providers-"));
+  const report = await bundle({ entry: "app/src/main.ts", outdir, write: false });
+  const shipped = bundledPackages(report.metafile);
+
+  const smuggled = HOST_LOADED_AI_SDK_PROVIDERS.filter((pkg) => shipped.includes(pkg));
+  assert.deepEqual(
+    smuggled,
+    [],
+    `these are loaded by the HOST through provider-map.ts's registry and cannot resolve in a ` +
+    `webview, so bundling them is pure weight: ${smuggled.join(", ")}. ` +
+    `Look for a LITERAL await import('<the package>') on praisonai-ts's Agent graph.`,
+  );
+
+  // The pair, so "nothing was found" cannot mean "nothing was looked at": the
+  // packages `ai` itself is built from ARE expected, and their presence proves
+  // bundledPackages reads a graph that really contains @ai-sdk scopes.
+  assert.ok(
+    shipped.includes("@ai-sdk/provider-utils"),
+    `expected ai's own @ai-sdk/* internals in the bundle; got ${shipped.join(", ")}`,
+  );
+});
+
+test("a literal import of a provider package IS reported -- the pair", async () => {
+  // Non-vacuity for the test above, driven through the real bundler. A
+  // `bundledPackages` that returned [] for everything, or a filter that never
+  // matched, would pass it forever; here the identical check must FAIL.
+  const dir = mkdtempSync(join(tmpdir(), "smuggle-"));
+  mkdirSync(join(dir, "node_modules/@ai-sdk/openai"), { recursive: true });
+  writeFileSync(
+    join(dir, "node_modules/@ai-sdk/openai/package.json"),
+    JSON.stringify({ name: "@ai-sdk/openai", version: "0.0.0", main: "index.js" }),
+  );
+  writeFileSync(join(dir, "node_modules/@ai-sdk/openai/index.js"), "export const createOpenAI = () => ({});");
+  writeFileSync(join(dir, "main.js"), "export const go = async () => (await import('@ai-sdk/openai')).createOpenAI();");
+  try {
+    const report = await bundle({ entry: join(dir, "main.js"), outdir: join(dir, "out"), write: false });
+    const shipped = bundledPackages(report.metafile);
+    assert.ok(
+      HOST_LOADED_AI_SDK_PROVIDERS.some((pkg) => shipped.includes(pkg)),
+      `a literal import() of a provider must be seen in the bundle; got ${shipped.join(", ")}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("an unresolvable import fails the gate, with the package named", async () => {

--- a/src/praisonai-mobile/tools/bundle.test.mjs
+++ b/src/praisonai-mobile/tools/bundle.test.mjs
@@ -17,12 +17,14 @@ import { join } from "node:path";
 import {
   bundle,
   bundledPackages,
+  bundledHostLoadedProviders,
+  isHostLoadedAISDKProvider,
+  AI_INTERNAL_AI_SDK_PACKAGES,
   forbiddenAmong,
   topLevelProcessReads,
   unresolvedBareImports,
   classifyBareImports,
   FORBIDDEN_BUILTINS,
-  HOST_LOADED_AI_SDK_PROVIDERS,
   SHELL_BUDGET_BYTES,
   LAZY_BUDGET_BYTES,
   isShippable,
@@ -347,7 +349,10 @@ test("no AI SDK provider package is bundled into the shipping app", async () => 
   const report = await bundle({ entry: "app/src/main.ts", outdir, write: false });
   const shipped = bundledPackages(report.metafile);
 
-  const smuggled = HOST_LOADED_AI_SDK_PROVIDERS.filter((pkg) => shipped.includes(pkg));
+  // The whole `@ai-sdk/*` namespace minus `ai`'s own internals, so a new
+  // provider upstream is covered without a second edit here -- not a four-name
+  // allowlist that `@ai-sdk/mistral` and friends would walk straight past.
+  const smuggled = bundledHostLoadedProviders(report.metafile);
   assert.deepEqual(
     smuggled,
     [],
@@ -369,24 +374,42 @@ test("a literal import of a provider package IS reported -- the pair", async () 
   // Non-vacuity for the test above, driven through the real bundler. A
   // `bundledPackages` that returned [] for everything, or a filter that never
   // matched, would pass it forever; here the identical check must FAIL.
+  //
+  // The fixture names `@ai-sdk/mistral` ON PURPOSE: it was never in the old
+  // four-name allowlist, so this test is also the proof that the namespace rule
+  // catches a provider the hand-kept list would have missed.
   const dir = mkdtempSync(join(tmpdir(), "smuggle-"));
-  mkdirSync(join(dir, "node_modules/@ai-sdk/openai"), { recursive: true });
+  mkdirSync(join(dir, "node_modules/@ai-sdk/mistral"), { recursive: true });
   writeFileSync(
-    join(dir, "node_modules/@ai-sdk/openai/package.json"),
-    JSON.stringify({ name: "@ai-sdk/openai", version: "0.0.0", main: "index.js" }),
+    join(dir, "node_modules/@ai-sdk/mistral/package.json"),
+    JSON.stringify({ name: "@ai-sdk/mistral", version: "0.0.0", main: "index.js" }),
   );
-  writeFileSync(join(dir, "node_modules/@ai-sdk/openai/index.js"), "export const createOpenAI = () => ({});");
-  writeFileSync(join(dir, "main.js"), "export const go = async () => (await import('@ai-sdk/openai')).createOpenAI();");
+  writeFileSync(join(dir, "node_modules/@ai-sdk/mistral/index.js"), "export const createMistral = () => ({});");
+  writeFileSync(join(dir, "main.js"), "export const go = async () => (await import('@ai-sdk/mistral')).createMistral();");
   try {
     const report = await bundle({ entry: join(dir, "main.js"), outdir: join(dir, "out"), write: false });
-    const shipped = bundledPackages(report.metafile);
+    const smuggled = bundledHostLoadedProviders(report.metafile);
     assert.ok(
-      HOST_LOADED_AI_SDK_PROVIDERS.some((pkg) => shipped.includes(pkg)),
-      `a literal import() of a provider must be seen in the bundle; got ${shipped.join(", ")}`,
+      smuggled.includes("@ai-sdk/mistral"),
+      `a literal import() of a provider must be seen in the bundle; got ${smuggled.join(", ")}`,
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("the provider gate is the @ai-sdk namespace minus ai's own internals", () => {
+  // The rule in one place, so a future edit to either side is caught here
+  // rather than in a bundle run. Providers -- named and unnamed -- are
+  // host-loaded; the three packages `ai` is built from are not.
+  assert.ok(isHostLoadedAISDKProvider("@ai-sdk/openai"));
+  assert.ok(isHostLoadedAISDKProvider("@ai-sdk/mistral"), "a provider absent from any hand list is still covered");
+  assert.ok(isHostLoadedAISDKProvider("@ai-sdk/groq"));
+  for (const internal of AI_INTERNAL_AI_SDK_PACKAGES) {
+    assert.equal(isHostLoadedAISDKProvider(internal), false, `${internal} is part of ai, not a provider`);
+  }
+  assert.equal(isHostLoadedAISDKProvider("ai"), false, "ai itself is the adapter, not a provider");
+  assert.equal(isHostLoadedAISDKProvider("zod"), false, "a non-@ai-sdk package is not a provider");
 });
 
 test("an unresolvable import fails the gate, with the package named", async () => {

--- a/src/praisonai-ts/src/agent/features/auth.ts
+++ b/src/praisonai-ts/src/agent/features/auth.ts
@@ -20,7 +20,13 @@
  * `register_subscription_provider` is.
  */
 
-import { listAuthProviders, resolveAuth, type LLMAuth } from '../../llm';
+// From `../../llm/auth`, the leaf, NOT from the `../../llm` barrel. The barrel
+// re-exports these same three symbols, but it also imports `openai` and
+// `../../llm/embeddings` at the top level -- and this file is on `Agent`'s
+// static graph, so importing it through the barrel put the OpenAI client and
+// three `@ai-sdk/*` provider packages into praisonai-mobile's webview bundle
+// (326.7kB, measured) for three functions that depend on nothing.
+import { listAuthProviders, resolveAuth, type LLMAuth } from '../../llm/auth';
 
 /**
  * Default model per subscription provider, used only when the caller gave

--- a/src/praisonai-ts/src/llm/auth.ts
+++ b/src/praisonai-ts/src/llm/auth.ts
@@ -1,0 +1,95 @@
+/**
+ * LLM auth (Python parity: `auth: Optional[str]` -> praisonaiagents.auth).
+ *
+ * A LEAF module, and that is the whole reason it is a file of its own.
+ *
+ * This block used to live in `llm/index.ts`, which is a barrel: it imports
+ * `openai` and `llm/embeddings` at the top level. `agent/features/auth.ts`
+ * needs exactly `resolveAuth`, `listAuthProviders` and `LLMAuth` from it --
+ * three symbols with no dependencies at all -- and reaching them through the
+ * barrel dragged the whole OpenAI client and the embedding stack onto every
+ * graph that could see `Agent`. On praisonai-mobile's webview bundle that was
+ * measured at 326.7kB of `@ai-sdk/*` provider packages nothing on a phone can
+ * call, against a 1600kB budget that had 23.6kB left.
+ *
+ * `llm/index.ts` re-exports every name below, so the public API is unchanged:
+ * `import { resolveAuth } from 'praisonai'` and `from 'praisonai/llm'` both
+ * still work, and there is still exactly ONE `authProviders` map because there
+ * is still exactly one module that declares it.
+ *
+ * The rule for this file: nothing here may import a module with a side effect
+ * or a heavy dependency. It is imported for three functions; it must cost
+ * three functions.
+ */
+
+/** Resolved credentials, mirroring Python's `SubscriptionCredentials`. */
+export interface LLMAuth {
+  apiKey?: string;
+  baseURL?: string;
+  headers?: Record<string, string>;
+}
+
+export type LLMAuthResolver = () => LLMAuth | Promise<LLMAuth>;
+
+/**
+ * What `LLMConfig.auth` accepts: resolved credentials, a function returning
+ * them, or the name of a provider registered with {@link registerAuthProvider}
+ * (Python's `register_subscription_provider`).
+ */
+export type LLMAuthSource = string | LLMAuth | LLMAuthResolver;
+
+const authProviders = new Map<string, LLMAuthResolver>();
+
+/** Python parity: `register_subscription_provider(name, factory)`. */
+export function registerAuthProvider(name: string, resolver: LLMAuthResolver): void {
+  authProviders.set(name, resolver);
+}
+
+/** Python parity: `list_subscription_providers()`. */
+export function listAuthProviders(): string[] {
+  return Array.from(authProviders.keys()).sort();
+}
+
+/** Test helper: forget every registered provider. */
+export function resetAuthProviders(): void {
+  authProviders.clear();
+}
+
+function validateAuth(auth: unknown, source: string): LLMAuth {
+  if (!auth || typeof auth !== 'object') {
+    throw new Error(`LLM auth (${source}) must resolve to an object { apiKey?, baseURL?, headers? }; got ${typeof auth}`);
+  }
+  const a = auth as LLMAuth;
+  if (a.apiKey !== undefined && typeof a.apiKey !== 'string') throw new Error(`LLM auth (${source}): apiKey must be a string`);
+  if (a.baseURL !== undefined && typeof a.baseURL !== 'string') throw new Error(`LLM auth (${source}): baseURL must be a string`);
+  if (a.headers !== undefined && (typeof a.headers !== 'object' || a.headers === null)) {
+    throw new Error(`LLM auth (${source}): headers must be a string map`);
+  }
+  return a;
+}
+
+/**
+ * Resolve an {@link LLMAuthSource} to credentials. Python's built-in named
+ * OAuth stores (`claude-code`, `codex`, `gemini-cli`, `qwen-cli`) read local
+ * CLI keychains and are not ported; a name resolves only when registered via
+ * {@link registerAuthProvider}. An unknown name throws rather than silently
+ * billing the plain API key.
+ */
+export async function resolveAuth(auth: LLMAuthSource): Promise<LLMAuth> {
+  if (typeof auth === 'function') return validateAuth(await auth(), 'function');
+  if (typeof auth === 'string') {
+    const resolver = authProviders.get(auth);
+    if (!resolver) {
+      const known = listAuthProviders();
+      throw new Error(
+        `LLM auth "${auth}" is not a registered credential source` +
+          (known.length ? ` (registered: ${known.join(', ')})` : '') +
+          `. Python's named OAuth stores (claude-code, codex, gemini-cli, qwen-cli) are not ported to TypeScript; ` +
+          `register one with registerAuthProvider("${auth}", () => ({ apiKey, baseURL, headers })) or pass ` +
+          `{ apiKey, baseURL, headers } directly.`
+      );
+    }
+    return validateAuth(await resolver(), `provider "${auth}"`);
+  }
+  return validateAuth(auth, 'object');
+}

--- a/src/praisonai-ts/src/llm/embeddings.ts
+++ b/src/praisonai-ts/src/llm/embeddings.ts
@@ -201,39 +201,82 @@ async function embedManyWithAISDK(
   };
 }
 
+/** Provider ids this function accepts, after alias folding. Kept as an
+ *  explicit list so an unsupported provider still fails with the message it
+ *  always did, rather than with whatever `createAISDKProvider` says about a
+ *  chat-only package that has no embedding model. */
+const AI_SDK_EMBEDDING_PROVIDERS: Record<string, string> = {
+  openai: 'openai',
+  oai: 'openai',
+  google: 'google',
+  gemini: 'google',
+  cohere: 'cohere',
+};
+
 /**
- * Get AI SDK embedding model for a provider
+ * Get AI SDK embedding model for a provider.
+ *
+ * The provider package is obtained through {@link createAISDKProvider} -- the
+ * registry `llm/providers/ai-sdk/provider-map.ts` already uses for every CHAT
+ * provider -- rather than by naming `@ai-sdk/openai`, `@ai-sdk/google` and
+ * `@ai-sdk/cohere` in three literal `import()` calls here.
+ *
+ * Two reasons, and the second is why it changed:
+ *
+ *  1. ONE way to load a provider. Chat went through the registry and
+ *     embeddings did not, so `registerCustomProvider('openai', ...)` took
+ *     effect for a completion and was ignored for an embedding of the same
+ *     provider.
+ *  2. A literal `import()` is a BUNDLER instruction, not only a runtime one.
+ *     esbuild follows it and emits the package as a chunk whether or not any
+ *     reachable code path calls it -- so praisonai-mobile's webview bundle
+ *     carried 326.7kB of `@ai-sdk/openai` + `@ai-sdk/google` + `@ai-sdk/cohere`
+ *     for a phone that never embeds anything, against a 1600kB budget with
+ *     23.6kB left. `provider-map.ts` resolves `providerInfo.package`, which a
+ *     bundler cannot follow, so the package is loaded by the HOST at runtime --
+ *     which is what "optional peer dependency" was supposed to mean.
+ *
+ * Node behaviour is unchanged: `createAISDKProvider('openai')` imports
+ * `@ai-sdk/openai` and calls `createOpenAI({})`, exactly as the three literal
+ * branches did. What is genuinely gone is embedding through a BUNDLED AI SDK
+ * provider in an environment with no module resolver (a browser with no import
+ * map) -- an environment where the CHAT path could never load a provider
+ * either, because it has always gone through this same registry.
  */
 async function getAISDKEmbeddingModel(provider: string, modelId: string): Promise<any> {
-  switch (provider.toLowerCase()) {
-    case 'openai':
-    case 'oai': {
-      const { createOpenAI } = await import('@ai-sdk/openai');
-      const openai = createOpenAI({});
-      return openai.embedding(modelId);
-    }
-    case 'google':
-    case 'gemini': {
-      const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
-      const google = createGoogleGenerativeAI({});
-      return google.textEmbeddingModel(modelId);
-    }
-    case 'cohere': {
-      try {
-        // Dynamic import - cohere is optional
-        const cohereModule = await import('@ai-sdk/cohere' as string);
-        const cohere = cohereModule.createCohere({});
-        return cohere.embedding(modelId);
-      } catch {
-        throw new Error(`Cohere provider not installed. Install with: npm install @ai-sdk/cohere`);
-      }
-    }
-    default:
-      throw new Error(
-        `Embedding provider '${provider}' not supported via AI SDK. ` +
-        `Supported: openai, google, cohere`
-      );
+  const resolved = AI_SDK_EMBEDDING_PROVIDERS[provider.toLowerCase()];
+  if (!resolved) {
+    throw new Error(
+      `Embedding provider '${provider}' not supported via AI SDK. ` +
+      `Supported: openai, google, cohere`
+    );
   }
+
+  const { createAISDKProvider } = await import('./providers/ai-sdk/provider-map');
+  let sdkProvider: any;
+  try {
+    sdkProvider = await createAISDKProvider(resolved, {});
+  } catch (error: unknown) {
+    // Preserved verbatim: cohere is the one provider praisonai-ts does not
+    // itself depend on, and "not installed" is actionable where the registry's
+    // generic MISSING_DEPENDENCY wording was not.
+    if (resolved === 'cohere') {
+      throw new Error(`Cohere provider not installed. Install with: npm install @ai-sdk/cohere`);
+    }
+    throw error;
+  }
+
+  // `textEmbeddingModel` is the AI SDK's ProviderV2 member; `embedding` is the
+  // older per-package alias the branches above used. Try both rather than
+  // assume, so a provider shipping only one still works.
+  const factory = sdkProvider?.textEmbeddingModel ?? sdkProvider?.embedding;
+  if (typeof factory !== 'function') {
+    throw new Error(
+      `AI SDK provider '${resolved}' exposes no embedding model factory ` +
+      `(expected textEmbeddingModel or embedding)`
+    );
+  }
+  return factory.call(sdkProvider, modelId);
 }
 
 /**

--- a/src/praisonai-ts/src/llm/index.ts
+++ b/src/praisonai-ts/src/llm/index.ts
@@ -174,77 +174,27 @@ export function classifyLLMError(error: unknown): LLMErrorKind {
 // Auth (Python parity: `auth: Optional[str]` -> praisonaiagents.auth)
 // ============================================================================
 
-/** Resolved credentials, mirroring Python's `SubscriptionCredentials`. */
-export interface LLMAuth {
-  apiKey?: string;
-  baseURL?: string;
-  headers?: Record<string, string>;
-}
+// The implementation moved to `./auth`, a LEAF module, and is re-exported here
+// unchanged. This file is a barrel: it imports `openai` and `./embeddings` at
+// the top level, so anything reaching auth THROUGH it paid for both. The one
+// in-tree consumer, `agent/features/auth.ts`, wants three dependency-free
+// symbols -- and buying them here put 326.7kB of `@ai-sdk/*` on
+// praisonai-mobile's webview bundle, which no phone can call. See ./auth.ts.
+//
+// Re-exported rather than moved-and-forgotten: `resolveAuth`,
+// `registerAuthProvider`, `listAuthProviders`, `resetAuthProviders` and the
+// three types are public API from both 'praisonai' and 'praisonai/llm'.
+// `authProviders` stays a single Map because ./auth is a single module.
+export {
+  registerAuthProvider,
+  listAuthProviders,
+  resetAuthProviders,
+  resolveAuth,
+} from './auth';
+export type { LLMAuth, LLMAuthResolver, LLMAuthSource } from './auth';
 
-export type LLMAuthResolver = () => LLMAuth | Promise<LLMAuth>;
-
-/**
- * What `LLMConfig.auth` accepts: resolved credentials, a function returning
- * them, or the name of a provider registered with {@link registerAuthProvider}
- * (Python's `register_subscription_provider`).
- */
-export type LLMAuthSource = string | LLMAuth | LLMAuthResolver;
-
-const authProviders = new Map<string, LLMAuthResolver>();
-
-/** Python parity: `register_subscription_provider(name, factory)`. */
-export function registerAuthProvider(name: string, resolver: LLMAuthResolver): void {
-  authProviders.set(name, resolver);
-}
-
-/** Python parity: `list_subscription_providers()`. */
-export function listAuthProviders(): string[] {
-  return Array.from(authProviders.keys()).sort();
-}
-
-/** Test helper: forget every registered provider. */
-export function resetAuthProviders(): void {
-  authProviders.clear();
-}
-
-function validateAuth(auth: unknown, source: string): LLMAuth {
-  if (!auth || typeof auth !== 'object') {
-    throw new Error(`LLM auth (${source}) must resolve to an object { apiKey?, baseURL?, headers? }; got ${typeof auth}`);
-  }
-  const a = auth as LLMAuth;
-  if (a.apiKey !== undefined && typeof a.apiKey !== 'string') throw new Error(`LLM auth (${source}): apiKey must be a string`);
-  if (a.baseURL !== undefined && typeof a.baseURL !== 'string') throw new Error(`LLM auth (${source}): baseURL must be a string`);
-  if (a.headers !== undefined && (typeof a.headers !== 'object' || a.headers === null)) {
-    throw new Error(`LLM auth (${source}): headers must be a string map`);
-  }
-  return a;
-}
-
-/**
- * Resolve an {@link LLMAuthSource} to credentials. Python's built-in named
- * OAuth stores (`claude-code`, `codex`, `gemini-cli`, `qwen-cli`) read local
- * CLI keychains and are not ported; a name resolves only when registered via
- * {@link registerAuthProvider}. An unknown name throws rather than silently
- * billing the plain API key.
- */
-export async function resolveAuth(auth: LLMAuthSource): Promise<LLMAuth> {
-  if (typeof auth === 'function') return validateAuth(await auth(), 'function');
-  if (typeof auth === 'string') {
-    const resolver = authProviders.get(auth);
-    if (!resolver) {
-      const known = listAuthProviders();
-      throw new Error(
-        `LLM auth "${auth}" is not a registered credential source` +
-          (known.length ? ` (registered: ${known.join(', ')})` : '') +
-          `. Python's named OAuth stores (claude-code, codex, gemini-cli, qwen-cli) are not ported to TypeScript; ` +
-          `register one with registerAuthProvider("${auth}", () => ({ apiKey, baseURL, headers })) or pass ` +
-          `{ apiKey, baseURL, headers } directly.`
-      );
-    }
-    return validateAuth(await resolver(), `provider "${auth}"`);
-  }
-  return validateAuth(auth, 'object');
-}
+import { resolveAuth } from './auth';
+import type { LLMAuth, LLMAuthSource } from './auth';
 
 // ============================================================================
 // Config


### PR DESCRIPTION
**Lazy bundle 1576.4kB → 891.2kB. Headroom 23.6kB → 708.8kB.** Budget untouched.

## Why now

main sat at **98.5% of the 1600kB budget**, so any change of consequence failed the build. #4836 (eight Handoff options) needed 26.2kB and turned **nine jobs red**. Raising the budget would have moved the line instead of the weight — the failure mode this repo keeps finding.

## The whole path was one barrel re-export

`agent/features/auth.ts` is on the Agent's static graph and imported three **dependency-free** symbols from the `../../llm` barrel. That barrel statically imports `openai` *and* `llm/embeddings` — and embeddings named `@ai-sdk/openai`, `@ai-sdk/google`, `@ai-sdk/cohere` in three **literal** `import()` calls. A literal specifier is a bundler instruction, not merely a runtime one, so all three shipped to the phone.

| package | before | after |
|---|---:|---:|
| zod | 454.4kB | 102.7kB |
| @ai-sdk/openai | 168.1 | **0** |
| @ai-sdk/google | 144.2 | **0** |
| @ai-sdk/cohere | 14.4 | **0** |
| **total lazy** | **1576.4** | **891.2** |

326.7kB of providers was carrying **678kB**: with them gone, only the subset of zod that `ai` needs survives tree-shaking.

## The fix

The auth block moves to a leaf module (`llm/auth.ts`), and embeddings resolve providers through `createAISDKProvider` — the computed-specifier registry this codebase **already uses for every chat provider**, where embeddings were the lone exception.

That also fixes a real inconsistency: `registerCustomProvider('openai', …)` took effect for a completion and was silently ignored for an embedding of the same provider.

**Equivalence verified, not assumed:** old and new paths produce byte-identical model objects, both error messages are preserved verbatim, and all seven auth names still export from `praisonai` and `praisonai/llm` as the *same object* across ESM and CJS.

## A regression test comes with it

Without one, the next literal import costs 100–170kB in silence until the budget trips, and the cheapest-looking fix then is to raise the budget. The test asserts the app bundles none of the host-loaded provider packages, with a fixture proving a literal import **is** caught.

Confirmed non-vacuous: reintroducing one literal `import('@ai-sdk/openai')` fails two tests; restoring the file passes them.

## Deliberately not done

`ai` and its dependencies are another ~520kB, and the AI-SDK chat path cannot work in a webview anyway (the shipped chunks keep a bare computed specifier with no import map). But **`ai` is a hard dependency of the adapter, not a pluggable provider** — making its import non-analyzable would degrade every legitimate bundler consumer. Providers are the host's; `ai` is ours. The honest fix there is a mobile-specific backend, not an opaque specifier.

## One premise corrected

`tr46`/`whatwg-url` were suspected of contributing 297kB. They contribute **zero** — on disk, but in no metafile input, because the browser platform takes openai's fetch shim. Only the metafile says what ships.

## Verification

`tsc` clean · praisonai-ts **2,230 tests** · praisonai-mobile **1,670 tests** · webview gate 0 failures · `npm run boundaries` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added flexible LLM authentication using API keys, base URLs, headers, named providers, or resolver functions.
  - Added registration and discovery of custom authentication providers.
  - Expanded embedding provider resolution with support for provider aliases.

- **Bug Fixes**
  - Improved detection of AI providers used in mobile bundles.
  - Preserved clear errors for unsupported or unavailable embedding providers.
  - Improved fake DOM compatibility for element IDs.

- **Performance**
  - Reduced unnecessary mobile bundle size by loading AI providers more selectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->