### PR TITLE
fix(sandbox): enforce blocked_imports in execute(), the default path

### DIFF
--- a/src/praisonai-sandbox/praisonai_sandbox/subprocess.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/subprocess.py
@@ -229,6 +229,12 @@ class SubprocessSandbox:
         Python is checked by parsing rather than substring matching, so a
         blocked name inside a string or comment is not a false positive. Code
         that will not parse is left to the interpreter to reject.
+
+        Import bindings are resolved so aliases cannot slip a blocked call past
+        the check: `import os as x; x.system(...)` and `from os import system;
+        system(...)` both resolve back to `os.system`. Bare names are only
+        flagged when they are read (a Load) -- `subprocess = 3` or
+        `def f(eval): ...` bind a local of the same spelling and are harmless.
         """
         blocked = [b for b in (getattr(policy, "blocked_imports", None) or []) if b]
         if not blocked or language != "python":
@@ -245,6 +251,33 @@ class SubprocessSandbox:
         modules = {b for b in blocked if "." not in b}
         dotted = {b for b in blocked if "." in b}
 
+        # Names used in call position -- `eval(...)` -- so a bare blocked builtin
+        # is caught while a mere mention (`print(subprocess_count)`) is not.
+        called_names = {
+            n.func
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        }
+
+        # Resolve local bindings introduced by imports back to their real dotted
+        # names, so an alias cannot spell a blocked call differently:
+        #   import os as x        -> x     resolves to os
+        #   from os import system -> system resolves to os.system
+        # aliases: local name -> real module path (for attribute-call resolution)
+        # from_binds: local name -> real dotted name (for bare-name calls)
+        aliases: Dict[str, str] = {}
+        from_binds: Dict[str, str] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    bound = alias.asname or alias.name.split(".")[0]
+                    aliases[bound] = alias.name
+            elif isinstance(node, ast.ImportFrom):
+                base = node.module or ""
+                for alias in node.names:
+                    bound = alias.asname or alias.name
+                    from_binds[bound] = f"{base}.{alias.name}" if base else alias.name
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
@@ -255,6 +288,9 @@ class SubprocessSandbox:
                 name = node.module or ""
                 if name in modules or name.split(".")[0] in modules:
                     return f"Blocked import: {name}"
+                for alias in node.names:
+                    if from_binds.get(alias.asname or alias.name) in dotted:
+                        return f"Blocked import: {from_binds[alias.asname or alias.name]}"
             elif isinstance(node, ast.Attribute):
                 target = node
                 parts = []
@@ -262,13 +298,27 @@ class SubprocessSandbox:
                     parts.append(target.attr)
                     target = target.value
                 if isinstance(target, ast.Name):
-                    parts.append(target.id)
+                    # Translate the root through any import alias so
+                    # `import os as x; x.system()` resolves to os.system.
+                    root_real = aliases.get(target.id, target.id)
+                    parts.append(root_real)
                     full = ".".join(reversed(parts))
                     if full in dotted:
                         return f"Blocked call: {full}"
             elif isinstance(node, ast.Name):
-                if node.id in modules or node.id in dotted:
+                # Only a *read* of the name is a use; an assignment target or
+                # parameter merely rebinds the spelling and is harmless.
+                if not isinstance(node.ctx, ast.Load):
+                    continue
+                # A bare blocked name is only a threat when it is called:
+                # `eval('1+1')` matters, `print(subprocess)` (where subprocess
+                # is a local int or an unused mention) does not. Modules stay
+                # dangerous solely via `import`, already handled above.
+                if node in called_names and (node.id in modules or node.id in dotted):
                     return f"Blocked call: {node.id}"
+                # from os import system; system() -> resolves to os.system
+                if from_binds.get(node.id) in dotted:
+                    return f"Blocked call: {from_binds[node.id]}"
 
         return None
 

--- a/src/praisonai-sandbox/praisonai_sandbox/subprocess.py
+++ b/src/praisonai-sandbox/praisonai_sandbox/subprocess.py
@@ -211,6 +211,67 @@ class SubprocessSandbox:
         self._is_running = False
         logger.info("Subprocess sandbox stopped")
     
+    def _validate_code_against_policy(
+        self,
+        code: str,
+        language: str,
+        policy: SecurityPolicy,
+    ) -> Optional[str]:
+        """Return an error message when *code* violates *policy*.
+
+        blocked_imports was declared in SecurityPolicy, documented, and
+        serialised by to_dict() -- and read by nothing. Only run_command()
+        validated anything, and SandboxManager.run_code() goes through
+        execute(), so the default backend enforced no policy at all: strict()
+        still let code `import subprocess`, open a socket and read
+        /etc/passwd, reporting COMPLETED / exit 0.
+
+        Python is checked by parsing rather than substring matching, so a
+        blocked name inside a string or comment is not a false positive. Code
+        that will not parse is left to the interpreter to reject.
+        """
+        blocked = [b for b in (getattr(policy, "blocked_imports", None) or []) if b]
+        if not blocked or language != "python":
+            return None
+
+        import ast
+
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            return None
+
+        # "os.system" in the list means the attribute call, not the os module.
+        modules = {b for b in blocked if "." not in b}
+        dotted = {b for b in blocked if "." in b}
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    root = alias.name.split(".")[0]
+                    if alias.name in modules or root in modules:
+                        return f"Blocked import: {alias.name}"
+            elif isinstance(node, ast.ImportFrom):
+                name = node.module or ""
+                if name in modules or name.split(".")[0] in modules:
+                    return f"Blocked import: {name}"
+            elif isinstance(node, ast.Attribute):
+                target = node
+                parts = []
+                while isinstance(target, ast.Attribute):
+                    parts.append(target.attr)
+                    target = target.value
+                if isinstance(target, ast.Name):
+                    parts.append(target.id)
+                    full = ".".join(reversed(parts))
+                    if full in dotted:
+                        return f"Blocked call: {full}"
+            elif isinstance(node, ast.Name):
+                if node.id in modules or node.id in dotted:
+                    return f"Blocked call: {node.id}"
+
+        return None
+
     async def execute(
         self,
         code: str,
@@ -225,7 +286,22 @@ class SubprocessSandbox:
         
         limits = limits or self.config.resource_limits
         execution_id = str(uuid.uuid4())
-        
+
+        # Enforce the policy before the code is written or spawned. run_command()
+        # has always validated; execute() -- the default backend, and the path
+        # SandboxManager.run_code() takes -- validated nothing.
+        policy = self.config.security_policy
+        policy_error = self._validate_code_against_policy(code, language, policy)
+        if policy_error:
+            return SandboxResult(
+                execution_id=execution_id,
+                status=SandboxStatus.FAILED,
+                stdout="",
+                stderr=f"Security policy violation: {policy_error}",
+                exit_code=1,
+                error=f"Security policy violation: {policy_error}",
+            )
+
         code_file = os.path.join(self._temp_dir, f"code_{execution_id}.py")
         with open(code_file, "w") as f:
             f.write(code)

--- a/src/praisonai-sandbox/tests/test_execute_enforces_policy.py
+++ b/src/praisonai-sandbox/tests/test_execute_enforces_policy.py
@@ -1,0 +1,120 @@
+"""SubprocessSandbox.execute() must enforce the security policy.
+
+`run_command()` validated against the policy. `execute()` did not -- and
+execute() is the default backend (SandboxConfig.sandbox_type defaults to
+"subprocess") and the path SandboxManager.run_code() takes. So the policy was
+decorative on the route almost everyone uses:
+
+    SecurityPolicy.strict()  ->  allow_network=False,
+                                 blocked_imports=['subprocess','os.system','eval','exec']
+
+    execute(that code)       ->  status=COMPLETED, exit=0
+                                 "SUBPROCESS IMPORTED OK"
+                                 "NETWORK REACHED"
+                                 "PASSWD: ##"
+
+`blocked_imports` in particular was declared in SecurityPolicy, documented,
+and serialised by to_dict() -- and read by no code anywhere in the monorepo.
+
+Scope: this enforces blocked_imports and leaves the command policy to
+run_command(). It does NOT implement network isolation -- `allow_network=False`
+still needs OS-level sandboxing, and code importing a module that is not on the
+blocked list can still open a socket. That remains a real gap, not claimed here.
+
+Most cases exercise the validator directly rather than spawning an interpreter:
+an earlier draft ran real subprocesses per case and made this file flaky, and
+took two pre-existing tests down with it (clean main was stable over 5 runs,
+with that draft it was not). One end-to-end case still spawns, and stops the
+sandbox afterwards.
+"""
+import asyncio
+
+import pytest
+
+from praisonaiagents.sandbox.config import SandboxConfig, SecurityPolicy
+from praisonai_sandbox.subprocess import SubprocessSandbox
+
+
+def _validator(policy=None):
+    sandbox = SubprocessSandbox(SandboxConfig(
+        security_policy=policy or SecurityPolicy.strict()))
+    return lambda code, language="python": sandbox._validate_code_against_policy(
+        code, language, sandbox.config.security_policy)
+
+
+class TestBlockedImportsAreDetected:
+
+    def test_a_blocked_import(self):
+        assert _validator()("import subprocess\n") is not None
+
+    def test_from_import(self):
+        assert _validator()("from subprocess import run\n") is not None
+
+    def test_a_submodule_import(self):
+        assert _validator()("import subprocess.run\n") is not None
+
+    def test_an_aliased_import(self):
+        assert _validator()("import subprocess as sp\n") is not None
+
+    def test_a_dotted_call(self):
+        """'os.system' names the call, not the os module."""
+        assert _validator()("import os\nos.system('echo hi')\n") is not None
+
+    def test_a_bare_blocked_name(self):
+        assert _validator()("eval('1+1')\n") is not None
+
+
+class TestNoFalsePositives:
+
+    def test_a_blocked_word_inside_a_string(self):
+        """Substring matching would reject this; parsing does not."""
+        assert _validator()("print('the word subprocess in a string')\n") is None
+
+    def test_a_blocked_word_in_a_comment(self):
+        assert _validator()("# subprocess is mentioned here\nprint('ok')\n") is None
+
+    def test_a_variable_merely_named_like_one(self):
+        assert _validator()("subprocess_count = 3\nprint(subprocess_count)\n") is None
+
+    def test_harmless_code(self):
+        assert _validator()("print('hello')\n") is None
+
+    def test_unparseable_code_is_left_to_the_interpreter(self):
+        """A syntax error should surface as one, not as a policy violation."""
+        assert _validator()("def (\n") is None
+
+    def test_a_non_python_language_is_not_parsed_as_python(self):
+        assert _validator()("echo subprocess", language="bash") is None
+
+
+class TestThePolicyIsRespectedBothWays:
+
+    def test_permissive_blocks_nothing(self):
+        assert _validator(SecurityPolicy.permissive())("import subprocess\n") is None
+
+    def test_an_empty_blocked_list_blocks_nothing(self):
+        policy = SecurityPolicy.permissive()
+        policy.blocked_imports = []
+        assert _validator(policy)("import subprocess\n") is None
+
+
+class TestEndToEnd:
+    """One real execution, to prove the validator is actually wired in."""
+
+    def test_strict_policy_refuses_to_run_blocked_code(self):
+        async def go():
+            sandbox = SubprocessSandbox(SandboxConfig(
+                security_policy=SecurityPolicy.strict()))
+            try:
+                return await sandbox.execute("import subprocess\nprint('RAN')\n")
+            finally:
+                await sandbox.stop()
+
+        result = asyncio.run(go())
+        assert result.status.name == "FAILED"
+        assert "subprocess" in (result.stderr or "")
+        assert "RAN" not in (result.stdout or "")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/praisonai-sandbox/tests/test_execute_enforces_policy.py
+++ b/src/praisonai-sandbox/tests/test_execute_enforces_policy.py
@@ -64,6 +64,19 @@ class TestBlockedImportsAreDetected:
         assert _validator()("eval('1+1')\n") is not None
 
 
+class TestAliasesCannotBypass:
+    """A blocked dotted call must not be reachable by renaming the import."""
+
+    def test_a_dotted_call_through_an_import_alias(self):
+        assert _validator()("import os as x\nx.system('echo hi')\n") is not None
+
+    def test_a_dotted_call_through_a_from_import(self):
+        assert _validator()("from os import system\nsystem('echo hi')\n") is not None
+
+    def test_a_dotted_call_through_an_aliased_from_import(self):
+        assert _validator()("from os import system as s\ns('echo hi')\n") is not None
+
+
 class TestNoFalsePositives:
 
     def test_a_blocked_word_inside_a_string(self):
@@ -75,6 +88,14 @@ class TestNoFalsePositives:
 
     def test_a_variable_merely_named_like_one(self):
         assert _validator()("subprocess_count = 3\nprint(subprocess_count)\n") is None
+
+    def test_assigning_to_a_blocked_name_is_not_a_use(self):
+        """`subprocess = 3` rebinds the spelling; it does not import or call it."""
+        assert _validator()("subprocess = 3\nprint(subprocess)\n") is None
+
+    def test_a_parameter_named_like_a_blocked_name(self):
+        """A parameter definition is a binding, not a call to the builtin."""
+        assert _validator()("def f(eval):\n    return 1\nf(1)\n") is None
 
     def test_harmless_code(self):
         assert _validator()("print('hello')\n") is None


### PR DESCRIPTION
`run_command()` validated against the security policy. **`execute()` did not** — and `execute()` is the default backend (`SandboxConfig.sandbox_type` defaults to `"subprocess"`) and the path `SandboxManager.run_code()` takes. The policy was decorative on the route almost everyone uses.

## Ran against origin/main

```
SecurityPolicy.strict()  ->  allow_network=False,
                             blocked_imports=['subprocess','os.system','eval','exec']

execute(code)            ->  status=COMPLETED exit=0
                             SUBPROCESS IMPORTED OK
                             NETWORK REACHED
                             PASSWD: ##
```

`blocked_imports` was declared in `SecurityPolicy`, documented, and serialised by `to_dict()` — and **read by no code anywhere in the monorepo**.

## Approach

The check parses the code rather than scanning for substrings, so a blocked name inside a string, a comment, or a longer identifier (`subprocess_count`) is not a false positive. Code that will not parse is left to the interpreter to reject as a syntax error.

## Scope — what this does not do

This enforces `blocked_imports`. It does **not** implement network isolation. `allow_network=False` still needs OS-level sandboxing, and code importing a module that isn't on the blocked list can still open a socket. That gap is real and is not closed here.

## A mistake worth recording

A first version also ran the *command* through `_validate_command_against_policy`, by symmetry with `run_command()`. That was a category error, and it made the suite flaky in **5 of 8 runs**.

The command in `execute()` is machine-generated — the interpreter plus `code_<uuid4>.py` — and `blocked_commands` contains `'dd'`, which appears by chance in about **9% of random UUIDs** (measured: 37/400). Legitimate runs were rejected at random.

I spent three experiments blaming my own test file before testing the production change on its own, which found it immediately. Only user-supplied commands belong in that check, so it is left to `run_command()`.

**Related, pre-existing, untouched:** the same substring matching means `run_command("echo ddd")` is rejected today.

## Verification

15 tests — the validator exercised directly, plus one end-to-end run. Full suite **stable across 20 consecutive runs**; clean main measured 0/10 and the flaky version 5/8, so stability here is measured rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added validation that blocks sandboxed code containing imports or calls prohibited by the configured security policy.
  - Blocked code is refused before execution and returns a failed result.
  - Validation recognizes direct, aliased, dotted, and `from` imports while avoiding false positives in comments, strings, bindings, and non-executed references.

- **Tests**
  - Added comprehensive coverage for blocked imports, permissive and empty policies, syntax errors, non-Python code, and end-to-end execution refusal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->