### PR TITLE
fix(train): the vision path must read its config, and not publish by default

### DIFF
--- a/src/praisonai-train/praisonai_train/train_vision.py
+++ b/src/praisonai-train/praisonai_train/train_vision.py
@@ -74,6 +74,19 @@ class TrainVisionModel:
         print("DEBUG: Python Version:", sys.version)
         print("DEBUG: Python Path:", sys.executable)
 
+    @staticmethod
+    def _flag(value, default=False):
+        """Coerce a config flag to bool, accepting YAML booleans and strings.
+
+        Mirrors the LLM trainer's helper so `train: true` and `train: "true"`
+        both work; the old `.lower()` crashed on a real boolean.
+        """
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in ("true", "1", "yes", "on")
+
     def check_gpu(self):
         gpu_stats = torch.cuda.get_device_properties(0)
         print(f"DEBUG: GPU = {gpu_stats.name}. Max memory = {round(gpu_stats.total_memory/(1024**3),3)} GB.")
@@ -117,12 +130,17 @@ class TrainVisionModel:
             finetune_language_layers=self.config.get("finetune_language_layers", True),
             finetune_attention_modules=self.config.get("finetune_attention_modules", True),
             finetune_mlp_modules=self.config.get("finetune_mlp_modules", True),
-            r=16,
-            lora_alpha=16,
-            lora_dropout=0,
-            bias="none",
-            random_state=3407,
-            use_rslora=False,
+            # These were literals, so lora_r / lora_alpha / lora_dropout /
+            # random_state / use_rslora were accepted in the config, validated,
+            # and then ignored -- a vision run trained at r=16 whatever the
+            # user asked for. The defaults are the previous literals, so an
+            # existing config produces an identical run.
+            r=int(self.config.get("lora_r", 16)),
+            lora_alpha=int(self.config.get("lora_alpha", 16)),
+            lora_dropout=float(self.config.get("lora_dropout", 0)),
+            bias=self.config.get("lora_bias", "none"),
+            random_state=int(self.config.get("random_state", 3407)),
+            use_rslora=self._flag(self.config.get("use_rslora")),
             loftq_config=None
         )
         print("DEBUG: Vision LoRA adapters added.")
@@ -302,14 +320,21 @@ PARAMETER top_p 0.9
         self.print_system_info()
         self.check_gpu()
         self.check_ram()
-        if self.config.get("train", "true").lower() == "true":
+        if self._flag(self.config.get("train"), default=True):
             self.prepare_model()
             self.train_model()
-        if self.config.get("huggingface_save", "true").lower() == "true":
+        # Publishing defaults OFF and is skipped unless a target is set, exactly
+        # as the LLM trainer already does (train/llm/trainer.py). This path
+        # defaulted every flag to the string "true", so a config that merely
+        # omitted `huggingface_save` -- which is what `praisonai-train llm`
+        # writes, since it records only the keys the user supplied -- pushed the
+        # fine-tuned model to the Hub, or died on a missing `hf_model_name`
+        # after the training had already run.
+        if self._flag(self.config.get("huggingface_save")) and self.config.get("hf_model_name"):
             self.save_model_merged()
-        if self.config.get("huggingface_save_gguf", "true").lower() == "true":
+        if self._flag(self.config.get("huggingface_save_gguf")) and self.config.get("hf_model_name"):
             self.push_model_gguf()
-        if self.config.get("ollama_save", "true").lower() == "true":
+        if self._flag(self.config.get("ollama_save")) and self.config.get("ollama_model"):
             self.create_and_push_ollama_model()
 
 

--- a/src/praisonai-train/tests/unit/test_vision_config_is_honoured.py
+++ b/src/praisonai-train/tests/unit/test_vision_config_is_honoured.py
@@ -1,0 +1,118 @@
+"""The vision trainer must read its config, and must not publish by default.
+
+train_vision.py is selected automatically for any model whose name contains
+vision/-vl-/visionmodel, so a user never chooses this file -- the model name
+does. Two defects lived in it.
+
+1. The LoRA adapter was built from literals:
+
+       r=16, lora_alpha=16, lora_dropout=0, random_state=3407, use_rslora=False
+
+   so lora_r / lora_alpha / lora_dropout / random_state / use_rslora were
+   accepted in the config, validated, and ignored. A vision run trained at
+   r=16 whatever was asked for.
+
+2. Every stage was gated on `self.config.get(<key>, "true").lower() == "true"`
+   -- the default being the *string* "true", i.e. publishing ON when the key
+   is absent. `praisonai-train llm` writes only the keys the user supplied, so
+   `huggingface_save` is usually absent: a plain local run pushed the model to
+   the Hub, or died on a missing `hf_model_name` after training had completed.
+
+The LLM trainer already does the right thing, with a comment saying so
+("Publishing defaults OFF and is skipped unless a target is set"). This brings
+the vision path in line.
+"""
+import importlib.util
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def cls():
+    """Load train_vision with its GPU-only dependencies stubbed."""
+    for name in ("torch", "unsloth", "transformers", "datasets", "trl", "peft"):
+        module = types.ModuleType(name)
+        module.__version__ = "0.0-stub"
+        sys.modules.setdefault(name, module)
+    spec = importlib.util.spec_from_file_location(
+        "train_vision_under_test", "praisonai_train/train_vision.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.TrainVisionModel
+
+
+def _run(cls, config):
+    """Run the stage dispatcher, recording which stages fire."""
+    calls = []
+    inst = cls.__new__(cls)
+    inst.config = config
+    for name in ("check_gpu", "check_ram", "print_system_info", "prepare_model",
+                 "train_model", "save_model_merged", "push_model_gguf",
+                 "create_and_push_ollama_model"):
+        setattr(inst, name, (lambda k: (lambda *a, **kw: calls.append(k)))(name))
+    cls.run(inst)
+    return calls
+
+
+BASE = {"model_name": "some-vision-model", "train": "false"}
+
+
+class TestPublishingDefaultsOff:
+
+    def test_a_plain_config_does_not_push_to_the_hub(self, cls):
+        assert "save_model_merged" not in _run(cls, dict(BASE))
+
+    def test_a_plain_config_does_not_push_gguf(self, cls):
+        assert "push_model_gguf" not in _run(cls, dict(BASE))
+
+    def test_a_plain_config_does_not_push_to_ollama(self, cls):
+        assert "create_and_push_ollama_model" not in _run(cls, dict(BASE))
+
+    def test_asking_to_save_without_a_repo_name_skips_rather_than_crashes(self, cls):
+        """It used to reach save_model_merged and die on KeyError: 'hf_model_name'."""
+        calls = _run(cls, {**BASE, "huggingface_save": True})
+        assert "save_model_merged" not in calls
+
+    def test_an_explicit_save_with_a_repo_name_still_publishes(self, cls):
+        calls = _run(cls, {**BASE, "huggingface_save": "true", "hf_model_name": "me/m"})
+        assert "save_model_merged" in calls
+
+    def test_ollama_needs_its_target_too(self, cls):
+        calls = _run(cls, {**BASE, "ollama_save": True, "ollama_model": "m"})
+        assert "create_and_push_ollama_model" in calls
+
+
+class TestFlagsAcceptBothYamlForms:
+
+    def test_a_real_boolean_does_not_crash(self, cls):
+        """`train: true` used to hit .lower() on a bool."""
+        calls = _run(cls, {"model_name": "v", "train": True})
+        assert "train_model" in calls
+
+    def test_a_string_still_works(self, cls):
+        calls = _run(cls, {"model_name": "v", "train": "true"})
+        assert "train_model" in calls
+
+    def test_training_still_defaults_on(self, cls):
+        assert "train_model" in _run(cls, {"model_name": "v"})
+
+
+class TestLoraReadsTheConfig:
+
+    def test_the_literals_are_gone(self, cls):
+        import inspect
+        src = inspect.getsource(cls.prepare_model)
+        assert "r=16," not in src, "LoRA rank is still hardcoded"
+        assert 'self.config.get("lora_r"' in src
+
+    def test_the_previous_literals_remain_the_defaults(self, cls):
+        import inspect
+        src = inspect.getsource(cls.prepare_model)
+        for default in ('"lora_r", 16', '"lora_alpha", 16', '"random_state", 3407'):
+            assert default in src, f"default changed: {default}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/praisonai-train/tests/unit/train/test_vision_config_is_honoured.py
+++ b/src/praisonai-train/tests/unit/train/test_vision_config_is_honoured.py
@@ -23,6 +23,7 @@ The LLM trainer already does the right thing, with a comment saying so
 the vision path in line.
 """
 import importlib.util
+import os
 import sys
 import types
 
@@ -30,17 +31,24 @@ import pytest
 
 
 @pytest.fixture(scope="module")
-def cls():
+def mod():
     """Load train_vision with its GPU-only dependencies stubbed."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.normpath(
+        os.path.join(here, "..", "..", "..", "praisonai_train", "train_vision.py"))
     for name in ("torch", "unsloth", "transformers", "datasets", "trl", "peft"):
         module = types.ModuleType(name)
         module.__version__ = "0.0-stub"
         sys.modules.setdefault(name, module)
-    spec = importlib.util.spec_from_file_location(
-        "train_vision_under_test", "praisonai_train/train_vision.py")
+    spec = importlib.util.spec_from_file_location("train_vision_under_test", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return module.TrainVisionModel
+    return module
+
+
+@pytest.fixture(scope="module")
+def cls(mod):
+    return mod.TrainVisionModel
 
 
 def _run(cls, config):
@@ -99,19 +107,62 @@ class TestFlagsAcceptBothYamlForms:
         assert "train_model" in _run(cls, {"model_name": "v"})
 
 
+def _peft_kwargs(mod, config):
+    """Run prepare_model with the model loader stubbed, return the kwargs that
+    reached FastVisionModel.get_peft_model -- the arguments that actually train."""
+    captured = {}
+
+    class _Tokenizer:
+        pad_token = "<pad>"
+        eos_token = "</s>"
+        model_max_length = 2048
+
+    class _FastVisionModel:
+        @staticmethod
+        def from_pretrained(**kwargs):
+            return object(), _Tokenizer()
+
+        @staticmethod
+        def get_peft_model(model, **kwargs):
+            captured.update(kwargs)
+            return model
+
+    inst = mod.TrainVisionModel.__new__(mod.TrainVisionModel)
+    inst.config = config
+    original = mod.FastVisionModel if hasattr(mod, "FastVisionModel") else None
+    mod.FastVisionModel = _FastVisionModel
+    try:
+        inst.prepare_model()
+    finally:
+        if original is not None:
+            mod.FastVisionModel = original
+    return captured
+
+
 class TestLoraReadsTheConfig:
 
-    def test_the_literals_are_gone(self, cls):
-        import inspect
-        src = inspect.getsource(cls.prepare_model)
-        assert "r=16," not in src, "LoRA rank is still hardcoded"
-        assert 'self.config.get("lora_r"' in src
+    def test_configured_values_reach_get_peft_model(self, mod):
+        """The whole point of the fix: a value in the config must arrive at the
+        adapter. A swapped key or a lingering literal would fail here."""
+        kwargs = _peft_kwargs(mod, {
+            "model_name": "v", "load_in_4bit": True,
+            "lora_r": 8, "lora_alpha": 32, "lora_dropout": 0.05,
+            "random_state": 123, "use_rslora": True,
+        })
+        assert kwargs["r"] == 8
+        assert kwargs["lora_alpha"] == 32
+        assert kwargs["lora_dropout"] == 0.05
+        assert kwargs["random_state"] == 123
+        assert kwargs["use_rslora"] is True
 
-    def test_the_previous_literals_remain_the_defaults(self, cls):
-        import inspect
-        src = inspect.getsource(cls.prepare_model)
-        for default in ('"lora_r", 16', '"lora_alpha", 16', '"random_state", 3407'):
-            assert default in src, f"default changed: {default}"
+    def test_the_previous_literals_remain_the_defaults(self, mod):
+        """An existing config that set none of these must train identically."""
+        kwargs = _peft_kwargs(mod, {"model_name": "v", "load_in_4bit": True})
+        assert kwargs["r"] == 16
+        assert kwargs["lora_alpha"] == 16
+        assert kwargs["lora_dropout"] == 0
+        assert kwargs["random_state"] == 3407
+        assert kwargs["use_rslora"] is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`train_vision.py` is selected **automatically** for any model whose name contains `vision`/`-vl-`/`visionmodel` — a user never chooses this file, the model name does. Two defects lived in it.

## 1. LoRA was built from literals

```python
r=16, lora_alpha=16, lora_dropout=0, random_state=3407, use_rslora=False
```

So `lora_r`, `lora_alpha`, `lora_dropout`, `random_state` and `use_rslora` were accepted in the config, validated, and ignored. A vision run trained at `r=16` whatever was asked for.

The previous literals are now the defaults, so an existing config produces an identical run.

## 2. It published to the Hub by default

Every stage was gated on `self.config.get(<key>, "true").lower() == "true"` — the default being the **string `"true"`**, i.e. publishing **ON** when the key is absent.

`praisonai-train llm` writes only the keys the user supplied, so `huggingface_save` is usually absent. A plain local training run therefore **pushed the fine-tuned model to the Hub**, or died on a missing `hf_model_name` after the training had already completed.

The LLM trainer already does the right thing, and says so in a comment:

> *Publishing defaults OFF and is skipped unless a target is set — so a plain "train locally" config finishes with the LoRA saved to `lora_model/` instead of crashing on a missing repo name or pushing to someone else's account.*

The vision path was left behind. It now matches.

## Measured, with the stages stubbed

```
no publish keys            -> pushed to the Hub? False    (was True)
save=True but no repo name -> skipped                     (was KeyError)
explicit save + repo name  -> published
```

## A third thing, fixed in passing

The `.lower()` gating crashed on a real YAML boolean, so `train: true` was an error while `train: "true"` worked. Both work now, through the same `_flag` helper the LLM trainer uses.

11 tests; restoring publish-by-default turns them red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)