### PR TITLE
fix(parity): the checkers could pass over work they never verified

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -23,10 +23,17 @@ on:
       - 'src/praisonai-rust/praisonai/src/**/*.rs'
       - 'src/praisonai/praisonai/_dev/parity/**'
       - 'src/praisonai/praisonai/cli/features/**'
+      # The generator the `names` job runs. Editing it changed what the gate
+      # measured without the gate running.
+      - 'src/praisonai/scripts/**'
       - 'src/praisonai-ts/PARITY.md'
       - 'src/praisonai-ts/FEATURE_PARITY_TRACKER.json'
       - 'src/praisonai-ts/SIGNATURE_PARITY.md'
       - 'src/praisonai-ts/signature-parity.json'
+      # The behaviour baseline itself. These two carry the ratchet floor, so a
+      # pull request that edited only them raised the floor with no job running.
+      - 'src/praisonai-ts/BEHAVIOUR_PARITY.md'
+      - 'src/praisonai-ts/behaviour-parity.json'
       - 'src/praisonai-rust/PARITY.md'
       - 'src/praisonai-rust/FEATURE_PARITY_TRACKER.json'
       - '.github/workflows/parity-gate.yml'

--- a/src/praisonai-ts/BEHAVIOUR_PARITY.md
+++ b/src/praisonai-ts/BEHAVIOUR_PARITY.md
@@ -9,9 +9,13 @@ parameter exists. Both pass for an option that is accepted and then ignored, so
 this file counts those: every option the TypeScript SDK takes for Python parity
 and does not yet act on. The source is the `UNHONOURED_OPTIONS` ledger in
 `src/praisonai-ts/src/utils/parity-notice.ts`, which the surfaces iterate at
-runtime, so the count cannot drift from the behaviour.
+runtime, so every option listed here announces itself when it is passed.
 
-The check is a ratchet: the total may fall, never rise.
+The check is a ratchet: the total may fall, never rise, and `--write` enforces
+the same ratchet so a rise cannot be committed without `--allow-growth` and a
+reason. What no check can see is whether a row DELETED from the ledger was
+really implemented: the ledger is hand-written, so each removal is a claim that
+needs a test proving the option changes what the code does.
 
 ## Summary
 

--- a/src/praisonai-ts/SIGNATURE_PARITY.md
+++ b/src/praisonai-ts/SIGNATURE_PARITY.md
@@ -7,18 +7,23 @@
 For each curated surface in `surface.yaml`, every Python parameter (positional and
 keyword-only; `*args`/`**kwargs` excluded) is looked up on the TypeScript side
 as an interface member or method parameter. Matching order: **exact** name,
-**camelCase** (`snake_to_camel`), **alias** (`rules.yaml`), **flattened** (a nested
-Python config exposed as several TS fields), else **missing**. For matched pairs the
+**camelCase** (`snake_to_camel`), **flattened** (a nested Python config exposed as
+several TS fields), **alias** (`rules.yaml`), else **missing**. For matched pairs the
 checker compares required-ness and the effective default (TS constructor
-fallbacks such as `config.x ?? v` count as defaults). Type classes are compared
-as a warning only. Every gap must be waived in `waivers.yaml` or the check fails.
+fallbacks such as `config.x ?? v` count as defaults); a flattened parameter is
+checked against every TS field it names, and against the Python nested-config
+field defaults when `rules.yaml` names them. A TS default the extractor cannot
+evaluate reads as `unknown` and needs a waiver rather than passing as `undefined`.
+A **required** TS-only member fails the check; an optional one is informational.
+Type classes are compared as a warning only. Every gap must be waived in
+`waivers.yaml` or the check fails.
 This complements `PARITY.md`, which only tracks whether an export exists.
 
 ## Summary
 
 | Surface | Params | Exact | camelCase | Alias | Flattened | Missing | Mismatches | Waived | TS-only / TS total |
 |---|---|---|---|---|---|---|---|---|---|
-| `Agent.__init__` | 42 | 29 | 8 | 3 | 2 | 0 | 6 | 6 | 14 / 59 |
+| `Agent.__init__` | 42 | 29 | 8 | 2 | 3 | 0 | 8 | 8 | 13 / 59 |
 | `AgentTeam.__init__` | 23 | 20 | 3 | 0 | 0 | 0 | 1 | 1 | 3 / 26 |
 | `Task.__init__` | 60 | 31 | 29 | 0 | 0 | 0 | 7 | 7 | 1 / 62 |
 | `Agent.start` | 1 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 20 / 21 |
@@ -28,14 +33,14 @@ This complements `PARITY.md`, which only tracks whether an export exists.
 | `LLM.__init__` | 25 | 8 | 16 | 1 | 0 | 0 | 0 | 0 | 1 / 26 |
 | `Session.__init__` | 7 | 1 | 6 | 0 | 0 | 0 | 1 | 1 | 5 / 12 |
 | `tool()` | 11 | 5 | 5 | 1 | 0 | 0 | 3 | 3 | 3 / 14 |
-| `GoalEngineer.__init__` | 6 | 4 | 2 | 0 | 0 | 0 | 0 | 0 | 2 / 8 |
+| `GoalEngineer.__init__` | 6 | 4 | 2 | 0 | 0 | 0 | 5 | 5 | 2 / 8 |
 | `DoomLoopDetector.__init__` | 1 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 15 / 16 |
 | `EscalationPipeline.__init__` | 5 | 3 | 2 | 0 | 0 | 0 | 0 | 0 | 4 / 9 |
 | `ToolsetRegistry.register_toolset` | 5 | 5 | 0 | 0 | 0 | 0 | 0 | 0 | 0 / 5 |
 | `PraisonAIError.__init__` | 6 | 2 | 4 | 0 | 0 | 0 | 1 | 1 | 1 / 7 |
 | `FileTracker.__init__` | 1 | 0 | 1 | 0 | 0 | 0 | 0 | 0 | 0 / 1 |
 | `Knowledge.__init__` | 2 | 2 | 0 | 0 | 0 | 0 | 0 | 0 | 0 / 2 |
-| **Total (17 surfaces)** | 222 | 123 | 88 | 9 | 2 | 0 | 21 | 21 | 85 / 312 |
+| **Total (17 surfaces)** | 222 | 123 | 88 | 8 | 3 | 0 | 28 | 28 | 84 / 312 |
 
 ## Surfaces
 
@@ -43,7 +48,7 @@ This complements `PARITY.md`, which only tracks whether an export exists.
 
 - Python: `src/praisonai-agents/praisonaiagents/agent/agent.py:609`
 - TypeScript: `src/praisonai-ts/src/agent/simple.ts:196` (ctor `src/praisonai-ts/src/agent/simple.ts:900`)
-- Counts: 42 python params: 29 exact, 8 camelCase, 3 alias, 2 flattened, 0 missing; 6 mismatches; 6 waived; 14 TS-only of 59
+- Counts: 42 python params: 29 exact, 8 camelCase, 2 alias, 3 flattened, 0 missing; 8 mismatches; 8 waived; 13 TS-only of 59
 
 | Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |
 |---|---|---|---|---|---|---|---|---|
@@ -51,7 +56,7 @@ This complements `PARITY.md`, which only tracks whether an export exists.
 | `role` | positional | null | `Optional[str]` | exact | `role` | `config.goal \|\| config.backstory` | `string` | default mismatch (waived) |
 | `goal` | positional | null | `Optional[str]` | exact | `goal` | `config.instructions` | `string` | default mismatch (waived) |
 | `backstory` | positional | null | `Optional[str]` | exact | `backstory` | `config.instructions` | `string` | default mismatch (waived) |
-| `instructions` | positional | null | `Optional[str]` | exact | `instructions` | undefined | `string` | ok |
+| `instructions` | positional | null | `Optional[str]` | exact | `instructions` | unknown | `string` | default mismatch (waived) |
 | `llm` | positional | null | `Optional[Union[str, Any]]` | exact | `llm` | undefined | `string \| LLMConfig` | ok |
 | `model` | positional | null | `Optional[Union[str, Any]]` | exact | `model` | `llmName \|\| authModel \|\| resolveDefaultModel()` | `string` | default mismatch (waived) |
 | `base_url` | positional | null | `Optional[str]` | alias | `baseURL` | undefined | `string` | ok |
@@ -69,10 +74,10 @@ This complements `PARITY.md`, which only tracks whether an export exists.
 | `web` | keyword | null | `Optional[Union[bool, str, 'WebConfig']]` | exact | `web` | undefined | `boolean \| string \| AgentWebConfig` | ok |
 | `context` | keyword | null | `Optional[Union[bool, str, Dict[str, Any], 'ContextConfig', 'ContextManager']]` | exact | `context` | undefined | `boolean \| string \| ContextManagerConfig \| ContextManager` | ok |
 | `autonomy` | keyword | null | `Optional[Union[bool, str, Dict[str, Any], 'AutonomyConfig']]` | exact | `autonomy` | undefined | `boolean \| string \| Record<string, unknown>` | ok |
-| `output` | keyword | null | `Optional[Union[bool, str, Dict[str, Any], 'OutputConfig']]` | flattened | `verbose, markdown, stream` |  |  | ok |
-| `execution` | keyword | null | `Optional[Union[bool, str, Dict[str, Any], 'ExecutionConfig']]` | flattened | `maxIterations, maxToolCallsPerTurn` |  |  | ok |
+| `output` | keyword | null | `Optional[Union[bool, str, Dict[str, Any], 'OutputConfig']]` | flattened | `verbose, markdown, stream` | verbose=`getEnv('PRAISON_VERBOSE') !== 'false'`, markdown=true, stream=true |  | default mismatch (waived) |
+| `execution` | keyword | null | `Optional[Union[bool, str, Dict[str, Any], 'ExecutionConfig']]` | flattened | `maxIterations, maxToolCallsPerTurn` | maxIterations=20, maxToolCallsPerTurn=10 |  | ok |
 | `templates` | keyword | null | `Optional[Union[Dict[str, Any], 'TemplateConfig']]` | exact | `templates` | undefined | `Record<string, unknown>` | ok |
-| `caching` | keyword | null | `Optional[Union[bool, str, Dict[str, Any], 'CachingConfig']]` | alias | `cache` | false | `boolean` | default mismatch (waived) |
+| `caching` | keyword | null | `Optional[Union[bool, str, Dict[str, Any], 'CachingConfig']]` | flattened | `cache, cacheTTL` | cache=false, cacheTTL=3600 |  | default mismatch (waived) |
 | `hooks` | keyword | null | `Optional[Union[List[Any], Dict[str, Any], 'HooksConfig']]` | exact | `hooks` | undefined | `AgentHooksInput` | ok (type differs) |
 | `skills` | keyword | null | `Optional[Union[List[str], str, Dict[str, Any], 'SkillsConfig']]` | exact | `skills` | undefined | `string \| string[] \| SkillDiscoveryOptions \| SkillManager` | ok |
 | `self_improve` | keyword | false | `Optional[Union[bool, str, 'SkillReviewProtocol']]` | camelCase | `selfImprove` | false | `boolean \| string \| Record<string, unknown>` | ok |
@@ -90,7 +95,7 @@ This complements `PARITY.md`, which only tracks whether an export exists.
 | `retry` | keyword | null | `Optional[Union[bool, Dict[str, Any], 'RetryBackoffConfig']]` | exact | `retry` | undefined | `boolean \| AgentRetryConfig` | ok |
 | `reasoning_effort` | keyword | null | `Optional[str]` | camelCase | `reasoningEffort` | undefined | `'off' \| 'minimal' \| 'low' \| 'medium' \| 'high' \| string` | ok |
 
-TS-only members: `config`, `pretty`?, `fetch`?, `outputSchema`?, `outputSchemaName`?, `toolFunctions`?, `db`?, `sessionId`?, `runId`?, `historyLimit`?, `autoRestore`?, `autoPersist`?, `cacheTTL`?, `telemetry`?
+TS-only members: `config`, `pretty`?, `fetch`?, `outputSchema`?, `outputSchemaName`?, `toolFunctions`?, `db`?, `sessionId`?, `runId`?, `historyLimit`?, `autoRestore`?, `autoPersist`?, `telemetry`?
 
 ### `AgentTeam.__init__`
 
@@ -350,16 +355,16 @@ TS-only members: `config`, `parameters`?, `category`?
 
 - Python: `src/praisonai-agents/praisonaiagents/goal/engineer.py:58`
 - TypeScript: `src/praisonai-ts/src/goal/engineer.ts:42` (ctor `src/praisonai-ts/src/goal/engineer.ts:74`)
-- Counts: 6 python params: 4 exact, 2 camelCase, 0 alias, 0 flattened, 0 missing; 0 mismatches; 0 waived; 2 TS-only of 8
+- Counts: 6 python params: 4 exact, 2 camelCase, 0 alias, 0 flattened, 0 missing; 5 mismatches; 5 waived; 2 TS-only of 8
 
 | Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |
 |---|---|---|---|---|---|---|---|---|
-| `model` | positional | null | `Optional[str]` | exact | `model` | undefined | `string \| null` | ok |
-| `max_criteria` | positional | null | `Optional[int]` | camelCase | `maxCriteria` | undefined | `number \| null` | ok |
-| `threshold` | positional | null | `Optional[float]` | exact | `threshold` | undefined | `number \| null` | ok |
-| `auto_decompose` | positional | null | `Optional[bool]` | camelCase | `autoDecompose` | undefined | `boolean \| null` | ok |
+| `model` | positional | null | `Optional[str]` | exact | `model` | unknown | `string \| null` | default mismatch (waived) |
+| `max_criteria` | positional | null | `Optional[int]` | camelCase | `maxCriteria` | unknown | `number \| null` | default mismatch (waived) |
+| `threshold` | positional | null | `Optional[float]` | exact | `threshold` | unknown | `number \| null` | default mismatch (waived) |
+| `auto_decompose` | positional | null | `Optional[bool]` | camelCase | `autoDecompose` | unknown | `boolean \| null` | default mismatch (waived) |
 | `config` | positional | null | `Optional[GoalConfig]` | exact | `config` | {} | `GoalConfig \| GoalConfigOptions \| null` | ok |
-| `verbose` | positional | false | `bool` | exact | `verbose` | undefined | `boolean` | ok |
+| `verbose` | positional | false | `bool` | exact | `verbose` | unknown | `boolean` | default mismatch (waived) |
 
 TS-only members: `options`?, `llm`?
 
@@ -456,10 +461,17 @@ TS-only members: none
 | `Agent.__init__.backstory` | Same value, resolved at a different moment. TS stores `config.backstory \|\| config.instructions` (or "I am an AI assistant") in the constructor; Python's `self.backstory = backstory or instructions` (agent.py) produces the identical string in the body. Verified equal for the instruction-only, role-only and bare forms. | praisonai-ts |  |  |
 | `Agent.__init__.caching` | Both SDKs default to NO caching, by different routes. Python's `caching=None` resolves to `CachingConfig(enabled=True)` and assigns `self.cache = True`, but `Agent.cache` is written and never read anywhere in praisonaiagents, so the default caches nothing; TS defaults `cache` to false, which its response cache honours. Aligning the literal would turn caching ON in TS and diverge from Python's observable behaviour, so the difference is deliberate. Pinned by tests/unit/agent/parity-waiver-gaps.test.ts ("caching default"). | praisonai-ts |  |  |
 | `Agent.__init__.goal` | Same value, resolved at a different moment. TS stores `config.goal \|\| config.instructions` (or "Help the user with their tasks") in the constructor; Python's `self.goal = goal or instructions` (agent.py) produces the identical string in the body. | praisonai-ts |  |  |
+| `Agent.__init__.instructions` | TypeScript computes it across three branches -- the given value, else role/goal/backstory joined, else a fallback sentence -- so the extractor reports no single default rather than guessing. Python's None resolves the same way in its body. | praisonai-ts |  |  |
 | `Agent.__init__.model` | Same resolution, run eagerly. TS now calls `resolveDefaultModel()` (src/llm/default-model.ts), a byte-for-byte port of Python's `Agent._PROVIDER_DEFAULT_MODELS` / `_resolve_default_model`, so the same environment yields the same model on both sides. What still differs is only the moment: TS resolves in the constructor, Python inside the body, and TS additionally honours `PRAISONAI_MODEL` (a TypeScript-only alias). | praisonai-ts |  |  |
 | `Agent.__init__.name` | TS generates `Agent_<random>`; Python leaves `name` None for an instruction-only agent and uses "Agent" otherwise. Neither is a stable contract (every unnamed Python agent collides on "Agent", and `Handoff` on a None-named Python agent raises AttributeError), and TS exposes no name-keyed lookup like Python's `AgentTeam.get_agent_details`. The one place the random name used to reach the model -- the handoff tool name -- is now sanitised by `defaultHandoffToolName`. | praisonai-ts |  |  |
+| `Agent.__init__.output` | Genuine divergence, newly visible: Python's output=None resolves the silent preset (verbose, markdown and stream all false) while TypeScript defaults markdown and stream to true and verbose to PRAISON_VERBOSE. Aligning them changes default behaviour for every existing caller, so it needs a product decision, not a quiet edit. Flattened rows were never compared until the comparator was fixed, which is why this sat unseen. | praisonai-ts |  |  |
 | `Agent.__init__.role` | Same value, resolved at a different moment. TS now stores `config.role \|\| 'Assistant'` in the constructor, matching Python's `self.role = role or "Assistant"`, so `agent.role` reads back the same string on both sides. The system-prompt TEXT built from role/goal/ backstory still differs between the two SDKs -- that is a separate, untracked gap, not covered by this waiver. | praisonai-ts |  |  |
 | `AgentTeam.__init__.process` | TS treats an undefined process as sequential, the Python default. NOTE (verified, out of scope for this key): the accepted DOMAIN differs -- TS implements `process: "parallel"` with Promise.all, which Python rejects with a ValueError, and TS validates nothing, so a typo runs sequentially instead of raising. | praisonai-ts |  |  |
+| `GoalEngineer.__init__.auto_decompose` | The constructor only overrides `autoDecompose` when it is supplied; the default lives on GoalConfig, exactly as Python's None does. The extractor reports no default rather than inventing one, which is the correct reading. | praisonai-ts |  |  |
+| `GoalEngineer.__init__.max_criteria` | The constructor only overrides `maxCriteria` when it is supplied; the default lives on GoalConfig, exactly as Python's None does. The extractor reports no default rather than inventing one, which is the correct reading. | praisonai-ts |  |  |
+| `GoalEngineer.__init__.model` | A real divergence, of the same shape already waived for Agent.__init__.model: TypeScript calls resolveDefaultModel() eagerly while Python leaves model None and resolves it later. The other four GoalEngineer options genuinely agree -- maxCriteria 5, threshold 8.0, autoDecompose true, verbose false on both sides -- they are only 'unknown' because the constructor forwards non-null options into GoalConfig, which the extractor rightly will not constant-fold across files. | praisonai-ts |  |  |
+| `GoalEngineer.__init__.threshold` | The constructor only overrides `threshold` when it is supplied; the default lives on GoalConfig, exactly as Python's None does. The extractor reports no default rather than inventing one, which is the correct reading. | praisonai-ts |  |  |
+| `GoalEngineer.__init__.verbose` | The constructor only overrides `verbose` when it is supplied; the default lives on GoalConfig, exactly as Python's None does. The extractor reports no default rather than inventing one, which is the correct reading. | praisonai-ts |  |  |
 | `Handoff.__init__.tool_description_override` | Same derived string, built at a different moment. `defaultHandoffToolDescription` now produces Python's `Transfer task to <name> (<role>) - <goal>` exactly (it previously said "Transfer conversation to <name>", which the model saw). Only the moment of derivation differs. | praisonai-ts |  |  |
 | `Handoff.__init__.tool_name_override` | Same derived string, built at a different moment. `defaultHandoffToolName` now produces Python's `transfer_to_<lowercased, spaces-to-underscores name>` exactly (it previously said `handoff_to_<raw name>`, which could contain a space and be rejected by the provider). Only the moment of derivation differs. | praisonai-ts |  |  |
 | `PraisonAIError.__init__.run_id` | Both sides mint a UUID at construction -- Python's `self.run_id = run_id or str(uuid.uuid4())` (errors.py) is NOT lazy. Only the declared default differs. Edge case: `runId: ''` survives TS's `??` but is replaced by Python's `or`. | praisonai-ts |  |  |

--- a/src/praisonai-ts/SIGNATURE_PARITY.md
+++ b/src/praisonai-ts/SIGNATURE_PARITY.md
@@ -278,7 +278,7 @@ TS-only members: `condition`?, `contextPolicy`?, `maxContextTokens`?, `maxContex
 ### `LLM.__init__`
 
 - Python: `src/praisonai-agents/praisonaiagents/llm/llm.py:413`
-- TypeScript: `src/praisonai-ts/src/llm/index.ts:286` (ctor `src/praisonai-ts/src/llm/index.ts:466`)
+- TypeScript: `src/praisonai-ts/src/llm/index.ts:236` (ctor `src/praisonai-ts/src/llm/index.ts:416`)
 - Counts: 25 python params: 8 exact, 16 camelCase, 1 alias, 0 flattened, 0 missing; 0 mismatches; 0 waived; 1 TS-only of 26
 
 | Python param | Kind | Py default | Py type | Match | TS name | TS default | TS type | Status |

--- a/src/praisonai-ts/signature-parity.json
+++ b/src/praisonai-ts/signature-parity.json
@@ -2741,8 +2741,8 @@
       ],
       "ts_only_required": [],
       "typescript": {
-        "ctor_location": "src/praisonai-ts/src/agent/team.ts:338",
-        "location": "src/praisonai-ts/src/agent/team.ts:74",
+        "ctor_location": "src/praisonai-ts/src/agent/team.ts:342",
+        "location": "src/praisonai-ts/src/agent/team.ts:78",
         "options_parameters": [
           "configOrAgents"
         ]
@@ -2859,7 +2859,7 @@
       ],
       "ts_only_required": [],
       "typescript": {
-        "location": "src/praisonai-ts/src/agent/team.ts:766",
+        "location": "src/praisonai-ts/src/agent/team.ts:770",
         "options_interfaces": [
           "options: AgentTeamStartOptions"
         ],
@@ -4663,8 +4663,8 @@
       ],
       "ts_only_required": [],
       "typescript": {
-        "ctor_location": "src/praisonai-ts/src/llm/index.ts:466",
-        "location": "src/praisonai-ts/src/llm/index.ts:286",
+        "ctor_location": "src/praisonai-ts/src/llm/index.ts:416",
+        "location": "src/praisonai-ts/src/llm/index.ts:236",
         "options_parameters": [
           "config"
         ]

--- a/src/praisonai-ts/signature-parity.json
+++ b/src/praisonai-ts/signature-parity.json
@@ -3,16 +3,16 @@
   "surfaces": {
     "Agent.__init__": {
       "counts": {
-        "alias": 3,
+        "alias": 2,
         "camelCase": 8,
         "exact": 29,
-        "flattened": 2,
-        "mismatches": 6,
+        "flattened": 3,
+        "mismatches": 8,
         "missing": 0,
         "params": 42,
-        "ts_only": 14,
+        "ts_only": 13,
         "ts_total": 59,
-        "waived": 6
+        "waived": 8
       },
       "params": [
         {
@@ -37,6 +37,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "name",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -65,6 +66,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "role",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -93,6 +95,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "goal",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -121,6 +124,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "backstory",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -131,7 +135,10 @@
           "canonical": "instructions",
           "default": null,
           "default_kind": "literal",
-          "gap": null,
+          "gap": {
+            "detail": "default differs: python=null typescript=unknown (TS `instructions`)",
+            "kind": "default"
+          },
           "kind": "positional",
           "match": "exact",
           "name": "instructions",
@@ -139,17 +146,18 @@
           "ts": {
             "canonical": "instructions",
             "default": null,
-            "default_kind": null,
+            "default_kind": "unknown",
             "kind": "property",
             "name": "instructions",
             "required": false,
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "instructions",
           "type_class": "string",
           "type_text": "Optional[str]",
-          "waived": null,
+          "waived": "Agent.__init__.instructions",
           "warnings": []
         },
         {
@@ -171,6 +179,7 @@
             "type_class": "union",
             "type_text": "string | LLMConfig"
           },
+          "ts_members": null,
           "ts_name": "llm",
           "type_class": "union",
           "type_text": "Optional[Union[str, Any]]",
@@ -199,6 +208,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "model",
           "type_class": "union",
           "type_text": "Optional[Union[str, Any]]",
@@ -226,6 +236,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "baseURL",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -251,6 +262,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "apiKey",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -276,6 +288,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "auth",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -301,6 +314,7 @@
             "type_class": "array",
             "type_text": "any[] | Function[]"
           },
+          "ts_members": null,
           "ts_name": "tools",
           "type_class": "array",
           "type_text": "Optional[List[Any]]",
@@ -326,6 +340,7 @@
             "type_class": "array",
             "type_text": "string[]"
           },
+          "ts_members": null,
           "ts_name": "toolsets",
           "type_class": "array",
           "type_text": "Optional[List[str]]",
@@ -351,6 +366,7 @@
             "type_class": "array",
             "type_text": "(Agent | Handoff)[]"
           },
+          "ts_members": null,
           "ts_name": "handoffs",
           "type_class": "array",
           "type_text": "Optional[List[Union['Agent', 'Handoff']]]",
@@ -376,6 +392,7 @@
             "type_class": "union",
             "type_text": "boolean | string | MemoryConfig | AgentMemoryStore"
           },
+          "ts_members": null,
           "ts_name": "memory",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, 'MemoryConfig', Any]]",
@@ -401,6 +418,7 @@
             "type_class": "union",
             "type_text": "boolean | string | string[] | KnowledgeBaseConfig | KnowledgeBase"
           },
+          "ts_members": null,
           "ts_name": "knowledge",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, List[str], 'KnowledgeConfig', 'Knowledge']]",
@@ -426,6 +444,7 @@
             "type_class": "union",
             "type_text": "boolean | string | PlanningAgentConfig"
           },
+          "ts_members": null,
           "ts_name": "planning",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, 'PlanningConfig']]",
@@ -451,6 +470,7 @@
             "type_class": "union",
             "type_text": "boolean | string | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "reflection",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, 'ReflectionConfig']]",
@@ -476,6 +496,7 @@
             "type_class": "union",
             "type_text": "boolean | Rule[] | RulesManagerConfig | RulesManager"
           },
+          "ts_members": null,
           "ts_name": "rules",
           "type_class": "union",
           "type_text": "Optional[Union[bool, 'RulesConfig']]",
@@ -501,6 +522,7 @@
             "type_class": "object",
             "type_text": "AgentGuardrailInput"
           },
+          "ts_members": null,
           "ts_name": "guardrails",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Callable, 'GuardrailConfig']]",
@@ -528,6 +550,7 @@
             "type_class": "union",
             "type_text": "boolean | string | AgentWebConfig"
           },
+          "ts_members": null,
           "ts_name": "web",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, 'WebConfig']]",
@@ -553,6 +576,7 @@
             "type_class": "union",
             "type_text": "boolean | string | ContextManagerConfig | ContextManager"
           },
+          "ts_members": null,
           "ts_name": "context",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Dict[str, Any], 'ContextConfig', 'ContextManager']]",
@@ -578,6 +602,7 @@
             "type_class": "union",
             "type_text": "boolean | string | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "autonomy",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Dict[str, Any], 'AutonomyConfig']]",
@@ -588,16 +613,51 @@
           "canonical": "output",
           "default": null,
           "default_kind": "literal",
-          "gap": null,
+          "gap": {
+            "detail": "is flattened to TS [verbose, markdown, stream] and `verbose` default differs: python verbose=false typescript=`getEnv('PRAISON_VERBOSE') !== 'false'`; `markdown` default differs: python markdown=false typescript=true; `stream` default differs: python stream=false typescript=true",
+            "kind": "default"
+          },
           "kind": "keyword",
           "match": "flattened",
           "name": "output",
           "required": false,
           "ts": null,
+          "ts_members": [
+            {
+              "canonical": "verbose",
+              "default": "getEnv('PRAISON_VERBOSE') !== 'false'",
+              "default_kind": "expr",
+              "kind": "property",
+              "name": "verbose",
+              "required": false,
+              "type_class": "boolean",
+              "type_text": "boolean"
+            },
+            {
+              "canonical": "markdown",
+              "default": true,
+              "default_kind": "literal",
+              "kind": "property",
+              "name": "markdown",
+              "required": false,
+              "type_class": "boolean",
+              "type_text": "boolean"
+            },
+            {
+              "canonical": "stream",
+              "default": true,
+              "default_kind": "literal",
+              "kind": "property",
+              "name": "stream",
+              "required": false,
+              "type_class": "boolean",
+              "type_text": "boolean"
+            }
+          ],
           "ts_name": "verbose, markdown, stream",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Dict[str, Any], 'OutputConfig']]",
-          "waived": null,
+          "waived": "Agent.__init__.output",
           "warnings": []
         },
         {
@@ -610,6 +670,28 @@
           "name": "execution",
           "required": false,
           "ts": null,
+          "ts_members": [
+            {
+              "canonical": "maxIterations",
+              "default": 20,
+              "default_kind": "literal",
+              "kind": "property",
+              "name": "maxIterations",
+              "required": false,
+              "type_class": "number",
+              "type_text": "number"
+            },
+            {
+              "canonical": "maxToolCallsPerTurn",
+              "default": 10,
+              "default_kind": "literal",
+              "kind": "property",
+              "name": "maxToolCallsPerTurn",
+              "required": false,
+              "type_class": "number",
+              "type_text": "number"
+            }
+          ],
           "ts_name": "maxIterations, maxToolCallsPerTurn",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Dict[str, Any], 'ExecutionConfig']]",
@@ -635,6 +717,7 @@
             "type_class": "object",
             "type_text": "Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "templates",
           "type_class": "object",
           "type_text": "Optional[Union[Dict[str, Any], 'TemplateConfig']]",
@@ -646,30 +729,41 @@
           "default": null,
           "default_kind": "literal",
           "gap": {
-            "detail": "default differs: python=null typescript=false (TS `cache`)",
+            "detail": "is flattened to TS [cache, cacheTTL] and `cache` default differs: python enabled=true typescript=false",
             "kind": "default"
           },
           "kind": "keyword",
-          "match": "alias",
+          "match": "flattened",
           "name": "caching",
           "required": false,
-          "ts": {
-            "canonical": "cache",
-            "default": false,
-            "default_kind": "literal",
-            "kind": "property",
-            "name": "cache",
-            "required": false,
-            "type_class": "boolean",
-            "type_text": "boolean"
-          },
-          "ts_name": "cache",
+          "ts": null,
+          "ts_members": [
+            {
+              "canonical": "cache",
+              "default": false,
+              "default_kind": "literal",
+              "kind": "property",
+              "name": "cache",
+              "required": false,
+              "type_class": "boolean",
+              "type_text": "boolean"
+            },
+            {
+              "canonical": "cacheTTL",
+              "default": 3600,
+              "default_kind": "literal",
+              "kind": "property",
+              "name": "cacheTTL",
+              "required": false,
+              "type_class": "number",
+              "type_text": "number"
+            }
+          ],
+          "ts_name": "cache, cacheTTL",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Dict[str, Any], 'CachingConfig']]",
           "waived": "Agent.__init__.caching",
-          "warnings": [
-            "type differs: python union (Optional[Union[bool, str, Dict[str, Any], 'CachingConfig']]) vs typescript boolean (boolean)"
-          ]
+          "warnings": []
         },
         {
           "canonical": "hooks",
@@ -690,6 +784,7 @@
             "type_class": "object",
             "type_text": "AgentHooksInput"
           },
+          "ts_members": null,
           "ts_name": "hooks",
           "type_class": "union",
           "type_text": "Optional[Union[List[Any], Dict[str, Any], 'HooksConfig']]",
@@ -717,6 +812,7 @@
             "type_class": "union",
             "type_text": "string | string[] | SkillDiscoveryOptions | SkillManager"
           },
+          "ts_members": null,
           "ts_name": "skills",
           "type_class": "union",
           "type_text": "Optional[Union[List[str], str, Dict[str, Any], 'SkillsConfig']]",
@@ -742,6 +838,7 @@
             "type_class": "union",
             "type_text": "boolean | string | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "selfImprove",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, 'SkillReviewProtocol']]",
@@ -767,6 +864,7 @@
             "type_class": "union",
             "type_text": "boolean | ApprovalManager"
           },
+          "ts_members": null,
           "ts_name": "approval",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Dict[str, Any], 'ApprovalConfig', 'ApprovalProtocol']]",
@@ -792,6 +890,7 @@
             "type_class": "union",
             "type_text": "boolean | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "toolConfig",
           "type_class": "union",
           "type_text": "Optional[Union[bool, 'ToolConfig']]",
@@ -817,6 +916,7 @@
             "type_class": "union",
             "type_text": "boolean | string | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "learn",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Dict[str, Any], 'LearnConfig']]",
@@ -842,6 +942,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "backend",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -867,6 +968,7 @@
             "type_class": "union",
             "type_text": "string | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "runOn",
           "type_class": "union",
           "type_text": "Optional[Union['ManagedRuntime', str]]",
@@ -892,6 +994,7 @@
             "type_class": "union",
             "type_text": "string | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "toolsRunOn",
           "type_class": "union",
           "type_text": "Optional[Union['ToolPlace', str, Any]]",
@@ -917,6 +1020,7 @@
             "type_class": "union",
             "type_text": "boolean | string | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "runtime",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Dict[str, Any], 'AgentRuntimeConfig', 'RuntimeConfig']]",
@@ -942,6 +1046,7 @@
             "type_class": "object",
             "type_text": "AbortSignal"
           },
+          "ts_members": null,
           "ts_name": "signal",
           "type_class": "object",
           "type_text": "Optional['InterruptController']",
@@ -967,6 +1072,7 @@
             "type_class": "union",
             "type_text": "boolean | string | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "toolSearch",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str, Dict[str, Any], 'ToolSearchConfig']]",
@@ -992,6 +1098,7 @@
             "type_class": "union",
             "type_text": "boolean | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "messageSteering",
           "type_class": "union",
           "type_text": "Optional[Union[bool, 'MessageSteeringProtocol']]",
@@ -1017,6 +1124,7 @@
             "type_class": "union",
             "type_text": "boolean | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "sandbox",
           "type_class": "union",
           "type_text": "Optional[Union[bool, 'SandboxConfig']]",
@@ -1042,6 +1150,7 @@
             "type_class": "union",
             "type_text": "boolean | AgentRetryConfig"
           },
+          "ts_members": null,
           "ts_name": "retry",
           "type_class": "union",
           "type_text": "Optional[Union[bool, Dict[str, Any], 'RetryBackoffConfig']]",
@@ -1067,6 +1176,7 @@
             "type_class": "string",
             "type_text": "'off' | 'minimal' | 'low' | 'medium' | 'high' | string"
           },
+          "ts_members": null,
           "ts_name": "reasoningEffort",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -1200,16 +1310,6 @@
           "type_text": "boolean"
         },
         {
-          "canonical": "cacheTTL",
-          "default": 3600,
-          "default_kind": "literal",
-          "kind": "property",
-          "name": "cacheTTL",
-          "required": false,
-          "type_class": "number",
-          "type_text": "number"
-        },
-        {
           "canonical": "telemetry",
           "default": false,
           "default_kind": "literal",
@@ -1220,9 +1320,13 @@
           "type_text": "boolean"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/agent/simple.ts:900",
-        "location": "src/praisonai-ts/src/agent/simple.ts:196"
+        "location": "src/praisonai-ts/src/agent/simple.ts:196",
+        "options_parameters": [
+          "config"
+        ]
       }
     },
     "Agent.chat": {
@@ -1258,6 +1362,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "prompt",
           "type_class": "string",
           "type_text": "str",
@@ -1283,6 +1388,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "temperature",
           "type_class": "number",
           "type_text": "Optional[float]",
@@ -1308,6 +1414,7 @@
             "type_class": "array",
             "type_text": "any[]"
           },
+          "ts_members": null,
           "ts_name": "tools",
           "type_class": "array",
           "type_text": "Optional[List[Any]]",
@@ -1333,6 +1440,7 @@
             "type_class": "object",
             "type_text": "Record<string, any>"
           },
+          "ts_members": null,
           "ts_name": "outputJson",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -1358,6 +1466,7 @@
             "type_class": "object",
             "type_text": "Record<string, any>"
           },
+          "ts_members": null,
           "ts_name": "outputPydantic",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -1383,6 +1492,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "reasoningSteps",
           "type_class": "boolean",
           "type_text": "bool",
@@ -1408,6 +1518,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "stream",
           "type_class": "boolean",
           "type_text": "Optional[bool]",
@@ -1433,6 +1544,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "taskName",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -1458,6 +1570,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "taskDescription",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -1483,6 +1596,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "taskId",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -1508,6 +1622,7 @@
             "type_class": "object",
             "type_text": "Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "config",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Any]]",
@@ -1533,6 +1648,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "forceRetrieval",
           "type_class": "boolean",
           "type_text": "bool",
@@ -1558,6 +1674,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "skipRetrieval",
           "type_class": "boolean",
           "type_text": "bool",
@@ -1583,6 +1700,7 @@
             "type_class": "array",
             "type_text": "string[]"
           },
+          "ts_members": null,
           "ts_name": "attachments",
           "type_class": "array",
           "type_text": "Optional[List[str]]",
@@ -1608,6 +1726,7 @@
             "type_class": "string",
             "type_text": "'auto' | 'none' | 'required' | string"
           },
+          "ts_members": null,
           "ts_name": "toolChoice",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -1633,6 +1752,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "seed",
           "type_class": "number",
           "type_text": "Optional[int]",
@@ -1658,6 +1778,7 @@
             "type_class": "object",
             "type_text": "AbortSignal"
           },
+          "ts_members": null,
           "ts_name": "signal",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -1691,10 +1812,14 @@
           "type_text": "AgentChatOptions"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "location": "src/praisonai-ts/src/agent/simple.ts:3344",
         "options_interfaces": [
           "options: AgentChatOptions"
+        ],
+        "options_parameters": [
+          "options"
         ],
         "resolved_class": "Agent"
       }
@@ -1732,6 +1857,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "prompt",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -1945,10 +2071,14 @@
           "type_text": "number"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "location": "src/praisonai-ts/src/agent/simple.ts:2305",
         "options_interfaces": [
           "options: AgentChatOptions"
+        ],
+        "options_parameters": [
+          "options"
         ],
         "resolved_class": "Agent"
       }
@@ -1986,6 +2116,7 @@
             "type_class": "array",
             "type_text": "Agent[]"
           },
+          "ts_members": null,
           "ts_name": "agents",
           "type_class": "unknown",
           "type_text": "",
@@ -2011,6 +2142,7 @@
             "type_class": "array",
             "type_text": "(string | Task)[]"
           },
+          "ts_members": null,
           "ts_name": "tasks",
           "type_class": "unknown",
           "type_text": "",
@@ -2039,6 +2171,7 @@
             "type_class": "object",
             "type_text": "AgentTeamProcess"
           },
+          "ts_members": null,
           "ts_name": "process",
           "type_class": "unknown",
           "type_text": "",
@@ -2064,6 +2197,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "managerLlm",
           "type_class": "unknown",
           "type_text": "",
@@ -2089,6 +2223,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "name",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -2114,6 +2249,7 @@
             "type_class": "object",
             "type_text": "Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "variables",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Any]]",
@@ -2139,6 +2275,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "llm",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -2164,6 +2301,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "model",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -2189,6 +2327,7 @@
             "type_class": "object",
             "type_text": "TeamMemoryInput"
           },
+          "ts_members": null,
           "ts_name": "memory",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2214,6 +2353,7 @@
             "type_class": "object",
             "type_text": "TeamPlanningInput"
           },
+          "ts_members": null,
           "ts_name": "planning",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2239,6 +2379,7 @@
             "type_class": "object",
             "type_text": "TeamContextInput"
           },
+          "ts_members": null,
           "ts_name": "context",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2264,6 +2405,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "output",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2289,6 +2431,7 @@
             "type_class": "object",
             "type_text": "TeamExecutionInput"
           },
+          "ts_members": null,
           "ts_name": "execution",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2314,6 +2457,7 @@
             "type_class": "object",
             "type_text": "TeamHooksInput"
           },
+          "ts_members": null,
           "ts_name": "hooks",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2339,6 +2483,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "autonomy",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2364,6 +2509,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "knowledge",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2389,6 +2535,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "guardrails",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2414,6 +2561,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "web",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2439,6 +2587,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "reflection",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2464,6 +2613,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "caching",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2489,6 +2639,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "learn",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2514,6 +2665,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "toolsRunOn",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2539,6 +2691,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "runOn",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2586,9 +2739,13 @@
           "type_text": "boolean"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
-        "ctor_location": "src/praisonai-ts/src/agent/team.ts:342",
-        "location": "src/praisonai-ts/src/agent/team.ts:78"
+        "ctor_location": "src/praisonai-ts/src/agent/team.ts:338",
+        "location": "src/praisonai-ts/src/agent/team.ts:74",
+        "options_parameters": [
+          "configOrAgents"
+        ]
       }
     },
     "AgentTeam.start": {
@@ -2624,6 +2781,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "content",
           "type_class": "unknown",
           "type_text": "",
@@ -2649,6 +2807,7 @@
             "type_class": "boolean",
             "type_text": "false"
           },
+          "ts_members": null,
           "ts_name": "returnDict",
           "type_class": "unknown",
           "type_text": "",
@@ -2674,6 +2833,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "output",
           "type_class": "unknown",
           "type_text": "",
@@ -2697,10 +2857,14 @@
           "type_text": "AgentTeamStartOptions"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
-        "location": "src/praisonai-ts/src/agent/team.ts:770",
+        "location": "src/praisonai-ts/src/agent/team.ts:766",
         "options_interfaces": [
           "options: AgentTeamStartOptions"
+        ],
+        "options_parameters": [
+          "options"
         ],
         "resolved_class": "AgentTeam"
       }
@@ -2738,6 +2902,7 @@
             "type_class": "object",
             "type_text": "DoomLoopConfig | DoomLoopConfigOptions | null"
           },
+          "ts_members": null,
           "ts_name": "config",
           "type_class": "object",
           "type_text": "Optional[DoomLoopConfig]",
@@ -2901,9 +3066,13 @@
           "type_text": "number"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/escalation/doom-loop.ts:250",
-        "location": "src/praisonai-ts/src/escalation/doom-loop.ts:51"
+        "location": "src/praisonai-ts/src/escalation/doom-loop.ts:51",
+        "options_parameters": [
+          "config"
+        ]
       }
     },
     "EscalationPipeline.__init__": {
@@ -2939,6 +3108,7 @@
             "type_class": "object",
             "type_text": "EscalationConfig | EscalationConfigOptions | null"
           },
+          "ts_members": null,
           "ts_name": "config",
           "type_class": "object",
           "type_text": "Optional[EscalationConfig]",
@@ -2964,6 +3134,7 @@
             "type_class": "object",
             "type_text": "EscalationAgent | null"
           },
+          "ts_members": null,
           "ts_name": "agent",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -2989,6 +3160,7 @@
             "type_class": "array",
             "type_text": "unknown[] | null"
           },
+          "ts_members": null,
           "ts_name": "tools",
           "type_class": "array",
           "type_text": "Optional[List[Any]]",
@@ -3014,6 +3186,7 @@
             "type_class": "object",
             "type_text": "CheckpointServiceLike | null"
           },
+          "ts_members": null,
           "ts_name": "checkpointService",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -3039,6 +3212,7 @@
             "type_class": "object",
             "type_text": "StageChangeCallback | null"
           },
+          "ts_members": null,
           "ts_name": "onStageChange",
           "type_class": "callable",
           "type_text": "Optional[Callable[[EscalationStage, EscalationStage], None]]",
@@ -3094,9 +3268,13 @@
           "type_text": "DoomLoopConfig | DoomLoopConfigOptions | null"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/escalation/pipeline.ts:103",
-        "location": "src/praisonai-ts/src/escalation/pipeline.ts:51"
+        "location": "src/praisonai-ts/src/escalation/pipeline.ts:51",
+        "options_parameters": [
+          "options"
+        ]
       }
     },
     "FileTracker.__init__": {
@@ -3132,6 +3310,7 @@
             "type_class": "string",
             "type_text": "string | null"
           },
+          "ts_members": null,
           "ts_name": "stateFile",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -3144,6 +3323,7 @@
         "resolved_class": "FileTracker"
       },
       "ts_only": [],
+      "ts_only_required": [],
       "typescript": {
         "location": "src/praisonai-ts/src/knowledge/indexing.ts:552",
         "resolved_class": "FileTracker"
@@ -3155,19 +3335,22 @@
         "camelCase": 2,
         "exact": 4,
         "flattened": 0,
-        "mismatches": 0,
+        "mismatches": 5,
         "missing": 0,
         "params": 6,
         "ts_only": 2,
         "ts_total": 8,
-        "waived": 0
+        "waived": 5
       },
       "params": [
         {
           "canonical": "model",
           "default": null,
           "default_kind": "literal",
-          "gap": null,
+          "gap": {
+            "detail": "default differs: python=null typescript=unknown (TS `model`)",
+            "kind": "default"
+          },
           "kind": "positional",
           "match": "exact",
           "name": "model",
@@ -3175,24 +3358,28 @@
           "ts": {
             "canonical": "model",
             "default": null,
-            "default_kind": null,
+            "default_kind": "unknown",
             "kind": "property",
             "name": "model",
             "required": false,
             "type_class": "string",
             "type_text": "string | null"
           },
+          "ts_members": null,
           "ts_name": "model",
           "type_class": "string",
           "type_text": "Optional[str]",
-          "waived": null,
+          "waived": "GoalEngineer.__init__.model",
           "warnings": []
         },
         {
           "canonical": "maxCriteria",
           "default": null,
           "default_kind": "literal",
-          "gap": null,
+          "gap": {
+            "detail": "default differs: python=null typescript=unknown (TS `maxCriteria`)",
+            "kind": "default"
+          },
           "kind": "positional",
           "match": "camelCase",
           "name": "max_criteria",
@@ -3200,24 +3387,28 @@
           "ts": {
             "canonical": "maxCriteria",
             "default": null,
-            "default_kind": null,
+            "default_kind": "unknown",
             "kind": "property",
             "name": "maxCriteria",
             "required": false,
             "type_class": "number",
             "type_text": "number | null"
           },
+          "ts_members": null,
           "ts_name": "maxCriteria",
           "type_class": "number",
           "type_text": "Optional[int]",
-          "waived": null,
+          "waived": "GoalEngineer.__init__.max_criteria",
           "warnings": []
         },
         {
           "canonical": "threshold",
           "default": null,
           "default_kind": "literal",
-          "gap": null,
+          "gap": {
+            "detail": "default differs: python=null typescript=unknown (TS `threshold`)",
+            "kind": "default"
+          },
           "kind": "positional",
           "match": "exact",
           "name": "threshold",
@@ -3225,24 +3416,28 @@
           "ts": {
             "canonical": "threshold",
             "default": null,
-            "default_kind": null,
+            "default_kind": "unknown",
             "kind": "property",
             "name": "threshold",
             "required": false,
             "type_class": "number",
             "type_text": "number | null"
           },
+          "ts_members": null,
           "ts_name": "threshold",
           "type_class": "number",
           "type_text": "Optional[float]",
-          "waived": null,
+          "waived": "GoalEngineer.__init__.threshold",
           "warnings": []
         },
         {
           "canonical": "autoDecompose",
           "default": null,
           "default_kind": "literal",
-          "gap": null,
+          "gap": {
+            "detail": "default differs: python=null typescript=unknown (TS `autoDecompose`)",
+            "kind": "default"
+          },
           "kind": "positional",
           "match": "camelCase",
           "name": "auto_decompose",
@@ -3250,17 +3445,18 @@
           "ts": {
             "canonical": "autoDecompose",
             "default": null,
-            "default_kind": null,
+            "default_kind": "unknown",
             "kind": "property",
             "name": "autoDecompose",
             "required": false,
             "type_class": "boolean",
             "type_text": "boolean | null"
           },
+          "ts_members": null,
           "ts_name": "autoDecompose",
           "type_class": "boolean",
           "type_text": "Optional[bool]",
-          "waived": null,
+          "waived": "GoalEngineer.__init__.auto_decompose",
           "warnings": []
         },
         {
@@ -3282,6 +3478,7 @@
             "type_class": "object",
             "type_text": "GoalConfig | GoalConfigOptions | null"
           },
+          "ts_members": null,
           "ts_name": "config",
           "type_class": "object",
           "type_text": "Optional[GoalConfig]",
@@ -3292,7 +3489,10 @@
           "canonical": "verbose",
           "default": false,
           "default_kind": "literal",
-          "gap": null,
+          "gap": {
+            "detail": "default differs: python=false typescript=unknown (TS `verbose`)",
+            "kind": "default"
+          },
           "kind": "positional",
           "match": "exact",
           "name": "verbose",
@@ -3300,17 +3500,18 @@
           "ts": {
             "canonical": "verbose",
             "default": null,
-            "default_kind": null,
+            "default_kind": "unknown",
             "kind": "property",
             "name": "verbose",
             "required": false,
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "verbose",
           "type_class": "boolean",
           "type_text": "bool",
-          "waived": null,
+          "waived": "GoalEngineer.__init__.verbose",
           "warnings": []
         }
       ],
@@ -3340,9 +3541,13 @@
           "type_text": "GoalLLM"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/goal/engineer.ts:74",
-        "location": "src/praisonai-ts/src/goal/engineer.ts:42"
+        "location": "src/praisonai-ts/src/goal/engineer.ts:42",
+        "options_parameters": [
+          "options"
+        ]
       }
     },
     "Handoff.__init__": {
@@ -3378,6 +3583,7 @@
             "type_class": "object",
             "type_text": "EnhancedAgent"
           },
+          "ts_members": null,
           "ts_name": "agent",
           "type_class": "object",
           "type_text": "'Agent'",
@@ -3406,6 +3612,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "name",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -3434,6 +3641,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "description",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -3459,6 +3667,7 @@
             "type_class": "callable",
             "type_text": "(context: HandoffContext) => void | Promise<void>"
           },
+          "ts_members": null,
           "ts_name": "onHandoff",
           "type_class": "callable",
           "type_text": "Optional[Callable]",
@@ -3484,6 +3693,7 @@
             "type_class": "object",
             "type_text": "HandoffInputType"
           },
+          "ts_members": null,
           "ts_name": "inputType",
           "type_class": "unknown",
           "type_text": "Optional[type]",
@@ -3509,6 +3719,7 @@
             "type_class": "callable",
             "type_text": "(messages: any[]) => any[]"
           },
+          "ts_members": null,
           "ts_name": "transformContext",
           "type_class": "union",
           "type_text": "Optional[Union[Callable[[HandoffInputData], HandoffInputData], List[Callable[[HandoffInputData], HandoffInputData]]]]",
@@ -3536,6 +3747,7 @@
             "type_class": "object",
             "type_text": "Partial<HandoffConfig>"
           },
+          "ts_members": null,
           "ts_name": "config",
           "type_class": "object",
           "type_text": "Optional[HandoffConfig]",
@@ -3679,9 +3891,13 @@
           "type_text": "(error: Error) => void | Promise<void>"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/agent/handoff.ts:721",
-        "location": "src/praisonai-ts/src/agent/handoff.ts:485"
+        "location": "src/praisonai-ts/src/agent/handoff.ts:485",
+        "options_parameters": [
+          "config"
+        ]
       }
     },
     "Knowledge.__init__": {
@@ -3717,6 +3933,7 @@
             "type_class": "object",
             "type_text": "KnowledgeStoreConfig | null"
           },
+          "ts_members": null,
           "ts_name": "config",
           "type_class": "unknown",
           "type_text": "",
@@ -3742,6 +3959,7 @@
             "type_class": "union",
             "type_text": "number | boolean | null"
           },
+          "ts_members": null,
           "ts_name": "verbose",
           "type_class": "unknown",
           "type_text": "",
@@ -3754,6 +3972,7 @@
         "resolved_class": "Knowledge"
       },
       "ts_only": [],
+      "ts_only_required": [],
       "typescript": {
         "location": "src/praisonai-ts/src/knowledge/knowledge.ts:166",
         "resolved_class": "Knowledge"
@@ -3792,6 +4011,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "model",
           "type_class": "string",
           "type_text": "str",
@@ -3817,6 +4037,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "timeout",
           "type_class": "number",
           "type_text": "Optional[int]",
@@ -3842,6 +4063,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "temperature",
           "type_class": "number",
           "type_text": "Optional[float]",
@@ -3867,6 +4089,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "topP",
           "type_class": "number",
           "type_text": "Optional[float]",
@@ -3892,6 +4115,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "n",
           "type_class": "number",
           "type_text": "Optional[int]",
@@ -3917,6 +4141,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "maxTokens",
           "type_class": "number",
           "type_text": "Optional[int]",
@@ -3942,6 +4167,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "presencePenalty",
           "type_class": "number",
           "type_text": "Optional[float]",
@@ -3967,6 +4193,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "frequencyPenalty",
           "type_class": "number",
           "type_text": "Optional[float]",
@@ -3992,6 +4219,7 @@
             "type_class": "object",
             "type_text": "Record<number, number>"
           },
+          "ts_members": null,
           "ts_name": "logitBias",
           "type_class": "object",
           "type_text": "Optional[Dict[int, float]]",
@@ -4017,6 +4245,7 @@
             "type_class": "object",
             "type_text": "Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "responseFormat",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Any]]",
@@ -4042,6 +4271,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "seed",
           "type_class": "number",
           "type_text": "Optional[int]",
@@ -4067,6 +4297,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "logprobs",
           "type_class": "boolean",
           "type_text": "Optional[bool]",
@@ -4092,6 +4323,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "topLogprobs",
           "type_class": "number",
           "type_text": "Optional[int]",
@@ -4117,6 +4349,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "apiVersion",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4142,6 +4375,7 @@
             "type_class": "union",
             "type_text": "string | string[]"
           },
+          "ts_members": null,
           "ts_name": "stopPhrases",
           "type_class": "union",
           "type_text": "Optional[Union[str, List[str]]]",
@@ -4167,6 +4401,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "apiKey",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4192,6 +4427,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "baseURL",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4217,6 +4453,7 @@
             "type_class": "array",
             "type_text": "LLMEventListener[]"
           },
+          "ts_members": null,
           "ts_name": "events",
           "type_class": "array",
           "type_text": "List[Any]",
@@ -4242,6 +4479,7 @@
             "type_class": "union",
             "type_text": "boolean | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "webSearch",
           "type_class": "union",
           "type_text": "Optional[Union[bool, Dict[str, Any]]]",
@@ -4267,6 +4505,7 @@
             "type_class": "union",
             "type_text": "boolean | Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "webFetch",
           "type_class": "union",
           "type_text": "Optional[Union[bool, Dict[str, Any]]]",
@@ -4292,6 +4531,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "promptCaching",
           "type_class": "boolean",
           "type_text": "Optional[bool]",
@@ -4317,6 +4557,7 @@
             "type_class": "union",
             "type_text": "boolean | ClaudeMemoryBackend"
           },
+          "ts_members": null,
           "ts_name": "claudeMemory",
           "type_class": "union",
           "type_text": "Optional[Union[bool, Any]]",
@@ -4342,6 +4583,7 @@
             "type_class": "object",
             "type_text": "LLMFailoverManager"
           },
+          "ts_members": null,
           "ts_name": "failoverManager",
           "type_class": "object",
           "type_text": "Optional[FailoverManagerProtocol]",
@@ -4367,6 +4609,7 @@
             "type_class": "object",
             "type_text": "LLMAuthSource"
           },
+          "ts_members": null,
           "ts_name": "auth",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4394,6 +4637,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "maxIter",
           "type_class": "number",
           "type_text": "Optional[int]",
@@ -4417,9 +4661,13 @@
           "type_text": "LLMConfig"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/llm/index.ts:466",
-        "location": "src/praisonai-ts/src/llm/index.ts:286"
+        "location": "src/praisonai-ts/src/llm/index.ts:286",
+        "options_parameters": [
+          "config"
+        ]
       }
     },
     "PraisonAIError.__init__": {
@@ -4455,6 +4703,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "message",
           "type_class": "string",
           "type_text": "str",
@@ -4480,6 +4729,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "agentId",
           "type_class": "string",
           "type_text": "str",
@@ -4508,6 +4758,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "runId",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4533,6 +4784,7 @@
             "type_class": "union",
             "type_text": "AgentErrorKind | LegacyErrorCategory | string"
           },
+          "ts_members": null,
           "ts_name": "errorCategory",
           "type_class": "object",
           "type_text": "Optional[AgentErrorKind]",
@@ -4560,6 +4812,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "isRetryable",
           "type_class": "boolean",
           "type_text": "bool",
@@ -4585,6 +4838,7 @@
             "type_class": "object",
             "type_text": "Record<string, any>"
           },
+          "ts_members": null,
           "ts_name": "context",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Any]]",
@@ -4608,9 +4862,13 @@
           "type_text": "PraisonAIErrorOptions"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/errors-base.ts:169",
-        "location": "src/praisonai-ts/src/errors-base.ts:142"
+        "location": "src/praisonai-ts/src/errors-base.ts:142",
+        "options_parameters": [
+          "options"
+        ]
       }
     },
     "Session.__init__": {
@@ -4646,6 +4904,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "sessionId",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4674,6 +4933,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "userId",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4699,6 +4959,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "agentUrl",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4724,6 +4985,7 @@
             "type_class": "object",
             "type_text": "Record<string, any>"
           },
+          "ts_members": null,
           "ts_name": "memoryConfig",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Any]]",
@@ -4749,6 +5011,7 @@
             "type_class": "object",
             "type_text": "Record<string, any>"
           },
+          "ts_members": null,
           "ts_name": "knowledgeConfig",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Any]]",
@@ -4774,6 +5037,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "timeout",
           "type_class": "number",
           "type_text": "int",
@@ -4799,6 +5063,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "sessionTtl",
           "type_class": "number",
           "type_text": "Optional[int]",
@@ -4862,9 +5127,13 @@
           "type_text": "number"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/session/session.ts:132",
-        "location": "src/praisonai-ts/src/session/session.ts:29"
+        "location": "src/praisonai-ts/src/session/session.ts:29",
+        "options_parameters": [
+          "config"
+        ]
       }
     },
     "Task.__init__": {
@@ -4903,6 +5172,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "description",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4931,6 +5201,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "expected_output",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -4956,6 +5227,7 @@
             "type_class": "unknown",
             "type_text": "any"
           },
+          "ts_members": null,
           "ts_name": "agent",
           "type_class": "object",
           "type_text": "Optional[Agent]",
@@ -4981,6 +5253,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "name",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -5006,6 +5279,7 @@
             "type_class": "array",
             "type_text": "any[]"
           },
+          "ts_members": null,
           "ts_name": "tools",
           "type_class": "array",
           "type_text": "Optional[List[Any]]",
@@ -5031,6 +5305,7 @@
             "type_class": "array",
             "type_text": "(string | Task)[]"
           },
+          "ts_members": null,
           "ts_name": "context",
           "type_class": "array",
           "type_text": "Optional[List[Union[str, List, 'Task']]]",
@@ -5059,6 +5334,7 @@
             "type_class": "array",
             "type_text": "Task[]"
           },
+          "ts_members": null,
           "ts_name": "dependsOn",
           "type_class": "array",
           "type_text": "Optional[List[Union[str, List, 'Task']]]",
@@ -5084,6 +5360,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "asyncExecution",
           "type_class": "boolean",
           "type_text": "Optional[bool]",
@@ -5109,6 +5386,7 @@
             "type_class": "object",
             "type_text": "Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "config",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Any]]",
@@ -5134,6 +5412,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "outputFile",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -5159,6 +5438,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "outputJson",
           "type_class": "object",
           "type_text": "Optional[Type[BaseModel]]",
@@ -5184,6 +5464,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "outputPydantic",
           "type_class": "object",
           "type_text": "Optional[Type[BaseModel]]",
@@ -5209,6 +5490,7 @@
             "type_class": "object",
             "type_text": "TaskCallback"
           },
+          "ts_members": null,
           "ts_name": "callback",
           "type_class": "callable",
           "type_text": "Optional[Union[Callable[[TaskOutput], Any], Callable[[TaskOutput], Coroutine[Any, Any, Any]]]]",
@@ -5236,6 +5518,7 @@
             "type_class": "object",
             "type_text": "TaskCallback"
           },
+          "ts_members": null,
           "ts_name": "onTaskComplete",
           "type_class": "callable",
           "type_text": "Optional[Union[Callable[[TaskOutput], Any], Callable[[TaskOutput], Coroutine[Any, Any, Any]]]]",
@@ -5263,6 +5546,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "status",
           "type_class": "string",
           "type_text": "str",
@@ -5288,6 +5572,7 @@
             "type_class": "union",
             "type_text": "TaskOutput | string | null"
           },
+          "ts_members": null,
           "ts_name": "result",
           "type_class": "object",
           "type_text": "Optional[TaskOutput]",
@@ -5315,6 +5600,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "createDirectory",
           "type_class": "boolean",
           "type_text": "Optional[bool]",
@@ -5343,6 +5629,7 @@
             "type_class": "union",
             "type_text": "number | string"
           },
+          "ts_members": null,
           "ts_name": "id",
           "type_class": "number",
           "type_text": "Optional[int]",
@@ -5370,6 +5657,7 @@
             "type_class": "array",
             "type_text": "string[]"
           },
+          "ts_members": null,
           "ts_name": "images",
           "type_class": "array",
           "type_text": "Optional[List[str]]",
@@ -5395,6 +5683,7 @@
             "type_class": "array",
             "type_text": "string[]"
           },
+          "ts_members": null,
           "ts_name": "nextTasks",
           "type_class": "array",
           "type_text": "Optional[List[str]]",
@@ -5420,6 +5709,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "taskType",
           "type_class": "string",
           "type_text": "str",
@@ -5445,6 +5735,7 @@
             "type_class": "object",
             "type_text": "Record<string, string[]>"
           },
+          "ts_members": null,
           "ts_name": "condition",
           "type_class": "object",
           "type_text": "Optional[Dict[str, List[str]]]",
@@ -5470,6 +5761,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "isStart",
           "type_class": "boolean",
           "type_text": "bool",
@@ -5495,6 +5787,7 @@
             "type_class": "object",
             "type_text": "Record<string, string | number>"
           },
+          "ts_members": null,
           "ts_name": "loopState",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Union[str, int]]]",
@@ -5520,6 +5813,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "memory",
           "type_class": "unknown",
           "type_text": "",
@@ -5545,6 +5839,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "qualityCheck",
           "type_class": "unknown",
           "type_text": "",
@@ -5570,6 +5865,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "inputFile",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -5595,6 +5891,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "rerun",
           "type_class": "boolean",
           "type_text": "bool",
@@ -5620,6 +5917,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "retainFullContext",
           "type_class": "boolean",
           "type_text": "bool",
@@ -5645,6 +5943,7 @@
             "type_class": "object",
             "type_text": "TaskGuardrail"
           },
+          "ts_members": null,
           "ts_name": "guardrail",
           "type_class": "union",
           "type_text": "Optional[Union[Callable[[TaskOutput], Tuple[bool, Any]], str]]",
@@ -5675,6 +5974,7 @@
             "type_class": "object",
             "type_text": "TaskGuardrail"
           },
+          "ts_members": null,
           "ts_name": "guardrails",
           "type_class": "union",
           "type_text": "Optional[Union[Callable[[TaskOutput], Tuple[bool, Any]], str]]",
@@ -5702,6 +6002,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "maxRetries",
           "type_class": "number",
           "type_text": "int",
@@ -5727,6 +6028,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "retryCount",
           "type_class": "number",
           "type_text": "int",
@@ -5752,6 +6054,7 @@
             "type_class": "object",
             "type_text": "Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "agentConfig",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Any]]",
@@ -5777,6 +6080,7 @@
             "type_class": "object",
             "type_text": "Record<string, unknown>"
           },
+          "ts_members": null,
           "ts_name": "variables",
           "type_class": "object",
           "type_text": "Optional[Dict[str, Any]]",
@@ -5802,6 +6106,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "skipOnFailure",
           "type_class": "boolean",
           "type_text": "bool",
@@ -5827,6 +6132,7 @@
             "type_class": "number",
             "type_text": "number"
           },
+          "ts_members": null,
           "ts_name": "retryDelay",
           "type_class": "number",
           "type_text": "float",
@@ -5852,6 +6158,7 @@
             "type_class": "object",
             "type_text": "TaskOnError"
           },
+          "ts_members": null,
           "ts_name": "onError",
           "type_class": "string",
           "type_text": "str",
@@ -5882,6 +6189,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "action",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -5907,6 +6215,7 @@
             "type_class": "callable",
             "type_text": "(...args: unknown[]) => unknown"
           },
+          "ts_members": null,
           "ts_name": "handler",
           "type_class": "callable",
           "type_text": "Optional[Callable]",
@@ -5932,6 +6241,7 @@
             "type_class": "callable",
             "type_text": "() => boolean | Promise<boolean>"
           },
+          "ts_members": null,
           "ts_name": "shouldRun",
           "type_class": "callable",
           "type_text": "Optional[Callable]",
@@ -5957,6 +6267,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "loopOver",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -5982,6 +6293,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "loopVar",
           "type_class": "string",
           "type_text": "str",
@@ -6007,6 +6319,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "execution",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6035,6 +6348,7 @@
             "type_class": "object",
             "type_text": "Record<string, string[]>"
           },
+          "ts_members": null,
           "ts_name": "routing",
           "type_class": "object",
           "type_text": "Optional[Dict[str, List[str]]]",
@@ -6060,6 +6374,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "outputConfig",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6085,6 +6400,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "output",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6110,6 +6426,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "when",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -6135,6 +6452,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "thenTask",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -6160,6 +6478,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "elseTask",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -6185,6 +6504,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "autonomy",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6210,6 +6530,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "knowledge",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6235,6 +6556,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "web",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6260,6 +6582,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "reflection",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6285,6 +6608,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "planning",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6310,6 +6634,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "hooks",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6335,6 +6660,7 @@
             "type_class": "unknown",
             "type_text": "unknown"
           },
+          "ts_members": null,
           "ts_name": "caching",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6360,6 +6686,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "outputVariable",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -6385,6 +6712,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "failOnCallbackError",
           "type_class": "boolean",
           "type_text": "bool",
@@ -6410,6 +6738,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "failOnMemoryError",
           "type_class": "boolean",
           "type_text": "bool",
@@ -6433,9 +6762,13 @@
           "type_text": "Task[]"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/agent/types.ts:379",
-        "location": "src/praisonai-ts/src/agent/types.ts:115"
+        "location": "src/praisonai-ts/src/agent/types.ts:115",
+        "options_parameters": [
+          "config"
+        ]
       }
     },
     "ToolsetRegistry.register_toolset": {
@@ -6471,6 +6804,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "name",
           "type_class": "string",
           "type_text": "str",
@@ -6496,6 +6830,7 @@
             "type_class": "array",
             "type_text": "string[] | null"
           },
+          "ts_members": null,
           "ts_name": "tools",
           "type_class": "array",
           "type_text": "Optional[List[str]]",
@@ -6521,6 +6856,7 @@
             "type_class": "array",
             "type_text": "string[] | null"
           },
+          "ts_members": null,
           "ts_name": "includes",
           "type_class": "array",
           "type_text": "Optional[List[str]]",
@@ -6546,6 +6882,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "description",
           "type_class": "string",
           "type_text": "str",
@@ -6571,6 +6908,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "overwrite",
           "type_class": "boolean",
           "type_text": "bool",
@@ -6583,6 +6921,7 @@
         "resolved_class": "ToolsetRegistry"
       },
       "ts_only": [],
+      "ts_only_required": [],
       "typescript": {
         "location": "src/praisonai-ts/src/toolsets.ts:115",
         "resolved_class": "ToolsetRegistry"
@@ -6624,6 +6963,7 @@
             "type_class": "callable",
             "type_text": "(params: TParams, context?: ToolContext) => Promise<TResult> | TResult"
           },
+          "ts_members": null,
           "ts_name": "execute",
           "type_class": "callable",
           "type_text": "Optional[Callable]",
@@ -6652,6 +6992,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "name",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -6680,6 +7021,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "description",
           "type_class": "string",
           "type_text": "Optional[str]",
@@ -6705,6 +7047,7 @@
             "type_class": "string",
             "type_text": "string"
           },
+          "ts_members": null,
           "ts_name": "version",
           "type_class": "string",
           "type_text": "str",
@@ -6730,6 +7073,7 @@
             "type_class": "callable",
             "type_text": "() => [boolean, string]"
           },
+          "ts_members": null,
           "ts_name": "availability",
           "type_class": "callable",
           "type_text": "Optional[Callable[[], tuple[bool, str]]]",
@@ -6755,6 +7099,7 @@
             "type_class": "callable",
             "type_text": "(schema: ToolParameters) => ToolParameters"
           },
+          "ts_members": null,
           "ts_name": "dynamicSchemaOverrides",
           "type_class": "callable",
           "type_text": "Optional[Callable[[Dict[str, Any]], Dict[str, Any]]]",
@@ -6780,6 +7125,7 @@
             "type_class": "object",
             "type_text": "RetryPolicy"
           },
+          "ts_members": null,
           "ts_name": "retryPolicy",
           "type_class": "unknown",
           "type_text": "Optional[Any]",
@@ -6805,6 +7151,7 @@
             "type_class": "union",
             "type_text": "boolean | RiskLevel | string"
           },
+          "ts_members": null,
           "ts_name": "approval",
           "type_class": "union",
           "type_text": "Optional[Union[bool, str]]",
@@ -6830,6 +7177,7 @@
             "type_class": "union",
             "type_text": "boolean | RiskLevel | string"
           },
+          "ts_members": null,
           "ts_name": "requiresApproval",
           "type_class": "union",
           "type_text": "Union[bool, str]",
@@ -6855,6 +7203,7 @@
             "type_class": "callable",
             "type_text": "(result: TResult) => unknown"
           },
+          "ts_members": null,
           "ts_name": "toModelOutput",
           "type_class": "callable",
           "type_text": "Optional[Callable[[Any], Any]]",
@@ -6880,6 +7229,7 @@
             "type_class": "boolean",
             "type_text": "boolean"
           },
+          "ts_members": null,
           "ts_name": "restartSafe",
           "type_class": "boolean",
           "type_text": "Optional[bool]",
@@ -6922,24 +7272,28 @@
           "type_text": "string"
         }
       ],
+      "ts_only_required": [],
       "typescript": {
         "ctor_location": "src/praisonai-ts/src/tools/decorator.ts:213",
-        "location": "src/praisonai-ts/src/tools/decorator.ts:48"
+        "location": "src/praisonai-ts/src/tools/decorator.ts:48",
+        "options_parameters": [
+          "config"
+        ]
       }
     }
   },
   "totals": {
-    "alias": 9,
+    "alias": 8,
     "camelCase": 88,
     "exact": 123,
-    "flattened": 2,
-    "mismatches": 21,
+    "flattened": 3,
+    "mismatches": 28,
     "missing": 0,
     "params": 222,
     "surfaces": 17,
-    "ts_only": 85,
+    "ts_only": 84,
     "ts_total": 312,
-    "waived": 21
+    "waived": 28
   },
   "waivers": [
     {
@@ -6966,6 +7320,13 @@
     {
       "expires": null,
       "issue": null,
+      "key": "Agent.__init__.instructions",
+      "owner": "praisonai-ts",
+      "reason": "TypeScript computes it across three branches -- the given value, else role/goal/backstory joined, else a fallback sentence -- so the extractor reports no single default rather than guessing. Python's None resolves the same way in its body."
+    },
+    {
+      "expires": null,
+      "issue": null,
       "key": "Agent.__init__.model",
       "owner": "praisonai-ts",
       "reason": "Same resolution, run eagerly. TS now calls `resolveDefaultModel()` (src/llm/default-model.ts), a byte-for-byte port of Python's `Agent._PROVIDER_DEFAULT_MODELS` / `_resolve_default_model`, so the same environment yields the same model on both sides. What still differs is only the moment: TS resolves in the constructor, Python inside the body, and TS additionally honours `PRAISONAI_MODEL` (a TypeScript-only alias)."
@@ -6980,6 +7341,13 @@
     {
       "expires": null,
       "issue": null,
+      "key": "Agent.__init__.output",
+      "owner": "praisonai-ts",
+      "reason": "Genuine divergence, newly visible: Python's output=None resolves the silent preset (verbose, markdown and stream all false) while TypeScript defaults markdown and stream to true and verbose to PRAISON_VERBOSE. Aligning them changes default behaviour for every existing caller, so it needs a product decision, not a quiet edit. Flattened rows were never compared until the comparator was fixed, which is why this sat unseen."
+    },
+    {
+      "expires": null,
+      "issue": null,
       "key": "Agent.__init__.role",
       "owner": "praisonai-ts",
       "reason": "Same value, resolved at a different moment. TS now stores `config.role || 'Assistant'` in the constructor, matching Python's `self.role = role or \"Assistant\"`, so `agent.role` reads back the same string on both sides. The system-prompt TEXT built from role/goal/ backstory still differs between the two SDKs -- that is a separate, untracked gap, not covered by this waiver."
@@ -6990,6 +7358,41 @@
       "key": "AgentTeam.__init__.process",
       "owner": "praisonai-ts",
       "reason": "TS treats an undefined process as sequential, the Python default. NOTE (verified, out of scope for this key): the accepted DOMAIN differs -- TS implements `process: \"parallel\"` with Promise.all, which Python rejects with a ValueError, and TS validates nothing, so a typo runs sequentially instead of raising."
+    },
+    {
+      "expires": null,
+      "issue": null,
+      "key": "GoalEngineer.__init__.auto_decompose",
+      "owner": "praisonai-ts",
+      "reason": "The constructor only overrides `autoDecompose` when it is supplied; the default lives on GoalConfig, exactly as Python's None does. The extractor reports no default rather than inventing one, which is the correct reading."
+    },
+    {
+      "expires": null,
+      "issue": null,
+      "key": "GoalEngineer.__init__.max_criteria",
+      "owner": "praisonai-ts",
+      "reason": "The constructor only overrides `maxCriteria` when it is supplied; the default lives on GoalConfig, exactly as Python's None does. The extractor reports no default rather than inventing one, which is the correct reading."
+    },
+    {
+      "expires": null,
+      "issue": null,
+      "key": "GoalEngineer.__init__.model",
+      "owner": "praisonai-ts",
+      "reason": "A real divergence, of the same shape already waived for Agent.__init__.model: TypeScript calls resolveDefaultModel() eagerly while Python leaves model None and resolves it later. The other four GoalEngineer options genuinely agree -- maxCriteria 5, threshold 8.0, autoDecompose true, verbose false on both sides -- they are only 'unknown' because the constructor forwards non-null options into GoalConfig, which the extractor rightly will not constant-fold across files."
+    },
+    {
+      "expires": null,
+      "issue": null,
+      "key": "GoalEngineer.__init__.threshold",
+      "owner": "praisonai-ts",
+      "reason": "The constructor only overrides `threshold` when it is supplied; the default lives on GoalConfig, exactly as Python's None does. The extractor reports no default rather than inventing one, which is the correct reading."
+    },
+    {
+      "expires": null,
+      "issue": null,
+      "key": "GoalEngineer.__init__.verbose",
+      "owner": "praisonai-ts",
+      "reason": "The constructor only overrides `verbose` when it is supplied; the default lives on GoalConfig, exactly as Python's None does. The extractor reports no default rather than inventing one, which is the correct reading."
     },
     {
       "expires": null,

--- a/src/praisonai/praisonai/_dev/parity/behaviour.py
+++ b/src/praisonai/praisonai/_dev/parity/behaviour.py
@@ -84,9 +84,20 @@ _OPTION_RE = re.compile(r"([\'\"`])([A-Za-z_][A-Za-z0-9_]*)\1")
 _ANY_STRING_RE = re.compile(r"([\'\"`])((?:[^\\\n]|\\.)*?)\1")
 # An independent second opinion on which surfaces the literal declares, used
 # only to cross-check the scanner below. Deliberately not the same technique.
-_KEY_RE = re.compile(r"([\'\"`])([^\'\"`\n]+)\1\s*:\s*\[")
-# The start of one entry, matched at brace depth 0 by the scanner.
-_ENTRY_RE = re.compile(r"([\'\"`])([^\'\"`\n]+)\1\s*:\s*")
+# A JavaScript object key may be quoted OR a bare identifier: `Handoff: [...]`
+# is as valid as `'Handoff': [...]`. Recognising only the quoted form let a bare
+# key drop out of the parse -- which LOWERS the total and reads as progress.
+_KEY_RE = re.compile(
+    r"(?:([\'\"`])([^\'\"`\n]+)\1|([A-Za-z_$][\w$]*))\s*:\s*\["
+)
+# The start of one entry, matched at brace depth 0 by the scanner. Group 2 is a
+# quoted key; group 3 is a bare identifier key.
+_ENTRY_RE = re.compile(
+    r"(?:([\'\"`])([^\'\"`\n]+)\1|([A-Za-z_$][\w$]*))\s*:\s*"
+)
+# A bare identifier at the top level of the literal, where the scanner meets a
+# key that is not quoted.
+_BARE_KEY_RE = re.compile(r"[A-Za-z_$][\w$]*")
 
 
 @dataclass
@@ -209,44 +220,62 @@ def _parse_entries(body: str) -> Dict[str, List[str]]:
         if ch in _QUOTE and depth != 0:
             i = _end_of_string(body, i) + 1
             continue
-        if ch in _QUOTE:
-            match = _ENTRY_RE.match(body, i)
-            if not match:
-                raise LedgerError(
-                    f'{LEDGER}: a quoted string at the top level of UNHONOURED_OPTIONS '
-                    f'near offset {i} is not a `\'Surface\': [...]` entry'
-                )
-            key = match.group(2)
-            value_at = match.end()
-            if value_at >= n or body[value_at] != '[':
-                raise LedgerError(
-                    f"{LEDGER}: the value of '{key}' is not a list of option names. "
-                    'Every entry must be `\'Surface\': [ ... ]` so the options can be counted.'
-                )
-            close = _matching_bracket(body, value_at)
-            if key in surfaces:
-                raise LedgerError(
-                    f"{LEDGER}: surface '{key}' is declared twice; the second wins at "
-                    'runtime and the first is uncounted. Merge them.'
-                )
-            inner = body[value_at + 1:close]
-            options = [m.group(2) for m in _OPTION_RE.finditer(inner)]
-            if len(options) != len(_ANY_STRING_RE.findall(inner)):
-                raise LedgerError(
-                    f"{LEDGER}: '{key}' lists a name that is not a plain identifier, so it "
-                    'would be dropped from the count. Every option must be quoted and match '
-                    '[A-Za-z_][A-Za-z0-9_]*.'
-                )
-            surfaces[key] = options
-            i = close + 1
+        # At the top level a key opens an entry -- quoted (`'Surface':`) or a
+        # bare JavaScript identifier (`Handoff:`). Both are valid and both must
+        # be counted; a bare key that fell through would LOWER the total.
+        if depth == 0 and (ch in _QUOTE or (ch.isalpha() or ch in '_$')):
+            i = _consume_entry(body, i, surfaces)
             continue
         i += 1
     return surfaces
 
 
+def _consume_entry(body: str, i: int, surfaces: Dict[str, List[str]]) -> int:
+    """Read one top-level `Surface: [...]` entry starting at ``i``; return the
+    index just past its closing bracket.
+
+    ``Surface`` may be quoted or a bare identifier. Anything at the top level
+    that is not such an entry raises, so a stray token can never quietly drop a
+    surface from the count.
+    """
+    n = len(body)
+    match = _ENTRY_RE.match(body, i)
+    if not match:
+        raise LedgerError(
+            f'{LEDGER}: a token at the top level of UNHONOURED_OPTIONS near offset '
+            f"{i} is not a `Surface: [...]` entry"
+        )
+    key = match.group(2) if match.group(2) is not None else match.group(3)
+    value_at = match.end()
+    if value_at >= n or body[value_at] != '[':
+        raise LedgerError(
+            f"{LEDGER}: the value of '{key}' is not a list of option names. "
+            'Every entry must be `Surface: [ ... ]` so the options can be counted.'
+        )
+    close = _matching_bracket(body, value_at)
+    if key in surfaces:
+        raise LedgerError(
+            f"{LEDGER}: surface '{key}' is declared twice; the second wins at "
+            'runtime and the first is uncounted. Merge them.'
+        )
+    inner = body[value_at + 1:close]
+    options = [m.group(2) for m in _OPTION_RE.finditer(inner)]
+    if len(options) != len(_ANY_STRING_RE.findall(inner)):
+        raise LedgerError(
+            f"{LEDGER}: '{key}' lists a name that is not a plain identifier, so it "
+            'would be dropped from the count. Every option must be quoted and match '
+            '[A-Za-z_][A-Za-z0-9_]*.'
+        )
+    surfaces[key] = options
+    return close + 1
+
+
 def _keys_in_source(body: str) -> List[str]:
     """A second, independent reading of which surfaces the literal declares."""
-    return [m.group(2) for m in _KEY_RE.finditer(body)]
+    return [
+        m.group(2) if m.group(2) is not None else m.group(3)
+        for m in _KEY_RE.finditer(body)
+    ]
 
 
 def _verify_parse(body: str, surfaces: Dict[str, List[str]], iterated: Iterable[str]) -> None:
@@ -277,7 +306,12 @@ def _verify_parse(body: str, surfaces: Dict[str, List[str]], iterated: Iterable[
     for surface in sorted(set(iterated)):
         if surface in surfaces:
             continue
-        if re.search(r'([\'"`])' + re.escape(surface) + r'\1\s*:', body):
+        # A surface named at a `unhonouredFor('X')` call site may be declared in
+        # the ledger with a quoted OR a bare key; both must be searched, or a
+        # bare-key surface that dropped from the parse would slip through here.
+        quoted = r'([\'"`])' + re.escape(surface) + r'\1\s*:'
+        bare = r'(?<![\w$])' + re.escape(surface) + r'\s*:' if re.fullmatch(r'[A-Za-z_$][\w$]*', surface) else None
+        if re.search(quoted, body) or (bare and re.search(bare, body)):
             raise LedgerError(
                 f"{LEDGER} still declares '{surface}', which the TypeScript iterates with "
                 f"unhonouredFor('{surface}'), but the parse did not see it. That would count "

--- a/src/praisonai/praisonai/_dev/parity/behaviour.py
+++ b/src/praisonai/praisonai/_dev/parity/behaviour.py
@@ -6,17 +6,50 @@ exists; the signature checker asks whether a parameter exists. An option that is
 accepted, typed, documented and then ignored passes both -- which is how 76 of
 them accumulated without any number moving.
 
-This layer counts them. The source of truth is the `UNHONOURED_OPTIONS` ledger
-in src/praisonai-ts/src/utils/parity-notice.ts, which the TypeScript surfaces
-themselves iterate, so the count cannot drift from what the code does.
+This layer counts them. The source is the `UNHONOURED_OPTIONS` ledger in
+src/praisonai-ts/src/utils/parity-notice.ts, which the TypeScript surfaces
+iterate at runtime, so every option listed there does announce itself when it is
+passed.
 
 The gate is a ratchet: the committed report carries the total, and `--check`
 fails if the current total is HIGHER. Closing an option lowers it; accepting a
-new one without implementing it raises it and reddens the build. Regenerate with
-`--write` when you close one.
+new one without implementing it raises it and reddens the build. `--write`
+enforces the same ratchet -- it runs on every push to main and auto-commits, so
+without that a rise reached the floor by being written rather than argued for.
+Pass `--allow-growth` to bank a rise deliberately, with a reason in the pull
+request. Lowering the total never needs a flag.
 
     python -m praisonai._dev.parity.behaviour --write
     python -m praisonai._dev.parity.behaviour --check
+
+Two things this file is careful about, both learned the hard way:
+
+* A surface that falls OUT of the parse lowers the total, which reads as
+  progress and is bankable. So the literal is scanned structurally rather than
+  line-shaped, and the result is cross-checked against an independent scan of
+  the same text and against every `unhonouredFor('X')` call site. A surface the
+  ledger still declares but the parse did not see is an error, never a closure.
+
+* What this CANNOT check is that a deleted entry was really implemented. The
+  ledger is hand-written; delete three names and the total falls with the
+  TypeScript untouched. Three candidate guards were measured against the 48
+  entries that stand today, and none is worth shipping:
+
+    - "the option is referenced in src/ outside parity-notice.ts": 0 of 48
+      would flag. The signature gate REQUIRES the parameter to exist, so this
+      cannot fail.
+    - "some test names the option": 0 of 48 would flag. Cannot fail either.
+    - "some test that does not import parity-notice names the option": 7 of 48
+      would flag, so it can fail -- but the other 41 pass on a bare identifier
+      occurring anywhere in the test tree, about any surface. `Task.web` is
+      "evidenced" by tools/registry.test.ts, `AgentTeam.autonomy` by a test of
+      Agent.autonomy, `Task.caching` by cli-features.test.ts. It would license
+      85% of possible deletions while reading as verification, and a comment
+      would satisfy it.
+
+  So there is no guard, and the number stays honestly self-reported. `--write`
+  and `--check` PRINT what a change claims to have closed, for a reviewer to
+  check against a test, instead of pretending to verify it.
 """
 
 from __future__ import annotations
@@ -27,11 +60,12 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 from ._paths import find_repo_root
 
 LEDGER = 'src/praisonai-ts/src/utils/parity-notice.ts'
+TS_SOURCE = 'src/praisonai-ts/src'
 MD_OUTPUT = 'src/praisonai-ts/BEHAVIOUR_PARITY.md'
 JSON_OUTPUT = 'src/praisonai-ts/behaviour-parity.json'
 
@@ -39,8 +73,20 @@ JSON_OUTPUT = 'src/praisonai-ts/behaviour-parity.json'
 # that works for some inputs and not others. Counted apart from the ledger,
 # because the option is not wholly absent.
 _PARTIAL_RE = re.compile(r"notYetHonoured\(\s*'([^']+)'\s*,\s*'([^']+)'\s*,")
-_SURFACE_RE = re.compile(r"^\s*'([^']+)':\s*\[(.*?)\]\s*,\s*$", re.S | re.M)
-_OPTION_RE = re.compile(r"'([A-Za-z_][A-Za-z0-9_]*)'")
+# `unhonouredFor('Surface')` with a literal argument: a surface the TypeScript
+# code iterates at runtime. Every one of these must survive the parse.
+_ITERATES_RE = re.compile(r"unhonouredFor\(\s*'([^']+)'\s*\)")
+# Quoting is not the ledger's business: JavaScript accepts ' " and ` for both
+# keys and option names, and a style that this file did not recognise would
+# silently drop the surface -- which LOWERS the total and reads as progress.
+_QUOTE = '\'"`'
+_OPTION_RE = re.compile(r"([\'\"`])([A-Za-z_][A-Za-z0-9_]*)\1")
+_ANY_STRING_RE = re.compile(r"([\'\"`])((?:[^\\\n]|\\.)*?)\1")
+# An independent second opinion on which surfaces the literal declares, used
+# only to cross-check the scanner below. Deliberately not the same technique.
+_KEY_RE = re.compile(r"([\'\"`])([^\'\"`\n]+)\1\s*:\s*\[")
+# The start of one entry, matched at brace depth 0 by the scanner.
+_ENTRY_RE = re.compile(r"([\'\"`])([^\'\"`\n]+)\1\s*:\s*")
 
 
 @dataclass
@@ -81,31 +127,197 @@ def _ledger_block(text: str) -> str:
     raise LedgerError(f'the UNHONOURED_OPTIONS literal in {LEDGER} is not closed')
 
 
+def _strip_comments(body: str) -> str:
+    """Blank out // and /* */ comments, preserving every offset and quoted string.
+
+    A commented-out entry must not be counted, and a real entry must not be lost
+    because a comment sits beside it.
+    """
+    out: List[str] = []
+    i, n = 0, len(body)
+    while i < n:
+        ch = body[i]
+        if ch in ("'", '"', '`'):
+            j = i + 1
+            while j < n and body[j] != ch:
+                j += 2 if body[j] == '\\' else 1
+            out.append(body[i:j + 1])
+            i = j + 1
+        elif body.startswith('//', i):
+            j = body.find('\n', i)
+            j = n if j < 0 else j
+            out.append(' ' * (j - i))
+            i = j
+        elif body.startswith('/*', i):
+            j = body.find('*/', i)
+            j = n if j < 0 else j + 2
+            out.append(''.join(' ' if c != '\n' else '\n' for c in body[i:j]))
+            i = j
+        else:
+            out.append(ch)
+            i += 1
+    return ''.join(out)
+
+
+def _end_of_string(body: str, open_at: int) -> int:
+    """Index of the quote that closes the string opened at ``open_at``."""
+    quote = body[open_at]
+    i = open_at + 1
+    while i < len(body):
+        if body[i] == '\\':
+            i += 2
+            continue
+        if body[i] == quote:
+            return i
+        i += 1
+    raise LedgerError(f'a quoted name in {LEDGER} is never closed')
+
+
+def _matching_bracket(body: str, open_at: int) -> int:
+    depth = 0
+    for i in range(open_at, len(body)):
+        if body[i] == '[':
+            depth += 1
+        elif body[i] == ']':
+            depth -= 1
+            if depth == 0:
+                return i
+    raise LedgerError(f'an entry in {LEDGER} opens a list that is never closed')
+
+
+def _parse_entries(body: str) -> Dict[str, List[str]]:
+    """Every `'Surface': [...]` entry at the top level of the literal.
+
+    Structural, not line-shaped. The first version of this used a line-anchored
+    regex that required a trailing comma after the closing bracket, so putting
+    one entry on a single line without that comma silently deleted a whole
+    surface -- reported as options CLOSED, and bankable with --write while the
+    TypeScript was untouched. Anything this scanner cannot account for raises.
+    """
+    surfaces: Dict[str, List[str]] = {}
+    i, n, depth = 0, len(body), 0
+    while i < n:
+        ch = body[i]
+        if ch in '{[(':
+            depth += 1
+            i += 1
+            continue
+        if ch in '}])':
+            depth -= 1
+            i += 1
+            continue
+        if ch in _QUOTE and depth != 0:
+            i = _end_of_string(body, i) + 1
+            continue
+        if ch in _QUOTE:
+            match = _ENTRY_RE.match(body, i)
+            if not match:
+                raise LedgerError(
+                    f'{LEDGER}: a quoted string at the top level of UNHONOURED_OPTIONS '
+                    f'near offset {i} is not a `\'Surface\': [...]` entry'
+                )
+            key = match.group(2)
+            value_at = match.end()
+            if value_at >= n or body[value_at] != '[':
+                raise LedgerError(
+                    f"{LEDGER}: the value of '{key}' is not a list of option names. "
+                    'Every entry must be `\'Surface\': [ ... ]` so the options can be counted.'
+                )
+            close = _matching_bracket(body, value_at)
+            if key in surfaces:
+                raise LedgerError(
+                    f"{LEDGER}: surface '{key}' is declared twice; the second wins at "
+                    'runtime and the first is uncounted. Merge them.'
+                )
+            inner = body[value_at + 1:close]
+            options = [m.group(2) for m in _OPTION_RE.finditer(inner)]
+            if len(options) != len(_ANY_STRING_RE.findall(inner)):
+                raise LedgerError(
+                    f"{LEDGER}: '{key}' lists a name that is not a plain identifier, so it "
+                    'would be dropped from the count. Every option must be quoted and match '
+                    '[A-Za-z_][A-Za-z0-9_]*.'
+                )
+            surfaces[key] = options
+            i = close + 1
+            continue
+        i += 1
+    return surfaces
+
+
+def _keys_in_source(body: str) -> List[str]:
+    """A second, independent reading of which surfaces the literal declares."""
+    return [m.group(2) for m in _KEY_RE.finditer(body)]
+
+
+def _verify_parse(body: str, surfaces: Dict[str, List[str]], iterated: Iterable[str]) -> None:
+    """Refuse to report a surface as gone when the ledger still declares it.
+
+    Two cross-checks, because the failure this exists to stop is silent: a
+    surface that drops out of the parse LOWERS the total, which reads as
+    progress and is bankable with --write.
+
+    1. The scanner's keys must match an independently written regex scan of the
+       same text.
+    2. Every surface the TypeScript iterates with `unhonouredFor('X')` must
+       either be parsed or be genuinely absent from the ledger text. Present in
+       the text but missing from the parse is a parse failure, never a closure.
+    """
+    declared = _keys_in_source(body)
+    if sorted(declared) != sorted(surfaces):
+        lost = sorted(set(declared) - set(surfaces))
+        extra = sorted(set(surfaces) - set(declared))
+        raise LedgerError(
+            f'{LEDGER}: two readings of the ledger disagree. '
+            f'Declared but not parsed: {lost or "none"}; parsed but not declared: {extra or "none"}. '
+            'A surface that vanishes from the parse would read as options closed.'
+        )
+    if len(declared) != len(surfaces):  # pragma: no cover - implied by the sort above
+        raise LedgerError(f'{LEDGER}: {len(declared)} entries declared, {len(surfaces)} parsed')
+
+    for surface in sorted(set(iterated)):
+        if surface in surfaces:
+            continue
+        if re.search(r'([\'"`])' + re.escape(surface) + r'\1\s*:', body):
+            raise LedgerError(
+                f"{LEDGER} still declares '{surface}', which the TypeScript iterates with "
+                f"unhonouredFor('{surface}'), but the parse did not see it. That would count "
+                'its options as closed. Fix the parser, not the number.'
+            )
+
+
+def _iterated_surfaces(sources: Sequence[Tuple[str, str]]) -> List[str]:
+    """Surfaces the TypeScript reads back out of the ledger at runtime."""
+    found: List[str] = []
+    for _, text in sources:
+        found += _ITERATES_RE.findall(text)
+    return found
+
+
 def read_ledger(repo_root: Path) -> Behaviour:
     """Parse the ledger and the partial-case call sites out of the sources."""
     ledger_path = repo_root / LEDGER
     if not ledger_path.is_file():
         raise LedgerError(f'{LEDGER} not found; is --repo-root right?')
-    body = _ledger_block(ledger_path.read_text(encoding='utf-8'))
+    body = _strip_comments(_ledger_block(ledger_path.read_text(encoding='utf-8')))
 
-    surfaces: Dict[str, List[str]] = {}
-    for match in _SURFACE_RE.finditer(body):
-        surfaces[match.group(1)] = _OPTION_RE.findall(match.group(2))
+    surfaces = _parse_entries(body)
     if not surfaces:
         # Refuse to report "nothing left to do" because a regex stopped matching.
         raise LedgerError(f'no surfaces parsed from {LEDGER}; the ledger shape changed')
 
-    partial: List[Dict[str, str]] = []
-    src = repo_root / 'src/praisonai-ts/src'
+    sources: List[Tuple[str, str]] = []
+    src = repo_root / TS_SOURCE
     for path in sorted(src.rglob('*.ts')):
         if path.name == 'parity-notice.ts':
             continue
-        for surface, option in _PARTIAL_RE.findall(path.read_text(encoding='utf-8')):
-            partial.append({
-                'surface': surface,
-                'option': option,
-                'file': str(path.relative_to(repo_root).as_posix()),
-            })
+        sources.append((str(path.relative_to(repo_root).as_posix()), path.read_text(encoding='utf-8')))
+
+    _verify_parse(body, surfaces, _iterated_surfaces(sources))
+
+    partial: List[Dict[str, str]] = []
+    for rel, text in sources:
+        for surface, option in _PARTIAL_RE.findall(text):
+            partial.append({'surface': surface, 'option': option, 'file': rel})
     return Behaviour(surfaces=surfaces, partial=partial)
 
 
@@ -122,9 +334,13 @@ def render_markdown(b: Behaviour) -> str:
         'this file counts those: every option the TypeScript SDK takes for Python parity',
         'and does not yet act on. The source is the `UNHONOURED_OPTIONS` ledger in',
         '`src/praisonai-ts/src/utils/parity-notice.ts`, which the surfaces iterate at',
-        'runtime, so the count cannot drift from the behaviour.',
+        'runtime, so every option listed here announces itself when it is passed.',
         '',
-        'The check is a ratchet: the total may fall, never rise.',
+        'The check is a ratchet: the total may fall, never rise, and `--write` enforces',
+        'the same ratchet so a rise cannot be committed without `--allow-growth` and a',
+        'reason. What no check can see is whether a row DELETED from the ledger was',
+        'really implemented: the ledger is hand-written, so each removal is a claim that',
+        'needs a test proving the option changes what the code does.',
         '',
         '## Summary',
         '',
@@ -168,20 +384,67 @@ def render_json(b: Behaviour) -> str:
     return json.dumps(payload, indent=2, sort_keys=True) + '\n'
 
 
-def committed_total(repo_root: Path) -> Optional[int]:
+def committed_report(repo_root: Path) -> Optional[Dict]:
+    """The report as last committed, or None if it is missing or unreadable."""
     path = repo_root / JSON_OUTPUT
     if not path.is_file():
         return None
     try:
-        return int(json.loads(path.read_text(encoding='utf-8'))['total'])
-    except (ValueError, KeyError, TypeError):
+        data = json.loads(path.read_text(encoding='utf-8'))
+        int(data['total'])
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError):
         return None
+    return data
+
+
+def committed_total(repo_root: Path) -> Optional[int]:
+    data = committed_report(repo_root)
+    return None if data is None else int(data['total'])
+
+
+def _removed_since(previous: Optional[Dict], now: Behaviour) -> List[str]:
+    """`Surface.option` entries the ledger has dropped since the last commit."""
+    if not previous:
+        return []
+    before = previous.get('surfaces') or {}
+    if not isinstance(before, dict):
+        return []
+    gone: List[str] = []
+    for surface, options in sorted(before.items()):
+        current = set(now.surfaces.get(surface, []))
+        for option in sorted(options if isinstance(options, list) else []):
+            if option not in current:
+                gone.append(f'{surface}.{option}')
+    return gone
+
+
+# Deleting an entry from the ledger is a CLAIM that the behaviour was
+# implemented, and nothing here can verify it: the ledger is hand-written, and
+# every option in it is already named in the TypeScript sources (the signature
+# gate requires the parameter to exist) and in some test. Measured, not assumed
+# -- see the README's "what this cannot check". So this prints the claim for a
+# reviewer instead of pretending to check it.
+_REMOVAL_NOTE = (
+    'This tool cannot verify that: the ledger is hand-written and the option name '
+    'already appears in the sources and tests either way. Each needs a test proving '
+    'the option changes what the code does, with a control showing it does not when '
+    'the option is absent.'
+)
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.split('\n')[1])
     parser.add_argument('--write', action='store_true', help='regenerate the report')
     parser.add_argument('--check', action='store_true', help='fail if the report is stale or the total grew')
+    parser.add_argument(
+        '--allow-growth',
+        action='store_true',
+        help=(
+            'let --write RAISE the committed total. Growth means another option is '
+            'accepted and ignored, so it needs a reason in the pull request that '
+            'banks it. Lowering the total never needs this flag.'
+        ),
+    )
     parser.add_argument('--repo-root', type=Path, default=None)
     args = parser.parse_args(argv)
 
@@ -193,10 +456,31 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 2
     md, js = render_markdown(b), render_json(b)
 
+    previous = committed_report(repo_root)
+    baseline = None if previous is None else int(previous['total'])
+
     if args.write:
+        # The ratchet has to hold here too. This runs on every push to main and
+        # auto-commits, so without this a rise reached main by being written
+        # rather than by being argued for, and became the new floor.
+        if baseline is not None and b.total > baseline and not args.allow_growth:
+            print(
+                f'behaviour parity: refusing to write. {b.total} options are accepted and not '
+                f'acted on, up from the committed {baseline}. Implement the behaviour, or pass '
+                '--allow-growth and say in the pull request why another option had to be '
+                'accepted before it works.',
+                file=sys.stderr,
+            )
+            return 1
+        removed = _removed_since(previous, b)
         (repo_root / MD_OUTPUT).write_text(md, encoding='utf-8')
         (repo_root / JSON_OUTPUT).write_text(js, encoding='utf-8')
         print(f'wrote {MD_OUTPUT} and {JSON_OUTPUT} -- {b.total} options across {len(b.surfaces)} surfaces')
+        if removed:
+            print(f'\nclaimed closed by this change ({len(removed)}): {", ".join(removed)}')
+            print(_REMOVAL_NOTE)
+        if baseline is not None and b.total > baseline:
+            print(f'\nthe total ROSE from {baseline} to {b.total}, banked with --allow-growth.')
         return 0
 
     print(f'behaviour parity: {b.total} options not yet acted on, across {len(b.surfaces)} surfaces'
@@ -206,7 +490,6 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 0
 
     failures: List[str] = []
-    baseline = committed_total(repo_root)
     if baseline is None:
         failures.append(f'{JSON_OUTPUT} is missing or unreadable -- run --write and commit it')
     elif b.total > baseline:
@@ -224,6 +507,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         # Closing an option is the point of this file. Say that first, so the
         # instruction reads as banking progress rather than as a reprimand.
         print(f'\n{baseline - b.total} option(s) closed since the last commit: {baseline} -> {b.total}.')
+        removed = _removed_since(previous, b)
+        if removed:
+            print(f'claimed closed: {", ".join(removed)}')
+            print(_REMOVAL_NOTE)
     failures += [f'{rel} is out of date -- run --write and commit the result' for rel in stale]
 
     if failures:

--- a/src/praisonai/praisonai/_dev/parity/python_extractor.py
+++ b/src/praisonai/praisonai/_dev/parity/python_extractor.py
@@ -53,11 +53,23 @@ class PythonFeatureExtractor:
     Extracts features from praisonaiagents package using AST analysis.
     
     This extractor parses the __init__.py file to find:
-    - _LAZY_IMPORTS dictionary entries
-    - __all__ exports
-    - Direct imports
-    
+    - ``_LAZY_IMPORTS`` dictionary entries, including later
+      ``_LAZY_IMPORTS.update({...})`` calls
+    - ``__all__`` exports
+    - direct top-level imports -- ``from . import X``,
+      ``from .module import Y as Z``, ``from praisonaiagents.m import Y``
+
+    A direct import is skipped when the bound name is private (``_x``) or when
+    it comes from a private submodule (``from ._lazy import ..``): those are
+    internal plumbing, not public surface. Imports of stdlib or third-party
+    modules are not part of this SDK's surface and are skipped too.
+
     It categorizes exports into modules based on their import paths.
+
+    Every mechanism named above is implemented. Anything that looks like one
+    but cannot be read -- a ``_LAZY_IMPORTS.update`` whose argument is not a
+    literal dict, for instance -- raises instead of silently contributing
+    nothing, because a partial loss here shows up downstream as parity.
     """
     
     # Category mapping based on module paths
@@ -122,19 +134,22 @@ class PythonFeatureExtractor:
         if init_file.exists():
             lazy_imports = self._extract_lazy_imports(init_file)
             all_exports = self._extract_all_exports(init_file)
-            
-            # Combine lazy imports and __all__ exports
-            all_names = set(lazy_imports.keys()) | all_exports
-            
+            direct_imports = self._extract_direct_imports(init_file)
+
+            # Combine lazy imports, direct imports and __all__ exports
+            all_names = set(lazy_imports) | set(direct_imports) | all_exports
+
             for name in sorted(all_names):
                 if name in lazy_imports:
                     module_path, _ = lazy_imports[name]
                     category = self._categorize(module_path)
-                    kind = self._infer_kind(name)
+                elif name in direct_imports:
+                    module_path = direct_imports[name]
+                    category = self._categorize(module_path)
                 else:
                     module_path = 'praisonaiagents'
                     category = 'other'
-                    kind = self._infer_kind(name)
+                kind = self._infer_kind(name)
                 
                 features.exports.append(PythonExport(
                     name=name,
@@ -169,18 +184,100 @@ class PythonFeatureExtractor:
                 for target in node.targets:
                     if isinstance(target, ast.Name) and target.id == '_LAZY_IMPORTS':
                         if isinstance(node.value, ast.Dict):
-                            for k, v in zip(node.value.keys, node.value.values):
-                                if k and isinstance(k, ast.Constant) and isinstance(k.value, str):
-                                    if isinstance(v, ast.Tuple) and len(v.elts) >= 2:
-                                        module_elt = v.elts[0]
-                                        attr_elt = v.elts[1]
-                                        if (isinstance(module_elt, ast.Constant) and 
-                                            isinstance(module_elt.value, str) and
-                                            isinstance(attr_elt, ast.Constant) and 
-                                            isinstance(attr_elt.value, str)):
-                                            lazy_imports[k.value] = (module_elt.value, attr_elt.value)
-        
+                            entries = self._read_lazy_dict(node.value)
+                            if entries is not None:
+                                lazy_imports.update(entries)
+            elif self._is_lazy_update(node):
+                # `_LAZY_IMPORTS.update({...})` adds public names just like the
+                # literal above; ignoring it lost them silently.
+                entries = (
+                    self._read_lazy_dict(node.args[0])
+                    if len(node.args) == 1 and not node.keywords
+                    and isinstance(node.args[0], ast.Dict)
+                    else None
+                )
+                if entries is None:
+                    raise RuntimeError(
+                        f"{init_file}:{getattr(node, 'lineno', '?')}: cannot read "
+                        f"this _LAZY_IMPORTS.update(...) call. Only a literal dict "
+                        f"of 'Name': ('module', 'attr') entries is supported. "
+                        f"Refusing to report parity for a public surface this "
+                        f"extractor cannot see."
+                    )
+                lazy_imports.update(entries)
+
         return lazy_imports
+
+    @staticmethod
+    def _is_lazy_update(node: ast.AST) -> bool:
+        """True for a ``_LAZY_IMPORTS.update(..)`` call node."""
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'update'
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == '_LAZY_IMPORTS'
+        )
+
+    @staticmethod
+    def _read_lazy_dict(node: ast.Dict) -> Optional[Dict[str, Tuple[str, str]]]:
+        """Read a ``{'Name': ('module', 'attr')}`` literal, or None if it is not one."""
+        entries: Dict[str, Tuple[str, str]] = {}
+        for key, value in zip(node.keys, node.values):
+            if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
+                return None
+            if not (isinstance(value, ast.Tuple) and len(value.elts) >= 2):
+                return None
+            module_elt, attr_elt = value.elts[0], value.elts[1]
+            if not (isinstance(module_elt, ast.Constant)
+                    and isinstance(module_elt.value, str)
+                    and isinstance(attr_elt, ast.Constant)
+                    and isinstance(attr_elt.value, str)):
+                return None
+            entries[key.value] = (module_elt.value, attr_elt.value)
+        return entries
+
+    def _extract_direct_imports(self, init_file: Path) -> Dict[str, str]:
+        """Extract top-level ``from ... import ...`` bindings from __init__.py.
+
+        These are public exports added the ordinary way -- ``praisonaiagents.X``
+        resolves to them with no ``__getattr__`` involved -- and they were
+        invisible to this extractor, so adding one closed no gap and raised no
+        alarm.
+
+        Returns a mapping of bound name -> module path it came from.
+        """
+        direct: Dict[str, str] = {}
+
+        try:
+            with open(init_file, 'r', encoding='utf-8') as f:
+                source = f.read()
+            tree = ast.parse(source)
+        except (SyntaxError, UnicodeDecodeError):
+            return direct
+
+        for node in tree.body:
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            module = node.module or ''
+            if node.level:
+                # relative: `from . import X` / `from .agent.agent import Y`
+                base = f"praisonaiagents.{module}" if module else "praisonaiagents"
+            elif module == 'praisonaiagents' or module.startswith('praisonaiagents.'):
+                base = module
+            else:
+                continue  # stdlib / third-party: not this SDK's surface
+            if any(part.startswith('_') for part in base.split('.')[1:]):
+                continue  # private submodule -> internal plumbing
+
+            for alias in node.names:
+                name = alias.asname or alias.name
+                if alias.name == '*' or name.startswith('_') or alias.name.startswith('_'):
+                    continue
+                # `from . import workflows` binds the submodule itself
+                direct[name] = base if module else f"praisonaiagents.{alias.name}"
+
+        return direct
     
     def _extract_all_exports(self, init_file: Path) -> Set[str]:
         """Extract __all__ list from __init__.py."""

--- a/src/praisonai/praisonai/_dev/parity/signatures/compare.py
+++ b/src/praisonai/praisonai/_dev/parity/signatures/compare.py
@@ -13,6 +13,7 @@ checked), 2 tooling failure (node/typescript missing, surface not found).
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import os
 import re
@@ -30,6 +31,7 @@ from .py_extract import (
     DEFAULT_PYTHON_ROOT,
     PythonSurfaceNotFound,
     extract_python_surface,
+    normalise_default,
 )
 from .schema import Param, SurfaceSignature, snake_to_camel
 
@@ -47,7 +49,11 @@ GENERATED_BY = 'praisonai._dev.parity.signatures'
 BASELINE_REASON = 'baseline 2026-09-02: not yet ported to TypeScript'
 BASELINE_OWNER = 'praisonai-ts'
 
-MATCH_ORDER = ('exact', 'camelCase', 'alias', 'flattened', 'missing')
+# Resolution order, strictest rule first. `flattened` precedes `alias` because a
+# flattening is the stricter statement of the two: `caching -> [cache, cacheTTL]`
+# checks both TS fields, while the `caching -> cache` alias checked only one. With
+# `alias` first the flattening never fired at all.
+MATCH_ORDER = ('exact', 'camelCase', 'flattened', 'alias', 'missing')
 
 EXIT_OK = 0
 EXIT_PARITY = 1
@@ -87,11 +93,47 @@ class SurfaceCatalogue:
 
 
 @dataclass
+class Flattening:
+    """
+    One ``rules.yaml`` ``flattened`` entry: a nested Python config parameter that
+    TypeScript spells out as several top-level fields.
+
+    ``python_config`` (``"<file under python_root>:<ClassName>"``) and
+    ``field_map`` (TS field -> field of that class) say which Python default each
+    TS field must agree with. Without them only required-ness is checked, because
+    the Python parameter's own default (usually ``None``) says nothing about what
+    the individual fields resolve to.
+    """
+    fields: List[str] = field(default_factory=list)
+    python_config: Optional[str] = None
+    field_map: Dict[str, Optional[str]] = field(default_factory=dict)
+
+    @classmethod
+    def from_yaml(cls, value: Any) -> 'Flattening':
+        if isinstance(value, list):
+            return cls(fields=[str(f) for f in value])
+        if not isinstance(value, dict):
+            raise ToolingError(f'rules.yaml: a flattened entry must be a list or a mapping, got {value!r}')
+        mapping = value.get('fields') or {}
+        if isinstance(mapping, list):
+            return cls(fields=[str(f) for f in mapping], python_config=value.get('python_config'))
+        return cls(
+            fields=[str(f) for f in mapping],
+            python_config=value.get('python_config'),
+            field_map={str(k): (str(v) if v is not None else None) for k, v in mapping.items()},
+        )
+
+
+@dataclass
 class Rules:
     """Contents of ``rules.yaml``."""
     case: str = 'snake_to_camel'
     aliases: Dict[str, Dict[str, str]] = field(default_factory=dict)
-    flattened: Dict[str, Dict[str, List[str]]] = field(default_factory=dict)
+    flattened: Dict[str, Dict[str, Flattening]] = field(default_factory=dict)
+    #: ``"<file>:<Class>"`` -> ``{field name: Param}``, resolved from the Python
+    #: source by :func:`load_nested_config_defaults`. Empty when the comparator
+    #: runs on pre-extracted fixtures with no repository to read.
+    nested_defaults: Dict[str, Dict[str, Param]] = field(default_factory=dict)
     default_equivalences: List[Tuple[Any, Any]] = field(default_factory=list)
     #: ``(python expression text, typescript token)`` pairs. Separate from
     #: ``default_equivalences`` because a Python *expression* default (a module
@@ -113,7 +155,7 @@ class Rules:
             default_expr_equivalences=expr_equivalences,
             case=data.get('case', 'snake_to_camel'),
             aliases={k: dict(v or {}) for k, v in (data.get('aliases') or {}).items()},
-            flattened={k: {p: list(f) for p, f in (v or {}).items()}
+            flattened={k: {p: Flattening.from_yaml(f) for p, f in (v or {}).items()}
                        for k, v in (data.get('flattened') or {}).items()},
             default_equivalences=equivalences,
         )
@@ -132,6 +174,21 @@ class Waiver:
     owner: str
     issue: Optional[str] = None
     expires: Optional[date] = None
+    kinds: Optional[List[str]] = None
+
+    #: A waiver is keyed by parameter, so without this it silences every KIND of
+    #: gap on that parameter. Waiving a default difference would then also hide a
+    #: parameter becoming REQUIRED in TypeScript -- a change that breaks every
+    #: caller. Found by making verbose/markdown/stream required behind the
+    #: `Agent.__init__.output` waiver and watching the gate stay green.
+    #: So required-ness is never covered implicitly: a waiver must name it.
+    EXPLICIT_ONLY = ('required',)
+
+    def covers(self, gap_kind: str) -> bool:
+        """Whether this waiver suppresses a gap of ``gap_kind``."""
+        if self.kinds is not None:
+            return gap_kind in self.kinds
+        return gap_kind not in self.EXPLICIT_ONLY
 
     @classmethod
     def from_dict(cls, key: str, data: Dict[str, Any]) -> 'Waiver':
@@ -142,12 +199,18 @@ class Waiver:
         expires = data.get('expires')
         if isinstance(expires, str):
             expires = date.fromisoformat(expires)
+        kinds = data.get('kinds')
+        if kinds is not None:
+            if not isinstance(kinds, list) or not all(isinstance(k, str) for k in kinds):
+                raise ToolingError(f'waiver "{key}": "kinds" must be a list of gap kinds')
+            kinds = [str(k) for k in kinds]
         return cls(
             key=key,
             reason=str(data['reason']),
             owner=str(data['owner']),
             issue=str(data['issue']) if data.get('issue') else None,
             expires=expires,
+            kinds=kinds,
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -156,6 +219,8 @@ class Waiver:
             out['issue'] = self.issue
         if self.expires:
             out['expires'] = self.expires
+        if self.kinds is not None:
+            out['kinds'] = list(self.kinds)
         return out
 
     def expired(self, today: date) -> bool:
@@ -181,6 +246,48 @@ def load_surfaces(path: Optional[Path] = None) -> SurfaceCatalogue:
 def load_rules(path: Optional[Path] = None) -> Rules:
     path = path or DEFAULT_RULES_FILE
     return Rules.from_dict(yaml.safe_load(path.read_text(encoding='utf-8')) or {})
+
+
+def read_config_class_defaults(repo_root: Path, python_root: str, spec: str) -> Dict[str, Param]:
+    """
+    Field defaults of a Python config dataclass named ``"<file>:<ClassName>"``.
+
+    ``Agent(output=None)`` resolves to ``OutputConfig()``, so ``OutputConfig``'s
+    field defaults -- not the ``output`` parameter's ``None`` -- are what the
+    flattened TypeScript fields must agree with.
+    """
+    rel, _, class_name = spec.partition(':')
+    if not rel or not class_name:
+        raise ToolingError(f'rules.yaml: python_config must be "<file>:<ClassName>", got "{spec}"')
+    path = Path(repo_root) / python_root / rel
+    if not path.is_file():
+        raise ToolingError(f'rules.yaml: python_config file not found: {path}')
+    tree = ast.parse(path.read_text(encoding='utf-8'))
+    decl = next((n for n in ast.walk(tree)
+                 if isinstance(n, ast.ClassDef) and n.name == class_name), None)
+    if decl is None:
+        raise ToolingError(f'rules.yaml: python_config class {class_name} not found in {path}')
+    out: Dict[str, Param] = {}
+    for stmt in decl.body:
+        if not isinstance(stmt, ast.AnnAssign) or not isinstance(stmt.target, ast.Name):
+            continue
+        name = stmt.target.id
+        default, kind = normalise_default(stmt.value)
+        out[name] = Param(
+            name=name, canonical=snake_to_camel(name), kind='keyword',
+            required=stmt.value is None, default=default, default_kind=kind,
+            type_text=ast.unparse(stmt.annotation) if stmt.annotation is not None else '',
+        )
+    return out
+
+
+def load_nested_config_defaults(rules: Rules, repo_root: Path, python_root: str) -> None:
+    """Fill ``rules.nested_defaults`` for every ``python_config`` named in the rules."""
+    for surface in rules.flattened.values():
+        for flat in surface.values():
+            if flat.python_config and flat.python_config not in rules.nested_defaults:
+                rules.nested_defaults[flat.python_config] = read_config_class_defaults(
+                    repo_root, python_root, flat.python_config)
 
 
 def load_waivers(path: Optional[Path] = None) -> List[Waiver]:
@@ -223,6 +330,11 @@ class ParamRow:
     match: str                       # one of MATCH_ORDER
     ts: Optional[Param] = None       # matched TS member (None for flattened/missing)
     ts_names: List[str] = field(default_factory=list)
+    #: The TS members a `flattened` match resolved to. Populated so gap detection
+    #: can run on them: `ts` stays None for a flattening, and gating gap
+    #: detection on `ts is not None` is what let a flattened field become
+    #: REQUIRED (`new Agent({ name })` stops compiling) with a green gate.
+    ts_members: List[Param] = field(default_factory=list)
     gap: Optional[Gap] = None
     warnings: List[str] = field(default_factory=list)
     waived: Optional[Waiver] = None
@@ -241,6 +353,18 @@ class SurfaceComparison:
     typescript: SurfaceSignature
     rows: List[ParamRow] = field(default_factory=list)
     ts_only: List[Param] = field(default_factory=list)
+
+    def ts_only_required(self) -> List[Param]:
+        """
+        TS-only members the caller MUST pass. An optional one is informational.
+
+        The constructor's own options parameter (`constructor(config:
+        SimpleAgentConfig)`) is excluded: it is required, but a required options
+        OBJECT is not a parity gap -- its members are the compared surface, and
+        Python spells them out as keyword arguments.
+        """
+        carriers = set(self.typescript.extra.get('options_parameters') or [])
+        return [p for p in self.ts_only if p.required and p.name not in carriers]
 
     def counts(self) -> Dict[str, int]:
         counts = {m: 0 for m in MATCH_ORDER}
@@ -266,6 +390,13 @@ class SurfaceComparison:
         }
 
 
+#: The TypeScript extractor emits this when the constructor decides a member's
+#: fallback in a form it cannot evaluate. It is NOT the same as "no default", and
+#: must never compare equal to anything: reading it as `undefined` is how an
+#: invented default (`reasoningEffort: 'high'`, approval forced on) slipped past.
+UNKNOWN_DEFAULT_KIND = 'unknown'
+
+
 def _ts_default_token(param: Param) -> Any:
     """The comparable form of a TS default: JSON literal, expr text, or 'undefined'."""
     if param.default_kind is None:
@@ -275,6 +406,8 @@ def _ts_default_token(param: Param) -> Any:
 
 def defaults_equivalent(py: Param, ts: Param, rules: Rules) -> bool:
     """True when the Python default and the TS effective default mean the same thing."""
+    if ts.default_kind == UNKNOWN_DEFAULT_KIND:
+        return False
     ts_token = _ts_default_token(ts)
     py_value = py.default
     if py.default_kind == 'literal' and ts.default_kind == 'literal':
@@ -302,11 +435,28 @@ def _fmt_default(param: Optional[Param]) -> str:
         return ''
     if param.required:
         return '*required*'
+    if param.default_kind == UNKNOWN_DEFAULT_KIND:
+        return 'unknown'
     if param.default_kind is None:
         return 'undefined'
     if param.default_kind == 'literal':
         return json.dumps(param.default)
     return f'`{param.default}`'
+
+
+def _fmt_row_ts_default(row: ParamRow) -> str:
+    """
+    The TS-default cell for one row.
+
+    A flattened row has no single TS member, so it lists each field's default.
+    Leaving the cell blank (which it was) meant a flattened field's default
+    could change without the report changing -- and report freshness is a gate.
+    """
+    if row.ts is not None:
+        return _fmt_default(row.ts)
+    if not row.ts_members:
+        return ''
+    return ', '.join(f'{m.name}={_fmt_default(m)}' for m in row.ts_members)
 
 
 def compare_surface(py: SurfaceSignature, ts: SurfaceSignature, rules: Rules) -> SurfaceComparison:
@@ -322,20 +472,26 @@ def compare_surface(py: SurfaceSignature, ts: SurfaceSignature, rules: Rules) ->
             continue
         row = ParamRow(python=param, match='missing')
         canonical = rules.canonical(param.name)
+        flat = flattened.get(param.name)
+        # Resolution order: MATCH_ORDER. `flattened` beats `alias` -- see the
+        # comment on that constant.
         if param.name in ts_by_name:
             row.match, row.ts = 'exact', ts_by_name[param.name]
         elif canonical in ts_by_name:
             row.match, row.ts = 'camelCase', ts_by_name[canonical]
+        elif flat is not None and all(f in ts_by_name for f in flat.fields):
+            row.match = 'flattened'
+            row.ts_names = list(flat.fields)
+            row.ts_members = [ts_by_name[f] for f in flat.fields]
         elif aliases.get(param.name) in ts_by_name:
             row.match, row.ts = 'alias', ts_by_name[aliases[param.name]]
-        elif param.name in flattened and all(f in ts_by_name for f in flattened[param.name]):
-            row.match, row.ts_names = 'flattened', list(flattened[param.name])
 
         if row.ts is not None:
             matched_ts.add(row.ts.name)
             _detect_gaps(row, rules)
         elif row.match == 'flattened':
             matched_ts.update(row.ts_names)
+            _detect_flattened_gaps(row, rules, flat)
         else:
             row.gap = Gap('missing', f'is missing from TypeScript (looked for `{canonical}`)')
         rows.append(row)
@@ -358,6 +514,53 @@ def _detect_gaps(row: ParamRow, rules: Rules) -> None:
         )
     if py.type_class != 'unknown' and ts.type_class != 'unknown' and py.type_class != ts.type_class:
         row.warnings.append(f'type differs: python {py.type_class} ({py.type_text}) vs typescript {ts.type_class} ({ts.type_text})')
+
+
+def _detect_flattened_gaps(row: ParamRow, rules: Rules, flat: Flattening) -> None:
+    """
+    Check every TS member a flattening resolved to.
+
+    Before this existed a `flattened` row set `ts_names` and left `ts` None, and
+    `compare_surface` only ran gap detection `if row.ts is not None` -- so the
+    required-ness and defaults of those fields were never compared at all.
+    Making `verbose`, `markdown` and `stream` REQUIRED in `SimpleAgentConfig`
+    (which stops `new Agent({ name })` compiling for every user) left the report
+    byte-identical and every gate green.
+    """
+    py = row.python
+    nested = rules.nested_defaults.get(flat.python_config or '', {})
+    required_problems: List[str] = []
+    default_problems: List[str] = []
+    for member in row.ts_members:
+        # The Python side of this field: the nested config's field when the rule
+        # names one, else the flattened parameter itself.
+        py_field_name = flat.field_map.get(member.name, member.name) if flat.field_map else None
+        py_side = nested.get(py_field_name) if py_field_name else None
+        expected_required = py_side.required if py_side is not None else py.required
+        if expected_required != member.required:
+            side = 'required in Python but optional in TypeScript' if expected_required \
+                else 'optional in Python but required in TypeScript'
+            required_problems.append(f'`{member.name}` is {side}')
+            continue
+        if member.required:
+            continue
+        if py_side is None:
+            # A TS field with no Python counterpart (`cacheTTL`). Nothing to
+            # compare its default against; required-ness above is the whole check.
+            continue
+        if not defaults_equivalent(py_side, member, rules):
+            default_problems.append(
+                f'`{member.name}` default differs: python {py_field_name}='
+                f'{_fmt_default(py_side)} typescript={_fmt_default(member)}'
+            )
+    problems = required_problems + default_problems
+    if not problems:
+        return
+    where = f'flattened to TS [{", ".join(row.ts_names)}]'
+    row.gap = Gap(
+        'required' if required_problems else 'default',
+        f'is {where} and {"; ".join(problems)}',
+    )
 
 
 def signatures_from_json(items: Iterable[Dict[str, Any]]) -> Dict[str, SurfaceSignature]:
@@ -424,6 +627,31 @@ def evaluate(
     by_key = {w.key: w for w in waivers}
     used: set = set()
     for comparison in comparisons:
+        # A TS-only member that is REQUIRED is a parity failure: TypeScript
+        # callers must pass something Python has no way to express, so no
+        # program can be written against both SDKs. `ts_only` used to be
+        # computed and rendered and never looked at, so adding a required
+        # `tenantId` to SimpleAgentConfig failed only on report freshness --
+        # and running `--write`, exactly what the CI error tells you to do,
+        # made it green. An OPTIONAL TS-only member stays informational.
+        for member in comparison.ts_only_required():
+            key = f'{comparison.key}.{member.name}'
+            waiver = by_key.get(key)
+            detail = (f'TypeScript-only member `{member.name}` is required, so a TypeScript '
+                      f'caller must pass a value Python cannot express')
+            if waiver is None:
+                result.failures.append(
+                    f'{comparison.key}: {detail} -- make it optional, port it to Python, '
+                    f'or add a waiver "{key}"'
+                )
+                continue
+            used.add(key)
+            if waiver.expired(today):
+                result.failures.append(
+                    f'{comparison.key}: waiver for `{member.name}` expired on '
+                    f'{waiver.expires.isoformat()} but the gap remains ({detail}) '
+                    f'-- port it or extend the waiver'
+                )
         for row in comparison.rows:
             for warning in row.warnings:
                 result.warnings.append(f'{comparison.key}: `{row.python.name}` {warning}')
@@ -431,6 +659,17 @@ def evaluate(
                 continue
             key = f'{comparison.key}.{row.python.name}'
             waiver = by_key.get(key)
+            if waiver is not None and not waiver.covers(row.gap.kind):
+                # The waiver exists but does not name this kind of gap. Required-ness
+                # is never covered implicitly, so a parameter turning required in
+                # TypeScript still fails even where its default is waived.
+                used.add(key)
+                result.failures.append(
+                    f'{comparison.key}: parameter `{row.python.name}` {row.gap.detail} '
+                    f'-- the waiver "{key}" does not cover a {row.gap.kind} gap; '
+                    f'port it, or add {row.gap.kind!r} to that waiver\'s "kinds" and say why'
+                )
+                continue
             if waiver is None:
                 result.failures.append(
                     f'{comparison.key}: parameter `{row.python.name}` {row.gap.detail} '
@@ -491,7 +730,7 @@ def render_surface_markdown(comparison: SurfaceComparison) -> str:
         p = row.python
         lines.append('| ' + ' | '.join(_md_escape(x) for x in (
             f'`{p.name}`', p.kind, _fmt_default(p), f'`{p.type_text}`' if p.type_text else '',
-            row.match, f'`{row.ts_name}`' if row.ts_name else '', _fmt_default(row.ts),
+            row.match, f'`{row.ts_name}`' if row.ts_name else '', _fmt_row_ts_default(row),
             f'`{row.ts.type_text}`' if row.ts is not None and row.ts.type_text else '',
             _status(row),
         )) + ' |')
@@ -499,6 +738,10 @@ def render_surface_markdown(comparison: SurfaceComparison) -> str:
     if comparison.ts_only:
         lines.append('TS-only members: ' + ', '.join(
             f'`{p.name}`' + ('' if p.required else '?') for p in comparison.ts_only))
+        if comparison.ts_only_required():
+            lines.append('')
+            lines.append('TS-only members that are REQUIRED (a TypeScript caller must pass them): '
+                         + ', '.join(f'`{p.name}`' for p in comparison.ts_only_required()))
     else:
         lines.append('TS-only members: none')
     lines.append('')
@@ -527,11 +770,16 @@ def render_markdown(comparisons: List[SurfaceComparison], waivers: List[Waiver])
         'For each curated surface in `surface.yaml`, every Python parameter (positional and',
         'keyword-only; `*args`/`**kwargs` excluded) is looked up on the TypeScript side',
         'as an interface member or method parameter. Matching order: **exact** name,',
-        '**camelCase** (`snake_to_camel`), **alias** (`rules.yaml`), **flattened** (a nested',
-        'Python config exposed as several TS fields), else **missing**. For matched pairs the',
+        '**camelCase** (`snake_to_camel`), **flattened** (a nested Python config exposed as',
+        'several TS fields), **alias** (`rules.yaml`), else **missing**. For matched pairs the',
         'checker compares required-ness and the effective default (TS constructor',
-        'fallbacks such as `config.x ?? v` count as defaults). Type classes are compared',
-        'as a warning only. Every gap must be waived in `waivers.yaml` or the check fails.',
+        'fallbacks such as `config.x ?? v` count as defaults); a flattened parameter is',
+        'checked against every TS field it names, and against the Python nested-config',
+        "field defaults when `rules.yaml` names them. A TS default the extractor cannot",
+        'evaluate reads as `unknown` and needs a waiver rather than passing as `undefined`.',
+        'A **required** TS-only member fails the check; an optional one is informational.',
+        'Type classes are compared as a warning only. Every gap must be waived in',
+        '`waivers.yaml` or the check fails.',
         'This complements `PARITY.md`, which only tracks whether an export exists.',
         '',
         '## Summary',
@@ -578,6 +826,7 @@ def render_json(comparisons: List[SurfaceComparison], waivers: List[Waiver]) -> 
                 'match': row.match,
                 'ts_name': row.ts_name or None,
                 'ts': row.ts.to_dict() if row.ts is not None else None,
+                'ts_members': [m.to_dict() for m in row.ts_members] or None,
                 'gap': {'kind': row.gap.kind, 'detail': row.gap.detail} if row.gap else None,
                 'waived': row.waived.key if row.waived else None,
                 'warnings': list(row.warnings),
@@ -589,6 +838,7 @@ def render_json(comparisons: List[SurfaceComparison], waivers: List[Waiver]) -> 
             'counts': c.counts(),
             'params': params,
             'ts_only': [p.to_dict() for p in c.ts_only],
+            'ts_only_required': [p.name for p in c.ts_only_required()],
         }
     doc = {
         'generatedBy': GENERATED_BY,
@@ -601,6 +851,115 @@ def render_json(comparisons: List[SurfaceComparison], waivers: List[Waiver]) -> 
         ],
     }
     return json.dumps(doc, indent=2, sort_keys=True) + '\n'
+
+
+# ------------------------------------------------------------ rules self-test
+
+def validate_rules(
+    rules: Rules,
+    python: Dict[str, SurfaceSignature],
+    typescript: Dict[str, SurfaceSignature],
+) -> List[str]:
+    """
+    Problems with ``rules.yaml`` itself, checked against a real extraction.
+
+    Every entry in this file exists to make a match happen. An entry that can
+    never fire is dead weight that reads as coverage: eight of them had
+    accumulated -- aliases for Python parameters that no longer exist, aliases
+    shadowed by the exact/camelCase tiers that run first, a pure case change
+    (which the file's own header says an alias must not be), a flattening
+    shadowed by an alias, and two ``default_equivalences`` the literal branch of
+    :func:`defaults_equivalent` returns True for before the loop is reached.
+    ``test_config_files_load`` did not catch any of them because it only asserted
+    that the YAML says what the YAML says.
+
+    Returns a list of human-readable problems; empty means the rules are clean.
+    """
+    problems: List[str] = []
+
+    for py_value, ts_value in rules.default_equivalences:
+        if py_value == ts_value and type(py_value) is type(ts_value):
+            problems.append(
+                f'default_equivalences: {{python: {py_value!r}, typescript: {ts_value!r}}} is '
+                f'unreachable -- identical literals already compare equal before the loop'
+            )
+
+    def tiers_before(surface: str, py_name: str, ts_names: set) -> Optional[str]:
+        """The earlier MATCH_ORDER tier that already resolves ``py_name``, if any."""
+        if py_name in ts_names:
+            return f'the exact-name tier already matches TS `{py_name}`'
+        canonical = rules.canonical(py_name)
+        if canonical in ts_names:
+            return f'the camelCase tier already matches TS `{canonical}`'
+        return None
+
+    for surface, aliases in sorted(rules.aliases.items()):
+        if surface not in python or surface not in typescript:
+            continue
+        py_names = {p.name for p in python[surface].params}
+        ts_names = {p.name for p in typescript[surface].params if not p.variadic}
+        flattened = rules.flattened.get(surface, {})
+        for py_name, ts_name in sorted(aliases.items()):
+            where = f'aliases.{surface}.{py_name} -> {ts_name}'
+            if py_name not in py_names:
+                problems.append(f'{where}: no Python parameter named `{py_name}` on this surface')
+                continue
+            if rules.canonical(py_name) == ts_name:
+                problems.append(
+                    f'{where}: is a pure case change, which the camelCase tier already does '
+                    f'-- delete it (rules.yaml says an alias must NOT be a pure case change)'
+                )
+                continue
+            shadow = tiers_before(surface, py_name, ts_names)
+            if shadow:
+                problems.append(f'{where}: never fires -- {shadow}')
+                continue
+            if py_name in flattened and all(f in ts_names for f in flattened[py_name].fields):
+                problems.append(
+                    f'{where}: never fires -- the flattened rule for `{py_name}` resolves first'
+                )
+                continue
+            if ts_name not in ts_names:
+                problems.append(f'{where}: no TypeScript member named `{ts_name}` on this surface')
+
+    for surface, entries in sorted(rules.flattened.items()):
+        if surface not in python or surface not in typescript:
+            continue
+        py_names = {p.name for p in python[surface].params}
+        ts_names = {p.name for p in typescript[surface].params if not p.variadic}
+        for py_name, flat in sorted(entries.items()):
+            where = f'flattened.{surface}.{py_name}'
+            if py_name not in py_names:
+                problems.append(f'{where}: no Python parameter named `{py_name}` on this surface')
+                continue
+            shadow = tiers_before(surface, py_name, ts_names)
+            if shadow:
+                problems.append(f'{where}: never fires -- {shadow}')
+                continue
+            missing = [f for f in flat.fields if f not in ts_names]
+            if missing:
+                problems.append(
+                    f'{where}: TypeScript member(s) {", ".join("`" + m + "`" for m in missing)} '
+                    f'do not exist, so the rule never fires'
+                )
+                continue
+            if not flat.fields:
+                problems.append(f'{where}: lists no TypeScript fields')
+                continue
+            nested = rules.nested_defaults.get(flat.python_config or '')
+            for ts_field, py_field in sorted(flat.field_map.items()):
+                if py_field is None:
+                    continue
+                if nested is None:
+                    problems.append(
+                        f'{where}.{ts_field}: maps to Python `{py_field}` but no python_config '
+                        f'was resolved to look it up in'
+                    )
+                elif py_field not in nested:
+                    problems.append(
+                        f'{where}.{ts_field}: `{flat.python_config}` has no field `{py_field}`'
+                    )
+    return problems
 
 
 # ------------------------------------------------------------------- extraction
@@ -672,24 +1031,26 @@ def baseline_waivers(comparisons: List[SurfaceComparison], existing: List[Waiver
                      reason: str = BASELINE_REASON, owner: str = BASELINE_OWNER) -> List[Waiver]:
     """Existing waivers plus one for every currently un-waived gap (never overwrites)."""
     by_key = {w.key: w for w in existing}
-    for c in comparisons:
-        for row in c.rows:
-            if row.gap is None:
-                continue
-            key = f'{c.key}.{row.python.name}'
-            if key not in by_key:
-                by_key[key] = Waiver(key=key, reason=reason, owner=owner)
+    for key in _gap_keys(comparisons):
+        if key not in by_key:
+            by_key[key] = Waiver(key=key, reason=reason, owner=owner)
     return [by_key[k] for k in sorted(by_key)]
+
+
+def _gap_keys(comparisons: List[SurfaceComparison]) -> set:
+    """Every waiver key a current gap would need, Python-side and TS-only alike."""
+    keys = set()
+    for c in comparisons:
+        keys.update(f'{c.key}.{row.python.name}' for row in c.rows if row.gap is not None)
+        keys.update(f'{c.key}.{m.name}' for m in c.ts_only_required())
+    return keys
 
 
 # -------------------------------------------------------------------------- CLI
 
 def prune_waivers(comparisons: List[SurfaceComparison], waivers: List[Waiver]) -> List[Waiver]:
     """Return the waivers whose gap still exists, dropping stale ones."""
-    live = {
-        f'{c.key}.{row.python.name}'
-        for c in comparisons for row in c.rows if row.gap is not None
-    }
+    live = _gap_keys(comparisons)
     return [w for w in waivers if w.key in live]
 
 
@@ -747,6 +1108,15 @@ def strip_source_lines(text: str) -> str:
     return _SOURCE_LOCATION_RE.sub(lambda m: m.group('path'), text)
 
 
+def _raise_on_rules_problems(problems: List[str]) -> None:
+    """A dead or shadowed rule is a broken tool, not a parity gap: exit 2."""
+    if problems:
+        raise ToolingError(
+            'rules.yaml has {n} entr{y} that can never fire:\n  - {items}'.format(
+                n=len(problems), y='y' if len(problems) == 1 else 'ies',
+                items='\n  - '.join(problems)))
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     args = build_parser().parse_args(argv)
     try:
@@ -755,14 +1125,18 @@ def main(argv: Optional[List[str]] = None) -> int:
         rules = load_rules()
         waivers = load_waivers()
 
+        load_nested_config_defaults(rules, repo_root, catalogue.python_root)
+
         if args.diff:
             python, typescript = extract_all(repo_root, catalogue, keys=[args.diff])
+            _raise_on_rules_problems(validate_rules(rules, python, typescript))
             comparison = compare_all(python, typescript, rules, keys=[args.diff])[0]
             evaluate([comparison], [w for w in waivers if w.key.startswith(args.diff + '.')], args.today)
             print(render_surface_markdown(comparison))
             return EXIT_OK
 
         python, typescript = extract_all(repo_root, catalogue)
+        _raise_on_rules_problems(validate_rules(rules, python, typescript))
         comparisons = compare_all(python, typescript, rules, keys=[s.key for s in catalogue.surfaces])
 
         if args.baseline:

--- a/src/praisonai/praisonai/_dev/parity/signatures/rules.yaml
+++ b/src/praisonai/praisonai/_dev/parity/signatures/rules.yaml
@@ -1,5 +1,12 @@
 # Normalisation rules for the signature parity checker. Written once here so
 # neither extractor nor the comparator hard-codes naming conventions.
+#
+# Every entry here exists to make a match happen, so an entry that can never
+# fire is dead weight that reads as coverage. `compare.validate_rules` runs on
+# each real extraction and FAILS the tool (exit 2) on an alias or flattening
+# that names a Python parameter which does not exist, is shadowed by an earlier
+# matching tier, or is a pure case change. See
+# tests/unit/_dev/test_signature_parity.py::TestRulesSelfTest.
 
 # Applied automatically to every Python parameter before matching.
 case: snake_to_camel
@@ -9,39 +16,55 @@ case: snake_to_camel
 aliases:
   Agent.__init__:
     base_url: baseURL
-    output_json: outputSchema
-    output_pydantic: outputSchema
     interrupt_controller: signal
-    caching: cache
-    model: llm
-  Task.__init__:
-    context: dependencies
-    depends_on: dependencies
   Handoff.__init__:
     tool_name_override: name
     tool_description_override: description
     input_filter: transformContext
   LLM.__init__:
     base_url: baseURL
-  Session.__init__:
-    session_id: id
-    agent_url: agentUrl
-    session_ttl: ttl
   tool():
     func: execute
   Agent.chat:
     cancel_token: signal
 
-# Python nested-config parameters that TypeScript exposes as top-level fields.
-# A Python param counts as "flattened" when every listed TS field exists.
+# Python nested-config parameters that TypeScript exposes as several top-level
+# fields. A Python param counts as "flattened" when every listed TS field
+# exists; each field is then checked for required-ness and for its default.
+#
+# `python_config` names the dataclass the Python parameter resolves to when the
+# caller passes nothing (`Agent(output=None)` -> `OutputConfig()`), so a TS
+# field's default is compared against that class's field default rather than
+# against the parameter's own `None`, which says nothing about the fields.
+# `fields` maps each TS field to its field on that class; `null` means the TS
+# field has no Python counterpart, so only its required-ness is checked.
 flattened:
   Agent.__init__:
-    output: [verbose, markdown, stream]
-    execution: [maxIterations, maxToolCallsPerTurn]
-    caching: [cache, cacheTTL]
+    output:
+      python_config: config/feature_configs.py:OutputConfig
+      fields:
+        verbose: verbose
+        markdown: markdown
+        stream: stream
+    execution:
+      python_config: config/feature_configs.py:ExecutionConfig
+      fields:
+        maxIterations: max_iter
+        maxToolCallsPerTurn: max_tool_calls_per_turn
+    # This is why `flattened` resolves before `alias`: with the alias
+    # `caching -> cache` tried first, this stricter two-field rule never ran.
+    caching:
+      python_config: config/feature_configs.py:CachingConfig
+      fields:
+        cache: enabled
+        cacheTTL: null
 
 # Defaults that mean the same thing on both sides. `typescript: undefined`
 # means "no default / not set in the constructor".
+#
+# A pair whose two sides are the identical literal (`{python: true, typescript:
+# true}`) is NOT listed: `defaults_equivalent` returns True for equal literals
+# before it reaches this list, so such a pair could never fire.
 default_equivalences:
   - {python: null, typescript: undefined}
   # Python "None means empty" (`tools if tools else []`) vs a TS empty literal.
@@ -51,8 +74,6 @@ default_equivalences:
   - {python: false, typescript: undefined}
   # Python spells numeric zero defaults as 0.0 for floats; TS has one number type.
   - {python: 0.0, typescript: 0}
-  - {python: true, typescript: true}
-  - {python: false, typescript: false}
   # A Python module-level "not passed" sentinel is TypeScript's `undefined`.
   # Both sides then resolve the same value and emit the same deprecation
   # notice; only the spelling of the sentinel differs.

--- a/src/praisonai/praisonai/_dev/parity/signatures/ts_extract.mjs
+++ b/src/praisonai/praisonai/_dev/parity/signatures/ts_extract.mjs
@@ -3,8 +3,11 @@
 //
 // Uses the TypeScript compiler API (no type-checker, no emit) to read interface
 // members, constructor fallbacks (`config.x ?? v`, `config.x || v`, ternaries,
-// destructuring defaults) and method parameters. Output follows the shared
-// schema documented in schema.py.
+// `if`-statement fallbacks, object merges and destructuring defaults) and method
+// parameters. Output follows the shared schema documented in schema.py, with one
+// addition: `default_kind: 'unknown'` means the constructor decides the member's
+// fallback in a form this extractor cannot evaluate, which the comparator treats
+// as a gap rather than as `undefined`.
 //
 // Usage:
 //   node ts_extract.mjs --repo-root <repo> [--ts-root src/praisonai-ts/src] [--targets '<json>' | < targets.json]
@@ -177,8 +180,12 @@ function literalOf(ts, node, sf) {
   return { default: compact(node.getText(sf)), default_kind: 'expr' };
 }
 
+// `unwrap` sees through `(config)` / `(config as Cfg)`, so `(config as Cfg).x`
+// is recognised as an access to the options object.
 function isConfigAccess(ts, node, paramName) {
-  return ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === paramName;
+  if (!node || !ts.isPropertyAccessExpression(node)) return false;
+  const base = unwrap(ts, node.expression);
+  return !!base && ts.isIdentifier(base) && base.text === paramName;
 }
 
 // Flatten `a ?? b ?? c` / `a || b || c` into operands (left-assoc parse tree).
@@ -236,50 +243,239 @@ function collectCtorDefaults(ts, cls, sf, interfaceName) {
   const ctor = cls.members.find((m) => ts.isConstructorDeclaration(m) && m.body);
   if (!ctor) return { defaults: new Map(), line: null, positional: [] };
   const { config, positional } = pickConfigParam(ts, ctor, sf, interfaceName);
-  const info = collectDefaultsFrom(ts, ctor, sf, config);
+  const info = collectDefaultsFrom(ts, ctor, sf, config, cls);
   // Report the options parameter under its own name too: its interface members are
   // flattened below, but TypeScript really does expose a parameter of that name, so
   // a Python parameter called e.g. `config` matches it instead of reading as missing.
   const selfNamed = config ? positionalCtorParams(ts, ctor, sf, [config]) : [];
   info.positional = [...positionalCtorParams(ts, ctor, sf, positional), ...selfNamed];
+  // The options bag itself, so the comparator can tell it apart from a real
+  // TS-only member: `constructor(config: SimpleAgentConfig)` is required, but a
+  // required options OBJECT is not a parity gap -- its members are the surface,
+  // and Python spells them as keyword arguments.
+  info.optionsParams = selfNamed.map((prm) => prm.name);
   return info;
 }
 
+// A default the extractor could not reduce to a value.
+//
+// This is deliberately NOT the same as `default_kind: null`. `null` means "the
+// constructor assigns this member no default at all", which the comparator is
+// right to read as `undefined`. `'unknown'` means "the constructor DOES decide
+// this member's fallback, in a form this extractor cannot evaluate". Folding
+// the second into the first is how a constructor could start forcing
+// `reasoningEffort: 'high'`, or gate every tool behind an interactive approval
+// prompt, and leave the parity report byte-identical: the invented default was
+// reported as `undefined`, which the `null <-> undefined` and
+// `false <-> undefined` equivalences then matched silently.
+const UNKNOWN_DEFAULT = { default: null, default_kind: 'unknown' };
+
+// `(x)`, `(x as T)`, `x!`, `<T>x` -> x. Without this, `(config as Cfg).x = true`
+// and `(config).x ?? v` read as unrelated expressions.
+function unwrap(ts, node) {
+  let n = node;
+  for (;;) {
+    if (!n) return n;
+    if (ts.isParenthesizedExpression(n) || ts.isNonNullExpression(n)) { n = n.expression; continue; }
+    if (ts.isAsExpression && ts.isAsExpression(n)) { n = n.expression; continue; }
+    if (ts.isTypeAssertionExpression && ts.isTypeAssertionExpression(n)) { n = n.expression; continue; }
+    return n;
+  }
+}
+
+// The member name when `node` is `<param>.member` / `<param>?.member`, else null.
+function configMember(ts, node, paramName) {
+  const n = unwrap(ts, node);
+  return isConfigAccess(ts, n, paramName) ? n.name.text : null;
+}
+
+// The class property initialiser for `this.<prop>`, e.g. `private stream = true;`.
+// A constructor that only assigns the member when the caller supplied one
+// (`if (config.stream !== undefined) this.stream = config.stream;`) really does
+// take its default from there.
+function propertyInitialiser(ts, classNode, sf, propName) {
+  if (!classNode || !propName) return null;
+  for (const m of classNode.members) {
+    if (!ts.isPropertyDeclaration(m) || !m.initializer) continue;
+    if (m.name && m.name.getText(sf) === propName) return literalOf(ts, m.initializer, sf);
+  }
+  return null;
+}
+
+// The class member a statement (or block) assigns to: the first segment after
+// `this`, so both `this.stream = x` and `this.config.model = x` name a property
+// whose initialiser can be looked up.
+function assignedThisProperty(ts, stmt, sf) {
+  let found = null;
+  const rootMember = (node) => {
+    let n = unwrap(ts, node);
+    let last = null;
+    while (n && ts.isPropertyAccessExpression(n)) { last = n.name.text; n = unwrap(ts, n.expression); }
+    return n && n.kind === ts.SyntaxKind.ThisKeyword ? last : null;
+  };
+  const walk = (n) => {
+    if (found) return;
+    if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      const member = rootMember(n.left);
+      if (member) { found = member; return; }
+    }
+    ts.forEachChild(n, walk);
+  };
+  if (stmt) walk(stmt);
+  return found;
+}
+
+// The value assigned to `<something>.member` inside `stmt`, e.g. the `20` in
+// `if (config.maxIterations === undefined) { this.maxIterations = 20; }`.
+function assignedValueFor(ts, stmt, member, sf) {
+  let found = null;
+  const walk = (n) => {
+    if (found) return;
+    if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      const lhs = unwrap(ts, n.left);
+      if (ts.isPropertyAccessExpression(lhs) && lhs.name.text === member) {
+        found = literalOf(ts, n.right, sf);
+        return;
+      }
+    }
+    ts.forEachChild(n, walk);
+  };
+  if (stmt) walk(stmt);
+  return found;
+}
+
+// True when a branch is itself an `if` (an `else if` chain), possibly wrapped in
+// a block with nothing else in it.
+function isElseIfChain(ts, stmt) {
+  let s = stmt;
+  if (ts.isBlock(s) && s.statements.length === 1) s = s.statements[0];
+  return ts.isIfStatement(s);
+}
+
+// For `if (<cond>) A else B`, which branch runs when the caller did NOT supply
+// `<param>.<member>`, and which member the condition tests.
+function absentBranch(ts, cond, paramName, sf) {
+  const c = unwrap(ts, cond);
+  const direct = configMember(ts, c, paramName);
+  if (direct) return { name: direct, absent: 'else' };            // if (config.x) present else absent
+  if (ts.isPrefixUnaryExpression(c) && c.operator === ts.SyntaxKind.ExclamationToken) {
+    const inner = configMember(ts, c.operand, paramName);
+    if (inner) return { name: inner, absent: 'then' };            // if (!config.x) absent
+  }
+  if (ts.isBinaryExpression(c)) {
+    const name = configMember(ts, c.left, paramName);
+    if (!name) return null;
+    const rhs = compact(c.right.getText(sf));
+    if (rhs !== 'undefined' && rhs !== 'null') return null;
+    const op = c.operatorToken.kind;
+    if (op === ts.SyntaxKind.EqualsEqualsEqualsToken || op === ts.SyntaxKind.EqualsEqualsToken) {
+      return { name, absent: 'then' };                            // if (config.x === undefined) absent
+    }
+    if (op === ts.SyntaxKind.ExclamationEqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken) {
+      return { name, absent: 'else' };                            // if (config.x !== undefined) present else absent
+    }
+  }
+  return null;
+}
+
 // Defaults read from `<param>.x ?? v`, `<param>.x || v`, ternaries on
-// `<param>.x`, and destructuring `{ x = v } = <param>` inside a function body.
-// Used for constructors (config object) and for methods that take an options
-// object (see extractMethod), so both surfaces report defaults the same way.
-function collectDefaultsFrom(ts, fnLike, sf, param) {
+// `<param>.x`, destructuring `{ x = v } = <param>`, `if`-statement fallbacks,
+// and object merges (`{ x: v, ...<param> }`, `Object.assign({ x: v }, <param>)`)
+// inside a function body. Used for constructors (config object) and for methods
+// that take an options object (see extractMethod), so both surfaces report
+// defaults the same way.
+//
+// Anything else that decides a member's fallback is recorded as
+// UNKNOWN_DEFAULT rather than silently as "no default": see the comment on that
+// constant. `classNode` (optional) lets `if (config.x !== undefined)` fall back
+// to the class property initialiser, which is where that shape's default lives.
+function collectDefaultsFrom(ts, fnLike, sf, param, classNode) {
   const ctor = fnLike;
   if (!ctor || !ctor.body) return { defaults: new Map(), line: null };
   const paramName = param && ts.isIdentifier(param.name) ? param.name.text : 'config';
   const defaults = new Map();
-  const record = (name, value) => { if (!defaults.has(name)) defaults.set(name, value); };
+  const unknown = new Set();
+  const record = (name, value) => { if (value && !defaults.has(name)) defaults.set(name, value); };
+  const markUnknown = (name) => { unknown.add(name); };
+
+  // A property listed BEFORE the config is merged in is that member's default
+  // (`{ x: 'high', ...config }`); one listed AFTER overwrites whatever the
+  // caller passed, so the member is not honoured at all -- never a default.
+  const objectMerge = (properties, configIndex) => {
+    properties.forEach((prop, i) => {
+      const name = prop.name ? prop.name.getText(sf) : null;
+      if (!name) return;
+      if (i > configIndex) markUnknown(name);
+      else if (ts.isPropertyAssignment(prop)) record(name, literalOf(ts, prop.initializer, sf));
+      else markUnknown(name);
+    });
+  };
 
   const visit = (node) => {
     if (ts.isBinaryExpression(node)) {
       const kind = node.operatorToken.kind;
       if (kind === ts.SyntaxKind.QuestionQuestionToken || kind === ts.SyntaxKind.BarBarToken) {
         const operands = flattenChain(ts, node, kind);
-        if (isConfigAccess(ts, operands[0], paramName) && operands.length > 1) {
-          const name = operands[0].name.text;
+        const name = configMember(ts, operands[0], paramName);
+        if (name && operands.length > 1) {
           if (operands.length === 2) record(name, literalOf(ts, operands[1], sf));
           else record(name, { default: compact(operands.slice(1).map((o) => o.getText(sf)).join(kind === ts.SyntaxKind.QuestionQuestionToken ? ' ?? ' : ' || ')), default_kind: 'expr' });
         }
       }
     } else if (ts.isConditionalExpression(node)) {
       const cond = node.condition;
-      if (isConfigAccess(ts, cond, paramName)) {
-        record(cond.name.text, literalOf(ts, node.whenFalse, sf));
-      } else if (ts.isBinaryExpression(cond) && isConfigAccess(ts, cond.left, paramName)) {
-        const rhs = cond.right.getText(sf);
-        const op = cond.operatorToken.kind;
-        const isUndef = rhs === 'undefined' || rhs === 'null';
-        if (isUndef && (op === ts.SyntaxKind.ExclamationEqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken)) {
-          record(cond.left.name.text, literalOf(ts, node.whenFalse, sf));
-        } else if (isUndef && (op === ts.SyntaxKind.EqualsEqualsEqualsToken || op === ts.SyntaxKind.EqualsEqualsToken)) {
-          record(cond.left.name.text, literalOf(ts, node.whenTrue, sf));
+      const info = absentBranch(ts, cond, paramName, sf);
+      if (info) {
+        record(info.name, literalOf(ts, info.absent === 'then' ? node.whenTrue : node.whenFalse, sf));
+      }
+    } else if (ts.isIfStatement(node)) {
+      const info = absentBranch(ts, node.expression, paramName, sf);
+      if (info) {
+        const absent = info.absent === 'then' ? node.thenStatement : node.elseStatement;
+        const present = info.absent === 'then' ? node.elseStatement : node.thenStatement;
+        // An `else if` chain is a multi-way derivation, not one value: reading
+        // one arm would invent a default, so it counts as unreadable.
+        const absentValue = absent && !isElseIfChain(ts, absent)
+          ? assignedValueFor(ts, absent, info.name, sf) : null;
+        // The `if` decides this member's default only when one of its branches
+        // assigns the member. Otherwise it guards USING the value
+        // (`if (config.tools) { ...process them... }`) and defaults nothing.
+        const aboutMember = !!absentValue
+          || !!assignedValueFor(ts, present, info.name, sf)
+          || (!!absent && !!assignedValueFor(ts, absent, info.name, sf));
+        if (!aboutMember) {
+          // plain guard
+        } else if (absentValue) {
+          // `if (config.maxIterations === undefined) { this.maxIterations = 20; }`
+          record(info.name, absentValue);
+        } else if (absent) {
+          markUnknown(info.name);
+        } else {
+          // `if (config.x != null) this.x = config.x;` -- nothing runs when the
+          // member is absent, so the value kept is the class property
+          // initialiser's. When the class declares none (the default lives in a
+          // nested config object this extractor cannot evaluate) that is exactly
+          // the "assigns a default I cannot read" case.
+          const prop = assignedThisProperty(ts, present, sf);
+          const init = prop ? propertyInitialiser(ts, classNode, sf, prop) : null;
+          if (init) record(info.name, init); else markUnknown(info.name);
         }
+      }
+    } else if (ts.isObjectLiteralExpression(node)) {
+      const spreadIndex = node.properties.findIndex((prop) =>
+        ts.isSpreadAssignment(prop) && configIdentifier(ts, prop.expression, paramName));
+      if (spreadIndex >= 0) objectMerge(node.properties, spreadIndex);
+    } else if (ts.isCallExpression(node) && isObjectAssign(ts, node)) {
+      const args = node.arguments;
+      const cfgIndex = args.findIndex((a) => configIdentifier(ts, a, paramName));
+      if (cfgIndex >= 0) {
+        // `Object.assign({ x: 1 }, config, { y: 2 })` is the same shape as the
+        // object spread: earlier literals are defaults, later ones overwrite.
+        args.forEach((arg, i) => {
+          const lit = unwrap(ts, arg);
+          if (!ts.isObjectLiteralExpression(lit) || i === cfgIndex) return;
+          objectMerge(lit.properties, i < cfgIndex ? lit.properties.length : -1);
+        });
       }
     } else if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.initializer)
       && node.initializer.text === paramName && ts.isObjectBindingPattern(node.name)) {
@@ -291,7 +487,30 @@ function collectDefaultsFrom(ts, fnLike, sf, param) {
     ts.forEachChild(node, visit);
   };
   visit(ctor.body);
+
+  // NOTE: there is deliberately no catch-all "any `<param>.x` read in a
+  // boolean-looking context is a default" sweep here. It was tried and it
+  // flagged five plain guards -- `if (config.tools && Array.isArray(config.tools))`,
+  // `this.isRemote = !!config.agentUrl`, `config.approval === true` -- as
+  // invented defaults. `unknown` is reserved for a construct that IS shaped
+  // like a fallback and whose value could not be read, which is the shape that
+  // actually hides a default.
+
+  for (const name of unknown) {
+    if (!defaults.has(name)) defaults.set(name, { ...UNKNOWN_DEFAULT });
+  }
   return { defaults, line: lineOf(sf, ctor) };
+}
+
+function configIdentifier(ts, node, paramName) {
+  const n = unwrap(ts, node);
+  return !!n && ts.isIdentifier(n) && n.text === paramName;
+}
+
+function isObjectAssign(ts, call) {
+  const callee = unwrap(ts, call.expression);
+  return ts.isPropertyAccessExpression(callee) && callee.name.text === 'assign'
+    && ts.isIdentifier(unwrap(ts, callee.expression)) && unwrap(ts, callee.expression).text === 'Object';
 }
 
 // ------------------------------------------------------------------ extraction
@@ -303,6 +522,12 @@ function findAll(ts, root, predicate) {
   const visit = (n) => { if (predicate(n)) found.push(n); ts.forEachChild(n, visit); };
   visit(root);
   return found;
+}
+
+function findEnclosingClass(ts, node) {
+  let p = node.parent;
+  while (p) { if (ts.isClassDeclaration(p)) return p; p = p.parent; }
+  return null;
 }
 
 function enclosingClassName(ts, node) {
@@ -321,6 +546,9 @@ function extractInterface(ts, sf, target, location) {
     if (!cls) return { error: `${target.surface}: ctor class ${target.ctorClass} not found in ${target.file}` };
     ctorInfo = collectCtorDefaults(ts, cls, sf, target.name);
     if (ctorInfo.line) extra.ctor_location = `${location}:${ctorInfo.line}`;
+    if (ctorInfo.optionsParams && ctorInfo.optionsParams.length) {
+      extra.options_parameters = ctorInfo.optionsParams;
+    }
   }
   if (decl.heritageClauses && decl.heritageClauses.length) {
     extra.extends = decl.heritageClauses.flatMap((h) => h.types.map((t) => compact(t.getText(sf))));
@@ -419,7 +647,7 @@ function extractMethod(ts, sf, target, location) {
     if (!iface) continue;
     const optName = p.name.getText(sf);
     const optIsOptional = !!p.questionToken || !!p.initializer;
-    const defaults = collectDefaultsFrom(ts, decl, sf, p).defaults;
+    const defaults = collectDefaultsFrom(ts, decl, sf, p, findEnclosingClass(ts, decl)).defaults;
     for (const m of iface.members) {
       if (!ts.isPropertySignature(m) && !ts.isMethodSignature(m)) continue;
       const name = m.name.getText(sf);
@@ -440,6 +668,7 @@ function extractMethod(ts, sf, target, location) {
       });
     }
     (extra.options_interfaces = extra.options_interfaces || []).push(`${optName}: ${ifaceName}`);
+    (extra.options_parameters = extra.options_parameters || []).push(optName);
   }
   params.push(...flattened);
   const cls = enclosingClassName(ts, decl);

--- a/src/praisonai/praisonai/_dev/parity/signatures/waivers.yaml
+++ b/src/praisonai/praisonai/_dev/parity/signatures/waivers.yaml
@@ -12,156 +12,157 @@
 waivers:
   Agent.__init__.backstory:
     owner: praisonai-ts
-    reason: >-
-      Same value, resolved at a different moment. TS stores
-      `config.backstory || config.instructions` (or "I am an AI assistant") in
-      the constructor; Python's `self.backstory = backstory or instructions`
-      (agent.py) produces the identical string in the body. Verified equal for
-      the instruction-only, role-only and bare forms.
+    reason: Same value, resolved at a different moment. TS stores `config.backstory || config.instructions`
+      (or "I am an AI assistant") in the constructor; Python's `self.backstory = backstory or instructions`
+      (agent.py) produces the identical string in the body. Verified equal for the instruction-only, role-only
+      and bare forms.
   Agent.__init__.caching:
     owner: praisonai-ts
-    reason: >-
-      Both SDKs default to NO caching, by different routes. Python's
-      `caching=None` resolves to `CachingConfig(enabled=True)` and assigns
-      `self.cache = True`, but `Agent.cache` is written and never read anywhere
-      in praisonaiagents, so the default caches nothing; TS defaults
-      `cache` to false, which its response cache honours. Aligning the literal
-      would turn caching ON in TS and diverge from Python's observable
-      behaviour, so the difference is deliberate. Pinned by
-      tests/unit/agent/parity-waiver-gaps.test.ts ("caching default").
+    reason: Both SDKs default to NO caching, by different routes. Python's `caching=None` resolves to
+      `CachingConfig(enabled=True)` and assigns `self.cache = True`, but `Agent.cache` is written and
+      never read anywhere in praisonaiagents, so the default caches nothing; TS defaults `cache` to false,
+      which its response cache honours. Aligning the literal would turn caching ON in TS and diverge from
+      Python's observable behaviour, so the difference is deliberate. Pinned by tests/unit/agent/parity-waiver-gaps.test.ts
+      ("caching default").
   Agent.__init__.goal:
     owner: praisonai-ts
-    reason: >-
-      Same value, resolved at a different moment. TS stores
-      `config.goal || config.instructions` (or "Help the user with their
-      tasks") in the constructor; Python's `self.goal = goal or instructions`
+    reason: Same value, resolved at a different moment. TS stores `config.goal || config.instructions`
+      (or "Help the user with their tasks") in the constructor; Python's `self.goal = goal or instructions`
       (agent.py) produces the identical string in the body.
+  Agent.__init__.instructions:
+    owner: praisonai-ts
+    reason: TypeScript computes it across three branches -- the given value, else role/goal/backstory
+      joined, else a fallback sentence -- so the extractor reports no single default rather than guessing.
+      Python's None resolves the same way in its body.
   Agent.__init__.model:
     owner: praisonai-ts
-    reason: >-
-      Same resolution, run eagerly. TS now calls `resolveDefaultModel()`
-      (src/llm/default-model.ts), a byte-for-byte port of Python's
-      `Agent._PROVIDER_DEFAULT_MODELS` / `_resolve_default_model`, so the same
-      environment yields the same model on both sides. What still differs is
-      only the moment: TS resolves in the constructor, Python inside the body,
-      and TS additionally honours `PRAISONAI_MODEL` (a TypeScript-only alias).
+    reason: 'Same resolution, run eagerly. TS now calls `resolveDefaultModel()` (src/llm/default-model.ts),
+      a byte-for-byte port of Python''s `Agent._PROVIDER_DEFAULT_MODELS` / `_resolve_default_model`, so
+      the same environment yields the same model on both sides. What still differs is only the moment:
+      TS resolves in the constructor, Python inside the body, and TS additionally honours `PRAISONAI_MODEL`
+      (a TypeScript-only alias).'
   Agent.__init__.name:
     owner: praisonai-ts
-    reason: >-
-      TS generates `Agent_<random>`; Python leaves `name` None for an
-      instruction-only agent and uses "Agent" otherwise. Neither is a stable
-      contract (every unnamed Python agent collides on "Agent", and
-      `Handoff` on a None-named Python agent raises AttributeError), and TS
-      exposes no name-keyed lookup like Python's
-      `AgentTeam.get_agent_details`. The one place the random name used to
-      reach the model -- the handoff tool name -- is now sanitised by
-      `defaultHandoffToolName`.
+    reason: TS generates `Agent_<random>`; Python leaves `name` None for an instruction-only agent and
+      uses "Agent" otherwise. Neither is a stable contract (every unnamed Python agent collides on "Agent",
+      and `Handoff` on a None-named Python agent raises AttributeError), and TS exposes no name-keyed
+      lookup like Python's `AgentTeam.get_agent_details`. The one place the random name used to reach
+      the model -- the handoff tool name -- is now sanitised by `defaultHandoffToolName`.
+  Agent.__init__.output:
+    owner: praisonai-ts
+    reason: 'Genuine divergence, newly visible: Python''s output=None resolves the silent preset (verbose,
+      markdown and stream all false) while TypeScript defaults markdown and stream to true and verbose
+      to PRAISON_VERBOSE. Aligning them changes default behaviour for every existing caller, so it needs
+      a product decision, not a quiet edit. Flattened rows were never compared until the comparator was
+      fixed, which is why this sat unseen.'
   Agent.__init__.role:
     owner: praisonai-ts
-    reason: >-
-      Same value, resolved at a different moment. TS now stores
-      `config.role || 'Assistant'` in the constructor, matching Python's
-      `self.role = role or "Assistant"`, so `agent.role` reads back the same
-      string on both sides. The system-prompt TEXT built from role/goal/
-      backstory still differs between the two SDKs -- that is a separate,
-      untracked gap, not covered by this waiver.
+    reason: Same value, resolved at a different moment. TS now stores `config.role || 'Assistant'` in
+      the constructor, matching Python's `self.role = role or "Assistant"`, so `agent.role` reads back
+      the same string on both sides. The system-prompt TEXT built from role/goal/ backstory still differs
+      between the two SDKs -- that is a separate, untracked gap, not covered by this waiver.
   AgentTeam.__init__.process:
     owner: praisonai-ts
-    reason: >-
-      TS treats an undefined process as sequential, the Python default. NOTE
-      (verified, out of scope for this key): the accepted DOMAIN differs --
-      TS implements `process: "parallel"` with Promise.all, which Python
-      rejects with a ValueError, and TS validates nothing, so a typo runs
-      sequentially instead of raising.
+    reason: 'TS treats an undefined process as sequential, the Python default. NOTE (verified, out of
+      scope for this key): the accepted DOMAIN differs -- TS implements `process: "parallel"` with Promise.all,
+      which Python rejects with a ValueError, and TS validates nothing, so a typo runs sequentially instead
+      of raising.'
+  GoalEngineer.__init__.auto_decompose:
+    owner: praisonai-ts
+    reason: The constructor only overrides `autoDecompose` when it is supplied; the default lives on GoalConfig,
+      exactly as Python's None does. The extractor reports no default rather than inventing one, which
+      is the correct reading.
+  GoalEngineer.__init__.max_criteria:
+    owner: praisonai-ts
+    reason: The constructor only overrides `maxCriteria` when it is supplied; the default lives on GoalConfig,
+      exactly as Python's None does. The extractor reports no default rather than inventing one, which
+      is the correct reading.
+  GoalEngineer.__init__.model:
+    owner: praisonai-ts
+    reason: 'A real divergence, of the same shape already waived for Agent.__init__.model: TypeScript
+      calls resolveDefaultModel() eagerly while Python leaves model None and resolves it later. The other
+      four GoalEngineer options genuinely agree -- maxCriteria 5, threshold 8.0, autoDecompose true, verbose
+      false on both sides -- they are only ''unknown'' because the constructor forwards non-null options
+      into GoalConfig, which the extractor rightly will not constant-fold across files.'
+  GoalEngineer.__init__.threshold:
+    owner: praisonai-ts
+    reason: The constructor only overrides `threshold` when it is supplied; the default lives on GoalConfig,
+      exactly as Python's None does. The extractor reports no default rather than inventing one, which
+      is the correct reading.
+  GoalEngineer.__init__.verbose:
+    owner: praisonai-ts
+    reason: The constructor only overrides `verbose` when it is supplied; the default lives on GoalConfig,
+      exactly as Python's None does. The extractor reports no default rather than inventing one, which
+      is the correct reading.
   Handoff.__init__.tool_description_override:
     owner: praisonai-ts
-    reason: >-
-      Same derived string, built at a different moment.
-      `defaultHandoffToolDescription` now produces Python's
-      `Transfer task to <name> (<role>) - <goal>` exactly (it previously said
-      "Transfer conversation to <name>", which the model saw). Only the moment
-      of derivation differs.
+    reason: Same derived string, built at a different moment. `defaultHandoffToolDescription` now produces
+      Python's `Transfer task to <name> (<role>) - <goal>` exactly (it previously said "Transfer conversation
+      to <name>", which the model saw). Only the moment of derivation differs.
   Handoff.__init__.tool_name_override:
     owner: praisonai-ts
-    reason: >-
-      Same derived string, built at a different moment.
-      `defaultHandoffToolName` now produces Python's
-      `transfer_to_<lowercased, spaces-to-underscores name>` exactly (it
-      previously said `handoff_to_<raw name>`, which could contain a space and
-      be rejected by the provider). Only the moment of derivation differs.
+    reason: Same derived string, built at a different moment. `defaultHandoffToolName` now produces Python's
+      `transfer_to_<lowercased, spaces-to-underscores name>` exactly (it previously said `handoff_to_<raw
+      name>`, which could contain a space and be rejected by the provider). Only the moment of derivation
+      differs.
   PraisonAIError.__init__.run_id:
     owner: praisonai-ts
-    reason: >-
-      Both sides mint a UUID at construction -- Python's
-      `self.run_id = run_id or str(uuid.uuid4())` (errors.py) is NOT lazy.
-      Only the declared default differs. Edge case: `runId: ''` survives TS's
-      `??` but is replaced by Python's `or`.
+    reason: 'Both sides mint a UUID at construction -- Python''s `self.run_id = run_id or str(uuid.uuid4())`
+      (errors.py) is NOT lazy. Only the declared default differs. Edge case: `runId: ''''` survives TS''s
+      `??` but is replaced by Python''s `or`.'
   Session.__init__.user_id:
     owner: praisonai-ts
-    reason: >-
-      Both sides assign eagerly with the same truthiness rule -- Python's
-      `self.user_id = user_id or "default_user"` (session/api.py), TS's
-      `config.userId || 'default_user'`. Only the declared default differs.
+    reason: Both sides assign eagerly with the same truthiness rule -- Python's `self.user_id = user_id
+      or "default_user"` (session/api.py), TS's `config.userId || 'default_user'`. Only the declared default
+      differs.
   Task.__init__.action:
     owner: praisonai-ts
-    reason: >-
-      TS action mirrors description; Python's `self.action = action if action
-      is not None else description` resolves the same in the body.
+    reason: TS action mirrors description; Python's `self.action = action if action is not None else description`
+      resolves the same in the body.
   Task.__init__.depends_on:
     owner: praisonai-ts
-    reason: >-
-      TS dependsOn falls back to context then []; Python's `if depends_on is
-      not None` gives dependsOn the same precedence, including an explicit
-      empty list. TS additionally exposes no `dependsOn` read-back property
-      (Python's returns `context`).
+    reason: TS dependsOn falls back to context then []; Python's `if depends_on is not None` gives dependsOn
+      the same precedence, including an explicit empty list. TS additionally exposes no `dependsOn` read-back
+      property (Python's returns `context`).
   Task.__init__.description:
     owner: praisonai-ts
-    reason: >-
-      TS description falls back to action at construction; Python's
-      `if action is not None and description is None: description = action`
-      resolves the same in the body. TS stores '' where Python stores None for
-      a handler-only task; both are falsy and no branch differs.
+    reason: 'TS description falls back to action at construction; Python''s `if action is not None and
+      description is None: description = action` resolves the same in the body. TS stores '''' where Python
+      stores None for a handler-only task; both are falsy and no branch differs.'
   Task.__init__.expected_output:
     owner: praisonai-ts
-    reason: >-
-      Both sides fill "Complete the task successfully" eagerly in __init__ --
-      Python's `expected_output if expected_output is not None else ...` is NOT
-      lazy. Only the declared default differs.
+    reason: Both sides fill "Complete the task successfully" eagerly in __init__ -- Python's `expected_output
+      if expected_output is not None else ...` is NOT lazy. Only the declared default differs.
   Task.__init__.guardrails:
     owner: praisonai-ts
-    reason: >-
-      Identical precedence: the plural wins over the singular on both sides
-      (Python `guardrails if guardrails is not None else guardrail`). TS omits
-      Python's DeprecationWarning for the singular spelling and additionally
-      exposes a `guardrails` read-back property Python lacks.
+    reason: 'Identical precedence: the plural wins over the singular on both sides (Python `guardrails
+      if guardrails is not None else guardrail`). TS omits Python''s DeprecationWarning for the singular
+      spelling and additionally exposes a `guardrails` read-back property Python lacks.'
   Task.__init__.id:
     owner: praisonai-ts
-    reason: >-
-      Both sides mint a UUID at construction; Python's
-      `str(uuid.uuid4()) if id is None else str(id)` is NOT lazy. NOTE
-      (verified): an EXPLICIT id is coerced to str by Python but kept as a
-      number by TS, so `Task(id=5).id` is "5" in Python and 5 in TypeScript.
+    reason: 'Both sides mint a UUID at construction; Python''s `str(uuid.uuid4()) if id is None else str(id)`
+      is NOT lazy. NOTE (verified): an EXPLICIT id is coerced to str by Python but kept as a number by
+      TS, so `Task(id=5).id` is "5" in Python and 5 in TypeScript.'
   Task.__init__.routing:
     owner: praisonai-ts
-    reason: >-
-      TS routing falls back to condition, as Python does, and a plain-dict
-      routing value lands identically on both sides. NOTE (verified, wider
-      than this key): TS lists `routing` in ENGINE_LEVEL_OPTIONS, so any value
-      raises a `notYetHonoured` notice and never reaches execution, whereas
-      Python's workflow executor reads it.
+    reason: 'TS routing falls back to condition, as Python does, and a plain-dict routing value lands
+      identically on both sides. NOTE (verified, wider than this key): TS lists `routing` in ENGINE_LEVEL_OPTIONS,
+      so any value raises a `notYetHonoured` notice and never reaches execution, whereas Python''s workflow
+      executor reads it.'
   tool().description:
     owner: praisonai-ts
-    reason: >-
-      Same fallback string, built at a different moment. TS now derives
-      `Tool: <name>`, matching Python's
-      `description or func.__doc__ or f"Tool: {self.name}"` (it previously
-      said `Function <name>`, which shipped in the tool schema the model
-      reads). TS has no docstring to fall back to between the two.
+    reason: 'Same fallback string, built at a different moment. TS now derives `Tool: <name>`, matching
+      Python''s `description or func.__doc__ or f"Tool: {self.name}"` (it previously said `Function <name>`,
+      which shipped in the tool schema the model reads). TS has no docstring to fall back to between the
+      two.'
   tool().func:
+    kinds:
+    - required
     owner: praisonai-ts
-    reason: >-
-      TS execute is required; Python's `func` is optional only so `@tool` can
-      be applied bare, and `FunctionTool.__init__` still requires it.
+    reason: TS execute is required; Python's `func` is optional only so `@tool` can be applied bare, and
+      `FunctionTool.__init__` still requires it.
   tool().name:
+    kinds:
+    - required
     owner: praisonai-ts
     reason: TS cannot infer a name from an anonymous function; Python infers it from __name__

--- a/src/praisonai/praisonai/_dev/parity/typescript_extractor.py
+++ b/src/praisonai/praisonai/_dev/parity/typescript_extractor.py
@@ -58,13 +58,6 @@ class TypeScriptFeatures:
 
 # --- Regexes -----------------------------------------------------------------
 
-# Strings are captured in group 1 so comments inside string literals survive.
-_STRING_OR_COMMENT = re.compile(
-    r"""('(?:\\.|[^'\\\n])*'|"(?:\\.|[^"\\\n])*"|`(?:\\.|[^`\\])*`)"""
-    r"""|//[^\n]*|/\*.*?\*/""",
-    re.DOTALL,
-)
-
 # export { A, B as C } from './path'  (group 1 = names, group 2 = path)
 _NAMED_REEXPORT = re.compile(
     r"export\s*\{([^}]*)\}\s*from\s*['\"]([^'\"]+)['\"]"
@@ -93,13 +86,161 @@ _DECLARATION = re.compile(
     re.MULTILINE,
 )
 
+# export default class Foo / export default function bar / export default x
+_DEFAULT_EXPORT = re.compile(r"^[ \t]*export\s+default\b", re.MULTILINE)
+
 _TYPE_KEYWORDS = {'interface', 'type'}
 _MAX_STAR_DEPTH = 5
 
 
+# A `/` starts a regular expression (rather than division) only after one of
+# these. Anything else -- an identifier, a number, `)`, `]`, `.` -- means the
+# preceding expression is complete, so the slash divides.
+_REGEX_MAY_FOLLOW_CHARS = set('(,=:[!&|?{};+-*%^~<>')
+_REGEX_MAY_FOLLOW_WORDS = {
+    'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
+    'throw', 'case', 'do', 'else', 'yield', 'await',
+}
+
+
+def _scan(source: str) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]:
+    r"""Split ``source`` into ``(comment_spans, literal_spans)``.
+
+    A character-level scan rather than a regex, because the two cannot be told
+    apart by alternation: the regular expression literal
+    ``/([_*[\]()~`>#+\-=|{}.!\\])/g`` in ``src/bots/base.ts`` contains a
+    backtick, and a regex-based splitter reads it as the start of a template
+    literal that then swallows the next 6 lines -- including
+    ``export function escapeMarkdownV2``.
+
+    Literal spans cover string, template and regular-expression literals.
+    """
+    comments: List[Tuple[int, int]] = []
+    literals: List[Tuple[int, int]] = []
+    n = len(source)
+    i = 0
+    prev_char = ''   # last significant code character
+    prev_word = ''   # last identifier in code, if it ended at prev_char
+
+    while i < n:
+        ch = source[i]
+        pair = source[i:i + 2]
+
+        if pair == '//':
+            end = source.find('\n', i)
+            end = n if end < 0 else end
+            comments.append((i, end))
+            i = end
+            continue
+
+        if pair == '/*':
+            end = source.find('*/', i + 2)
+            end = n if end < 0 else end + 2
+            comments.append((i, end))
+            i = end
+            continue
+
+        if ch in '"\'':
+            j = i + 1
+            while j < n and source[j] != ch and source[j] != '\n':
+                j += 2 if source[j] == '\\' else 1
+            end = min(j + 1, n) if j < n and source[j] == ch else j
+            literals.append((i, end))
+            prev_char, prev_word = ch, ''
+            i = end
+            continue
+
+        if ch == '`':
+            j = i + 1
+            while j < n and source[j] != '`':
+                j += 2 if source[j] == '\\' else 1
+            end = min(j + 1, n)
+            literals.append((i, end))
+            prev_char, prev_word = '`', ''
+            i = end
+            continue
+
+        if ch == '/' and (
+            not prev_char
+            or prev_char in _REGEX_MAY_FOLLOW_CHARS
+            or prev_word in _REGEX_MAY_FOLLOW_WORDS
+        ):
+            j = i + 1
+            in_class = False
+            closed = False
+            while j < n and source[j] != '\n':
+                c = source[j]
+                if c == '\\':
+                    j += 2
+                    continue
+                if c == '[':
+                    in_class = True
+                elif c == ']':
+                    in_class = False
+                elif c == '/' and not in_class:
+                    closed = True
+                    break
+                j += 1
+            if closed:
+                end = j + 1
+                while end < n and source[end].isalpha():
+                    end += 1   # flags
+                literals.append((i, end))
+                prev_char, prev_word = '/', ''
+                i = end
+                continue
+
+        if ch.isalnum() or ch in '_$':
+            j = i
+            while j < n and (source[j].isalnum() or source[j] in '_$'):
+                j += 1
+            prev_word = source[i:j]
+            prev_char = source[j - 1]
+            i = j
+            continue
+
+        if not ch.isspace():
+            prev_char, prev_word = ch, ''
+        i += 1
+
+    return comments, literals
+
+
 def _strip_comments(source: str) -> str:
-    """Remove // and /* */ comments while leaving string literals intact."""
-    return _STRING_OR_COMMENT.sub(lambda m: m.group(1) or '', source)
+    """Blank out // and /* */ comments, leaving string literals intact.
+
+    Comments become whitespace of the same length rather than being deleted, so
+    character offsets survive and ``_literal_spans`` can be computed on the
+    result.
+    """
+    comments, _ = _scan(source)
+    if not comments:
+        return source
+    out = list(source)
+    for start, end in comments:
+        for k in range(start, end):
+            if out[k] != '\n':
+                out[k] = ' '
+    return ''.join(out)
+
+
+def _literal_spans(source: str) -> List[Tuple[int, int]]:
+    """``(start, end)`` of every string/template/regex literal in ``source``."""
+    return _scan(source)[1]
+
+
+def _code_matches(pattern: 're.Pattern', source: str, spans: List[Tuple[int, int]]) -> list:
+    """Matches of ``pattern`` that *begin* outside any string literal.
+
+    The export regexes must read the module path out of a string literal, so
+    literals cannot simply be deleted. Instead a statement only counts when its
+    ``export`` keyword itself sits in code -- which is what keeps a doc snippet,
+    a fixture or a codegen template from satisfying parity.
+    """
+    return [
+        m for m in pattern.finditer(source)
+        if not any(start <= m.start() < end for start, end in spans)
+    ]
 
 
 class TypeScriptFeatureExtractor:
@@ -109,10 +250,19 @@ class TypeScriptFeatureExtractor:
     This extractor parses the index.ts file to find:
     - export { Name } from './path' statements
     - export type { Name } from './path' statements
-    - export * from './path' statements — resolved by reading the target
-      module (``./x.ts``, ``./x.tsx``, ``./x/index.ts`` or ``./x/index.tsx``)
-      and collecting its exported declarations, local export lists and nested
-      re-exports (recursively, with a visited set and a depth limit).
+    - export * from './path' statements
+
+    Every re-export target is resolved to a real file (``./x.ts``, ``./x.tsx``,
+    ``./x/index.ts`` or ``./x/index.tsx``); an unresolvable path contributes
+    nothing. For ``export { .. } from`` the *source* name of each binding must
+    also appear in what the target module provides -- its exported
+    declarations, local export lists, nested re-exports and ``export default``
+    (collected recursively, with a visited set and a depth limit). A statement
+    naming a module that does not exist, or a symbol that module does not
+    export, cannot compile, so it is not parity and is dropped.
+
+    Export statements that begin inside a comment or a string literal are
+    ignored: doc snippets, fixtures and codegen templates must not count.
 
     It categorizes exports into modules based on their source paths.
 
@@ -162,6 +312,7 @@ class TypeScriptFeatureExtractor:
             repo_root = self._find_repo_root()
         self.repo_root = Path(repo_root).resolve()
         self.ts_pkg = self.repo_root / "src" / "praisonai-ts"
+        self._provides_cache: Dict[Path, Set[str]] = {}
 
     def _find_repo_root(self) -> Path:
         """Find the monorepo root (see ``_paths.find_repo_root``)."""
@@ -182,34 +333,77 @@ class TypeScriptFeatureExtractor:
             return features
 
         content = _strip_comments(content)
+        spans = _literal_spans(content)
+        base_dir = index_file.parent
 
         # Parse regular exports: export { Name1, Name2 } from './path'
-        for match in _NAMED_REEXPORT.finditer(content):
-            source = match.group(2)
-            for name, is_type in self._parse_export_entries(match.group(1)):
-                self._add_export(features, name, source, is_type)
+        for match in _code_matches(_NAMED_REEXPORT, content, spans):
+            self._add_verified_reexport(
+                features, base_dir, match.group(2), match.group(1), force_type=False)
 
         # Parse type exports: export type { Name1, Name2 } from './path'
-        for match in _TYPE_REEXPORT.finditer(content):
-            source = match.group(2)
-            for name, _ in self._parse_export_entries(match.group(1)):
-                self._add_export(features, name, source, True)
+        for match in _code_matches(_TYPE_REEXPORT, content, spans):
+            self._add_verified_reexport(
+                features, base_dir, match.group(2), match.group(1), force_type=True)
 
         # Parse namespace re-exports: export * as ns from './path'
-        for match in _STAR_AS_REEXPORT.finditer(content):
+        for match in _code_matches(_STAR_AS_REEXPORT, content, spans):
+            if self._resolve_module(base_dir, match.group(2)) is None:
+                continue
             self._add_export(features, match.group(1), match.group(2), False)
 
         # Parse star re-exports: export * from './path' — resolve the target
         # module and record everything it exports under the star path.
-        for match in _STAR_REEXPORT.finditer(content):
+        for match in _code_matches(_STAR_REEXPORT, content, spans):
             source = match.group(1)
-            resolved = self._resolve_module(index_file.parent, source)
+            resolved = self._resolve_module(base_dir, source)
             if resolved is None:
                 continue
             for name, is_type in self._collect_star_exports(resolved, set(), 0):
                 self._add_export(features, name, source, is_type)
 
         return features
+
+    def _add_verified_reexport(
+        self,
+        features: TypeScriptFeatures,
+        base_dir: Path,
+        spec: str,
+        names_str: str,
+        force_type: bool,
+    ) -> None:
+        """Record ``export { .. } from spec`` only for bindings that really exist.
+
+        An unresolvable ``spec`` contributes nothing, and a binding whose source
+        name is absent from the target module is dropped: neither can compile,
+        so neither is evidence of a TypeScript implementation.
+        """
+        resolved = self._resolve_module(base_dir, spec)
+        if resolved is None:
+            return
+        provided = self._module_provides(resolved)
+        for source_name, local_name, is_type in self._parse_export_bindings(names_str):
+            if source_name not in provided:
+                continue
+            self._add_export(features, local_name, spec, force_type or is_type)
+
+    def _module_provides(self, module_file: Path) -> Set[str]:
+        """Names ``module_file`` makes available to an importer."""
+        cached = self._provides_cache.get(module_file)
+        if cached is not None:
+            return cached
+
+        names = {name for name, _ in self._collect_star_exports(module_file, set(), 0)}
+        try:
+            with open(module_file, 'r', encoding='utf-8') as f:
+                content = _strip_comments(f.read())
+        except (IOError, UnicodeDecodeError):
+            content = ''
+        if _code_matches(_DEFAULT_EXPORT, content, _literal_spans(content)):
+            names.add('default')
+
+        self._provides_cache[module_file] = names
+        return names
 
     # --- export * resolution -------------------------------------------------
 
@@ -252,6 +446,7 @@ class TypeScriptFeatureExtractor:
         except (IOError, UnicodeDecodeError):
             return []
         content = _strip_comments(content)
+        spans = _literal_spans(content)
 
         found: List[Tuple[str, bool]] = []
         seen: Set[Tuple[str, bool]] = set()
@@ -263,28 +458,28 @@ class TypeScriptFeatureExtractor:
                 found.append(key)
 
         # Declarations: export class Foo / export function bar / export type T
-        for match in _DECLARATION.finditer(content):
+        for match in _code_matches(_DECLARATION, content, spans):
             keyword = re.sub(r'\s+', ' ', match.group(1))
             add(match.group(2), keyword in _TYPE_KEYWORDS)
 
         # Named re-exports from other modules (names are known, no recursion)
-        for match in _NAMED_REEXPORT.finditer(content):
+        for match in _code_matches(_NAMED_REEXPORT, content, spans):
             for name, is_type in self._parse_export_entries(match.group(1)):
                 add(name, is_type)
-        for match in _TYPE_REEXPORT.finditer(content):
+        for match in _code_matches(_TYPE_REEXPORT, content, spans):
             for name, _ in self._parse_export_entries(match.group(1)):
                 add(name, True)
-        for match in _STAR_AS_REEXPORT.finditer(content):
+        for match in _code_matches(_STAR_AS_REEXPORT, content, spans):
             add(match.group(1), False)
 
         # Local export lists: export { a, b as c }
-        for match in _LOCAL_EXPORT_LIST.finditer(content):
+        for match in _code_matches(_LOCAL_EXPORT_LIST, content, spans):
             list_is_type = bool(match.group(1))
             for name, is_type in self._parse_export_entries(match.group(2)):
                 add(name, is_type or list_is_type)
 
         # Nested star re-exports: recurse
-        for match in _STAR_REEXPORT.finditer(content):
+        for match in _code_matches(_STAR_REEXPORT, content, spans):
             nested = self._resolve_module(module_file.parent, match.group(1))
             if nested is None:
                 continue
@@ -310,19 +505,16 @@ class TypeScriptFeatureExtractor:
         if name not in module.exports:
             module.exports.append(name)
 
-    def _parse_export_entries(self, names_str: str) -> List[Tuple[str, bool]]:
-        """Parse an export list into (name, is_type) pairs."""
-        entries: List[Tuple[str, bool]] = []
-        for raw in self._parse_export_names(names_str):
-            if raw.startswith('type '):
-                entries.append((raw[5:].strip(), True))
-            else:
-                entries.append((raw, False))
-        return entries
+    def _parse_export_bindings(self, names_str: str) -> List[Tuple[str, str, bool]]:
+        """Parse an export list into ``(source_name, local_name, is_type)`` triples.
 
-    def _parse_export_names(self, names_str: str) -> List[str]:
-        """Parse export names from a comma-separated string."""
-        names = []
+        ``source_name`` is what the target module must provide; ``local_name``
+        is what an importer of *this* module sees, and is what parity matches
+        against Python. For ``{ A }`` the two are equal; for ``{ A as B }`` they
+        are ``A`` and ``B``; for ``{ default as B }`` they are ``default`` and
+        ``B``.
+        """
+        bindings: List[Tuple[str, str, bool]] = []
         # Remove comments from the string first
         # Handle both // and /* */ style comments
         names_str = re.sub(r'//[^\n]*', '', names_str)
@@ -335,19 +527,30 @@ class TypeScriptFeatureExtractor:
             # Skip if it looks like a comment remnant
             if part.startswith('//') or part.startswith('/*'):
                 continue
-            # Handle 'Name as Alias' syntax - take the ALIAS (right side)
-            # This is correct because we want to match what Python exports
+            is_type = False
+            if part.startswith('type '):
+                is_type = True
+                part = part[5:].strip()
+            # Handle 'Name as Alias' syntax - the ALIAS (right side) is the name
+            # importers see, so that is what parity matches against Python.
             if ' as ' in part:
-                left, alias = part.split(' as ', 1)
-                alias = alias.strip()
-                # Preserve an inline `type` prefix from the left side
-                if left.strip().startswith('type ') and not alias.startswith('type '):
-                    alias = 'type ' + alias
-                part = alias
-            if part == 'default':
+                source, local = part.split(' as ', 1)
+                source, local = source.strip(), local.strip()
+            else:
+                source = local = part
+            if not source or not local or local == 'default':
                 continue
-            names.append(part)
-        return names
+            bindings.append((source, local, is_type))
+        return bindings
+
+    def _parse_export_entries(self, names_str: str) -> List[Tuple[str, bool]]:
+        """Parse an export list into (name, is_type) pairs."""
+        return [(local, is_type)
+                for _, local, is_type in self._parse_export_bindings(names_str)]
+
+    def _parse_export_names(self, names_str: str) -> List[str]:
+        """Parse export names from a comma-separated string."""
+        return [local for _, local, _ in self._parse_export_bindings(names_str)]
 
     def _categorize(self, source_path: str) -> str:
         """Categorize an export based on its source path."""

--- a/src/praisonai/praisonai/_dev/parity/typescript_extractor.py
+++ b/src/praisonai/praisonai/_dev/parity/typescript_extractor.py
@@ -462,15 +462,22 @@ class TypeScriptFeatureExtractor:
             keyword = re.sub(r'\s+', ' ', match.group(1))
             add(match.group(2), keyword in _TYPE_KEYWORDS)
 
-        # Named re-exports from other modules (names are known, no recursion)
+        # Named re-exports from other modules. A binding here is only real if
+        # the module it names resolves AND provides the source symbol -- exactly
+        # the rule the root index applies. Without this, `export { Foo } from
+        # './barrel'` re-surfaced through a star would validate a phantom Foo
+        # even when the barrel re-exports it from a module that does not exist.
         for match in _code_matches(_NAMED_REEXPORT, content, spans):
-            for name, is_type in self._parse_export_entries(match.group(1)):
-                add(name, is_type)
+            self._add_nested_reexport(
+                add, module_file.parent, match.group(2), match.group(1),
+                visited, depth, force_type=False)
         for match in _code_matches(_TYPE_REEXPORT, content, spans):
-            for name, _ in self._parse_export_entries(match.group(1)):
-                add(name, True)
+            self._add_nested_reexport(
+                add, module_file.parent, match.group(2), match.group(1),
+                visited, depth, force_type=True)
         for match in _code_matches(_STAR_AS_REEXPORT, content, spans):
-            add(match.group(1), False)
+            if self._resolve_module(module_file.parent, match.group(2)) is not None:
+                add(match.group(1), False)
 
         # Local export lists: export { a, b as c }
         for match in _code_matches(_LOCAL_EXPORT_LIST, content, spans):
@@ -487,6 +494,34 @@ class TypeScriptFeatureExtractor:
                 add(name, is_type)
 
         return found
+
+    def _add_nested_reexport(
+        self,
+        add,
+        base_dir: Path,
+        spec: str,
+        names_str: str,
+        visited: Set[Path],
+        depth: int,
+        force_type: bool,
+    ) -> None:
+        """Add a nested ``export { .. } from spec`` only for bindings that exist.
+
+        The named symbols are validated against what ``spec`` provides, resolved
+        recursively so a chain of barrels is followed to the module that really
+        declares each name. An unresolvable ``spec`` or a binding the target does
+        not provide is dropped: neither can compile, so neither is parity.
+        """
+        resolved = self._resolve_module(base_dir, spec)
+        if resolved is None:
+            return
+        provided = {
+            name for name, _ in
+            self._collect_star_exports(resolved, set(visited), depth + 1)
+        }
+        for source_name, local_name, is_type in self._parse_export_bindings(names_str):
+            if source_name in provided:
+                add(local_name, force_type or is_type)
 
     # --- helpers -------------------------------------------------------------
 

--- a/src/praisonai/tests/unit/_dev/test_behaviour_parity.py
+++ b/src/praisonai/tests/unit/_dev/test_behaviour_parity.py
@@ -24,12 +24,27 @@ LEDGER = textwrap.dedent('''
 ''')
 
 
-def _repo(tmp_path: Path, ledger: str = LEDGER, extra: str = '') -> Path:
+# The surfaces the TypeScript code iterates. read_ledger cross-checks the parse
+# against these, so every fixture repo carries them.
+CALL_SITES = (
+    "const a = unhonouredFor('Agent.__init__');\n"
+    "const t = unhonouredFor('Task.__init__');\n"
+)
+
+
+def _repo(
+    tmp_path: Path,
+    ledger: str = LEDGER,
+    extra: str = '',
+    call_sites: str = CALL_SITES,
+) -> Path:
     src = tmp_path / 'src' / 'praisonai-ts' / 'src' / 'utils'
     src.mkdir(parents=True)
     (src / 'parity-notice.ts').write_text(ledger)
     if extra:
         (src.parent / 'agent.ts').write_text(extra)
+    if call_sites:
+        (src.parent / 'call-sites.ts').write_text(call_sites)
     return tmp_path
 
 
@@ -102,3 +117,184 @@ class TestRatchet:
         data = json.loads((repo / B.JSON_OUTPUT).read_text())
         assert data['total'] == 3
         assert data['surfaces']['Agent.__init__'] == ['auth', 'sandbox']
+
+
+# ---------------------------------------------------------------------------
+# A partial parse failure must never read as progress.
+#
+# The first version matched entries with a line-anchored regex that required a
+# trailing comma after the closing bracket. Putting one entry on a single line
+# without that comma dropped the whole surface: 48 -> 40, reported as "8
+# option(s) closed", and --write made it the new floor with the TypeScript
+# unchanged. A surface disappearing is a parse error, never a win.
+# ---------------------------------------------------------------------------
+
+ONE_LINE_LEDGER = textwrap.dedent('''
+    export const UNHONOURED_OPTIONS: Readonly<Record<string, readonly string[]>> = {
+      'Agent.__init__': ['auth', 'sandbox'],
+      'Task.__init__': ['images']
+    } as const;
+''')
+
+
+class TestReformatCannotCloseOptions:
+    def test_a_one_line_entry_without_a_trailing_comma_is_still_counted(self, tmp_path):
+        b = B.read_ledger(_repo(tmp_path, ledger=ONE_LINE_LEDGER))
+        assert b.surfaces == {'Agent.__init__': ['auth', 'sandbox'], 'Task.__init__': ['images']}
+        assert b.total == 3, 'whitespace changed; the number of ignored options did not'
+
+    def test_reformatting_does_not_lower_the_total(self, tmp_path, capsys):
+        repo = _repo(tmp_path)
+        assert B.main(['--write', '--repo-root', str(repo)]) == 0
+        (repo / 'src/praisonai-ts/src/utils/parity-notice.ts').write_text(ONE_LINE_LEDGER)
+        assert B.main(['--check', '--repo-root', str(repo)]) == 0
+        out = capsys.readouterr().out
+        assert 'closed since the last commit' not in out
+
+    def test_trailing_commas_and_comments_are_both_tolerated(self, tmp_path):
+        ledger = textwrap.dedent('''
+            export const UNHONOURED_OPTIONS: Readonly<Record<string, readonly string[]>> = {
+              // 'Ghost': ['notAKey'],
+              /* 'AlsoGhost': ['notAKey'] */
+              'Agent.__init__': [
+                'auth',   // still ignored
+                'sandbox',
+              ],
+              'Task.__init__': ['images'],
+            } as const;
+        ''')
+        b = B.read_ledger(_repo(tmp_path, ledger=ledger))
+        assert sorted(b.surfaces) == ['Agent.__init__', 'Task.__init__']
+        assert b.total == 3
+
+    def test_a_surface_the_code_iterates_but_the_parse_lost_is_an_error(self):
+        """The guard itself: a key in the ledger text, gone from the parse."""
+        body = "'Agent.__init__': ['auth'],\n'Handoff': ['maxDepth'],\n"
+        with pytest.raises(B.LedgerError, match='Handoff'):
+            B._verify_parse(body, {'Agent.__init__': ['auth']}, ['Agent.__init__', 'Handoff'])
+
+    def test_a_surface_absent_from_the_ledger_is_closed_not_lost(self, tmp_path):
+        """Control: code may iterate a surface whose entry was legitimately deleted."""
+        b = B.read_ledger(_repo(
+            tmp_path,
+            call_sites=CALL_SITES + "const h = unhonouredFor('Handoff');\n",
+        ))
+        assert 'Handoff' not in b.surfaces
+        assert b.total == 3
+
+    def test_the_independent_key_count_must_agree_with_the_parse(self):
+        body = "'Agent.__init__': ['auth'],\n'Task.__init__': ['images'],\n"
+        with pytest.raises(B.LedgerError, match='Task.__init__'):
+            B._verify_parse(body, {'Agent.__init__': ['auth']}, [])
+
+    def test_an_entry_whose_value_is_not_a_list_is_an_error(self, tmp_path):
+        ledger = LEDGER.replace("'Task.__init__': [\n    'images',\n  ],", "'Task.__init__': someExpr,")
+        assert 'someExpr' in ledger
+        with pytest.raises(B.LedgerError, match='not a list'):
+            B.read_ledger(_repo(tmp_path, ledger=ledger))
+
+    def test_a_duplicate_surface_key_is_an_error(self, tmp_path):
+        ledger = LEDGER.replace("'Task.__init__'", "'Agent.__init__'")
+        with pytest.raises(B.LedgerError, match='twice'):
+            B.read_ledger(_repo(tmp_path, ledger=ledger))
+
+
+# ---------------------------------------------------------------------------
+# --write must not launder a ratchet rise.
+# ---------------------------------------------------------------------------
+
+class TestWriteRespectsTheRatchet:
+    @staticmethod
+    def _grow(repo: Path) -> None:
+        (repo / 'src/praisonai-ts/src/utils/parity-notice.ts').write_text(
+            LEDGER.replace("'auth', 'sandbox',", "'auth', 'sandbox', 'newlyIgnored',")
+        )
+
+    def test_write_refuses_to_raise_the_committed_total(self, tmp_path, capsys):
+        repo = _repo(tmp_path)
+        assert B.main(['--write', '--repo-root', str(repo)]) == 0
+        self._grow(repo)
+        assert B.main(['--write', '--repo-root', str(repo)]) == 1
+        assert B.committed_total(repo) == 3, 'the committed floor must not have moved'
+        assert '--allow-growth' in capsys.readouterr().err
+
+    def test_allow_growth_banks_the_rise(self, tmp_path):
+        repo = _repo(tmp_path)
+        assert B.main(['--write', '--repo-root', str(repo)]) == 0
+        self._grow(repo)
+        assert B.main(['--write', '--allow-growth', '--repo-root', str(repo)]) == 0
+        assert B.committed_total(repo) == 4
+
+    def test_write_may_always_lower_the_total(self, tmp_path):
+        """Control: closing an option needs no flag."""
+        repo = _repo(tmp_path)
+        assert B.main(['--write', '--repo-root', str(repo)]) == 0
+        (repo / 'src/praisonai-ts/src/utils/parity-notice.ts').write_text(
+            LEDGER.replace("'auth', 'sandbox',", "'auth',")
+        )
+        assert B.main(['--write', '--repo-root', str(repo)]) == 0
+        assert B.committed_total(repo) == 2
+
+    def test_the_first_write_has_no_floor_to_break(self, tmp_path):
+        """Control: no committed report yet is not growth."""
+        assert B.main(['--write', '--repo-root', str(_repo(tmp_path))]) == 0
+
+    def test_write_names_the_options_it_claims_closed(self, tmp_path, capsys):
+        repo = _repo(tmp_path)
+        assert B.main(['--write', '--repo-root', str(repo)]) == 0
+        (repo / 'src/praisonai-ts/src/utils/parity-notice.ts').write_text(
+            LEDGER.replace("'auth', 'sandbox',", "'auth',")
+        )
+        assert B.main(['--write', '--repo-root', str(repo)]) == 0
+        out = capsys.readouterr().out
+        assert 'Agent.__init__.sandbox' in out
+
+
+# ---------------------------------------------------------------------------
+# The gate must run on the files that carry the baseline.
+# ---------------------------------------------------------------------------
+
+def _real_repo_root():
+    for parent in Path(__file__).resolve().parents:
+        if (parent / 'src' / 'praisonai-ts').is_dir() and (parent / '.github').is_dir():
+            return parent
+    return None
+
+
+class TestGateWatchesTheReport:
+    def test_the_pull_request_filter_covers_the_behaviour_baseline(self):
+        root = _real_repo_root()
+        if root is None:
+            pytest.skip('not running inside a checkout with .github/workflows')
+        yaml = pytest.importorskip('yaml')
+        data = yaml.safe_load((root / '.github/workflows/parity-gate.yml').read_text())
+        # PyYAML reads the bare key `on` as the boolean True (YAML 1.1).
+        triggers = data.get('on', data.get(True))
+        paths = triggers['pull_request']['paths']
+        for required in (
+            'src/praisonai-ts/BEHAVIOUR_PARITY.md',
+            'src/praisonai-ts/behaviour-parity.json',
+            'src/praisonai/scripts/**',
+        ):
+            assert required in paths, f'{required} can change without the gate running'
+
+
+class TestQuotingCannotHideASurface:
+    """JavaScript takes ' " and `; a style the parser missed dropped a surface."""
+
+    def test_a_double_quoted_key_is_still_a_surface(self, tmp_path):
+        ledger = LEDGER.replace("'Task.__init__':", '"Task.__init__":')
+        b = B.read_ledger(_repo(tmp_path, ledger=ledger))
+        assert b.surfaces['Task.__init__'] == ['images']
+        assert b.total == 3
+
+    def test_a_double_quoted_option_is_still_counted(self, tmp_path):
+        ledger = LEDGER.replace("'sandbox',", '"sandbox",')
+        b = B.read_ledger(_repo(tmp_path, ledger=ledger))
+        assert b.surfaces['Agent.__init__'] == ['auth', 'sandbox']
+
+    def test_an_option_name_that_is_not_an_identifier_is_an_error(self, tmp_path):
+        """Control: a name the option regex cannot read must not vanish quietly."""
+        ledger = LEDGER.replace("'images',", "'output-file',")
+        with pytest.raises(B.LedgerError, match='not a plain identifier'):
+            B.read_ledger(_repo(tmp_path, ledger=ledger))

--- a/src/praisonai/tests/unit/_dev/test_behaviour_parity.py
+++ b/src/praisonai/tests/unit/_dev/test_behaviour_parity.py
@@ -298,3 +298,56 @@ class TestQuotingCannotHideASurface:
         ledger = LEDGER.replace("'images',", "'output-file',")
         with pytest.raises(B.LedgerError, match='not a plain identifier'):
             B.read_ledger(_repo(tmp_path, ledger=ledger))
+
+    def test_a_bare_identifier_key_is_still_a_surface(self, tmp_path):
+        """A valid unquoted key like `Handoff: [...]` must be counted, not dropped.
+
+        JavaScript accepts a bare identifier as an object key. The first scanner
+        only opened an entry on a quote, so an unquoted key fell out of the parse
+        -- which LOWERS the total and reads as options closed while the
+        TypeScript is untouched.
+        """
+        ledger = textwrap.dedent('''
+            export const UNHONOURED_OPTIONS: Readonly<Record<string, readonly string[]>> = {
+              'Agent.__init__': [
+                'auth', 'sandbox',
+              ],
+              Handoff: [
+                'maxDepth', 'detectCycles',
+              ],
+            } as const;
+        ''')
+        call_sites = (
+            "const a = unhonouredFor('Agent.__init__');\n"
+            "const h = unhonouredFor('Handoff');\n"
+        )
+        b = B.read_ledger(_repo(tmp_path, ledger=ledger, call_sites=call_sites))
+        assert b.surfaces['Handoff'] == ['maxDepth', 'detectCycles']
+        assert b.total == 4
+
+    def test_bare_key_surface_that_the_ts_iterates_cannot_be_lost(self, tmp_path):
+        """Control: even if the parse missed a bare key, the unhonouredFor guard
+        must catch it rather than let the options read as closed.
+
+        Simulated by naming a surface at a call site that the parser does not
+        return; the cross-check must refuse rather than count it closed.
+        """
+        # A well-formed bare-key ledger, but the call site iterates a surface the
+        # ledger declares with a bare key -- proving the guard now sees bare keys.
+        ledger = textwrap.dedent('''
+            export const UNHONOURED_OPTIONS: Readonly<Record<string, readonly string[]>> = {
+              'Agent.__init__': [
+                'auth',
+              ],
+              Handoff: [
+                'maxDepth',
+              ],
+            } as const;
+        ''')
+        call_sites = (
+            "const a = unhonouredFor('Agent.__init__');\n"
+            "const h = unhonouredFor('Handoff');\n"
+        )
+        # Sanity: with the fix, this parses cleanly and the guard is satisfied.
+        b = B.read_ledger(_repo(tmp_path, ledger=ledger, call_sites=call_sites))
+        assert 'Handoff' in b.surfaces

--- a/src/praisonai/tests/unit/_dev/test_parity_tracker.py
+++ b/src/praisonai/tests/unit/_dev/test_parity_tracker.py
@@ -1122,6 +1122,85 @@ class TestNamedReexportMustResolve:
             )
             assert 'Deep' in TypeScriptFeatureExtractor(root).extract().get_export_names()
 
+    def test_nested_named_reexport_of_a_real_symbol_resolves(self):
+        """Control: a name reaching index.ts through a barrel's `export { X } from`."""
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index="export { Deep } from './agent';\n",
+                ts_files={
+                    "agent/index.ts": "export { Deep } from './deep';\n",
+                    "agent/deep.ts": "export class Deep {}\n",
+                },
+                autostub_reexports=False,
+            )
+            assert 'Deep' in TypeScriptFeatureExtractor(root).extract().get_export_names()
+
+    def test_nested_named_reexport_of_a_phantom_symbol_is_dropped(self):
+        """A barrel that re-exports a name from a module that does not exist must
+        not validate that name. Before the fix, ``export { Phantom } from
+        './missing'`` inside a barrel was trusted by source name alone, so an
+        uncompilable phantom re-export reached parity through one extra hop.
+        """
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index="export { Phantom } from './agent';\n",
+                ts_files={
+                    # The barrel resolves, but the module it re-exports from does not.
+                    "agent/index.ts": "export { Phantom } from './no-such-module';\n",
+                },
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'Phantom' not in names
+
+    def test_nested_named_reexport_of_a_symbol_the_target_lacks_is_dropped(self):
+        """The barrel and its target both resolve, but the target does not declare
+        the named symbol -- so it cannot compile and is not parity."""
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index="export { Missing } from './agent';\n",
+                ts_files={
+                    "agent/index.ts": "export { Missing } from './deep';\n",
+                    "agent/deep.ts": "export class SomethingElse {}\n",
+                },
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'Missing' not in names
+
+    def test_phantom_nested_reexport_does_not_close_a_gap(self):
+        """Generator level: a phantom nested re-export leaves the row TODO."""
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                py_init=py_init_with('Agent', 'TotallyNewCapability'),
+                ts_index=(
+                    "export { Agent } from './agent';\n"
+                    "export { TotallyNewCapability } from './barrel';\n"
+                ),
+                ts_files={
+                    "agent/index.ts": "export class Agent {}\n",
+                    "barrel/index.ts": "export { TotallyNewCapability } from './nope';\n",
+                },
+                autostub_reexports=False,
+            )
+            tracker = ParityTrackerGenerator(root).generate()
+            rows = all_rows(tracker)
+            assert rows['Agent']['status'] == 'DONE'
+            assert rows['TotallyNewCapability']['status'] == 'TODO'
+            assert tracker['summary']['gapCount'] == 1
+
     def test_phantom_reexport_does_not_close_a_gap(self):
         """Generator level: the row stays TODO and gapCount stays 1."""
         from praisonai._dev.parity.generator import ParityTrackerGenerator

--- a/src/praisonai/tests/unit/_dev/test_parity_tracker.py
+++ b/src/praisonai/tests/unit/_dev/test_parity_tracker.py
@@ -6,6 +6,7 @@ Tests the Python and TypeScript feature extractors and the parity tracker genera
 
 import json
 import os
+import re
 import tempfile
 from datetime import date
 from pathlib import Path
@@ -40,8 +41,18 @@ def make_repo(
     ts_files: Optional[Dict[str, str]] = None,
     rust_lib: Optional[str] = None,
     cli_features: Optional[Dict[str, str]] = None,
+    autostub_reexports: bool = True,
 ) -> Path:
-    """Create a minimal monorepo layout under ``root`` and return it."""
+    """Create a minimal monorepo layout under ``root`` and return it.
+
+    ``autostub_reexports`` materialises a target module for every
+    ``export { .. } from './x'`` / ``export * as ns from './x'`` in ``ts_index``
+    that the test did not supply itself, declaring the *source* name of each
+    binding. Named re-exports are only counted when their target resolves and
+    provides the symbol, so a fixture that omits the target is a fixture with a
+    broken import -- which is a different test. Pass ``False`` to write exactly
+    the files given and test what happens when a target really is missing.
+    """
     pkg_dir = root / "src" / "praisonai-agents" / "praisonaiagents"
     pkg_dir.mkdir(parents=True, exist_ok=True)
     (pkg_dir / "__init__.py").write_text(py_init)
@@ -54,6 +65,9 @@ def make_repo(
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content)
 
+    if autostub_reexports:
+        _stub_reexport_targets(ts_dir, ts_index)
+
     wrapper_dir = root / "src" / "praisonai" / "praisonai" / "cli" / "features"
     wrapper_dir.mkdir(parents=True, exist_ok=True)
     for name, content in (cli_features or {}).items():
@@ -64,6 +78,38 @@ def make_repo(
         rust_src.mkdir(parents=True, exist_ok=True)
         (rust_src / "lib.rs").write_text(rust_lib)
     return root
+
+
+_REEXPORT_IN_INDEX = re.compile(
+    r"export\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['\"]([^'\"]+)['\"]"
+    r"|export\s*\*\s*as\s+[A-Za-z_$][\w$]*\s*from\s*['\"]([^'\"]+)['\"]"
+)
+
+
+def _stub_reexport_targets(ts_dir: Path, ts_index: str) -> None:
+    """Write a module for each re-export target in ``ts_index`` that is absent."""
+    for names, spec, ns_spec in _REEXPORT_IN_INDEX.findall(ts_index):
+        spec = spec or ns_spec
+        if not spec.startswith('.'):
+            continue
+        rel = spec[2:] if spec.startswith('./') else spec
+        if any((ts_dir / c).exists() for c in (f"{rel}.ts", f"{rel}/index.ts")):
+            continue
+        decls = []
+        for raw in names.split(','):
+            raw = raw.strip()
+            if not raw:
+                continue
+            source = raw.split(' as ', 1)[0].strip()
+            if source.startswith('type '):
+                source = source[5:].strip()
+            if source == 'default':
+                decls.append("export default class _Default {}")
+            else:
+                decls.append(f"export class {source} {{}}")
+        target = ts_dir / f"{rel}.ts"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text('\n'.join(decls) + '\n')
 
 
 def py_init_with(*names: str) -> str:
@@ -835,9 +881,12 @@ class TestGenerateParityTracker:
             # Non-empty on both sides so the generator produces a baseline
             # (an empty source is now refused before drift can be checked).
             root = make_repo(Path(tmpdir), py_init=py_init_with('Agent'),
-                             ts_index="export { Agent } from './agent';")
+                             ts_index="export { Agent } from './agent';",
+                             ts_files={"agent.ts": "export class Agent {}\nexport class Tool {}\n"})
             generate_parity_tracker(repo_root=root, target='ts')
             # Mutate the TypeScript surface: the committed tracker is now stale.
+            # ``Tool`` really is declared in ./agent, so this is drift, not a
+            # broken import that the extractor would drop.
             (root / "src" / "praisonai-ts" / "src" / "index.ts").write_text(
                 "export { Agent, Tool } from './agent';")
             assert generate_parity_tracker(repo_root=root, target='ts', check=True) == 1
@@ -910,6 +959,9 @@ class TestExtractorFailureIsNotParity:
         ts = Path(tmpdir) / "src" / "praisonai-ts" / "src"
         ts.mkdir(parents=True)
         (ts / "index.ts").write_text(index_source)
+        # A named re-export only counts when its target resolves and provides
+        # the symbol, so the fixture ships the module it names.
+        (ts / "agent.ts").write_text("export class Agent {}\n")
         return Path(tmpdir)
 
     def test_unparseable_python_source_raises_instead_of_reporting_no_gaps(self):
@@ -946,3 +998,630 @@ class TestExtractorFailureIsNotParity:
             tracker = ParityTrackerGenerator(root).generate()
             assert tracker["summary"]["pythonCoreFeatures"] == 1
             assert tracker["summary"]["gapCount"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Defect 1: a named re-export whose target does not exist is not parity
+# ---------------------------------------------------------------------------
+
+class TestNamedReexportMustResolve:
+    """`export { X } from './nope'` must not count as a TypeScript export.
+
+    ``export *`` targets were resolved (and skipped when unresolvable) but
+    ``export { .. } from`` names were recorded with no check that the path or
+    the symbol existed. Measured before the fix: adding
+    ``TotallyNewCapability`` to ``praisonaiagents.__all__`` gave gapCount 1 and
+    ``--check`` exit 1; appending
+    ``export { TotallyNewCapability } from "./no/such/module";`` to
+    ``src/index.ts`` flipped it to gapCount 0, ``✅ exported`` and exit 0 --
+    while ``tsc`` could not compile that line at all.
+    """
+
+    def test_named_reexport_from_missing_module_is_not_an_export(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index='export { TotallyNewCapability } from "./no/such/module";\n',
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'TotallyNewCapability' not in names
+
+    def test_type_reexport_from_missing_module_is_not_an_export(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index='export type { GhostConfig } from "./no/such/module";\n',
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'GhostConfig' not in names
+
+    def test_star_as_reexport_from_missing_module_is_not_an_export(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index="export * as ghostNs from './no/such/module';\n",
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'ghostNs' not in names
+
+    def test_named_reexport_of_symbol_the_target_lacks_is_dropped(self):
+        """The file exists but does not export the name -- still not parity."""
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index="export { Agent, NeverDefined } from './agent';\n",
+                ts_files={"agent/index.ts": "export class Agent {}\n"},
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'Agent' in names           # control: really is there
+            assert 'NeverDefined' not in names
+
+    def test_aliased_reexport_is_checked_against_the_source_name(self):
+        """`export { Real as Public }` must look for `Real` in the target."""
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index=(
+                    "export { Real as PublicName } from './agent';\n"
+                    "export { Absent as AlsoPublic } from './agent';\n"
+                ),
+                ts_files={"agent/index.ts": "export class Real {}\n"},
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'PublicName' in names
+            assert 'AlsoPublic' not in names
+
+    def test_default_reexport_is_kept_when_target_has_a_default(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index=(
+                    "export { default as Wired } from './wired';\n"
+                    "export { default as Unwired } from './unwired';\n"
+                ),
+                ts_files={
+                    "wired.ts": "export default class Thing {}\n",
+                    "unwired.ts": "export class Thing {}\n",
+                },
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'Wired' in names
+            assert 'Unwired' not in names
+
+    def test_reexport_through_a_barrel_still_resolves(self):
+        """Control: the name reaches index.ts through one more hop."""
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index="export { Deep } from './agent';\n",
+                ts_files={
+                    "agent/index.ts": "export * from './deep';\n",
+                    "agent/deep.ts": "export class Deep {}\n",
+                },
+                autostub_reexports=False,
+            )
+            assert 'Deep' in TypeScriptFeatureExtractor(root).extract().get_export_names()
+
+    def test_phantom_reexport_does_not_close_a_gap(self):
+        """Generator level: the row stays TODO and gapCount stays 1."""
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                py_init=py_init_with('Agent', 'TotallyNewCapability'),
+                ts_index=(
+                    "export { Agent } from './agent';\n"
+                    'export { TotallyNewCapability } from "./no/such/module";\n'
+                ),
+                ts_files={"agent/index.ts": "export class Agent {}\n"},
+                autostub_reexports=False,
+            )
+            tracker = ParityTrackerGenerator(root).generate()
+            rows = all_rows(tracker)
+            assert rows['Agent']['status'] == 'DONE'
+            assert rows['TotallyNewCapability']['status'] == 'TODO'
+            assert tracker['summary']['gapCount'] == 1
+
+
+# ---------------------------------------------------------------------------
+# Defect 2: an export statement inside a string literal is not an export
+# ---------------------------------------------------------------------------
+
+class TestExportsInsideStringLiteralsDoNotCount:
+    """Doc snippets, fixtures and codegen templates must not satisfy parity.
+
+    ``_strip_comments`` deliberately preserved string literals and then ran the
+    export regexes over them. Measured before the fix: adding
+    ``export const DOC_SNIPPET = `export { DocSnippetOnly } from "./made-up";`;``
+    to ``src/index.ts`` marked ``DocSnippetOnly`` DONE and dropped gapCount to 0.
+    """
+
+    def test_reexport_inside_template_literal_is_not_an_export(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index=(
+                    "export { Agent } from './agent';\n"
+                    'export const DOC_SNIPPET = `export { DocSnippetOnly } from "./agent";`;\n'
+                ),
+                ts_files={"agent/index.ts": "export class Agent {}\nexport class DocSnippetOnly {}\n"},
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'Agent' in names          # control: the real statement counts
+            assert 'DOC_SNIPPET' not in names or True  # local const, not a re-export
+            assert 'DocSnippetOnly' not in names
+
+    def test_reexport_inside_quoted_strings_is_not_an_export(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index=(
+                    "export { Agent } from './agent';\n"
+                    "const single = 'export { SingleQuoted } from \"./agent\";';\n"
+                    'const dbl = "export { DoubleQuoted } from \'./agent\';";\n'
+                ),
+                ts_files={
+                    "agent/index.ts":
+                        "export class Agent {}\nexport class SingleQuoted {}\n"
+                        "export class DoubleQuoted {}\n"
+                },
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'Agent' in names
+            assert 'SingleQuoted' not in names
+            assert 'DoubleQuoted' not in names
+
+    def test_declaration_inside_template_literal_is_not_an_export(self):
+        """Same rule inside a star-exported module, for `export class` templates."""
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        module = (
+            "export class RealThing {}\n"
+            "export const TEMPLATE = `\n"
+            "export class TemplatedGhost {}\n"
+            "`;\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                ts_index="export * from './codegen';\n",
+                ts_files={"codegen/index.ts": module},
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'RealThing' in names
+            assert 'TEMPLATE' in names       # the const itself really is exported
+            assert 'TemplatedGhost' not in names
+
+    def test_doc_snippet_does_not_close_a_gap(self):
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                py_init=py_init_with('Agent', 'DocSnippetOnly'),
+                ts_index=(
+                    "export { Agent } from './agent';\n"
+                    'export const DOC_SNIPPET = `export { DocSnippetOnly } from "./made-up";`;\n'
+                ),
+                ts_files={"agent/index.ts": "export class Agent {}\n"},
+                autostub_reexports=False,
+            )
+            tracker = ParityTrackerGenerator(root).generate()
+            assert all_rows(tracker)['DocSnippetOnly']['status'] == 'TODO'
+            assert tracker['summary']['gapCount'] == 1
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: the Python extractor must see exports added the ordinary way
+# ---------------------------------------------------------------------------
+
+class TestPythonDirectImportsAndLazyUpdate:
+    """The class docstring promised ``_LAZY_IMPORTS``, ``__all__`` and "Direct
+    imports"; only the first two were implemented, and ``_LAZY_IMPORTS.update``
+    was ignored outright. Measured before the fix: appending
+    ``from .agent.agent import Agent as BrandNewThing`` and
+    ``_LAZY_IMPORTS.update({'AnotherNewThing': (...)})`` to
+    ``praisonaiagents/__init__.py`` left both names untracked and ``--check``
+    green. ``_refuse_empty`` only catches a *total* zero, so partial loss like
+    this was invisible.
+    """
+
+    def _extract(self, tmpdir, init_source):
+        from praisonai._dev.parity.python_extractor import PythonFeatureExtractor
+
+        root = make_repo(Path(tmpdir), py_init=init_source)
+        return PythonFeatureExtractor(root).extract()
+
+    def test_direct_relative_import_with_alias_is_an_export(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            features = self._extract(tmpdir, (
+                "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                "from .agent.agent import Agent as BrandNewThing\n"
+            ))
+            names = {e.name for e in features.exports}
+            assert 'BrandNewThing' in names
+
+    def test_direct_relative_import_is_categorised_by_its_module(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            features = self._extract(tmpdir, (
+                "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                "from .agent.agent import Agent as BrandNewThing\n"
+            ))
+            row = next(e for e in features.exports if e.name == 'BrandNewThing')
+            assert row.category == 'agent'
+            assert row.module_path == 'praisonaiagents.agent.agent'
+
+    def test_from_dot_import_submodule_is_an_export(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            features = self._extract(tmpdir, (
+                "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                "from . import workflows\n"
+            ))
+            assert 'workflows' in {e.name for e in features.exports}
+
+    def test_absolute_self_import_is_an_export(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            features = self._extract(tmpdir, (
+                "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                "from praisonaiagents.task.task import Task\n"
+            ))
+            assert 'Task' in {e.name for e in features.exports}
+
+    def test_private_names_and_private_modules_are_not_exports(self):
+        """Control: the plumbing imports the real __init__.py already has."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            features = self._extract(tmpdir, (
+                "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                "from . import _logging\n"
+                "from ._lazy import lazy_import\n"
+                "from .agent.agent import Agent as _hidden\n"
+                "import os\n"
+                "from typing import Any\n"
+                "from pydantic import BaseModel\n"
+            ))
+            names = {e.name for e in features.exports}
+            assert '_logging' not in names
+            assert 'lazy_import' not in names     # private module -> internal plumbing
+            assert '_hidden' not in names
+            # Someone else's names are not this SDK's public surface
+            assert 'os' not in names
+            assert 'Any' not in names
+            assert 'BaseModel' not in names
+            assert names == {'Agent'}
+
+    def test_star_import_does_not_invent_a_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            features = self._extract(tmpdir, (
+                "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                "from .agent.agent import *\n"
+            ))
+            assert '*' not in {e.name for e in features.exports}
+
+    def test_lazy_imports_update_entries_are_collected(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            features = self._extract(tmpdir, (
+                "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                "_LAZY_IMPORTS.update({'AnotherNewThing': ('praisonaiagents.task.task', 'Task')})\n"
+            ))
+            names = {e.name for e in features.exports}
+            assert 'AnotherNewThing' in names
+            row = next(e for e in features.exports if e.name == 'AnotherNewThing')
+            assert row.category == 'task'
+
+    def test_unreadable_lazy_imports_update_fails_loudly(self):
+        """A form we cannot read must raise, not silently drop the entries."""
+        from praisonai._dev.parity.python_extractor import PythonFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(Path(tmpdir), py_init=(
+                "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                "_EXTRA = {'X': ('praisonaiagents.agent.agent', 'X')}\n"
+                "_LAZY_IMPORTS.update(_EXTRA)\n"
+            ))
+            with pytest.raises(RuntimeError, match="_LAZY_IMPORTS.update"):
+                PythonFeatureExtractor(root).extract()
+
+    def test_docstring_promises_only_what_it_implements(self):
+        """Every mechanism the docstring names must actually be extracted."""
+        from praisonai._dev.parity.python_extractor import PythonFeatureExtractor
+
+        doc = PythonFeatureExtractor.__doc__ or ""
+        for claim in ("_LAZY_IMPORTS", "__all__", "import"):
+            assert claim in doc, claim
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            features = self._extract(tmpdir, (
+                "_LAZY_IMPORTS = {'Lazy': ('praisonaiagents.agent.agent', 'Lazy')}\n"
+                "_LAZY_IMPORTS.update({'Updated': ('praisonaiagents.agent.agent', 'Updated')})\n"
+                "from .task.task import Task as Direct\n"
+                "__all__ = ['OnlyInAll']\n"
+            ))
+            names = {e.name for e in features.exports}
+            assert {'Lazy', 'Updated', 'Direct', 'OnlyInAll'} <= names
+
+
+# ---------------------------------------------------------------------------
+# Defect 4: mutations that survived the suite
+# ---------------------------------------------------------------------------
+
+class TestSurvivingMutations:
+    """Three mutations passed the whole suite; each now has a test that fails.
+
+    1. ``generator._check_json``: ``if _tracker_equal_ignoring_date(..)`` ->
+       ``if True`` -- nothing tested that ``--check`` detects a stale
+       ``FEATURE_PARITY_TRACKER.json``; only the markdown half was covered.
+    2. ``python_extractor``: ``all_exports = self._extract_all_exports(..)`` ->
+       ``set()`` -- ``__all__`` contributes real names that no test read back
+       out of ``extract()``.
+    3. ``typescript_extractor._strip_comments`` -> identity -- no fixture put a
+       commented-out export where the regexes could see it.
+    """
+
+    # --- mutation 1: stale JSON must fail --check ---------------------------
+
+    def test_check_json_detects_a_stale_tracker(self):
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(Path(tmpdir), py_init=py_init_with('Agent'),
+                             ts_index="export { Agent } from './agent';")
+            generator = ParityTrackerGenerator(root)
+            assert generator.write_typescript() == 0
+            assert generator.write_typescript(check=True) == 0   # control
+
+            stale = json.loads(generator.ts_output.read_text())
+            stale['summary']['gapCount'] = 999
+            generator.ts_output.write_text(json.dumps(stale, indent=2) + '\n')
+
+            assert generator.write_typescript(check=True) == 1
+
+    def test_check_json_detects_drift_in_the_gap_matrix_only(self):
+        """Even a change the markdown would render identically must be caught."""
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(Path(tmpdir), py_init=py_init_with('Agent'),
+                             ts_index="export { Agent } from './agent';")
+            generator = ParityTrackerGenerator(root)
+            generator.write_typescript()
+
+            stale = json.loads(generator.ts_output.read_text())
+            stale['generatedBy'] = 'someone else'
+            generator.ts_output.write_text(json.dumps(stale, indent=2) + '\n')
+
+            assert generator.write_typescript(check=True) == 1
+
+    def test_check_json_still_tolerates_a_changed_date(self):
+        """Control: the date field alone must not fail --check."""
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(Path(tmpdir), py_init=py_init_with('Agent'),
+                             ts_index="export { Agent } from './agent';")
+            generator = ParityTrackerGenerator(root)
+            generator.write_typescript()
+
+            aged = json.loads(generator.ts_output.read_text())
+            aged['lastUpdated'] = '2000-01-01'
+            generator.ts_output.write_text(json.dumps(aged, indent=2) + '\n')
+
+            assert generator.write_typescript(check=True) == 0
+
+    def test_check_json_fails_on_a_missing_or_corrupt_file(self):
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(Path(tmpdir), py_init=py_init_with('Agent'),
+                             ts_index="export { Agent } from './agent';")
+            generator = ParityTrackerGenerator(root)
+            assert generator.write_typescript(check=True) == 1     # not written yet
+
+            generator.write_typescript()
+            generator.ts_output.write_text("{ not json")
+            assert generator.write_typescript(check=True) == 1
+
+    # --- mutation 2: __all__ must reach extract() ---------------------------
+
+    def test_all_only_names_reach_extract(self):
+        from praisonai._dev.parity.python_extractor import PythonFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(Path(tmpdir), py_init=(
+                "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                "__all__ = ['Agent', 'OnlyInAll', 'AlsoOnlyInAll']\n"
+            ))
+            features = PythonFeatureExtractor(root).extract()
+            names = {e.name for e in features.exports}
+            assert names == {'Agent', 'OnlyInAll', 'AlsoOnlyInAll'}
+
+    def test_all_only_names_become_gaps(self):
+        """The generator must see them too, not just the extractor."""
+        from praisonai._dev.parity.generator import ParityTrackerGenerator
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                py_init=(
+                    "_LAZY_IMPORTS = {'Agent': ('praisonaiagents.agent.agent', 'Agent')}\n"
+                    "__all__ = ['Agent', 'OnlyInAll']\n"
+                ),
+                ts_index="export { Agent } from './agent';",
+            )
+            tracker = ParityTrackerGenerator(root).generate()
+            assert all_rows(tracker)['OnlyInAll']['status'] == 'TODO'
+            assert tracker['summary']['pythonCoreFeatures'] == 2
+
+    @requires_real_repo
+    def test_real_all_only_names_are_tracked(self):
+        """The real ``__all__`` contributes names no ``_LAZY_IMPORTS`` entry has."""
+        from praisonai._dev.parity.python_extractor import PythonFeatureExtractor
+
+        extractor = PythonFeatureExtractor(REAL_REPO_ROOT)
+        init_file = extractor.agents_pkg / "__init__.py"
+        lazy = set(extractor._extract_lazy_imports(init_file))
+        all_only = extractor._extract_all_exports(init_file) - lazy
+        assert all_only, "fixture assumption broken: __all__ adds nothing"
+
+        names = {e.name for e in extractor.extract().exports}
+        assert all_only <= names
+
+    # --- mutation 3: comments must be stripped ------------------------------
+
+    def test_block_comment_declaration_at_column_zero_is_not_an_export(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        module = (
+            "/*\n"
+            "export class CommentedOutGhost {}\n"
+            "*/\n"
+            "export class RealThing {}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(Path(tmpdir), ts_index="export * from './m';\n",
+                             ts_files={"m/index.ts": module}, autostub_reexports=False)
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'RealThing' in names
+            assert 'CommentedOutGhost' not in names
+
+    def test_commented_out_reexport_in_index_is_not_an_export(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        index = (
+            "export { Agent } from './agent';\n"
+            "// export { LineCommented } from './agent';\n"
+            "/* export { BlockCommented } from './agent'; */\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir), ts_index=index,
+                ts_files={"agent/index.ts":
+                          "export class Agent {}\nexport class LineCommented {}\n"
+                          "export class BlockCommented {}\n"},
+                autostub_reexports=False,
+            )
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'Agent' in names
+            assert 'LineCommented' not in names
+            assert 'BlockCommented' not in names
+
+    def test_strip_comments_keeps_module_paths_intact(self):
+        """Control: stripping must not eat the string literals export needs."""
+        from praisonai._dev.parity.typescript_extractor import _strip_comments
+
+        src = "export { A } from './agent'; // trailing\n"
+        stripped = _strip_comments(src)
+        assert "'./agent'" in stripped
+        assert "trailing" not in stripped
+
+
+# ---------------------------------------------------------------------------
+# The generator must be deterministic
+# ---------------------------------------------------------------------------
+
+class TestDeterministicOutput:
+    """Two runs in a row must produce byte-identical files."""
+
+    def test_second_run_is_byte_identical(self):
+        from praisonai._dev.parity.generator import generate_parity_tracker
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(
+                Path(tmpdir),
+                py_init=py_init_with('Agent', 'Task', 'Missing'),
+                ts_index="export { Agent } from './agent';\nexport * from './task';\n",
+                ts_files={"task/index.ts": "export class Task {}\n"},
+                rust_lib="pub struct Agent;\n",
+            )
+            assert generate_parity_tracker(repo_root=root, target='all') == 0
+            first = {
+                p: p.read_bytes()
+                for p in sorted(root.rglob("*"))
+                if p.name in ("FEATURE_PARITY_TRACKER.json", "PARITY.md")
+            }
+            assert first, "nothing was written"
+
+            assert generate_parity_tracker(repo_root=root, target='all') == 0
+            second = {p: p.read_bytes() for p in first}
+            assert second == first
+
+
+class TestRegexLiteralsAreNotTemplateLiterals:
+    """A regex literal containing a backtick must not swallow the next exports.
+
+    Found while adding the string-literal guard: ``src/bots/base.ts`` has
+    ``const MDV2_ESCAPE_RE = /([_*[\\]()~`>#+\\-=|{}.!\\\\])/g;``. A regex-based
+    splitter reads that backtick as the start of a template literal running to
+    the next backtick six lines later, hiding ``escapeMarkdownV2`` and
+    ``markdownToSlack``. Only a real scanner tells the two apart.
+    """
+
+    MODULE = (
+        "const MDV2_ESCAPE_RE = /([_*[\\]()~`>#+\\-=|{}.!\\\\])/g;\n"
+        "\n"
+        "/**\n"
+        " * Escape every special character in `text`.\n"
+        " */\n"
+        "export function escapeMarkdownV2(text: string): string {\n"
+        "  return text.replace(MDV2_ESCAPE_RE, '\\\\$1');\n"
+        "}\n"
+        "export function markdownToSlack(text: string): string { return text; }\n"
+    )
+
+    def test_exports_after_a_regex_literal_are_still_found(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(Path(tmpdir), ts_index="export * from './bots/base';\n",
+                             ts_files={"bots/base.ts": self.MODULE}, autostub_reexports=False)
+            names = TypeScriptFeatureExtractor(root).extract().get_export_names()
+            assert 'escapeMarkdownV2' in names
+            assert 'markdownToSlack' in names
+
+    def test_division_is_not_mistaken_for_a_regex(self):
+        """Control: a real division must not open a literal either."""
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        module = (
+            "const ratio = total / count; const other = (a) / b;\n"
+            "export class AfterDivision {}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = make_repo(Path(tmpdir), ts_index="export * from './m';\n",
+                             ts_files={"m/index.ts": module}, autostub_reexports=False)
+            assert 'AfterDivision' in TypeScriptFeatureExtractor(root).extract().get_export_names()
+
+    @requires_real_repo
+    def test_real_bots_module_exports_survive(self):
+        from praisonai._dev.parity.typescript_extractor import TypeScriptFeatureExtractor
+
+        names = TypeScriptFeatureExtractor(REAL_REPO_ROOT).extract().get_export_names()
+        assert 'escapeMarkdownV2' in names
+        assert 'markdownToSlack' in names

--- a/src/praisonai/tests/unit/_dev/test_signature_parity.py
+++ b/src/praisonai/tests/unit/_dev/test_signature_parity.py
@@ -52,15 +52,24 @@ def ts_param(name, default=None, default_kind=None, required=False, kind='proper
     }
 
 
-def sig(language, params, surface=SURFACE):
-    return {'surface': surface, 'language': language, 'location': f'{language}.src:1', 'params': params}
+def sig(language, params, surface=SURFACE, extra=None):
+    return {'surface': surface, 'language': language, 'location': f'{language}.src:1',
+            'params': params, 'extra': extra or {}}
 
 
-def default_rules(aliases=None, flattened=None):
+def flattening(fields, python_config=None, field_map=None):
+    """A `rules.yaml` flattened entry: TS field names, optionally mapped to
+    fields of the Python nested-config class those TS defaults must agree with."""
+    return C.Flattening(fields=list(fields), python_config=python_config, field_map=field_map or {})
+
+
+def default_rules(aliases=None, flattened=None, nested_defaults=None):
     return C.Rules(
         aliases={SURFACE: aliases or {}},
-        flattened={SURFACE: flattened or {}},
-        default_equivalences=[(None, 'undefined'), (True, True), (False, False)],
+        flattened={SURFACE: {k: (v if isinstance(v, C.Flattening) else flattening(v))
+                             for k, v in (flattened or {}).items()}},
+        default_equivalences=[(None, 'undefined'), (False, 'undefined')],
+        nested_defaults=nested_defaults or {},
     )
 
 
@@ -585,8 +594,12 @@ class TestCli:
         assert len({s.key for s in catalogue.surfaces}) == len(catalogue.surfaces), 'duplicate surface keys'
         rules = C.load_rules()
         assert rules.aliases['Agent.__init__']['base_url'] == 'baseURL'
-        assert rules.flattened['Agent.__init__']['output'] == ['verbose', 'markdown', 'stream']
+        assert rules.flattened['Agent.__init__']['output'].fields == ['verbose', 'markdown', 'stream']
         assert (None, 'undefined') in rules.default_equivalences
+        # NOTE: this test asserts only that the YAML says what the YAML says,
+        # which is why eight dead entries survived in it. The check with teeth
+        # is TestRulesSelfTest, which runs `validate_rules` against a real
+        # extraction.
         for w in C.load_waivers():
             assert w.reason and w.owner
 
@@ -881,6 +894,43 @@ class TestStalenessIgnoresLineNumbers:
         assert C.strip_source_lines(text) == text
 
 
+class TestWaiverScopeByGapKind:
+    """A waiver is keyed by parameter, so it must not silence every KIND of gap.
+
+    Found by making `verbose`, `markdown` and `stream` required behind the
+    `Agent.__init__.output` waiver, which covers their DEFAULTS: the gate stayed
+    green over a change that stops `new Agent({ name: 'x' })` compiling.
+    Required-ness is therefore never covered implicitly.
+    """
+
+    @staticmethod
+    def _waiver(**kw):
+        return C.Waiver(key=SURFACE + '.name', reason='r', owner='o', **kw)
+
+    def test_a_default_waiver_does_not_cover_a_required_gap(self):
+        assert self._waiver().covers('default') is True
+        assert self._waiver().covers('required') is False
+
+    def test_naming_required_covers_it(self):
+        """Control: a waiver may still cover required-ness when it says so."""
+        assert self._waiver(kinds=['required']).covers('required') is True
+
+    def test_naming_kinds_excludes_the_others(self):
+        """Control: an explicit list is exhaustive, not additive."""
+        w = self._waiver(kinds=['required'])
+        assert w.covers('default') is False and w.covers('missing') is False
+
+    def test_kinds_survives_a_write_read_round_trip(self, tmp_path):
+        path = tmp_path / 'waivers.yaml'
+        C.write_waivers(path, [self._waiver(kinds=['required'])])
+        assert C.load_waivers(path)[0].kinds == ['required']
+
+    def test_a_malformed_kinds_is_a_tooling_error(self):
+        """Control: a typo must fail loudly, not silently waive nothing."""
+        with pytest.raises(C.ToolingError, match='kinds'):
+            C.Waiver.from_dict('S.p', {'reason': 'r', 'owner': 'o', 'kinds': 'required'})
+
+
 class TestPruneWaivers:
     def _comparison_with_gap(self, gap_name='auth'):
         py = C.signatures_from_json([sig('python', [py_param(gap_name), py_param('name')])])[SURFACE]
@@ -898,3 +948,535 @@ class TestPruneWaivers:
         comparison = self._comparison_with_gap()
         live = waiver('Agent.__init__.auth')
         assert [w.key for w in C.prune_waivers([comparison], [live])] == ['Agent.__init__.auth']
+
+
+# --------------------------------------------------- flattened parameters (D1)
+
+class TestFlattenedGapDetection:
+    """
+    A `flattened` match sets `ts_names` and leaves `ts` None, and
+    `compare_surface` used to run gap detection only `if row.ts is not None`.
+    The required-ness and defaults of the TS fields a flattening names were
+    therefore never compared at all.
+
+    Reproduced on the real repository: deleting three `?` in `SimpleAgentConfig`
+    to make `verbose`, `markdown` and `stream` REQUIRED -- which stops
+    `new Agent({ name: 'x' })` compiling for every user -- passed `--check`,
+    the names gate, the behaviour gate and all 142 tests, with a byte-identical
+    report.
+    """
+
+    PY = [py_param('output', default=None)]
+    FIELDS = ['verbose', 'markdown', 'stream']
+    NESTED = {
+        'praisonaiagents:OutputConfig': {
+            name: C.Param(name=name, canonical=name, kind='keyword', required=False,
+                          default=False, default_kind='literal')
+            for name in FIELDS
+        }
+    }
+
+    def _rules(self, mapped=True):
+        flat = flattening(
+            self.FIELDS,
+            python_config='praisonaiagents:OutputConfig' if mapped else None,
+            field_map={f: f for f in self.FIELDS} if mapped else None,
+        )
+        return default_rules(flattened={'output': flat},
+                             nested_defaults=self.NESTED if mapped else None)
+
+    def _ts(self, **overrides):
+        out = []
+        for name in self.FIELDS:
+            kwargs = {'default': False, 'default_kind': 'literal'}
+            kwargs.update(overrides.get(name, {}))
+            out.append(ts_param(name, **kwargs))
+        return out
+
+    def test_control_all_optional_with_matching_defaults_passes(self):
+        comps, ev = run([sig('python', self.PY)], [sig('typescript', self._ts())],
+                        rules=self._rules())
+        assert ev.ok, ev.failures
+        assert row(comps, 'output').match == 'flattened'
+        assert [p.name for p in row(comps, 'output').ts_members] == self.FIELDS
+
+    def test_a_required_flattened_member_is_a_gap(self):
+        """The headline defect: `verbose: boolean` instead of `verbose?: boolean`."""
+        ts = self._ts(verbose={'required': True, 'default': None, 'default_kind': None})
+        comps, ev = run([sig('python', self.PY)], [sig('typescript', ts)], rules=self._rules())
+        assert not ev.ok
+        gap = row(comps, 'output').gap
+        assert gap is not None and gap.kind == 'required'
+        assert 'verbose' in gap.detail and 'required in TypeScript' in gap.detail
+        assert any('output' in f and 'verbose' in f for f in ev.failures)
+
+    def test_every_required_member_is_named_not_just_the_first(self):
+        ts = self._ts(**{n: {'required': True, 'default': None, 'default_kind': None}
+                         for n in self.FIELDS})
+        comps, ev = run([sig('python', self.PY)], [sig('typescript', ts)], rules=self._rules())
+        assert not ev.ok
+        detail = row(comps, 'output').gap.detail
+        for name in self.FIELDS:
+            assert f'`{name}`' in detail
+
+    def test_member_default_is_compared_against_the_nested_config_field(self):
+        """`Agent(output=None)` resolves to `OutputConfig()`, so its field
+        defaults -- not the parameter's own `None` -- are the Python side."""
+        ts = self._ts(markdown={'default': True, 'default_kind': 'literal'},
+                      stream={'default': True, 'default_kind': 'literal'})
+        comps, ev = run([sig('python', self.PY)], [sig('typescript', ts)], rules=self._rules())
+        assert not ev.ok
+        gap = row(comps, 'output').gap
+        assert gap.kind == 'default'
+        assert '`markdown` default differs' in gap.detail
+        assert '`stream` default differs' in gap.detail
+        # `verbose` agrees with OutputConfig.verbose, so only the field list mentions it.
+        assert '`verbose` default differs' not in gap.detail
+
+    def test_field_with_no_python_counterpart_is_checked_for_requiredness_only(self):
+        """`cacheTTL` has no field on `CachingConfig`: nothing to compare a
+        default against, but a required one is still a gap."""
+        rules = default_rules(
+            flattened={'caching': flattening(['cache', 'cacheTTL'],
+                                             python_config='praisonaiagents:CachingConfig',
+                                             field_map={'cache': 'enabled', 'cacheTTL': None})},
+            nested_defaults={'praisonaiagents:CachingConfig': {
+                'enabled': C.Param(name='enabled', canonical='enabled', kind='keyword',
+                                   required=False, default=False, default_kind='literal')}},
+        )
+        py = [py_param('caching', default=None)]
+        ok_ts = [ts_param('cache', default=False, default_kind='literal'),
+                 ts_param('cacheTTL', default=3600, default_kind='literal')]
+        _, ev = run([sig('python', py)], [sig('typescript', ok_ts)], rules=rules)
+        assert ev.ok, ev.failures
+        bad_ts = [ts_param('cache', default=False, default_kind='literal'),
+                  ts_param('cacheTTL', required=True)]
+        comps, ev = run([sig('python', py)], [sig('typescript', bad_ts)], rules=rules)
+        assert not ev.ok and row(comps, 'caching').gap.kind == 'required'
+        assert 'cacheTTL' in row(comps, 'caching').gap.detail
+
+    def test_a_flattened_gap_is_waivable_under_the_python_parameter_name(self):
+        ts = self._ts(markdown={'default': True, 'default_kind': 'literal'})
+        _, ev = run([sig('python', self.PY)], [sig('typescript', ts)], rules=self._rules(),
+                    waivers=[waiver(f'{SURFACE}.output')])
+        assert ev.ok, ev.failures
+
+    def test_without_a_nested_config_only_requiredness_is_checked(self):
+        """A flattening with no `python_config` cannot know what the fields
+        should default to, so it must not invent a default gap."""
+        ts = self._ts(markdown={'default': True, 'default_kind': 'literal'})
+        _, ev = run([sig('python', self.PY)], [sig('typescript', ts)], rules=self._rules(mapped=False))
+        assert ev.ok, ev.failures
+
+
+# --------------------------------------------------- unrecognised defaults (D2)
+
+class TestUnknownTsDefault:
+    """
+    `collectDefaultsFrom` recognised only a handful of TS defaulting forms, and
+    anything else recorded nothing -- `default_kind: null`, compared as
+    `undefined`, silently matched by the `null <-> undefined` and
+    `false <-> undefined` equivalences.
+
+    Reproduced on the real repository: rewriting one line to
+    `this.reasoningEffort = ({ reasoningEffort: 'high', ...config }).reasoningEffort;`
+    left the report byte-identical and every gate green, and so did an
+    `if`-statement default that gated every tool behind an interactive prompt.
+    """
+
+    def test_unknown_ts_default_is_a_gap(self):
+        py = [py_param('reasoning_effort', default=None)]
+        ts = [ts_param('reasoningEffort', default=None, default_kind='unknown')]
+        comps, ev = run([sig('python', py)], [sig('typescript', ts)])
+        assert not ev.ok
+        assert row(comps, 'reasoning_effort').gap.kind == 'default'
+        assert 'unknown' in row(comps, 'reasoning_effort').gap.detail
+
+    def test_unknown_is_not_matched_by_the_false_undefined_equivalence(self):
+        """A `false <-> undefined` Python default must not absorb an unknown."""
+        py = [py_param('approval', default=False)]
+        ts = [ts_param('approval', default=None, default_kind='unknown')]
+        _, ev = run([sig('python', py)], [sig('typescript', ts)])
+        assert not ev.ok
+
+    def test_control_genuinely_no_default_is_still_undefined(self):
+        py = [py_param('approval', default=None)]
+        ts = [ts_param('approval')]
+        _, ev = run([sig('python', py)], [sig('typescript', ts)])
+        assert ev.ok, ev.failures
+
+    def test_unknown_is_waivable(self):
+        py = [py_param('reasoning_effort', default=None)]
+        ts = [ts_param('reasoningEffort', default=None, default_kind='unknown')]
+        _, ev = run([sig('python', py)], [sig('typescript', ts)],
+                    waivers=[waiver(f'{SURFACE}.reasoning_effort')])
+        assert ev.ok, ev.failures
+
+    def test_unknown_renders_distinctly_from_undefined(self):
+        py = [py_param('reasoning_effort', default=None), py_param('other', default=None)]
+        ts = [ts_param('reasoningEffort', default=None, default_kind='unknown'), ts_param('other')]
+        comps, _ = run([sig('python', py)], [sig('typescript', ts)],
+                       waivers=[waiver(f'{SURFACE}.reasoning_effort')])
+        md = C.render_markdown(comps, [])
+        assert '| unknown |' in md and '| undefined |' in md
+
+
+# ------------------------------------------------ TS-only required member (D3)
+
+class TestTsOnlyRequiredMember:
+    """
+    `ts_only` was computed and rendered but `evaluate()` never looked at it.
+    Reproduced on the real repository: adding a required `tenantId` to
+    `SimpleAgentConfig` failed only on report freshness, and running `--write`
+    -- exactly what the CI error tells you to do -- made it green.
+    """
+
+    def test_required_ts_only_member_fails(self):
+        ts = BASE_TS + [ts_param('tenantId', required=True)]
+        comps, ev = run([sig('python', BASE_PY)], [sig('typescript', ts)])
+        assert not ev.ok
+        assert any('tenantId' in f and SURFACE in f for f in ev.failures)
+        assert [p.name for p in comps[0].ts_only_required()] == ['tenantId']
+
+    def test_optional_ts_only_member_stays_informational(self):
+        ts = BASE_TS + [ts_param('tenantId', required=False)]
+        comps, ev = run([sig('python', BASE_PY)], [sig('typescript', ts)])
+        assert ev.ok, ev.failures
+        assert [p.name for p in comps[0].ts_only] == ['tenantId']
+        assert comps[0].ts_only_required() == []
+
+    def test_required_ts_only_member_is_waivable(self):
+        ts = BASE_TS + [ts_param('tenantId', required=True)]
+        _, ev = run([sig('python', BASE_PY)], [sig('typescript', ts)],
+                    waivers=[waiver(f'{SURFACE}.tenantId')])
+        assert ev.ok, ev.failures
+
+    def test_expired_waiver_on_a_ts_only_member_fails(self):
+        ts = BASE_TS + [ts_param('tenantId', required=True)]
+        _, ev = run([sig('python', BASE_PY)], [sig('typescript', ts)],
+                    waivers=[waiver(f'{SURFACE}.tenantId', expires=date(2026, 1, 1))])
+        assert not ev.ok
+        assert any('expired' in f for f in ev.failures)
+
+    def test_the_options_parameter_itself_is_not_a_gap(self):
+        """`constructor(config: SimpleAgentConfig)` is required, but a required
+        options OBJECT is not a parity gap: its members are the surface, and
+        Python spells them out as keyword arguments."""
+        ts = BASE_TS + [ts_param('config', required=True, kind='positional')]
+        comps, ev = run([sig('python', BASE_PY)],
+                        [sig('typescript', ts, extra={'options_parameters': ['config']})])
+        assert ev.ok, ev.failures
+        assert comps[0].ts_only_required() == []
+
+    def test_baseline_and_prune_cover_ts_only_gaps(self):
+        """Without this, `--baseline` would never write the waiver the gate
+        demands and `--prune` would delete it again as stale."""
+        ts = BASE_TS + [ts_param('tenantId', required=True)]
+        comps, _ = run([sig('python', BASE_PY)], [sig('typescript', ts)])
+        assert [w.key for w in C.baseline_waivers(comps, [])] == [f'{SURFACE}.tenantId']
+        live = waiver(f'{SURFACE}.tenantId')
+        assert [w.key for w in C.prune_waivers(comps, [live, waiver(f'{SURFACE}.gone')])] == [live.key]
+
+    def test_required_ts_only_member_is_named_in_the_report(self):
+        ts = BASE_TS + [ts_param('tenantId', required=True), ts_param('optional_extra')]
+        comps, _ = run([sig('python', BASE_PY)], [sig('typescript', ts)],
+                       waivers=[waiver(f'{SURFACE}.tenantId')])
+        md = C.render_markdown(comps, [])
+        assert 'TS-only members that are REQUIRED' in md and '`tenantId`' in md
+
+
+# --------------------------------------------------- rules.yaml self-test (D4)
+
+class TestRulesSelfTest:
+    """
+    Eight entries in `rules.yaml` fired zero times on a real run and nothing
+    noticed, because `test_config_files_load` only asserted that the YAML says
+    what the YAML says. `validate_rules` checks the config against a real
+    extraction so dead config cannot accumulate again.
+    """
+
+    @staticmethod
+    def _sides(py_names, ts_names):
+        python = C.signatures_from_json([sig('python', [py_param(n) for n in py_names])])
+        typescript = C.signatures_from_json([sig('typescript', [ts_param(n) for n in ts_names])])
+        return python, typescript
+
+    def _problems(self, rules, py_names=('name',), ts_names=('name',)):
+        python, typescript = self._sides(py_names, ts_names)
+        return C.validate_rules(rules, python, typescript)
+
+    def test_control_a_live_alias_is_clean(self):
+        rules = default_rules(aliases={'base_url': 'baseURL'})
+        assert self._problems(rules, ['base_url'], ['baseURL']) == []
+
+    def test_alias_for_a_python_parameter_that_does_not_exist(self):
+        rules = default_rules(aliases={'output_json': 'outputSchema'})
+        problems = self._problems(rules, ['name'], ['outputSchema'])
+        assert len(problems) == 1
+        assert 'output_json' in problems[0] and 'no Python parameter' in problems[0]
+
+    def test_alias_shadowed_by_the_exact_name_tier(self):
+        rules = default_rules(aliases={'model': 'llm'})
+        problems = self._problems(rules, ['model'], ['model', 'llm'])
+        assert len(problems) == 1
+        assert 'never fires' in problems[0] and 'exact-name' in problems[0]
+
+    def test_alias_shadowed_by_the_camel_case_tier(self):
+        rules = default_rules(aliases={'session_id': 'id'})
+        problems = self._problems(rules, ['session_id'], ['sessionId', 'id'])
+        assert len(problems) == 1
+        assert 'never fires' in problems[0] and 'camelCase' in problems[0]
+
+    def test_alias_that_is_a_pure_case_change(self):
+        rules = default_rules(aliases={'agent_url': 'agentUrl'})
+        problems = self._problems(rules, ['agent_url'], ['agentUrl'])
+        assert len(problems) == 1
+        assert 'pure case change' in problems[0]
+
+    def test_alias_shadowed_by_a_flattening(self):
+        """`caching -> cache` used to win over the stricter two-field rule."""
+        rules = default_rules(aliases={'caching': 'cache'},
+                              flattened={'caching': flattening(['cache', 'cacheTTL'])})
+        problems = self._problems(rules, ['caching'], ['cache', 'cacheTTL'])
+        assert len(problems) == 1
+        assert 'never fires' in problems[0] and 'flattened' in problems[0]
+
+    def test_alias_naming_a_typescript_member_that_does_not_exist(self):
+        rules = default_rules(aliases={'base_url': 'baseURL'})
+        problems = self._problems(rules, ['base_url'], ['name'])
+        assert len(problems) == 1 and 'no TypeScript member' in problems[0]
+
+    def test_flattening_for_a_python_parameter_that_does_not_exist(self):
+        rules = default_rules(flattened={'output': flattening(['verbose'])})
+        problems = self._problems(rules, ['name'], ['verbose'])
+        assert len(problems) == 1 and 'no Python parameter' in problems[0]
+
+    def test_flattening_whose_typescript_fields_do_not_exist(self):
+        rules = default_rules(flattened={'output': flattening(['verbose', 'markdown'])})
+        problems = self._problems(rules, ['output'], ['verbose'])
+        assert len(problems) == 1 and 'markdown' in problems[0] and 'never fires' in problems[0]
+
+    def test_flattening_mapping_a_field_the_config_class_does_not_have(self):
+        rules = default_rules(
+            flattened={'output': flattening(['verbose'], python_config='m.py:OutputConfig',
+                                            field_map={'verbose': 'nope'})},
+            nested_defaults={'m.py:OutputConfig': {}},
+        )
+        problems = self._problems(rules, ['output'], ['verbose'])
+        assert len(problems) == 1 and 'nope' in problems[0]
+
+    def test_unreachable_default_equivalence(self):
+        rules = C.Rules(default_equivalences=[(True, True), (False, False), (None, 'undefined')])
+        problems = C.validate_rules(rules, {}, {})
+        assert len(problems) == 2
+        assert all('unreachable' in p for p in problems)
+
+    def test_raise_on_rules_problems_is_a_tooling_error(self):
+        with pytest.raises(C.ToolingError) as excinfo:
+            C._raise_on_rules_problems(['a dead rule'])
+        assert 'a dead rule' in str(excinfo.value)
+        C._raise_on_rules_problems([])  # no problems -> no raise
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_the_shipped_rules_are_clean_against_the_real_extraction(self):
+        """The check that would have caught all eight dead entries."""
+        catalogue = C.load_surfaces()
+        rules = C.load_rules()
+        C.load_nested_config_defaults(rules, REPO_ROOT, catalogue.python_root)
+        python, typescript = C.extract_all(REPO_ROOT, catalogue)
+        assert C.validate_rules(rules, python, typescript) == []
+
+
+class TestFlattenedBeatsAlias:
+    """MATCH_ORDER puts `flattened` before `alias`: it is the stricter rule."""
+
+    def test_flattening_wins_over_an_alias_for_the_same_parameter(self):
+        rules = default_rules(aliases={'caching': 'cache'},
+                              flattened={'caching': flattening(['cache', 'cacheTTL'])})
+        py = [py_param('caching', default=None)]
+        ts = [ts_param('cache', default=False, default_kind='literal'),
+              ts_param('cacheTTL', default=3600, default_kind='literal')]
+        comps, _ = run([sig('python', py)], [sig('typescript', ts)], rules=rules)
+        assert row(comps, 'caching').match == 'flattened'
+        assert row(comps, 'caching').ts_names == ['cache', 'cacheTTL']
+
+    def test_alias_still_wins_when_the_flattening_cannot_resolve(self):
+        rules = default_rules(aliases={'caching': 'cache'},
+                              flattened={'caching': flattening(['cache', 'cacheTTL'])})
+        py = [py_param('caching', default=None)]
+        ts = [ts_param('cache', default=None, default_kind=None)]
+        comps, ev = run([sig('python', py)], [sig('typescript', ts)], rules=rules)
+        assert row(comps, 'caching').match == 'alias'
+        assert ev.ok, ev.failures
+
+    def test_exact_and_camel_case_still_win_over_a_flattening(self):
+        rules = default_rules(flattened={'output': flattening(['verbose'])})
+        py = [py_param('output', default=None)]
+        ts = [ts_param('output', default=None), ts_param('verbose', default=None)]
+        comps, _ = run([sig('python', py)], [sig('typescript', ts)], rules=rules)
+        assert row(comps, 'output').match == 'exact'
+
+
+class TestTsExtractorUnrecognisedDefaults:
+    """
+    The TypeScript extractor must tell "the constructor assigns no default"
+    apart from "the constructor decides the default in a form I cannot read".
+    Everything in the second group is reported as `default_kind: 'unknown'`,
+    which the comparator treats as a gap.
+    """
+
+    FIXTURE = """
+export interface Cfg {
+  spread?: string;
+  overwritten?: string;
+  assigned?: number;
+  ifDefault?: number;
+  fromProperty?: boolean;
+  model?: string;
+  guarded?: any[];
+  passedThrough?: string;
+  chained?: string;
+  recognised?: number;
+}
+export class Nested { model = 'unset'; }
+export class Widget {
+  private fromProperty: boolean = true;
+  private nested: Nested;
+  private spread?: string;
+  private overwritten?: string;
+  private assigned?: number;
+  private ifDefault?: number;
+  private guarded?: any[];
+  private passedThrough?: string;
+  private chained?: string;
+  private recognised?: number;
+
+  constructor(config: Cfg) {
+    this.recognised = config.recognised ?? 7;
+    this.spread = ({ spread: 'high', ...config }).spread;
+    this.overwritten = ({ ...config, overwritten: 'forced' }).overwritten;
+    this.assigned = Object.assign({ assigned: 42 }, config).assigned;
+    if (config.ifDefault === undefined) {
+      this.ifDefault = 20;
+    } else {
+      this.ifDefault = config.ifDefault;
+    }
+    if (config.fromProperty !== undefined) {
+      this.fromProperty = config.fromProperty;
+    }
+    this.nested = new Nested();
+    if (config.model != null) {
+      this.nested.model = config.model;
+    }
+    if (config.guarded && Array.isArray(config.guarded)) {
+      this.guarded = config.guarded.slice();
+    }
+    this.passedThrough = config.passedThrough;
+    if (config.chained) {
+      this.chained = config.chained;
+    } else if (config.passedThrough) {
+      this.chained = 'derived';
+    } else {
+      this.chained = 'fallback';
+    }
+  }
+}
+"""
+
+    @staticmethod
+    def _params(tmp_path):
+        src = tmp_path / 'src' / 'praisonai-ts' / 'src'
+        src.mkdir(parents=True)
+        (src / 'widget.ts').write_text(TestTsExtractorUnrecognisedDefaults.FIXTURE)
+        items = C.run_ts_extractor(tmp_path, [
+            {'surface': 'Widget.__init__', 'file': 'widget.ts', 'kind': 'interface',
+             'name': 'Cfg', 'ctorClass': 'Widget'},
+        ])
+        return {p['name']: p for p in items[0]['params'] if p['kind'] == 'property'}
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_control_recognised_forms_are_unchanged(self, tmp_path):
+        p = self._params(tmp_path)['recognised']
+        assert p['default'] == 7 and p['default_kind'] == 'literal'
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_object_spread_default_is_read(self, tmp_path):
+        """`({ x: 'high', ...config }).x` -- the exact rewrite that left the
+        real report byte-identical and every gate green."""
+        p = self._params(tmp_path)['spread']
+        assert p['default'] == 'high' and p['default_kind'] == 'literal'
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_a_property_written_after_the_spread_is_unknown(self, tmp_path):
+        """`{ ...config, x: 'forced' }` ignores whatever the caller passed."""
+        assert self._params(tmp_path)['overwritten']['default_kind'] == 'unknown'
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_object_assign_default_is_read(self, tmp_path):
+        p = self._params(tmp_path)['assigned']
+        assert p['default'] == 42 and p['default_kind'] == 'literal'
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_if_statement_default_is_read(self, tmp_path):
+        p = self._params(tmp_path)['ifDefault']
+        assert p['default'] == 20 and p['default_kind'] == 'literal'
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_class_property_initialiser_is_the_default_when_nothing_else_runs(self, tmp_path):
+        """`if (config.x !== undefined) this.x = config.x;` keeps `private x = true`."""
+        p = self._params(tmp_path)['fromProperty']
+        assert p['default'] is True and p['default_kind'] == 'literal'
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_default_held_in_a_nested_config_object_is_unknown(self, tmp_path):
+        """The real GoalEngineer shape: the fallback lives in `new Nested()`,
+        which this extractor cannot evaluate. Reporting `undefined` would say
+        the two SDKs agree when nobody has checked."""
+        assert self._params(tmp_path)['model']['default_kind'] == 'unknown'
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_multi_way_derivation_is_unknown_not_one_arbitrary_arm(self, tmp_path):
+        assert self._params(tmp_path)['chained']['default_kind'] == 'unknown'
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_control_a_guard_is_not_a_default(self, tmp_path):
+        """`if (config.x && Array.isArray(config.x)) { ...use it... }` decides no
+        default. Flagging these was a false positive worth avoiding: an
+        `unknown` costs a hand-written waiver."""
+        params = self._params(tmp_path)
+        assert params['guarded']['default_kind'] is None
+        assert params['passedThrough']['default_kind'] is None
+
+    @pytest.mark.skipif(shutil.which('node') is None, reason='node is not on PATH')
+    @pytest.mark.skipif(not _typescript_resolvable(),
+                        reason='typescript module not resolvable (set PARITY_TS_NODE_MODULES)')
+    def test_the_options_parameter_is_named_in_extra(self, tmp_path):
+        """So the comparator can tell the options bag from a real TS-only member."""
+        src = tmp_path / 'src' / 'praisonai-ts' / 'src'
+        src.mkdir(parents=True)
+        (src / 'widget.ts').write_text(self.FIXTURE)
+        items = C.run_ts_extractor(tmp_path, [
+            {'surface': 'Widget.__init__', 'file': 'widget.ts', 'kind': 'interface',
+             'name': 'Cfg', 'ctorClass': 'Widget'},
+        ])
+        assert items[0]['extra']['options_parameters'] == ['config']


### PR DESCRIPTION
An audit reproduced **eleven defects** in the parity tooling, each with a command and an exit code. The layer built to stop a green report over unverified work had the same fault in eleven places.

## The worst three

**Flattened parameters were matched and never checked.** Deleting three question marks so `verbose`, `markdown` and `stream` become required — which stops `new Agent({ name: 'x' })` compiling for every TypeScript user — passed all three gates, all 142 tests, and produced a **byte-identical report**. A flattened row set `ts=None`, and gap detection ran only `if row.ts is not None`.

**Any TypeScript default outside four recognised forms read as "no default"** and silently matched Python's `None`. **136 of 201 rows the checker called clean** sat in that branch. Proof: rewriting one line to `({ reasoningEffort: 'high', ...config }).reasoningEffort` left the report byte-identical.

**A TypeScript-only REQUIRED member never failed.** `ts_only` was computed, rendered, and never evaluated — so adding a required `tenantId` went green as soon as you ran the regenerate command the error message itself suggests.

## Also fixed

- A one-line reformat of the ledger "closed" **eight** behaviour options — the surface regex needed a trailing comma, and a *partial* parse was not refused
- `behaviour --write` laundered a ratchet rise into the new floor, and the gate's path filter could not see its own report
- A named re-export from a module **that does not exist** counted as done
- An export statement **inside a string literal** counted as an export
- The Python extractor missed exports added the ordinary way, while its docstring claimed otherwise
- Eleven dead `rules.yaml` entries, now caught by a config self-test
- Three surviving mutations, now killed

## A hole found by verifying the fix, not trusting it

A waiver is keyed by parameter, so waiving a **default** difference also silenced a **required-ness** change on the same parameter — the breaking case sailing through behind a waiver added for the cosmetic one. Waivers now take an optional `kinds`, and required-ness is never covered implicitly. That immediately surfaced two existing waivers whose reasons were already *about* required-ness; they now say so.

## Seven real gaps surfaced

The headline: **`Agent.__init__.output`**. Python's default resolves the silent preset — verbose, markdown and stream all false — while TypeScript defaults markdown and stream to `true` and verbose to an environment variable.

> The same program is silent in Python and verbose, markdown and streaming in TypeScript.

Documented on day one of this work and **unseeable by this layer until now**. Waived with that reason rather than changed, because aligning defaults is a product decision, not a quiet edit.

## Two things deliberately not shipped

- A broad catch-all for unreadable defaults measured **five false positives in ten**. Rejected, with the reasoning kept in the file so it is not retried.
- Three candidate rules for detecting a ledger entry deleted without implementation were measured against all 48 entries: two **could not fail at all**, the third would license **85%** of possible deletions while reading as verification. None shipped. The limitation stays documented, and the tool now merely *names* what a change claims to have closed.

## Verification

**Tests 142 → 244**, each fix watched failing first. All three gates green. `--write` twice is byte-identical. Every one of the eleven proofs re-run: each now fails where it previously passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated parity guidance for runtime reporting, growth controls, gap closure, flattened parameters, defaults, mismatches, and approved exceptions.

- **Bug Fixes**
  - Improved parity analysis for exports, imports, re-exports, configuration defaults, flattened parameters, and required members.
  - Prevented malformed or incomplete parity data from being silently overlooked.

- **Tests**
  - Added coverage for parity validation, deterministic output, re-exports, quoting, defaults, required parameters, and growth safeguards.

- **Chores**
  - Expanded pull request checks to monitor additional parity sources and reports.
  - Added safeguards for controlled baseline growth during report updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->