### PR TITLE
feat(mobile): a visual identity -- type scale, spacing rhythm, two designed themes

### DIFF
--- a/src/praisonai-mobile/app/app.css
+++ b/src/praisonai-mobile/app/app.css
@@ -35,29 +35,250 @@
   --inset-bottom: var(--safe-area-inset-bottom);
   --inset-left: var(--safe-area-inset-left);
 
-  --ground: #ffffff;
-  --panel: #f5f6f8;
+  /*
+   * ---- Type -------------------------------------------------------------
+   *
+   * The SYSTEM STACK, and that is a decision rather than a default.
+   *
+   * A webfont was considered and rejected on three counts, in order of weight:
+   *
+   *   1. Script coverage. ui/src/i18n/strings.ts is a translated UI and
+   *      main.ts sets `dir="rtl"` from the requested tag, so this app renders
+   *      Arabic, and on a Chinese or Japanese device it renders CJK. A
+   *      Latin-subset webfont would leave every one of those users reading a
+   *      MIXED typeface -- the webfont for the Latin, the system font for
+   *      everything else -- which looks worse than the system font alone and
+   *      cannot be fixed without shipping megabytes.
+   *   2. The boot indicator. app/index.html paints a wordmark and "Starting…"
+   *      on the first frame, before app.js exists, specifically so a cold
+   *      start does not look like a broken install. A webfont makes that first
+   *      frame either invisible (`font-display: block`) or a flash of one face
+   *      handing over to another -- reintroducing, in the app's first 200ms,
+   *      exactly the "is this broken?" the indicator was written to remove.
+   *   3. Bytes and a request. The shell budget is ~85 kB of 400 and app.css is
+   *      a render-blocking <link>; a self-hosted woff2 is another file in the
+   *      critical path, and `font-src 'self' data:` in index.html's CSP means
+   *      it could not be a CDN even if that were desirable.
+   *
+   * Committing to it means using it properly, which is what the scale below
+   * is for. `system-ui` leads the stack: it is the generic that resolves to
+   * whatever the platform actually ships, and the named faces behind it are
+   * the fallbacks for engines that do not know it.
+   */
+  --sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, Menlo, "Roboto Mono", monospace;
+
+  /*
+   * Six steps, and not a geometric scale, on purpose.
+   *
+   * A constant ratio produces fractional pixels at the small end, where a
+   * phone has no room for them: 12px and 12.6px are the same size to the eye
+   * and different to the layout. So the scale is two bands with different
+   * jobs. 12-13-14 is the INFORMATION band -- timestamps, help notes, tool
+   * metadata -- where the steps are about a pixel and the job is to be quietly
+   * distinguishable without shouting. 16-18-22 is the HIERARCHY band, where
+   * the steps open up because that is where the eye is meant to be led.
+   *
+   * 16px (--text-base) is the message text and every text input. It is a floor
+   * as well as a size: iOS zooms the whole page when a field smaller than 16px
+   * takes focus, which is why `.composer textarea` states it in px below.
+   */
+  --text-xs: .75rem;      /* 12px -- eyebrows, tool meta, dropped-event counts */
+  --text-sm: .8125rem;    /* 13px -- help notes, timestamps, secondary states  */
+  --text-md: .875rem;     /* 14px -- buttons, reasoning, secondary UI          */
+  --text-base: 1rem;      /* 16px -- message text, inputs                      */
+  --text-lg: 1.125rem;    /* 18px -- screen headings, the empty-state title    */
+  --text-xl: 1.375rem;    /* 22px -- the boot wordmark, and nothing else       */
+
+  /*
+   * Three weights, because on Android there are three.
+   *
+   * Roboto ships 400/500/700 as separate faces, and CSS font matching for a
+   * requested weight above 500 searches UPWARD first -- so `font-weight: 550`,
+   * which this file used for settings labels, resolved to 550 on iOS (SF is
+   * variable) and to 700, full bold, on Android. A label meant to be a shade
+   * heavier than its value was rendering bolder than the screen heading above
+   * it. 500 is the only "slightly heavier" that means the same thing on both.
+   */
+  --weight-normal: 400;
+  --weight-medium: 500;   /* labels, chat titles: heavier, never bold          */
+  --weight-strong: 700;   /* headings and the wordmark                         */
+
+  --leading-tight: 1.25;  /* headings, where lines are short and few           */
+  --leading-snug: 1.4;    /* UI text and one-line rows                         */
+  --leading-normal: 1.55; /* message prose, read for minutes at a time         */
+  --tracking-eyebrow: .09em;
+
+  /*
+   * ---- Space ------------------------------------------------------------
+   *
+   * Seven steps on a 4px grid, in rem rather than px, and that is the
+   * consequential half.
+   *
+   * Android's font-scale setting reaches a WebView as a text zoom, which
+   * scales the root font size -- so rem spacing grows with the type and px
+   * spacing does not. At font_scale 1.5, px gutters around 24px text give a
+   * cramped screen. Keeping the ratio of text to space constant is the
+   * behaviour this file already had (every padding was a rem literal); the
+   * scale names those values instead of inventing a new one per element.
+   *
+   * Hairlines stay in px: a 1px border is a device pixel, not a text
+   * relationship, and a "1.5px" border is a blurry one.
+   */
+  --space-1: .25rem;      /*  4px */
+  --space-2: .375rem;     /*  6px */
+  --space-3: .5rem;       /*  8px */
+  --space-4: .75rem;      /* 12px */
+  --space-5: 1rem;        /* 16px */
+  --space-6: 1.5rem;      /* 24px */
+  --space-7: 2rem;        /* 32px */
+
+  /*
+   * The screen-edge gutter, and the one number in this file that is also
+   * written somewhere else: app/src/main.ts sets the composer's
+   * `padding-inline-start/end` INLINE (an inline style beats the stylesheet,
+   * so it has to) as `calc(<inset> + .75rem)`. The two must agree or the
+   * composer sits a few pixels off every other screen edge in the app.
+   * app/src/css.test.ts asserts they still do.
+   */
+  --gutter: var(--space-4);
+
+  /* ---- Radius -----------------------------------------------------------
+   *
+   * Three steps and a pill. The bubble radius is larger than the row radius so
+   * a message reads as a soft object and a settings row reads as a rectangle;
+   * `--radius` keeps its name because it is the middle step and most of the
+   * file already means that by it. */
+  --radius-sm: 8px;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --radius-pill: 999px;
+
+  /*
+   * ---- Colour: the LIGHT theme, designed as itself ----------------------
+   *
+   * Three surfaces, and the relationship between them is what carries the
+   * structure. `--ground` is the reading surface -- the transcript, the
+   * settings list, the page. `--chrome` is the topbar and the composer, the
+   * two bars that frame it. `--panel` is a control: a text field, a secondary
+   * button.
+   *
+   * In light, chrome is LIGHTER than ground and panel is DARKER. That is not
+   * an accident of picking greys; it is how the two behave. A bar brighter
+   * than the page reads as floating above it, and a control duller than the
+   * page reads as recessed into it. The dark block below re-derives both
+   * relationships rather than inverting these numbers -- see the note there,
+   * because one of them comes out the other way round.
+   *
+   * The neutrals are a cool grey, near enough to neutral to read as paper, and
+   * deliberately NOT tinted toward the accent: a teal-grey ground under a teal
+   * accent muddies both, and this app's one chromatic event should be the
+   * accent.
+   */
+  --ground: #f7f8fa;
+  --chrome: #ffffff;
+  --panel: #eceff4;
+  --rule: #dfe3e9;
+  --rule-strong: #c8ced7;
   --ink: #14171c;
   --soft: #5b636e;
-  --rule: #e2e5ea;
+
+  /* The brand green. It is also index.html's `theme-color`, so the Android
+     status bar and this token are the same decision. */
   --accent: #1f7a63;
+  --accent-ink: #ffffff;
+
+  /*
+   * The user's own message, as its OWN pair rather than as the accent.
+   *
+   * They were one token, and that is what forced the dark theme into a corner:
+   * `--accent` in dark has to be light enough to read as text on a near-black
+   * ground (it is #7fd1b9, 10.6:1), and a bubble filled with it is then the
+   * brightest object on the screen -- repeated down the whole transcript.
+   * Splitting the roles lets each theme answer the question its own way. See
+   * the dark block.
+   */
+  --user-bg: #1f7a63;
+  --user-ink: #ffffff;
+
   --bad: #a6413c;
+  --bad-bg: #fbeceb;
   --warn: #b34700;
-  --radius: 12px;
-  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --warn-bg: #fdf1e7;
+
+  /*
+   * The five tones, which ui/src/transcript/view-model.ts already names
+   * (`RowTone`) and app/src/dom.ts already writes as `data-tone` -- and which
+   * this stylesheet had no rule for at all, so a `warning` notice and a
+   * `neutral` one were the same grey.
+   *
+   * Defined in terms of the tokens above rather than as fresh hexes, so the
+   * dark block redefines all five by redefining --soft/--accent/--bad/--warn.
+   * A custom property is substituted where it is USED, so these follow.
+   *
+   * `pending` and `neutral` share --soft on purpose: "in progress" and
+   * "nothing to report" are both the absence of an outcome, and giving
+   * in-progress a colour of its own would make every running tool an event.
+   */
+  --tone-neutral: var(--soft);
+  --tone-pending: var(--soft);
+  --tone-success: var(--accent);
+  --tone-failure: var(--bad);
+  --tone-warning: var(--warn);
 }
 
+/*
+ * ---- Colour: the DARK theme, designed as itself ------------------------
+ *
+ * Not an inversion of the block above, and three tokens in here are the proof.
+ *
+ * `--chrome` stays LIGHTER than `--ground` in both themes, because "the bar
+ * floats above the page" is a fact about bars, not about light. Inverting the
+ * light values would have made the dark topbar darker than the transcript,
+ * which reads as a hole rather than as a frame.
+ *
+ * `--panel` goes the other way. In light it is darker than the ground; here it
+ * is lighter. A control is distinguished from the page by being NEARER the
+ * light source, and in a dark UI that means brighter -- the one relationship
+ * that genuinely does flip, and the reason "invert the palette" produces
+ * recessed-looking buttons in dark mode.
+ *
+ * `--user-bg` is the clearest case. In light it is the full accent: a dark
+ * saturated block on a pale ground, which RECEDES -- legible at a glance
+ * without pulling the eye. Inverted, the same rule in dark is a pale mint
+ * block on near-black, which ADVANCES: 10.6:1 against the ground, the
+ * brightest thing on the screen, once per user message, all the way down a
+ * conversation. So dark gets its own deep green -- 2.05:1 against the ground,
+ * plainly a distinct surface and quietly so -- with its own light ink on it at
+ * 8.1:1. The bubble is still the second-loudest object in the transcript in
+ * both themes; it is no longer the loudest one in exactly one of them.
+ *
+ * Everything a screen reader relies on is unchanged either way: alignment,
+ * `data-speaker` and the visually-hidden "You said:" carry the speaker, and
+ * colour only confirms it.
+ *
+ * Every text pair in both themes clears WCAG AA for body text. The worst in
+ * this block is --soft on --panel at 6.3:1; the worst in the light block is
+ * --accent on --panel at 4.5:1.
+ */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
     --ground: #0f1114;
-    --panel: #1a1e24;
+    --chrome: #16191f;
+    --panel: #1c2027;
+    --rule: #262b33;
+    --rule-strong: #39414c;
     --ink: #e8eaed;
     --soft: #9aa1ac;
-    --rule: #262b33;
     --accent: #7fd1b9;
+    --accent-ink: #0f1114;
+    --user-bg: #254f43;
+    --user-ink: #e8f3ee;
     --bad: #e58b86;
+    --bad-bg: #2e1c1b;
     --warn: #f78c6c;
+    --warn-bg: #2e2219;
   }
 }
 
@@ -73,8 +294,9 @@ html, body {
   color: var(--ink);
   font-family: var(--sans);
   font-size: 16px;
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* NO viewport units anywhere in this file, deliberately. 100vh includes an
@@ -102,28 +324,84 @@ html, body {
 .topbar {
   display: flex;
   align-items: center;
-  gap: .5rem;
-  padding: calc(var(--inset-top) + .5rem) 
-           calc(var(--inset-right) + .75rem) .5rem
-           calc(var(--inset-left) + .75rem);
+  gap: var(--space-3);
+  padding: calc(var(--inset-top) + var(--space-3))
+           calc(var(--inset-right) + var(--gutter)) var(--space-3)
+           calc(var(--inset-left) + var(--gutter));
   border-bottom: 1px solid var(--rule);
-  background: var(--ground);
+  background: var(--chrome);
 }
-.topbar h1 { font-size: 1rem; font-weight: 600; margin: 0; flex: 1; }
+.topbar h1 {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-strong);
+  line-height: var(--leading-tight);
+  /* Optical correction, and only at this size. Default tracking is set for
+     body text; at 18px and up a heading looks loose without a hair of
+     negative. */
+  letter-spacing: -.01em;
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/*
+ * The heading on every screen that is NOT the chat screen.
+ *
+ * `screenHeading` in main.ts has emitted `<h2 class="screen-heading">` since it
+ * was written and this file had no rule for it at all, so Settings and Chats
+ * were titled at the user agent's default `h2` -- 1.5em (24px) bold with
+ * 0.83em margins above and below -- while the chat screen's own title, one tap
+ * away, was 16px. The two screens did not look like the same application.
+ */
+.screen-heading {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-strong);
+  line-height: var(--leading-tight);
+  letter-spacing: -.01em;
+  color: var(--ink);
+  margin: 0 0 var(--space-4);
+}
+/* `tabindex="-1"` is what lets focus.ts move focus here on a route change; it
+   must not also paint a ring when the move was made for a tap. A real keyboard
+   focus still gets one, from `:focus-visible` below. */
+.screen-heading:focus { outline: none; }
 
 .transcript {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: .75rem calc(var(--inset-right) + .75rem) .75rem
-           calc(var(--inset-left) + .75rem);
+  padding: var(--space-4) calc(var(--inset-right) + var(--gutter)) var(--space-4)
+           calc(var(--inset-left) + var(--gutter));
   display: flex;
   flex-direction: column;
-  gap: .6rem;
+  gap: var(--space-3);
+  background: var(--ground);
 }
 
-.row { border-radius: var(--radius); padding: .55rem .75rem; max-width: 100%; }
+.row { border-radius: var(--radius); padding: var(--space-3) var(--space-4); max-width: 100%; }
+
+/*
+ * The rhythm of a CONVERSATION, out of a flat list of rows.
+ *
+ * The transcript is a single flex column of siblings -- there is no turn
+ * element to hang a margin on, and ui/src/render/reconcile.ts places rows by
+ * index, so introducing one would mean changing the reconciler rather than the
+ * stylesheet. Adjacent siblings get it for free: the two boundaries worth
+ * marking are the ones either side of the user's message, because that is
+ * where one turn ends and the next begins. Everything inside a turn -- the
+ * answer, its reasoning, its tool rows -- keeps the tight base gap and reads
+ * as one block.
+ *
+ * `+` rather than `:has()`: this file is parsed by whatever WebView the
+ * declared minSdkVersion ships, and the adjacent sibling combinator has worked
+ * everywhere for twenty years.
+ */
+.row + .row-user { margin-top: var(--space-4); }
+.row-user + .row { margin-top: var(--space-4); }
 
 /*
  * The user's own message.
@@ -146,21 +424,73 @@ html, body {
  */
 .row-user {
   align-self: flex-end;
-  max-width: 85%;
-  background: var(--accent);
-  color: var(--ground);
+  max-width: 82%;
+  background: var(--user-bg);
+  color: var(--user-ink);
+  border-radius: var(--radius-lg);
+  /*
+   * One corner cut, on the trailing bottom edge -- the whole of this file's
+   * decoration budget, spent here because it is the one place it does work: it
+   * points the bubble back at the person who wrote it, so the SHAPE alone says
+   * which side a message is on, before any colour is read.
+   *
+   * A LOGICAL corner, not `border-bottom-right-radius`. `border-radius`'s
+   * physical corners do not follow `dir`, so the physical version would put
+   * the notch on the far side of an Arabic bubble -- pointing away from the
+   * speaker. An engine too old for logical radii simply keeps all four corners
+   * round, which is this design one notch short rather than a broken one.
+   */
+  border-end-end-radius: var(--radius-sm);
+  padding: var(--space-3) var(--space-4);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
-/* Sent, and NOT in the stored conversation. A block of its own so it reads as a
-   separate statement about the message rather than as part of it. */
+/*
+ * Sent, and NOT in the stored conversation. A block of its own so it reads as a
+ * separate statement about the message rather than as part of it.
+ *
+ * `opacity: .92`, and the exact number is load-bearing. It was `.85`, which
+ * put white text on the light-theme bubble at 4.26:1 -- under AA, on the one
+ * line in the transcript whose whole job is to tell you your message was not
+ * saved. Nothing reported it, because contrast through an `opacity` is a fact
+ * about the composited pixel and no stylesheet review sees it; the case in
+ * tools/screen-layout.test.mjs composites the layers and does. .92 is 4.68:1
+ * light and 7.16:1 dark, and it is still visibly a subordinate line.
+ */
 .row-user .user-note {
   display: block;
-  margin-top: .3rem;
-  font-size: .78rem;
-  opacity: .85;
+  margin-top: var(--space-1);
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  opacity: .92;
 }
-.row-text { background: var(--panel); white-space: pre-wrap; overflow-wrap: anywhere; }
+
+/*
+ * The assistant's answer: prose on the page, NOT a bubble.
+ *
+ * It was a full-width `--panel` block, and that is the wrong shape for what it
+ * holds. A bubble is a device for short, alternating, roughly equal turns; the
+ * assistant's turn here is the long one -- paragraphs, sometimes the whole
+ * screen -- and a filled box at 100% width is not a bubble at all, it is a
+ * container with prose in it. Stacked down a transcript the effect was a
+ * column of grey slabs with the reading inside them.
+ *
+ * Unboxing it makes the two speakers ASYMMETRIC, which is the point: the user
+ * writes objects (short, aligned, bubbled) and the model writes text (long,
+ * full width, on the page). That reads as a conversation faster than two
+ * mirrored bubble colours do, and it gives the long side the full measure with
+ * no inner padding to lose it to.
+ *
+ * Nothing accessible rested on the background -- the comment on `.row-user`
+ * above names the three signals that do, and none of them is this one.
+ */
+.row-text {
+  padding-inline: 0;
+  padding-block: var(--space-1);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: var(--leading-normal);
+}
 .row-text.streaming::after {
   content: "▍";
   color: var(--accent);
@@ -172,53 +502,193 @@ html, body {
   * { transition: none !important; }
 }
 
-.row-reasoning { color: var(--soft); font-size: .9rem; border-left: 2px solid var(--rule); border-radius: 0; }
-.row-tool { display: flex; flex-wrap: wrap; gap: .4rem .6rem; align-items: baseline;
-  border: 1px solid var(--rule); font-family: var(--mono); font-size: .82rem; }
-.row-tool[data-status="failed"] { border-color: var(--bad); color: var(--bad); }
+/* The model's thinking: the same prose column, set back behind it. Smaller,
+   soft, and marked with a rule on the leading edge rather than boxed, so it
+   reads as an aside to the answer below rather than as another message.
+   `border-inline-start` and `padding-inline` so the rule stays on the reading
+   edge in Arabic. */
+.row-reasoning {
+  color: var(--soft);
+  font-size: var(--text-md);
+  line-height: var(--leading-snug);
+  border-inline-start: 2px solid var(--rule-strong);
+  border-radius: 0;
+  padding-block: var(--space-1);
+  padding-inline: var(--space-4) 0;
+}
+
+.row-tool {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  align-items: baseline;
+  border: 1px solid var(--rule);
+  background: var(--chrome);
+  font-family: var(--mono);
+  font-size: var(--text-sm);
+}
+.row-tool .tool-name { color: var(--ink); min-width: 0; overflow-wrap: anywhere; }
+.row-tool .tool-meta { color: var(--soft); margin-inline-start: auto; font-size: var(--text-xs); }
+.tool-output {
+  margin: var(--space-2) 0 0;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  width: 100%;
+  color: var(--soft);
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+}
+
+/*
+ * A tool's status, as a chip.
+ *
+ * app/src/dom.ts has written the status IN WORDS into `span.tool-status` since
+ * it was fixed -- "Running" / "Succeeded" / "Failed" / "No result" -- and this
+ * file had no rule for that span, so the word sat inside the mono run and read
+ * as part of the tool's name. Meanwhile the only colour on the row was a
+ * border, and there were rules for `failed` and `ok` and NONE for `running` or
+ * `unresolved`: a tool that never came back was pixel-for-pixel a tool still
+ * working, which ui/src/transcript/view-model.ts calls the defect the whole
+ * transcript layer is written against.
+ *
+ * Four statuses, four tones, taken from the map `toneForTool` already exports.
+ * The chip carries the tone and the border echoes it. The word is still the
+ * primary signal and still what a screen reader gets; this only makes the eye
+ * agree with it.
+ */
+.row-tool .tool-status {
+  flex: 0 0 auto;
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: .02em;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
+  border: 1px solid currentColor;
+  color: var(--tone-neutral);
+}
+.row-tool[data-status="running"] { border-color: var(--rule); }
+.row-tool[data-status="running"] .tool-status { color: var(--tone-pending); }
 .row-tool[data-status="ok"] { border-color: var(--accent); }
-.row-tool .tool-meta { color: var(--soft); margin-left: auto; }
-.tool-output { margin: .35rem 0 0; white-space: pre-wrap; overflow-x: auto; width: 100%;
-  color: var(--soft); font-size: .78rem; }
+.row-tool[data-status="ok"] .tool-status { color: var(--tone-success); }
+.row-tool[data-status="failed"] { border-color: var(--bad); }
+.row-tool[data-status="failed"] .tool-status { color: var(--tone-failure); }
+.row-tool[data-status="unresolved"] { border-color: var(--warn); }
+.row-tool[data-status="unresolved"] .tool-status { color: var(--tone-warning); }
+/* Only the failed row tints its name as well. `unresolved` gets the warning
+   colour on the chip and the border and keeps its name in ink: "we never heard
+   back" is a fact about the call, not about the tool. */
+.row-tool[data-status="failed"] .tool-name { color: var(--bad); }
 
-.row-approval { border: 1px solid var(--warn); display: flex; flex-wrap: wrap; gap: .4rem; align-items: center; }
-.row-approval p { margin: 0 0 .3rem; width: 100%; }
-.row-error { border: 1px solid var(--bad); color: var(--bad); }
+.row-approval {
+  border: 1px solid var(--warn);
+  background: var(--warn-bg);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+.row-approval p {
+  margin: 0 0 var(--space-1);
+  width: 100%;
+  font-weight: var(--weight-medium);
+}
+/* The buttons sit on the tinted panel, so they need their own ground to keep
+   reading as controls instead of dissolving into it. */
+.row-approval button { background: var(--chrome); }
+
+.row-error {
+  border: 1px solid var(--bad);
+  background: var(--bad-bg);
+  color: var(--bad);
+  font-size: var(--text-md);
+  line-height: var(--leading-snug);
+}
 /* An error row is a TITLE chosen by kind and, under it, the provider's prose.
-   `display: block` is the whole rule and it is required rather than cosmetic:
-   both are spans inside one row, so without it they run together and the row
-   reads "Sign-in problemThe OPENAI_API_KEY environment variable...". No colour
-   is stated here on purpose -- `.row-error` above already sets one and both
-   spans inherit it, so this adds no token for the dark-scheme gate to check
-   and nothing for a palette pass to have to keep in step. */
-.row-error .error-title { display: block; font-weight: 600; }
-.row-notice { color: var(--soft); font-size: .88rem; text-align: center; }
-.row-dropped { color: var(--warn); font-size: .8rem; }
+   `display: block` is required rather than cosmetic: both are spans inside one
+   row, so without it they run together and the row reads "Sign-in problemThe
+   OPENAI_API_KEY environment variable...". No colour is stated here on purpose
+   -- `.row-error` above already sets one and both spans inherit it. */
+.row-error .error-title { display: block; font-weight: var(--weight-strong); }
 
-/* A chat row is a DIV holding two controls now -- one that opens the chat and
-   one that deletes it -- because a button cannot legally contain a button and
-   there was no way to delete a conversation at all before. Only new selectors
-   are added here; nothing above changes. */
-.row-chat { display: flex; align-items: baseline; gap: .5rem; padding: 0; }
-.chat-open { flex: 1 1 auto; min-width: 0; display: flex; align-items: baseline; gap: .5rem;
-  text-align: start; background: none; border: none; }
-.chat-title { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
-  white-space: nowrap; }
-/* The time the list is SORTED by, which nothing rendered until now. Muted and
-   smaller: it is context for the title, not a second title. */
-.chat-updated { flex: 0 0 auto; color: var(--soft); font-size: .8rem; }
-.chat-delete { flex: 0 0 auto; }
-.chat-delete[data-armed="true"] { border-color: var(--bad); color: var(--bad); }
+/*
+ * A notice, by TONE.
+ *
+ * app/src/dom.ts writes `data-tone` on every notice and error row and this
+ * file styled none of it, so "Stopped" (warning) and an informational line
+ * looked identical. The base is the quiet one -- centred and soft, which is
+ * right for the neutral case that is most of them -- and each tone that is
+ * actually emitted says so.
+ */
+.row-notice {
+  color: var(--tone-neutral);
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  text-align: center;
+}
+/* The measure limit is scoped to the TRANSCRIPT, not put on `.row-notice`
+   itself. `buildSettingsScreen` emits the same class for its warnings, and
+   `.screen-settings` is a flex column too -- so an unscoped `align-self:
+   center; max-width: 34ch` would have quietly narrowed and floated the
+   settings warnings as well, which is a change to a screen this rule is not
+   about. In the transcript it earns its place: a centred line running the full
+   width of a phone reads as a paragraph rather than as an aside, the same
+   argument `.empty-body` makes. */
+.transcript .row-notice { align-self: center; max-width: 34ch; }
+.row-notice[data-tone="warning"] { color: var(--tone-warning); }
+.row-notice[data-tone="failure"] { color: var(--tone-failure); }
+.row-notice[data-tone="success"] { color: var(--tone-success); }
+
+.row-dropped {
+  color: var(--tone-warning);
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+  text-align: center;
+  align-self: center;
+}
+
+/*
+ * "Jump to latest", which had NO rule in this file at all.
+ *
+ * main.ts builds it as `button.jump-latest` and appends it as a direct child of
+ * the `.screen` flex column, between the transcript and the composer. With no
+ * rule of its own it fell to the bare `button` styling and to the column's
+ * default `align-items: stretch` -- so the moment scroll.ts unhid it, a
+ * full-bleed 44px slab appeared across the screen and pushed the composer
+ * down. It is an affordance, and it should look like one.
+ *
+ * In FLOW rather than absolutely positioned, deliberately. Floating it over
+ * the transcript would mean positioning it against the composer, whose height
+ * moves with the keyboard on every focus -- and the composer's relationship to
+ * the keyboard is the most expensive thing in this file to have got right. A
+ * centred pill costs one row of the transcript and cannot desynchronise from
+ * anything.
+ *
+ * `min-height` is inherited from `button` and stays 44px: this is a touch
+ * target, and a smaller pill would be a prettier one that is harder to hit.
+ */
+.jump-latest {
+  align-self: center;
+  flex: 0 0 auto;
+  margin-block: var(--space-1) var(--space-2);
+  padding-inline: var(--space-5);
+  border-radius: var(--radius-pill);
+  border-color: var(--rule-strong);
+  background: var(--chrome);
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+}
 
 .composer {
   display: flex;
-  gap: .5rem;
+  gap: var(--space-3);
   align-items: flex-end;
   border-top: 1px solid var(--rule);
-  background: var(--ground);
-  padding: .5rem calc(var(--inset-right) + .75rem)
-           calc(var(--inset-bottom) + .5rem)
-           calc(var(--inset-left) + .75rem);
+  background: var(--chrome);
+  padding: var(--space-3) calc(var(--inset-right) + var(--gutter))
+           calc(var(--inset-bottom) + var(--space-3))
+           calc(var(--inset-left) + var(--gutter));
   /* main.ts sets this from the shell's live keyboard height. It is a padding
      rather than a transform so the transcript's scroll height shrinks with it
      and the last message stays reachable. */
@@ -229,24 +699,31 @@ html, body {
      reintroduced here: measured 76px of padding with a 34px home indicator
      where 42px is correct, and a keyboard's height of dead space above the
      keyboard once one opens. */
-  padding-bottom: calc(var(--keyboard-height, 0px) + .5rem);
+  padding-bottom: calc(var(--keyboard-height, 0px) + var(--space-3));
 }
 .composer textarea {
   flex: 1;
+  min-width: 0;
   resize: none;
   font: inherit;
+  line-height: var(--leading-snug);
   color: inherit;
   background: var(--panel);
   border: 1px solid var(--rule);
   border-radius: var(--radius);
-  padding: .5rem .65rem;
-  /* 16px minimum: iOS zooms the whole page when focusing a smaller field. */
+  padding: var(--space-3) var(--space-4);
+  /* 16px minimum: iOS zooms the whole page when focusing a smaller field.
+     Stated in px rather than as --text-base because it is a FLOOR imposed by
+     the platform, not a step on the type scale that happens to sit there. */
   font-size: 16px;
 }
+.composer textarea::placeholder { color: var(--soft); }
 
 button {
   font: inherit;
-  font-size: .9rem;
+  font-size: var(--text-md);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
   cursor: pointer;
   border: 1px solid var(--rule);
   background: var(--panel);
@@ -255,13 +732,24 @@ button {
   /* 44px is the platform minimum touch target on both platforms. */
   min-height: 44px;
   min-width: 44px;
-  padding: 0 .75rem;
+  padding: 0 var(--space-4);
 }
-button[data-variant="primary"] { background: var(--accent); border-color: var(--accent); color: var(--ground); }
+button[data-variant="primary"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+  font-weight: var(--weight-strong);
+}
 button:disabled { opacity: .45; cursor: default; }
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
-.empty { margin: auto; color: var(--soft); text-align: center; padding: 2rem 1rem; }
+.empty {
+  margin: auto;
+  color: var(--soft);
+  text-align: center;
+  padding: var(--space-7) var(--space-5);
+  font-size: var(--text-md);
+}
 
 /*
  * The empty chat: the welcome, and the "you need a key" guidance.
@@ -295,13 +783,14 @@ button:disabled { opacity: .45; cursor: default; }
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: .5rem;
+  gap: var(--space-3);
   text-align: center;
   /* The inline padding follows the safe area for the same reason every other
      screen's does: a landscape cutout would otherwise clip the first and last
-     characters of every line. */
-  padding: 1.5rem calc(var(--inset-right) + 1.25rem)
-           1.5rem calc(var(--inset-left) + 1.25rem);
+     characters of every line. The gutter is ADDED to the inset, never
+     replacing it, so a device with no inset on a side still keeps it. */
+  padding: var(--space-6) calc(var(--inset-right) + var(--space-5))
+           var(--space-6) calc(var(--inset-left) + var(--space-5));
 }
 /* Stated explicitly, exactly as `.screen[hidden]` and `.setting-error[hidden]`
    are: the author `display: flex` above beats the user agent's
@@ -312,8 +801,10 @@ button:disabled { opacity: .45; cursor: default; }
 
 .empty-state .empty-title {
   margin: 0;
-  font-size: 1.15rem;
-  font-weight: 600;
+  font-size: var(--text-lg);
+  font-weight: var(--weight-strong);
+  line-height: var(--leading-tight);
+  letter-spacing: -.01em;
   color: var(--ink);
 }
 /* Muted, and narrow: a centred sentence running the full width of a phone is
@@ -322,24 +813,108 @@ button:disabled { opacity: .45; cursor: default; }
   margin: 0;
   max-width: 30ch;
   color: var(--soft);
-  font-size: .95rem;
+  font-size: var(--text-md);
+  line-height: var(--leading-snug);
 }
-.empty-state button { margin-top: .5rem; }
+.empty-state button { margin-top: var(--space-3); }
 .empty-state button[hidden] { display: none; }
+
 /*
- * A row in the chat list. `.row-chat` is the class `buildChatsScreen` emits;
- * this block was written as `.chat-row`, which the app has never painted, so
- * every row fell back to the bare `button` rule: a centre-aligned, auto-width
- * pill instead of a full-width list row. The `.title` / `.when` children it
- * also styled do not exist either -- the row's title is its own text node --
- * so the truncation lives on the row itself, where a chat named from a long
- * first message would otherwise wrap to as many lines as it liked.
+ * A row in the chat list.
+ *
+ * There was one `.row-chat` block here and then a SECOND one 130 lines later,
+ * each written by a different fix and neither aware of the other: the first
+ * set `align-items: baseline; padding: 0` for the two-control row the list
+ * builds today, and the second -- a repair of a block that had been written as
+ * `.chat-row`, which nothing paints -- set `align-items: center` and put the
+ * padding back. Same specificity, so the later one silently won half the
+ * declarations of the earlier one. They are one rule now, and the surviving
+ * behaviour is what the later block produced, which is what has actually been
+ * on screen.
+ *
+ * The row is a DIV holding two controls -- one that opens the chat and one
+ * that deletes it -- because a button cannot legally contain a button. The
+ * padding is asymmetric for the same reason: the leading edge carries the
+ * gutter for the title, and the trailing edge gives way to the delete
+ * control's own 44px target.
  */
-.row-chat { display: flex; align-items: center; gap: .5rem; width: 100%;
-  border: 1px solid var(--rule); border-radius: var(--radius); padding: .6rem .75rem;
-  background: var(--panel); text-align: left;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.row-chat-unreadable { color: var(--warn); border-color: var(--warn); }
+.row-chat {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3) var(--space-2) var(--space-4);
+  background: var(--chrome);
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.row-chat + .row-chat { margin-top: var(--space-3); }
+.row-chat-unreadable { color: var(--warn); border-color: var(--warn); background: var(--warn-bg); }
+
+/*
+ * `align-items: center`, and it was `baseline`.
+ *
+ * Baseline is the better answer to "line up a 16px title with a 12px
+ * timestamp", and it is the wrong answer here because of the box it is in.
+ * `.chat-open` is a button, so it inherits `min-height: 44px` -- one line of
+ * text in a 44px box -- and a single-line flex container aligns a baseline
+ * group to the START of the line. So the title sat at the top of its 44px
+ * while `Delete`, whose label the user agent centres in ITS 44px, sat about
+ * 10px lower: two controls on one row visibly out of line.
+ *
+ * Measured on an Android 15 emulator at 420dpi. It was there before this
+ * change and hidden by `Delete` having a border of its own to sit inside; the
+ * moment the destructive control was quietened to plain text the two were
+ * plainly not on the same line. Centring costs the ~2px of baseline drift
+ * between the two sizes, which is invisible, and buys the alignment, which is
+ * not.
+ */
+.chat-open {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  text-align: start;
+  background: none;
+  border: none;
+  /* The row already carries the gutter. Without this the button keeps
+     `button`'s own `padding: 0 var(--space-4)` and the title is indented twice
+     as far as the row it sits in. */
+  padding-inline: 0;
+}
+.chat-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  color: var(--ink);
+}
+/* The time the list is SORTED by, which nothing rendered until now. Muted and
+   smaller: it is context for the title, not a second title. */
+.chat-updated {
+  flex: 0 0 auto;
+  color: var(--soft);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-normal);
+}
+/* Quiet until it is armed. It destroys a conversation, so it must not be the
+   loudest thing on the row -- and once armed it must be unmistakable. */
+.chat-delete {
+  flex: 0 0 auto;
+  background: none;
+  border-color: transparent;
+  color: var(--soft);
+  font-weight: var(--weight-normal);
+}
+.chat-delete[data-armed="true"] { border-color: var(--bad); color: var(--bad); background: var(--bad-bg); }
 
 /*
  * Every screen that is NOT the chat screen.
@@ -370,20 +945,21 @@ button:disabled { opacity: .45; cursor: default; }
 .screen-chats {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: calc(var(--inset-top) + .75rem)
-           calc(var(--inset-right) + .75rem)
-           calc(var(--inset-bottom) + .75rem)
-           calc(var(--inset-left) + .75rem);
+  padding: calc(var(--inset-top) + var(--gutter))
+           calc(var(--inset-right) + var(--gutter))
+           calc(var(--inset-bottom) + var(--gutter))
+           calc(var(--inset-left) + var(--gutter));
 }
-/* The rows already carry `.row`'s own .75rem inline padding, so without this
+/* The rows already carry `.row`'s own gutter of inline padding, so without this
    they would be indented twice as far as the headings they sit under. */
 .screen-settings .row-setting { padding-inline: 0; }
 
-.setting { display: flex; flex-direction: column; gap: .25rem; padding: .6rem 0; border-bottom: 1px solid var(--rule); }
-.setting .label { font-weight: 550; }
-.setting .help { color: var(--soft); font-size: .84rem; }
-.setting input, .setting select { font: inherit; font-size: 16px; padding: .45rem .55rem;
-  border: 1px solid var(--rule); border-radius: 8px; background: var(--panel); color: inherit; }
+.setting { display: flex; flex-direction: column; gap: var(--space-1); padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--rule); }
+.setting .label { font-weight: var(--weight-medium); }
+.setting .help { color: var(--soft); font-size: var(--text-sm); }
+.setting input, .setting select { font: inherit; font-size: 16px; padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--rule); border-radius: var(--radius-sm); background: var(--panel); color: inherit; }
 /* A refused setting, next to the field it was refused for. The row builder in
    main.ts renders `.row-setting`, so the rules above (written against a
    `.setting` class nothing emits) do not reach it -- these are matched on the
@@ -391,21 +967,25 @@ button:disabled { opacity: .45; cursor: default; }
    same reason `.screen[hidden]` is: an author `display` declaration beats the
    user agent's, and an always-visible empty error box beside every field reads
    as a rendering fault. */
-.row-setting { display: flex; flex-direction: column; gap: .25rem; }
-.row-setting .setting-input { font: inherit; font-size: 16px; padding: .45rem .55rem;
-  border: 1px solid var(--rule); border-radius: 8px; background: var(--panel); color: inherit; }
-.setting-error { display: block; margin: .1rem 0 0; color: var(--warn); font-size: .84rem; }
+.row-setting { display: flex; flex-direction: column; gap: var(--space-1); }
+.row-setting .setting-input, .row-setting select { font: inherit; font-size: 16px;
+  padding: var(--space-2) var(--space-3); border: 1px solid var(--rule); border-radius: var(--radius-sm);
+  background: var(--panel); color: inherit; }
+.setting-error { display: block; margin: var(--space-1) 0 0; color: var(--warn); font-size: var(--text-sm);
+  line-height: var(--leading-snug); }
 .setting-error[hidden] { display: none; }
 /* The `help` every def has carried since the registry was written, painted for
    the first time. It sits between the label and the control, so it is read
    before the field rather than as a footnote under it. */
-.row-setting .setting-help { display: block; margin: 0; color: var(--soft); font-size: .84rem; }
+.row-setting .setting-help { display: block; margin: 0; color: var(--soft); font-size: var(--text-sm);
+  line-height: var(--leading-snug); }
 /* "Set Engine to remote-http to use this." Not `--warn`: nothing is wrong, the
    field is simply switched off, and a warning colour on a normal state is how
    a screen teaches people to ignore warnings. `[hidden]` explicitly, for the
    same reason `.setting-error[hidden]` is: this rule's `display: block` is an
    author declaration and beats the user agent's `[hidden] { display: none }`. */
-.row-setting .setting-inactive { display: block; margin: .1rem 0 0; color: var(--soft); font-size: .84rem; }
+.row-setting .setting-inactive { display: block; margin: var(--space-1) 0 0; color: var(--soft);
+  font-size: var(--text-sm); line-height: var(--leading-snug); }
 .row-setting .setting-inactive[hidden] { display: none; }
 /* A field nothing reads, drawn as a field nothing reads. `opacity` alone would
    also fade the label and the help, which are still worth reading -- this is on
@@ -416,11 +996,12 @@ button:disabled { opacity: .45; cursor: default; }
 /* A secret row. The presence word sits above the field, so "Configured" is the
    first thing read -- the answer to the only question a masked field cannot
    show. `Remove` is a plain, small control: it destroys a credential, so it
-   must not be the easiest thing on the row to hit by accident. */
-.row-setting-secret .setting-presence { color: var(--soft); font-size: .84rem; }
-.setting-clear { font: inherit; font-size: .84rem; align-self: flex-start;
-  margin-top: .25rem; padding: .3rem .6rem; color: var(--ink);
-  background: none; border: 1px solid var(--rule); border-radius: .4rem; }
+   must not be the easiest thing on the row to hit by accident. It keeps
+   `button`'s 44px target; only its LOOK is quiet. */
+.row-setting-secret .setting-presence { color: var(--soft); font-size: var(--text-sm); }
+.setting-clear { font: inherit; font-size: var(--text-sm); font-weight: var(--weight-normal);
+  align-self: flex-start; margin-top: var(--space-1); padding: var(--space-1) var(--space-3);
+  color: var(--ink); background: none; border: 1px solid var(--rule); border-radius: var(--radius-sm); }
 /* Stated explicitly, exactly like `.setting-error[hidden]`: `align-self` does
    not create a display declaration but `.setting-clear` is a flex ITEM, and the
    button is hidden by main.ts the moment there is no key to remove. An
@@ -439,18 +1020,21 @@ button:disabled { opacity: .45; cursor: default; }
  * the ink colour while the rest go soft, and its rows sit in a panel so the
  * eye lands there first.
  */
-.screen-settings .settings-section { font-size: .72rem; letter-spacing: .1em;
-  text-transform: uppercase; color: var(--soft); margin: 1.4rem 0 .3rem; font-weight: 600; }
-.screen-settings .settings-section:first-of-type { margin-top: .6rem; }
+.screen-settings .settings-section { font-size: var(--text-xs); letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase; color: var(--soft); margin: var(--space-6) 0 var(--space-1);
+  font-weight: var(--weight-strong); line-height: var(--leading-snug); }
+.screen-settings .settings-section:first-of-type { margin-top: var(--space-3); }
 .screen-settings .settings-section[data-lead] { color: var(--ink); }
-.screen-settings .row-setting .setting-label { font-weight: 550; }
-.screen-settings .row-setting[data-lead] { background: var(--panel); border-radius: var(--radius);
-  padding: .6rem .75rem; }
+.screen-settings .row-setting .setting-label { font-weight: var(--weight-medium); }
+.screen-settings .row-setting[data-lead] { background: var(--chrome); border: 1px solid var(--rule);
+  border-radius: var(--radius); padding: var(--space-3) var(--space-4); }
 
-.section-heading { font-size: .72rem; letter-spacing: .1em; text-transform: uppercase;
-  color: var(--soft); margin: 1.2rem 0 .3rem; }
-.warning { border: 1px solid var(--warn); color: var(--warn); border-radius: var(--radius);
-  padding: .55rem .75rem; margin: .5rem 0; font-size: .86rem; }
+.section-heading { font-size: var(--text-xs); letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase; color: var(--soft); margin: var(--space-5) 0 var(--space-1);
+  font-weight: var(--weight-strong); }
+.warning { border: 1px solid var(--warn); background: var(--warn-bg); color: var(--warn);
+  border-radius: var(--radius); padding: var(--space-3) var(--space-4); margin: var(--space-3) 0;
+  font-size: var(--text-md); line-height: var(--leading-snug); }
 
 /*
  * Visually hidden, still announced.
@@ -488,6 +1072,12 @@ button:disabled { opacity: .45; cursor: default; }
  * the one outcome worse than the blank page -- a white flash handing over to a
  * dark UI on every launch.
  *
+ * It is also the only place --text-xl is used, and the only place the wordmark
+ * appears at all. That is the whole of this app's brand expression: one word,
+ * at one size, for the second before the conversation arrives. A chat app is
+ * looked at for long stretches, and anything a logo could add to the twentieth
+ * minute of reading it would subtract.
+ *
  * `margin: auto` inside `#root`'s flex column centres it, the same idiom
  * `.empty` uses. The insets are still added as padding: centred content
  * clears a status bar on a phone-shaped viewport by construction, but a short
@@ -500,16 +1090,23 @@ button:disabled { opacity: .45; cursor: default; }
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: .4rem;
+  gap: var(--space-2);
   text-align: center;
-  padding: calc(var(--inset-top) + 1rem) calc(var(--inset-right) + 1.25rem)
-           calc(var(--inset-bottom) + 1rem) calc(var(--inset-left) + 1.25rem);
+  padding: calc(var(--inset-top) + var(--space-5)) calc(var(--inset-right) + var(--space-5))
+           calc(var(--inset-bottom) + var(--space-5)) calc(var(--inset-left) + var(--space-5));
 }
-.boot-mark { margin: 0; font-size: 1.4rem; font-weight: 600; color: var(--ink); }
-.boot-note { margin: 0; font-size: .9rem; color: var(--soft); }
+.boot-mark {
+  margin: 0;
+  font-size: var(--text-xl);
+  font-weight: var(--weight-strong);
+  line-height: var(--leading-tight);
+  letter-spacing: -.015em;
+  color: var(--ink);
+}
+.boot-note { margin: 0; font-size: var(--text-md); color: var(--soft); }
 /* The failure notice boot-guard.js reveals. `[hidden]` is spelled out for the
    same reason `.screen[hidden]` and `.setting-error[hidden]` are: an author
    `display` declaration beats the user agent's, and this repository has twice
    shipped an element that ignored `hidden` because of one. */
-.boot-failed { margin: .4rem 0 0; max-width: 22rem; font-size: .9rem; color: var(--bad); }
+.boot-failed { margin: var(--space-2) 0 0; max-width: 22rem; font-size: var(--text-md); color: var(--bad); }
 .boot-note[hidden], .boot-failed[hidden] { display: none; }

--- a/src/praisonai-mobile/app/app.css
+++ b/src/praisonai-mobile/app/app.css
@@ -367,7 +367,7 @@ html, body {
 /* `tabindex="-1"` is what lets focus.ts move focus here on a route change; it
    must not also paint a ring when the move was made for a tap. A real keyboard
    focus still gets one, from `:focus-visible` below. */
-.screen-heading:focus { outline: none; }
+.screen-heading:focus:not(:focus-visible) { outline: none; }
 
 .transcript {
   flex: 1;

--- a/src/praisonai-mobile/app/src/boot-screen.test.ts
+++ b/src/praisonai-mobile/app/src/boot-screen.test.ts
@@ -125,16 +125,29 @@ test("the boot indicator takes its colours from the theme tokens, so a dark devi
     [],
     `the boot indicator must not name a colour; use the :root tokens:\n${rules}`,
   );
+  const colourTokens = new Set<string>();
   for (const decl of rules.matchAll(/(?:^|[;{])\s*(?:color|background(?:-color)?)\s*:([^;}]*)/g)) {
-    assert.match(decl[1] ?? "", /var\(--/, `a boot colour must come from a token: ${decl[0]}`);
+    const value = decl[1] ?? "";
+    assert.match(value, /var\(--/, `a boot colour must come from a token: ${decl[0]}`);
+    for (const use of value.matchAll(/var\((--[\w-]+)/g)) colourTokens.add(use[1] ?? "");
   }
 
   // And the tokens it uses must actually be the ones the dark theme moves. A
   // token that only ever has one value would pass the check above while
   // painting the same colour in both themes.
+  //
+  // Only the tokens named in a COLOUR declaration, which is the whole of what
+  // this test is about. It used to walk every `var()` in these rules and skip
+  // the two inset families by prefix, which held only while colour and the
+  // insets were the only tokens in the file. The boot indicator now takes its
+  // size and its spacing from the type and space scales as well -- --text-xl,
+  // --space-2 -- and a scale step has no business having a dark value, so the
+  // skip-list would have had to grow a name every time the design system did.
+  // Collecting the tokens out of the colour declarations this loop already
+  // inspects states what was meant instead of listing what was not.
   const dark = /@media \(prefers-color-scheme: dark\)\s*\{([\s\S]*?)\n\}/.exec(css)?.[1] ?? "";
-  for (const token of [...rules.matchAll(/var\((--[\w-]+)/g)].map((m) => m[1] ?? "")) {
-    if (token.startsWith("--inset") || token.startsWith("--safe-area")) continue;
+  assert.ok(colourTokens.size > 0, "no colour token was collected, so nothing below is checked");
+  for (const token of colourTokens) {
     assert.match(dark, new RegExp(`${token}\\s*:`), `${token} is not redefined for dark mode`);
   }
 });

--- a/src/praisonai-mobile/app/src/css.test.ts
+++ b/src/praisonai-mobile/app/src/css.test.ts
@@ -397,3 +397,57 @@ test("the settings sections are styled on the class the app actually emits", () 
   const lead = rulesFor('.screen-settings .settings-section[data-lead]');
   assert.match(lead.map((r) => r.body).join(" "), /color\s*:\s*var\(--ink\)/);
 });
+
+test("nothing removes the focus ring from a keyboard focus", () => {
+  /*
+   * This branch introduced `.screen-heading:focus { outline: none }` and a
+   * comment claiming "a real keyboard focus still gets one, from
+   * `:focus-visible` below". The comment was wrong, and specificity is why:
+   * `.screen-heading:focus` is (0,2,0) and the global `:focus-visible` rule is
+   * (0,1,0), so the suppression won for BOTH kinds of focus and route
+   * navigation to a heading left a keyboard user with no visible focus at all.
+   * `praisonai-triage-agent[bot]` caught it and scoped the rule to
+   * `:focus:not(:focus-visible)`, which is the correct idiom.
+   *
+   * None of the gates on this branch saw it -- they measure colour, size and
+   * weight, and this is a rule that removes something. So the invariant is
+   * stated directly: a rule may quieten a programmatic focus, but no rule may
+   * take the outline off an element that is `:focus-visible`.
+   *
+   * Text-level rather than computed, deliberately: `:focus-visible` depends on
+   * the heuristics of the last input modality, which a headless browser cannot
+   * be made to assert both ways reliably. The cascade, however, is decidable
+   * from the selector alone.
+   */
+  const killers = RULES.filter((rule) =>
+    declarationsOf(rule.body).some(
+      ([prop, value]) => prop === "outline" && /^(none|0)\b/.test(value.trim()),
+    ),
+  );
+  assert.ok(
+    killers.length > 0,
+    "no rule suppresses an outline -- if that is now true, delete this test rather than letting it pass vacuously",
+  );
+  for (const rule of killers) {
+    for (const selector of rule.selector.split(",").map((s) => s.trim())) {
+      if (!/:focus\b/.test(selector)) continue;
+      assert.match(
+        selector,
+        /:not\(\s*:focus-visible\s*\)/,
+        `"${selector}" removes the outline from every focus, keyboard included; ` +
+          "scope it with :focus:not(:focus-visible)",
+      );
+    }
+  }
+
+  // And the ring it must not remove has to exist in the first place.
+  const ring = RULES.filter((r) => r.selector.split(",").some((s) => s.trim() === ":focus-visible"));
+  assert.equal(ring.length, 1, "app.css must declare the :focus-visible ring exactly once");
+  // Destructured and re-guarded rather than indexed: `assert.equal` on the
+  // length narrows nothing for tsc, and `npm test` strips types without
+  // checking them -- so an indexed read passes every run here and fails
+  // `npm run typecheck`, which is the first thing `npm run check` does.
+  const [only] = ring;
+  assert.ok(only !== undefined, "the :focus-visible rule must have been parsed");
+  assert.match(only.body, /outline:\s*\d/, "the ring must actually draw an outline");
+});

--- a/src/praisonai-mobile/app/src/css.test.ts
+++ b/src/praisonai-mobile/app/src/css.test.ts
@@ -222,7 +222,93 @@ test("the empty state keeps clear of the safe area", () => {
   for (const name of ["--inset-left", "--inset-right"]) {
     assert.ok(value.includes(name), `.empty-state ignores ${name}: ${value}`);
   }
-  assert.match(value, /\+\s*[\d.]+rem/, `the gutter must survive a zero inset: ${value}`);
+  // RESOLVED, not matched as text. This read `/\+\s*[\d.]+rem/` -- a literal
+  // rem after the plus -- which was true only while every gutter in the file
+  // was a hardcoded number. The moment they became scale tokens the assertion
+  // failed, and the tempting repair (allow `var(...)` too) would have passed
+  // over `+ var(--nonexistent)` and over `+ var(--space-0)` if that were 0.
+  // So the token is looked up on `:root` and the NUMBER it resolves to is what
+  // is checked.
+  const gutter = addendOf(value);
+  assert.ok(gutter > 0, `the gutter must survive a zero inset, and it is ${gutter}rem: ${value}`);
+});
+
+/** Every custom property declared on `:root`, for resolving one token to the
+ *  number it stands for. Only `:root` -- a token redefined for dark mode is a
+ *  colour, and no geometry in this file is theme-dependent. */
+const ROOT_TOKENS = new Map(
+  declarationsOf(ruleFor(":root").body).filter(([prop]) => prop.startsWith("--")),
+);
+
+/**
+ * A token's value in rem, following `var()` indirection as far as it goes.
+ *
+ * `--gutter: var(--space-4)` and `--space-4: .75rem` is two hops, and the
+ * point of the scale is that a rule names the role rather than the number --
+ * so a test that cannot follow the indirection cannot check the number.
+ * Anything that does not end at a rem literal returns NaN, which fails every
+ * comparison below rather than passing one.
+ */
+function remOf(token: string, seen = new Set<string>()): number {
+  if (seen.has(token)) return Number.NaN;
+  seen.add(token);
+  const raw = ROOT_TOKENS.get(token);
+  if (raw === undefined) return Number.NaN;
+  const indirect = /^var\((--[a-z0-9-]+)\)$/.exec(raw.trim())?.[1];
+  if (indirect !== undefined) return remOf(indirect, seen);
+  const rem = /^([\d.]+)rem$/.exec(raw.trim())?.[1];
+  return rem === undefined ? Number.NaN : Number(rem);
+}
+
+/** The rem added to an inset inside `calc(var(--inset-x) + <addend>)`, whether
+ *  the addend is written as a literal or as a scale token. */
+function addendOf(padding: string): number {
+  const literal = /\+\s*([\d.]+)rem/.exec(padding)?.[1];
+  if (literal !== undefined) return Number(literal);
+  const token = /\+\s*var\((--[a-z0-9-]+)\)/.exec(padding)?.[1];
+  return token === undefined ? Number.NaN : remOf(token);
+}
+
+test("the stylesheet's gutter and the one main.ts writes inline are the same number", () => {
+  // The composer is the ONE element whose inline padding is written from
+  // script -- an inline style beats the stylesheet, and it has to, because the
+  // value moves with the live insets. So the gutter exists twice: as
+  // `--gutter` here and as a literal inside a template string in main.ts.
+  //
+  // Nothing connected them. Renaming or retuning the scale would have left the
+  // composer sitting a few pixels off every other screen edge in the app --
+  // the kind of drift that is invisible in a screenshot of one screen and
+  // obvious the moment you tab between two.
+  const scripted = /padding-inline-start",\s*`([^`]*)`/.exec(main)?.[1] ?? "";
+  const inline = addendOf(scripted);
+  assert.ok(inline > 0, `main.ts writes no gutter at all: ${scripted}`);
+
+  const token = remOf("--gutter");
+  assert.ok(Number.isFinite(token), "--gutter must resolve to a rem through :root");
+  assert.equal(
+    token,
+    inline,
+    `app.css lays out on a ${token}rem gutter and main.ts writes ${inline}rem inline`,
+  );
+
+  // And the stylesheet's own screen edges use that token rather than a number
+  // of their own, which is what makes the check above worth making.
+  // BOTH inline sides, separately. The first version of this loop asked for
+  // `--inset-(right|left)` in one alternation, which is satisfied by either --
+  // so replacing the right-hand gutter with a bare `.5rem` left the left-hand
+  // one matching and the mutation survived. A screen inset correctly on one
+  // edge and wrongly on the other is precisely the defect worth catching.
+  for (const selector of [".screen-settings,\n.screen-chats", ".transcript", ".topbar"]) {
+    const rule = RULES.find((r) => r.selector.replace(/\s+/g, " ") === selector.replace(/\s+/g, " "));
+    assert.ok(rule !== undefined, `app.css must still declare "${selector}"`);
+    for (const side of ["right", "left"] as const) {
+      assert.match(
+        rule.body,
+        new RegExp(`calc\\(var\\(--inset-${side}\\)\\s*\\+\\s*var\\(--gutter\\)\\)`),
+        `${selector} must build its ${side} padding from --gutter`,
+      );
+    }
+  }
 });
 
 /**

--- a/src/praisonai-mobile/tools/screen-layout.test.mjs
+++ b/src/praisonai-mobile/tools/screen-layout.test.mjs
@@ -133,7 +133,7 @@ after(async () => {
 /** The built app on a phone-sized viewport, with the four inset variables
  *  standing in for a notched device. Each case gets its OWN context, so one
  *  case's injected stylesheet and appended nodes cannot reach the next. */
-async function openApp(t) {
+async function openApp(t, { seedChats = false } = {}) {
   const { server, browser } = await shell();
 
   // `serviceWorkers: "block"` because this file is about layout and the service
@@ -149,6 +149,37 @@ async function openApp(t) {
     serviceWorkers: "block",
   });
   t.after(() => context.close());
+  /*
+   * Stored conversations, for the cases that need the chats list to have rows
+   * in it -- written through the SAME localStorage keys and JSON envelope
+   * `core/src/chat/repository.ts` reads (`praisonai.chats.<id>`, and
+   * `{schemaVersion, chat:{id,title,updated,engineId,messages}}`), so the rows
+   * on screen are painted by `buildChatsScreen` from real stored chats rather
+   * than pasted in as markup by the test.
+   *
+   * That distinction is not pedantry: the case that measures the type scale
+   * walks whatever is on screen, and an empty chats list has no `.chat-title`
+   * on it at all. Measured -- a mutation putting a hardcoded `15px` on
+   * `.chat-title` SURVIVED the scale check until these rows existed, because
+   * the element it broke was never rendered.
+   */
+  if (seedChats) {
+    await context.addInitScript(() => {
+      const put = (id, title, ago, messages) =>
+        localStorage.setItem(`praisonai.chats.${id}`, JSON.stringify({
+          schemaVersion: 1,
+          chat: { id, title, updated: Date.now() - ago, engineId: "remote-http", messages },
+        }));
+      put("chat-1", "Three days in Lisbon", 4 * 60_000, [
+        { role: "user", content: "Plan three days in Lisbon.", at: Date.now() - 5 * 60_000 },
+        { role: "assistant", content: "Day 1: Alfama.", at: Date.now() - 4 * 60_000 },
+      ]);
+      put("chat-2", "Why is the parser dropping the last frame of a stream?", 3 * 3600_000, [
+        { role: "user", content: "Why is the parser dropping the last frame?", at: Date.now() - 3 * 3600_000 },
+      ]);
+      put("chat-3", "Untitled", 30 * 3600_000, []);
+    });
+  }
   const page = await context.newPage();
   await page.route((u) => u.href.startsWith(ENGINE), (route) => route.abort("connectionrefused"));
   await page.goto(`http://127.0.0.1:${server.address().port}/`, { waitUntil: "load" });
@@ -298,4 +329,417 @@ test("a chat row is a full-width list row, and a long title is truncated", async
     measured.height < 100,
     `a long chat title grew the row to ${measured.height}px instead of staying one line`,
   );
+});
+
+/*
+ * ---- The visual identity, measured rather than declared --------------------
+ *
+ * Everything below asserts COMPUTED style in the same real engine the geometry
+ * cases above use, and for the same reason: app/src/css.test.ts reads the
+ * stylesheet as text, so it can check that a declaration is written and cannot
+ * check what the declaration DOES. A contrast ratio, a resolved type step and
+ * the relative brightness of two surfaces are all facts about the rendered
+ * page, and none of them survives being spelled out as a string match.
+ *
+ * The rows are built here with the class names and data attributes
+ * `app/src/dom.ts` emits, exactly as the chat-row case above builds a
+ * `.row-chat`. `app/src/main.test.ts` and `app/src/dom.test.ts` hold the other
+ * half of every one of those pairs -- that the builder still emits these names
+ * -- so a rename fails on that side rather than passing vacuously on this one.
+ */
+
+/** One of each row kind, as the app writes them. Built in the page. */
+const TRANSCRIPT_FIXTURE = `
+  <div class="row row-user" data-speaker="user" data-state="unstored">
+    <span class="sr-only">You said:</span><span class="user-text">Plan three days in Lisbon.</span>
+    <span class="user-note">Not saved</span></div>
+  <div class="row row-text">Day 1: Alfama and the viewpoints. Day 2: Belem. Day 3: Sintra.</div>
+  <div class="row row-reasoning">The user wants an itinerary, so I will keep each day short.</div>
+  <div class="row row-tool" data-status="running"><span class="tool-status">Running</span>
+    <span class="tool-name">search</span><span class="tool-meta">0.4s</span></div>
+  <div class="row row-tool" data-status="ok"><span class="tool-status">Succeeded</span>
+    <span class="tool-name">read_file</span><span class="tool-meta">0.3s</span>
+    <pre class="tool-output">hello</pre></div>
+  <div class="row row-tool" data-status="failed"><span class="tool-status">Failed</span>
+    <span class="tool-name">rm</span><span class="tool-meta">0.1s</span></div>
+  <div class="row row-tool" data-status="unresolved"><span class="tool-status">No result</span>
+    <span class="tool-name">slow_tool</span><span class="tool-meta">&mdash;</span></div>
+  <div class="row row-approval" data-state="pending"><p>Allow search?</p>
+    <button type="button" data-choice="allow">Allow</button>
+    <button type="button" data-choice="deny">Deny</button></div>
+  <div class="row row-error" data-tone="failure" data-recovery="retry">The engine is rate limited.</div>
+  <div class="row row-notice" data-tone="warning">Stopped</div>
+  <div class="row row-notice" data-tone="neutral">Reconnected</div>
+  <div class="row row-dropped">2 events were dropped</div>
+`;
+
+/**
+ * WCAG 2.x relative luminance and contrast, defined in the page so the numbers
+ * come from the colours the ENGINE resolved -- `var()` chains, the dark-scheme
+ * block, `currentColor` and all -- rather than from hexes copied out of the
+ * stylesheet into the test, which is the mistake that makes a colour gate
+ * agree with itself forever.
+ */
+const COLOUR_HELPERS = `
+  function parse(c) {
+    const m = c.match(/rgba?\\(([^)]+)\\)/);
+    if (!m) return null;
+    const p = m[1].split(",").map((n) => parseFloat(n));
+    return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 };
+  }
+  function over(fg, bg) {
+    // Source-over compositing, so an element with opacity or an rgba colour is
+    // judged on what is actually on the glass.
+    const a = fg.a;
+    return { r: fg.r * a + bg.r * (1 - a), g: fg.g * a + bg.g * (1 - a), b: fg.b * a + bg.b * (1 - a), a: 1 };
+  }
+  function lum(c) {
+    const f = (v) => { v /= 255; return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); };
+    return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b);
+  }
+  function ratio(a, b) {
+    const x = lum(a), y = lum(b);
+    return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+  }
+  /** The colour actually behind an element: the first ancestor that paints one,
+   *  composited down through every translucent layer above it. */
+  function backdrop(el) {
+    const stack = [];
+    for (let n = el; n; n = n.parentElement) {
+      const s = getComputedStyle(n);
+      const c = parse(s.backgroundColor);
+      if (c && c.a > 0) stack.push({ c, o: parseFloat(s.opacity) });
+      if (c && c.a === 1 && parseFloat(s.opacity) === 1) break;
+    }
+    let out = { r: 255, g: 255, b: 255, a: 1 };
+    for (let i = stack.length - 1; i >= 0; i -= 1) {
+      const l = stack[i];
+      out = over({ ...l.c, a: l.c.a * l.o }, out);
+    }
+    return out;
+  }
+  /** The effective opacity of an element, including every ancestor's. */
+  function chainOpacity(el) {
+    let o = 1;
+    for (let n = el; n; n = n.parentElement) o *= parseFloat(getComputedStyle(n).opacity);
+    return o;
+  }
+`;
+
+/** Open the app, put a full transcript in it, and set the colour scheme. */
+async function openTranscript(t, scheme, options = {}) {
+  const page = await openApp(t, options);
+  await page.emulateMedia({ colorScheme: scheme });
+  await page.evaluate((html) => {
+    const transcript = document.querySelector("main.transcript");
+    // The welcome panel is up on a fresh chat and the stylesheet takes the
+    // transcript's stretch away while it is; these rows are the "has rows"
+    // case, so put the screen into it the way main.ts does.
+    const screen = document.querySelector('.screen[data-screen="chat"]');
+    delete screen.dataset.empty;
+    document.querySelector(".empty-state").hidden = true;
+    transcript.innerHTML = html;
+  }, TRANSCRIPT_FIXTURE);
+  return page;
+}
+
+/** Every text-bearing element under #root that is actually on screen, with the
+ *  contrast of its composited colour against its composited backdrop. */
+const CONTRAST_SWEEP = `(() => {
+  ${COLOUR_HELPERS}
+  const out = [];
+  for (const el of document.querySelectorAll("#root *")) {
+    // Only elements with their OWN text: a wrapper's colour is never read.
+    const own = [...el.childNodes].some((n) => n.nodeType === 3 && n.textContent.trim() !== "");
+    if (!own) continue;
+    if (el.closest(".sr-only")) continue;                     // never painted
+    if (el.disabled || el.closest("[disabled]")) continue;    // WCAG exempts disabled controls
+    if (el.closest("[hidden]") || el.hidden) continue;        // not on screen
+    if (el.getBoundingClientRect().width === 0) continue;
+    const s = getComputedStyle(el);
+    const fg = parse(s.color);
+    if (!fg) continue;
+    const bg = backdrop(el);
+    const composited = over({ ...fg, a: fg.a * chainOpacity(el) }, bg);
+    const r = ratio(composited, bg);
+    const px = parseFloat(s.fontSize);
+    const bold = parseInt(s.fontWeight, 10) >= 700;
+    // WCAG's large-text threshold: 24px, or 18.66px when bold.
+    const need = px >= 24 || (bold && px >= 18.66) ? 3 : 4.5;
+    if (r < need) {
+      out.push({ what: el.className || el.tagName, text: el.textContent.trim().slice(0, 30),
+                 ratio: Math.round(r * 100) / 100, need });
+    }
+  }
+  return out;
+})()`;
+
+for (const scheme of ["light", "dark"]) {
+  test(`every word on every screen clears WCAG AA in ${scheme} mode`, async (t) => {
+    /*
+     * All THREE screens, not just the transcript.
+     *
+     * This swept `.transcript *, .topbar *, .composer *` and passed while a
+     * mutation dimming `.chat-updated` to #a8b0ba -- a timestamp on the chats
+     * list at 2.9:1 -- survived, because the element was on a screen the sweep
+     * never visited. A contrast gate that checks one screen out of three is a
+     * gate that reports on the screen you happened to be looking at.
+     *
+     * Each screen is measured while it is the VISIBLE one: `mount.ts` sets
+     * `hidden` on the others, and a hidden element has no useful computed
+     * style to read.
+     */
+    const findings = [];
+    let swept = 0;
+
+    // A FRESH page per route, rather than one page walked through all three.
+    // Only the chat screen builds a `.topbar`, and the topbar is where the
+    // navigation buttons live -- so from Settings there is nothing to click to
+    // reach Chats, and a loop that tried timed out on a button `mount.ts` had
+    // correctly hidden. Going back is the OS gesture, which is not a control
+    // on the page at all.
+    for (const route of ["chat", "settings", "chats"]) {
+      const page = await openTranscript(t, scheme, { seedChats: true });
+      if (route !== "chat") {
+        await page.locator(`button[data-action="navigate"][data-route="${route}"]`).click();
+        await page.locator(`.screen-${route}`).waitFor({ timeout: 10_000 });
+      }
+      for (const f of await page.evaluate(CONTRAST_SWEEP)) findings.push({ ...f, route });
+      // The sample cannot shrink to nothing and still pass: a sweep that found
+      // no text would report no failures either.
+      const counted = await page.evaluate(`
+        [...document.querySelectorAll("#root *")].filter((el) =>
+          !el.hidden && !el.closest("[hidden]") && el.getBoundingClientRect().width > 0 &&
+          [...el.childNodes].some((n) => n.nodeType === 3 && n.textContent.trim() !== "")
+        ).length`);
+      assert.ok(counted > 3, `only ${counted} text elements were visible on ${route}: nothing was swept`);
+      swept += counted;
+    }
+    assert.ok(swept > 20, `only ${swept} text elements across all three screens`);
+
+    assert.deepEqual(
+      findings,
+      [],
+      `${scheme} mode has text below its WCAG AA threshold:\n` +
+        findings.map((f) => `  ${f.ratio}:1 (needs ${f.need}) on ${f.route}: ${f.what} -- "${f.text}"`).join("\n"),
+    );
+  });
+}
+
+for (const [scheme, direction] of [["light", "recedes"], ["dark", "advances"]]) {
+  test(`the ${scheme} theme is designed, not inverted: the user's bubble ${direction} by the right amount`, async (t) => {
+    // The specific defect that inverting one palette into the other produces
+    // here, as a number.
+    //
+    // `--accent` in dark has to be light enough to read as TEXT on a near-black
+    // ground -- it is 10.6:1 -- so a bubble FILLED with it, which is what one
+    // shared token gives you, is a beacon: the brightest thing on the screen,
+    // once per user message, all the way down a conversation. In light the
+    // identical rule is the opposite experience, because there the same fill is
+    // DARKER than the page and recedes.
+    //
+    // So the invariant is not "which surface is brightest" -- in dark the
+    // bubble is legitimately the brightest, it is the only raised surface in
+    // the transcript. It is the DIRECTION and the MAGNITUDE of the step:
+    // away from the page in each theme's own sense, far enough to be plainly a
+    // surface and no further. 10.56 fails the ceiling; 1.0 fails the floor.
+    const page = await openTranscript(t, scheme);
+
+    const measured = await page.evaluate(`(() => {
+      ${COLOUR_HELPERS}
+      const bubble = backdrop(document.querySelector(".row-user"));
+      const ground = backdrop(document.querySelector(".transcript"));
+      return { bubble: lum(bubble), ground: lum(ground), separation: ratio(bubble, ground) };
+    })()`);
+
+    if (scheme === "light") {
+      assert.ok(
+        measured.bubble < measured.ground,
+        "in light the bubble is a dark fill on a pale page: it must recede, not glow",
+      );
+    } else {
+      assert.ok(
+        measured.bubble > measured.ground,
+        "in dark the bubble is the one raised surface in the transcript",
+      );
+    }
+    assert.ok(
+      measured.separation > 1.5,
+      `the ${scheme} bubble is only ${measured.separation.toFixed(2)}:1 against the transcript: ` +
+        "it reads as no bubble at all",
+    );
+    // The ceiling is what inverting the palette breaks. A dark bubble filled
+    // with `--accent` measures 10.56:1 here.
+    assert.ok(
+      measured.separation < 6,
+      `the ${scheme} bubble is ${measured.separation.toFixed(2)}:1 against the transcript -- a beacon, ` +
+        "repeated once per message down the whole conversation",
+    );
+  });
+}
+
+test("the two speakers are told apart by shape and side, not only by colour", async (t) => {
+  // The transcript layer is written against exactly this: a conversation whose
+  // sides differ only in hue is one a colour-blind reader cannot follow and a
+  // screen-reader user never hears. So the user's row is pulled to the end of
+  // the flex column and filled, and the assistant's is left as prose on the
+  // page -- and the assistant's row must NOT have picked up a fill of its own,
+  // which is what made both sides slabs before.
+  const page = await openTranscript(t, "light");
+
+  const shape = await page.evaluate(`(() => {
+    ${COLOUR_HELPERS}
+    const user = document.querySelector(".row-user");
+    const text = document.querySelector(".row-text");
+    const transcript = document.querySelector(".transcript");
+    const us = getComputedStyle(user), ts = getComputedStyle(text);
+    return {
+      userAlign: us.alignSelf,
+      userFilled: ratio(backdrop(user), backdrop(transcript)),
+      assistantOwnBackground: parse(ts.backgroundColor).a,
+      userRight: user.getBoundingClientRect().right,
+      assistantRight: text.getBoundingClientRect().right,
+      userLeft: user.getBoundingClientRect().left,
+      assistantLeft: text.getBoundingClientRect().left,
+      userCorners: [us.borderTopLeftRadius, us.borderTopRightRadius,
+                    us.borderBottomRightRadius, us.borderBottomLeftRadius],
+    };
+  })()`);
+
+  assert.equal(shape.userAlign, "flex-end", "the user's row must hug the trailing edge");
+  assert.ok(
+    shape.userLeft > shape.assistantLeft + 8,
+    `the user's row starts at ${shape.userLeft} and the assistant's at ${shape.assistantLeft}: ` +
+      "the indent is what says whose turn it is",
+  );
+  assert.equal(
+    shape.assistantOwnBackground,
+    0,
+    "the assistant's answer is prose on the page; a fill turns a long answer into a slab",
+  );
+  assert.ok(
+    shape.userFilled > 3,
+    `the user's bubble is only ${shape.userFilled.toFixed(2)}:1 against the transcript`,
+  );
+  // One corner cut, and exactly one: the notch that points the bubble back at
+  // the person who wrote it. Three round and one small is the whole shape.
+  const distinct = new Set(shape.userCorners);
+  assert.equal(
+    distinct.size,
+    2,
+    `the user bubble's corners are ${JSON.stringify(shape.userCorners)}: one notch, not four or none`,
+  );
+});
+
+test("every size and weight in the app is a step on the type scale", async (t) => {
+  /*
+   * A scale nothing is held to is a comment. This walks the real DOM of all
+   * three screens and asserts each rendered font-size is a step -- so the next
+   * `font-size: .82rem` written by hand fails here rather than quietly making
+   * the scale seven steps, then nine.
+   *
+   * A FRESH page per route, for a reason that cost a mutation: this first
+   * clicked Settings and then Chats on one page and swept afterwards, and
+   * `ui/src/screens.ts` UNMOUNTS the screen you leave -- so the settings
+   * markup was not in the document at all when the sweep ran. A mutation
+   * putting `.72rem` on the settings eyebrow survived it. Each route is now
+   * measured while it is the one on screen, exactly as the contrast sweep is.
+   */
+  const sizes = new Map();
+  const weights = new Map();
+  let allowed = null;
+  let root = null;
+
+  for (const route of ["chat", "settings", "chats"]) {
+    const page = await openTranscript(t, "light", { seedChats: true });
+    if (route !== "chat") {
+      await page.locator(`button[data-action="navigate"][data-route="${route}"]`).click();
+      await page.locator(`.screen-${route}`).waitFor({ timeout: 10_000 });
+    }
+
+    const measured = await page.evaluate(() => {
+      const rootPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
+      const steps = ["--text-xs", "--text-sm", "--text-md", "--text-base", "--text-lg", "--text-xl"];
+      const css = getComputedStyle(document.documentElement);
+      const seen = [];
+      for (const el of document.querySelectorAll("#root *")) {
+        const own = [...el.childNodes].some((n) => n.nodeType === 3 && n.textContent.trim() !== "");
+        if (!own || el.closest(".sr-only")) continue;
+        if (el.hidden || el.closest("[hidden]") || el.getBoundingClientRect().width === 0) continue;
+        const style = getComputedStyle(el);
+        seen.push([
+          Math.round(parseFloat(style.fontSize) * 100) / 100,
+          el.className || el.tagName,
+          parseInt(style.fontWeight, 10),
+        ]);
+      }
+      return {
+        rootPx,
+        allowed: steps.map((s) => Math.round(parseFloat(css.getPropertyValue(s)) * rootPx * 100) / 100),
+        seen,
+      };
+    });
+
+    root ??= measured.rootPx;
+    allowed ??= measured.allowed;
+    assert.ok(measured.seen.length >= 3, `only ${measured.seen.length} sized elements on ${route}`);
+    for (const [px, what, weight] of measured.seen) {
+      if (!sizes.has(px)) sizes.set(px, `${what} (${route})`);
+      if (!weights.has(weight)) weights.set(weight, `${what} (${route})`);
+    }
+  }
+
+  // 0.02px, not half a pixel. The tolerance exists only for the rounding in
+  // `px = round(rem * root * 100) / 100`, and every step lands on a whole pixel
+  // at a 16px root. A half-pixel window is wide enough to accept `.82rem`
+  // (13.12px) as `--text-sm` (13px) -- which is exactly the hand-written size
+  // this scale replaced, so the gate would have passed over its own reason for
+  // existing. Verified by mutation: at 0.51 that substitution survives, at 0.02
+  // it fails.
+  const offScale = [...sizes.entries()].filter(
+    ([px]) => !allowed.some((a) => Math.abs(a - px) < 0.02),
+  );
+  assert.deepEqual(
+    offScale,
+    [],
+    `sizes that are not a step on the scale (allowed: ${allowed?.join(", ")}px at a ${root}px root):\n` +
+      offScale.map(([px, what]) => `  ${px}px on ${what}`).join("\n"),
+  );
+  // The sample cannot shrink to nothing and still pass.
+  assert.ok(sizes.size >= 5, `only ${sizes.size} distinct sizes found across three screens`);
+
+  /*
+   * And the WEIGHTS, which is the half of the type decision a size check
+   * cannot see.
+   *
+   * This file used `font-weight: 550` for settings labels. CSS font matching
+   * for a requested weight above 500 searches UPWARD first, and Roboto ships
+   * 400/500/700 as separate faces -- so 550 rendered as 550 on iOS, where SF
+   * is variable, and as 700, full bold, on Android. A label meant to read a
+   * shade heavier than its value was bolder than the screen heading above it,
+   * on one platform only, and no screenshot of the other would ever show it.
+   *
+   * Three values, named on :root, and nothing else. 400/500/700 are the three
+   * Android actually has, so a rule that asks for one of them gets the same
+   * answer on both platforms.
+   */
+  const namedWeights = await (async () => {
+    const page = await openTranscript(t, "light");
+    return page.evaluate(() => {
+      const css = getComputedStyle(document.documentElement);
+      return ["--weight-normal", "--weight-medium", "--weight-strong"]
+        .map((n) => parseInt(css.getPropertyValue(n).trim(), 10));
+    });
+  })();
+  assert.deepEqual(namedWeights, [400, 500, 700], "the three weights Android has, named on :root");
+
+  const offWeight = [...weights.entries()].filter(([w]) => !namedWeights.includes(w));
+  assert.deepEqual(
+    offWeight,
+    [],
+    `weights that are not one of ${namedWeights.join("/")} -- a weight between two faces ` +
+      `resolves differently on Android and iOS:\n` +
+      offWeight.map(([w, what]) => `  ${w} on ${what}`).join("\n"),
+  );
+  assert.ok(weights.size >= 2, `only ${weights.size} distinct weights: the hierarchy is not being used`);
 });

--- a/src/praisonai-mobile/tools/screen-layout.test.mjs
+++ b/src/praisonai-mobile/tools/screen-layout.test.mjs
@@ -367,7 +367,6 @@ const TRANSCRIPT_FIXTURE = `
   <div class="row row-approval" data-state="pending"><p>Allow search?</p>
     <button type="button" data-choice="allow">Allow</button>
     <button type="button" data-choice="deny">Deny</button></div>
-  <div class="row row-error" data-tone="failure" data-recovery="retry">The engine is rate limited.</div>
   <div class="row row-notice" data-tone="warning">Stopped</div>
   <div class="row row-notice" data-tone="neutral">Reconnected</div>
   <div class="row row-dropped">2 events were dropped</div>
@@ -425,6 +424,28 @@ const COLOUR_HELPERS = `
     return o;
   }
 `;
+
+/**
+ * A REAL error row, rendered by the app rather than pasted in by the test.
+ *
+ * `.row-error` is the one row kind this file can provoke honestly. The web
+ * build's default engine is `remote-http` at `ENGINE`, and `openApp` already
+ * routes that address to `connectionrefused` -- so sending a message drives
+ * the actual failure path: the engine adapter, `classify.ts`, the view model's
+ * `errorKind`, and `dom.ts`'s title-plus-prose renderer.
+ *
+ * Worth the round trip because a fixture cannot check the thing that matters
+ * here. #4873 added `.error-title` and `.error-message` as two spans inside
+ * one row, and the CSS that separates them is a single `display: block`; a
+ * hand-written fixture of an error row is a copy of that markup which agrees
+ * with itself no matter what `dom.ts` later does. This asks the app.
+ */
+async function provokeRealError(page) {
+  await page.locator('textarea[aria-label="Message"]').fill("Hello");
+  await page.locator('button[data-action="send"]').click();
+  await page.locator(".row-error").waitFor({ timeout: 30_000 });
+  return page;
+}
 
 /** Open the app, put a full transcript in it, and set the colour scheme. */
 async function openTranscript(t, scheme, options = {}) {
@@ -498,9 +519,18 @@ for (const scheme of ["light", "dark"]) {
     // reach Chats, and a loop that tried timed out on a button `mount.ts` had
     // correctly hidden. Going back is the OS gesture, which is not a control
     // on the page at all.
-    for (const route of ["chat", "settings", "chats"]) {
-      const page = await openTranscript(t, scheme, { seedChats: true });
-      if (route !== "chat") {
+    // "error" is the chat screen again, with a row the APP produced rather than
+    // one the fixture pasted in -- see `provokeRealError`. The fixture covers
+    // the kinds no refused connection can make (tool, approval, dropped); this
+    // covers the one it can, and covers it as `dom.ts` actually renders it.
+    for (const route of ["chat", "error", "settings", "chats"]) {
+      const page = route === "error"
+        ? await provokeRealError(await openApp(t)).then(async (p) => {
+            await p.emulateMedia({ colorScheme: scheme });
+            return p;
+          })
+        : await openTranscript(t, scheme, { seedChats: true });
+      if (route !== "chat" && route !== "error") {
         await page.locator(`button[data-action="navigate"][data-route="${route}"]`).click();
         await page.locator(`.screen-${route}`).waitFor({ timeout: 10_000 });
       }
@@ -742,4 +772,51 @@ test("every size and weight in the app is a step on the type scale", async (t) =
       offWeight.map(([w, what]) => `  ${w} on ${what}`).join("\n"),
   );
   assert.ok(weights.size >= 2, `only ${weights.size} distinct weights: the hierarchy is not being used`);
+});
+
+test("the error row still shows its title above the provider's prose", async (t) => {
+  /*
+   * #4873 landed `.error-title` / `.error-message` into `.row-error` while this
+   * branch was rewriting every rule in the stylesheet, so the two changes met
+   * for the first time in a rebase. The whole of the separation between the two
+   * spans is one `display: block`; lose it and the row reads
+   * "Sign-in problemThe OPENAI_API_KEY environment variable is missing..." with
+   * nothing failing anywhere.
+   *
+   * Driven through the real failure path rather than a fixture, so it also
+   * proves the title is still CHOSEN -- `classify.ts` -> `errorKind` ->
+   * `strings.errorTitle` -- and not just markup this test wrote itself.
+   */
+  const page = await provokeRealError(await openApp(t));
+
+  const seen = await page.evaluate(() => {
+    const row = document.querySelector(".row-error");
+    const title = row.querySelector(".error-title");
+    const message = row.querySelector(".error-message");
+    const box = (el) => (el ? el.getBoundingClientRect() : null);
+    return {
+      title: title?.textContent ?? null,
+      message: message?.textContent ?? null,
+      display: title ? getComputedStyle(title).display : null,
+      weight: title ? parseInt(getComputedStyle(title).fontWeight, 10) : null,
+      titleBottom: box(title)?.bottom ?? null,
+      messageTop: box(message)?.top ?? null,
+      rowRecovery: row.dataset.recovery,
+    };
+  });
+
+  assert.ok(seen.title !== null && seen.title.trim() !== "", "the error row must render a title");
+  assert.ok(seen.message !== null && seen.message.trim() !== "", "and keep the provider's prose under it");
+  assert.notEqual(seen.title, seen.message, "the title is chosen by kind, not a copy of the message");
+  assert.equal(seen.display, "block", "without display:block the two spans run into one sentence");
+  // The geometry, not just the declaration: the title's box must END at or
+  // above where the message's box STARTS, which is what "on its own line"
+  // means and what a `display: inline` regression would break.
+  assert.ok(
+    seen.titleBottom <= seen.messageTop + 0.5,
+    `the title ends at y=${seen.titleBottom} and the message starts at y=${seen.messageTop}: same line`,
+  );
+  // The weight has to be a step this branch's scale admits, or the type gate
+  // and this one disagree about the same element.
+  assert.ok([400, 500, 700].includes(seen.weight), `the title's weight is ${seen.weight}`);
 });


### PR DESCRIPTION
The mobile app was correct and read as a prototype: system font at one weight, no type scale, no spacing rhythm, colour chosen per element. `:root` held the safe-area insets and nothing else. This gives it a system, and holds the system to gates that measure the **rendered page** rather than the stylesheet text.

**Rebased onto `f2aa9eb5cd`.** The nine failures this PR showed were all inherited from a red `main`; none survive. Three things changed on the way:

- **My first commit is gone.** It fixed the `FakeNode.id` typecheck failure — #4873 landed the same fix first, including the `assert.ok(help !== null)` guard. Carrying a second copy would have been a conflicting duplicate, so it is dropped rather than merged.
- **`praisonai-triage-agent[bot]`'s commit is kept, and it was right.** See below.
- **A third commit adds the two gates this branch was missing**, both found where it met `main`.

---

## The bot caught a real regression, and it was mine

This branch added `.screen-heading:focus { outline: none }` with a comment asserting *"a real keyboard focus still gets one, from `:focus-visible` below"*. That was **false**. `.screen-heading:focus` is (0,2,0); the global `:focus-visible` rule is (0,1,0). The suppression won for *both* kinds of focus, so route navigation to a heading left a keyboard user with no visible focus indicator at all.

The bot scoped it to `:focus:not(:focus-visible)` — the correct idiom, and the one I should have written. Kept as it stands. The third commit adds the gate that should have made it unnecessary: **any rule setting `outline: none` on a `:focus` state must carry `:not(:focus-visible)`**. Stated on the cascade rather than measured, deliberately — `:focus-visible` depends on last-input-modality heuristics a headless browser cannot assert both ways reliably, while "does this selector kill a keyboard focus ring" is decidable from the selector alone.

## The error row, verified on the real page

#4873 landed `.error-title` / `.error-message` as two spans inside `.row-error` while this branch was rewriting every rule in the stylesheet — the two met for the first time in a rebase. The whole separation between them is one `display: block`; lose it and the row reads `Sign-in problemThe OPENAI_API_KEY environment variable is missing…` with nothing failing anywhere.

So the hand-built `.row-error` is **dropped from the fixture** and the app is made to produce a real one. The web build's default engine is `remote-http` at `ENGINE`, and the harness already routes that address to `connectionrefused` — sending a message drives the actual path: engine adapter → `classify.ts` → `errorKind` → `dom.ts`'s renderer. A fixture of an error row is a copy of that markup that agrees with itself no matter what `dom.ts` later does.

That real row is now swept for contrast in both themes alongside the three screens, and asserted structurally: a title, the prose kept in full underneath, the two on separate lines **as geometry** (the title's box ends at or above where the message's begins — which an `inline` regression breaks), and a weight the scale admits.

#4873's rule arrived as `font-weight: 600`, which this branch's weight gate rejects: 600 is not one of the three weights Roboto ships and resolves to 700 there anyway. It is `--weight-strong` here — the same 700 on Android, now a named step.

## Typeface — the system stack, committed to rather than defaulted to

A webfont was considered and rejected, worst cost first: `ui/src/i18n/strings.ts` is a translated UI and `main.ts` sets `dir="rtl"`, so a Latin subset leaves Arabic and CJK users reading two typefaces; `index.html` paints a wordmark on the first frame *precisely* so a cold start does not look broken, and a webfont makes that frame a flash or a blank; and `app.css` is a render-blocking `<link>` under `font-src 'self'`.

**Three weights — 400/500/700, the three Roboto ships.** This file used `font-weight: 550`; CSS font matching searches *upward* above 500, so it rendered 550 on iOS and **700, full bold, on Android** — settings labels heavier than the heading above them.

## Type scale — six steps, two bands

`12/13/14` is the **information** band (timestamps, help, tool meta), `16/18/22` is the **hierarchy** band. Deliberately not geometric: a constant ratio lands on fractional pixels at the small end, where a phone has no room for them.

## Space — seven steps, 4px grid, in rem

Android's font-scale reaches a WebView as a text zoom, so rem spacing grows with the type and px spacing does not. It is also what this file already used, so the rhythm changes and the behaviour does not. `--gutter` names the one number `main.ts` also writes inline, and a test asserts the two agree.

## Colour — both themes designed, neither inverted

Three surfaces (`--ground` / `--chrome` / `--panel`), ink and soft, the brand accent, a user-message pair, `bad`/`warn` with tinted grounds, and the five `RowTone` values `view-model.ts` has always named and this stylesheet never styled.

Two tokens prove it is not an inversion:

- **`--chrome` is lighter than `--ground` in *both* themes.** A bar floats above a page whatever the light. Inverting would make the dark topbar darker than the transcript — a hole, not a frame.
- **`--panel` flips.** A control is distinguished by being nearer the light source; in a dark UI that means brighter. This is the relationship that genuinely inverts, and the reason "invert the palette" gives you recessed-looking buttons in dark mode.

**`--user-bg` is the case that mattered.** It was `--accent`, which in dark has to be light enough to read as *text* on near-black (10.6:1) — so every user bubble was the brightest object on the screen, once per message, all the way down a conversation, while the identical rule in light gives a dark fill that *recedes*. Dark now steps 2.05:1.

Every text pair in both themes clears WCAG AA. Worst is **4.5:1 light, 6.3:1 dark**.

## The message list — the user writes objects, the model writes text

The user's row keeps its bubble, its alignment, and gains one logical corner notch (`border-end-end-radius`, so it follows `dir` rather than pointing away from an Arabic speaker). The assistant's row **loses its fill**: a 100%-wide filled box is not a bubble, it is a container with prose in it, and stacked down a transcript it was a column of grey slabs. Nothing accessible rested on that background — alignment, `data-speaker` and the visually-hidden "You said:" carry the speaker, all untouched.

Turn rhythm comes from `+` combinators either side of the user's row: there is no turn element and `reconcile.ts` places rows by index. A tool's status is a chip coloured by its tone — which is what finally makes `unresolved` stop looking identical to `running`.

## Defects found on the way

- `.user-note` at `opacity: .85` was white on the light bubble at **4.26:1, under AA** — on the one line whose job is to say your message was not saved. Contrast through an opacity is a fact about the composited pixel; no stylesheet review sees it.
- Two `.row-chat` blocks 136 lines apart, written by different fixes, the later silently winning half the earlier one's declarations.
- `.chat-open` kept `button`'s inline padding inside a row that already had a gutter — every chat title indented twice.
- `.chat-open` was `align-items: baseline` inside a 44px button box, so the title sat ~10px above the `Delete` beside it. Invisible while Delete had a border; obvious once the destructive control was quietened.
- `.screen-heading` and `.jump-latest` had **no rule at all**. Settings and Chats were titled at the UA default `h2` while the chat title one tap away was 16px; the jump affordance was a full-bleed slab that shoved the composer down.
- The topbar overflowed at `font_scale 1.5` — "New chat" wrapped, "Settings" was clipped.

## Gates — mutation-tested, seven for seven

| mutation | killed by |
|---|---|
| `display: inline` on the error title | error-row test |
| `font-weight: 600` on the error title | error-row test |
| the bot's fix reverted to `.screen-heading:focus` | focus-ring test |
| `.82rem` on a tool row | type scale |
| `.72rem` on the settings eyebrow | type scale |
| `.chat-updated` dimmed past AA | contrast sweep |
| the transcript's right gutter as a literal | gutter agreement |

Four of these **survived their first version**, and each bought a better gate: a 0.51px tolerance accepted the exact `.82rem` the scale replaced; the contrast sweep visited only one of three screens; the type sweep measured screens `screens.ts` had already unmounted; and the gutter check matched left-*or*-right.

## Numbers, measured on this tree

`npm run check` exits 0 on **Node 22.18.0 and 24.12.0** — 1688 tests, 0 failures, exit code read from the command itself.

Bundle, freshly measured on `f2aa9eb5cd` + this branch, with `praisonai-ts/dist` rebuilt from source:

```
shell   87.7 kB of 400 kB   (21.9%)
lazy   871.6 kB of 1600 kB  (54.5%)
```

Both far inside budget — #4874 and #4882 reclaimed a great deal. **Treat the lazy figure as approximate**: `src/praisonai-ts/.gitignore` ignores `package-lock.json`, so `npm install` re-resolves every `^` range on each run and the same commit measures differently across a day. Mine resolved `ai@6.0.3`, `@ai-sdk/openai@3.0.1`, `@ai-sdk/google@3.0.1`, `@ai-sdk/provider@3.0.0`. Worth a lockfile, but not in a stylesheet PR.

`app.css` grows **22.6 kB → 46.2 kB raw, 7.9 kB → 15.4 kB gzipped**, about 60% of it comment. It ships verbatim and is render-blocking, so the number belongs in the review; there is no CSS budget to trip, which is itself worth a decision.

## Verified on an Android 15 emulator

API 35, 1080×1920 @ 420dpi. Before and after, light and dark, at `font_scale` 1.0 and 1.5: chat empty, chat with a conversation, Chats, Settings, Settings scrolled, the composer with the keyboard up, and the boot indicator on a cold start. Each build was confirmed on the device by `lastUpdateTime` before any capture was trusted.

The behaviours this stylesheet carries were re-checked **on the device**: safe-area insets, the composer above the keyboard, the settings scroll, the boot indicator painting dark on a dark device, the empty-state panel, and the settings row states.

**Not covered by those captures:** the device runs the in-process engine with no key, so it shows the empty state and never an error row — the error row is covered by the new real-engine test in Chromium instead. Also unverified: iOS entirely, RTL on a device, the old-WebView floor for logical properties, `.jump-latest` on screen, and a physical device or display cutout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refreshed the mobile app’s visual design with consistent typography, spacing, colors, and corner radii.
  - Expanded dark-mode styling across the app for improved visual consistency.
  - Updated chat bubbles, reasoning rows, tool-status chips, notices, chat list rows, and the jump-to-latest control.
  - Improved screen headings, buttons, empty states, settings, and boot-screen presentation.
  - Enhanced keyboard focus indicators and refined layout gutters for better accessibility and alignment.
  - Improved message readability, including clearer user-message styling and error presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->