### PR TITLE
perf(mobile): take the team subsystem off the phone's graph, 1607.1 -> 1587.4kB

### DIFF
--- a/src/praisonai-mobile/tools/app-bundle.test.mjs
+++ b/src/praisonai-mobile/tools/app-bundle.test.mjs
@@ -94,6 +94,46 @@ test("praisonai reaches no eager chunk -- the split is real", () => {
   assert.ok(lazyWithEngine.length > 0, "and praisonai IS in the bundle, in a lazy chunk");
 });
 
+test("the phone's graph carries no multi-agent team machinery", () => {
+  // `praisonai/mobile` exports one class, `Agent`. It does NOT export
+  // AgentTeam, and no mobile path can construct one -- there is no team
+  // screen, no team engine, no way in.
+  //
+  // It arrived anyway, and invisibly: `agent/simple.ts` -- the module the
+  // allowlist takes `Agent` from -- ended a 3600-line file with
+  // `export { AgentTeam, ... } from './team'`. A value re-export is a static
+  // import, so ./team and its four helpers rode along, 19.7kB of a phone's
+  // download for code it cannot reach. esbuild could not drop it: the two
+  // modules were a cycle, and an unused re-export is a side-effect import of a
+  // module it cannot prove pure. Nothing failed until the lazy budget did, at
+  // which point the cheapest-looking fix is to raise the budget.
+  //
+  // So the shape is asserted, not just the total. A barrel re-export costs
+  // whatever sits behind it, and the next one will not announce itself either.
+  // Every segment after `team`, not just one lowercase word: `team-manager`
+  // and `team-options` are today's helpers, but `team-task-runner` is the
+  // shape #4872 is heading for and a one-segment matcher would wave it
+  // through. Widened by praisonai-triage-agent[bot] on this branch; kept
+  // because it is strictly stricter and still rejects simple.js/handoff.js.
+  const onGraph = report.chunks
+    .flatMap((c) => inputsOf(c.name))
+    .filter(isUpstream)
+    .filter((input) => /\/agent\/team(?:-[^/]+)*\.js$/.test(input));
+  assert.deepEqual(
+    onGraph,
+    [],
+    `the team subsystem is on the webview graph: ${onGraph.join(", ")}\n` +
+    `    Something the allowlist reaches re-exports it. Take the classes from\n` +
+    `    ./team where they live, not through a module a phone must load.`,
+  );
+  // Non-vacuous: the matcher must be looking at real upstream inputs in the
+  // shape it expects, or an empty list proves nothing. agent/simple IS there.
+  const simple = report.chunks
+    .flatMap((c) => inputsOf(c.name))
+    .filter((input) => isUpstream(input) && /\/agent\/simple\.js$/.test(input));
+  assert.ok(simple.length > 0, "agent/simple.js must be on the graph -- it is where Agent lives");
+});
+
 test("the CLI-only packages are reached lazily, and only lazily", () => {
   // They are external (bundle.mjs says why), and external is safe only behind
   // an import(). This pins the upstream fact that makes that true: no static

--- a/src/praisonai-ts/src/agent/index.ts
+++ b/src/praisonai-ts/src/agent/index.ts
@@ -9,7 +9,11 @@
  */
 
 // Core exports - the main API surface
-export { Agent, AgentTeam, PraisonAIAgents, Agents } from './simple';
+export { Agent } from './simple';
+// From './team', not './simple'. Re-exporting them through ./simple put the
+// whole team subsystem on the webview graph that takes `Agent` from there;
+// see the note at the bottom of ./simple.
+export { AgentTeam, PraisonAIAgents, Agents } from './team';
 export type { SimpleAgentConfig, AgentTeamConfig, PraisonAIAgentsConfig, AgentEvent, AgentStreamOptions, StopReason, AgentMessage } from './simple';
 // Python-parity surfaces (see src/praisonai-ts/SIGNATURE_PARITY.md)
 export type {

--- a/src/praisonai-ts/src/agent/proxy.ts
+++ b/src/praisonai-ts/src/agent/proxy.ts
@@ -1,4 +1,5 @@
-import { Agent as SimpleAgent, AgentTeam as SimpleAgentTeam, SimpleAgentConfig } from './simple';
+import { Agent as SimpleAgent, SimpleAgentConfig } from './simple';
+import { AgentTeam as SimpleAgentTeam } from './team';
 import { Agent as TaskAgent, TaskAgentTeam, TaskAgentConfig } from './types';
 import { Task } from './types';
 import type { ChatCompletionTool } from 'openai/resources/chat/completions';

--- a/src/praisonai-ts/src/agent/simple.ts
+++ b/src/praisonai-ts/src/agent/simple.ts
@@ -3644,9 +3644,21 @@ export class Agent {
   }
 }
 
-// AgentTeam and its aliases live in ./team; re-exported here so every existing
-// import path (the `./simple` and `./agent/simple` specifiers) keeps working unchanged.
-export { AgentTeam, PraisonAIAgents, Agents } from './team';
+// AgentTeam and its aliases live in ./team, and are re-exported from
+// `./index` (`praisonai`, `praisonai/agent`) -- NOT from here.
+//
+// They used to be re-exported from this file too, for the `./simple` and
+// `./agent/simple` specifiers. That cost 19.7kB on every phone. `src/mobile.ts`
+// -- the webview allowlist -- takes `Agent` from THIS module, and a value
+// re-export is a static import: it put ./team and its four helpers
+// (team-manager, team-options, team-memory, team-planning) on the graph of a
+// bundle that deliberately does not export AgentTeam and has no path that can
+// construct one. esbuild cannot drop it: the two modules formed a cycle, and
+// the re-export is a side-effect import of a module it cannot prove pure.
+//
+// TYPES still come from here, because `export type` is erased and costs
+// nothing. Only the three classes moved, and only one specifier deep --
+// `praisonai/agent` serves them, as does `praisonai` itself.
 export type {
   AgentTeamProcess,
   AgentTeamConfig,

--- a/src/praisonai-ts/src/agent/team.ts
+++ b/src/praisonai-ts/src/agent/team.ts
@@ -1,7 +1,11 @@
 import { Logger } from '../utils/logger';
 import { getEnv } from '../llm/openaiClientOptions';
 import { notYetHonoured, unhonouredFor } from '../utils/parity-notice';
-import { Agent, type AgentChatOptions } from './simple';
+// Type-only on purpose: every use of `Agent` in this file is a type
+// position, and the runtime class is reached through the dynamic
+// `import('./simple')` in ./team-manager. A value import here would put
+// the two modules back in a cycle, which is what hid the cost below.
+import type { Agent, AgentChatOptions } from './simple';
 import type { Task, TaskOutput } from './types';
 import type { ContextManager } from '../context/manager';
 import type { Plan, TodoList } from '../planning';

--- a/src/praisonai-ts/tests/development/simple/multi-agent-tools.ts
+++ b/src/praisonai-ts/tests/development/simple/multi-agent-tools.ts
@@ -1,4 +1,4 @@
-import { Agent, PraisonAIAgents } from '../../../src/agent/simple';
+import { Agent, PraisonAIAgents } from '../../../src/agent';
 
 async function getWeather(location: string) {
   console.log(`Getting weather for ${location}...`);

--- a/src/praisonai-ts/tests/development/simple/multi-agents-detailed.ts
+++ b/src/praisonai-ts/tests/development/simple/multi-agents-detailed.ts
@@ -1,4 +1,4 @@
-import { Agent, PraisonAIAgents } from '../../../src/agent/simple';
+import { Agent, PraisonAIAgents } from '../../../src/agent';
 
 // Create research agent
 const researchAgent = new Agent({ 

--- a/src/praisonai-ts/tests/development/simple/task-based-agent-tools.ts
+++ b/src/praisonai-ts/tests/development/simple/task-based-agent-tools.ts
@@ -1,4 +1,4 @@
-import { Agent, PraisonAIAgents } from '../../../src/agent/simple';
+import { Agent, PraisonAIAgents } from '../../../src/agent';
 
 async function getWeather(location: string) {
   console.log(`Getting weather for ${location}...`);

--- a/src/praisonai-ts/tests/development/simple/task-based-agent.ts
+++ b/src/praisonai-ts/tests/development/simple/task-based-agent.ts
@@ -1,4 +1,4 @@
-import { Agent, PraisonAIAgents } from '../../../src/agent/simple';
+import { Agent, PraisonAIAgents } from '../../../src/agent';
 
 // Create recipe agent
 const recipeAgent = new Agent({

--- a/src/praisonai-ts/tests/unit/agent/parity-agentteam-features.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/parity-agentteam-features.test.ts
@@ -8,7 +8,7 @@
  */
 process.env.PRAISONAI_PARITY_SILENT = '1';
 
-import { Agent, AgentTeam } from '../../../src/agent/simple';
+import { Agent, AgentTeam } from '../../../src/agent';
 import { resetParityNotices } from '../../../src/utils/parity-notice';
 
 /**

--- a/src/praisonai-ts/tests/unit/agent/parity-agentteam.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/parity-agentteam.test.ts
@@ -3,7 +3,7 @@
  */
 process.env.PRAISONAI_PARITY_SILENT = '1';
 
-import { Agent, AgentTeam } from '../../../src/agent/simple';
+import { Agent, AgentTeam } from '../../../src/agent';
 import { Task } from '../../../src/agent/types';
 import { resetParityNotices, unhonouredOptions } from '../../../src/utils/parity-notice';
 

--- a/src/praisonai-ts/tests/unit/agent/rename-aliases.test.ts
+++ b/src/praisonai-ts/tests/unit/agent/rename-aliases.test.ts
@@ -9,25 +9,25 @@
 describe('AgentTeam Rename', () => {
   describe('Primary Class', () => {
     it('should export AgentTeam as primary class', async () => {
-      const { AgentTeam } = await import('../../../src/agent/simple');
+      const { AgentTeam } = await import('../../../src/agent');
       expect(AgentTeam).toBeDefined();
       expect(typeof AgentTeam).toBe('function');
     });
 
     it('should have AgentTeam as the class name', async () => {
-      const { AgentTeam } = await import('../../../src/agent/simple');
+      const { AgentTeam } = await import('../../../src/agent');
       expect(AgentTeam.name).toBe('AgentTeam');
     });
   });
 
   describe('Silent Aliases', () => {
     it('should export PraisonAIAgents as alias for AgentTeam', async () => {
-      const { AgentTeam, PraisonAIAgents } = await import('../../../src/agent/simple');
+      const { AgentTeam, PraisonAIAgents } = await import('../../../src/agent');
       expect(PraisonAIAgents).toBe(AgentTeam);
     });
 
     it('should export Agents as alias for AgentTeam', async () => {
-      const { AgentTeam, Agents } = await import('../../../src/agent/simple');
+      const { AgentTeam, Agents } = await import('../../../src/agent');
       expect(Agents).toBe(AgentTeam);
     });
   });
@@ -35,7 +35,7 @@ describe('AgentTeam Rename', () => {
   describe('Type Exports', () => {
     it('should export AgentTeamConfig type', async () => {
       // Type-only test - if this compiles, the type exists
-      const { AgentTeam } = await import('../../../src/agent/simple');
+      const { AgentTeam } = await import('../../../src/agent');
       expect(AgentTeam).toBeDefined();
     });
   });
@@ -96,21 +96,21 @@ describe('AgentFlow Rename', () => {
 
 describe('Backward Compatibility', () => {
   it('should allow instantiation with old name PraisonAIAgents', async () => {
-    const { PraisonAIAgents, Agent } = await import('../../../src/agent/simple');
+    const { PraisonAIAgents, Agent } = await import('../../../src/agent');
     const agent = new Agent({ instructions: 'Test agent' });
     const team = new PraisonAIAgents([agent]);
     expect(team).toBeDefined();
   });
 
   it('should allow instantiation with old name Agents', async () => {
-    const { Agents, Agent } = await import('../../../src/agent/simple');
+    const { Agents, Agent } = await import('../../../src/agent');
     const agent = new Agent({ instructions: 'Test agent' });
     const team = new Agents([agent]);
     expect(team).toBeDefined();
   });
 
   it('should allow instantiation with new name AgentTeam', async () => {
-    const { AgentTeam, Agent } = await import('../../../src/agent/simple');
+    const { AgentTeam, Agent } = await import('../../../src/agent');
     const agent = new Agent({ instructions: 'Test agent' });
     const team = new AgentTeam([agent]);
     expect(team).toBeDefined();


### PR DESCRIPTION
**Lazy bundle 1607.1kB → 1587.4kB against a 1600kB budget. The budget is untouched.**

Rebased onto `06136d08f` (#4873). Every number below is re-measured on that base, from a wiped `node_modules`, with `npm install` in praisonai-ts and `npm ci` in praisonai-mobile — exactly what `mobile.yml` runs. `main` on that same tree still measures **1607.1kB** and still fails the gate.

## What actually grew

Rebuilding praisonai-ts at each commit against **one fixed dependency tree**, so upstream churn is constant across the rows:

| commit | | lazy | Δ |
|---|---|---:|---:|
| `bae2b6474` | baseline | 1528.0kB | |
| `7e45d8b10` | #4841 — 21 Agent/`chat` options | 1591.9kB | **+63.9** |
| `cbe9b490a` | #4838 — Task engine, 28 options | 1591.9kB | **+0.0** |
| `354a43b8c` | #4837 — 7 AgentTeam settings | 1607.1kB | **+15.2** |

Three corrections to the obvious story:

- **#4838 put nothing on the phone at all.** Its Task engine is genuinely unreachable from `praisonai/mobile`.
- **#4841 added the most, and none of it can be removed.** Its title claims it kept its additions off the webview graph; it did not (+63.9kB: `agent/features/*` 38.4, `agent/simple` +11.7, toolsets, runtime registry, config). But that is *live* code — a phone runs `Agent.chat()`, so its option handling executes there. Cutting it would make the bundle small by making it broken.
- **#4837's 15.2kB is the opposite:** team logic a phone can never reach. That is the byte the budget was defending against.

## One line put it there

`agent/simple.ts` — the module `src/mobile.ts`, the webview allowlist, takes `Agent` from — ended 3600 lines with:

```ts
export { AgentTeam, PraisonAIAgents, Agents } from './team';
```

A value re-export is a static import. So `./team` plus `team-manager`, `team-options`, `team-memory` and `team-planning` landed in the engine chunk of a bundle that **deliberately does not export AgentTeam** and has no path that can construct one — no team screen, no team engine, no way in.

esbuild cannot drop it. The two modules formed a cycle, and an unused re-export is a side-effect import of a module it cannot prove pure. `"sideEffects": false` on praisonai-ts changes nothing — measured, still 1607.1kB, because the package is reached through a `file:` link whose real path is outside `node_modules`.

## The fix

The three classes come from `./team`, where they live. `praisonai` and `praisonai/agent` serve them exactly as before — same class, aliases still identical — so every canonical import is unchanged. Only the deep specifier `praisonai/agent/simple` stops serving them, one level below the barrel that does. Types still come from `./simple`: `export type` is erased and costs nothing.

`team.ts`'s `import { Agent }` becomes `import type`. Every use of `Agent` in that file is already a type position and the runtime class comes from the dynamic `import('./simple')` in `team-manager` — so this is free, and it keeps the cycle from re-forming.

**19.7kB reclaimed:** #4837's entire contribution plus 4.5kB that predated it.

## Why reclaim rather than raise

The weight had no business being on the graph, so raising the ceiling would have moved the line instead of the weight. `LAZY_BUDGET_BYTES` stays at 1600kB and `depgraph.test.mjs`'s pins are unchanged.

## A regression test comes with it, asserting the shape

The total already had a test. What it could not say is *why*. The new test asserts no `agent/team*` input appears in any chunk, and proves its own matcher non-vacuous against `agent/simple.js`.

Confirmed non-vacuous on this base: restoring the re-export puts the bundle back at exactly **1607.1kB** and fails this test, the LAZY-allowance test, and the whole-gate test — 3 of 10.

The matcher accepts every segment after `team`, not one lowercase word, so a future `team-task-runner.js` (the shape #4872 is heading for) cannot slip past. That widening was pushed onto this branch by `praisonai-triage-agent[bot]`; it is kept because it is strictly stricter and still rejects `simple.js` and `handoff.js`. The bot's two other hunks on this branch were its own copy of #4847's typecheck fix and are dropped, since #4873 landed that on `main`.

## Verification, all on the rebased tree

- `npm run check` **exit 0** on Node 22.18.0 and 24.12.0, sequentially, exit code read from the command rather than through a pipe — **no local patching**, 1676 tests each
- praisonai-ts **2379 tests** pass; `npm run check:webview` 0 problems
- `npm run test:bundle` **30/30** (the fixtures that prove each check can fail); `npm run test:web` 3/3; `npm run check:upstream` clean
- name / signature / behaviour parity gates all clean
- `npm run build` exits 0 and reports `lazy 1587.4kB of a 1600kB budget`
- **The engine still answers.** The shipped lazy chunk was served over HTTP and imported in headless Chromium: it exports exactly `Agent, getEnv, randomUUID`, no team symbol, no page errors, and `agent.chat("What is the capital of France?")` returned "The capital of France is Paris."

## Two things found on the way, not fixed here

1. **#4874 is the large reclaim and is orthogonal to this one.** It removes 326.7kB of `@ai-sdk/*` provider packages that `llm/embeddings` names in literal `import()` calls. One correction to its diagnosis: those three packages were already on the graph at `bae2b6474`, *before* the `agent/features/auth.ts` barrel import it blames — `agent/simple.ts` dynamically imports `llm/embeddings` itself. The fix still works; the cause is one edge older. The two PRs touch different files and compose.
2. **The gate's number is not reproducible.** `mobile.yml` runs `npm install` in praisonai-ts (no committed lockfile). Against a day-old resolved tree this same commit measured **1576.4kB**; against a fresh install, **1587.4kB** — an 11kB swing from upstream releases alone, and 30.7kB was observed on an earlier pair. That is comparable to the headroom this PR leaves, so the budget cannot be defended at high occupancy while the measurement moves on its own. Being filed separately.

## Not done

No Android emulator run. The change is a JS module-graph change with the Rust shell untouched; the shipped chunk was proved to load and answer a turn in Chromium, which is the WebView's engine, and `bundle-target.test.mjs` builds every chunk at the declared `minSdkVersion` floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Agent and multi-agent capabilities are now exposed through the primary agent module.
  * Multi-agent classes are no longer available from the simple-agent module path.

* **Bug Fixes**
  * Improved module loading to prevent circular runtime dependencies while preserving agent functionality.
  * Ensured mobile webviews include simple-agent support without bundling multi-agent team machinery.

* **Tests**
  * Added coverage verifying the mobile app graph excludes multi-agent team modules.
  * Updated agent and multi-agent tests to use the primary agent module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->