### PR TITLE
fix(parity): stop every branch conflicting on the same generated reports

### DIFF
--- a/src/praisonai/praisonai/_dev/parity/behaviour.py
+++ b/src/praisonai/praisonai/_dev/parity/behaviour.py
@@ -545,7 +545,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         if removed:
             print(f'claimed closed: {", ".join(removed)}')
             print(_REMOVAL_NOTE)
-    failures += [f'{rel} is out of date -- run --write and commit the result' for rel in stale]
+    # A stale generated report is a warning, not a failure.
+    # update-parity-tracker.yml regenerates and commits all of these on every push to main, so a pull request never has to carry them -- and when every branch regenerated the same file, every branch conflicted with every other on it.
+    # The substantive checks below still fail; only the freshness of a file that main rewrites by itself is downgraded.
+    for rel in stale:
+        print(f'note: {rel} is out of date -- main regenerates it on push; '
+              'run --write if you want it in this change')
 
     if failures:
         print(f'\nFAILURES ({len(failures)}):')

--- a/src/praisonai/praisonai/_dev/parity/signatures/compare.py
+++ b/src/praisonai/praisonai/_dev/parity/signatures/compare.py
@@ -1108,6 +1108,25 @@ def strip_source_lines(text: str) -> str:
     return _SOURCE_LOCATION_RE.sub(lambda m: m.group('path'), text)
 
 
+def classify_report_freshness(evaluation: 'Evaluation', path: Path, rel: Path, content: str) -> None:
+    """Record how a committed generated report compares to the freshly rendered one.
+
+    Missing is a failure: there is no baseline to compare against. Stale is a
+    warning: update-parity-tracker.yml regenerates and commits this file on every
+    push to main, so a pull request never has to carry it -- and while every branch
+    regenerated the same file, every branch conflicted with every other one on it.
+    The substantive checks still fail; only the freshness of a file main rewrites
+    by itself is downgraded.
+    """
+    if not path.is_file():
+        evaluation.failures.append(f'{rel} does not exist -- run --write and commit it')
+    elif strip_source_lines(path.read_text(encoding='utf-8')) != strip_source_lines(content):
+        evaluation.warnings.append(
+            f'{rel} is out of date -- main regenerates it on push; '
+            'run --write if you want it in this change'
+        )
+
+
 def _raise_on_rules_problems(problems: List[str]) -> None:
     """A dead or shadowed rule is a broken tool, not a parity gap: exit 2."""
     if problems:
@@ -1165,21 +1184,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(f'wrote {MD_OUTPUT} and {JSON_OUTPUT}')
         else:
             for path, content in ((md_path, md), (json_path, js)):
-                rel = path.relative_to(repo_root)
-                if not path.is_file():
-                    # Missing is still a failure: there is no baseline to compare against.
-                    evaluation.failures.append(f'{rel} does not exist -- run --write and commit it')
-                elif strip_source_lines(path.read_text(encoding='utf-8')) != strip_source_lines(content):
-                    # Stale is a warning, not a failure. update-parity-tracker.yml
-                    # regenerates and commits this file on every push to main, so a
-                    # pull request never has to carry it -- and while every branch
-                    # regenerated the same file, every branch conflicted with every
-                    # other one on it. The substantive checks above still fail; only
-                    # the freshness of a file main rewrites by itself is downgraded.
-                    evaluation.warnings.append(
-                        f'{rel} is out of date -- main regenerates it on push; '
-                        'run --write if you want it in this change'
-                    )
+                classify_report_freshness(evaluation, path, path.relative_to(repo_root), content)
 
         _print_report(evaluation, comparisons)
         if evaluation.ok:

--- a/src/praisonai/praisonai/_dev/parity/signatures/compare.py
+++ b/src/praisonai/praisonai/_dev/parity/signatures/compare.py
@@ -1167,9 +1167,19 @@ def main(argv: Optional[List[str]] = None) -> int:
             for path, content in ((md_path, md), (json_path, js)):
                 rel = path.relative_to(repo_root)
                 if not path.is_file():
+                    # Missing is still a failure: there is no baseline to compare against.
                     evaluation.failures.append(f'{rel} does not exist -- run --write and commit it')
                 elif strip_source_lines(path.read_text(encoding='utf-8')) != strip_source_lines(content):
-                    evaluation.failures.append(f'{rel} is out of date -- run --write and commit the result')
+                    # Stale is a warning, not a failure. update-parity-tracker.yml
+                    # regenerates and commits this file on every push to main, so a
+                    # pull request never has to carry it -- and while every branch
+                    # regenerated the same file, every branch conflicted with every
+                    # other one on it. The substantive checks above still fail; only
+                    # the freshness of a file main rewrites by itself is downgraded.
+                    evaluation.warnings.append(
+                        f'{rel} is out of date -- main regenerates it on push; '
+                        'run --write if you want it in this change'
+                    )
 
         _print_report(evaluation, comparisons)
         if evaluation.ok:

--- a/src/praisonai/tests/unit/_dev/test_behaviour_parity.py
+++ b/src/praisonai/tests/unit/_dev/test_behaviour_parity.py
@@ -96,11 +96,31 @@ class TestRatchet:
         self._write(repo)
         ledger = repo / 'src/praisonai-ts/src/utils/parity-notice.ts'
         ledger.write_text(LEDGER.replace("'auth', 'sandbox',", "'auth',"))
-        # Still exit 1: the committed report must be regenerated to bank it.
-        assert B.main(['--check', '--repo-root', str(repo)]) == 1
+        # Exit 0: closing an option is progress, and a stale generated report is
+        # only a note now -- main regenerates and commits it on push, so requiring
+        # every branch to carry it made every branch conflict with every other.
+        assert B.main(['--check', '--repo-root', str(repo)]) == 0
         out = capsys.readouterr().out
         assert '1 option(s) closed' in out and '3 -> 2' in out
         assert 'up from' not in out, 'closing an option must not read as a regression'
+        assert 'out of date' in out, 'the stale report is still mentioned, just not fatal'
+
+    def test_a_stale_report_alone_does_not_fail(self, tmp_path, capsys):
+        """Control: staleness is a note; the substance is what fails."""
+        repo = _repo(tmp_path)
+        self._write(repo)
+        (repo / B.JSON_OUTPUT).write_text('{"total": 3, "surfaces": {}, "partial": []}\n')
+        assert B.main(['--check', '--repo-root', str(repo)]) == 0
+        assert 'out of date' in capsys.readouterr().out
+
+    def test_a_stale_report_does_not_hide_a_rise(self, tmp_path, capsys):
+        """Control: the ratchet still fires when the report is also stale."""
+        repo = _repo(tmp_path)
+        self._write(repo)
+        ledger = repo / 'src/praisonai-ts/src/utils/parity-notice.ts'
+        ledger.write_text(LEDGER.replace("'auth', 'sandbox',", "'auth', 'sandbox', 'newlyIgnored',"))
+        assert B.main(['--check', '--repo-root', str(repo)]) == 1
+        assert 'up from 3' in capsys.readouterr().out
 
     def test_a_missing_report_fails(self, tmp_path):
         """Control: no committed baseline is a failure, not a free pass."""

--- a/src/praisonai/tests/unit/_dev/test_signature_parity.py
+++ b/src/praisonai/tests/unit/_dev/test_signature_parity.py
@@ -894,6 +894,58 @@ class TestStalenessIgnoresLineNumbers:
         assert C.strip_source_lines(text) == text
 
 
+class TestReportFreshnessContract:
+    """The merge gate: a missing report fails, a stale one only warns.
+
+    This is the contract the CLI enforces in --check mode. update-parity-tracker.yml
+    rewrites the report on every push to main, so a stale copy on a branch is a note;
+    but a missing copy leaves nothing to compare against, so it stays fatal.
+    """
+
+    def test_a_missing_report_is_a_failure(self, tmp_path):
+        ev = C.Evaluation()
+        path = tmp_path / 'SIGNATURE_PARITY.md'
+        C.classify_report_freshness(ev, path, Path('SIGNATURE_PARITY.md'), 'content')
+        assert not ev.ok
+        assert ev.failures and 'does not exist' in ev.failures[0]
+        assert not ev.warnings
+
+    def test_a_stale_report_is_a_warning_not_a_failure(self, tmp_path):
+        """Control: staleness must not fail, or every branch conflicts again."""
+        ev = C.Evaluation()
+        path = tmp_path / 'SIGNATURE_PARITY.md'
+        path.write_text('an older rendering', encoding='utf-8')
+        C.classify_report_freshness(ev, path, Path('SIGNATURE_PARITY.md'), 'the fresh rendering')
+        assert ev.ok
+        assert ev.warnings and 'out of date' in ev.warnings[0]
+
+    def test_a_fresh_report_is_silent(self, tmp_path):
+        """Control: an up-to-date report is neither a failure nor a warning."""
+        ev = C.Evaluation()
+        path = tmp_path / 'SIGNATURE_PARITY.md'
+        path.write_text('identical', encoding='utf-8')
+        C.classify_report_freshness(ev, path, Path('SIGNATURE_PARITY.md'), 'identical')
+        assert ev.ok and not ev.warnings and not ev.failures
+
+    def test_a_line_only_shift_is_not_staleness(self, tmp_path):
+        """Control: a report differing only in :line numbers is still fresh."""
+        ev = C.Evaluation()
+        content = 'Python: `agent.py:583`\n'
+        path = tmp_path / 'SIGNATURE_PARITY.md'
+        path.write_text('Python: `agent.py:601`\n', encoding='utf-8')
+        C.classify_report_freshness(ev, path, Path('SIGNATURE_PARITY.md'), content)
+        assert ev.ok and not ev.warnings and not ev.failures
+
+    def test_a_stale_report_does_not_mask_a_live_failure(self, tmp_path):
+        """A pre-existing substantive failure survives a stale-report warning."""
+        ev = C.Evaluation(failures=['Agent.__init__: `auth` is required in TS only'])
+        path = tmp_path / 'SIGNATURE_PARITY.md'
+        path.write_text('old', encoding='utf-8')
+        C.classify_report_freshness(ev, path, Path('SIGNATURE_PARITY.md'), 'new')
+        assert not ev.ok
+        assert ev.warnings and 'out of date' in ev.warnings[0]
+
+
 class TestWaiverScopeByGapKind:
     """A waiver is keyed by parameter, so it must not silence every KIND of gap.
 


### PR DESCRIPTION
Two open pull requests could not merge, both on the same two files:

```
src/praisonai-ts/BEHAVIOUR_PARITY.md
src/praisonai-ts/behaviour-parity.json
```

**That is not bad luck — it is structural.** Every branch that closes an option regenerates them, so every branch conflicts with every other branch. And the conflict is in *generated* content nobody edits by hand, which is the worst kind to resolve: the diff carries no intent, so there is nothing to reason about.

## The requirement was redundant from the start

`update-parity-tracker.yml` already regenerates **all eight** generated reports on every push to main and commits them. Main heals itself within a minute of a merge. Asking each pull request to carry the same regeneration bought nothing and cost a conflict every time.

## The change

A **stale** report is now a note, not a failure, in both the behaviour and signature checks:

```
note: src/praisonai-ts/behaviour-parity.json is out of date --
      main regenerates it on push; run --write if you want it in this change
```

A **missing** report is still a failure, because then there is no baseline to compare against.

## What deliberately did not change

The substance. Verified by running, with a deliberately stale report in place:

```
$ python3 -m praisonai._dev.parity.behaviour --check     # ledger +1 option
49 options are accepted but not acted on, up from 48 ...
exit 1
```

The ratchet reads the **committed** baseline, so a stale-but-lower committed total is a *stricter* floor, never a looser one. Every signature gap — missing, required, default, TypeScript-only required — still fails.

## Tests

Three cover the new contract, two of them controls:

- closing an option exits 0, still names the improvement, still mentions the stale file
- a stale report alone does not fail
- **a stale report does not hide a rise**

249 → 252 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Out-of-date generated reports are now reported as informational warnings instead of causing validation to fail.
  * Validation still fails when required reports are missing or unreadable, or when parity results exceed the committed baseline.
  * Closing options now succeeds even when generated reports are stale.
  * Report freshness checks now distinguish missing, unchanged, stale, and line-number-only changes more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->