### PR TITLE
fix(mobile): the lazy bundle gate could not fire, at 787kB of slack

### DIFF
--- a/src/praisonai-mobile/tools/bundle.mjs
+++ b/src/praisonai-mobile/tools/bundle.mjs
@@ -154,24 +154,67 @@ export function praisonaiRoot() {
  * (zod 426kB, `ai` 276kB, @ai-sdk/openai 166kB, @ai-sdk/google 142kB, openai
  * 102kB, praisonai itself 79kB) plus ~100kB of lowering, because async
  * functions and classes become generators and prototypes below Chrome 55-72.
- * The ceiling sits ~10% above that on purpose: one more provider is 100-170kB
- * (measured), so adding one is a decision, not a drift.
+ * The ceiling was set ~10% above that on purpose: one more provider is
+ * 100-170kB (measured), so adding one is a decision, not a drift. That ratio,
+ * not the digits it produced, is the rule this constant is governed by.
  *
- * That decision was taken: the parity work that filled the accepted-and-ignored
- * option gaps -- the Task engine, the AgentTeam settings, and the Handoff
- * context/limits engine -- landed the real behaviour those options always
- * advertised, and the engine grew from 1459.6kB to ~1610kB across them. Not a
- * drift (no provider was added) and not one PR's doing (each is ~10-50kB of
- * honoured settings); the sum is the honest cost of the options finally working.
- * The ceiling moves once, deliberately, to 1700kB: it clears the measured
- * ~1610kB and leaves the ~90kB that a next provider would need to be its own
- * decision rather than being pre-spent here.
+ * That decision was taken, and then it was undone. The parity work that filled
+ * the accepted-and-ignored option gaps -- the Task engine, the AgentTeam
+ * settings, the Handoff context/limits engine -- grew the engine from 1459.6kB
+ * to ~1610kB, and the ceiling was moved to 1700kB to clear it. But #4874 and
+ * #4882 had already taken three AI SDK provider packages and the team subsystem
+ * off the phone's graph, and against the tree the raise actually landed on the
+ * bundle was ~900kB, not ~1610kB. The raising PR's own commit message reports
+ * "1528.0kB of its 1600kB budget" -- 72kB UNDER the ceiling it then raised. So
+ * 1700kB was never a decision about this bundle; it was a decision about a
+ * branch that no longer existed, and it left 787kB of slack, enough to nearly
+ * double the engine before the gate could say anything.
+ *
+ * The number below is re-derived from the bundle that exists, not restored to
+ * the last one that had an argument -- 1600kB was ~10% over 1459.6kB, and that
+ * relationship is what carried the argument, not the digits. Measured on
+ * main at 9f591344cb, npm ci with praisonai-ts's now-tracked lockfile
+ * (ai 6.0.277, @ai-sdk/openai 3.0.109, @ai-sdk/google 3.0.121): 934,472 bytes,
+ * 912.6kB across 17 lazy chunks, byte-identical across repeated builds.
+ *
+ * The ceiling has to sit inside a window with a floor and a lid:
+ *
+ *   floor  912.6 + 30 = 942.6kB. #4883 recorded the same commit measuring
+ *          1576.4 -> 1607.1 -> 1587.4kB in a day, because praisonai-ts
+ *          gitignored package-lock.json while CI built it with npm, so every
+ *          run re-resolved every `^` range. #4884 fixed that -- the lockfile
+ *          is tracked and `npm install` honours it -- so the +-30kB band is no
+ *          longer expected day to day. It is still budgeted for, because a
+ *          lockfile refresh moves the number in one step and a gate that goes
+ *          red on its own is a gate people widen instead of read.
+ *
+ *   lid    912.6 + 100 = 1012.6kB. 100kB is the SMALLEST provider on the
+ *          measured list above (openai; @ai-sdk/openai is 166kB). A ceiling at
+ *          or above the lid cannot trip on a new provider, which is the one
+ *          thing this constant was created to force. 1700kB was 687kB above
+ *          the lid.
+ *
+ * 1000kB. Two independent derivations land there: 912.6 + 30 (drift) + ~57
+ * (growth) = ~1000, and the original "~10% over measured" rule gives 1003.9.
+ * It sits 57kB clear of the floor and 12kB under the lid.
+ *
+ * Of the 87.4kB of headroom, 30kB is for drift and 57.4kB is for growth. 57.4kB
+ * is more than any single honoured-behaviour PR has cost (10-50kB each, across
+ * the Task engine, AgentTeam and Handoff work), so ordinary parity work lands
+ * without touching this line; it is less than 100kB, so a provider cannot.
+ *
+ * If you are here to raise it: say what you measured, on which tree, and which
+ * of the two bounds you are choosing to break. Widening past 1012.6kB is
+ * choosing that a new provider no longer needs a decision. That has now been
+ * attempted twice in two days -- praisonai-triage-agent[bot] pushed 1600 ->
+ * 1750 onto an unrelated open PR in reaction to a red check (reverted, see
+ * #4873), and the 1700 above -- so the bar is a measurement, not a round number.
  *
  * `tools/depgraph.test.mjs` pins both values; `bundle.test.mjs` proves each
  * can fail, and that neither is the other in disguise.
  */
 export const SHELL_BUDGET_BYTES = 400 * 1024;
-export const LAZY_BUDGET_BYTES = 1700 * 1024;
+export const LAZY_BUDGET_BYTES = 1000 * 1024;
 
 /**
  * Every bare (non-relative) import esbuild could not resolve.

--- a/src/praisonai-mobile/tools/bundle.test.mjs
+++ b/src/praisonai-mobile/tools/bundle.test.mjs
@@ -337,10 +337,10 @@ test("no AI SDK provider package is bundled into the shipping app", async () => 
   // The headroom this asserts was reclaimed, not granted. `llm/embeddings.ts`
   // named `@ai-sdk/openai`, `@ai-sdk/google` and `@ai-sdk/cohere` in three
   // LITERAL `import()` calls, so esbuild emitted all three as chunks: 326.7kB
-  // of the 1600kB lazy budget, for an embedding path no mobile screen calls and
-  // that could not have loaded a provider anyway -- every OTHER provider goes
-  // through provider-map.ts's computed `import(providerInfo.package)`, which a
-  // webview has no resolver for.
+  // of the then-1600kB lazy budget, for an embedding path no mobile screen
+  // calls and that could not have loaded a provider anyway -- every OTHER
+  // provider goes through provider-map.ts's computed
+  // `import(providerInfo.package)`, which a webview has no resolver for.
   //
   // Without this test the next literal `import('@ai-sdk/anything')` upstream
   // costs 100-170kB in silence until the budget trips, at which point the

--- a/src/praisonai-mobile/tools/depgraph.test.mjs
+++ b/src/praisonai-mobile/tools/depgraph.test.mjs
@@ -356,11 +356,15 @@ test("the size budgets and the webview targets are the values the gate claims", 
   assert.equal(SHELL_BUDGET_BYTES, 400 * 1024, "the shell budget is what makes a dependency a decision");
   // The lazy allowance is a second number on purpose (bundle.mjs says why),
   // pinned for the same reason as the first: the engine went from 0 to 1460kB
-  // in one PR, and the next provider is 100-170kB. Moved to 1700kB once the
-  // accepted-and-ignored option gaps were filled (Task engine, AgentTeam,
-  // Handoff) and the honoured behaviour grew the engine to ~1610kB -- a
-  // deliberate step, documented in bundle.mjs, not a silent raise.
-  assert.equal(LAZY_BUDGET_BYTES, 1700 * 1024, "the lazy allowance is a decision too");
+  // in one PR, and the next provider is 100-170kB. It was raised to 1700kB
+  // against a branch measuring ~1610kB, but the reclaims in #4874 and #4882 had
+  // already taken the bundle to ~900kB on the tree that raise landed on, so it
+  // left 787kB of slack -- a ceiling nothing could reach. Re-derived from the
+  // measured 912.6kB: 1000kB, which is above the +-30kB drift band #4883
+  // recorded and below 912.6 + 100kB, the smallest provider. bundle.mjs holds
+  // the derivation; changing this line means breaking one of those two bounds
+  // on purpose.
+  assert.equal(LAZY_BUDGET_BYTES, 1000 * 1024, "the lazy allowance is a decision too");
   // The Chrome floor is DERIVED from `minSdkVersion`, not restated here. This
   // line said `chrome108` while tauri.conf.json declared `minSdkVersion: 26`
   // -- Android 8.0, WebView ~Chrome 58 -- so the two numbers disagreed and a


### PR DESCRIPTION
`LAZY_BUDGET_BYTES` was **1700 kB**. The bundle is **912.6 kB**. That is 787 kB of slack — the gate could not fire until someone nearly doubled the engine.

This changes the constant and the argument beside it. **No feature work is touched.**

## Why 1700 kB was never a decision about this bundle

The raise in #4836 was documented and deliberate, but it was measured on a branch that no longer existed by the time it landed:

| | |
|---|---|
| #4874 | took three AI SDK provider packages off the phone's graph |
| #4882 | took the team subsystem off it (1607.1 → 1587.4 kB) |
| #4836 | raised the ceiling 1600 → 1700 kB, merged after both |

Its comment cites a `~1610kB` engine. Against the tree it actually merged onto, the bundle was ~900 kB. And its own commit message reports:

> the mobile bundle is **1528.0kB of its 1600kB budget**

72 kB **under** the ceiling it then raised. Nothing in that PR needed the headroom.

This is also the second widening in two days. `praisonai-triage-agent[bot]` pushed 1600 → 1750 onto an unrelated open PR in reaction to a red check; that one was reverted (#4873). This one landed.

## Measurement

CI's exact recipe — `npm install` in `src/praisonai-ts`, `npm ci` in `src/praisonai-mobile`, `npm run build`, on `main` at `9f591344cb`:

```
bundle: shell 87.7kB of a 400kB budget, lazy 912.6kB of a 1700kB budget, 19 chunks, 10 external
```

**934,472 bytes = 912.6 kB** across 17 lazy chunks, byte-identical across repeated builds.

## On reproducibility (#4883)

#4883 recorded the same commit measuring 1576.4 → 1607.1 → 1587.4 kB in a day, because `praisonai-ts` gitignored `package-lock.json` while CI built it with npm. **That is now fixed** — #4884 tracked the lockfile, and this measurement confirms it holds: `npm install` did not modify `package-lock.json`, and resolved exactly `ai@6.0.277`, `@ai-sdk/openai@3.0.109`, `@ai-sdk/google@3.0.121`, `@ai-sdk/provider@3.0.15`.

So the ±30 kB band is no longer expected day to day. It is still budgeted for below, because a lockfile refresh moves the number in one step, and a gate that goes red on its own gets widened instead of read.

## Re-derived, not restored

Restoring 1600 kB would keep a number whose argument is stale: 1600 was ~10% over the then-measured 1459.6 kB. **The ratio is the rule, not the digits.** Against today's bundle, 1600 kB leaves 687 kB of slack — still a ceiling a new provider cannot reach.

The ceiling has a floor and a lid:

- **floor — 942.6 kB.** 912.6 + 30 kB, the drift band #4883 recorded. Below this the gate can go red with no change to the repository.
- **lid — 1012.6 kB.** 912.6 + 100 kB, the *smallest* provider on `bundle.mjs`'s own measured list (`openai`; `@ai-sdk/openai` is 166 kB). At or above the lid, adding a provider cannot trip the gate — the one thing this constant was created to force. **1700 kB sat 687 kB above the lid.**

### 1000 kB

Two independent derivations land there: `912.6 + 30 (drift) + ~57 (growth) ≈ 1000`, and the original "~10% over measured" rule gives 1003.9. It sits 57 kB clear of the floor and 12 kB under the lid.

**Headroom split — 87.4 kB total:**
- **30 kB for drift.** Absorbs the recorded ±30 kB band even though the lockfile now pins it.
- **57.4 kB for growth.** More than any single honoured-behaviour PR has cost (10–50 kB each, across the Task engine, AgentTeam and Handoff work), so ordinary parity work lands without touching this line. Less than 100 kB, so a provider cannot.

The derivation is written into `bundle.mjs` beside the constant, ending with what the next person raising it has to state: what they measured, on which tree, and which of the two bounds they are choosing to break.

## Verification

| Check | Result |
|---|---|
| `npm run check`, Node 22.18 | **exit 0** — 1688 tests, 0 fail |
| `npm run check`, Node 24.12 | **exit 0** — 1688 tests, 0 fail |
| `npm run test:bundle`, both | **exit 0** — 33 tests, 0 fail |
| `npm run build`, both | **exit 0** — lazy 912.6 kB of 1000 kB |

Exit codes read from the commands themselves, never through a pipe.

### Mutation tests — the gate can still go red

Every anchor asserted present before the edit was applied; all reverted after.

| Mutation | Result |
|---|---|
| ceiling → 900 kB (under the measured 912.6) | `npm run build` **exit 1**: `✖ chunks behind an import() total 912.6kB, over the 900kB lazy budget.` |
| same edit, against the pin | `depgraph.test.mjs` **exit 1**: `AssertionError: the lazy allowance is a decision too` |
| `if (false && lazyBytes > LAZY_BUDGET_BYTES)` | `npm run test:bundle` **exit 1**: `✖ lazy chunks over the LAZY allowance fail the build` (32 pass, 1 fail) |

At 1700 kB the first of these was not reachable without inventing 787 kB of bundle. It now fires on a 13 kB overrun.

## Scope

- `tools/bundle.mjs` — the constant, and the reasoning beside it
- `tools/depgraph.test.mjs` — the pin, kept in step
- `tools/bundle.test.mjs` — one stale comment saying `1600kB` is the current budget, now `then-1600kB`

`app-bundle.test.mjs` and `build-webview.mjs` import the constant rather than restating it, so nothing else needed changing. No new importer of any `*-contract.ts` was added (#4813).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the mobile app’s lazy bundle size limit to 1,000 kB, reducing allowable bundle growth and helping prevent unnecessary increases in shipped app size.

* **Tests**
  * Updated bundle validation checks and related guidance to reflect the revised size limit and current bundle measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->