### PR TITLE
fix(bot): forward group_policy/allow_silence/silence_token in _build_capabilities

### DIFF
--- a/src/praisonai-bot/praisonai_bot/cli/commands/bot.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/bot.py
@@ -47,6 +47,9 @@ def _build_capabilities(
     stt_model: Optional[str] = None,
     stream: bool = False,
     stream_edit_interval: int = 700,
+    group_policy: str = "mention_only",
+    allow_silence: bool = False,
+    silence_token: Optional[str] = None,
     session_id: Optional[str] = None,
     user_id: Optional[str] = None,
 ) -> "BotCapabilities":
@@ -83,6 +86,9 @@ def _build_capabilities(
         stt_model=stt_model,
         stream=stream,
         stream_edit_interval=stream_edit_interval,
+        group_policy=group_policy,
+        allow_silence=allow_silence,
+        silence_token=silence_token,
         session_id=session_id,
         user_id=user_id,
     )


### PR DESCRIPTION
## Problem

`praisonai bot telegram` and `praisonai bot discord` crash on startup:

```
TypeError: _build_capabilities() got an unexpected keyword argument 'group_policy'
```

Both commands define the group-behaviour flags and forward them
(`src/praisonai-bot/praisonai_bot/cli/commands/bot.py`, lines 150-152 / 189-191
and 229-231 / 266-268):

```python
group_policy: str = typer.Option("mention_only", "--group-policy", ...),
allow_silence: bool = typer.Option(False, "--allow-silence", ...),
silence_token: Optional[str] = typer.Option(None, "--silence-token", ...),
...
capabilities = _build_capabilities(
    ...
    group_policy=group_policy,
    allow_silence=allow_silence,
    silence_token=silence_token,
    ...
)
```

But `_build_capabilities()` is keyword-only with no `**kwargs`, and its
27-parameter signature never grew those three names, so the call raises
before `BotHandler().start_telegram(...)` / `start_discord(...)` is reached.

The other five call sites (`slack`, `whatsapp`, `linear`, `email`,
`agentmail`) don't pass them, so telegram/discord are the only two
affected — and they're the only two commands that expose the flags.

Reproducing the binding failure against the real signature (AST-extracted
from `main`, so no hand-copying):

```
_build_capabilities: 27 params
  telegram/discord kwargs -> TypeError: got an unexpected keyword argument 'group_policy'
  slack kwargs            -> BIND OK
```

## Fix

`BotCapabilities` already declares all three fields with the same defaults:

```python
# Group behavior
group_policy: str = "mention_only"   # respond_all, mention_only, command_only
allow_silence: bool = False          # Allow agent to return NO_REPLY to stay silent
silence_token: Optional[str] = None  # Custom silence token
```

so the helper just needs the parameters added and forwarded, matching the
defaults exactly. +6 lines, no behaviour change for the five call sites
that don't pass them.

After the change, all seven call sites bind cleanly:

```
line 169: BIND OK (30 kwargs)   # telegram
line 248: BIND OK (28 kwargs)   # discord
line 323: BIND OK (25 kwargs)   # slack
line 406: BIND OK (25 kwargs)   # whatsapp
line 494: BIND OK (19 kwargs)   # linear
line 548: BIND OK (6 kwargs)    # email
line 590: BIND OK (6 kwargs)    # agentmail
```

The mismatch dates from the two PRs landing in opposite order: #2116
factored the seven duplicated `BotCapabilities(...)` constructions into
`_build_capabilities()`, and #2133 then added the silence flags to the
telegram/discord commands without extending the new helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring bot behavior in group conversations.
  * Added configurable silent replies using a custom silence token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->