### PR TITLE
fix(ts): memory scored random vectors, not embeddings

### DIFF
--- a/src/praisonai-ts/src/embeddings/index.ts
+++ b/src/praisonai-ts/src/embeddings/index.ts
@@ -141,11 +141,23 @@ export function embeddings(texts: string[], config?: EmbeddingConfig): BatchEmbe
 
 /**
  * Async generate embedding for a single text.
+ *
+ * Delegates to the real network-backed embedder in `../llm/embeddings`
+ * (AI SDK preferred, native OpenAI fallback) rather than the throwing sync
+ * placeholder. `model` is the only field that maps across; the returned
+ * `dimensions` is the real vector length, not a lookup.
+ *
  * Python parity: praisonaiagents/knowledge
  */
 export async function aembed(text: string, config?: EmbeddingConfig): Promise<EmbeddingResult> {
-  // In production, this would make async API call
-  return embed(text, config);
+  const cfg = { ..._globalConfig, ...config };
+  const { embed: embedAsync } = await import('../llm/embeddings');
+  const { embedding } = await embedAsync(text, { model: cfg.model });
+  return {
+    embedding,
+    model: cfg.model ?? 'text-embedding-3-small',
+    dimensions: embedding.length,
+  };
 }
 
 /**
@@ -158,11 +170,21 @@ export async function aembedding(text: string, config?: EmbeddingConfig): Promis
 
 /**
  * Async generate embeddings for multiple texts.
+ *
+ * Delegates to the real `embedMany` in `../llm/embeddings` rather than the
+ * throwing sync placeholder.
+ *
  * Python parity: praisonaiagents/knowledge
  */
 export async function aembeddings(texts: string[], config?: EmbeddingConfig): Promise<BatchEmbeddingResult> {
-  // In production, this would make async API call
-  return embeddings(texts, config);
+  const cfg = { ..._globalConfig, ...config };
+  const { embedMany } = await import('../llm/embeddings');
+  const { embeddings: vectors } = await embedMany(texts, { model: cfg.model });
+  return {
+    embeddings: vectors,
+    model: cfg.model ?? 'text-embedding-3-small',
+    dimensions: vectors[0]?.length ?? getDimensions(cfg.model),
+  };
 }
 
 // ============================================================================

--- a/src/praisonai-ts/src/embeddings/index.ts
+++ b/src/praisonai-ts/src/embeddings/index.ts
@@ -98,15 +98,15 @@ export function embed(text: string, config?: EmbeddingConfig): EmbeddingResult {
   const cfg = { ..._globalConfig, ...config };
   const dimensions = getDimensions(cfg.model);
   
-  // Placeholder implementation - would call OpenAI API
-  // In production, this would use the LLM client
-  const embedding = new Array(dimensions).fill(0).map(() => Math.random() * 2 - 1);
-  
-  return {
-    embedding,
-    model: cfg.model ?? 'text-embedding-3-small',
-    dimensions,
-  };
+  // Embedding requires a network call, so it cannot be done synchronously.
+  // This function previously returned random vectors, which made every
+  // similarity search silently meaningless rather than failing.
+  throw new Error(
+    `Cannot embed synchronously (model '${cfg.model ?? 'text-embedding-3-small'}', ` +
+      `${dimensions} dims). Use the async embedder instead:\n` +
+      "  import { embed } from 'praisonai/llm/embeddings';\n" +
+      '  const { embedding } = await embed(text, { model });'
+  );
 }
 
 /**
@@ -125,16 +125,14 @@ export function embeddings(texts: string[], config?: EmbeddingConfig): BatchEmbe
   const cfg = { ..._globalConfig, ...config };
   const dimensions = getDimensions(cfg.model);
   
-  // Placeholder implementation
-  const embeddingsList = texts.map(() => 
-    new Array(dimensions).fill(0).map(() => Math.random() * 2 - 1)
+  // Same reason as embed(): a real embedding needs the network.
+  throw new Error(
+    `Cannot embed ${texts.length} text(s) synchronously (model ` +
+      `'${cfg.model ?? 'text-embedding-3-small'}', ${dimensions} dims). ` +
+      "Use the async embedder instead:\n" +
+      "  import { embedMany } from 'praisonai/llm/embeddings';\n" +
+      '  const vectors = await embedMany(texts, { model });'
   );
-  
-  return {
-    embeddings: embeddingsList,
-    model: cfg.model ?? 'text-embedding-3-small',
-    dimensions,
-  };
 }
 
 // ============================================================================

--- a/src/praisonai-ts/src/memory/adapters.ts
+++ b/src/praisonai-ts/src/memory/adapters.ts
@@ -28,7 +28,7 @@ import { AdapterRegistry, BackendNotAvailableError } from '../utils/adapter-regi
 import type { AdapterClass, AdapterFactory, AdapterKwargs } from '../utils/adapter-registry';
 import { ChromaVectorStore } from '../integrations/vector/chroma';
 import type { ChromaConfig } from '../integrations/vector/chroma';
-import { embed, getDimensions } from '../embeddings';
+import { getDimensions } from '../embeddings';
 import { notYetHonoured } from '../utils/parity-notice';
 
 export type MaybePromise<T> = T | Promise<T>;
@@ -374,7 +374,14 @@ export class ChromaMemory implements MemoryProtocol {
     const port = config.port ?? 8000;
     this.baseUrl = config.path ?? `http://${host}:${port}`;
     this.store = config.store ?? new ChromaVectorStore({ host: config.host, port: config.port, path: config.path });
-    this.embedder = config.embedder ?? ((text, model) => embed(text, { model }).embedding);
+    // Default to the real async embedder. This previously used the sync
+    // placeholder in ../embeddings, which returned random vectors -- so every
+    // semantic search over memory scored noise, with nothing to indicate it.
+    this.embedder = config.embedder ?? (async (text, model) => {
+      const { embed: embedAsync } = await import('../llm/embeddings');
+      const result = await embedAsync(text, { model });
+      return result.embedding;
+    });
     this.fetchImpl = config.fetchImpl ?? (globalThis as { fetch?: typeof fetch }).fetch;
   }
 

--- a/src/praisonai-ts/tests/unit/memory/embedder-is-real.test.ts
+++ b/src/praisonai-ts/tests/unit/memory/embedder-is-real.test.ts
@@ -27,12 +27,22 @@ describe('sync embedding placeholders', () => {
   });
 });
 
+jest.mock('../../../src/llm/embeddings', () => ({
+  embed: jest.fn(async (_text: string, opts?: { model?: string }) => ({
+    embedding: [0.1, 0.2, 0.3],
+    usage: { tokens: 1 },
+  })),
+}));
+
 describe('ChromaMemory default embedder', () => {
-  it('does not use the sync placeholder', async () => {
-    const src = await import('fs').then((fs) =>
-      fs.readFileSync(require.resolve('../../../src/memory/adapters.ts'), 'utf8')
-    );
-    expect(src).not.toMatch(/embed\(text,\s*\{\s*model\s*\}\)\.embedding/);
-    expect(src).toMatch(/llm\/embeddings/);
+  it('routes through the real async embedder, not the sync placeholder', async () => {
+    const { embed: realEmbed } = await import('../../../src/llm/embeddings');
+    const { ChromaMemory } = await import('../../../src/memory/adapters');
+
+    const memory = new ChromaMemory({ embeddingModel: 'text-embedding-3-small' });
+    const vector = await (memory as any).embedText('hello', {});
+
+    expect(realEmbed).toHaveBeenCalledWith('hello', { model: 'text-embedding-3-small' });
+    expect(vector).toEqual([0.1, 0.2, 0.3]);
   });
 });

--- a/src/praisonai-ts/tests/unit/memory/embedder-is-real.test.ts
+++ b/src/praisonai-ts/tests/unit/memory/embedder-is-real.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Memory must not score noise.
+ *
+ * The default memory embedder was the sync placeholder in src/embeddings,
+ * which returned `Math.random()` vectors. Every similarity search over memory
+ * was therefore meaningless, with nothing to indicate it — the module even
+ * claimed "Python parity" in its docstring.
+ */
+
+import { embed, embeddings, getDimensions } from '../../../src/embeddings';
+
+describe('sync embedding placeholders', () => {
+  it('refuses to embed rather than returning random vectors', () => {
+    expect(() => embed('hello')).toThrow(/Cannot embed synchronously/);
+  });
+
+  it('names the async replacement in the error', () => {
+    expect(() => embed('hello')).toThrow(/await embed\(/);
+  });
+
+  it('refuses batches too', () => {
+    expect(() => embeddings(['a', 'b'])).toThrow(/Cannot embed 2 text\(s\) synchronously/);
+  });
+
+  it('still reports dimensions, which needs no network', () => {
+    expect(getDimensions('text-embedding-3-small')).toBe(1536);
+  });
+});
+
+describe('ChromaMemory default embedder', () => {
+  it('does not use the sync placeholder', async () => {
+    const src = await import('fs').then((fs) =>
+      fs.readFileSync(require.resolve('../../../src/memory/adapters.ts'), 'utf8')
+    );
+    expect(src).not.toMatch(/embed\(text,\s*\{\s*model\s*\}\)\.embedding/);
+    expect(src).toMatch(/llm\/embeddings/);
+  });
+});


### PR DESCRIPTION
## The bug

`src/embeddings/index.ts` returned `Math.random() * 2 - 1` for every vector:

```ts
// Placeholder implementation - would call OpenAI API
const embedding = new Array(dimensions).fill(0).map(() => Math.random() * 2 - 1);
```

and `src/memory/adapters.ts:377` wired it as ChromaMemory's default embedder:

```ts
this.embedder = config.embedder ?? ((text, model) => embed(text, { model }).embedding);
```

**So every semantic search over memory ranked noise.** Nothing indicated it. The module's own docstring claimed *"Python parity: praisonaiagents/knowledge"* while returning random numbers.

This is the worst kind of silent failure: it never errors, the vectors are the right shape and the right dimension, and the results look like results.

## Why the placeholder existed

Embedding needs a network call and these functions are synchronous. That's a real constraint — but returning plausible-looking garbage is the wrong answer to it, because a caller cannot tell a random vector from a real one.

## The change

- **The sync `embed`/`embeddings` now throw**, naming the async replacement and its import path, instead of returning noise. `getDimensions` still works — it needs no network.
- **ChromaMemory defaults to the real async embedder** in `src/llm/embeddings.ts`. `MemoryEmbedder` is already typed `MaybePromise<number[]>` and is awaited at the call site (`adapters.ts:404`), so this needed no contract change.

Anyone who passed their own `embedder` is unaffected. Anyone who did not was getting noise, and now gets either real embeddings or a clear error.

## Verification

```
2538 tests pass, 87 skipped, 145 suites
build clean (tsc cjs + esm)
5 new tests in tests/unit/memory/embedder-is-real.test.ts
```

## How it was found

Reading the Vercel AI SDK, Mastra and LangChain.js at source for a local-model comparison. All three derive embedding dimensions empirically from the first real vector; none fabricates one. Mastra's approach — `dimension: embeddings[0]?.length` — is the right long-term answer for both SDKs and is worth adopting separately.

That review also turned up three more TypeScript defects, each needing its own PR:

- `provider-map.ts:214` derives the factory name by string munging — `create${capitalize(resolved.replace(/-/g,''))}` — so `lm-studio` looks for `createLmstudio`, which `@ai-sdk/openai-compatible` does not export. **Three of the four advertised local providers throw on load.**
- `types.ts:315` names `ollama-ai-provider`, whose only release declares `specificationVersion = "v1"` and cannot load against the pinned `ai` major.
- `OLLAMA_BASE_URL` is read as an API-key presence gate and never applied as a `baseURL` — unset gives a spurious auth failure for a server that needs no key; set is silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Synchronous embedding requests now return a clear error instead of placeholder vectors.
  - Asynchronous embedding workflows now use real network-backed embeddings and report accurate vector dimensions.
  - Chroma memory’s default embedder now generates genuine embeddings for stored content.
  - Dimension lookup remains available without making a network request.
  - Updated behavior provides more reliable embedding results and clearer feedback when synchronous operations are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->