### PR TITLE
feat: close two capability gaps found by reading seven competitor frameworks

### DIFF
--- a/.github/actions/claude-code-action/action.yml
+++ b/.github/actions/claude-code-action/action.yml
@@ -288,7 +288,7 @@ runs:
         fi
         
         # Add allowed tools (include GitHub tools by default)
-        TOOLS="mcp__github__issue_read,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__add_issue_comment,mcp__github__pull_request_read,Read,Write,Edit,Bash"
+        TOOLS="mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__add_issue_comment,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,Read,Write,Edit,Bash"
         if [[ -n "$INPUT_ALLOWED_TOOLS" ]]; then
           TOOLS="$TOOLS,$INPUT_ALLOWED_TOOLS"
         fi

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -319,8 +319,11 @@ jobs:
             Replace
           allowed_tools: |
             mcp__github__add_issue_comment
-            mcp__github__pull_request_read
-            mcp__github__issue_read
+            mcp__github__get_pull_request
+            mcp__github__get_pull_request_files
+            mcp__github__get_pull_request_reviews
+            mcp__github__get_pull_request_status
+            mcp__github__get_issue
             mcp__github__get_issue_comments
             Glob
             Grep


### PR DESCRIPTION
A multi-agent sweep read **crewai, langgraph, agno, pydantic-ai, google adk-python, openai-agents-python and mastra** from local checkouts — not from memory or marketing — and put every claimed gap through a refutation pass that had to search PraisonAI *under different vocabulary* before agreeing.

**Four of seven top claims did not survive.** These are two that did.

Full analysis: https://claude.ai/code/artifact/5c00cc94-5dce-4e91-afba-20015a9a032b

---

## 1. Resuming a workflow discarded the value the human just supplied

`_prepare_workflow_loop` built `all_variables` from the workflow defaults plus the caller's `variables`, then did:

```python
all_variables = checkpoint_data.get("variables", all_variables)
```

The checkpoint's variables **replaced** the caller's — so this was accepted and silently thrown away:

```
praisonai workflow run wf --resume --var reviewer_decision=approved
```

That is the whole mechanism by which a human hands a decision back to a run that paused for review, which is why a one-line bug matters more than its size suggests.

**Verified by running it**, not by reading:

```
before   all_variables = {'topic': 'x'}                                    reviewer_decision absent
after    all_variables = {'topic':'x', 'stage':'drafted',
                          'reviewer_decision':'approved'}
```

Precedence is now workflow defaults → checkpoint → what the caller supplied *now*. The freshest statement of intent wins, and checkpoint state still survives.

### A correction to the finding

The sweep originally reported this as "PraisonAI cannot do durable human-in-the-loop at all". The verifier found **three of its four claimed costs were wrong** — PraisonAI already has arbitrary mid-run questions (`tools/clarify.py`), Slack/Telegram approval with durable storage, crash-resume via `agent/durable.py`, and checkpoint resume days later in another process. Only the *value hand-back* was broken. This PR fixes exactly that, and nothing more.

---

## 2. An OpenAPI spec could not become tools

Every `openapi` hit in the monorepo was PraisonAI **emitting** a spec (`recipe/serve.py`, `app/agentos.py`, `ui/agui`, `ui/a2a`). Nothing consumed one, so pointing an agent at an existing REST API meant hand-writing a function per endpoint.

```python
toolset = OpenAPIToolset(spec_url="https://api.example.com/openapi.json",
                         auth={"type": "bearer", "token": TOKEN})
agent = Agent(name="ops", tools=toolset.get_tools())
```

Supports `spec_dict`/`spec_str`/`spec_url`, `base_url`, `auth` (bearer/api_key/basic), `tool_filter`, `tool_name_prefix`, `header_provider`; OpenAPI 3 and Swagger 2 base-URL inference; local `$ref` resolution with cycle-breaking.

**Built on what exists, not beside it.** The OpenAI tool dict comes from the existing `mcp_schema_utils.build_openai_tool_dict`, and each operation is shaped like `mcp_sse.SSEMCPTool` — so `Agent(tools=toolset.get_tools())` needs no Agent-side change. Confirmed by constructing a real `Agent` with generated tools.

**Honest about cost:** a workaround existed. `MCP()` takes an arbitrary stdio command, so an `openapi-mcp-server` fronts a spec today. What this removes is an extra process, an npx dependency, and the absence of `tool_filter`.

---

## Not fixed here, deliberately

The third confirmed gap — **per-end-user tool credentials with suspend-for-consent** — is a multi-tenant auth change that wants its own PR. Worth recording what the sweep found: its OAuth 2.1 client **already exists** at `mcp/oauth_provider.py` (340 lines: discovery, dynamic registration, PKCE, loopback callback, refresh) with **zero callers**. So that gap is wiring plus a principal dimension, not a rewrite.

## Four claims that did not survive refutation

Listed because a report showing only confirmations teaches nothing about its own reliability:

| claim | where it actually lives |
|---|---|
| Human-in-the-loop output review (vs crewai) | PraisonAI calls it **guardrails**; same shape as crewai's `_handle_regular_feedback`. The claim searched only crewai's vocabulary. |
| PDF/audio/video as first-class input (vs crewai) | `_build_multimodal_prompt` has a third branch the claim stopped short of. |
| Pluggable model interface (vs pydantic-ai) | Three non-monkeypatch routes, two verified end to end. |
| Stub model for offline tests (vs pydantic-ai) | Four supported offline paths, all verified by running them. |

## Verification

**26 new tests.** Five mutations killed:

| mutation | |
|---|---|
| checkpoint replaces the caller again (the original bug) | killed |
| path parameters no longer substituted into the URL | killed |
| `$ref`s no longer resolved | killed |
| auth type never recognised | killed |
| `tool_filter` ignored | killed |

The 5 failures in `tests/unit/tools` are **identical on clean main** (verified by stashing) and are part of the 122 tracked in #4748. This branch takes that directory from **622 to 795 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub automation to use current read-only tools for retrieving issues and pull request details.
  * Added access to pull request files, reviews, and status information for automated assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->