### PR TITLE
fix(cli): four surface defects — hooks exit code, wrong advertised paths, unreachable --public

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/commands/call.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/call.py
@@ -16,20 +16,47 @@ def call_main(
     ctx: typer.Context,
     model: Optional[str] = typer.Option(None, "--model", "-m", help="LLM model to use"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
+    public: bool = typer.Option(
+        False,
+        "--public",
+        help="Expose the call server publicly via ngrok (required for inbound PSTN webhooks)",
+    ),
+    port: Optional[int] = typer.Option(
+        None, "--port", help="Port to run the call server on (default: $PORT or 8090)"
+    ),
+    host: Optional[str] = typer.Option(
+        None, "--host", help="Host to bind the call server to (default: 127.0.0.1)"
+    ),
 ):
     """
     Start voice/call interaction mode.
-    
+
+    --public/--port/--host are forwarded to the call server. They were
+    previously reachable only through the PUBLIC/PORT environment variables,
+    which made inbound PSTN (the one setup that needs a public webhook)
+    unreachable from the CLI.
+
     Examples:
         praisonai call
         praisonai call --model gpt-4o
+        praisonai call --public
+        praisonai call --host 0.0.0.0 --port 9000
     """
     from praisonai_code._wrapper_bridge import run_wrapper_command
-    
+
     argv = ['call']
     if model:
         argv.extend(['--model', model])
     if verbose:
         argv.append('--verbose')
-    
+    if public:
+        argv.append('--public')
+    # Only forward when the user actually asked: the call server's own
+    # defaults differ from the legacy argparse defaults (PORT/8090 vs 8005),
+    # so forwarding unconditionally would silently retarget the port.
+    if port is not None:
+        argv.extend(['--port', str(port)])
+    if host is not None:
+        argv.extend(['--host', host])
+
     run_wrapper_command(argv, feature="call")

--- a/src/praisonai-code/praisonai_code/cli/commands/hooks.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/hooks.py
@@ -2,6 +2,12 @@
 Hooks command group for PraisonAI CLI.
 
 Provides hook management commands.
+
+Only actions the legacy handler actually implements are registered here.
+``add`` and ``remove`` used to be advertised but were never implemented: the
+handler printed "Unknown hooks action" and the dispatcher still exited 0, so a
+script that "added" a hook succeeded while doing nothing. Hooks are configured
+by editing the file that ``praisonai hooks init`` creates.
 """
 
 import typer
@@ -11,34 +17,23 @@ app = typer.Typer(help="Hook management")
 
 @app.command("list")
 def hooks_list():
-    """List available hooks."""
+    """List configured hooks."""
     from praisonai_code._wrapper_bridge import run_wrapper_command
-    
-    argv = ['hooks', 'list']
-    
-    run_wrapper_command(argv, feature="hooks")
+
+    run_wrapper_command(['hooks', 'list'], feature="hooks")
 
 
-@app.command("add")
-def hooks_add(
-    name: str = typer.Argument(..., help="Hook name"),
-    event: str = typer.Option(..., "--event", "-e", help="Event to hook into"),
-):
-    """Add a hook."""
+@app.command("stats")
+def hooks_stats():
+    """Show hooks statistics."""
     from praisonai_code._wrapper_bridge import run_wrapper_command
-    
-    argv = ['hooks', 'add', name, '--event', event]
-    
-    run_wrapper_command(argv, feature="hooks")
+
+    run_wrapper_command(['hooks', 'stats'], feature="hooks")
 
 
-@app.command("remove")
-def hooks_remove(
-    name: str = typer.Argument(..., help="Hook name to remove"),
-):
-    """Remove a hook."""
+@app.command("init")
+def hooks_init():
+    """Create the hooks.json template in this workspace."""
     from praisonai_code._wrapper_bridge import run_wrapper_command
-    
-    argv = ['hooks', 'remove', name]
-    
-    run_wrapper_command(argv, feature="hooks")
+
+    run_wrapper_command(['hooks', 'init'], feature="hooks")

--- a/src/praisonai-code/praisonai_code/cli/commands/plugins.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/plugins.py
@@ -37,6 +37,26 @@ def _resolve_installer(global_env: bool = False):
     return [sys.executable, "-m", "pip", "install"]
 
 
+def _plugin_create_command_name():
+    """Name of the registered command that creates a single-file plugin.
+
+    Derived from this Typer app's own command registry so a hint printed to the
+    user can never advertise a subcommand that is not registered (issue: the
+    ``discover`` empty-state used to point at a non-existent ``plugins init``).
+    """
+    registered = {
+        getattr(cmd, "name", None) or getattr(cmd, "callback", None).__name__
+        for cmd in app.registered_commands
+    }
+    for candidate in ("create", "init", "new"):
+        if candidate in registered:
+            return candidate
+    raise RuntimeError(
+        "plugins app registers no plugin-creation command; "
+        f"registered commands: {sorted(n for n in registered if n)}"
+    )
+
+
 def _registered_entry_point_names():
     """Return the set of currently registered entry-point plugin names."""
     try:
@@ -626,7 +646,10 @@ def plugins_discover(
             
             if not plugins:
                 console.print("[yellow]No single-file plugins found.[/yellow]")
-                console.print("\nCreate one with: praisonai plugins init <name>")
+                console.print(
+                    "\nCreate one with: praisonai plugins "
+                    f"{_plugin_create_command_name()} <name>"
+                )
                 return
             
             table = Table(title=f"Single-File Plugins ({len(plugins)} found)")

--- a/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
+++ b/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
@@ -82,6 +82,30 @@ def _get_call_module():
     call_module = getattr(_mod, 'call')
     return call_module
 
+
+def _build_call_args(args, argv=None):
+    """Build the ``praisonai.api.call.main()`` argv from parsed CLI args.
+
+    ``--port``/``--host`` are forwarded only when the user typed them. The
+    call server's own defaults (``$PORT``, else 8090 / 127.0.0.1) differ from
+    the shared argparse defaults (8005 / 127.0.0.1), so always forwarding
+    ``args.port`` would silently move the server off its documented port.
+    """
+    raw = sys.argv[1:] if argv is None else list(argv)
+
+    def _typed(flag):
+        return any(a == flag or a.startswith(flag + "=") for a in raw)
+
+    call_args = []
+    if getattr(args, "public", False):
+        call_args.append("--public")
+    if _typed("--port") and getattr(args, "port", None) is not None:
+        call_args.extend(["--port", str(args.port)])
+    if _typed("--host") and getattr(args, "host", None) is not None:
+        call_args.extend(["--host", str(args.host)])
+    return call_args
+
+
 def _get_gradio():
     """Lazy import gradio only when gradio UI is used.
     
@@ -648,10 +672,7 @@ class PraisonAI:
                 print("[red]ERROR: Call feature is not installed. Install with:[/red]")
                 print("\npip install \"praisonai[call]\"\n")
                 return
-            call_args = []
-            if args.public:
-                call_args.append('--public')
-            _get_call_module().main(call_args)
+            _get_call_module().main(_build_call_args(args))
             return
 
         if args.command == 'train':
@@ -1058,9 +1079,7 @@ class PraisonAI:
                 print("\npip install \"praisonai[call]\"\n")
                 sys.exit(1)
             
-            call_args = []
-            if args.public:
-                call_args.append('--public')
+            call_args = _build_call_args(args)
             _get_call_module().main(call_args)
             sys.exit(0)
 
@@ -1189,8 +1208,9 @@ class PraisonAI:
                 
                 # Get action from remaining args
                 action = unknown_args[0] if unknown_args else 'list'
-                self.handle_hooks_command(action)
-                sys.exit(0)
+                # Propagate the handler's exit code: an unknown action used to
+                # print an error and still exit 0, so scripts saw success.
+                sys.exit(self.handle_hooks_command(action) or 0)
 
             elif args.command == 'knowledge':
                 self._require_agents()

--- a/src/praisonai-code/tests/unit/cli/test_cli_surface_defects.py
+++ b/src/praisonai-code/tests/unit/cli/test_cli_surface_defects.py
@@ -1,0 +1,344 @@
+"""Regression gates for four CLI surface defects.
+
+Each test pins one defect and fails against the code as it stood before the
+accompanying fix:
+
+1. ``praisonai hooks add`` printed "Unknown hooks action: add" and still exited
+   ``0``, so a script that added a hook succeeded while doing nothing. The
+   hooks Typer group also advertised ``add``/``remove`` (never implemented)
+   while omitting ``init``/``stats`` (which work).
+2. ``praisonai hooks list`` told users to create ``.praison/hooks.json`` while
+   ``HooksManager.CONFIG_FILE`` is ``.praisonai/hooks.json``; ``hooks init``
+   wrote that same wrong path, so init-then-list never saw the hooks.
+3. ``praisonai plugins discover``'s empty state said "Create one with:
+   praisonai plugins init <name>". There is no ``init`` command; it is
+   ``create``.
+4. ``praisonai call`` accepted only ``--model``/``--verbose``, so ``--public``
+   (the ngrok exposure inbound PSTN requires) and ``--host`` were reachable
+   only through environment variables.
+
+Expected values are derived from the real source of truth --
+``HooksManager.CONFIG_FILE`` and the Typer command registries -- rather than
+restating a corrected literal, so they cannot drift the way the bugs did.
+
+Note on shape: the legacy argparse layer deliberately parses an *empty* argv
+under pytest (``build_argument_parser(in_test_env)``), so a CliRunner
+invocation cannot exercise the legacy leg in-process. The delegation chain is
+therefore pinned seam by seam, plus one real subprocess that reads the process
+exit code directly.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+import pytest
+from typer.testing import CliRunner
+
+from praisonaiagents.memory import HooksManager
+
+import praisonai_code._wrapper_bridge as wrapper_bridge
+import praisonai_code.cli.commands.call as call_command
+import praisonai_code.cli.commands.hooks as hooks_command
+import praisonai_code.cli.commands.plugins as plugins_command
+from praisonai_code.cli.legacy import praison_ai as legacy
+
+
+runner = CliRunner()
+
+
+def _registered_names(app):
+    return [cmd.name or cmd.callback.__name__ for cmd in app.registered_commands]
+
+
+def _hooks_handler():
+    from praisonai.cli.legacy.subcommand_handlers import handle_hooks_command
+
+    return handle_hooks_command
+
+
+@pytest.fixture()
+def wrapper_argv(monkeypatch):
+    """Capture the legacy argv a Typer stub hands to the wrapper."""
+    calls = []
+    monkeypatch.setattr(
+        wrapper_bridge, "run_wrapper_command", lambda argv, *, feature: calls.append(list(argv))
+    )
+    return calls
+
+
+# --------------------------------------------------------------------------
+# Defect 1: an action that fails must not exit 0
+# --------------------------------------------------------------------------
+
+def test_unknown_hooks_action_returns_nonzero(tmp_path, monkeypatch):
+    """The handler reports failure as an exit code, not just as printed text.
+
+    ``None`` is not acceptable: the dispatcher does ``sys.exit(code or 0)``, so
+    an implicit ``None`` return is exactly the original "exits 0" defect. The
+    assertion therefore demands a real non-zero int.
+    """
+    monkeypatch.chdir(tmp_path)
+    handler = _hooks_handler()
+    for action in ("add", "remove", "definitely-not-an-action"):
+        code = handler(None, action)
+        assert isinstance(code, int) and code != 0, (
+            f"hooks action {action!r} returned {code!r}; the dispatcher's "
+            f"sys.exit({code!r} or 0) would report success"
+        )
+
+
+def test_known_hooks_actions_return_zero(tmp_path, monkeypatch):
+    """The success path still reports success."""
+    monkeypatch.chdir(tmp_path)
+    handler = _hooks_handler()
+    for action in ("list", "stats", "init", "help"):
+        assert handler(None, action) == 0, action
+
+
+def test_hooks_dispatch_propagates_handler_exit_code():
+    """The legacy dispatcher must exit with the handler's code, not a fixed 0.
+
+    Pins the ``sys.exit(0)`` one level above the handler, so fixing only the
+    handler cannot leave the defect in place.
+    """
+    import inspect
+
+    source = inspect.getsource(legacy)
+    marker = "elif args.command == 'hooks':"
+    assert marker in source, "hooks dispatch branch not found"
+    branch = source.split(marker, 1)[1].split("elif args.command ==", 1)[0]
+    assert "handle_hooks_command" in branch
+    assert "sys.exit(0)" not in branch, (
+        "hooks dispatch still exits 0 unconditionally; a failed action would "
+        f"report success. Branch:\n{branch}"
+    )
+
+
+def test_hooks_group_advertises_only_actions_the_handler_accepts(tmp_path, monkeypatch, wrapper_argv):
+    """Every registered hooks subcommand must map to an action that succeeds.
+
+    ``add``/``remove`` were registered but unimplemented. This goes red if
+    either comes back, and equally if a registered command stops working.
+    """
+    names = _registered_names(hooks_command.app)
+    assert names, "hooks group registers no commands"
+
+    for name in names:
+        wrapper_argv.clear()
+        result = runner.invoke(hooks_command.app, [name])
+        assert result.exit_code == 0, f"{name}: {result.output}"
+        assert wrapper_argv, f"'hooks {name}' dispatched nothing"
+        argv = wrapper_argv[0]
+        assert argv[0] == "hooks"
+        action = argv[1]
+
+        monkeypatch.chdir(tmp_path)
+        assert _hooks_handler()(None, action) == 0, (
+            f"'praisonai hooks {name}' is advertised but the handler rejects "
+            f"action {action!r}"
+        )
+
+
+def test_hooks_add_exits_nonzero_end_to_end(tmp_path):
+    """Read the real process exit code, not a message.
+
+    This is the user-visible contract: ``praisonai hooks add`` must not report
+    success while doing nothing.
+    """
+    pytest.importorskip("praisonai")
+    proc = subprocess.run(
+        [sys.executable, "-m", "praisonai", "hooks", "add", "myhook", "--event", "BEFORE_TOOL"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert proc.returncode != 0, (
+        "'praisonai hooks add' exited 0 while adding nothing.\n"
+        f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Defect 2: the advertised hooks path must be the one that is read
+# --------------------------------------------------------------------------
+
+def test_no_hooks_message_names_the_real_config_file(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    assert _hooks_handler()(None, "list") == 0
+    out = capsys.readouterr().out
+    assert HooksManager.CONFIG_FILE in out, (
+        f"'hooks list' advertises a path that is not "
+        f"{HooksManager.CONFIG_FILE!r}: {out!r}"
+    )
+
+
+def test_hooks_init_writes_the_file_the_manager_loads(tmp_path, monkeypatch):
+    """init -> list must round-trip: init wrote a path list never read."""
+    monkeypatch.chdir(tmp_path)
+    assert _hooks_handler()(None, "init") == 0
+
+    expected = tmp_path / HooksManager.CONFIG_FILE.replace("/", os.sep)
+    assert expected.is_file(), (
+        f"hooks init did not create {expected}; created instead: "
+        f"{sorted(str(p.relative_to(tmp_path)) for p in tmp_path.rglob('hooks.json'))}"
+    )
+
+    manager = HooksManager(workspace_path=str(tmp_path))
+    assert manager.get_stats().get("total_hooks", 0) > 0, (
+        "hooks written by 'hooks init' are invisible to HooksManager"
+    )
+
+
+# --------------------------------------------------------------------------
+# Defect 3: the plugin-creation hint must name a registered command
+# --------------------------------------------------------------------------
+
+def test_plugin_create_hint_names_a_registered_command():
+    advertised = plugins_command._plugin_create_command_name()
+    assert advertised in _registered_names(plugins_command.app), (
+        f"'praisonai plugins {advertised}' is advertised but not registered; "
+        f"registered: {_registered_names(plugins_command.app)}"
+    )
+
+
+def test_plugins_discover_empty_state_hint_resolves(monkeypatch):
+    """The empty-state hint must name a command the plugins app really has."""
+    from praisonaiagents.plugins import discovery
+
+    monkeypatch.setattr(discovery, "discover_plugins", lambda *a, **k: [])
+    result = runner.invoke(plugins_command.app, ["discover"])
+    assert result.exit_code == 0, result.output
+
+    hint_line = next(
+        (line for line in result.output.splitlines() if "Create one with:" in line),
+        None,
+    )
+    assert hint_line is not None, result.output
+    advertised = hint_line.split("praisonai plugins", 1)[1].split()[0]
+    assert advertised in _registered_names(plugins_command.app), (
+        f"empty-state hint advertises 'praisonai plugins {advertised}', which "
+        f"is not registered: {_registered_names(plugins_command.app)}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Defect 4: --public/--port/--host must reach the call server
+# --------------------------------------------------------------------------
+
+def _run_server_capture(monkeypatch):
+    call_mod = pytest.importorskip("praisonai.api.call")
+    captured = {}
+
+    def fake_run_server(port, host="127.0.0.1", use_public=False):
+        captured.update(port=port, host=host, use_public=use_public)
+
+    monkeypatch.setattr(call_mod, "run_server", fake_run_server)
+    return call_mod, captured
+
+
+@pytest.mark.parametrize(
+    "cli_args, expected_call_argv",
+    [
+        ([], []),
+        (["--public"], ["--public"]),
+        (["--port", "9111"], ["--port", "9111"]),
+        (["--host", "0.0.0.0"], ["--host", "0.0.0.0"]),
+        (
+            ["--public", "--host", "0.0.0.0", "--port", "9111"],
+            ["--public", "--port", "9111", "--host", "0.0.0.0"],
+        ),
+    ],
+)
+def test_call_command_forwards_server_options(cli_args, expected_call_argv, monkeypatch, wrapper_argv):
+    """Leg 1: the Typer command must accept and forward the server options."""
+    result = runner.invoke(call_command.app, cli_args)
+    assert result.exit_code == 0, result.output
+    assert wrapper_argv, "call command dispatched nothing"
+    legacy_argv = wrapper_argv[0]
+    assert legacy_argv[0] == "call"
+
+    # Leg 2: the legacy dispatcher maps its parsed args onto the call server's
+    # own argv. Reconstruct the args the legacy parser would produce.
+    parsed = argparse.Namespace(
+        public="--public" in legacy_argv,
+        port=int(legacy_argv[legacy_argv.index("--port") + 1]) if "--port" in legacy_argv else 8005,
+        host=legacy_argv[legacy_argv.index("--host") + 1] if "--host" in legacy_argv else "127.0.0.1",
+    )
+    assert legacy._build_call_args(parsed, argv=legacy_argv) == expected_call_argv
+
+
+@pytest.mark.parametrize(
+    "cli_args, expected",
+    [
+        ([], {"port": 8090, "host": "127.0.0.1", "use_public": False}),
+        (["--public"], {"port": 8090, "host": "127.0.0.1", "use_public": True}),
+        (["--port", "9111"], {"port": 9111, "host": "127.0.0.1", "use_public": False}),
+        (
+            ["--host", "0.0.0.0", "--port", "9111"],
+            {"port": 9111, "host": "0.0.0.0", "use_public": False},
+        ),
+    ],
+)
+def test_call_options_reach_run_server(cli_args, expected, monkeypatch, wrapper_argv):
+    """Full chain: Typer options -> legacy argv -> api.call.main -> run_server.
+
+    Plain ``praisonai call`` must keep the call server's own default port
+    (``$PORT``, else 8090); the shared argparse ``--port`` default is 8005, so
+    forwarding it unconditionally would silently retarget the port.
+    """
+    monkeypatch.delenv("PORT", raising=False)
+    call_mod, captured = _run_server_capture(monkeypatch)
+
+    assert runner.invoke(call_command.app, cli_args).exit_code == 0
+    legacy_argv = wrapper_argv[0]
+    parsed = argparse.Namespace(
+        public="--public" in legacy_argv,
+        port=int(legacy_argv[legacy_argv.index("--port") + 1]) if "--port" in legacy_argv else 8005,
+        host=legacy_argv[legacy_argv.index("--host") + 1] if "--host" in legacy_argv else "127.0.0.1",
+    )
+    call_mod.main(legacy._build_call_args(parsed, argv=legacy_argv))
+
+    assert captured == expected
+
+
+def test_public_bind_disables_the_auth_escape_hatch(monkeypatch):
+    """--public must not open an unauthenticated surface.
+
+    ``run_server`` forces ``0.0.0.0`` under ``--public`` and publishes it as
+    ``PRAISONAI_CALL_BIND_HOST``; the ``PRAISONAI_CALL_AUTH=disabled`` escape
+    hatch is honoured only for a loopback bind, so exposing the server
+    publicly cannot also switch authentication off.
+    """
+    import asyncio
+
+    fastapi = pytest.importorskip("fastapi")
+    from praisonai.api import agent_invoke
+
+    monkeypatch.setenv("PRAISONAI_CALL_AUTH", "disabled")
+    monkeypatch.setenv("PRAISONAI_CALL_BIND_HOST", "0.0.0.0")
+    with pytest.raises(fastapi.HTTPException) as exc:
+        asyncio.run(agent_invoke.verify_token(request=None, authorization=None))
+    assert exc.value.status_code == 503
+
+
+def test_run_server_publishes_the_public_bind_host(monkeypatch):
+    """The bind host the auth guard reads must reflect the --public override."""
+    call_mod = pytest.importorskip("praisonai.api.call")
+
+    monkeypatch.setattr(call_mod, "OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(call_mod, "setup_public_url", lambda port: "https://example.ngrok.app")
+    monkeypatch.delenv("PRAISONAI_CALL_BIND_HOST", raising=False)
+
+    seen = {}
+    fake_uvicorn = type("_U", (), {"run": staticmethod(lambda app, **kw: seen.update(kw))})
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(call_mod, "build_call_app", lambda **kw: object())
+
+    # A user asking for --public with a loopback --host must still end up bound
+    # (and reported) as 0.0.0.0, so PRAISONAI_CALL_AUTH=disabled stays refused.
+    call_mod.run_server(port=9111, host="127.0.0.1", use_public=True)
+    assert seen["host"] == "0.0.0.0"
+    assert os.environ["PRAISONAI_CALL_BIND_HOST"] == "0.0.0.0"

--- a/src/praisonai/praisonai/cli/legacy/subcommand_handlers.py
+++ b/src/praisonai/praisonai/cli/legacy/subcommand_handlers.py
@@ -305,12 +305,17 @@ def handle_rules_command(self, action: str, action_args: list):
     except Exception as e:
         print(f"[red]ERROR: Rules command failed: {e}[/red]")
 
-def handle_hooks_command(self, action: str):
+def handle_hooks_command(self, action: str) -> int:
     """
     Handle hooks subcommand actions.
-    
+
     Args:
-        action: The hooks action (list, stats, init)
+        action: The hooks action (list, stats, init, help)
+
+    Returns:
+        Process exit code: ``0`` when the action ran, non-zero when it did
+        not. An unknown action previously printed an error and still exited
+        ``0``, so a script adding a hook "succeeded" while doing nothing.
     """
     try:
         from praisonaiagents.memory import HooksManager
@@ -329,8 +334,12 @@ def handle_hooks_command(self, action: str):
                 for event in stats.get('events', []):
                     print(f"  - {event}")
             else:
-                print("[yellow]No hooks configured. Create .praison/hooks.json[/yellow]")
-                
+                print(
+                    "[yellow]No hooks configured. Create "
+                    f"{HooksManager.CONFIG_FILE}[/yellow]"
+                )
+            return 0
+
         elif action == 'stats':
             stats = hooks.get_stats()
             table = Table(title="Hooks Statistics")
@@ -341,14 +350,20 @@ def handle_hooks_command(self, action: str):
                 table.add_row(str(key), str(value))
             
             console.print(table)
-            
+            return 0
+
         elif action == 'init':
-            hooks_dir = os.path.join(os.getcwd(), ".praison")
-            os.makedirs(hooks_dir, exist_ok=True)
-            hooks_file = os.path.join(hooks_dir, "hooks.json")
+            # Derive the file location from the manager itself; a literal here
+            # is exactly how the CLI came to advertise a path the loader never
+            # reads (HooksManager.CONFIG_FILE is ".praisonai/hooks.json").
+            hooks_file = os.path.join(
+                os.getcwd(), HooksManager.CONFIG_FILE.replace("/", os.sep)
+            )
+            os.makedirs(os.path.dirname(hooks_file), exist_ok=True)
             
             if os.path.exists(hooks_file):
                 print(f"[yellow]hooks.json already exists at {hooks_file}[/yellow]")
+                return 0
             else:
                 template = {
                     "enabled": True,
@@ -367,6 +382,7 @@ def handle_hooks_command(self, action: str):
                     json.dump(template, f, indent=2)
                 print(f"[green]✅ Created hooks.json at {hooks_file}[/green]")
                 print("[cyan]Edit the file to configure your hooks[/cyan]")
+                return 0
                 
         elif action == 'help' or action == '--help':
             print("[bold]Hooks Commands:[/bold]")
@@ -379,15 +395,19 @@ def handle_hooks_command(self, action: str):
             print("  pre_run_command, post_run_command")
             print("  pre_user_prompt, post_user_prompt")
             print("  pre_mcp_tool_use, post_mcp_tool_use")
+            return 0
         else:
             print(f"[red]Unknown hooks action: {action}[/red]")
             print("Use 'praisonai hooks help' for available commands")
-            
+            return 1
+
     except ImportError as e:
         print(f"[red]ERROR: Failed to import hooks module: {e}[/red]")
         print("Make sure praisonaiagents is installed: pip install praisonaiagents")
+        return 1
     except Exception as e:
         print(f"[red]ERROR: Hooks command failed: {e}[/red]")
+        return 1
 
 def handle_knowledge_command(self, action: str, action_args: list):
     """


### PR DESCRIPTION
Four independently reproduced CLI defects: a command that lies about succeeding, two messages that send users to nonexistent paths, and a feature reachable only by environment variable.

## Reproduced before fixing

```
$ praisonai hooks add myhook --event BEFORE_TOOL
Unknown hooks action: add
Use 'praisonai hooks help' for available commands
exit: 0                                    # <- advertised command, error printed, success reported

$ praisonai hooks list
No hooks configured. Create .praison/hooks.json
$ python -c "from praisonaiagents.memory import HooksManager; print(HooksManager.CONFIG_FILE)"
.praisonai/hooks.json                      # <- following the instruction never works

$ praisonai plugins discover                # (in an empty plugin dir)
No single-file plugins found.
Create one with: praisonai plugins init <name>
$ praisonai plugins --help
list info enable disable doctor reload add create install discover remove
                                           # <- there is no `init`; it is `create`

$ praisonai call --public
Error: No such option '--public'.
exit: 2
$ praisonai --call --public
Error: No such option '--call'.
exit: 2                                    # <- the legacy flag form is intercepted too
```

## Fixes

**1. `hooks add`/`remove` reported success while doing nothing.** `handle_hooks_command` now returns a real exit code, and the legacy dispatcher exits with it instead of a hard-coded `sys.exit(0)`. The Typer group advertised `add`/`remove` (never implemented) while omitting `init`/`stats` (which work); it now registers only actions the handler accepts, so `praisonai hooks add` exits 2 and `hooks stats`/`hooks init` are reachable.

**2. The hooks path the CLI advertises is now the path it reads.** `hooks list` and `hooks init` both derive the location from `HooksManager.CONFIG_FILE` rather than restating a literal, so it cannot drift again. `hooks init` previously wrote `.praison/hooks.json` while the loader read `.praisonai/hooks.json` — init-then-list never saw the hooks. That round trip now works:

```
$ praisonai hooks list
No hooks configured. Create .praisonai/hooks.json
$ praisonai hooks init
✅ Created hooks.json at .../.praisonai/hooks.json
$ praisonai hooks list
Configured Hooks:
  - pre_write_code
  - pre_run_command
  - post_write_code
```

**3. The plugin hint names a registered command.** Derived from the Typer app's own command registry via `_plugin_create_command_name()`, which raises if no creation command is registered rather than printing a name that does not resolve. Output is now `Create one with: praisonai plugins create <name>`.

**4. `--public`, `--port` and `--host` reach the call server.** Wired through `commands/call.py` -> `run_wrapper_command` -> `legacy/praison_ai.py` -> `api/call.py:main()`. Port and host are forwarded **only when typed**: the shared argparse `--port` default is 8005 while the call server's own default is `$PORT` (else 8090), so forwarding unconditionally would have silently retargeted the port. Both call sites in `praison_ai.py` now share one `_build_call_args()` helper.

## Security note on #4

`--public` reaches the same code path `PUBLIC=true` already reached; no guard is weakened.

- `run_server` still forces the bind to `0.0.0.0` under `--public` and publishes it as `PRAISONAI_CALL_BIND_HOST`, so the `PRAISONAI_CALL_AUTH=disabled` escape hatch stays refused (503) for a non-loopback bind — `praisonai call --public --host 127.0.0.1` cannot smuggle a loopback bind host past that check.
- The inbound-call route and the media-stream socket still fail closed when `CALL_SERVER_TOKEN` is unset (503 / ws close 4003).
- `--host` lets a user bind `0.0.0.0` without `--public`; the existing warning still prints and the token gate still applies.

Two tests pin this: `test_public_bind_disables_the_auth_escape_hatch` and `test_run_server_publishes_the_public_bind_host`.

## Gates

`src/praisonai-code/tests/unit/cli/test_cli_surface_defects.py` (20 tests). Expected values are derived from `HooksManager.CONFIG_FILE` and the Typer command registries, not from corrected literals, so the tests cannot drift the way the bugs did. One test reads the real process exit code from a subprocess.

The legacy argparse layer deliberately parses an *empty* argv under pytest (`build_argument_parser(in_test_env)`), so a single in-process CliRunner call cannot exercise the legacy leg. The chain is pinned seam by seam instead: Typer options -> legacy argv -> `_build_call_args` -> `api.call.main` -> `run_server`.

Every gate mutation-tested — each bug reintroduced one at a time, with the anchor asserted unique before applying so a silent no-op cannot report a false SURVIVED:

| Mutation | Result | Killed by |
| --- | --- | --- |
| unknown-action returns nothing | KILLED | `test_unknown_hooks_action_returns_nonzero` |
| dispatcher hard-codes exit 0 | KILLED | `test_hooks_dispatch_propagates_handler_exit_code` |
| re-advertise unimplemented `hooks add` | KILLED | `test_hooks_group_advertises_only_actions_the_handler_accepts` |
| no-hooks message restates a literal path | KILLED | `test_no_hooks_message_names_the_real_config_file` |
| `hooks init` writes the wrong dir | KILLED | `test_hooks_init_writes_the_file_the_manager_loads` |
| plugin hint hard-codes `init` | KILLED | `test_plugins_discover_empty_state_hint_resolves` |
| call command drops `--public`/`--port`/`--host` | KILLED | `test_call_command_forwards_server_options` (3 cases) |
| port forwarded unconditionally | KILLED | `test_call_command_forwards_server_options` + `test_call_options_reach_run_server` (5 cases) |

Survivors: none.

The first pass of the exit-code gate did **survive** its mutation: `assert handler(...) != 0` passes for an implicit `None` return. The assertion now demands a non-zero `int`, because the dispatcher does `sys.exit(code or 0)` and `None` is exactly the original defect.

## Regression check

`src/praisonai-code/tests/unit`: 827 passed / 14 failed with this change; 807 passed / **the same 14 failed** on `origin/main` without it (`test_help_encoding`, `test_managed_config_layer`, `test_config_interpolation_provenance`, `test_lazy_command_paths[mcp]`, `test_registry_builtin_shadowing`, `test_run_subtree_context`, `test_standalone_stub_commands[rules]`). No new failures; +20 tests. `src/praisonai/tests/unit/test_call_server_auth.py` passes.

## Not changed

`praisonai_code/cli/features/hooks.py` defines a second, richer `handle_hooks_command` (`run`/`test`/`validate`/`load`) that nothing imports — dead code, left alone rather than expanded in a defect fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--public`, `--port`, and `--host` options to the `call` command.
  - Plugin discovery now displays the correct command for creating a plugin.

- **Bug Fixes**
  - Hook commands now use the correct configuration location.
  - Hook command failures return an appropriate non-zero exit status.
  - Removed non-functional `hooks add` and `hooks remove` commands.
  - Updated documentation and examples for the new `call` options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->