### PR TITLE
fix: make google-adk extra resolvable

### DIFF
--- a/src/praisonai/pyproject.toml
+++ b/src/praisonai/pyproject.toml
@@ -169,7 +169,8 @@ agno = [
     "praisonai-tools>=0.1.0",
 ]
 google-adk = [
-    "praisonai-frameworks[google-adk]>=0.1.8",
+    "praisonai-frameworks>=0.1.8",
+    "google-adk[extensions]>=2.5,<3",
     "praisonai-tools>=0.1.0",
 ]
 pydantic-ai = [

--- a/src/praisonai/tests/unit/test_optional_dependency_metadata.py
+++ b/src/praisonai/tests/unit/test_optional_dependency_metadata.py
@@ -1,0 +1,20 @@
+"""Regression tests for installable wrapper extras."""
+
+from pathlib import Path
+
+import toml
+
+
+PYPROJECT = Path(__file__).parents[2] / "pyproject.toml"
+
+
+def test_google_adk_extra_avoids_legacy_frameworks_adk_pin():
+    metadata = toml.loads(PYPROJECT.read_text(encoding="utf-8"))
+    requirements = metadata["project"]["optional-dependencies"]["google-adk"]
+
+    assert "praisonai-frameworks>=0.1.8" in requirements
+    assert "google-adk[extensions]>=2.5,<3" in requirements
+    assert not any(
+        requirement.startswith("praisonai-frameworks[google-adk]")
+        for requirement in requirements
+    )


### PR DESCRIPTION
## Summary

`pip install "praisonai[google-adk]"` currently fails dependency resolution.

The wrapper extra depends on `praisonai-frameworks[google-adk]`, whose published dependency range selects Google ADK 2.3.x. That dependency chain resolves to LiteLLM 1.83.14, which requires `click==8.1.8`, while `praisonai` and `praisonai-code` require `click>=8.4.2`.

## How this was found

This was discovered while installing the project from a clean environment and checking the optional extras. A dry-run installation of `praisonai[google-adk]` failed before any provider or runtime was initialized.

Inspecting the resolver output revealed the conflicting dependency chain:

`praisonai[google-adk]`
→ `praisonai-frameworks[google-adk]`
→ `google-adk[extensions]` 2.3.x
→ `litellm==1.83.14`
→ `click==8.1.8`

This conflicts with the `click>=8.4.2` requirement declared by `praisonai` and `praisonai-code`.

This PR keeps the existing Google ADK framework adapter while moving ownership of the compatible Google ADK SDK version range to the PraisonAI wrapper.

## Changes

- Replace `praisonai-frameworks[google-adk]>=0.1.8` with the plain `praisonai-frameworks>=0.1.8` adapter dependency.
- Add `google-adk[extensions]>=2.5,<3` directly to the `praisonai[google-adk]` extra.
- Add a regression test to ensure the legacy framework extra and its incompatible dependency pin are not reintroduced.

## Test plan

- [x] `python -m pytest src/praisonai/tests/unit/test_optional_dependency_metadata.py -q` — 1 passed.
- [x] Dry-run installation of `src/praisonai[google-adk]` — successfully resolved 189 packages.
- [x] Isolated smoke test with `praisonai-frameworks==0.1.10` and the minimum supported `google-adk[extensions]==2.5.0` — adapter import and agent construction succeeded.
- [x] `git diff --check` — passed.

## Scope

No runtime API or framework adapter behavior is changed. The fix is limited to the wrapper's optional dependency metadata and its regression coverage.

## Notes

`src/praisonai/uv.lock` was not regenerated because the project currently has unrelated, pre-existing conflicts between other optional extras. The affected `google-adk` extra was resolved and tested independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the Google ADK optional dependency configuration to install compatible framework and Google ADK packages.
  - Added an upper version limit for Google ADK to help prevent incompatible upgrades.

- **Tests**
  - Added coverage to verify the optional dependency metadata remains correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->