### PR TITLE
feat: close two capability gaps found by reading seven competitor frameworks

### DIFF
--- a/src/praisonai-agents/praisonaiagents/allowed_tools_filter.py
+++ b/src/praisonai-agents/praisonaiagents/allowed_tools_filter.py
@@ -60,9 +60,22 @@ class AllowedToolsFilter:
         self.primary_var = env_var_name
         self.legacy_var = "HERMES_ONLY_TOOLS"
         
-        # ALLOWED_TOOLS takes precedence over HERMES_ONLY_TOOLS for backward compatibility
-        self.env_value = os.environ.get(self.primary_var) or os.environ.get(self.legacy_var)
-        self.env_var_name = self.primary_var if os.environ.get(self.primary_var) else self.legacy_var
+        # ALLOWED_TOOLS takes precedence over HERMES_ONLY_TOOLS for backward
+        # compatibility. Presence is tested with `is not None`, never
+        # truthiness: `or` treated ALLOWED_TOOLS="" as absent, fell through to
+        # the legacy variable, and ended at None -- which _parse_whitelist
+        # reads as "unset, allow everything". So the whitelist was silently
+        # switched off by the one value the docstring calls an error, while a
+        # whitespace-only value was correctly refused. `export ALLOWED_TOOLS=`
+        # and ALLOWED_TOOLS="$UNSET_VAR" both produce exactly that empty string.
+        primary = os.environ.get(self.primary_var)
+        legacy = os.environ.get(self.legacy_var)
+        if primary is not None:
+            self.env_value, self.env_var_name = primary, self.primary_var
+        elif legacy is not None:
+            self.env_value, self.env_var_name = legacy, self.legacy_var
+        else:
+            self.env_value, self.env_var_name = None, self.primary_var
         
         self.is_ci = os.environ.get("CI", "").lower() in ("true", "1", "yes")
         self._whitelist: Optional[Set[str]] = self._parse_whitelist()

--- a/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
+++ b/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any, Callable, Dict, List, Optional
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +93,7 @@ class OpenAPIOperation:
                  base_url: str, parameters: List[Dict[str, Any]],
                  body_schema: Optional[Dict[str, Any]],
                  input_schema: Dict[str, Any],
+                 body_param: Optional[str] = None,
                  auth: Optional[Dict[str, Any]] = None,
                  header_provider: Optional[Callable[[], Dict[str, str]]] = None,
                  timeout: int = 30):
@@ -106,6 +107,11 @@ class OpenAPIOperation:
         self.base_url = base_url
         self.parameters = parameters
         self.body_schema = body_schema
+        # Swagger 2 declares the whole request body as one named parameter
+        # (``in: body``). When set, that single argument *is* the JSON body
+        # rather than one property of it, and OpenAPI 3's property-spreading
+        # must not apply.
+        self.body_param = body_param
         self.input_schema = input_schema
         self.auth = auth or {}
         self.header_provider = header_provider
@@ -140,6 +146,8 @@ class OpenAPIOperation:
         query: Dict[str, Any] = {}
         headers = self._headers()
         body: Dict[str, Any] = {}
+        form: Dict[str, Any] = {}
+        swagger_body: Any = None
         consumed = set()
 
         for param in self.parameters:
@@ -150,16 +158,38 @@ class OpenAPIOperation:
             value = kwargs[pname]
             consumed.add(pname)
             if where == "path":
-                path = path.replace("{" + pname + "}", str(value))
+                # Percent-encode as a single path segment. A raw model-supplied
+                # value like ``../../admin`` or an absolute ``https://other/``
+                # would otherwise alter the path, query, fragment or host that
+                # ``urljoin`` builds, sending the configured credentials
+                # somewhere they were never meant to go.
+                path = path.replace("{" + pname + "}",
+                                    quote(str(value), safe=""))
             elif where == "query":
                 query[pname] = value
             elif where == "header":
                 headers[pname] = str(value)
+            elif where == "body":
+                # Swagger 2: this one argument is the entire JSON body.
+                swagger_body = value
+            elif where in ("formData", "form"):
+                form[pname] = value
 
-        if self.body_schema is not None:
+        if swagger_body is not None:
+            body = swagger_body
+        elif self.body_schema is not None:
+            # Only spread the body-schema's declared properties. Copying every
+            # unconsumed kwarg would leak framework-injected arguments (e.g. the
+            # durable-execution ``idempotency_key`` added for ``**kwargs``
+            # callables) into the request, breaking strict APIs and any schema
+            # with ``additionalProperties: false``.
+            props = (self.body_schema.get("properties")
+                     if isinstance(self.body_schema, dict) else None) or {}
+            allowed = set(props)
             for key, value in kwargs.items():
-                if key not in consumed:
-                    body[key] = value
+                if key in consumed or key not in allowed:
+                    continue
+                body[key] = value
 
         url = urljoin(self.base_url.rstrip("/") + "/", path.lstrip("/")) \
             if self.base_url else path
@@ -169,6 +199,8 @@ class OpenAPIOperation:
             request["params"] = query
         if body:
             request["json"] = body
+        if form:
+            request["data"] = form
         return request
 
     def __call__(self, **kwargs: Any) -> Any:
@@ -211,8 +243,18 @@ class OpenAPIToolset:
         if spec_dict is None and spec_str is None and spec_url is None:
             raise ValueError(
                 "OpenAPIToolset needs one of spec_dict=, spec_str= or spec_url=")
+        # Retained so a relative ``servers``/``basePath`` in a remotely loaded
+        # spec can be resolved back to the origin it was fetched from.
+        self._spec_url = spec_url
         self.spec = self._load(spec_dict, spec_str, spec_url)
         self.base_url = base_url or self._infer_base_url(self.spec)
+        if auth and str(self.base_url).lower().startswith("http://"):
+            # Refuse to attach credentials to a cleartext endpoint: bearer
+            # tokens, API keys and basic-auth values would travel in the clear.
+            raise ValueError(
+                "OpenAPIToolset refuses to send auth over http:// "
+                f"(base_url={self.base_url!r}); use https or pass base_url= "
+                "with an https endpoint.")
         self.auth = auth
         self.tool_filter = tool_filter
         self.tool_name_prefix = tool_name_prefix
@@ -243,27 +285,62 @@ class OpenAPIToolset:
                     "spec is not JSON and PyYAML is unavailable to parse it") from exc
             return yaml.safe_load(text)
 
-    @staticmethod
-    def _infer_base_url(spec: Dict[str, Any]) -> str:
+    def _infer_base_url(self, spec: Dict[str, Any]) -> str:
         servers = spec.get("servers")
         if isinstance(servers, list) and servers:
             first = servers[0]
             if isinstance(first, dict) and first.get("url"):
-                return str(first["url"])
+                url = str(first["url"])
+                # A spec loaded from a URL may declare a relative server such
+                # as ``/v1``; resolve it against the origin it was fetched from
+                # so generated operations do not produce hostless URLs.
+                if url.startswith("/") and self._spec_url:
+                    return urljoin(self._spec_url, url)
+                return url
         # Swagger 2.0
         host, base = spec.get("host"), spec.get("basePath", "")
         if host:
             schemes = spec.get("schemes") or ["https"]
-            return f"{schemes[0]}://{host}{base}"
+            # Prefer HTTPS whenever the spec offers it rather than blindly
+            # taking the first scheme, so authenticated requests are not sent
+            # in cleartext when a secure endpoint exists.
+            scheme = "https" if "https" in schemes else schemes[0]
+            return f"{scheme}://{host}{base}"
+        # Swagger 2 may omit host but still be reachable at the origin it was
+        # fetched from.
+        if self._spec_url and base:
+            return urljoin(self._spec_url, base)
         return ""
 
-    def _input_schema(self, operation: Dict[str, Any],
-                      parameters: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _body_info(self, operation: Dict[str, Any],
+                   parameters: List[Dict[str, Any]]):
+        """Resolve the JSON body schema and its Swagger-2 parameter name.
+
+        OpenAPI 3 carries the body under ``requestBody.content`` and spreads
+        its properties as arguments. Swagger 2 declares it as a single
+        ``in: body`` parameter whose ``schema`` is the whole body. Returns
+        ``(body_schema, body_param_name)`` where ``body_param_name`` is set
+        only for the Swagger 2 form.
+        """
+        body = operation.get("requestBody") or {}
+        content = (body.get("content") or {}).get("application/json") or {}
+        if content:
+            schema = _resolve_ref(content.get("schema") or {}, self.spec)
+            return (schema if isinstance(schema, dict) else None), None
+        for param in parameters:
+            if param.get("in") == "body":
+                schema = _resolve_ref(param.get("schema") or {}, self.spec)
+                return (schema if isinstance(schema, dict) else None), param.get("name")
+        return None, None
+
+    def _input_schema(self, parameters: List[Dict[str, Any]],
+                      body_schema: Optional[Dict[str, Any]],
+                      body_param: Optional[str]) -> Dict[str, Any]:
         properties: Dict[str, Any] = {}
         required: List[str] = []
         for param in parameters:
             pname = param.get("name")
-            if not pname:
+            if not pname or param.get("in") == "body":
                 continue
             schema = _resolve_ref(param.get("schema") or {"type": "string"}, self.spec)
             if param.get("description"):
@@ -272,10 +349,10 @@ class OpenAPIToolset:
             if param.get("required"):
                 required.append(pname)
 
-        body = operation.get("requestBody") or {}
-        content = (body.get("content") or {}).get("application/json") or {}
-        body_schema = _resolve_ref(content.get("schema") or {}, self.spec) if content else None
-        if isinstance(body_schema, dict) and body_schema.get("properties"):
+        if body_param:
+            # Swagger 2: expose the body as one named object argument.
+            properties.setdefault(body_param, body_schema or {"type": "object"})
+        elif isinstance(body_schema, dict) and body_schema.get("properties"):
             for key, value in body_schema["properties"].items():
                 properties.setdefault(key, value)
             required.extend(r for r in (body_schema.get("required") or [])
@@ -304,15 +381,17 @@ class OpenAPIToolset:
                     name = f"{self.tool_name_prefix}{name}"
                 parameters = [_resolve_ref(p, self.spec)
                               for p in (shared + (operation.get("parameters") or []))]
-                body = operation.get("requestBody")
+                body_schema, body_param = self._body_info(operation, parameters)
                 tools.append(OpenAPIOperation(
                     name=name,
                     description=(operation.get("summary")
                                  or operation.get("description") or ""),
                     method=method, path=path, base_url=self.base_url,
                     parameters=parameters,
-                    body_schema={} if body else None,
-                    input_schema=self._input_schema(operation, parameters),
+                    body_schema=body_schema,
+                    body_param=body_param,
+                    input_schema=self._input_schema(
+                        parameters, body_schema, body_param),
                     auth=self.auth, header_provider=self.header_provider,
                     timeout=self.timeout))
         return tools

--- a/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
+++ b/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
@@ -1,0 +1,321 @@
+"""Turn an OpenAPI/Swagger spec into callable agent tools.
+
+PraisonAI emits OpenAPI specs in several places (``recipe/serve.py``,
+``app/agentos.py``, ``ui/agui``, ``ui/a2a``) and consumed one nowhere, so
+pointing an agent at an existing REST API meant hand-writing a function per
+endpoint. A whole spec is now one line:
+
+    from praisonaiagents.tools.openapi_toolset import OpenAPIToolset
+
+    toolset = OpenAPIToolset(spec_url="https://api.example.com/openapi.json",
+                             auth={"type": "bearer", "token": os.environ["API_TOKEN"]})
+    agent = Agent(name="ops", tools=toolset.get_tools())
+
+There is an existing workaround -- ``MCP("npx -y @ivotoby/openapi-mcp-server
+...")`` fronts a spec as an MCP server -- so this is not a capability that was
+unreachable. What it costs is an extra process, an npx dependency, and no
+reuse of PraisonAI's own tool plumbing. Everything here routes through the
+same helpers the MCP tools use, so a generated tool is indistinguishable from
+any other to the Agent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urljoin
+
+logger = logging.getLogger(__name__)
+
+_BODY_METHODS = {"post", "put", "patch", "delete"}
+_HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options"}
+
+
+def _resolve_ref(schema: Any, root: Dict[str, Any], _seen: Optional[set] = None) -> Any:
+    """Expand local ``$ref`` pointers against the document.
+
+    Only local refs are followed: a remote ``$ref`` would mean fetching an
+    arbitrary URL while merely *describing* a tool, which is a surprising
+    thing for spec parsing to do. Cycles are broken rather than recursed --
+    a self-referential schema is common in real specs and must not hang.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    seen = _seen or set()
+    ref = schema.get("$ref")
+    if isinstance(ref, str) and ref.startswith("#/"):
+        if ref in seen:
+            return {"type": "object"}
+        target: Any = root
+        for part in ref[2:].split("/"):
+            if not isinstance(target, dict) or part not in target:
+                return {"type": "object"}
+            target = target[part]
+        return _resolve_ref(target, root, seen | {ref})
+    out: Dict[str, Any] = {}
+    for key, value in schema.items():
+        if key == "$ref":
+            continue
+        if isinstance(value, dict):
+            out[key] = _resolve_ref(value, root, seen)
+        elif isinstance(value, list):
+            out[key] = [_resolve_ref(v, root, seen) if isinstance(v, dict) else v
+                        for v in value]
+        else:
+            out[key] = value
+    return out
+
+
+def _operation_name(method: str, path: str, operation: Dict[str, Any]) -> str:
+    """A stable, model-friendly tool name."""
+    raw = operation.get("operationId")
+    if raw:
+        name = "".join(c if (c.isalnum() or c == "_") else "_" for c in str(raw))
+    else:
+        # No operationId: build one from the verb and path so the name is
+        # still deterministic across runs rather than positional.
+        cleaned = path.strip("/").replace("{", "").replace("}", "")
+        name = method + "_" + "".join(c if c.isalnum() else "_" for c in cleaned)
+    name = "_".join(filter(None, name.split("_")))
+    return name or f"{method}_operation"
+
+
+class OpenAPIOperation:
+    """One spec operation, callable like any other PraisonAI tool.
+
+    Shaped like ``mcp_sse.SSEMCPTool``: ``__name__``/``__qualname__``/``__doc__``
+    are what the Agent inspects to recognise a tool, so a generated operation
+    needs no Agent-side change.
+    """
+
+    def __init__(self, *, name: str, description: str, method: str, path: str,
+                 base_url: str, parameters: List[Dict[str, Any]],
+                 body_schema: Optional[Dict[str, Any]],
+                 input_schema: Dict[str, Any],
+                 auth: Optional[Dict[str, Any]] = None,
+                 header_provider: Optional[Callable[[], Dict[str, str]]] = None,
+                 timeout: int = 30):
+        self.name = name
+        self.__name__ = name
+        self.__qualname__ = name
+        self.__doc__ = description or f"{method.upper()} {path}"
+        self.description = self.__doc__
+        self.method = method.lower()
+        self.path = path
+        self.base_url = base_url
+        self.parameters = parameters
+        self.body_schema = body_schema
+        self.input_schema = input_schema
+        self.auth = auth or {}
+        self.header_provider = header_provider
+        self.timeout = timeout
+
+    # -- request construction ------------------------------------------------
+    def _headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        kind = str(self.auth.get("type", "")).lower()
+        if kind == "bearer" and self.auth.get("token"):
+            headers["Authorization"] = f"Bearer {self.auth['token']}"
+        elif kind == "api_key" and self.auth.get("key"):
+            headers[self.auth.get("name") or "X-API-Key"] = self.auth["key"]
+        elif kind == "basic" and self.auth.get("value"):
+            headers["Authorization"] = f"Basic {self.auth['value']}"
+        if self.header_provider:
+            try:
+                headers.update(self.header_provider() or {})
+            except Exception:  # noqa: BLE001 - a bad provider must not kill the call
+                logger.warning("header_provider raised; continuing without it",
+                               exc_info=True)
+        return headers
+
+    def build_request(self, **kwargs: Any) -> Dict[str, Any]:
+        """Bind arguments to path, query, header and body.
+
+        Separated from ``__call__`` so the binding can be asserted in a test
+        without a transport: the mapping from arguments to an HTTP request is
+        the part that carries the bugs.
+        """
+        path = self.path
+        query: Dict[str, Any] = {}
+        headers = self._headers()
+        body: Dict[str, Any] = {}
+        consumed = set()
+
+        for param in self.parameters:
+            pname = param.get("name")
+            if pname is None or pname not in kwargs:
+                continue
+            where = param.get("in")
+            value = kwargs[pname]
+            consumed.add(pname)
+            if where == "path":
+                path = path.replace("{" + pname + "}", str(value))
+            elif where == "query":
+                query[pname] = value
+            elif where == "header":
+                headers[pname] = str(value)
+
+        if self.body_schema is not None:
+            for key, value in kwargs.items():
+                if key not in consumed:
+                    body[key] = value
+
+        url = urljoin(self.base_url.rstrip("/") + "/", path.lstrip("/")) \
+            if self.base_url else path
+        request: Dict[str, Any] = {"method": self.method.upper(), "url": url,
+                                   "headers": headers}
+        if query:
+            request["params"] = query
+        if body:
+            request["json"] = body
+        return request
+
+    def __call__(self, **kwargs: Any) -> Any:
+        try:
+            import httpx
+        except ImportError:
+            return ("openapi tools need httpx: pip install httpx")
+        request = self.build_request(**kwargs)
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.request(**request)
+                response.raise_for_status()
+                try:
+                    return response.json()
+                except ValueError:
+                    return response.text
+        except Exception as exc:  # noqa: BLE001 - the model must see the failure
+            # Returned rather than raised: a tool that raises ends the turn,
+            # while a returned error lets the model retry or explain.
+            return f"{self.name} failed: {exc}"
+
+    def to_openai_tool(self) -> Dict[str, Any]:
+        """The function-calling dict, via the same helper the MCP tools use."""
+        from ..mcp.mcp_schema_utils import build_openai_tool_dict
+        return build_openai_tool_dict(self.name, self.description, self.input_schema)
+
+
+class OpenAPIToolset:
+    """Every operation in a spec, as agent tools."""
+
+    def __init__(self, *, spec_dict: Optional[Dict[str, Any]] = None,
+                 spec_str: Optional[str] = None,
+                 spec_url: Optional[str] = None,
+                 base_url: Optional[str] = None,
+                 auth: Optional[Dict[str, Any]] = None,
+                 tool_filter: Optional[Callable[[str, str, str], bool]] = None,
+                 tool_name_prefix: Optional[str] = None,
+                 header_provider: Optional[Callable[[], Dict[str, str]]] = None,
+                 timeout: int = 30):
+        if spec_dict is None and spec_str is None and spec_url is None:
+            raise ValueError(
+                "OpenAPIToolset needs one of spec_dict=, spec_str= or spec_url=")
+        self.spec = self._load(spec_dict, spec_str, spec_url)
+        self.base_url = base_url or self._infer_base_url(self.spec)
+        self.auth = auth
+        self.tool_filter = tool_filter
+        self.tool_name_prefix = tool_name_prefix
+        self.header_provider = header_provider
+        self.timeout = timeout
+
+    @staticmethod
+    def _load(spec_dict, spec_str, spec_url) -> Dict[str, Any]:
+        if spec_dict is not None:
+            return spec_dict
+        if spec_str is not None:
+            text = spec_str
+        else:
+            import httpx
+            with httpx.Client(timeout=30) as client:
+                response = client.get(spec_url)
+                response.raise_for_status()
+                text = response.text
+        try:
+            return json.loads(text)
+        except ValueError:
+            # A YAML spec is as common as a JSON one; PyYAML is already a
+            # dependency, but say so plainly if it is somehow absent.
+            try:
+                import yaml
+            except ImportError as exc:  # pragma: no cover
+                raise ValueError(
+                    "spec is not JSON and PyYAML is unavailable to parse it") from exc
+            return yaml.safe_load(text)
+
+    @staticmethod
+    def _infer_base_url(spec: Dict[str, Any]) -> str:
+        servers = spec.get("servers")
+        if isinstance(servers, list) and servers:
+            first = servers[0]
+            if isinstance(first, dict) and first.get("url"):
+                return str(first["url"])
+        # Swagger 2.0
+        host, base = spec.get("host"), spec.get("basePath", "")
+        if host:
+            schemes = spec.get("schemes") or ["https"]
+            return f"{schemes[0]}://{host}{base}"
+        return ""
+
+    def _input_schema(self, operation: Dict[str, Any],
+                      parameters: List[Dict[str, Any]]) -> Dict[str, Any]:
+        properties: Dict[str, Any] = {}
+        required: List[str] = []
+        for param in parameters:
+            pname = param.get("name")
+            if not pname:
+                continue
+            schema = _resolve_ref(param.get("schema") or {"type": "string"}, self.spec)
+            if param.get("description"):
+                schema = {**schema, "description": param["description"]}
+            properties[pname] = schema
+            if param.get("required"):
+                required.append(pname)
+
+        body = operation.get("requestBody") or {}
+        content = (body.get("content") or {}).get("application/json") or {}
+        body_schema = _resolve_ref(content.get("schema") or {}, self.spec) if content else None
+        if isinstance(body_schema, dict) and body_schema.get("properties"):
+            for key, value in body_schema["properties"].items():
+                properties.setdefault(key, value)
+            required.extend(r for r in (body_schema.get("required") or [])
+                            if r not in required)
+
+        schema: Dict[str, Any] = {"type": "object", "properties": properties}
+        if required:
+            schema["required"] = required
+        return schema
+
+    def get_tools(self) -> List[OpenAPIOperation]:
+        """One callable per operation, ready for ``Agent(tools=...)``."""
+        tools: List[OpenAPIOperation] = []
+        paths = self.spec.get("paths") or {}
+        for path, item in paths.items():
+            if not isinstance(item, dict):
+                continue
+            shared = item.get("parameters") or []
+            for method, operation in item.items():
+                if method.lower() not in _HTTP_METHODS or not isinstance(operation, dict):
+                    continue
+                name = _operation_name(method, path, operation)
+                if self.tool_filter and not self.tool_filter(name, method, path):
+                    continue
+                if self.tool_name_prefix:
+                    name = f"{self.tool_name_prefix}{name}"
+                parameters = [_resolve_ref(p, self.spec)
+                              for p in (shared + (operation.get("parameters") or []))]
+                body = operation.get("requestBody")
+                tools.append(OpenAPIOperation(
+                    name=name,
+                    description=(operation.get("summary")
+                                 or operation.get("description") or ""),
+                    method=method, path=path, base_url=self.base_url,
+                    parameters=parameters,
+                    body_schema={} if body else None,
+                    input_schema=self._input_schema(operation, parameters),
+                    auth=self.auth, header_provider=self.header_provider,
+                    timeout=self.timeout))
+        return tools
+
+
+__all__ = ["OpenAPIToolset", "OpenAPIOperation"]

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -4515,7 +4515,21 @@ class WorkflowManager:
                         "continuing at the same step index because --rebase-checkpoint was set."
                     )
                 results = checkpoint_data.get("results", [])
-                all_variables = checkpoint_data.get("variables", all_variables)
+                # Layer, do not replace. The checkpoint's variables used to
+                # overwrite the caller's outright, so a value supplied ON the
+                # resume was accepted and silently thrown away:
+                #
+                #   praisonai workflow run wf --resume --var reviewer_decision=approved
+                #
+                # which is precisely how a human hands their answer back to a
+                # run that paused for review. Precedence is workflow defaults,
+                # then the checkpoint, then whatever the caller supplied now --
+                # the freshest statement of intent wins.
+                all_variables = {
+                    **all_variables,
+                    **(checkpoint_data.get("variables") or {}),
+                    **(variables or {}),
+                }
                 start_step = checkpoint_data.get("completed_steps", 0)
                 resumed_from_step = start_step
                 self._log(f"Resuming workflow from step {start_step + 1}")

--- a/src/praisonai-agents/tests/unit/security/test_allowed_tools_empty_string.py
+++ b/src/praisonai-agents/tests/unit/security/test_allowed_tools_empty_string.py
@@ -1,0 +1,107 @@
+"""An empty ALLOWED_TOOLS must not silently switch the whitelist off.
+
+The module's own docstring says:
+
+    ALLOWED_TOOLS unset          : all tools visible
+    ALLOWED_TOOLS empty string   : error - must specify tools or unset
+    ALLOWED_TOOLS with values    : only whitelisted tools visible
+
+The middle line was not what happened. Presence was tested by truthiness:
+
+    self.env_value = os.environ.get(primary) or os.environ.get(legacy)
+
+so ALLOWED_TOOLS="" was falsy, fell through to the legacy variable, and ended
+as None -- which _parse_whitelist reads as "unset, allow everything". The
+whitelist was therefore disabled by the exact value documented as an error,
+while a whitespace-only value was correctly refused. Measured before the fix:
+
+    ALLOWED_TOOLS=""     -> allows ['read_file', 'shell', 'write_file']
+    ALLOWED_TOOLS="  "   -> RAISED ValueError
+
+`export ALLOWED_TOOLS=` and `ALLOWED_TOOLS="$SOME_UNSET_VAR"` both produce
+that empty string, so this is reachable from an ordinary shell script or CI
+config that meant to restrict tools and instead removed the restriction.
+"""
+import logging
+
+import pytest
+
+from praisonaiagents.allowed_tools_filter import (
+    AllowedToolsFilter,
+    filter_tools_with_allowed_tools,
+)
+
+TOOLS = ["read_file", "write_file", "shell"]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    monkeypatch.delenv("HERMES_ONLY_TOOLS", raising=False)
+    logging.disable(logging.CRITICAL)
+    yield
+    logging.disable(logging.NOTSET)
+
+
+def _filter():
+    return sorted(filter_tools_with_allowed_tools(list(TOOLS), log_diagnostics=False))
+
+
+class TestEmptyIsAnError:
+
+    def test_an_empty_string_is_refused(self, monkeypatch):
+        monkeypatch.setenv("ALLOWED_TOOLS", "")
+        with pytest.raises(ValueError):
+            _filter()
+
+    def test_it_does_not_silently_allow_everything(self, monkeypatch):
+        """The security-relevant half: failing open is worse than failing."""
+        monkeypatch.setenv("ALLOWED_TOOLS", "")
+        try:
+            allowed = _filter()
+        except ValueError:
+            return  # refused, which is the point
+        pytest.fail(f"empty ALLOWED_TOOLS allowed {allowed}")
+
+    def test_whitespace_is_still_refused(self, monkeypatch):
+        monkeypatch.setenv("ALLOWED_TOOLS", "   ")
+        with pytest.raises(ValueError):
+            _filter()
+
+    def test_the_legacy_variable_is_refused_when_empty_too(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ONLY_TOOLS", "")
+        with pytest.raises(ValueError):
+            _filter()
+
+
+class TestDocumentedBehaviourIsUnchanged:
+
+    def test_unset_allows_every_tool(self):
+        assert _filter() == sorted(TOOLS)
+
+    def test_a_named_tool_is_the_only_one_allowed(self, monkeypatch):
+        monkeypatch.setenv("ALLOWED_TOOLS", "read_file")
+        assert _filter() == ["read_file"]
+
+    def test_a_comma_separated_list_works(self, monkeypatch):
+        monkeypatch.setenv("ALLOWED_TOOLS", "read_file, shell")
+        assert _filter() == ["read_file", "shell"]
+
+    def test_the_legacy_variable_still_works(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ONLY_TOOLS", "shell")
+        assert _filter() == ["shell"]
+
+    def test_the_primary_variable_wins_over_the_legacy_one(self, monkeypatch):
+        monkeypatch.setenv("ALLOWED_TOOLS", "read_file")
+        monkeypatch.setenv("HERMES_ONLY_TOOLS", "shell")
+        assert _filter() == ["read_file"]
+
+    def test_the_error_names_the_variable_that_was_set(self, monkeypatch):
+        """A message naming the wrong variable sends the user to the wrong line."""
+        monkeypatch.setenv("HERMES_ONLY_TOOLS", "")
+        with pytest.raises(ValueError, match="HERMES_ONLY_TOOLS"):
+            _filter()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/praisonai-agents/tests/unit/security/test_allowed_tools_empty_string.py
+++ b/src/praisonai-agents/tests/unit/security/test_allowed_tools_empty_string.py
@@ -96,6 +96,14 @@ class TestDocumentedBehaviourIsUnchanged:
         monkeypatch.setenv("HERMES_ONLY_TOOLS", "shell")
         assert _filter() == ["read_file"]
 
+    def test_an_empty_primary_still_wins_over_a_set_legacy(self, monkeypatch):
+        """Precedence is by presence, not truthiness: an empty ALLOWED_TOOLS
+        must be refused rather than silently deferring to HERMES_ONLY_TOOLS."""
+        monkeypatch.setenv("ALLOWED_TOOLS", "")
+        monkeypatch.setenv("HERMES_ONLY_TOOLS", "shell")
+        with pytest.raises(ValueError, match="ALLOWED_TOOLS"):
+            _filter()
+
     def test_the_error_names_the_variable_that_was_set(self, monkeypatch):
         """A message naming the wrong variable sends the user to the wrong line."""
         monkeypatch.setenv("HERMES_ONLY_TOOLS", "")

--- a/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
+++ b/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
@@ -146,5 +146,91 @@ class TestSelection:
         assert OpenAPIToolset(spec_dict=spec).base_url == "https://api.old.com/v2"
 
 
+class TestPathParameterSafety:
+    """A model-supplied path value must not be able to change the host."""
+
+    def test_an_absolute_value_cannot_hijack_the_url(self, tools):
+        from urllib.parse import urlparse
+
+        request = tools["getPet"].build_request(petId="https://attacker.example/x")
+        assert request["url"].startswith("https://api.example.com/v1/pets/")
+        # The value is encoded into a single path segment; the host stays ours.
+        assert urlparse(request["url"]).netloc == "api.example.com"
+
+    def test_traversal_stays_one_segment(self, tools):
+        request = tools["getPet"].build_request(petId="../../admin")
+        assert request["url"].startswith("https://api.example.com/v1/pets/")
+        assert "/admin" not in request["url"]
+
+    def test_a_query_or_fragment_in_a_path_value_is_encoded(self, tools):
+        request = tools["getPet"].build_request(petId="a?b#c")
+        assert request["url"].endswith("/pets/a%3Fb%23c")
+
+
+class TestSwagger2Body:
+    """Swagger 2 declares the body as an in:body parameter, not requestBody."""
+
+    SWAGGER = {
+        "swagger": "2.0", "host": "api.old.com", "basePath": "/v2",
+        "schemes": ["https"],
+        "paths": {"/pets": {"post": {
+            "operationId": "createPet",
+            "parameters": [{"name": "pet", "in": "body", "required": True,
+                            "schema": {"type": "object", "properties": {
+                                "name": {"type": "string"}}}}]}}},
+    }
+
+    def _tool(self):
+        ts = OpenAPIToolset(spec_dict=self.SWAGGER)
+        return next(t for t in ts.get_tools() if t.name == "createPet")
+
+    def test_the_body_argument_is_exposed(self):
+        assert "pet" in self._tool().input_schema["properties"]
+
+    def test_the_body_argument_becomes_the_json_body(self):
+        request = self._tool().build_request(pet={"name": "Rex"})
+        assert request["json"] == {"name": "Rex"}
+
+
+class TestRelativeServer:
+    """A relative server URL in a remotely loaded spec must be resolved."""
+
+    def test_a_relative_server_is_resolved_against_the_spec_url(self):
+        spec = {"openapi": "3.0.0", "servers": [{"url": "/v1"}], "paths": {}}
+        ts = OpenAPIToolset(spec_dict=spec,
+                            spec_url="https://api.example.com/openapi.json")
+        assert ts.base_url == "https://api.example.com/v1"
+
+
+class TestBodyDoesNotLeakFrameworkArgs:
+    """Framework-injected kwargs (idempotency_key) must not reach the body."""
+
+    def test_an_undeclared_argument_is_dropped_from_the_body(self, tools):
+        request = tools["createPet"].build_request(
+            name="Rex", tag="dog", idempotency_key="abc-123")
+        assert request["json"] == {"name": "Rex", "tag": "dog"}
+        assert "idempotency_key" not in request["json"]
+
+
+class TestCleartextAuthRefused:
+    """Credentials must never be attached to an http:// endpoint."""
+
+    def test_auth_over_http_is_refused(self):
+        spec = {"swagger": "2.0", "host": "api.old.com", "basePath": "/v2",
+                "schemes": ["http"], "paths": {}}
+        with pytest.raises(ValueError, match="http"):
+            OpenAPIToolset(spec_dict=spec, auth={"type": "bearer", "token": "T"})
+
+    def test_https_is_preferred_when_offered(self):
+        spec = {"swagger": "2.0", "host": "api.old.com", "basePath": "/v2",
+                "schemes": ["http", "https"], "paths": {}}
+        assert OpenAPIToolset(spec_dict=spec).base_url == "https://api.old.com/v2"
+
+    def test_http_without_auth_is_allowed(self):
+        spec = {"swagger": "2.0", "host": "api.old.com", "basePath": "/v2",
+                "schemes": ["http"], "paths": {}}
+        assert OpenAPIToolset(spec_dict=spec).base_url == "http://api.old.com/v2"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
+++ b/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
@@ -1,0 +1,150 @@
+"""An OpenAPI spec must become callable agent tools.
+
+PraisonAI emitted OpenAPI specs in four places and consumed one nowhere, so
+pointing an agent at an existing REST API meant hand-writing a function per
+endpoint. Google ADK ships OpenAPIToolset; this is the equivalent.
+
+The tests assert the ARGUMENT-TO-REQUEST BINDING, which is where the bugs
+live: a path parameter substituted into the URL, a query parameter in the
+query string, everything else in the JSON body, and $refs resolved against
+components/schemas so the model sees real field names rather than a pointer.
+"""
+import pytest
+
+from praisonaiagents.tools.openapi_toolset import OpenAPIToolset
+
+SPEC = {
+    "openapi": "3.0.0",
+    "servers": [{"url": "https://api.example.com/v1"}],
+    "components": {"schemas": {"Pet": {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "tag": {"type": "string"}},
+        "required": ["name"]}}},
+    "paths": {
+        "/pets/{petId}": {"get": {
+            "operationId": "getPet", "summary": "Fetch one pet",
+            "parameters": [
+                {"name": "petId", "in": "path", "required": True,
+                 "schema": {"type": "string"}},
+                {"name": "verbose", "in": "query", "schema": {"type": "boolean"}}]}},
+        "/pets": {"post": {
+            "operationId": "createPet", "summary": "Create a pet",
+            "requestBody": {"content": {"application/json": {
+                "schema": {"$ref": "#/components/schemas/Pet"}}}}}},
+    },
+}
+
+
+@pytest.fixture
+def tools():
+    ts = OpenAPIToolset(spec_dict=SPEC, auth={"type": "bearer", "token": "T0K3N"})
+    return {t.name: t for t in ts.get_tools()}
+
+
+class TestSpecBecomesTools:
+
+    def test_one_tool_per_operation(self, tools):
+        assert set(tools) == {"getPet", "createPet"}
+
+    def test_the_base_url_is_taken_from_the_spec(self):
+        assert OpenAPIToolset(spec_dict=SPEC).base_url == "https://api.example.com/v1"
+
+    def test_the_summary_becomes_the_description(self, tools):
+        assert "Fetch one pet" in tools["getPet"].__doc__
+
+    def test_a_tool_looks_like_a_tool_to_the_agent(self, tools):
+        """Agent inspects __name__/__qualname__/__doc__ to recognise a tool."""
+        tool = tools["getPet"]
+        assert tool.__name__ == "getPet" and tool.__qualname__ == "getPet"
+        assert callable(tool)
+
+    def test_an_operation_without_an_operationid_still_gets_a_stable_name(self):
+        spec = {"paths": {"/health": {"get": {"summary": "health"}}}}
+        names = [t.name for t in OpenAPIToolset(spec_dict=spec).get_tools()]
+        assert names == ["get_health"]
+
+
+class TestArgumentBinding:
+
+    def test_a_path_parameter_is_substituted_into_the_url(self, tools):
+        request = tools["getPet"].build_request(petId="p1")
+        assert request["url"] == "https://api.example.com/v1/pets/p1"
+        assert "{petId}" not in request["url"]
+
+    def test_a_query_parameter_goes_to_the_query_string(self, tools):
+        request = tools["getPet"].build_request(petId="p1", verbose=True)
+        assert request["params"] == {"verbose": True}
+
+    def test_a_path_parameter_never_leaks_into_the_body(self, tools):
+        request = tools["getPet"].build_request(petId="p1")
+        assert "json" not in request
+
+    def test_body_fields_go_to_the_json_body(self, tools):
+        request = tools["createPet"].build_request(name="Rex", tag="dog")
+        assert request["json"] == {"name": "Rex", "tag": "dog"}
+        assert request["method"] == "POST"
+
+    def test_the_auth_header_is_attached(self, tools):
+        assert tools["getPet"].build_request(petId="p")["headers"]["Authorization"] \
+            == "Bearer T0K3N"
+
+    def test_an_api_key_auth_uses_its_own_header_name(self):
+        ts = OpenAPIToolset(spec_dict=SPEC,
+                            auth={"type": "api_key", "key": "K", "name": "X-Custom"})
+        tool = next(t for t in ts.get_tools() if t.name == "getPet")
+        assert tool.build_request(petId="p")["headers"]["X-Custom"] == "K"
+
+
+class TestSchemas:
+
+    def test_a_ref_is_resolved_to_real_fields(self, tools):
+        """A model shown a $ref cannot fill the arguments in."""
+        schema = tools["createPet"].input_schema
+        assert set(schema["properties"]) == {"name", "tag"}
+        assert schema["required"] == ["name"]
+
+    def test_path_and_query_parameters_are_both_declared(self, tools):
+        assert set(tools["getPet"].input_schema["properties"]) == {"petId", "verbose"}
+
+    def test_required_follows_the_spec(self, tools):
+        assert tools["getPet"].input_schema["required"] == ["petId"]
+
+    def test_a_cyclic_ref_does_not_hang(self):
+        spec = {"components": {"schemas": {"Node": {
+                    "type": "object",
+                    "properties": {"child": {"$ref": "#/components/schemas/Node"}}}}},
+                "paths": {"/n": {"post": {"operationId": "mk", "requestBody": {
+                    "content": {"application/json": {
+                        "schema": {"$ref": "#/components/schemas/Node"}}}}}}}}
+        tools = OpenAPIToolset(spec_dict=spec).get_tools()
+        assert tools[0].input_schema["properties"]
+
+    def test_it_produces_a_usable_openai_tool_dict(self, tools):
+        dict_ = tools["createPet"].to_openai_tool()
+        assert dict_["type"] == "function"
+        assert dict_["function"]["name"] == "createPet"
+
+
+class TestSelection:
+
+    def test_tool_filter_excludes_operations(self):
+        ts = OpenAPIToolset(spec_dict=SPEC,
+                            tool_filter=lambda name, method, path: method == "get")
+        assert [t.name for t in ts.get_tools()] == ["getPet"]
+
+    def test_a_prefix_is_applied(self):
+        ts = OpenAPIToolset(spec_dict=SPEC, tool_name_prefix="petstore_")
+        assert all(t.name.startswith("petstore_") for t in ts.get_tools())
+
+    def test_no_spec_at_all_is_refused(self):
+        with pytest.raises(ValueError):
+            OpenAPIToolset()
+
+    def test_swagger_2_host_and_basepath(self):
+        spec = {"swagger": "2.0", "host": "api.old.com", "basePath": "/v2",
+                "schemes": ["https"], "paths": {}}
+        assert OpenAPIToolset(spec_dict=spec).base_url == "https://api.old.com/v2"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/praisonai-agents/tests/unit/workflows/test_resume_honours_supplied_variables.py
+++ b/src/praisonai-agents/tests/unit/workflows/test_resume_honours_supplied_variables.py
@@ -1,0 +1,95 @@
+"""Resuming a workflow must keep the value the human just supplied.
+
+A paused-for-review run is resumed with the reviewer's answer:
+
+    praisonai workflow run wf --resume --var reviewer_decision=approved
+
+`_prepare_workflow_loop` built `all_variables` from the workflow defaults plus
+the caller's `variables`, and then did:
+
+    all_variables = checkpoint_data.get("variables", all_variables)
+
+The checkpoint's variables REPLACED the caller's, so the answer was accepted
+and silently discarded -- the run resumed with the same state it paused in,
+and any step reading {{reviewer_decision}} saw nothing.
+
+That is the whole mechanism by which a human hands a decision back to a
+suspended run, which is why it matters more than its one-line size suggests.
+Precedence is now defaults, then checkpoint, then what the caller supplied
+now: the freshest statement of intent wins.
+"""
+import os
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from praisonaiagents.workflows.workflows import Workflow, WorkflowManager
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    mgr = WorkflowManager()
+    mgr._ensure_loaded()
+    mgr._workflows["review"] = Workflow(
+        name="review",
+        description="draft then apply a reviewed decision",
+        steps=[{"name": "draft", "action": "echo"},
+               {"name": "apply", "action": "use {{reviewer_decision}}"}],
+        variables={"topic": "x"},
+    )
+    return mgr
+
+
+def _resume(mgr, supplied, saved):
+    mgr._save_checkpoint(name="pending", workflow_name="review",
+                         completed_steps=1, results=[{"step": "draft"}],
+                         variables=saved)
+    state = mgr._prepare_workflow_loop(
+        workflow_name="review", variables=supplied, default_llm=None,
+        planning=False, resume="pending", rebase_checkpoint=True)
+    return state["state"]["all_variables"]
+
+
+class TestResumeKeepsTheSuppliedValue:
+
+    def test_the_humans_answer_survives_the_resume(self, manager):
+        variables = _resume(manager, {"reviewer_decision": "approved"},
+                            {"topic": "x"})
+        assert variables.get("reviewer_decision") == "approved", (
+            "the value supplied on resume was discarded"
+        )
+
+    def test_checkpoint_state_still_survives(self, manager):
+        """The fix must not trade one loss for another."""
+        variables = _resume(manager, {"reviewer_decision": "approved"},
+                            {"topic": "x", "stage": "drafted"})
+        assert variables.get("stage") == "drafted"
+
+    def test_the_supplied_value_wins_a_conflict(self, manager):
+        """The reviewer is correcting the run; their answer is the newer fact."""
+        variables = _resume(manager, {"stage": "revised"},
+                            {"stage": "drafted"})
+        assert variables.get("stage") == "revised"
+
+    def test_resuming_with_nothing_supplied_is_unchanged(self, manager):
+        """The existing behaviour for a plain --resume must not shift."""
+        variables = _resume(manager, None, {"topic": "x", "stage": "drafted"})
+        assert variables.get("stage") == "drafted"
+        assert variables.get("topic") == "x"
+
+    def test_workflow_defaults_are_not_lost(self, manager):
+        variables = _resume(manager, {"reviewer_decision": "yes"}, {})
+        assert variables.get("topic") == "x"
+
+    def test_all_three_layers_are_present_together(self, manager):
+        variables = _resume(manager, {"reviewer_decision": "approved"},
+                            {"stage": "drafted"})
+        assert variables.get("topic") == "x"            # workflow default
+        assert variables.get("stage") == "drafted"      # checkpoint
+        assert variables.get("reviewer_decision") == "approved"  # supplied now
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/praisonai-code/praisonai_code/cli/commands/up.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/up.py
@@ -59,8 +59,15 @@ class ServiceManager:
         try:
             import requests
         except ImportError:
-            self.console.print(f"[yellow]⚠️ Cannot health-check {service_name} (requests not installed)[/yellow]")
-            return True
+            # Fail closed: without a client the service cannot be confirmed
+            # healthy, and returning True here let both callers mark a service
+            # "Running" that was never checked. Reporting an unverified service
+            # as ready is the very defect this command was fixed to avoid.
+            self.console.print(
+                f"[yellow]⚠️ Cannot health-check {service_name} "
+                "(requests not installed); treating as not ready. "
+                "Install with: pip install requests[/yellow]")
+            return False
         
         self.console.print(f"[cyan]Waiting for {service_name} at {url}...[/cyan]")
         

--- a/src/praisonai-code/praisonai_code/cli/commands/up.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/up.py
@@ -25,7 +25,7 @@ class ServiceManager:
         self.services: List[subprocess.Popen] = []
         self.console = Console()
     
-    def add_service(self, cmd: List[str], name: str, env: Optional[dict] = None) -> subprocess.Popen:
+    def add_service(self, cmd: List[str], name: str, env: Optional[dict] = None) -> Optional[subprocess.Popen]:
         """Start a service and add to managed list."""
         self.console.print(f"[cyan]Starting {name}...[/cyan]")
         
@@ -37,6 +37,16 @@ class ServiceManager:
                 stderr=subprocess.DEVNULL,
             )
             self.services.append(proc)
+            # Popen succeeding means the process was spawned, not that it is
+            # alive. A bad flag, a missing dependency or a taken port all exit
+            # immediately, and this used to print "started (PID: N)" for them,
+            # with stderr going to DEVNULL so the reason was gone too.
+            time.sleep(0.5)
+            if proc.poll() is not None:
+                self.console.print(
+                    f"[red]❌ {name} exited immediately (code {proc.returncode})[/red]")
+                self.services.remove(proc)
+                return None
             self.console.print(f"[green]✅ {name} started (PID: {proc.pid})[/green]")
             return proc
             
@@ -181,16 +191,19 @@ def up_start(
                 ]
                 
                 langfuse_proc = manager.add_service(langfuse_cmd, "Langfuse", env)
+                # Only claim a service once it is actually up. This used to
+                # append before the health check and discard the check's
+                # result, so a dead or unreachable service was still rendered
+                # "Running" under a table headed "Services Ready".
+                if langfuse_proc is None:
+                    raise RuntimeError("Langfuse exited during startup")
+                if wait_timeout > 0 and not manager.wait_for_service(
+                        f"http://{host}:{langfuse_port}", "Langfuse",
+                        timeout=wait_timeout):
+                    raise RuntimeError("Langfuse never became healthy")
                 services_started.append(("Langfuse", f"http://{host}:{langfuse_port}"))
-                
-                # Wait for Langfuse to be ready
-                if wait_timeout > 0:
-                    manager.wait_for_service(
-                        f"http://{host}:{langfuse_port}", 
-                        "Langfuse", 
-                        timeout=wait_timeout
-                    )
-                    
+
+
             except Exception as e:
                 console.print(f"[red]Failed to start Langfuse: {e}[/red]")
                 console.print("[yellow]Try: pip install 'praisonai[langfuse]'[/yellow]")
@@ -209,16 +222,19 @@ def up_start(
                 ]
                 
                 langflow_proc = manager.add_service(langflow_cmd, "Langflow", env)
+                # Only claim a service once it is actually up. This used to
+                # append before the health check and discard the check's
+                # result, so a dead or unreachable service was still rendered
+                # "Running" under a table headed "Services Ready".
+                if langflow_proc is None:
+                    raise RuntimeError("Langflow exited during startup")
+                if wait_timeout > 0 and not manager.wait_for_service(
+                        f"http://{host}:{langflow_port}", "Langflow",
+                        timeout=wait_timeout):
+                    raise RuntimeError("Langflow never became healthy")
                 services_started.append(("Langflow", f"http://{host}:{langflow_port}"))
-                
-                # Wait for Langflow to be ready
-                if wait_timeout > 0:
-                    manager.wait_for_service(
-                        f"http://{host}:{langflow_port}", 
-                        "Langflow", 
-                        timeout=wait_timeout
-                    )
-                    
+
+
             except Exception as e:
                 console.print(f"[red]Failed to start Langflow: {e}[/red]")
                 console.print("[yellow]Try: pip install 'praisonai[flow]'[/yellow]")

--- a/src/praisonai-code/tests/unit/cli/test_up_reports_real_status.py
+++ b/src/praisonai-code/tests/unit/cli/test_up_reports_real_status.py
@@ -76,6 +76,22 @@ class TestHealthCheckResultIsUsed:
         assert manager.wait_for_service(
             "http://127.0.0.1:59997", "Langflow", timeout=1) is False
 
+    def test_missing_requests_reports_not_ready(self, manager, monkeypatch):
+        """Without a client the health cannot be confirmed, so it must fail
+        closed rather than returning True and marking the service ready."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _no_requests(name, *args, **kwargs):
+            if name == "requests":
+                raise ImportError("requests not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_requests)
+        assert manager.wait_for_service(
+            "http://127.0.0.1:59997", "Langflow", timeout=1) is False
+
     def test_the_command_gates_on_that_result(self):
         """Guards the wiring, not just the helper.
 

--- a/src/praisonai-code/tests/unit/cli/test_up_reports_real_status.py
+++ b/src/praisonai-code/tests/unit/cli/test_up_reports_real_status.py
@@ -1,0 +1,103 @@
+"""`praisonai up` must not report a dead service as running.
+
+Two defects compounded:
+
+1. `add_service` returned the Popen whenever the *spawn* succeeded. A bad
+   flag, a missing dependency or a taken port all exit immediately, and the
+   command printed "✅ Langflow started (PID: N)" for them. `stderr` goes to
+   DEVNULL, so the reason was discarded too.
+
+2. `services_started.append(...)` ran BEFORE the health check, and the check's
+   return value was thrown away at both call sites -- `wait_for_service`
+   returns a bool and nothing read it. A service that timed out printed a
+   yellow warning and was then rendered "✅ Running" in a table titled
+   "🎉 Services Ready", and the command exited 0.
+
+So `praisonai up` reported success for services that were not running, which
+is the worst possible answer for a command whose only job is to start them.
+"""
+import sys
+
+import pytest
+
+import praisonai_code.cli.commands.up as up
+
+
+@pytest.fixture
+def manager():
+    mgr = up.ServiceManager()
+    yield mgr
+    for proc in list(mgr.services):
+        try:
+            proc.kill()
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+class TestADeadServiceIsNotStarted:
+
+    def test_a_process_that_exits_immediately_returns_none(self, manager):
+        result = manager.add_service(
+            [sys.executable, "-c", "import sys; sys.exit(1)"], "Langflow")
+        assert result is None, "a service that died was reported as started"
+
+    def test_it_is_not_left_in_the_managed_list(self, manager):
+        manager.add_service(
+            [sys.executable, "-c", "import sys; sys.exit(1)"], "Langflow")
+        assert manager.services == [], (
+            "a dead process stayed in the shutdown list"
+        )
+
+    def test_a_nonzero_exit_is_still_a_failure(self, manager):
+        """Exit 0 immediately is also not a running service."""
+        assert manager.add_service(
+            [sys.executable, "-c", "pass"], "Langflow") is None
+
+
+class TestALiveServiceStillWorks:
+
+    def test_a_running_process_is_returned(self, manager):
+        proc = manager.add_service(
+            [sys.executable, "-c", "import time; time.sleep(30)"], "Langfuse")
+        assert proc is not None
+        assert proc.poll() is None
+
+    def test_it_is_tracked_for_shutdown(self, manager):
+        proc = manager.add_service(
+            [sys.executable, "-c", "import time; time.sleep(30)"], "Langfuse")
+        assert proc in manager.services
+
+
+class TestHealthCheckResultIsUsed:
+
+    def test_an_unreachable_service_reports_false(self, manager):
+        """The bool that both call sites used to discard."""
+        assert manager.wait_for_service(
+            "http://127.0.0.1:59997", "Langflow", timeout=1) is False
+
+    def test_the_command_gates_on_that_result(self):
+        """Guards the wiring, not just the helper.
+
+        Asserted against the source because driving the whole `up` command
+        needs Langflow and Langfuse installed. What must hold is that the
+        append happens after a checked health call, not before an unchecked
+        one.
+        """
+        import inspect
+
+        source = inspect.getsource(up)
+        assert "if wait_timeout > 0 and not manager.wait_for_service(" in source, (
+            "the health check result is not being tested"
+        )
+        assert "if False:" not in source
+        for service in ("Langfuse", "Langflow"):
+            gate = source.index(f'raise RuntimeError("{service} never became healthy")')
+            append = source.index(f'services_started.append(("{service}"')
+            assert gate < append, (
+                f"{service} is recorded as started before its health is checked"
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Four changes, from two sweeps. Every claim was validated by **running** it before anything was written, and one was reverted when running the existing suite proved it was not a defect.

Reports: [competitor gaps](https://claude.ai/code/artifact/5c00cc94-5dce-4e91-afba-20015a9a032b) · [internal sweep](https://claude.ai/code/artifact/28176eb2-a7d0-4a0b-aa79-e4d60d1c3e25)

---

## 1. `praisonai up` reported dead services as running

Two defects compounding, in a command whose only job is to start services. Reproduced by driving the real `ServiceManager`:

```
process exited with     : 1
still in mgr.services   : True
add_service returned    : Popen  (no failure signalled)
wait_for_service says   : False  <- discarded by both callers
```

- `add_service` caught only a **spawn** failure, so a bad flag, a missing dependency or a taken port still printed `✅ Langflow started (PID: N)`. `stderr=DEVNULL` discarded the reason.
- `services_started.append(...)` ran **before** the health check, whose `bool` return nothing read.

Result: `🎉 Services Ready … ✅ Running`, exit 0, for services that were gone.

`add_service` now polls after a grace period, reports the exit code and drops the process from the shutdown list. A service is recorded as started only after a health check that is consulted; failure raises into the existing per-service `except`, which already prints an install hint.

**7 tests. 2 mutations killed.**

---

## 2. An empty `ALLOWED_TOOLS` silently disabled the tool whitelist

The failure is inverted from intuition, which is what makes it dangerous:

```
ALLOWED_TOOLS=""    -> allows ['read_file', 'shell', 'write_file']
ALLOWED_TOOLS="  "  -> RAISED ValueError
```

Presence was tested by truthiness — `os.environ.get(primary) or os.environ.get(legacy)` — so `""` was falsy, fell through to `HERMES_ONLY_TOOLS`, and ended as `None`, which `_parse_whitelist` reads as *"unset, allow everything"*. The **more** obviously-empty value passed the check written to catch it.

`export ALLOWED_TOOLS=` and `ALLOWED_TOOLS="$UNSET_VAR"` both produce that empty string, so a shell script or CI config meaning to restrict tools instead removed the restriction, silently. The module's own docstring documents empty as an error.

Presence is now tested with `is not None`. The legacy variable keeps its precedence and its own name in the error message.

**10 tests. Mutation killed.**

---

## 3. Resuming a workflow discarded the human's supplied value

```python
all_variables = checkpoint_data.get("variables", all_variables)
```

The checkpoint's variables **replaced** the caller's, so `--resume --var reviewer_decision=approved` was accepted and thrown away — the entire mechanism by which a human hands a decision back to a run that paused for review.

```
before   all_variables = {'topic': 'x'}                    reviewer_decision absent
after    {'topic':'x', 'stage':'drafted', 'reviewer_decision':'approved'}
```

Precedence is now defaults → checkpoint → what the caller supplied now.

**6 tests. Mutation killed.**

---

## 4. An OpenAPI spec could not become tools

Every `openapi` hit in the monorepo was PraisonAI **emitting** a spec; nothing consumed one.

```python
toolset = OpenAPIToolset(spec_url="https://api.example.com/openapi.json",
                         auth={"type": "bearer", "token": TOKEN})
agent = Agent(name="ops", tools=toolset.get_tools())
```

`spec_dict`/`spec_str`/`spec_url`, `base_url`, `auth` (bearer/api_key/basic), `tool_filter`, `tool_name_prefix`, `header_provider`; OpenAPI 3 and Swagger 2; local `$ref` resolution with cycle-breaking.

Built on existing plumbing — the tool dict comes from `mcp_schema_utils.build_openai_tool_dict` and each operation is shaped like `mcp_sse.SSEMCPTool`, so `Agent(tools=…)` needed no change. **A workaround existed** (`MCP("npx -y @ivotoby/openapi-mcp-server …")`); this removes an extra process, an npx dependency and the absence of `tool_filter`.

**20 tests. 3 mutations killed.**

---

## What was checked and deliberately NOT changed

**`EventBus.get_history()` drops events published with no subscriber.** The behaviour is real, but it is intentional and pinned by two existing tests:

```python
assert len(bus.get_history()) == 0  # No history when no subscribers
# No subscribers, no sinks: publish returns an event, stores nothing.
```

I had written the fix and its tests before running the existing suite revealed this. Reverted. Whether the optimisation is right is a design question; overriding it under the banner of a bug fix would not be.

**`plugins.enable()` raising once a plugin is registered** — not reproduced. Both `enable()` and `disable()` returned cleanly, but my test plugin was not picked up by discovery, so the condition went unexercised. Unreproduced, not disproved.

**Four competitor claims refuted**, listed so the report's reliability can be judged: human-in-the-loop review (PraisonAI calls it *guardrails*), PDF/audio/video input (`_build_multimodal_prompt` has a third branch), pluggable model interface, and offline stub models — all already present.

---

## Verification summary

| | |
|---|---|
| new tests | **43** |
| mutations killed | **7** |
| claims validated | 4 internal + 7 competitor |
| claims refuted or reverted | 1 internal + 4 competitor |

Pre-existing failures were baselined by stashing, not assumed: the 5 in `tests/unit/tools`, the 3 in `tests/unit/bus` and 2 collection errors are identical on clean `main` (tracked under #4748). `tests/unit/tools` goes from **622 to 795 passing**; 41 CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tools that generate callable agent actions from OpenAPI and Swagger specifications.
  - OpenAPI requests support endpoint parameters, request bodies, authentication safeguards, and automatic response parsing.

- **Bug Fixes**
  - Resuming workflows now preserves variables supplied at resume time.
  - Empty tool-allowlist settings now produce a clear validation error.
  - Service startup now reports only processes that remain running and pass health checks.
  - Unreachable or unverified services are no longer reported as ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->