### PR TITLE
fix(ts): stop 13 observability adapters claiming to send telemetry they discard

### DIFF
--- a/src/praisonai-ts/src/cli/commands/observability.ts
+++ b/src/praisonai-ts/src/cli/commands/observability.ts
@@ -112,7 +112,11 @@ async function listProvidersCommand(options: ObservabilityOptions, outputFormat:
     features: tool.features
   }));
 
-  const ready = providers.filter(p => p.hasEnvKey);
+  // "Ready" must mean traces will actually arrive, not merely that a key is set.
+  // A tool that cannot deliver (e.g. weave) is never ready however its key is set;
+  // key-less built-ins are ready because they need no configuration to do their job.
+  // This mirrors the same predicate used by the aggregate doctor command below.
+  const ready = providers.filter(p => p.hasEnvKey && (p.delivers || !p.envKey));
   const builtIn = providers.filter(p => ['console', 'memory', 'noop'].includes(p.name));
   const external = providers.filter(p => !['console', 'memory', 'noop'].includes(p.name));
 
@@ -287,15 +291,36 @@ async function testCommand(toolName: string | undefined, options: ObservabilityO
     await adapter.flush();
 
     const latency = Date.now() - startTime;
-    // The trace above always succeeds locally. What matters is whether the
-    // adapter could deliver it; reporting "passed" regardless would be a lie.
-    const delivered = adapter.isEnabled;
+    const info = OBSERVABILITY_TOOLS[tool as ObservabilityToolName];
+
+    // "delivered" means the trace reached an external backend. That requires a
+    // delivery implementation (registry `delivers`) AND a live transport
+    // (`isEnabled`). The in-process memory adapter reports isEnabled === true,
+    // but it sends nothing anywhere, so isEnabled alone is not proof of delivery.
+    const delivered = info.delivers === true && adapter.isEnabled;
+
+    // A built-in local recorder (console/memory) has no envKey and never
+    // delivers externally, yet it does exactly what it claims: record locally.
+    // That is a genuine pass, distinct from a non-delivering external
+    // integration that silently drops the trace it advertised it would send.
+    const isLocalRecorder = !info.envKey && !info.delivers && adapter.isEnabled;
 
     if (outputFormat === 'json' && delivered) {
       outputJson(formatSuccess({
         tool,
-        status: 'success',
+        status: 'delivered',
         delivered: true,
+        latency_ms: latency,
+        trace_id: trace.traceId
+      }));
+    } else if (outputFormat === 'json' && isLocalRecorder) {
+      // success:true, but delivered:false — the trace was recorded in this
+      // process and never left it. A CI script must be able to tell local
+      // recording apart from real delivery via the `delivered` field.
+      outputJson(formatSuccess({
+        tool,
+        status: 'recorded',
+        delivered: false,
         latency_ms: latency,
         trace_id: trace.traceId
       }));
@@ -310,6 +335,13 @@ async function testCommand(toolName: string | undefined, options: ObservabilityO
     } else if (delivered) {
       await pretty.plain(`\n  ✅ Test Passed`);
       await pretty.plain(`  Tool: ${tool}`);
+      await pretty.plain(`  Delivered: ✅ sent to ${tool}`);
+      await pretty.plain(`  Latency: ${latency}ms`);
+      await pretty.dim(`  Trace ID: ${trace.traceId}`);
+    } else if (isLocalRecorder) {
+      await pretty.plain(`\n  ✅ Test Passed`);
+      await pretty.plain(`  Tool: ${tool}`);
+      await pretty.plain(`  Recorded in memory (built-in). Nothing is sent to an external backend.`);
       await pretty.plain(`  Latency: ${latency}ms`);
       await pretty.dim(`  Trace ID: ${trace.traceId}`);
     } else {

--- a/src/praisonai-ts/src/cli/commands/observability.ts
+++ b/src/praisonai-ts/src/cli/commands/observability.ts
@@ -108,6 +108,7 @@ async function listProvidersCommand(options: ObservabilityOptions, outputFormat:
     package: tool.package,
     envKey: tool.envKey,
     hasEnvKey: hasObservabilityToolEnvVar(tool.name),
+    delivers: tool.delivers,
     features: tool.features
   }));
 
@@ -134,9 +135,10 @@ async function listProvidersCommand(options: ObservabilityOptions, outputFormat:
 
     await pretty.plain('\n  External Integrations:');
     for (const p of external) {
-      const status = p.hasEnvKey ? '✅' : '⚠️';
+      const status = !p.delivers ? '❌' : (p.hasEnvKey ? '✅' : '⚠️');
       const keyInfo = p.envKey ? ` (${p.envKey})` : '';
-      await pretty.plain(`    ${status} ${p.name.padEnd(12)} ${p.description}${options.verbose ? keyInfo : ''}`);
+      const note = p.delivers ? '' : '  [no delivery - in-memory only]';
+      await pretty.plain(`    ${status} ${p.name.padEnd(12)} ${p.description}${options.verbose ? keyInfo : ''}${note}`);
     }
 
     await pretty.newline();
@@ -155,10 +157,12 @@ async function doctorCommand(toolName: string | undefined, options: Observabilit
       name: tool.name,
       envKey: tool.envKey,
       hasKey: hasObservabilityToolEnvVar(tool.name),
+      delivers: tool.delivers,
       package: tool.package
     }));
 
-    const ready = results.filter(r => r.hasKey);
+    // "Ready" must mean traces will actually arrive, not merely that a key is set.
+    const ready = results.filter(r => r.hasKey && (r.delivers || !r.envKey));
 
     if (outputFormat === 'json') {
       outputJson(formatSuccess({
@@ -210,17 +214,26 @@ async function doctorCommand(toolName: string | undefined, options: Observabilit
       package: tool.package,
       description: tool.description,
       features: tool.features,
-      status: hasKey || !tool.envKey ? 'ready' : 'missing_key'
+      delivers: tool.delivers,
+      status: !tool.delivers && tool.envKey
+        ? 'not_implemented'
+        : (hasKey || !tool.envKey ? 'ready' : 'missing_key')
     }));
   } else {
     await pretty.heading(`Observability Doctor: ${tool.name}`);
     await pretty.plain(`  Description: ${tool.description}`);
+    if (!tool.delivers && tool.envKey) {
+      await pretty.plain(`  Delivery: ❌ NOT IMPLEMENTED - traces are kept in memory and never sent to ${tool.name}.`);
+      await pretty.plain(`            Setting ${tool.envKey} will not change this.`);
+    } else if (tool.delivers) {
+      await pretty.plain(`  Delivery: ✅ Implemented`);
+    }
     if (tool.package) {
       await pretty.plain(`  Package: ${tool.package}`);
     }
     if (tool.envKey) {
       await pretty.plain(`  Environment Variable: ${tool.envKey}`);
-      await pretty.plain(`  Status: ${hasKey ? '✅ Ready' : '❌ Missing API Key'}`);
+      await pretty.plain(`  Status: ${!tool.delivers ? '❌ Not Implemented' : (hasKey ? '✅ Ready' : '❌ Missing API Key')}`);
       if (hasKey) {
         await pretty.dim(`  Key Preview: ${maskedKey}`);
       } else {
@@ -274,17 +287,36 @@ async function testCommand(toolName: string | undefined, options: ObservabilityO
     await adapter.flush();
 
     const latency = Date.now() - startTime;
+    // The trace above always succeeds locally. What matters is whether the
+    // adapter could deliver it; reporting "passed" regardless would be a lie.
+    const delivered = adapter.isEnabled;
 
-    if (outputFormat === 'json') {
+    if (outputFormat === 'json' && delivered) {
       outputJson(formatSuccess({
         tool,
         status: 'success',
+        delivered: true,
         latency_ms: latency,
         trace_id: trace.traceId
       }));
-    } else {
+    } else if (outputFormat === 'json') {
+      // success:false matters here. A CI script doing `... --json | jq .success`
+      // must not be told the tool works when nothing was delivered.
+      outputJson(formatError(
+        ERROR_CODES.RUNTIME_ERROR,
+        `The "${tool}" adapter recorded the trace in memory but did not send it anywhere. This integration has no delivery implementation.`,
+        { tool, status: 'not_delivered', delivered: false, latency_ms: latency, trace_id: trace.traceId }
+      ));
+    } else if (delivered) {
       await pretty.plain(`\n  ✅ Test Passed`);
       await pretty.plain(`  Tool: ${tool}`);
+      await pretty.plain(`  Latency: ${latency}ms`);
+      await pretty.dim(`  Trace ID: ${trace.traceId}`);
+    } else {
+      await pretty.plain(`\n  ⚠️  Not Delivered`);
+      await pretty.plain(`  Tool: ${tool}`);
+      await pretty.plain(`  The trace was recorded in memory but NOT sent to ${tool}.`);
+      await pretty.plain(`  This integration has no delivery implementation (isEnabled is false).`);
       await pretty.plain(`  Latency: ${latency}ms`);
       await pretty.dim(`  Trace ID: ${trace.traceId}`);
     }

--- a/src/praisonai-ts/src/observability/adapters/external/arize.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/arize.ts
@@ -1,23 +1,15 @@
 /**
  * Arize (Phoenix) Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Arize (Phoenix). It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class ArizeObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'arize';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'arize' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class ArizeObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('arize', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/axiom.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/axiom.ts
@@ -1,23 +1,15 @@
 /**
  * Axiom Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Axiom. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class AxiomObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'axiom';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'axiom' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class AxiomObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('axiom', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/braintrust.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/braintrust.ts
@@ -1,23 +1,15 @@
 /**
  * Braintrust Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Braintrust. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class BraintrustObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'braintrust';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'braintrust' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class BraintrustObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('braintrust', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/helicone.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/helicone.ts
@@ -1,23 +1,15 @@
 /**
  * Helicone Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Helicone. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class HeliconeObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'helicone';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'helicone' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class HeliconeObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('helicone', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/laminar.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/laminar.ts
@@ -1,23 +1,15 @@
 /**
  * Laminar Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Laminar. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class LaminarObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'laminar';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'laminar' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class LaminarObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('laminar', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/langfuse.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/langfuse.ts
@@ -74,6 +74,11 @@ export class LangfuseObservabilityAdapter implements ObservabilityAdapter {
   async shutdown(): Promise<void> {
     if (this.client) {
       await this.client.shutdownAsync();
+      // Clearing the client is what makes isEnabled report false again: a shut
+      // adapter has no live transport, so it must not keep claiming delivery.
+      // The factory caches adapters, so a stale non-null client here would let
+      // a reused instance advertise a terminated connection as enabled.
+      this.client = null;
     }
   }
   

--- a/src/praisonai-ts/src/observability/adapters/external/langfuse.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/langfuse.ts
@@ -28,7 +28,21 @@ type LangfuseClient = {
  */
 export class LangfuseObservabilityAdapter implements ObservabilityAdapter {
   readonly name = 'langfuse';
-  readonly isEnabled = true;
+
+  /**
+   * Langfuse is the one external adapter with real delivery, but delivery only
+   * happens once initialize() has successfully constructed a client from the
+   * optional `langfuse` SDK. Until then (and forever, if the SDK is not
+   * installed) every span goes to the in-memory adapter and nowhere else, so
+   * `isEnabled` is derived from the live client rather than hardcoded true.
+   */
+  get isEnabled(): boolean {
+    return this.client != null;
+  }
+
+  /** This adapter can deliver, unlike the adapters in ./undelivered.ts. */
+  readonly delivers: boolean = true;
+
   
   private client: any;
   private memory: MemoryObservabilityAdapter;
@@ -196,6 +210,13 @@ export class LangfuseObservabilityAdapter implements ObservabilityAdapter {
   async flush(): Promise<void> {
     if (this.client) {
       await this.client.flushAsync();
+      return;
     }
+    // No client means nothing was ever sent. Resolving quietly here would
+    // promise a delivery that did not happen.
+    console.warn(
+      '[OBSERVABILITY] flush() on the "langfuse" adapter delivered nothing: the langfuse SDK is not ' +
+        'available, so no client was created. Install it with: npm install langfuse'
+    );
   }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/langsmith.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/langsmith.ts
@@ -1,71 +1,21 @@
 /**
  * LangSmith Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to LangSmith. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
+ *
+ * NOTE: an earlier version of this adapter dynamically imported the `langsmith`
+ * SDK in initialize() and constructed a Client. That client was assigned to a
+ * private field and then never read by any other method, so no run was ever
+ * created or posted. The import has been removed rather than left in place,
+ * because it made the adapter look wired up when it was not.
  */
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-import type { 
-  ObservabilityAdapter, 
-  TraceContext, 
-  SpanContext, 
-  SpanKind, 
-  SpanStatus,
-  AttributionContext,
-  ProviderMetadata,
-  ObservabilityToolConfig
-} from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
-
-export class LangSmithObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'langsmith';
-  readonly isEnabled = true;
-  
-  private client: any;
-  private memory: MemoryObservabilityAdapter;
-  private config: ObservabilityToolConfig;
-  
+export class LangSmithObservabilityAdapter extends UndeliveredObservabilityAdapter {
   constructor(config?: ObservabilityToolConfig) {
-    this.config = config || { name: 'langsmith' };
-    this.memory = new MemoryObservabilityAdapter();
+    super('langsmith', config);
   }
-  
-  async initialize(): Promise<void> {
-    try {
-      // Dynamic import for optional dependency
-      const langsmithModule = await import('langsmith' as string);
-      const Client = langsmithModule.Client || langsmithModule.default;
-      this.client = new Client({
-        apiKey: this.config.apiKey || process.env.LANGCHAIN_API_KEY,
-        apiUrl: this.config.baseUrl,
-      });
-    } catch {
-      this.client = null;
-    }
-  }
-  
-  async shutdown(): Promise<void> {}
-  
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext {
-    return this.memory.startTrace(name, metadata, attribution);
-  }
-  
-  endTrace(traceId: string, status?: SpanStatus): void {
-    this.memory.endTrace(traceId, status);
-  }
-  
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext {
-    return this.memory.startSpan(traceId, name, kind, parentId);
-  }
-  
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void {
-    this.memory.endSpan(spanId, status, attributes);
-  }
-  
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void {
-    this.memory.addEvent(spanId, name, attributes);
-  }
-  
-  recordError(spanId: string, error: Error): void {
-    this.memory.recordError(spanId, error);
-  }
-  
-  async flush(): Promise<void> {}
 }

--- a/src/praisonai-ts/src/observability/adapters/external/langwatch.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/langwatch.ts
@@ -1,23 +1,15 @@
 /**
  * LangWatch Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to LangWatch. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class LangWatchObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'langwatch';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'langwatch' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class LangWatchObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('langwatch', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/maxim.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/maxim.ts
@@ -1,23 +1,15 @@
 /**
  * Maxim Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Maxim. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class MaximObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'maxim';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'maxim' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class MaximObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('maxim', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/patronus.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/patronus.ts
@@ -1,23 +1,15 @@
 /**
  * Patronus Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Patronus. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class PatronusObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'patronus';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'patronus' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class PatronusObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('patronus', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/scorecard.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/scorecard.ts
@@ -1,23 +1,15 @@
 /**
  * Scorecard Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Scorecard. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class ScorecardObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'scorecard';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'scorecard' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class ScorecardObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('scorecard', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/signoz.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/signoz.ts
@@ -1,23 +1,20 @@
 /**
- * SigNoz Observability Adapter (OpenTelemetry)
+ * SigNoz Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to SigNoz. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
+ *
+ * NOTE: SigNoz ingests OpenTelemetry. This package depends on
+ * `@opentelemetry/api` only, which is the instrumentation API and carries no
+ * SDK, no span processor and no exporter, so it cannot ship spans anywhere on
+ * its own. Real delivery needs an OTLP exporter dependency.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class SigNozObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'signoz';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'signoz' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class SigNozObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('signoz', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/traceloop.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/traceloop.ts
@@ -1,23 +1,15 @@
 /**
- * Traceloop Observability Adapter (OpenLLMetry)
+ * Traceloop Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Traceloop. It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class TraceloopObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'traceloop';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'traceloop' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class TraceloopObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('traceloop', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/external/undelivered.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/undelivered.ts
@@ -1,0 +1,109 @@
+/**
+ * Base class for observability adapters whose vendor delivery is NOT implemented.
+ *
+ * These adapters accept traces and spans and record them in memory so that
+ * enabling one never breaks a running application. They do NOT send anything
+ * to the vendor: no network call, no API key is read, no endpoint is contacted.
+ *
+ * Because they cannot deliver, they MUST report `isEnabled === false`. An
+ * adapter that reports itself enabled while discarding every span is worse
+ * than one that is absent, because the user believes their traces are safe.
+ *
+ * If you implement real delivery for one of these vendors, stop extending this
+ * class: give the adapter its own `isEnabled` derived from whether the
+ * transport is actually live (see `LangfuseObservabilityAdapter`).
+ */
+import type {
+  ObservabilityAdapter,
+  TraceContext,
+  SpanContext,
+  SpanKind,
+  SpanStatus,
+  AttributionContext,
+  ObservabilityToolConfig
+} from '../../types';
+import { MemoryObservabilityAdapter } from '../memory';
+
+/** Emitted on construction and on flush() so the deception is visible at runtime. */
+export const UNDELIVERED_WARNING_PREFIX = '[OBSERVABILITY]';
+
+export abstract class UndeliveredObservabilityAdapter implements ObservabilityAdapter {
+  readonly name: string;
+
+  /**
+   * Typed as `boolean` rather than the literal `false` on purpose: a subclass
+   * that wrongly sets this to `true` must still compile, so that the test
+   * suite is what catches it rather than a type error that is easy to
+   * silence with a cast.
+   */
+  readonly isEnabled: boolean = false;
+
+  /** Explicit, machine-readable statement that traces never reach the vendor. */
+  readonly delivers: boolean = false;
+
+  protected memory = new MemoryObservabilityAdapter();
+  protected config: ObservabilityToolConfig;
+  private warned = false;
+
+  constructor(vendor: string, config?: ObservabilityToolConfig) {
+    this.name = vendor;
+    this.config = config || { name: vendor };
+    this.warnNotDelivered();
+  }
+
+  /** Warns once per instance that this adapter cannot deliver traces. */
+  protected warnNotDelivered(): void {
+    if (this.warned) return;
+    this.warned = true;
+    console.warn(
+      `${UNDELIVERED_WARNING_PREFIX} The "${this.name}" adapter does not send traces to ${this.name}. ` +
+        `Delivery is not implemented: traces are held in memory only and are lost when the process exits. ` +
+        `isEnabled is false for this reason. Use the "langfuse" adapter, or the built-in "console"/"memory" ` +
+        `adapters, if you need trace output.`
+    );
+  }
+
+  async initialize(): Promise<void> {
+    this.warnNotDelivered();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.memory.shutdown();
+  }
+
+  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext {
+    return this.memory.startTrace(name, metadata, attribution);
+  }
+
+  endTrace(traceId: string, status?: SpanStatus): void {
+    this.memory.endTrace(traceId, status);
+  }
+
+  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext {
+    return this.memory.startSpan(traceId, name, kind, parentId);
+  }
+
+  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void {
+    this.memory.endSpan(spanId, status, attributes);
+  }
+
+  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void {
+    this.memory.addEvent(spanId, name, attributes);
+  }
+
+  recordError(spanId: string, error: Error): void {
+    this.memory.recordError(spanId, error);
+  }
+
+  /**
+   * MUST NOT resolve silently. flush() is the call a user makes to guarantee
+   * delivery before exit; resolving quietly would promise exactly the thing
+   * this adapter cannot do.
+   */
+  async flush(): Promise<void> {
+    console.warn(
+      `${UNDELIVERED_WARNING_PREFIX} flush() on the "${this.name}" adapter delivered nothing. ` +
+        `This adapter has no vendor transport; recorded spans are discarded.`
+    );
+  }
+}

--- a/src/praisonai-ts/src/observability/adapters/external/weave.ts
+++ b/src/praisonai-ts/src/observability/adapters/external/weave.ts
@@ -1,23 +1,15 @@
 /**
  * Weave (Weights & Biases) Observability Adapter
+ *
+ * DELIVERY IS NOT IMPLEMENTED. This adapter records traces in memory and sends
+ * nothing to Weave (Weights & Biases). It therefore reports `isEnabled === false` and warns on
+ * construction; see `./undelivered.ts` for the rationale.
  */
-import type { ObservabilityAdapter, TraceContext, SpanContext, SpanKind, SpanStatus, AttributionContext, ObservabilityToolConfig } from '../../types';
-import { MemoryObservabilityAdapter } from '../memory';
+import type { ObservabilityToolConfig } from '../../types';
+import { UndeliveredObservabilityAdapter } from './undelivered';
 
-export class WeaveObservabilityAdapter implements ObservabilityAdapter {
-  readonly name = 'weave';
-  readonly isEnabled = true;
-  private memory = new MemoryObservabilityAdapter();
-  private config: ObservabilityToolConfig;
-  
-  constructor(config?: ObservabilityToolConfig) { this.config = config || { name: 'weave' }; }
-  async initialize(): Promise<void> {}
-  async shutdown(): Promise<void> {}
-  startTrace(name: string, metadata?: Record<string, unknown>, attribution?: AttributionContext): TraceContext { return this.memory.startTrace(name, metadata, attribution); }
-  endTrace(traceId: string, status?: SpanStatus): void { this.memory.endTrace(traceId, status); }
-  startSpan(traceId: string, name: string, kind: SpanKind, parentId?: string): SpanContext { return this.memory.startSpan(traceId, name, kind, parentId); }
-  endSpan(spanId: string, status?: SpanStatus, attributes?: Record<string, unknown>): void { this.memory.endSpan(spanId, status, attributes); }
-  addEvent(spanId: string, name: string, attributes?: Record<string, unknown>): void { this.memory.addEvent(spanId, name, attributes); }
-  recordError(spanId: string, error: Error): void { this.memory.recordError(spanId, error); }
-  async flush(): Promise<void> {}
+export class WeaveObservabilityAdapter extends UndeliveredObservabilityAdapter {
+  constructor(config?: ObservabilityToolConfig) {
+    super('weave', config);
+  }
 }

--- a/src/praisonai-ts/src/observability/adapters/index.ts
+++ b/src/praisonai-ts/src/observability/adapters/index.ts
@@ -57,6 +57,16 @@ export async function createObservabilityAdapter(
   
   let adapter: ObservabilityAdapter;
   
+  // Vendors with no delivery implementation. These construct an adapter that
+  // records to memory, reports isEnabled === false and warns on construction.
+  const undelivered = UNDELIVERED_ADAPTER_LOADERS[name as string];
+  if (undelivered) {
+    adapter = new (await undelivered())(config);
+    await adapter.initialize?.();
+    adapterCache.set(cacheKey, adapter);
+    return adapter;
+  }
+  
   switch (name) {
     case 'noop':
       adapter = noopAdapter;
@@ -72,58 +82,6 @@ export async function createObservabilityAdapter(
       
     case 'langfuse':
       adapter = await createLangfuseAdapter(config);
-      break;
-      
-    case 'langsmith':
-      adapter = await createLangSmithAdapter(config);
-      break;
-      
-    case 'langwatch':
-      adapter = await createLangWatchAdapter(config);
-      break;
-      
-    case 'arize':
-      adapter = await createArizeAdapter(config);
-      break;
-      
-    case 'axiom':
-      adapter = await createAxiomAdapter(config);
-      break;
-      
-    case 'braintrust':
-      adapter = await createBraintrustAdapter(config);
-      break;
-      
-    case 'helicone':
-      adapter = await createHeliconeAdapter(config);
-      break;
-      
-    case 'laminar':
-      adapter = await createLaminarAdapter(config);
-      break;
-      
-    case 'maxim':
-      adapter = await createMaximAdapter(config);
-      break;
-      
-    case 'patronus':
-      adapter = await createPatronusAdapter(config);
-      break;
-      
-    case 'scorecard':
-      adapter = await createScorecardAdapter(config);
-      break;
-      
-    case 'signoz':
-      adapter = await createSigNozAdapter(config);
-      break;
-      
-    case 'traceloop':
-      adapter = await createTraceloopAdapter(config);
-      break;
-      
-    case 'weave':
-      adapter = await createWeaveAdapter(config);
       break;
       
     default:
@@ -150,146 +108,48 @@ export function clearAdapterCache(): void {
 }
 
 // ============================================================================
-// Lazy-loaded external adapter factories
-// These create wrapper adapters that delegate to external SDKs
+// External adapter factories
 // ============================================================================
+
+/**
+ * Vendors whose adapters do NOT deliver traces anywhere.
+ *
+ * Each entry constructs an adapter that records spans in memory, reports
+ * `isEnabled === false` and warns on construction. They are listed here rather
+ * than given individual factory functions because there is nothing
+ * vendor-specific left to do: none of them contacts its vendor.
+ *
+ * When you implement real delivery for one of these, remove it from this table
+ * and give it its own factory alongside `createLangfuseAdapter`.
+ */
+type ExternalAdapterCtor = new (config?: ObservabilityToolConfig) => ObservabilityAdapter;
+
+const UNDELIVERED_ADAPTER_LOADERS: Record<string, () => Promise<ExternalAdapterCtor>> = {
+  langsmith: async () => (await import('./external/langsmith')).LangSmithObservabilityAdapter,
+  langwatch: async () => (await import('./external/langwatch')).LangWatchObservabilityAdapter,
+  arize: async () => (await import('./external/arize')).ArizeObservabilityAdapter,
+  axiom: async () => (await import('./external/axiom')).AxiomObservabilityAdapter,
+  braintrust: async () => (await import('./external/braintrust')).BraintrustObservabilityAdapter,
+  helicone: async () => (await import('./external/helicone')).HeliconeObservabilityAdapter,
+  laminar: async () => (await import('./external/laminar')).LaminarObservabilityAdapter,
+  maxim: async () => (await import('./external/maxim')).MaximObservabilityAdapter,
+  patronus: async () => (await import('./external/patronus')).PatronusObservabilityAdapter,
+  scorecard: async () => (await import('./external/scorecard')).ScorecardObservabilityAdapter,
+  signoz: async () => (await import('./external/signoz')).SigNozObservabilityAdapter,
+  traceloop: async () => (await import('./external/traceloop')).TraceloopObservabilityAdapter,
+  weave: async () => (await import('./external/weave')).WeaveObservabilityAdapter,
+};
 
 async function createLangfuseAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
   try {
     const { LangfuseObservabilityAdapter } = await import('./external/langfuse');
     return new LangfuseObservabilityAdapter(config);
   } catch (error) {
-    console.warn('Langfuse not available, using memory adapter. Install with: npm install langfuse');
+    // This only fires if the local module itself fails to load. Whether the
+    // optional `langfuse` SDK is installed is decided in initialize(), which
+    // is what makes the adapter report isEnabled true or false.
+    console.warn('[OBSERVABILITY] Failed to load the langfuse adapter module, falling back to the memory adapter (traces are not delivered).');
     return new MemoryObservabilityAdapter();
   }
 }
 
-async function createLangSmithAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { LangSmithObservabilityAdapter } = await import('./external/langsmith');
-    return new LangSmithObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('LangSmith not available, using memory adapter. Install with: npm install langsmith');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createLangWatchAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { LangWatchObservabilityAdapter } = await import('./external/langwatch');
-    return new LangWatchObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('LangWatch not available, using memory adapter. Install with: npm install langwatch');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createArizeAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { ArizeObservabilityAdapter } = await import('./external/arize');
-    return new ArizeObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Arize not available, using memory adapter. Install with: npm install @arizeai/openinference-core');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createAxiomAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { AxiomObservabilityAdapter } = await import('./external/axiom');
-    return new AxiomObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Axiom not available, using memory adapter. Install with: npm install @axiomhq/js');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createBraintrustAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { BraintrustObservabilityAdapter } = await import('./external/braintrust');
-    return new BraintrustObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Braintrust not available, using memory adapter. Install with: npm install braintrust');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createHeliconeAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { HeliconeObservabilityAdapter } = await import('./external/helicone');
-    return new HeliconeObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Helicone not available, using memory adapter. Install with: npm install @helicone/helicone');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createLaminarAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { LaminarObservabilityAdapter } = await import('./external/laminar');
-    return new LaminarObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Laminar not available, using memory adapter. Install with: npm install @lmnr-ai/lmnr');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createMaximAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { MaximObservabilityAdapter } = await import('./external/maxim');
-    return new MaximObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Maxim not available, using memory adapter. Install with: npm install @maximai/maxim-js');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createPatronusAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { PatronusObservabilityAdapter } = await import('./external/patronus');
-    return new PatronusObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Patronus not available, using memory adapter. Install with: npm install patronus');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createScorecardAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { ScorecardObservabilityAdapter } = await import('./external/scorecard');
-    return new ScorecardObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Scorecard not available, using memory adapter. Install with: npm install @scorecard-ai/sdk');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createSigNozAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { SigNozObservabilityAdapter } = await import('./external/signoz');
-    return new SigNozObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('SigNoz not available, using memory adapter. Install with: npm install @opentelemetry/api');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createTraceloopAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { TraceloopObservabilityAdapter } = await import('./external/traceloop');
-    return new TraceloopObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Traceloop not available, using memory adapter. Install with: npm install @traceloop/node-server-sdk');
-    return new MemoryObservabilityAdapter();
-  }
-}
-
-async function createWeaveAdapter(config?: ObservabilityToolConfig): Promise<ObservabilityAdapter> {
-  try {
-    const { WeaveObservabilityAdapter } = await import('./external/weave');
-    return new WeaveObservabilityAdapter(config);
-  } catch (error) {
-    console.warn('Weave not available, using memory adapter. Install with: npm install weave');
-    return new MemoryObservabilityAdapter();
-  }
-}

--- a/src/praisonai-ts/src/observability/index.ts
+++ b/src/praisonai-ts/src/observability/index.ts
@@ -1,19 +1,31 @@
 /**
  * Observability Module - Unified tracing, logging, and metrics
  * 
- * Supports 14+ observability integrations:
- * - Langfuse, LangSmith, LangWatch
- * - Arize AX, Axiom, Braintrust
- * - Helicone, Laminar, Maxim
- * - Patronus, Scorecard, SigNoz
- * - Traceloop, Weave
+ * Delivery status, as of this version:
+ *
+ * - Langfuse   - delivers, via the optional `langfuse` SDK. `isEnabled` is true
+ *                only once initialize() has built a client from that SDK.
+ * - console    - prints traces locally (built-in).
+ * - memory     - keeps traces in process (built-in).
+ * - noop       - discards everything, and says so (`isEnabled === false`).
+ *
+ * LangSmith, LangWatch, Arize, Axiom, Braintrust, Helicone, Laminar, Maxim,
+ * Patronus, Scorecard, SigNoz, Traceloop and Weave have adapter shells but NO
+ * delivery: they record spans in memory and send nothing to the vendor. They
+ * report `isEnabled === false`, warn on construction, and warn again on
+ * flush(). Do not rely on them to get traces off the machine. See
+ * `adapters/external/undelivered.ts`.
  * 
  * @example Basic usage
  * ```typescript
  * import { createObservabilityAdapter, setObservabilityAdapter } from 'praisonai';
  * 
- * // Enable observability
+ * // Enable observability. Always check isEnabled: an adapter with no delivery
+ * // implementation reports false and will not send your traces anywhere.
  * const adapter = await createObservabilityAdapter('langfuse');
+ * if (!adapter.isEnabled) {
+ *   console.warn('traces will stay in memory only');
+ * }
  * setObservabilityAdapter(adapter);
  * 
  * // Use with agents

--- a/src/praisonai-ts/src/observability/types.ts
+++ b/src/praisonai-ts/src/observability/types.ts
@@ -108,7 +108,21 @@ export interface TraceContext {
  */
 export interface ObservabilityAdapter {
   readonly name: string;
+
+  /**
+   * Whether this adapter can currently deliver traces to its backend.
+   *
+   * MUST be false when the adapter cannot deliver - including when delivery is
+   * simply not implemented. Reporting true while discarding spans is worse
+   * than having no integration at all, because callers stop looking.
+   */
   readonly isEnabled: boolean;
+
+  /**
+   * Whether this adapter has a delivery implementation at all, independent of
+   * configuration. Absent is treated as false by callers that check it.
+   */
+  readonly delivers?: boolean;
   
   // Lifecycle
   initialize?(): Promise<void>;
@@ -174,6 +188,11 @@ export interface ObservabilityToolInfo {
   package?: string;
   envKey: string;
   description: string;
+  /**
+   * Whether traces actually reach this tool's backend. False means the adapter
+   * records spans in memory and sends nothing, no matter how it is configured.
+   */
+  delivers: boolean;
   features: {
     traces: boolean;
     spans: boolean;
@@ -194,6 +213,7 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: 'langfuse',
     envKey: 'LANGFUSE_SECRET_KEY',
     description: 'Langfuse observability platform',
+    delivers: true,
     features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
     docsUrl: 'https://langfuse.com/docs'
   },
@@ -202,7 +222,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: 'langsmith',
     envKey: 'LANGCHAIN_API_KEY',
     description: 'LangSmith by LangChain',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://docs.smith.langchain.com'
   },
   langwatch: {
@@ -210,7 +231,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: 'langwatch',
     envKey: 'LANGWATCH_API_KEY',
     description: 'LangWatch monitoring',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://docs.langwatch.ai'
   },
   arize: {
@@ -218,7 +240,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: '@arizeai/openinference-core',
     envKey: 'ARIZE_API_KEY',
     description: 'Arize AX (Phoenix)',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://docs.arize.com'
   },
   axiom: {
@@ -226,7 +249,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: '@axiomhq/js',
     envKey: 'AXIOM_TOKEN',
     description: 'Axiom logging and analytics',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://axiom.co/docs'
   },
   braintrust: {
@@ -234,7 +258,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: 'braintrust',
     envKey: 'BRAINTRUST_API_KEY',
     description: 'Braintrust AI evaluation',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://www.braintrust.dev/docs'
   },
   helicone: {
@@ -242,7 +267,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: '@helicone/helicone',
     envKey: 'HELICONE_API_KEY',
     description: 'Helicone observability proxy',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://docs.helicone.ai'
   },
   laminar: {
@@ -250,7 +276,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: '@lmnr-ai/lmnr',
     envKey: 'LMNR_PROJECT_API_KEY',
     description: 'Laminar AI observability',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://docs.lmnr.ai'
   },
   maxim: {
@@ -258,7 +285,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: '@maximai/maxim-js',
     envKey: 'MAXIM_API_KEY',
     description: 'Maxim AI testing',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://docs.getmaxim.ai'
   },
   patronus: {
@@ -266,7 +294,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: 'patronus',
     envKey: 'PATRONUS_API_KEY',
     description: 'Patronus AI evaluation',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://docs.patronus.ai'
   },
   scorecard: {
@@ -274,7 +303,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: '@scorecard-ai/sdk',
     envKey: 'SCORECARD_API_KEY',
     description: 'Scorecard AI testing',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://docs.getscorecard.ai'
   },
   signoz: {
@@ -282,7 +312,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: '@opentelemetry/api',
     envKey: 'SIGNOZ_ACCESS_TOKEN',
     description: 'SigNoz OpenTelemetry',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://signoz.io/docs'
   },
   traceloop: {
@@ -290,7 +321,8 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: '@traceloop/node-server-sdk',
     envKey: 'TRACELOOP_API_KEY',
     description: 'Traceloop OpenLLMetry',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://traceloop.com/docs'
   },
   weave: {
@@ -298,25 +330,29 @@ export const OBSERVABILITY_TOOLS: Record<ObservabilityToolName, ObservabilityToo
     package: 'weave',
     envKey: 'WANDB_API_KEY',
     description: 'Weights & Biases Weave',
-    features: { traces: true, spans: true, events: true, errors: true, metrics: true, export: true },
+    delivers: false,
+    features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false },
     docsUrl: 'https://wandb.ai/site/weave'
   },
   console: {
     name: 'console',
     envKey: '',
     description: 'Console logging (built-in)',
+    delivers: false,
     features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false }
   },
   memory: {
     name: 'memory',
     envKey: '',
     description: 'In-memory storage (built-in)',
+    delivers: false,
     features: { traces: true, spans: true, events: true, errors: true, metrics: false, export: false }
   },
   noop: {
     name: 'noop',
     envKey: '',
     description: 'No-op adapter (disabled)',
+    delivers: false,
     features: { traces: false, spans: false, events: false, errors: false, metrics: false, export: false }
   }
 };

--- a/src/praisonai-ts/tests/unit/observability/external-adapters.test.ts
+++ b/src/praisonai-ts/tests/unit/observability/external-adapters.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Honesty gates for the external observability adapters.
+ *
+ * The defect these guard against: an adapter that accepts every trace and span,
+ * discards all of it, and still reports `isEnabled === true`. A user who checks
+ * `isEnabled`, or who calls `flush()` before exit, is told everything is fine
+ * while nothing leaves the process.
+ *
+ * These tests DISCOVER adapters from the filesystem rather than naming them, so
+ * a fifteenth adapter dropped into adapters/external/ is covered on the day it
+ * is added.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { OBSERVABILITY_TOOLS, type ObservabilityAdapter, type ObservabilityToolName } from '../../../src/observability/types';
+
+const EXTERNAL_DIR = path.join(__dirname, '../../../src/observability/adapters/external');
+
+/** Not an adapter: the shared base class the non-delivering adapters extend. */
+const NON_ADAPTER_MODULES = new Set(['undelivered']);
+
+interface DiscoveredAdapter {
+  /** module basename, e.g. "weave" */
+  module: string;
+  /** exported class name, e.g. "WeaveObservabilityAdapter" */
+  className: string;
+  ctor: new (config?: any) => ObservabilityAdapter;
+}
+
+function discoverExternalAdapters(): DiscoveredAdapter[] {
+  const files = fs
+    .readdirSync(EXTERNAL_DIR)
+    .filter(f => f.endsWith('.ts') && !f.endsWith('.d.ts'))
+    .map(f => f.replace(/\.ts$/, ''))
+    .filter(m => !NON_ADAPTER_MODULES.has(m))
+    .sort();
+
+  const found: DiscoveredAdapter[] = [];
+  for (const module of files) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require(path.join(EXTERNAL_DIR, module));
+    for (const [className, exported] of Object.entries(mod)) {
+      if (typeof exported === 'function' && /ObservabilityAdapter$/.test(className)) {
+        found.push({ module, className, ctor: exported as DiscoveredAdapter['ctor'] });
+      }
+    }
+  }
+  return found;
+}
+
+const adapters = discoverExternalAdapters();
+
+describe('external observability adapters (discovered from disk)', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('discovers every adapter module on disk', () => {
+    // Sanity check on the discovery mechanism itself: if this silently found
+    // nothing, every other test in this file would vacuously pass.
+    expect(adapters.length).toBeGreaterThanOrEqual(14);
+    expect(adapters.map(a => a.module)).toContain('weave');
+    expect(adapters.map(a => a.module)).toContain('langfuse');
+  });
+
+  it('never reports isEnabled true before a transport has been established', () => {
+    // The universal invariant. A freshly constructed adapter has not connected
+    // to anything yet, so it cannot honestly claim to be enabled. An adapter
+    // with no delivery implementation at all never leaves this state.
+    for (const { className, ctor } of adapters) {
+      const adapter = new ctor();
+      expect(`${className}.isEnabled=${adapter.isEnabled}`).toBe(`${className}.isEnabled=false`);
+    }
+  });
+
+  it('reports isEnabled true after initialize() only if it can actually deliver', async () => {
+    for (const { className, module, ctor } of adapters) {
+      const adapter = new ctor();
+      await adapter.initialize?.();
+      if (adapter.isEnabled) {
+        const info = OBSERVABILITY_TOOLS[module as ObservabilityToolName];
+        expect(`${className} claims enabled; registry delivers=${info?.delivers}`).toBe(
+          `${className} claims enabled; registry delivers=true`
+        );
+      }
+    }
+  });
+
+  it('warns on construction when it has no delivery implementation', () => {
+    for (const { className, ctor } of adapters) {
+      warnSpy.mockClear();
+      const adapter = new ctor();
+      if (adapter.delivers) continue; // langfuse can deliver; it warns elsewhere
+      const messages = warnSpy.mock.calls.map(c => String(c[0])).join('\n');
+      expect(`${className}: ${messages.length > 0}`).toBe(`${className}: true`);
+      expect(messages.toLowerCase()).toContain(adapter.name.toLowerCase());
+      expect(messages.toLowerCase()).toContain('memory');
+    }
+  });
+
+  it('does not let flush() resolve silently when nothing was delivered', async () => {
+    // flush() is the call a user makes to guarantee delivery before exit.
+    // Resolving quietly is the whole defect, restated in one method.
+    let checked = 0;
+    for (const { className, ctor } of adapters) {
+      const adapter = new ctor();
+      await adapter.initialize?.();
+      if (adapter.isEnabled) continue; // a live transport may flush quietly
+      checked++;
+      warnSpy.mockClear();
+      await adapter.flush();
+      const messages = warnSpy.mock.calls.map(c => String(c[0])).join('\n');
+      expect(`${className} flush warned: ${warnSpy.mock.calls.length > 0}`).toBe(
+        `${className} flush warned: true`
+      );
+      expect(messages.toLowerCase()).toContain('flush');
+    }
+    // Anti-vacuity guard: if adapters wrongly report isEnabled true, the loop
+    // above skips them all and this test would pass without asserting anything.
+    // No vendor SDK is installed in the test environment, so nothing can
+    // legitimately be enabled here.
+    expect(`flush-checked ${checked}/${adapters.length}`).toBe(`flush-checked ${adapters.length}/${adapters.length}`);
+  });
+
+  it('still records spans in memory so enabling one never breaks an app', () => {
+    for (const { className, ctor } of adapters) {
+      const adapter = new ctor();
+      const trace = adapter.startTrace('t', { a: 1 });
+      const span = adapter.startSpan(trace.traceId, 's', 'llm');
+      expect(`${className} traceId set: ${Boolean(trace.traceId)}`).toBe(`${className} traceId set: true`);
+      expect(`${className} spanId set: ${Boolean(span.spanId)}`).toBe(`${className} spanId set: true`);
+      adapter.addEvent(span.spanId, 'e');
+      adapter.recordError(span.spanId, new Error('boom'));
+      adapter.endSpan(span.spanId, 'completed');
+      adapter.endTrace(trace.traceId, 'completed');
+    }
+  });
+
+  it('has a registry entry for every adapter found on disk', () => {
+    for (const { module, className } of adapters) {
+      const info = OBSERVABILITY_TOOLS[module as ObservabilityToolName];
+      expect(`${className} registered: ${Boolean(info)}`).toBe(`${className} registered: true`);
+      expect(typeof info.delivers).toBe('boolean');
+    }
+  });
+});
+
+describe('observability registry honesty', () => {
+  it('never advertises trace export for a tool that cannot deliver', () => {
+    for (const [name, info] of Object.entries(OBSERVABILITY_TOOLS)) {
+      if (!info.delivers) {
+        expect(`${name}.features.export=${info.features.export}`).toBe(`${name}.features.export=false`);
+      }
+    }
+  });
+
+  it('marks exactly the tools with a delivery implementation as delivering', () => {
+    const delivering = Object.values(OBSERVABILITY_TOOLS)
+      .filter(t => t.delivers)
+      .map(t => t.name)
+      .sort();
+    // Langfuse is the only external integration that actually posts anywhere.
+    // Adding a name here without implementing delivery re-introduces the bug.
+    expect(delivering).toEqual(['langfuse']);
+  });
+});
+
+describe('LangfuseObservabilityAdapter delivery state', () => {
+  it('is disabled while no client exists and enabled once one does', async () => {
+    const { LangfuseObservabilityAdapter } = require(path.join(EXTERNAL_DIR, 'langfuse'));
+    const adapter = new LangfuseObservabilityAdapter();
+    expect(adapter.isEnabled).toBe(false);
+    expect(adapter.delivers).toBe(true);
+
+    // Simulate a successfully constructed SDK client.
+    (adapter as any).client = { flushAsync: async () => {}, shutdownAsync: async () => {} };
+    expect(adapter.isEnabled).toBe(true);
+  });
+
+  it('warns on flush() when the SDK never produced a client', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { LangfuseObservabilityAdapter } = require(path.join(EXTERNAL_DIR, 'langfuse'));
+      const adapter = new LangfuseObservabilityAdapter();
+      await adapter.flush();
+      const messages = warnSpy.mock.calls.map(c => String(c[0])).join('\n');
+      expect(messages.toLowerCase()).toContain('delivered nothing');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('observability CLI reports delivery truthfully', () => {
+  let logSpy: any;
+  let warnSpy: any;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  function lastJson(): any {
+    const calls = logSpy.mock.calls.map((c: any[]) => String(c[0]));
+    return JSON.parse(calls[calls.length - 1]);
+  }
+
+  it('does not report a passing test for an adapter that delivered nothing', async () => {
+    const { execute } = require('../../../src/cli/commands/observability');
+    const { clearAdapterCache } = require('../../../src/observability/adapters');
+    clearAdapterCache();
+    process.env.WANDB_API_KEY = 'test-key-not-real';
+    try {
+      await execute(['test', 'weave'], { json: true });
+      const out = lastJson();
+      expect(out.success).toBe(false);
+      expect(out.error.details.delivered).toBe(false);
+      expect(out.error.details.status).toBe('not_delivered');
+    } finally {
+      delete process.env.WANDB_API_KEY;
+      clearAdapterCache();
+    }
+  });
+
+  it('does not report a non-delivering tool as ready even when its API key is set', async () => {
+    const { execute } = require('../../../src/cli/commands/observability');
+    process.env.WANDB_API_KEY = 'test-key-not-real';
+    try {
+      await execute(['doctor', 'weave'], { json: true });
+      const out = lastJson();
+      expect(out.data.delivers).toBe(false);
+      expect(out.data.status).toBe('not_implemented');
+    } finally {
+      delete process.env.WANDB_API_KEY;
+    }
+  });
+
+  it('never prints a Ready status for a non-delivering tool in human output', async () => {
+    // The pretty path is what a human actually reads; it must not contradict
+    // the JSON path by showing a green "Ready" for a tool that sends nothing.
+    const { execute } = require('../../../src/cli/commands/observability');
+    process.env.WANDB_API_KEY = 'test-key-not-real';
+    try {
+      await execute(['doctor', 'weave'], { output: 'pretty' });
+      const printed = logSpy.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+      expect(printed).toContain('Not Implemented');
+      expect(printed).not.toContain('Ready');
+    } finally {
+      delete process.env.WANDB_API_KEY;
+    }
+  });
+
+  it('still reports success for a built-in adapter that does what it claims', async () => {
+    const { execute } = require('../../../src/cli/commands/observability');
+    const { clearAdapterCache } = require('../../../src/observability/adapters');
+    clearAdapterCache();
+    await execute(['test', 'memory'], { json: true });
+    const out = lastJson();
+    expect(out.success).toBe(true);
+    expect(out.data.delivered).toBe(true);
+    clearAdapterCache();
+  });
+});

--- a/src/praisonai-ts/tests/unit/observability/external-adapters.test.ts
+++ b/src/praisonai-ts/tests/unit/observability/external-adapters.test.ts
@@ -186,6 +186,22 @@ describe('LangfuseObservabilityAdapter delivery state', () => {
     expect(adapter.isEnabled).toBe(true);
   });
 
+  it('reports disabled again after shutdown() so a reused instance never claims a dead transport', async () => {
+    const { LangfuseObservabilityAdapter } = require(path.join(EXTERNAL_DIR, 'langfuse'));
+    const adapter = new LangfuseObservabilityAdapter();
+    let shutdownCalled = false;
+    (adapter as any).client = {
+      flushAsync: async () => {},
+      shutdownAsync: async () => { shutdownCalled = true; }
+    };
+    expect(adapter.isEnabled).toBe(true);
+    await adapter.shutdown();
+    expect(shutdownCalled).toBe(true);
+    // The factory caches adapters; a stale client here would let the reused
+    // instance advertise a terminated connection as enabled.
+    expect(adapter.isEnabled).toBe(false);
+  });
+
   it('warns on flush() when the SDK never produced a client', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     try {
@@ -264,14 +280,19 @@ describe('observability CLI reports delivery truthfully', () => {
     }
   });
 
-  it('still reports success for a built-in adapter that does what it claims', async () => {
+  it('reports success for a built-in local recorder but does not claim delivery', async () => {
+    // The memory adapter does exactly what it claims — record in process — so
+    // the test passes. But it sends nothing anywhere, so `delivered` must be
+    // false: automation reading `delivered` must not mistake local recording
+    // for telemetry reaching an external backend.
     const { execute } = require('../../../src/cli/commands/observability');
     const { clearAdapterCache } = require('../../../src/observability/adapters');
     clearAdapterCache();
     await execute(['test', 'memory'], { json: true });
     const out = lastJson();
     expect(out.success).toBe(true);
-    expect(out.data.delivered).toBe(true);
+    expect(out.data.delivered).toBe(false);
+    expect(out.data.status).toBe('recorded');
     clearAdapterCache();
   });
 });


### PR DESCRIPTION
## The defect

`src/praisonai-ts/src/observability/adapters/external/` held 14 vendor adapters. Twelve were exactly 23 lines, LangSmith 71. Every one of them:

```ts
readonly isEnabled = true;                              // hardcoded
private memory = new MemoryObservabilityAdapter();
startTrace(...) { return this.memory.startTrace(...); } // every method -> in-memory
async flush(): Promise<void> {}                         // empty
```

No network call, no API key read, no endpoint. `arize, axiom, braintrust, helicone, laminar, langsmith, langwatch, maxim, patronus, scorecard, signoz, traceloop, weave` all reported themselves **enabled**, accepted every trace and span, and discarded the lot. A user who called `flush()` before exit got a resolved promise and nothing sent.

This is not a missing feature. It is a component that lies about its state, which is strictly worse than not shipping it.

Two adapters needed treatment different from the other twelve:

- **LangSmith** dynamically imported the `langsmith` SDK in `initialize()` and constructed a `Client` — then assigned it to a private field that **no other method ever read** (`grep -n 'this\.client' langsmith.ts` returns only the two assignment lines). It was a stub with decoration, not a partial implementation. The dead import is removed rather than left to imply wiring that was never there.
- **Langfuse**, the one adapter with real delivery, had the same bug in milder form: it hardcoded `isEnabled = true` even when the optional SDK was absent and `this.client` was null — the common case, since `langfuse` is not a dependency of this package.

## The decision, and why

**Route 1 (tell the truth) for all 13 non-delivering adapters; derived `isEnabled` for Langfuse.**

Implementing OTLP for the OTLP-compatible vendors was considered and rejected:

- This package depends on **`@opentelemetry/api` only** — the instrumentation API. It carries no SDK, no span processor and no exporter, and cannot ship a span anywhere. Notably, `@opentelemetry/api` is the very package the SigNoz registry entry advertises.
- Real delivery would mean adding exporter dependencies to a package that deliberately keeps them out, then shipping per-vendor endpoint paths and auth-header conventions for six services **that cannot be verified against the live backends from here**. A wrong header name yields an adapter that reports enabled and silently drops — the same defect, with more code and more confidence behind it.

Credential-derived enablement would have been the wrong fix for these 13: no value of `WANDB_API_KEY` can make an adapter with no transport deliver, so gating `isEnabled` on the env var just relocates the lie. Derivation is correct only where delivery exists, which is why Langfuse gets it and the others get a flat `false`.

## What changed

- **New `UndeliveredObservabilityAdapter` base** (`adapters/external/undelivered.ts`): `isEnabled = false`, warns on construction naming the adapter and stating traces are in-memory only, and `flush()` warns rather than resolving silently. The 13 adapters now extend it at ~15 lines each. They still record to memory, so enabling one never breaks a running app.
- **Langfuse**: `isEnabled` is now `get isEnabled() { return this.client != null; }`, and `flush()` warns when no client was ever created.
- **Registry**: `ObservabilityToolInfo` gains `delivers`; `features.export` corrected to `false` for every tool that cannot export (it was `true` for all 14).
- **CLI** (`observability` command) stopped lying:
  - `observability test weave --json` returned `{"success": true, "status": "success"}`. It now returns `success: false` with `status: "not_delivered"` — a CI script doing `| jq .success` must not be told the tool works.
  - `observability doctor weave` printed `Status: ✅ Ready` whenever `WANDB_API_KEY` was set. It now prints `Delivery: ❌ NOT IMPLEMENTED … Setting WANDB_API_KEY will not change this.`
  - `observability list` marks non-delivering integrations `[no delivery - in-memory only]`.
- **Factory**: the 13 per-vendor functions each had a `catch` printing "X not available, using memory adapter. Install with: npm install X". Those catches **could never fire** — the imports are local modules that always resolve, and none of them ever touched a vendor SDK. Replaced with one loader table (`adapters/index.ts` drops 228 lines).
- **Removed `src/observability/index.ts.new`** — a tracked, committed, 0-byte leftover (present since `2bad9a508b`).

The external adapter classes were never exported from the package root and still aren't; they are reachable only through `createObservabilityAdapter`. The surface that actually advertised them to users was the exported registry and the CLI, which is what this fixes.

## Tests

`tests/unit/observability/external-adapters.test.ts` — 15 tests. They **discover adapters from disk** (`fs.readdirSync` over `adapters/external/`, instantiating every export matching `/ObservabilityAdapter$/`) rather than naming them, so a fifteenth adapter is covered on the day it lands.

The central invariant is env-independent: **a freshly constructed external adapter, before `initialize()` has established a transport, must report `isEnabled === false`.** True for Langfuse (no client yet) and for everything with no transport at all.

Before/after on the same test file:

| | result |
|---|---|
| original adapters | **6 failed**, 5 passed |
| after the fix | **11 passed** (15 with the CLI gates) |

One gate initially passed *vacuously* against the old code — its `if (adapter.isEnabled) continue` skipped all 14 — so it now carries an explicit anti-vacuity assertion that every adapter was actually examined.

**Fifteenth-adapter check:** dropping a hollow `newrelic.ts` into the directory, named in no test, failed 5 gates with messages naming `NewRelicObservabilityAdapter`.

## Mutation testing

9 mutations, each anchor `assert`ed present and unambiguous before application (a missing anchor aborts rather than reporting a false SURVIVED). **9 killed, 0 survived.**

| mutation | killed by |
|---|---|
| flip weave back to `isEnabled = true` | `never reports isEnabled true before a transport has been established` |
| remove the construction warning | `warns on construction when it has no delivery implementation` |
| make `flush()` silently resolve | `does not let flush() resolve silently when nothing was delivered` |
| registry claims weave delivers | `marks exactly the tools with a delivery implementation as delivering` |
| langfuse hardcodes `isEnabled = true` | `is disabled while no client exists and enabled once one does` |
| remove langfuse's no-client flush warning | `warns on flush() when the SDK never produced a client` |
| CLI reports success regardless of delivery | `does not report a passing test for an adapter that delivered nothing` |
| CLI doctor calls a non-delivering tool Ready | `never prints a Ready status for a non-delivering tool in human output` |
| CLI doctor JSON status ignores delivery | `does not report a non-delivering tool as ready even when its API key is set` |

The 8th mutation **survived the first round** — the human-readable `doctor` path was untested while only its JSON twin was covered. A gate was added and it now dies.

## Checks

Exit codes read directly from each command, not through a pipe:

```
BUILD_EXIT=0            (npm run build)
TEST_EXIT=0             (npm test - 2601 passed, 0 failed, 149 suites)
VERIFY_DIST_EXIT=0      (npm run verify:dist)
MUTATION_EXIT=0
```

`npm run lint` exits 2 **on unmodified `origin/main` as well** — the script passes eslint 9 the removed `--ext` flag, and no `eslint.config.js` exists in the package at all. Pre-existing and untouched here.

## Findings reported, not fixed here

1. **Python is not equally hollow.** There is no Python analogue of the 12 stubs — no file sets `enabled = True`, delegates to an in-memory store and ships an empty `flush()`. `src/praisonai/praisonai/observability/langfuse.py` is genuinely functional (real SDK client, real credentials, real `flush()`, and it *raises* on missing credentials rather than silently no-op'ing). The verified `start_as_current_span` claim is accurate: exactly 1 occurrence in first-party `src/`, at `praisonaiagents/gateway/protocols.py:5615`, inside a docstring — but there it is a *documented* no-op extension seam, not a hidden hole. The real Python gap is different in kind: `praisonaiagents/obs/__init__.py:139-156` advertises 16 vendors that all route to `praisonai_tools.observability.providers.*`, a package not declared in `praisonai-agents`' `pyproject.toml`, so they raise `ImportError` on a default install. That fails **loudly**, which is a much less severe class of bug than the silent drop fixed here.

2. **A second, parallel observability system exists in this same package.** `src/integrations/observability/langfuse.ts` is a genuine hand-rolled implementation — `fetch` to `https://cloud.langfuse.com`, a real queue with `flushAt`/`flushInterval`, a real `flush()` — and it is exported from the package root alongside the `src/observability/` tree. Two subsystems with overlapping purpose, one of which needs no dependency at all. Worth consolidating; out of scope here.

3. **A non-reproducing build flake.** In one run, `dual-build.test.ts` and `verify:dist` both failed with `ERR_UNSUPPORTED_DIR_IMPORT` on `dist/esm/agent` — i.e. `scripts/esm-shim.js` had not rewritten specifiers — immediately after an `npm run build` that reported exit 0. A clean rebuild fixed it and it has not recurred across three subsequent full runs (including a deliberate replay of the exact command sequence). I could not root-cause it; it concerns the ESM shim step and is unrelated to this change, but flagging it since a build reporting success while emitting an unusable ESM tree is its own silent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observability tools now distinguish between traces delivered to a provider and traces retained locally.
  * CLI listing, diagnostics, and testing commands report accurate delivery and readiness statuses.
  * Langfuse status now reflects successful client initialization and shutdown state.

* **Bug Fixes**
  * Integrations without delivery support no longer appear falsely enabled or report successful delivery.
  * Undelivered integrations now provide clear warnings and status messages.
  * Documentation and provider metadata now reflect actual delivery capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->