### PR TITLE
fix(bot): declared platform wins, slack can start, bots stay up, failures exit non-zero

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -91,11 +91,17 @@ jobs:
             extra_ignore: --ignore=tests/unit/cli/test_message_queue.py
           - shard: bots-gateway
             workdir: src/praisonai-bot
+            # tests/unit/test_bots_cli.py sat at the top level and was collected
+            # by no workflow at all, which is why a TypeError that made
+            # `praisonai bot slack` unstartable shipped unnoticed. Named
+            # explicitly rather than adding the whole top-level directory, which
+            # carries suites with pre-existing env-dependent failures.
             paths: >-
               tests/unit/bots/
               tests/unit/gateway/
               tests/unit/cli/
               tests/unit/daemon/
+              tests/unit/test_bots_cli.py
             extra_ignore: ""
             pythonpath: >-
               ${{ github.workspace }}/src/praisonai-agents:${{ github.workspace }}/src/praisonai-code

--- a/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
+++ b/src/praisonai-bot/praisonai_bot/bots/_config_schema.py
@@ -11,7 +11,14 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -819,7 +826,14 @@ class GatewayConfigSchema(BaseModel):
     # Top-level fields for single-bot compatibility
     platform: Optional[str] = None
     token: Optional[str] = None
-    
+
+    # Set by the single-bot migration when a top-level ``platform:`` was
+    # declared. Credential-presence autofill uses it to refuse to bring up any
+    # *other* platform behind the operator's back (a ``platform: telegram``
+    # config must never start a Discord bot because ``DISCORD_BOT_TOKEN``
+    # happened to be exported).
+    _explicit_single_platform: Optional[str] = PrivateAttr(default=None)
+
     # Agent configuration (single or multiple)
     agent: Optional[AgentConfigSchema] = None
     agents: Optional[Dict[str, AgentConfigSchema]] = None
@@ -896,15 +910,36 @@ class GatewayConfigSchema(BaseModel):
                     ScheduleConfigSchema(**_spec)
                 except Exception as _e:
                     _log.warning("Ignoring invalid schedule %r: %s", _name, _e)
-        # Migrate single-bot format (platform + token at top level)
-        if self.platform and self.token and not self.channels:
+        # Migrate single-bot format (``platform:`` at top level).
+        #
+        # ``token:`` is deliberately NOT required here. Supplying the token via
+        # the environment (``export TELEGRAM_BOT_TOKEN=...``) is the documented
+        # way to run a single-bot ``bot.yaml``, and the old ``and self.token``
+        # guard dropped the declared platform entirely in that case — leaving
+        # ``channels`` empty so ``_autofill_channels_from_env`` below invented
+        # channels from whatever unrelated credentials happened to be in the
+        # environment. A config saying ``platform: telegram`` could therefore
+        # start a *Discord* bot with no warning. The declared platform now
+        # always wins, wherever its token comes from.
+        if self.platform and not self.channels:
+            declared_platform = self.platform.lower().strip()
+            token = self.token
+            if not token:
+                # No inline token: point the channel at the declared platform's
+                # own credential env var. This narrows nothing and widens
+                # nothing — it resolves exactly the variable this platform
+                # already documents, and an unset one degrades through the
+                # existing "channel skipped" path rather than silently
+                # switching platforms.
+                token = self._credential_env_ref(declared_platform)
             self.channels = {
-                self.platform: ChannelConfigSchema(
-                    platform=self.platform,
-                    token=self.token
+                declared_platform: ChannelConfigSchema(
+                    platform=declared_platform,
+                    token=token,
                 )
             }
-            
+            self._explicit_single_platform = declared_platform
+
         # Migrate BotOS platforms format to channels
         if self.platforms and not self.channels:
             for platform_name, platform_config in self.platforms.items():
@@ -1066,6 +1101,13 @@ class GatewayConfigSchema(BaseModel):
             return
 
         default_agent = self._default_agent_id()
+        # A single-bot config that names one ``platform:`` has *declared* what
+        # it wants to run. Auto-enabling a second platform from an unrelated
+        # credential that happens to be in the environment would silently widen
+        # the config beyond what the operator wrote, so it is refused — loudly,
+        # naming each platform that was skipped and how to opt in.
+        explicit_single = self._explicit_single_platform
+        skipped_for_explicit: List[str] = []
         for platform in platforms:
             key = platform.lower()
             if key in declared:
@@ -1077,6 +1119,9 @@ class GatewayConfigSchema(BaseModel):
             if not cred_vars:
                 continue
             if not all(os.environ.get(v) for v in cred_vars):
+                continue
+            if explicit_single is not None and key != explicit_single:
+                skipped_for_explicit.append(key)
                 continue
             self.channels[key] = ChannelConfigSchema(
                 platform=key,
@@ -1090,6 +1135,34 @@ class GatewayConfigSchema(BaseModel):
             logger.info(
                 "Auto-enabled channel %r from %s", key, cred_vars[0]
             )
+
+        if skipped_for_explicit:
+            logger.warning(
+                "Config declares 'platform: %s'; NOT auto-enabling %s despite "
+                "their credentials being present in the environment. The "
+                "declared platform wins. To run them too, list them under "
+                "'channels:' explicitly.",
+                explicit_single,
+                ", ".join(sorted(skipped_for_explicit)),
+            )
+
+    @staticmethod
+    def _credential_env_ref(platform: str) -> str:
+        """``"${ENV}"`` for a platform's primary credential var, else ``""``.
+
+        Used by the single-bot migration when ``platform:`` is declared without
+        an inline ``token:``. Resolves only the variable that *this* platform
+        already documents — it discovers nothing new from the environment.
+        """
+        try:
+            from ._registry import get_platform_credential_env
+
+            cred_vars = get_platform_credential_env(platform)
+        except Exception:
+            return ""
+        if not cred_vars:
+            return ""
+        return "${%s}" % cred_vars[0]
 
     def _register_adapter_refs(self) -> None:
         """Import & self-register any channel declaring an ``adapter:`` ref.

--- a/src/praisonai-bot/praisonai_bot/cli/commands/bot.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/bot.py
@@ -122,6 +122,83 @@ def bot_start(
     handler.start_from_config(resolved)
 
 
+@app.command("run")
+def bot_run(
+    platform: str = typer.Option(..., "--platform", "-P", help="Registered channel platform to run"),
+    token: Optional[str] = typer.Option(None, "--token", "-t", help="Channel token (falls back to the platform's own env var)"),
+    port: Optional[int] = typer.Option(None, "--port", "-p", help="Inbound port for webhook-style channels"),
+    agent: Optional[str] = typer.Option(None, "--agent", "-a", help="Agent YAML configuration file"),
+    model: Optional[str] = typer.Option(None, "--model", "-m", help="LLM model to use"),
+    browser: bool = typer.Option(False, "--browser", help="Enable browser control"),
+    browser_profile: str = typer.Option("default", "--browser-profile", help="Browser profile name"),
+    browser_headless: bool = typer.Option(False, "--browser-headless", help="Run browser headless"),
+    tools: Optional[List[str]] = typer.Option(None, "--tools", help="Tools to enable"),
+    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skills to enable"),
+    skills_dir: Optional[str] = typer.Option(None, "--skills-dir", help="Custom skills directory"),
+    memory: bool = typer.Option(False, "--memory", help="Enable memory"),
+    memory_provider: str = typer.Option("default", "--memory-provider", help="Memory provider"),
+    knowledge: bool = typer.Option(False, "--knowledge", help="Enable knowledge/RAG"),
+    knowledge_sources: Optional[List[str]] = typer.Option(None, "--knowledge-sources", help="Knowledge sources"),
+    web_search: bool = typer.Option(False, "--web", "--web-search", help="Enable web search"),
+    web_provider: str = typer.Option("duckduckgo", "--web-provider", help="Web search provider"),
+    sandbox: bool = typer.Option(False, "--sandbox", help="Enable sandbox mode"),
+    exec_enabled: bool = typer.Option(False, "--exec", help="Enable exec tool"),
+    auto_approve: bool = typer.Option(False, "--auto-approve", help="Auto-approve all tool executions"),
+    group_policy: str = typer.Option("mention_only", "--group-policy", help="Group behaviour: respond_all, mention_only, command_only"),
+    session_id: Optional[str] = typer.Option(None, "--session-id", help="Session ID"),
+    user_id: Optional[str] = typer.Option(None, "--user-id", help="User ID for memory isolation"),
+    thinking: Optional[str] = typer.Option(None, "--thinking", help="Thinking mode (off, minimal, low, medium, high)"),
+):
+    """Start any registered channel by name — including ones with no verb of their own.
+
+    ``praisonai bot <platform>`` covers the seven platforms with hand-written
+    commands. The registry also carries ``signal``, ``webhook`` and ``local``
+    (adapters shipped, no verb) plus every entry-point and drop-in plugin
+    channel — previously reachable only through ``bot start`` YAML. This is
+    their first-class verb.
+
+    Examples:
+        praisonai bot run --platform local
+        praisonai bot run --platform signal --agent agents.yaml
+        praisonai bot run --platform webhook --port 8080
+        praisonai bot run --platform my-plugin-channel --token $MY_TOKEN
+    """
+    from ..features.bots_cli import BotHandler
+
+    capabilities = _build_capabilities(
+        model=model,
+        browser=browser,
+        browser_profile=browser_profile,
+        browser_headless=browser_headless,
+        tools=tools,
+        skills=skills,
+        skills_dir=skills_dir,
+        memory=memory,
+        memory_provider=memory_provider,
+        knowledge=knowledge,
+        knowledge_sources=knowledge_sources,
+        web_search=web_search,
+        web_provider=web_provider,
+        sandbox=sandbox,
+        exec_enabled=exec_enabled,
+        auto_approve=auto_approve,
+        group_policy=group_policy,
+        session_id=session_id,
+        user_id=user_id,
+        thinking=thinking,
+    )
+
+    extra = {} if port is None else {"webhook_port": port}
+    handler = BotHandler()
+    handler.start_generic(
+        platform=platform,
+        token=token,
+        agent_file=agent,
+        capabilities=capabilities,
+        **extra,
+    )
+
+
 @app.command("telegram")
 def bot_telegram(
     token: Optional[str] = typer.Option(None, "--token", "-t", help="Telegram bot token", envvar="TELEGRAM_BOT_TOKEN"),

--- a/src/praisonai-bot/praisonai_bot/cli/features/bots_cli.py
+++ b/src/praisonai-bot/praisonai_bot/cli/features/bots_cli.py
@@ -19,9 +19,76 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NoReturn, Optional
 
 logger = logging.getLogger(__name__)
+
+
+class BotStartupError(SystemExit):
+    """A bot could not be started — the CLI must exit non-zero.
+
+    Subclasses :class:`SystemExit` so every existing call site (the Typer
+    commands, the legacy argparse dispatcher, a supervisor invoking the CLI)
+    gets a real non-zero process exit with no rewiring, while tests can still
+    assert on it by name and read ``.message``. Previously each of these paths
+    printed ``Error: ...`` and ``return``\\ ed, so ``praisonai bot start
+    --config /nope.yaml`` exited **0** and any script or systemd unit treating
+    exit 0 as success was misled.
+    """
+
+    def __init__(self, message: str, code: int = 1) -> None:
+        self.message = message
+        super().__init__(code)
+
+
+def _fail(message: str, *hints: str) -> NoReturn:
+    """Print an operator-facing error (plus hints) and exit non-zero."""
+    print(message)
+    for hint in hints:
+        print(hint)
+    raise BotStartupError(message)
+
+
+async def _serve_bot(bot: Any) -> None:
+    """Start ``bot`` and stay up until its inbound source stops.
+
+    Adapters split into two shapes. Telegram/Discord/Slack block inside
+    ``start()`` for the life of the connection. Linear, Webhook, Email,
+    AgentMail and WhatsApp-cloud instead arm a server or spawn a background
+    task and *return* — so a bare ``asyncio.run(bot.start())`` closed the loop
+    and tore the listening socket down immediately, and the command exited 0
+    having printed "Press Ctrl+C to stop". Mirrors the fix already applied to
+    ``Bot.start()`` (Issue #2869): once ``start()`` returns, hold the loop open
+    while the adapter still reports ``is_running``.
+    """
+    await bot.start()
+    try:
+        for attr in ("_poll_task", "_run_task", "_serve_task"):
+            task = getattr(bot, attr, None)
+            if task is not None and hasattr(task, "__await__"):
+                await task
+                return
+        while getattr(bot, "is_running", False):
+            await asyncio.sleep(0.5)
+    finally:
+        if getattr(bot, "is_running", False):
+            try:
+                await bot.stop()
+            except Exception:  # pragma: no cover - best-effort shutdown
+                # e.g. WhatsApp-web's neonize Go threads may already be gone.
+                logger.debug("Error during bot shutdown", exc_info=True)
+
+
+def _run_bot(bot: Any) -> None:
+    """Synchronous entry point: serve ``bot`` until stopped or interrupted."""
+    try:
+        asyncio.run(_serve_bot(bot))
+    except KeyboardInterrupt:
+        print("\nStopping bot...")
+        try:
+            asyncio.run(bot.stop())
+        except Exception:  # pragma: no cover - best-effort shutdown
+            logger.debug("Error during bot shutdown", exc_info=True)
 
 
 @dataclass
@@ -179,8 +246,7 @@ class BotHandler:
         self._load_dotenv()
         
         if not os.path.exists(config_file):
-            print(f"Error: Config file not found: {config_file}")
-            return
+            _fail(f"Error: Config file not found: {config_file}")
         
         try:
             # Use the canonical loader
@@ -189,16 +255,13 @@ class BotHandler:
             validated_config = load_and_validate_gateway_yaml(config_file)
             
         except ValueError as e:
-            print(f"Error: Invalid config: {e}")
-            return
+            _fail(f"Error: Invalid config: {e}")
         except Exception as e:
-            print(f"Error loading config: {e}")
-            return
+            _fail(f"Error loading config: {e}")
             
         # Get first channel from validated config
         if not validated_config.channels:
-            print("Error: No channels configured in bot config")
-            return
+            _fail("Error: No channels configured in bot config")
             
         # Pick first channel to start
         channel_name = next(iter(validated_config.channels))
@@ -290,7 +353,93 @@ class BotHandler:
                 inbox_id=channel.inbox_id or "",
                 domain=channel.domain or "",
             )
-    
+        else:
+            # Every other registered platform — the built-ins with an adapter
+            # but no bespoke CLI verb (``signal``, ``webhook``, ``local``),
+            # entry-point plugin channels, and ``adapter:`` drop-ins. Previously
+            # this if/elif chain simply fell off the end: the command printed
+            # nothing and exited 0 without starting anything.
+            self.start_generic(
+                platform=platform,
+                token=token or None,
+                capabilities=capabilities,
+                agent_config_dict=agent_config_dict,
+                channel=channel,
+            )
+
+    def start_generic(
+        self,
+        platform: str,
+        token: Optional[str] = None,
+        agent_file: Optional[str] = None,
+        capabilities: Optional[BotCapabilities] = None,
+        agent_config_dict: Optional[Dict[str, Any]] = None,
+        channel: Optional[Any] = None,
+        **extra: Any,
+    ) -> None:
+        """Start any registered platform through the generic ``Bot`` facade.
+
+        Gives ``signal``, ``webhook`` and ``local`` — which ship adapters but
+        never got a hand-written CLI verb — and every entry-point/drop-in plugin
+        channel a first-class way in, without a ninth near-identical 90-line
+        copy of ``start_telegram``. ``Bot`` already resolves the adapter from
+        the platform registry, fills platform tokens from their documented env
+        vars, and holds non-blocking adapters open under supervision.
+
+        Args:
+            platform: Registered platform name.
+            token: Explicit token; falls back to the platform's own env var.
+            agent_file: Optional path to an agent configuration file.
+            capabilities: Optional capabilities configuration.
+            agent_config_dict: Optional agent config dict from bot YAML.
+            channel: Optional validated channel schema to source extra kwargs.
+            **extra: Additional platform-specific adapter kwargs.
+        """
+        self._load_dotenv()
+        platform = (platform or "").lower().strip()
+        if not platform:
+            _fail("Error: No platform given")
+
+        try:
+            from praisonai_bot.bots._registry import list_platforms
+
+            known = {p.lower() for p in list_platforms()}
+        except Exception:
+            known = set()
+        if known and platform not in known:
+            _fail(
+                f"Error: Unknown platform '{platform}'",
+                f"Registered platforms: {', '.join(sorted(known))}",
+            )
+
+        if capabilities and capabilities.auto_approve:
+            os.environ["PRAISONAI_AUTO_APPROVE"] = "true"
+            logger.info("Auto-approve enabled for all tool executions")
+
+        try:
+            from praisonai_bot.bots import Bot
+        except ImportError as e:
+            _fail(f"Error: Bot adapter import failed. {e}")
+
+        kwargs: Dict[str, Any] = dict(extra)
+        if channel is not None:
+            # Only knobs every adapter understands. Anything platform-specific
+            # stays the caller's business rather than being guessed at here.
+            port = getattr(channel, "webhook_port", None)
+            if port is not None:
+                kwargs.setdefault("webhook_port", port)
+
+        agent = self._load_agent(
+            agent_file, capabilities, agent_config_dict=agent_config_dict
+        )
+        try:
+            bot = Bot(platform, agent=agent, token=token or None, **kwargs)
+        except Exception as e:
+            _fail(f"Error: Could not build the '{platform}' channel. {e}")
+
+        self._print_startup_info(platform.capitalize(), capabilities)
+        _run_bot(bot)
+
     def start_telegram(
         self,
         token: Optional[str] = None,
@@ -309,9 +458,10 @@ class BotHandler:
         self._load_dotenv()
         token = token or os.environ.get("TELEGRAM_BOT_TOKEN")
         if not token:
-            print("Error: Telegram bot token required")
-            print("Provide via --token or TELEGRAM_BOT_TOKEN environment variable")
-            return
+            _fail(
+                "Error: Telegram bot token required",
+                "Provide via --token or TELEGRAM_BOT_TOKEN environment variable",
+            )
         
         # Set auto-approve if enabled - use environment variable (persists across async contexts)
         if capabilities and capabilities.auto_approve:
@@ -321,9 +471,10 @@ class BotHandler:
         try:
             from praisonai_bot.bots import TelegramBot
         except ImportError as e:
-            print(f"Error: TelegramBot requires python-telegram-bot. {e}")
-            print("Install with: pip install python-telegram-bot")
-            return
+            _fail(
+                f"Error: TelegramBot requires python-telegram-bot. {e}",
+                "Install with: pip install python-telegram-bot",
+            )
         
         agent = self._load_agent(agent_file, capabilities, agent_config_dict=agent_config_dict)
         
@@ -342,11 +493,7 @@ class BotHandler:
         
         self._print_startup_info("Telegram", capabilities)
         
-        try:
-            asyncio.run(bot.start())
-        except KeyboardInterrupt:
-            print("\nStopping bot...")
-            asyncio.run(bot.stop())
+        _run_bot(bot)
     
     def start_discord(
         self,
@@ -365,9 +512,10 @@ class BotHandler:
         self._load_dotenv()
         token = token or os.environ.get("DISCORD_BOT_TOKEN")
         if not token:
-            print("Error: Discord bot token required")
-            print("Provide via --token or DISCORD_BOT_TOKEN environment variable")
-            return
+            _fail(
+                "Error: Discord bot token required",
+                "Provide via --token or DISCORD_BOT_TOKEN environment variable",
+            )
         
         # Set auto-approve if enabled - use environment variable (persists across async contexts)
         if capabilities and capabilities.auto_approve:
@@ -377,9 +525,10 @@ class BotHandler:
         try:
             from praisonai_bot.bots import DiscordBot
         except ImportError as e:
-            print(f"Error: DiscordBot requires discord.py. {e}")
-            print("Install with: pip install discord.py")
-            return
+            _fail(
+                f"Error: DiscordBot requires discord.py. {e}",
+                "Install with: pip install discord.py",
+            )
         
         agent = self._load_agent(agent_file, capabilities, agent_config_dict=agent_config_dict)
         
@@ -396,11 +545,7 @@ class BotHandler:
         
         self._print_startup_info("Discord", capabilities)
         
-        try:
-            asyncio.run(bot.start())
-        except KeyboardInterrupt:
-            print("\nStopping bot...")
-            asyncio.run(bot.stop())
+        _run_bot(bot)
     
     def start_slack(
         self,
@@ -424,9 +569,22 @@ class BotHandler:
         app_token = app_token or os.environ.get("SLACK_APP_TOKEN")
         
         if not token:
-            print("Error: Slack bot token required")
-            print("Provide via --token or SLACK_BOT_TOKEN environment variable")
-            return
+            _fail(
+                "Error: Slack bot token required",
+                "Provide via --token or SLACK_BOT_TOKEN environment variable",
+            )
+
+        # Socket Mode is the only inbound transport this command wires up, and
+        # it needs an app token. Without one ``SlackBot.start()`` logs a warning
+        # and returns having subscribed to nothing — the bot could send but
+        # never receive. Fail here instead of pretending to run.
+        if not app_token:
+            _fail(
+                "Error: Slack app token required (Socket Mode)",
+                "Provide via --app-token or SLACK_APP_TOKEN environment variable",
+                "Create one at https://api.slack.com/apps -> Basic Information "
+                "-> App-Level Tokens (scope: connections:write)",
+            )
         
         # Set auto-approve if enabled - use environment variable (persists across async contexts)
         if capabilities and capabilities.auto_approve:
@@ -436,17 +594,25 @@ class BotHandler:
         try:
             from praisonai_bot.bots import SlackBot
         except ImportError as e:
-            print(f"Error: SlackBot requires slack-bolt. {e}")
-            print("Install with: pip install slack-bolt")
-            return
+            _fail(
+                f"Error: SlackBot requires slack-bolt. {e}",
+                "Install with: pip install slack-bolt",
+            )
         
         agent = self._load_agent(agent_file, capabilities, agent_config_dict=agent_config_dict)
         
         # Create bot config with group and silence settings
         from praisonaiagents.bots import BotConfig
+        # NOTE: ``app_token`` is deliberately NOT passed to ``BotConfig`` — it
+        # is not one of its fields and doing so raised
+        # ``TypeError: BotConfig.__init__() got an unexpected keyword argument
+        # 'app_token'``, so ``praisonai bot slack`` (and ``bot start`` on any
+        # Slack channel) could not start at all. Adding the field would have
+        # been the same defect one layer along: nothing reads it. Socket Mode
+        # reads ``SlackBot._app_token``, which the adapter's own constructor
+        # parameter below sets.
         bot_config = BotConfig(
             token=token,
-            app_token=app_token,
             group_policy=capabilities.group_policy if capabilities else "mention_only",
             allow_silence=capabilities.allow_silence if capabilities else False,
             silence_token=capabilities.silence_token if capabilities else None,
@@ -456,11 +622,7 @@ class BotHandler:
         
         self._print_startup_info("Slack", capabilities)
         
-        try:
-            asyncio.run(bot.start())
-        except KeyboardInterrupt:
-            print("\nStopping bot...")
-            asyncio.run(bot.stop())
+        _run_bot(bot)
     
     def start_whatsapp(
         self,
@@ -507,16 +669,18 @@ class BotHandler:
             verify_token = verify_token or os.environ.get("WHATSAPP_VERIFY_TOKEN", "")
             
             if not token:
-                print("Error: WhatsApp access token required (Cloud mode)")
-                print("Provide via --token or WHATSAPP_ACCESS_TOKEN environment variable")
-                print("Or use --mode web for token-free QR scan mode")
-                return
+                _fail(
+                    "Error: WhatsApp access token required (Cloud mode)",
+                    "Provide via --token or WHATSAPP_ACCESS_TOKEN environment variable",
+                    "Or use --mode web for token-free QR scan mode",
+                )
             
             if not phone_number_id:
-                print("Error: WhatsApp phone number ID required (Cloud mode)")
-                print("Provide via --phone-id or WHATSAPP_PHONE_NUMBER_ID environment variable")
-                print("Or use --mode web for token-free QR scan mode")
-                return
+                _fail(
+                    "Error: WhatsApp phone number ID required (Cloud mode)",
+                    "Provide via --phone-id or WHATSAPP_PHONE_NUMBER_ID environment variable",
+                    "Or use --mode web for token-free QR scan mode",
+                )
         
         # Set auto-approve if enabled
         if capabilities and capabilities.auto_approve:
@@ -526,12 +690,12 @@ class BotHandler:
         try:
             from praisonai_bot.bots import WhatsAppBot
         except ImportError as e:
-            print(f"Error: WhatsAppBot import failed. {e}")
-            if mode == "web":
-                print("Install with: pip install 'praisonai[bot-whatsapp-web]'")
-            else:
-                print("Install with: pip install aiohttp")
-            return
+            _fail(
+                f"Error: WhatsAppBot import failed. {e}",
+                "Install with: pip install 'praisonai[bot-whatsapp-web]'"
+                if mode == "web"
+                else "Install with: pip install aiohttp",
+            )
         
         agent = self._load_agent(agent_file, capabilities, agent_config_dict=agent_config_dict)
         bot = WhatsAppBot(
@@ -564,14 +728,7 @@ class BotHandler:
             self._print_startup_info("WhatsApp", capabilities)
             print(f"Webhook server on port {webhook_port}")
         
-        try:
-            asyncio.run(bot.start())
-        except KeyboardInterrupt:
-            print("\nStopping bot...")
-            try:
-                asyncio.run(bot.stop())
-            except Exception:
-                pass  # neonize Go threads may already be gone
+        _run_bot(bot)
 
     def start_linear(
         self,
@@ -599,10 +756,11 @@ class BotHandler:
         signing_secret = signing_secret or os.environ.get("LINEAR_WEBHOOK_SECRET", "")
         
         if not token:
-            print("Error: Linear token required")
-            print("Provide via --token or LINEAR_OAUTH_TOKEN environment variable")
-            print("For personal API key, set LINEAR_API_KEY instead")
-            return
+            _fail(
+                "Error: Linear token required",
+                "Provide via --token or LINEAR_OAUTH_TOKEN environment variable",
+                "For personal API key, set LINEAR_API_KEY instead",
+            )
         
         if not signing_secret:
             print("Warning: LINEAR_WEBHOOK_SECRET not set - webhook signatures will not be verified")
@@ -615,9 +773,10 @@ class BotHandler:
         try:
             from praisonai_bot.bots import LinearBot
         except ImportError as e:
-            print(f"Error: LinearBot import failed. {e}")
-            print("Install with: pip install aiohttp")
-            return
+            _fail(
+                f"Error: LinearBot import failed. {e}",
+                "Install with: pip install aiohttp",
+            )
         
         agent = self._load_agent(agent_file, capabilities, agent_config_dict=agent_config_dict)
         bot = LinearBot(
@@ -635,11 +794,7 @@ class BotHandler:
         else:
             print("Webhook signature verification: disabled (set LINEAR_WEBHOOK_SECRET)")
         
-        try:
-            asyncio.run(bot.start())
-        except KeyboardInterrupt:
-            print("\nStopping bot...")
-            asyncio.run(bot.stop())
+        _run_bot(bot)
 
     def start_email(
         self,
@@ -665,9 +820,10 @@ class BotHandler:
         self._load_dotenv()
         token = token or os.environ.get("EMAIL_APP_PASSWORD")
         if not token:
-            print("Error: Email app password required")
-            print("Provide via --token or EMAIL_APP_PASSWORD environment variable")
-            return
+            _fail(
+                "Error: Email app password required",
+                "Provide via --token or EMAIL_APP_PASSWORD environment variable",
+            )
         
         if capabilities and capabilities.auto_approve:
             os.environ["PRAISONAI_AUTO_APPROVE"] = "true"
@@ -675,8 +831,7 @@ class BotHandler:
         try:
             from praisonai_bot.bots import EmailBot
         except ImportError as e:
-            print(f"Error: EmailBot import failed. {e}")
-            return
+            _fail(f"Error: EmailBot import failed. {e}")
         
         agent = self._load_agent(agent_file, capabilities, agent_config_dict=agent_config_dict)
         bot = EmailBot(
@@ -689,11 +844,7 @@ class BotHandler:
         
         self._print_startup_info("Email (IMAP/SMTP)", capabilities)
         
-        try:
-            asyncio.run(bot.start())
-        except KeyboardInterrupt:
-            print("\nStopping bot...")
-            asyncio.run(bot.stop())
+        _run_bot(bot)
 
     def start_agentmail(
         self,
@@ -717,9 +868,10 @@ class BotHandler:
         self._load_dotenv()
         token = token or os.environ.get("AGENTMAIL_API_KEY")
         if not token:
-            print("Error: AgentMail API key required")
-            print("Provide via --token or AGENTMAIL_API_KEY environment variable")
-            return
+            _fail(
+                "Error: AgentMail API key required",
+                "Provide via --token or AGENTMAIL_API_KEY environment variable",
+            )
         
         if capabilities and capabilities.auto_approve:
             os.environ["PRAISONAI_AUTO_APPROVE"] = "true"
@@ -727,9 +879,10 @@ class BotHandler:
         try:
             from praisonai_bot.bots import AgentMailBot
         except ImportError as e:
-            print(f"Error: AgentMailBot import failed. {e}")
-            print("Install with: pip install agentmail")
-            return
+            _fail(
+                f"Error: AgentMailBot import failed. {e}",
+                "Install with: pip install agentmail",
+            )
         
         inbox_id = inbox_id or os.environ.get("AGENTMAIL_INBOX_ID")
         domain = domain or os.environ.get("AGENTMAIL_DOMAIN")
@@ -746,11 +899,7 @@ class BotHandler:
         if inbox_id:
             print(f"Inbox: {inbox_id}")
         
-        try:
-            asyncio.run(bot.start())
-        except KeyboardInterrupt:
-            print("\nStopping bot...")
-            asyncio.run(bot.stop())
+        _run_bot(bot)
 
     def _get_agent_kwargs(self, capabilities: Optional[BotCapabilities]) -> Dict[str, Any]:
         """Extract Agent constructor kwargs from BotCapabilities (DRY).
@@ -1167,6 +1316,20 @@ def _build_capabilities_from_args(args) -> BotCapabilities:
 
 
 def handle_bot_command(args) -> int:
+    """Handle bot CLI command, returning an exit code (0 ok, non-zero error).
+
+    Thin wrapper that turns a :class:`BotStartupError` raised anywhere in the
+    dispatch below back into the integer exit code this function's callers
+    expect, so the legacy argparse path reports failure the same way the Typer
+    path does.
+    """
+    try:
+        return _handle_bot_command(args)
+    except BotStartupError as exc:
+        return int(exc.code or 1)
+
+
+def _handle_bot_command(args) -> int:
     """Handle bot CLI command.
     
     Args:

--- a/src/praisonai-bot/praisonai_bot/cli/features/bots_cli.py
+++ b/src/praisonai-bot/praisonai_bot/cli/features/bots_cli.py
@@ -423,11 +423,34 @@ class BotHandler:
 
         kwargs: Dict[str, Any] = dict(extra)
         if channel is not None:
-            # Only knobs every adapter understands. Anything platform-specific
-            # stays the caller's business rather than being guessed at here.
+            # Forward the validated channel's adapter-specific configuration so
+            # a ``bot start`` YAML routed through this generic facade reaches the
+            # adapter with the same fidelity as the gateway/BotOS path (which
+            # passes every channel key straight to ``Bot(...)`` at
+            # botos.py:1678). Copying only ``webhook_port`` here silently dropped
+            # Signal's ``account``/``bridge_url`` and — the security defect
+            # Greptile flagged — the Webhook adapter's ``verify`` (no env
+            # fallback), so a configured signature verifier was replaced by the
+            # adapter's unverified default. ``Bot`` forwards ``**kwargs`` to the
+            # adapter constructor, so this restores that fidelity.
+            #
+            # ``ChannelConfigSchema`` sets ``extra="allow"`` specifically so an
+            # adapter's own config keys survive validation "instead of being
+            # silently dropped … so they reach the adapter". Those live in
+            # ``model_extra`` — this is where Signal's ``account``/``bridge_url``
+            # and the Webhook adapter's ``path``/``verify`` land — so forward
+            # them verbatim. Nothing declared as a *facade/session* field is
+            # forwarded, so this cannot collide with ``Bot``'s own parameters.
+            extra_cfg = dict(getattr(channel, "model_extra", None) or {})
+            # The one explicit schema field the Webhook adapter also consumes:
+            # ``webhook_port`` (its ``verify``/``path``/``routes`` are extras).
             port = getattr(channel, "webhook_port", None)
             if port is not None:
-                kwargs.setdefault("webhook_port", port)
+                extra_cfg.setdefault("webhook_port", port)
+            for key, value in extra_cfg.items():
+                if key in kwargs or value in (None, ""):
+                    continue
+                kwargs[key] = value
 
         agent = self._load_agent(
             agent_file, capabilities, agent_config_dict=agent_config_dict

--- a/src/praisonai-bot/tests/unit/cli/test_bot_cli_defects.py
+++ b/src/praisonai-bot/tests/unit/cli/test_bot_cli_defects.py
@@ -1,0 +1,378 @@
+"""Regression tests for four silent ``praisonai bot`` defects.
+
+Each test here fails on the code as it stood before the accompanying fix:
+
+1. ``bot start`` started a *different* bot than ``platform:`` declared, because
+   the single-bot migration required an inline ``token:``. With the token in
+   the environment (the documented way) the declared platform was dropped and
+   credential autofill invented channels from unrelated env vars — a
+   ``platform: telegram`` config logged into Discord.
+2. ``bot slack`` could not start at all: ``BotConfig(app_token=...)`` is not a
+   field, so every Slack start raised ``TypeError``.
+3. ``bot linear`` returned from ``start()`` the instant the webhook socket was
+   armed, so ``asyncio.run`` tore it down and the command exited 0 without
+   ever serving.
+4. Twenty failure paths printed ``Error: ...`` and exited **0**.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from typer.testing import CliRunner
+
+from praisonai_bot.bots._config_schema import GatewayConfigSchema
+from praisonai_bot.cli.commands.bot import app as bot_app
+from praisonai_bot.cli.features.bots_cli import (
+    BotHandler,
+    BotStartupError,
+    _serve_bot,
+)
+
+# Every platform credential the registry knows about, so a test can start from
+# a known-clean environment instead of inheriting the developer's shell.
+_CREDENTIAL_ENV = (
+    "TELEGRAM_BOT_TOKEN",
+    "DISCORD_BOT_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "WHATSAPP_ACCESS_TOKEN",
+    "WHATSAPP_PHONE_NUMBER_ID",
+    "LINEAR_OAUTH_TOKEN",
+    "LINEAR_API_KEY",
+    "LINEAR_WEBHOOK_SECRET",
+    "EMAIL_APP_PASSWORD",
+    "EMAIL_ADDRESS",
+    "AGENTMAIL_API_KEY",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Drop every platform credential and stop ``.env`` re-seeding them."""
+    for name in _CREDENTIAL_ENV:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(BotHandler, "_load_dotenv", staticmethod(lambda: None))
+    return monkeypatch
+
+
+# ── Defect 1: the declared platform must win ────────────────────────────
+
+
+class TestDeclaredPlatformWins:
+    """Assert the *resolved platform*, never the log text."""
+
+    def test_platform_declared_without_inline_token_is_kept(self, clean_env):
+        """``platform: telegram`` + token in env resolves to a telegram channel."""
+        clean_env.setenv("TELEGRAM_BOT_TOKEN", "tg-token-from-env")
+
+        config = GatewayConfigSchema(
+            platform="telegram",
+            agent={"name": "assistant", "instructions": "Be helpful."},
+        )
+
+        assert list(config.channels) == ["telegram"]
+        assert config.channels["telegram"].platform == "telegram"
+
+    def test_unrelated_credential_cannot_replace_declared_platform(self, clean_env):
+        """A stray ``DISCORD_BOT_TOKEN`` must not turn a telegram bot into a discord one."""
+        clean_env.setenv("TELEGRAM_BOT_TOKEN", "tg-token-from-env")
+        clean_env.setenv("DISCORD_BOT_TOKEN", "discord-token-that-is-none-of-our-business")
+
+        config = GatewayConfigSchema(
+            platform="telegram",
+            agent={"name": "assistant", "instructions": "Be helpful."},
+        )
+
+        resolved = [
+            (channel.platform or name).lower()
+            for name, channel in config.channels.items()
+        ]
+        assert resolved == ["telegram"]
+        assert "discord" not in config.channels
+
+    def test_declared_platform_wins_even_with_no_matching_credential(self, clean_env):
+        """The exact reproduction: only DISCORD_BOT_TOKEN is exported."""
+        clean_env.setenv("DISCORD_BOT_TOKEN", "discord-token-that-is-none-of-our-business")
+
+        config = GatewayConfigSchema(
+            platform="telegram",
+            agent={"name": "assistant", "instructions": "Be helpful."},
+        )
+
+        first = next(iter(config.channels))
+        assert (config.channels[first].platform or first).lower() == "telegram"
+
+    def test_bot_start_dispatches_to_the_declared_platform(self, clean_env, tmp_path):
+        """End to end through the CLI handler: which ``start_*`` actually runs."""
+        clean_env.setenv("TELEGRAM_BOT_TOKEN", "tg-token-from-env")
+        clean_env.setenv("DISCORD_BOT_TOKEN", "discord-token-that-is-none-of-our-business")
+
+        config_file = tmp_path / "bot.yaml"
+        config_file.write_text(
+            "platform: telegram\n"
+            "agent:\n"
+            "  name: My Assistant\n"
+            "  instructions: Be helpful.\n"
+        )
+
+        dispatched: list[str] = []
+        for platform in ("telegram", "discord", "slack", "whatsapp", "email", "agentmail"):
+            clean_env.setattr(
+                BotHandler,
+                f"start_{platform}",
+                lambda self, *a, _p=platform, **kw: dispatched.append(_p),
+            )
+        clean_env.setattr(
+            BotHandler,
+            "start_generic",
+            lambda self, platform, *a, **kw: dispatched.append(f"generic:{platform}"),
+        )
+
+        BotHandler().start_from_config(str(config_file))
+
+        assert dispatched == ["telegram"]
+
+    def test_explicit_channels_block_still_autofills(self, clean_env):
+        """No regression: a gateway config without ``platform:`` keeps autofill."""
+        clean_env.setenv("DISCORD_BOT_TOKEN", "discord-token")
+
+        config = GatewayConfigSchema(
+            agent={"name": "assistant", "instructions": "Be helpful."},
+        )
+
+        assert "discord" in config.channels
+
+
+# ── Defect 2: bot slack must be able to start ───────────────────────────
+
+
+class _StubSlackBot:
+    instances: list["_StubSlackBot"] = []
+
+    def __init__(self, token=None, app_token=None, agent=None, config=None, **kwargs):
+        self.token = token
+        self.app_token = app_token
+        self.config = config
+        self.is_running = False
+        _StubSlackBot.instances.append(self)
+
+    async def start(self):
+        self.is_running = False  # return immediately; nothing to serve
+
+    async def stop(self):
+        self.is_running = False
+
+
+class TestSlackStarts:
+    def test_start_slack_builds_a_valid_bot_config(self, clean_env, monkeypatch):
+        """``BotConfig(app_token=...)`` raised TypeError — Slack could never start."""
+        clean_env.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+        clean_env.setenv("SLACK_APP_TOKEN", "xapp-test")
+
+        _StubSlackBot.instances.clear()
+        import praisonai_bot.bots as bots_pkg
+
+        monkeypatch.setattr(bots_pkg, "SlackBot", _StubSlackBot, raising=False)
+        monkeypatch.setattr(
+            BotHandler, "_load_agent", lambda self, *a, **kw: object()
+        )
+
+        BotHandler().start_slack()
+
+        assert len(_StubSlackBot.instances) == 1
+        bot = _StubSlackBot.instances[0]
+        # Socket Mode reads the adapter's own attribute, not a BotConfig field.
+        assert bot.app_token == "xapp-test"
+        assert not hasattr(bot.config, "app_token")
+
+    def test_missing_app_token_fails_loudly(self, clean_env):
+        """Socket Mode without an app token subscribed to nothing and 'ran'."""
+        clean_env.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+        with pytest.raises(BotStartupError) as excinfo:
+            BotHandler().start_slack()
+        assert excinfo.value.code == 1
+
+
+# ── Defect 3: a started bot must stay up ────────────────────────────────
+
+
+class _StubWebhookBot:
+    """Mimics LinearBot: ``start()`` arms a server and returns."""
+
+    instances: list["_StubWebhookBot"] = []
+
+    def __init__(self, *args, **kwargs):
+        self.is_running = False
+        self.served = False
+        self.stopped = False
+        _StubWebhookBot.instances.append(self)
+
+    async def start(self):
+        self.is_running = True
+
+        async def _inbound():
+            # Stands in for a webhook arriving shortly after startup.
+            await asyncio.sleep(0.2)
+            self.served = True
+            self.is_running = False
+
+        self._inbound_task = asyncio.ensure_future(_inbound())
+
+    async def stop(self):
+        self.stopped = True
+        self.is_running = False
+
+
+class TestBotStaysUp:
+    def test_serve_bot_blocks_until_the_bot_stops(self):
+        """``_serve_bot`` must not return while the adapter is still running."""
+        bot = _StubWebhookBot()
+        started = time.monotonic()
+        asyncio.run(_serve_bot(bot))
+        assert bot.served is True
+        assert time.monotonic() - started >= 0.15
+
+    def test_start_linear_serves_instead_of_exiting_immediately(
+        self, clean_env, monkeypatch
+    ):
+        """``bot linear`` returned in under a second having served nothing."""
+        clean_env.setenv("LINEAR_OAUTH_TOKEN", "lin_oauth_test")
+        clean_env.setenv("LINEAR_WEBHOOK_SECRET", "secret")
+
+        _StubWebhookBot.instances.clear()
+        import praisonai_bot.bots as bots_pkg
+
+        monkeypatch.setattr(bots_pkg, "LinearBot", _StubWebhookBot, raising=False)
+        monkeypatch.setattr(
+            BotHandler, "_load_agent", lambda self, *a, **kw: object()
+        )
+
+        BotHandler().start_linear(webhook_port=18999)
+
+        assert len(_StubWebhookBot.instances) == 1
+        assert _StubWebhookBot.instances[0].served is True
+
+    def test_start_email_serves_instead_of_exiting_immediately(
+        self, clean_env, monkeypatch
+    ):
+        """Same shape: EmailBot spawns a poll task and returns from start()."""
+        clean_env.setenv("EMAIL_APP_PASSWORD", "app-password")
+
+        _StubWebhookBot.instances.clear()
+        import praisonai_bot.bots as bots_pkg
+
+        monkeypatch.setattr(bots_pkg, "EmailBot", _StubWebhookBot, raising=False)
+        monkeypatch.setattr(
+            BotHandler, "_load_agent", lambda self, *a, **kw: object()
+        )
+
+        BotHandler().start_email(email_address="a@b.c")
+
+        assert _StubWebhookBot.instances[0].served is True
+
+
+# ── Defect 4: failure paths must exit non-zero ──────────────────────────
+
+
+class TestExitCodes:
+    """Assert exit codes, not messages."""
+
+    runner = CliRunner()
+
+    def test_start_with_missing_config_exits_nonzero(self, clean_env):
+        result = self.runner.invoke(bot_app, ["start", "--config", "/nope/nope.yaml"])
+        assert result.exit_code != 0
+
+    def test_start_with_invalid_config_exits_nonzero(self, clean_env, tmp_path):
+        bad = tmp_path / "bot.yaml"
+        bad.write_text("channels:\n  nonsense:\n    platform: not-a-real-platform\n")
+        result = self.runner.invoke(bot_app, ["start", "--config", str(bad)])
+        assert result.exit_code != 0
+
+    def test_email_without_password_exits_nonzero(self, clean_env):
+        result = self.runner.invoke(bot_app, ["email"])
+        assert result.exit_code != 0
+
+    def test_telegram_without_token_exits_nonzero(self, clean_env):
+        result = self.runner.invoke(bot_app, ["telegram"])
+        assert result.exit_code != 0
+
+    def test_discord_without_token_exits_nonzero(self, clean_env):
+        result = self.runner.invoke(bot_app, ["discord"])
+        assert result.exit_code != 0
+
+    def test_slack_without_token_exits_nonzero(self, clean_env):
+        result = self.runner.invoke(bot_app, ["slack"])
+        assert result.exit_code != 0
+
+    def test_linear_without_token_exits_nonzero(self, clean_env):
+        result = self.runner.invoke(bot_app, ["linear"])
+        assert result.exit_code != 0
+
+    def test_agentmail_without_key_exits_nonzero(self, clean_env):
+        result = self.runner.invoke(bot_app, ["agentmail"])
+        assert result.exit_code != 0
+
+    def test_whatsapp_without_token_exits_nonzero(self, clean_env):
+        result = self.runner.invoke(bot_app, ["whatsapp"])
+        assert result.exit_code != 0
+
+    def test_run_with_unknown_platform_exits_nonzero(self, clean_env, monkeypatch):
+        """Rejected up front, by name — not as an incidental crash deeper in."""
+
+        def _never(*a, **kw):  # pragma: no cover - must not be reached
+            raise AssertionError("agent was built for an unknown platform")
+
+        monkeypatch.setattr(BotHandler, "_load_agent", _never)
+        result = self.runner.invoke(bot_app, ["run", "--platform", "not-a-platform"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, BotStartupError)
+
+
+# ── Reachability: platforms with adapters but no CLI verb ───────────────
+
+
+class TestGenericRun:
+    def test_signal_webhook_and_local_are_reachable(self, clean_env, monkeypatch):
+        """``signal``/``webhook``/``local`` ship adapters; they now have a verb."""
+        from praisonai_bot.bots._registry import list_platforms
+
+        registered = {p.lower() for p in list_platforms()}
+        assert {"signal", "webhook", "local"} <= registered
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            BotHandler,
+            "start_generic",
+            lambda self, platform, *a, **kw: seen.append(platform),
+        )
+        result = CliRunner().invoke(bot_app, ["run", "--platform", "local"])
+        assert result.exit_code == 0
+        assert seen == ["local"]
+
+    def test_bot_start_does_not_silently_no_op_on_a_verbless_platform(
+        self, clean_env, tmp_path
+    ):
+        """``bot start`` used to fall off its if/elif chain and exit 0."""
+        config_file = tmp_path / "bot.yaml"
+        config_file.write_text(
+            "platform: local\n"
+            "agent:\n"
+            "  name: My Assistant\n"
+            "  instructions: Be helpful.\n"
+        )
+
+        seen: list[str] = []
+        clean_env.setattr(
+            BotHandler,
+            "start_generic",
+            lambda self, platform, *a, **kw: seen.append(platform),
+        )
+
+        BotHandler().start_from_config(str(config_file))
+
+        assert seen == ["local"]

--- a/src/praisonai-bot/tests/unit/cli/test_bot_cli_defects.py
+++ b/src/praisonai-bot/tests/unit/cli/test_bot_cli_defects.py
@@ -23,7 +23,10 @@ import time
 import pytest
 from typer.testing import CliRunner
 
-from praisonai_bot.bots._config_schema import GatewayConfigSchema
+from praisonai_bot.bots._config_schema import (
+    ChannelConfigSchema,
+    GatewayConfigSchema,
+)
 from praisonai_bot.cli.commands.bot import app as bot_app
 from praisonai_bot.cli.features.bots_cli import (
     BotHandler,
@@ -376,3 +379,80 @@ class TestGenericRun:
         BotHandler().start_from_config(str(config_file))
 
         assert seen == ["local"]
+
+
+# ── Generic path must not drop adapter-specific channel config ──────────
+
+
+class _StubGenericBot:
+    """Records the kwargs the generic facade forwarded to the adapter."""
+
+    instances: list["_StubGenericBot"] = []
+
+    def __init__(self, platform, agent=None, token=None, **kwargs):
+        self.platform = platform
+        self.token = token
+        self.kwargs = kwargs
+        self.is_running = False
+        _StubGenericBot.instances.append(self)
+
+    async def start(self):
+        self.is_running = False
+
+    async def stop(self):
+        self.is_running = False
+
+
+class TestGenericForwardsAdapterConfig:
+    """The generic ``bot start`` path forwarded only ``webhook_port``.
+
+    Greptile flagged this: a configured Webhook channel lost its ``verify``
+    (no env fallback) so a signature verifier was silently replaced by the
+    adapter's unverified default, and a Signal channel lost ``account`` /
+    ``bridge_url``. These assert the fields reach the ``Bot`` facade.
+    """
+
+    def test_webhook_verify_and_path_are_forwarded(self, clean_env, monkeypatch):
+        _StubGenericBot.instances.clear()
+        import praisonai_bot.bots as bots_pkg
+
+        monkeypatch.setattr(bots_pkg, "Bot", _StubGenericBot, raising=False)
+        monkeypatch.setattr(
+            BotHandler, "_load_agent", lambda self, *a, **kw: object()
+        )
+
+        channel = ChannelConfigSchema(
+            platform="webhook",
+            path="/hooks",
+            verify={"type": "hmac", "secret": "s"},
+        )
+
+        BotHandler().start_generic(platform="webhook", channel=channel)
+
+        assert len(_StubGenericBot.instances) == 1
+        fwd = _StubGenericBot.instances[0].kwargs
+        assert fwd.get("verify") == {"type": "hmac", "secret": "s"}
+        assert fwd.get("path") == "/hooks"
+
+    def test_signal_account_and_bridge_url_are_forwarded(
+        self, clean_env, monkeypatch
+    ):
+        _StubGenericBot.instances.clear()
+        import praisonai_bot.bots as bots_pkg
+
+        monkeypatch.setattr(bots_pkg, "Bot", _StubGenericBot, raising=False)
+        monkeypatch.setattr(
+            BotHandler, "_load_agent", lambda self, *a, **kw: object()
+        )
+
+        channel = ChannelConfigSchema(
+            platform="signal",
+            account="+15551234567",
+            bridge_url="http://localhost:9090",
+        )
+
+        BotHandler().start_generic(platform="signal", channel=channel)
+
+        fwd = _StubGenericBot.instances[0].kwargs
+        assert fwd.get("account") == "+15551234567"
+        assert fwd.get("bridge_url") == "http://localhost:9090"


### PR DESCRIPTION
Four defects in `src/praisonai-bot`, three of them silent. Each was reproduced end to end before being fixed, and each fix ships with a test that fails before it.

## 1. `praisonai bot start` started a DIFFERENT bot than the config declared

`praisonai_bot/bots/_config_schema.py` gated the single-bot migration on an inline token:

```python
if self.platform and self.token and not self.channels:   # <- requires token
```

Supplying the token via the environment — the documented way — failed that guard, so the declared `platform:` was **dropped**, `channels` stayed empty, and `_autofill_channels_from_env()` then invented channels from whatever unrelated credentials happened to be exported. `bots_cli.py` started the first one.

Reproduced with a config saying `platform: telegram` and only `DISCORD_BOT_TOKEN` in the environment:

```
LoginFailure: Improper token has been passed.
  discord/http.py:843 in static_login  (401 Unauthorized)
Starting Discord bot...
```

No warning that `platform:` had been ignored. A user pointing the CLI at their Telegram config logged into their Discord workspace.

**Fix.** The declared platform now wins wherever its token comes from. When a config names one `platform:`, credential autofill refuses to bring up any *other* platform and logs a WARNING naming each one it skipped, instead of silently replacing the operator's choice:

```
WARNING Config declares 'platform: telegram'; NOT auto-enabling discord, slack
despite their credentials being present in the environment. The declared
platform wins. To run them too, list them under 'channels:' explicitly.
```

Nothing new is discovered from the environment — the bug was that autofill was too eager, so the fix narrows it. A tokenless `platform: telegram` resolves exactly `${TELEGRAM_BOT_TOKEN}`, the variable that platform already documents; an unset one degrades through the existing "channel skipped" path.

After the fix, the same command starts **Telegram**.

## 2. `praisonai bot slack` could not start at all

`bots_cli.py` passed `app_token=` to `BotConfig`, which has 36 fields and no `app_token` among them:

```
TypeError: BotConfig.__init__() got an unexpected keyword argument 'app_token'
```

This also fired via `bot start` on any Slack channel.

**Decision: drop the kwarg, do not add the field.** `SlackBot.__init__` already takes `app_token` as its own parameter and stores `self._app_token`, which is what `AsyncSocketModeHandler` reads at `slack.py:825`. A `BotConfig` field nothing consumes would have been the same defect one layer along.

Related, and deliberate: Socket Mode without an app token subscribes to nothing — the old code logged a warning and "ran" a bot that could send but never receive. A missing app token is now a hard error with instructions for minting one.

After the fix the command reaches the real Slack auth call (`invalid_auth` with a fake token) instead of dying in `BotConfig`.

## 3. `praisonai bot linear` exited 0 in under a second and never served

`LinearBot.start()` arms an aiohttp `TCPSite`, awaits `site.start()`, and returns. `asyncio.run(bot.start())` then closed the loop, tore the socket down, and the command exited 0 having printed *"Press Ctrl+C to stop"* and a webhook URL. A systemd or daemon wrapper saw a clean exit and did not restart it.

```
EXIT_CODE=0  ELAPSED=1s
Starting Linear bot...
Press Ctrl+C to stop
Webhook endpoint: http://0.0.0.0:18099/webhook
```

**Siblings with the same shape:** `email` (spawns a poll task and returns), `agentmail` (all four modes), `webhook`. All were affected.

**Fix.** A `_serve_bot` helper — mirroring the fix already applied inside `Bot.start()` for #2869 — holds the loop open while the adapter reports `is_running`, for all seven start paths. Blocking adapters (Telegram/Discord/Slack) are unaffected: their `start()` still returns only when the connection ends.

Verified with a live probe against the running process:

```
SERVED after 1 s -> HTTP 200
```

## 4. Twenty failure paths exited 0

`grep -c "typer.Exit\|sys.exit"` on `bots_cli.py` returned **0** against 20 `print("Error: …"); return` sites.

```
$ praisonai bot start --config /nope/nope.yaml
Error: Config file not found: /nope/nope.yaml        EXIT 0
$ praisonai bot email
Error: Email app password required                   EXIT 0
```

**Fix.** Nineteen fatal sites now route through `_fail()`, which raises `BotStartupError(SystemExit)` so every caller — Typer, the legacy argparse dispatcher, a supervisor invoking the CLI — sees a real non-zero exit with no rewiring. Both commands above now exit **1**.

The twentieth site, `_load_agent`'s degrade-to-a-default-agent fallback, is a deliberate no-op and is left alone rather than turned into a failure.

## Also settled: platforms with adapters and no verb

`bot <platform>` exposed 7 platforms while `_BUILTIN_PLATFORMS` registers 10. `signal`, `webhook` and `local` ship adapters with no CLI verb — and worse, `start_from_config`'s `if/elif` chain simply **fell off the end** for them, so `bot start` on a `platform: local` config printed nothing and exited 0 without starting anything.

Added `praisonai bot run --platform <name>`, which resolves any registered platform through the existing generic `Bot` facade — so it also gives entry-point and drop-in plugin channels a first-class verb, rather than three more hand-written 90-line copies of `start_telegram`. `bot start`'s fallthrough now routes there instead of no-opping, and an unknown platform is rejected up front by name.

## Why CI did not catch any of this

The `bots-gateway` shard in `test-core.yml` collects `tests/unit/{bots,gateway,cli,daemon}/` only. `src/praisonai-bot/tests/unit/test_bots_cli.py` — the one existing CLI-surface suite — sits at the top level and was **collected by no workflow at all**. That file is now named explicitly in the shard, and the new tests live under `tests/unit/cli/` where CI already looks.

## Verification

- **22 new tests** in `src/praisonai-bot/tests/unit/cli/test_bot_cli_defects.py`. Defect 1 asserts the *resolved platform*, not log text. Defect 4 asserts *exit codes*, not messages.
- **18/18 mutations killed.** Every defect was reintroduced individually and a named test went red. Each mutation anchor was asserted present and the edit asserted non-identity before applying, so a silent no-op mutation cannot report a false SURVIVED.
- Full bot suite: **2199 passed**. The 4 remaining failures (`test_bot_gap_features.py::TestConfigSchema` x3, `test_botos_admission.py::test_disabled_by_default_no_gate`) fail identically on `origin/main` and are environment-dependent (they assume no platform credentials are exported).
- No token value is logged or echoed anywhere by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `bot run` to start registered platforms, including Signal, Webhook, Local, and plugin channels.
  - Added support for configuring a single bot by platform using the platform’s documented credentials.

- **Bug Fixes**
  - Bot startup failures now return clear non-zero exit statuses instead of appearing successful.
  - Fixed non-blocking channels exiting immediately instead of continuing to serve.
  - Fixed platform selection being overridden by unrelated credentials.
  - Corrected Slack Socket Mode credential handling and validation.
  - Prevented unsupported platforms from being started silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->