### PR TITLE
fix(code): six commands that reported success for work they did not do

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/commands/browser_tool.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/browser_tool.py
@@ -3,9 +3,17 @@ Browser command group for PraisonAI CLI.
 
 Provides browser control commands for agent automation.
 Inspired by moltbot's browser CLI.
+
+Every subcommand here drives ``praisonai_tools.BrowserBaseTool``, whose ``run``
+reports failure by *returning* a value (``{"error": "Unknown action: click"}``)
+rather than raising. Printing that return value and falling off the end of the
+function therefore exits 0 for work that never happened, so results go through
+``_require_success`` and output paths are verified after writing.
 """
 
-from typing import Optional
+import json
+import os
+from typing import Any, Optional
 
 import typer
 
@@ -14,6 +22,152 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+_NOT_INSTALLED = (
+    "Error: Browser tools not installed\nInstall with: pip install praisonai-tools"
+)
+
+
+class _BrowserError(RuntimeError):
+    """A browser action reported failure (by return value or by raising)."""
+
+
+def _load_browser():
+    """Return a BrowserBaseTool instance, or exit 1 with install instructions."""
+    try:
+        from praisonai_tools import BrowserBaseTool
+    except ImportError:
+        print(_NOT_INSTALLED)
+        raise typer.Exit(1)
+    return BrowserBaseTool()
+
+
+def _result_error(result: Any) -> Optional[str]:
+    """Return the failure message carried by ``result``, or None if it succeeded.
+
+    ``BrowserBaseTool.run`` signals failure in-band and differently by version:
+    older builds raise, newer ones return ``{"error": ...}`` or a string that
+    begins with "Error". All three must end up non-zero.
+    """
+    if result is None:
+        return "browser returned no result"
+    if isinstance(result, dict):
+        for key in ("error", "err"):
+            if result.get(key):
+                return str(result[key])
+        if result.get("ok") is False or result.get("success") is False:
+            return str(result.get("message") or result)
+        return None
+    if isinstance(result, str):
+        stripped = result.strip()
+        lowered = stripped.lower()
+        if lowered.startswith(("error", "unknown action", "unsupported action")):
+            return stripped
+    return None
+
+
+def _requested(**flags) -> dict:
+    """Keep only the options the user actually changed from their default.
+
+    Forwarding every flag unconditionally would break against a
+    ``praisonai-tools`` build whose ``run`` does not accept them. Forwarding
+    none is what made ``--headless``/``--double``/``--submit``/``--format``
+    no-ops. So: an untouched default is dropped, and a flag the user typed is
+    forwarded and reported if the installed tool cannot honour it.
+    """
+    return {k: v for k, v in flags.items() if v not in (None, False, "")}
+
+
+def _run_action(browser, action: str, **kwargs) -> Any:
+    """Invoke one browser action, converting every failure mode into an exception.
+
+    Unsupported keyword arguments are reported rather than dropped: a flag the
+    installed ``praisonai-tools`` cannot honour must not look like it worked.
+    """
+    try:
+        result = browser.run(action=action, **kwargs)
+    except TypeError as e:
+        raise _BrowserError(
+            f"the installed praisonai-tools does not support "
+            f"{action}({', '.join(sorted(kwargs))}): {e}"
+        ) from e
+    except Exception as e:
+        raise _BrowserError(str(e)) from e
+
+    error = _result_error(result)
+    if error:
+        raise _BrowserError(error)
+    return result
+
+
+def _profile_arg(profile: str) -> Optional[str]:
+    """``--profile default`` is the implicit default, so it is not an ask."""
+    return None if profile == "default" else profile
+
+
+def _fail(message: str) -> None:
+    print(f"Error: {message}")
+    raise typer.Exit(1)
+
+
+def _write_text_output(result: Any, output: str, label: str) -> None:
+    """Write textual page content to ``output``, or fail loudly."""
+    text = result if isinstance(result, str) else None
+    if text is None and isinstance(result, dict):
+        for key in ("text", "content", "snapshot", "data"):
+            if isinstance(result.get(key), str):
+                text = result[key]
+                break
+    if text is None:
+        _fail(
+            f"{label} returned no page text to write "
+            f"({type(result).__name__}); nothing was saved to {output}"
+        )
+    with open(output, "w") as f:
+        f.write(text)
+    print(f"{label} saved to: {output}")
+
+
+def _screenshot_bytes(result: Any) -> Optional[bytes]:
+    """Extract image bytes from a screenshot result, across tool versions."""
+    if isinstance(result, (bytes, bytearray)):
+        return bytes(result)
+    if isinstance(result, dict):
+        for key in ("bytes", "image", "data", "screenshot"):
+            value = result.get(key)
+            if isinstance(value, (bytes, bytearray)):
+                return bytes(value)
+            if isinstance(value, str) and value:
+                decoded = _maybe_base64(value)
+                if decoded is not None:
+                    return decoded
+        for key in ("path", "file", "filename", "output"):
+            value = result.get(key)
+            if isinstance(value, str) and os.path.isfile(value):
+                with open(value, "rb") as f:
+                    return f.read()
+    if isinstance(result, str):
+        if os.path.isfile(result):
+            with open(result, "rb") as f:
+                return f.read()
+        decoded = _maybe_base64(result)
+        if decoded is not None:
+            return decoded
+    return None
+
+
+def _maybe_base64(value: str) -> Optional[bytes]:
+    """Decode a base64 (or data: URI) payload, or return None if it is not one."""
+    import base64
+    import binascii
+
+    payload = value.split(",", 1)[1] if value.startswith("data:") else value
+    if len(payload) < 32:
+        return None
+    try:
+        return base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
 
 @app.command("status")
 def browser_status(
@@ -21,28 +175,43 @@ def browser_status(
     json_output: bool = typer.Option(False, "--json", help="Output JSON"),
 ):
     """Check browser status.
-    
+
     Examples:
         praisonai browser-tool status
         praisonai browser-tool --profile chrome status
     """
     try:
+        from praisonai_tools import BrowserBaseTool  # noqa: F401
+
+        available = True
+    except ImportError:
+        available = False
+
+    if json_output:
+        print(json.dumps(
+            {
+                "available": available,
+                "profile": profile,
+                "status": "ready" if available else "not_installed",
+            },
+            indent=2,
+        ))
+        return
+
+    try:
         from rich.console import Console
+
         console = Console()
-        
-        # Check if browser tools are available
-        try:
-            from praisonai_tools import BrowserBaseTool
-            console.print(f"[green]✓[/green] Browser tools available")
+        if available:
+            console.print("[green]✓[/green] Browser tools available")
             console.print(f"  Profile: {profile}")
-            console.print(f"  Status: Ready")
-        except ImportError:
+            console.print("  Status: Ready")
+        else:
             console.print("[yellow]![/yellow] Browser tools not installed")
             console.print("  Install with: pip install praisonai-tools")
-            
     except ImportError:
         print(f"Browser status: Profile={profile}")
-        print("Install rich for better output: pip install rich")
+        print("Available" if available else "Not installed")
 
 
 @app.command("open")
@@ -52,26 +221,21 @@ def browser_open(
     headless: bool = typer.Option(False, "--headless", help="Run in headless mode"),
 ):
     """Open a URL in the browser.
-    
+
     Examples:
         praisonai browser-tool open https://example.com
         praisonai browser-tool open https://example.com --headless
     """
+    browser = _load_browser()
+    print(f"Opening {url} in browser (profile: {profile})...")
     try:
-        from praisonai_tools import BrowserBaseTool
-        
-        print(f"Opening {url} in browser (profile: {profile})...")
-        browser = BrowserBaseTool()
-        result = browser.run(action="navigate", url=url)
-        print(f"Result: {result}")
-        
-    except ImportError:
-        print("Error: Browser tools not installed")
-        print("Install with: pip install praisonai-tools")
-        raise typer.Exit(1)
-    except Exception as e:
-        print(f"Error: {e}")
-        raise typer.Exit(1)
+        result = _run_action(
+            browser, "navigate", url=url,
+            **_requested(profile=_profile_arg(profile), headless=headless),
+        )
+    except _BrowserError as e:
+        _fail(str(e))
+    print(f"Result: {result}")
 
 
 @app.command("snapshot")
@@ -81,32 +245,26 @@ def browser_snapshot(
     format: str = typer.Option("aria", "--format", "-f", help="Snapshot format (aria, ai)"),
 ):
     """Take a snapshot of the current page.
-    
+
     Examples:
         praisonai browser-tool snapshot
         praisonai browser-tool snapshot --output snapshot.txt
     """
+    browser = _load_browser()
+    print(f"Taking snapshot (profile: {profile})...")
     try:
-        from praisonai_tools import BrowserBaseTool
-        
-        print(f"Taking snapshot (profile: {profile})...")
-        browser = BrowserBaseTool()
-        result = browser.run(action="snapshot")
-        
-        if output:
-            with open(output, "w") as f:
-                f.write(str(result))
-            print(f"Snapshot saved to: {output}")
-        else:
-            print(result)
-            
-    except ImportError:
-        print("Error: Browser tools not installed")
-        print("Install with: pip install praisonai-tools")
-        raise typer.Exit(1)
-    except Exception as e:
-        print(f"Error: {e}")
-        raise typer.Exit(1)
+        result = _run_action(
+            browser, "snapshot",
+            **_requested(profile=_profile_arg(profile),
+                         format=None if format == "aria" else format),
+        )
+    except _BrowserError as e:
+        _fail(str(e))
+
+    if output:
+        _write_text_output(result, output, "Snapshot")
+    else:
+        print(result)
 
 
 @app.command("screenshot")
@@ -117,31 +275,39 @@ def browser_screenshot(
     format: str = typer.Option("png", "--format", "-f", help="Image format (png, jpeg)"),
 ):
     """Take a screenshot of the current page.
-    
+
     Examples:
         praisonai browser-tool screenshot
         praisonai browser-tool screenshot --output page.png --full-page
     """
+    browser = _load_browser()
+    print(f"Taking screenshot (profile: {profile})...")
     try:
-        from praisonai_tools import BrowserBaseTool
-        
-        print(f"Taking screenshot (profile: {profile})...")
-        browser = BrowserBaseTool()
-        result = browser.run(action="screenshot", full_page=full_page)
-        
-        if output:
-            # Save screenshot to file
-            print(f"Screenshot saved to: {output}")
-        else:
-            print(f"Screenshot captured: {result}")
-            
-    except ImportError:
-        print("Error: Browser tools not installed")
-        print("Install with: pip install praisonai-tools")
-        raise typer.Exit(1)
-    except Exception as e:
-        print(f"Error: {e}")
-        raise typer.Exit(1)
+        result = _run_action(
+            browser,
+            "screenshot",
+            full_page=full_page,
+            **_requested(profile=_profile_arg(profile),
+                         format=None if format == "png" else format),
+        )
+    except _BrowserError as e:
+        _fail(str(e))
+
+    if not output:
+        print(f"Screenshot captured: {result}")
+        return
+
+    # This branch used to print "Screenshot saved to: {output}" without writing
+    # anything at all, so `--output shot.png` reported success and left no file.
+    data = _screenshot_bytes(result)
+    if data is None:
+        _fail(
+            f"screenshot returned no image data ({type(result).__name__}); "
+            f"nothing was saved to {output}"
+        )
+    with open(output, "wb") as f:
+        f.write(data)
+    print(f"Screenshot saved to: {output}")
 
 
 @app.command("click")
@@ -151,25 +317,21 @@ def browser_click(
     double: bool = typer.Option(False, "--double", help="Double click"),
 ):
     """Click an element on the page.
-    
+
     Examples:
         praisonai browser-tool click "#submit-button"
         praisonai browser-tool click "ref:123" --double
     """
+    browser = _load_browser()
+    print(f"{'Double-clicking' if double else 'Clicking'} element: {selector}")
     try:
-        from praisonai_tools import BrowserBaseTool
-        
-        print(f"Clicking element: {selector}")
-        browser = BrowserBaseTool()
-        result = browser.run(action="click", selector=selector)
-        print(f"Result: {result}")
-        
-    except ImportError:
-        print("Error: Browser tools not installed")
-        raise typer.Exit(1)
-    except Exception as e:
-        print(f"Error: {e}")
-        raise typer.Exit(1)
+        result = _run_action(
+            browser, "click", selector=selector,
+            **_requested(profile=_profile_arg(profile), double=double),
+        )
+    except _BrowserError as e:
+        _fail(str(e))
+    print(f"Result: {result}")
 
 
 @app.command("type")
@@ -180,25 +342,24 @@ def browser_type(
     submit: bool = typer.Option(False, "--submit", help="Submit after typing"),
 ):
     """Type text into an element.
-    
+
     Examples:
         praisonai browser-tool type "#search-input" "hello world"
         praisonai browser-tool type "#search-input" "hello world" --submit
     """
+    browser = _load_browser()
+    print(f"Typing into element: {selector}")
     try:
-        from praisonai_tools import BrowserBaseTool
-        
-        print(f"Typing into element: {selector}")
-        browser = BrowserBaseTool()
-        result = browser.run(action="type", selector=selector, text=text)
-        print(f"Result: {result}")
-        
-    except ImportError:
-        print("Error: Browser tools not installed")
-        raise typer.Exit(1)
-    except Exception as e:
-        print(f"Error: {e}")
-        raise typer.Exit(1)
+        result = _run_action(
+            browser,
+            "type",
+            selector=selector,
+            text=text,
+            **_requested(profile=_profile_arg(profile), submit=submit),
+        )
+    except _BrowserError as e:
+        _fail(str(e))
+    print(f"Result: {result}")
 
 
 @app.command("navigate")
@@ -207,24 +368,20 @@ def browser_navigate(
     profile: str = typer.Option("default", "--profile", "-p", help="Browser profile name"),
 ):
     """Navigate to a URL.
-    
+
     Examples:
         praisonai browser-tool navigate https://example.com
     """
+    browser = _load_browser()
+    print(f"Navigating to: {url}")
     try:
-        from praisonai_tools import BrowserBaseTool
-        
-        print(f"Navigating to: {url}")
-        browser = BrowserBaseTool()
-        result = browser.run(action="navigate", url=url)
-        print(f"Result: {result}")
-        
-    except ImportError:
-        print("Error: Browser tools not installed")
-        raise typer.Exit(1)
-    except Exception as e:
-        print(f"Error: {e}")
-        raise typer.Exit(1)
+        result = _run_action(
+            browser, "navigate", url=url,
+            **_requested(profile=_profile_arg(profile)),
+        )
+    except _BrowserError as e:
+        _fail(str(e))
+    print(f"Result: {result}")
 
 
 @app.command("profiles")
@@ -232,7 +389,7 @@ def browser_profiles(
     json_output: bool = typer.Option(False, "--json", help="Output JSON"),
 ):
     """List available browser profiles.
-    
+
     Examples:
         praisonai browser-tool profiles
         praisonai browser-tool profiles --json
@@ -242,23 +399,22 @@ def browser_profiles(
         {"name": "chrome", "description": "Chrome browser via extension relay"},
         {"name": "headless", "description": "Headless browser for automation"},
     ]
-    
+
     if json_output:
-        import json
         print(json.dumps(profiles, indent=2))
     else:
         try:
             from rich.console import Console
             from rich.table import Table
-            
+
             console = Console()
             table = Table(title="Browser Profiles")
             table.add_column("Name", style="cyan")
             table.add_column("Description")
-            
+
             for p in profiles:
                 table.add_row(p["name"], p["description"])
-            
+
             console.print(table)
         except ImportError:
             for p in profiles:

--- a/src/praisonai-code/praisonai_code/cli/commands/chat.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/chat.py
@@ -171,6 +171,14 @@ def chat_main(
     from praisonai_code.cli.utils.stdin import resolve_cli_input
     prompt = resolve_cli_input(prompt)
 
+    # --file/-f attachments appear in this command's own docstring examples
+    # (`praisonai chat "Summarize this" --file README.md`). Resolve them here,
+    # before the credential gate and the --profile branch return, so both the
+    # profiled and non-profiled single-prompt paths receive the attachment
+    # instead of silently dropping it.
+    from praisonai_code.cli.interactive.attachments import prepend_attachments
+    prompt = prepend_attachments(prompt, file)
+
     # --pure / --no-plugins: suppression is scoped by the @scopes_no_plugins
     # decorator, which sets PRAISONAI_NO_PLUGINS for the duration of this call
     # and always restores the prior value on return, so it never leaks into a
@@ -273,6 +281,21 @@ def chat_main(
     # a full interactive chat session with no `praisonai` wrapper required.
     from praisonai_code.cli.interactive.async_tui import AsyncTUI, AsyncTUIConfig
 
+    # --continue resumes the most recent stored session. Resolved here rather
+    # than inside the TUI so an explicit --session always wins, and so an empty
+    # store degrades to a fresh session instead of an error. The TUI's own
+    # resume path (Issue #4910) then rehydrates the agent from this id.
+    resolved_session_id = session_id
+    if resolved_session_id is None and continue_session:
+        try:
+            from praisonai_code.cli.session import get_session_store
+
+            resolved_session_id = get_session_store().get_last_session_id()
+        except Exception:
+            resolved_session_id = None
+        if resolved_session_id is None:
+            typer.echo("No previous session to continue; starting a new one.", err=True)
+
     # `resolved_model` was resolved above (before the onboarding gate) so the
     # gate validated the exact model dispatched here — no re-resolution needed.
     # `--continue` was declared and dropped, so `praisonai chat -c` silently
@@ -297,15 +320,15 @@ def chat_main(
         show_status_bar=not compact,
         session_id=resolved_session_id,
         resume=bool(resolved_session_id) and (continue_session or bool(session_id)),
-        # `--no-acp`/`--no-lsp` were declared and dropped, so the tools they
-        # name loaded anyway; the AsyncTUIConfig fields for them already exist
-        # and `code` already sets them.
-        enable_acp=not no_acp,
-        enable_lsp=not no_lsp,
         workspace=workspace,
         debug=debug,
         autonomy_mode=autonomy,
         no_rules=no_rules,
+        # --no-acp/--no-lsp were parsed and dropped, so there was no way to
+        # turn the ACP/LSP runtimes off from `chat` (`code` already passes
+        # these through to the same config).
+        enable_acp=not no_acp,
+        enable_lsp=not no_lsp,
         # Consolidated capability options: thread the supplied flags onto the
         # same Agent params `run`/YAML/Python use so interactive sessions honour
         # them instead of dropping them (issue #4890). Unset flags stay None so
@@ -321,7 +344,7 @@ def chat_main(
     )
     
     tui = AsyncTUI(config=tui_config)
-    
+
     if prompt:
         # Single prompt mode - direct response, no streaming
         response = tui.run_single(prompt)
@@ -423,20 +446,26 @@ def _run_profiled_chat(
 # --no-color, --theme) are not honoured by the async TUI. Saying so is one line,
 # and stops the CLI making a promise it does not keep.
 # test_every_listed_option_really_is_unread pins this list against the body so it
-# cannot rot once an option is genuinely wired.
+# cannot rot once an option is genuinely wired, and
+# test_every_dropped_option_really_is_listed pins the other direction.
+#
+# The four below the blank line were dropped just as silently but were never
+# declared: they are the ones whose values `_run_legacy_terminal_chat` consumes
+# -- a function this module defines and never calls -- which is why they read as
+# wired to a grep and are not.
 _UNWIRED_CHAT_OPTIONS = {
     "hooks": "--hooks",
     "ui_backend": "--ui-backend",
     "no_color": "--no-color",
     "theme": "--theme",
-    # These four were declared and dropped without any warning at all -- the
-    # table only covered the four above, so it was a subset of the real gap.
-    # `--continue`, `--no-acp` and `--no-lsp` are now genuinely wired; these
-    # remain unimplemented and say so rather than being accepted in silence.
+    # These were declared and dropped without any warning at all -- the table
+    # only covered the four above, so it was a subset of the real gap.
+    # `--continue`, `--no-acp`, `--no-lsp` and `--file` are now genuinely wired;
+    # these remain unimplemented and say so rather than being accepted in
+    # silence.
     "tools": "--tools",
     "toolset": "--toolset",
     "user_id": "--user-id",
-    "file": "--file",
     "output": "--output",
 }
 

--- a/src/praisonai-code/praisonai_code/cli/commands/chat.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/chat.py
@@ -285,34 +285,25 @@ def chat_main(
     # than inside the TUI so an explicit --session always wins, and so an empty
     # store degrades to a fresh session instead of an error. The TUI's own
     # resume path (Issue #4910) then rehydrates the agent from this id.
+    # Prefer the project session index (the bare-TUI launch path) and fall back
+    # to the flat unified store so either recorded a session is honoured.
     resolved_session_id = session_id
     if resolved_session_id is None and continue_session:
-        try:
-            from praisonai_code.cli.session import get_session_store
-
-            resolved_session_id = get_session_store().get_last_session_id()
-        except Exception:
-            resolved_session_id = None
-        if resolved_session_id is None:
-            typer.echo("No previous session to continue; starting a new one.", err=True)
-
-    # `resolved_model` was resolved above (before the onboarding gate) so the
-    # gate validated the exact model dispatched here — no re-resolution needed.
-    # `--continue` was declared and dropped, so `praisonai chat -c` silently
-    # started a brand-new session. Resolve the last session id the same way the
-    # bare-TUI launch does.
-    resolved_session_id = session_id
-    if continue_session and not resolved_session_id:
         try:
             from praisonai_code.cli.state.project_sessions import find_last_session
 
             resolved_session_id = find_last_session()
         except Exception:  # noqa: BLE001 - continuity is best-effort
             resolved_session_id = None
-        if not resolved_session_id:
-            typer.echo(
-                "No previous sessions found. Starting new session.", err=True
-            )
+        if resolved_session_id is None:
+            try:
+                from praisonai_code.cli.session import get_session_store
+
+                resolved_session_id = get_session_store().get_last_session_id()
+            except Exception:  # noqa: BLE001 - continuity is best-effort
+                resolved_session_id = None
+        if resolved_session_id is None:
+            typer.echo("No previous session to continue; starting a new one.", err=True)
 
     tui_config = AsyncTUIConfig(
         model=resolved_model,

--- a/src/praisonai-code/praisonai_code/cli/commands/code.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/code.py
@@ -584,7 +584,6 @@ def _run_resident_code(prompt, args, *, plan=False, session_id=None):
         enable_lsp=not getattr(args, "no_lsp", False),
         autonomy_mode=getattr(args, "autonomy", True),
         execution=getattr(args, "execution", None),
-        autonomy_mode=getattr(args, "autonomy", True),
     )
 
     tui = AsyncTUI(config=tui_config)

--- a/src/praisonai-code/praisonai_code/cli/commands/code.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/code.py
@@ -208,6 +208,13 @@ def code_main(
     from praisonai_code.cli.utils.append_prompt import apply_append_system_prompt
     apply_append_system_prompt(append_system_prompt)
 
+    # --file/-f attachments are documented in this command's own examples
+    # (`praisonai code "Fix the bug" --file main.py`) but never reached the
+    # agent. Attach here, ahead of every dispatch branch below, so the headless
+    # (-p), profiled, resident-TUI and wrapper paths all receive them.
+    from praisonai_code.cli.interactive.attachments import prepend_attachments
+    prompt = prepend_attachments(prompt, file)
+
     # Validate --thinking up front so an unknown value fails closed before any
     # work is done (consistent with MODE_RULES validation on custom agents).
     from praisonai_code.cli.features.thinking import thinking_to_budget
@@ -458,7 +465,8 @@ def code_main(
     args.no_lsp = no_lsp
     # `--no-autonomy` was declared here and dropped, while `chat` wires the
     # identical flag onto AsyncTUIConfig.autonomy_mode -- so `praisonai code
-    # --no-autonomy` ran fully autonomous anyway.
+    # --no-autonomy` ran fully autonomous anyway. Both dispatch paths now read
+    # it from here.
     args.autonomy = autonomy
     args.resume_session = session_id if session_id else ('last' if continue_session else None)
     # Reasoning effort (mapped to the core thinking_budget) and named agent
@@ -576,6 +584,7 @@ def _run_resident_code(prompt, args, *, plan=False, session_id=None):
         enable_lsp=not getattr(args, "no_lsp", False),
         autonomy_mode=getattr(args, "autonomy", True),
         execution=getattr(args, "execution", None),
+        autonomy_mode=getattr(args, "autonomy", True),
     )
 
     tui = AsyncTUI(config=tui_config)

--- a/src/praisonai-code/praisonai_code/cli/interactive/async_tui.py
+++ b/src/praisonai-code/praisonai_code/cli/interactive/async_tui.py
@@ -508,6 +508,48 @@ class AsyncTUI:
         "move_file", "execute_command", "run_command", "shell", "bash",
     })
 
+    def _persist_turn(self, user_content: str, assistant_content: Optional[str]) -> None:
+        """Write a completed turn to the session store.
+
+        Nothing in the TUI wrote to it, so a fresh ``praisonai chat`` / bare
+        ``praisonai`` / standalone ``praisonai code`` produced zero saved
+        sessions: ``/sessions`` answered "No saved sessions found." and
+        ``/continue`` (and ``--session``/``--continue``) had nothing to resume,
+        so every conversation on the default interactive path was lost on exit.
+        The resume machinery added for Issue #4910 works; there was simply never
+        anything for it to find.
+
+        Best-effort: a storage failure must never break the turn the user just
+        completed, so it degrades to a debug log.
+        """
+        if not self.session_id or not user_content:
+            return
+        try:
+            from praisonai_code.cli.session import get_session_store
+
+            store = get_session_store()
+            session = store.get_or_create(self.session_id)
+            if self.config.model:
+                session.current_model = self.config.model
+            session.add_user_message(user_content)
+            if assistant_content:
+                session.add_assistant_message(assistant_content)
+            store.save(session)
+        except Exception as e:
+            logger.debug(f"Could not persist turn to session store: {e}")
+
+    def _reset_agent_context(self) -> None:
+        """Drop the model's context too, so /clear and /new mean what they say.
+
+        ``_conversation_history`` drives the transcript pane; the agent keeps
+        its own ``chat_history``, and a resumed session is re-attached to the
+        store on the next build. Clearing only the former left the model still
+        answering from the conversation the user just cleared.
+        """
+        self._resume_session_id = None
+        self._agent = None
+        self._review_agent = None
+
     def _get_agent(self, read_only: bool = False):
         """Lazy-load the agent with tools.
 
@@ -622,17 +664,25 @@ class AsyncTUI:
                 # context rather than only redisplaying it (Issue #4910). The
                 # read-only review agent stays stateless. Best-effort: a failure
                 # degrades to the display-only transcript instead of aborting.
-                if not read_only and self._resume_session_id:
-                    try:
-                        from praisonai_code.cli.state.project_sessions import (
-                            apply_cli_session_continuity,
-                        )
+                # A *resumed* session restores prior turns; a fresh one still
+                # needs auto_save wired, or nothing is ever written and there is
+                # no session to resume later -- which is why /sessions reported
+                # "No saved sessions found." on every install (see
+                # ``_persist_turn``, which covers the flat unified store that
+                # /sessions and /continue actually read).
+                if not read_only:
+                    continuity_id = self._resume_session_id or self.session_id
+                    if continuity_id:
+                        try:
+                            from praisonai_code.cli.state.project_sessions import (
+                                apply_cli_session_continuity,
+                            )
 
-                        apply_cli_session_continuity(
-                            agent, self._resume_session_id
-                        )
-                    except Exception as exc:  # pragma: no cover - defensive
-                        logger.debug("Session continuity wiring failed: %s", exc)
+                            apply_cli_session_continuity(
+                                agent, continuity_id, auto_save=continuity_id
+                            )
+                        except Exception as exc:  # pragma: no cover - defensive
+                            logger.debug("Session continuity wiring failed: %s", exc)
 
                 return agent
         except ImportError as e:
@@ -1119,12 +1169,14 @@ Tips:
         elif cmd == "clear":
             self.messages.clear()
             self._conversation_history.clear()
+            self._reset_agent_context()
             self.messages.append(ChatMessage(role="system", content="Conversation cleared."))
             return True
         
         elif cmd == "new":
             self.messages.clear()
             self._conversation_history.clear()
+            self._reset_agent_context()
             import uuid
             self.session_id = str(uuid.uuid4())[:8]
             self.messages.append(ChatMessage(role="system", content=f"New session: {self.session_id}"))
@@ -1250,6 +1302,20 @@ Tips:
                     messages = data.get("messages", [])
                     self._conversation_history = messages
                     self.session_id = data.get("session_id", self.session_id)
+                    # Reported "Imported N messages" and then answered as though
+                    # none of them existed. Persist the imported turns and route
+                    # through the same resume path /continue uses, so the model
+                    # actually sees them.
+                    for i in range(0, len(messages) - 1, 2):
+                        if messages[i].get("role") == "user":
+                            self._persist_turn(
+                                messages[i].get("content", ""),
+                                messages[i + 1].get("content")
+                                if messages[i + 1].get("role") == "assistant"
+                                else None,
+                            )
+                    self._resume_session_id = self.session_id
+                    self._agent = None
                     self.messages.append(ChatMessage(
                         role="system",
                         content=f"Imported {len(messages)} messages from {args}"
@@ -1842,9 +1908,11 @@ Example: /handoff code "refactor the auth module" """
                 self.messages.append(ChatMessage(role="system", content=f"Tools used: {tools_used}"))
             
             streamed_msg = streamed["message"]
+            assistant_text: Optional[str] = None
             if error[0]:
                 self.messages.append(ChatMessage(role="assistant", content=f"Error: {error[0]}"))
-                self._conversation_history.append({"role": "assistant", "content": f"Error: {error[0]}"})
+                assistant_text = f"Error: {error[0]}"
+                self._conversation_history.append({"role": "assistant", "content": assistant_text})
             elif result[0]:
                 # If the turn already streamed its narrative into a live
                 # assistant message, reuse it as the finalised turn (updating it
@@ -1856,7 +1924,12 @@ Example: /handoff code "refactor the auth module" """
                         streamed_msg.content = result[0]
                 else:
                     self.messages.append(ChatMessage(role="assistant", content=result[0]))
+                assistant_text = result[0]
                 self._conversation_history.append({"role": "assistant", "content": result[0]})
+
+            # Persist the completed turn so /sessions, /continue and the
+            # --session/--continue flags have something to find.
+            self._persist_turn(prompt, assistant_text)
             
             self._update_output()
             
@@ -2038,11 +2111,18 @@ Example: /handoff code "refactor the auth module" """
                 
                 self.messages.append(ChatMessage(role="user", content=user_input))
                 print("  ⏳ Praison AI is thinking... (Ctrl-C to interrupt)")
+                self._conversation_history.append(
+                    {"role": "user", "content": user_input}
+                )
                 response = self._execute_prompt_interruptible(user_input)
-                
+
                 if response:
                     self.messages.append(ChatMessage(role="assistant", content=response))
+                    self._conversation_history.append(
+                        {"role": "assistant", "content": response}
+                    )
                     print(f"\n● {response}\n")
+                self._persist_turn(user_input, response)
                 
             except KeyboardInterrupt:
                 print("\n  Use /exit to quit")

--- a/src/praisonai-code/praisonai_code/cli/interactive/async_tui.py
+++ b/src/praisonai-code/praisonai_code/cli/interactive/async_tui.py
@@ -538,6 +538,58 @@ class AsyncTUI:
         except Exception as e:
             logger.debug(f"Could not persist turn to session store: {e}")
 
+    def _persist_imported_messages(
+        self, session_id: str, messages: List[dict]
+    ) -> None:
+        """Persist an imported transcript to *both* stores.
+
+        The model rehydrates from the project session store (via
+        ``apply_cli_session_continuity``); ``/sessions`` and ``/continue`` list
+        from the flat unified store. Writing only one left the other empty --
+        so the previous pair-stepping loop, which wrote solely to the unified
+        store, imported a transcript the model never received and dropped any
+        trailing or non-alternating message. ``set_chat_history`` replaces the
+        project transcript verbatim (every role preserved, no pairing), and the
+        unified mirror keeps the session discoverable. Best-effort: a storage
+        failure degrades to a debug log rather than aborting the import.
+        """
+        if not session_id or not messages:
+            return
+        # Normalise to {role, content} so the project store restores exactly
+        # what was imported, in order, regardless of alternation.
+        normalised = [
+            {
+                "role": m.get("role", "user"),
+                "content": m.get("content", "") or "",
+            }
+            for m in messages
+        ]
+        try:
+            from praisonai_code.cli.state.project_sessions import (
+                get_project_session_store,
+            )
+
+            get_project_session_store().set_chat_history(session_id, normalised)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Could not persist import to project store: %s", e)
+
+        # Mirror into the flat unified store so /sessions and /continue list it.
+        try:
+            from praisonai_code.cli.session import get_session_store
+
+            store = get_session_store()
+            session = store.get_or_create(session_id)
+            if self.config.model:
+                session.current_model = self.config.model
+            for msg in normalised:
+                if msg["role"] == "user":
+                    session.add_user_message(msg["content"])
+                elif msg["role"] == "assistant":
+                    session.add_assistant_message(msg["content"])
+            store.save(session)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Could not persist import to unified store: %s", e)
+
     def _reset_agent_context(self) -> None:
         """Drop the model's context too, so /clear and /new mean what they say.
 
@@ -545,10 +597,20 @@ class AsyncTUI:
         its own ``chat_history``, and a resumed session is re-attached to the
         store on the next build. Clearing only the former left the model still
         answering from the conversation the user just cleared.
+
+        Rotating ``session_id`` is what actually severs the model context: the
+        rebuilt agent wires continuity from ``self._resume_session_id or
+        self.session_id``, and ``apply_cli_session_continuity`` re-reads the
+        stored turns for that id. Keeping the old id (the ``/clear`` case) meant
+        the next prompt reloaded the exact conversation the user just cleared;
+        assigning a fresh id gives the continuity read an empty history.
         """
+        import uuid
+
         self._resume_session_id = None
         self._agent = None
         self._review_agent = None
+        self.session_id = str(uuid.uuid4())[:8]
 
     def _get_agent(self, read_only: bool = False):
         """Lazy-load the agent with tools.
@@ -1177,8 +1239,6 @@ Tips:
             self.messages.clear()
             self._conversation_history.clear()
             self._reset_agent_context()
-            import uuid
-            self.session_id = str(uuid.uuid4())[:8]
             self.messages.append(ChatMessage(role="system", content=f"New session: {self.session_id}"))
             return True
         
@@ -1303,17 +1363,15 @@ Tips:
                     self._conversation_history = messages
                     self.session_id = data.get("session_id", self.session_id)
                     # Reported "Imported N messages" and then answered as though
-                    # none of them existed. Persist the imported turns and route
-                    # through the same resume path /continue uses, so the model
-                    # actually sees them.
-                    for i in range(0, len(messages) - 1, 2):
-                        if messages[i].get("role") == "user":
-                            self._persist_turn(
-                                messages[i].get("content", ""),
-                                messages[i + 1].get("content")
-                                if messages[i + 1].get("role") == "assistant"
-                                else None,
-                            )
+                    # none of them existed: the pair-stepping loop wrote to the
+                    # flat UnifiedSessionStore, but the rebuilt agent restores
+                    # context from the *project* session store -- so the model
+                    # saw none of the import and any trailing/non-alternating
+                    # message was dropped. Write the full transcript verbatim to
+                    # the same store `apply_cli_session_continuity` reads, then
+                    # route through the resume path so the model actually sees
+                    # every imported turn.
+                    self._persist_imported_messages(self.session_id, messages)
                     self._resume_session_id = self.session_id
                     self._agent = None
                     self.messages.append(ChatMessage(

--- a/src/praisonai-code/praisonai_code/cli/interactive/attachments.py
+++ b/src/praisonai-code/praisonai_code/cli/interactive/attachments.py
@@ -1,0 +1,47 @@
+"""Rendering for ``--file`` / ``-f`` attachments.
+
+``chat``, ``code`` and the interactive core all accept file attachments and must
+agree on the wrapper the model sees, so the format lives in one place.
+"""
+
+import logging
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def render_file_attachments(files: Optional[Iterable[str]]) -> str:
+    """Return attached file contents as one ``<attached_files>`` block.
+
+    Unreadable and missing paths are warned about and skipped rather than
+    aborting the run. Returns "" when nothing could be attached.
+    """
+    parts: List[str] = []
+    for filepath in files or []:
+        path = Path(filepath)
+        if not (path.exists() and path.is_file()):
+            logger.warning(f"Attachment not found, skipping: {filepath}")
+            continue
+        try:
+            content = path.read_text()
+        except Exception as e:
+            logger.warning(f"Could not read file {filepath}: {e}")
+            continue
+        parts.append(f'<file path="{filepath}">\n{content}\n</file>')
+
+    if parts:
+        return "<attached_files>\n" + "\n".join(parts) + "\n</attached_files>"
+    return ""
+
+
+def prepend_attachments(prompt: Optional[str], files: Optional[Iterable[str]]) -> Optional[str]:
+    """Put attached files in front of ``prompt``.
+
+    ``praisonai chat --file a.py`` with no prompt is a legitimate "here, read
+    this" opener, so attachments alone still produce a prompt.
+    """
+    block = render_file_attachments(files)
+    if not block:
+        return prompt
+    return f"{block}\n\n{prompt}" if prompt else block

--- a/src/praisonai-code/praisonai_code/runtime/server.py
+++ b/src/praisonai-code/praisonai_code/runtime/server.py
@@ -75,6 +75,46 @@ class SessionEventHub:
             return bool(self._subscribers.get(session_id))
 
 
+def _apply_cold_path_parity(config: Dict[str, Any]) -> None:
+    """Give a runtime-built agent the context and tools the cold path gives it.
+
+    In-process, ``praisonai run`` registers the AGENTS.md/CLAUDE.md subtree hook
+    and auto-discovers project-local ``.praisonai/tools/*.py``. The warm runtime
+    built a bare ``Agent``, so attaching to a running daemon produced an agent
+    with no project rules and no local tools -- which returns fluent text and
+    exits 0 with nothing done, indistinguishable from success until you check
+    the filesystem.
+
+    ``run_main`` already refuses to attach when ``--tools``/``--toolset``/
+    ``--mcp``/``--instructions`` are supplied, so only the two *implicit*
+    sources were missing here. Both are project-scoped, and the runtime
+    descriptor is project-scoped too, so the daemon resolves the same ones the
+    client would have.
+
+    Best-effort in both halves: parity wiring must never stop the daemon
+    serving a turn.
+    """
+    try:
+        from ..cli.commands.run import (
+            _auto_discover_project_tools,
+            _wire_subtree_context_hook,
+        )
+    except Exception:
+        return
+
+    try:
+        local_tools = _auto_discover_project_tools([])
+        if local_tools:
+            config["tools"] = list(config.get("tools") or []) + local_tools
+    except Exception:
+        pass
+
+    try:
+        _wire_subtree_context_hook(config)
+    except Exception:
+        pass
+
+
 class WarmRuntime:
     """Holds warm agent state and executes prompts for the runtime server."""
 
@@ -115,6 +155,7 @@ class WarmRuntime:
                 resolved = resolved or self._default_model
                 if resolved:
                     config["llm"] = resolved
+                _apply_cold_path_parity(config)
                 agent = Agent(**config)
                 self._agents[key] = agent
             return agent
@@ -166,6 +207,7 @@ class WarmRuntime:
         }
         if resolved:
             config["llm"] = resolved
+        _apply_cold_path_parity(config)
         agent = Agent(**config)
 
         # Rehydrate prior history + wire persistence via the shared CLI helper.

--- a/src/praisonai-code/tests/unit/cli/test_browser_tool_reports_truth.py
+++ b/src/praisonai-code/tests/unit/cli/test_browser_tool_reports_truth.py
@@ -1,0 +1,223 @@
+"""`praisonai browser-tool` must not report success for work it did not do.
+
+Six of eight subcommands exited 0 regardless of outcome, because
+``BrowserBaseTool.run`` reports failure by *returning* a value
+(``{"error": "Unknown action: click"}``) rather than raising -- so the command
+printed that dict as "Result:" and fell off the end.
+
+Worse, ``screenshot --output shot.png`` printed "Screenshot saved to:
+shot.png" without ever opening the file, and ``snapshot --output`` wrote the
+error dict to disk as though it were page text.
+
+These tests inject a fake BrowserBaseTool so the failure modes are exercised
+without a browser, a network, or the optional praisonai-tools package.
+"""
+
+import sys
+import types
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import praisonai_code.cli.commands.browser_tool as bt
+
+runner = CliRunner()
+
+
+def _install_fake_tool(monkeypatch, run_impl):
+    """Provide a praisonai_tools module whose BrowserBaseTool.run is run_impl."""
+
+    class FakeBrowser:
+        calls = []
+
+        def run(self, **kwargs):
+            FakeBrowser.calls.append(kwargs)
+            return run_impl(**kwargs)
+
+    FakeBrowser.calls = []
+    module = types.ModuleType("praisonai_tools")
+    module.BrowserBaseTool = FakeBrowser
+    monkeypatch.setitem(sys.modules, "praisonai_tools", module)
+    return FakeBrowser
+
+
+# --------------------------------------------------------------------------
+# In-band errors must become non-zero exits
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("args", [
+    ["click", "#submit"],
+    ["type", "#search", "hello"],
+    ["navigate", "https://example.com"],
+    ["open", "https://example.com"],
+    ["snapshot"],
+    ["screenshot"],
+])
+def test_an_unknown_action_exits_non_zero(monkeypatch, args):
+    _install_fake_tool(
+        monkeypatch, lambda **kw: {"error": f"Unknown action: {kw.get('action')}"}
+    )
+    result = runner.invoke(bt.app, args)
+    assert result.exit_code != 0, (
+        f"browser-tool {' '.join(args)} exited 0 while the browser reported "
+        f"an error:\n{result.output}"
+    )
+
+
+def test_a_string_error_is_also_caught(monkeypatch):
+    _install_fake_tool(monkeypatch, lambda **kw: "Error: no page is open")
+    result = runner.invoke(bt.app, ["click", "#submit"])
+    assert result.exit_code != 0
+
+
+def test_a_raising_tool_exits_non_zero(monkeypatch):
+    def _boom(**kw):
+        raise RuntimeError("browser crashed")
+
+    _install_fake_tool(monkeypatch, _boom)
+    result = runner.invoke(bt.app, ["click", "#submit"])
+    assert result.exit_code != 0
+    assert "browser crashed" in result.output
+
+
+def test_a_genuine_success_still_exits_zero(monkeypatch):
+    _install_fake_tool(monkeypatch, lambda **kw: {"ok": True, "title": "Example"})
+    result = runner.invoke(bt.app, ["navigate", "https://example.com"])
+    assert result.exit_code == 0, result.output
+
+
+# --------------------------------------------------------------------------
+# screenshot --output must produce a file
+# --------------------------------------------------------------------------
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+
+
+def test_screenshot_output_writes_the_file(monkeypatch, tmp_path):
+    _install_fake_tool(monkeypatch, lambda **kw: {"bytes": _PNG})
+    target = tmp_path / "shot.png"
+
+    result = runner.invoke(bt.app, ["screenshot", "--output", str(target)])
+
+    assert result.exit_code == 0, result.output
+    assert target.exists(), (
+        "reported 'Screenshot saved to' but wrote nothing:\n" + result.output
+    )
+    assert target.read_bytes() == _PNG
+
+
+def test_screenshot_accepts_a_base64_payload(monkeypatch, tmp_path):
+    import base64
+
+    encoded = base64.b64encode(_PNG).decode()
+    _install_fake_tool(monkeypatch, lambda **kw: {"image": encoded})
+    target = tmp_path / "shot.png"
+
+    assert runner.invoke(bt.app, ["screenshot", "-o", str(target)]).exit_code == 0
+    assert target.read_bytes() == _PNG
+
+
+def test_screenshot_with_no_image_data_fails_instead_of_claiming_success(
+    monkeypatch, tmp_path
+):
+    _install_fake_tool(monkeypatch, lambda **kw: {"ok": True})
+    target = tmp_path / "shot.png"
+
+    result = runner.invoke(bt.app, ["screenshot", "--output", str(target)])
+
+    assert result.exit_code != 0
+    assert not target.exists()
+    assert "Screenshot saved to" not in result.output
+
+
+# --------------------------------------------------------------------------
+# snapshot --output must not write an error as page text
+# --------------------------------------------------------------------------
+
+def test_snapshot_output_writes_the_page_text(monkeypatch, tmp_path):
+    _install_fake_tool(monkeypatch, lambda **kw: "heading: Example Domain")
+    target = tmp_path / "snap.txt"
+
+    assert runner.invoke(bt.app, ["snapshot", "-o", str(target)]).exit_code == 0
+    assert target.read_text() == "heading: Example Domain"
+
+
+def test_snapshot_never_writes_an_error_dict_as_page_text(monkeypatch, tmp_path):
+    _install_fake_tool(monkeypatch, lambda **kw: {"error": "Unknown action: snapshot"})
+    target = tmp_path / "snap.txt"
+
+    result = runner.invoke(bt.app, ["snapshot", "--output", str(target)])
+
+    assert result.exit_code != 0
+    assert not target.exists(), (
+        "wrote the browser's error dict to disk as though it were page content"
+    )
+
+
+# --------------------------------------------------------------------------
+# Declared flags must reach the tool
+# --------------------------------------------------------------------------
+
+def test_headless_double_and_submit_reach_the_tool(monkeypatch):
+    fake = _install_fake_tool(monkeypatch, lambda **kw: {"ok": True})
+
+    runner.invoke(bt.app, ["open", "https://example.com", "--headless"])
+    assert fake.calls[-1].get("headless") is True
+
+    runner.invoke(bt.app, ["click", "#x", "--double"])
+    assert fake.calls[-1].get("double") is True
+
+    runner.invoke(bt.app, ["type", "#x", "hi", "--submit"])
+    assert fake.calls[-1].get("submit") is True
+
+
+def test_a_non_default_profile_and_format_reach_the_tool(monkeypatch):
+    fake = _install_fake_tool(monkeypatch, lambda **kw: "text")
+
+    runner.invoke(bt.app, ["snapshot", "--profile", "chrome", "--format", "ai"])
+    assert fake.calls[-1].get("profile") == "chrome"
+    assert fake.calls[-1].get("format") == "ai"
+
+
+def test_untouched_defaults_are_not_forwarded(monkeypatch):
+    """A build of praisonai-tools with a narrow run() must keep working."""
+    fake = _install_fake_tool(monkeypatch, lambda **kw: "text")
+
+    runner.invoke(bt.app, ["snapshot"])
+    assert set(fake.calls[-1]) == {"action"}, fake.calls[-1]
+
+
+def test_a_flag_the_tool_cannot_honour_is_reported_not_dropped(monkeypatch):
+    def _narrow(**kw):
+        if set(kw) - {"action", "selector"}:
+            raise TypeError(f"run() got unexpected kwargs: {sorted(set(kw) - {'action', 'selector'})}")
+        return {"ok": True}
+
+    _install_fake_tool(monkeypatch, _narrow)
+
+    assert runner.invoke(bt.app, ["click", "#x"]).exit_code == 0
+    result = runner.invoke(bt.app, ["click", "#x", "--double"])
+    assert result.exit_code != 0
+    assert "does not support" in result.output
+
+
+# --------------------------------------------------------------------------
+# status --json
+# --------------------------------------------------------------------------
+
+def test_status_json_emits_json(monkeypatch):
+    import json
+
+    _install_fake_tool(monkeypatch, lambda **kw: None)
+    result = runner.invoke(bt.app, ["status", "--json", "--profile", "chrome"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["profile"] == "chrome"
+    assert payload["available"] is True
+
+
+def test_missing_praisonai_tools_still_exits_non_zero(monkeypatch):
+    monkeypatch.setitem(sys.modules, "praisonai_tools", None)
+    result = runner.invoke(bt.app, ["click", "#x"])
+    assert result.exit_code != 0

--- a/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
+++ b/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
@@ -108,6 +108,33 @@ def test_a_missing_attachment_does_not_abort_the_run(tmp_path, tui):
     assert tui.last_prompt == "hi"
 
 
+def test_profiled_chat_still_receives_the_attachment(tmp_path, tui, monkeypatch):
+    """`--profile` returns before the TUI path, so it must get --file too.
+
+    The profiling branch dispatched to `_run_profiled_chat` before attachments
+    were resolved, so `praisonai chat "..." --file notes.md --profile` silently
+    sent only the bare prompt to the model.
+    """
+    captured = {}
+
+    def _fake_profiled(prompt, model=None, verbose=False, profile_deep=False):
+        captured["prompt"] = prompt
+
+    monkeypatch.setattr(chat_module, "_run_profiled_chat", _fake_profiled)
+
+    doc = tmp_path / "notes.md"
+    doc.write_text("the launch code is hunter2")
+
+    result = _invoke(
+        chat_module.chat_main, ["Summarise this", "--file", str(doc), "--profile"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "the launch code is hunter2" in captured.get("prompt", ""), (
+        "profiling dropped the --file attachment"
+    )
+
+
 # --------------------------------------------------------------------------
 # --continue
 # --------------------------------------------------------------------------

--- a/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
+++ b/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
@@ -1,0 +1,211 @@
+"""Options `chat` and `code` accept must reach the runtime, or be declared unwired.
+
+`praisonai chat --file README.md` and `praisonai code "fix it" --file main.py`
+are the commands' *own* docstring examples, and both parsed the attachment and
+threw it away. `praisonai chat --continue` started a brand-new session with a
+fresh uuid. `praisonai code --no-autonomy` was the only way to turn
+auto-delegation off, and it did nothing.
+
+These tests drive the real command bodies with the TUI stubbed, and assert on
+the config and prompt that actually reach it.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import praisonai_code.cli.commands.chat as chat_module
+import praisonai_code.cli.commands.code as code_module
+
+
+class _CapturingTUI:
+    """Records the config and prompt the command dispatched with."""
+
+    last_config = None
+    last_prompt = None
+    execution_failed = False
+
+    def __init__(self, config=None, *args, **kwargs):
+        type(self).last_config = config
+
+    def run_single(self, prompt):
+        type(self).last_prompt = prompt
+        return ""
+
+    def run(self):
+        type(self).last_prompt = None
+        return None
+
+
+@pytest.fixture
+def tui(monkeypatch):
+    _CapturingTUI.last_config = None
+    _CapturingTUI.last_prompt = None
+    monkeypatch.setattr(
+        "praisonai_code.llm.credentials.ensure_configured_or_onboard",
+        lambda model=None, interactive=True: model,
+    )
+    monkeypatch.setattr(
+        "praisonai_code.cli.interactive.async_tui.AsyncTUI", _CapturingTUI
+    )
+    # `code` only takes the resident-TUI path when the wrapper is absent.
+    monkeypatch.setattr(
+        "praisonai_code._wrapper_bridge.wrapper_available", lambda: False
+    )
+    return _CapturingTUI
+
+
+def _invoke(fn, args):
+    app = typer.Typer()
+    app.command()(fn)
+    return CliRunner().invoke(app, args)
+
+
+# --------------------------------------------------------------------------
+# --file / -f
+# --------------------------------------------------------------------------
+
+def test_chat_file_attachment_reaches_the_prompt(tmp_path, tui):
+    doc = tmp_path / "notes.md"
+    doc.write_text("the launch code is hunter2")
+
+    result = _invoke(chat_module.chat_main, ["Summarise this", "--file", str(doc)])
+
+    assert result.exit_code == 0, result.output
+    assert tui.last_prompt is not None, "chat never dispatched a prompt"
+    assert "the launch code is hunter2" in tui.last_prompt
+    assert "Summarise this" in tui.last_prompt
+
+
+def test_code_file_attachment_reaches_the_prompt(tmp_path, tui):
+    doc = tmp_path / "main.py"
+    doc.write_text("def broken():\n    return 1 / 0\n")
+
+    result = _invoke(code_module.code_main, ["Fix the bug", "--file", str(doc)])
+
+    assert result.exit_code == 0, result.output
+    assert tui.last_prompt is not None
+    assert "return 1 / 0" in tui.last_prompt
+
+
+def test_attachment_without_a_prompt_still_reaches_the_model(tmp_path, tui):
+    doc = tmp_path / "notes.md"
+    doc.write_text("read me")
+    _invoke(chat_module.chat_main, ["--file", str(doc)])
+    # No prompt means the interactive path, which never calls run_single --
+    # the point here is only that the command accepts it and does not crash.
+    assert tui.last_config is not None
+
+
+def test_a_missing_attachment_does_not_abort_the_run(tmp_path, tui):
+    result = _invoke(
+        chat_module.chat_main, ["hi", "--file", str(tmp_path / "nope.md")]
+    )
+    assert result.exit_code == 0, result.output
+    assert tui.last_prompt == "hi"
+
+
+# --------------------------------------------------------------------------
+# --continue
+# --------------------------------------------------------------------------
+
+def test_chat_continue_resumes_the_last_session(tmp_path, tui, monkeypatch):
+    from praisonai_code.cli.session import UnifiedSessionStore
+    import praisonai_code.cli.session as session_pkg
+
+    store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
+    store.get_or_create("earlier-one")
+    monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
+
+    _invoke(chat_module.chat_main, ["hi", "--continue"])
+
+    assert tui.last_config.session_id == "earlier-one", (
+        "--continue started a brand-new session instead of resuming"
+    )
+
+
+def test_an_explicit_session_beats_continue(tmp_path, tui, monkeypatch):
+    from praisonai_code.cli.session import UnifiedSessionStore
+    import praisonai_code.cli.session as session_pkg
+
+    store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
+    store.get_or_create("earlier-one")
+    monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
+
+    _invoke(chat_module.chat_main, ["hi", "--continue", "--session", "chosen"])
+
+    assert tui.last_config.session_id == "chosen"
+
+
+def test_continue_with_no_history_says_so_and_carries_on(tmp_path, tui, monkeypatch):
+    from praisonai_code.cli.session import UnifiedSessionStore
+    import praisonai_code.cli.session as session_pkg
+
+    store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
+    monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
+
+    result = _invoke(chat_module.chat_main, ["hi", "--continue"])
+
+    assert result.exit_code == 0
+    assert "No previous session" in result.output
+
+
+# --------------------------------------------------------------------------
+# --no-acp / --no-lsp / --no-autonomy
+# --------------------------------------------------------------------------
+
+def test_chat_no_acp_and_no_lsp_reach_the_tui(tui):
+    _invoke(chat_module.chat_main, ["hi", "--no-acp", "--no-lsp"])
+    assert tui.last_config.enable_acp is False
+    assert tui.last_config.enable_lsp is False
+
+
+def test_chat_acp_and_lsp_default_to_on(tui):
+    _invoke(chat_module.chat_main, ["hi"])
+    assert tui.last_config.enable_acp is True
+    assert tui.last_config.enable_lsp is True
+
+
+def test_code_no_autonomy_reaches_the_tui(tui):
+    _invoke(code_module.code_main, ["hi", "--no-autonomy"])
+    assert tui.last_config.autonomy_mode is False, (
+        "--no-autonomy was accepted and dropped; auto-delegation stayed on"
+    )
+
+
+def test_code_autonomy_defaults_to_on(tui):
+    _invoke(code_module.code_main, ["hi"])
+    assert tui.last_config.autonomy_mode is True
+
+
+# --------------------------------------------------------------------------
+# The pin
+# --------------------------------------------------------------------------
+
+def _unread_params(module, func_name, exempt=frozenset({"ctx", "pure"})):
+    """Parameters the function declares and never loads in its body.
+
+    ``pure``/``--no-plugins`` is consumed by the @scopes_no_plugins decorator,
+    so it is wired despite not appearing in the body.
+    """
+    tree = ast.parse(Path(module.__file__).read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name == func_name
+    )
+    a = fn.args
+    params = [x.arg for x in a.posonlyargs + a.args + a.kwonlyargs]
+    read = {
+        n.id for stmt in fn.body for n in ast.walk(stmt)
+        if isinstance(n, ast.Name)
+    }
+    return [p for p in params if p not in read and p not in exempt]
+
+
+def test_code_declares_no_option_it_ignores():
+    """`code` has no unwired-option warning, so it must have none to warn about."""
+    assert _unread_params(code_module, "code_main") == []

--- a/src/praisonai-code/tests/unit/cli/test_chat_unwired_options.py
+++ b/src/praisonai-code/tests/unit/cli/test_chat_unwired_options.py
@@ -15,10 +15,46 @@ The tests stub the *actual* runtime chat_main dispatches to -- the credential
 gate and the async TUI -- so a supplied option exercises the warning without
 depending on external state (an API key, a local endpoint, or a real TTY).
 """
+import ast
+from pathlib import Path
+
 import typer
 from typer.testing import CliRunner
 
 import praisonai_code.cli.commands.chat as chat_module
+
+
+# ``--pure``/``--no-plugins`` is consumed by the @scopes_no_plugins decorator
+# rather than by the body, so it is wired despite never being named inside.
+_WIRED_BY_DECORATOR = {"ctx", "pure"}
+
+
+def _chat_main_ast():
+    module = ast.parse(Path(chat_module.__file__).read_text())
+    return next(
+        n for n in ast.walk(module)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name == "chat_main"
+    )
+
+
+def _chat_main_params():
+    a = _chat_main_ast().args
+    return [x.arg for x in a.posonlyargs + a.args + a.kwonlyargs]
+
+
+def _names_read_by_chat_main():
+    """Names actually loaded somewhere in chat_main's body.
+
+    Only the body -- a parameter's default is a ``typer.Option(...)`` call that
+    mentions the flag string, not a read of the value.
+    """
+    return {
+        node.id
+        for stmt in _chat_main_ast().body
+        for node in ast.walk(stmt)
+        if isinstance(node, ast.Name)
+    }
 
 
 class _StubTUI:
@@ -100,35 +136,18 @@ class TestUnwiredChatOptions:
         """A warning must not become a failure."""
         assert _run(monkeypatch, "--theme", "dark").exit_code == 0
 
-    def test_every_listed_option_really_is_unread(self, monkeypatch):
-        """Guards the list itself against drifting as options get wired up.
+    def test_every_listed_option_really_is_unread(self):
+        """Guards the list against drifting as options get wired up.
 
-        If someone implements one of these, this test fails and tells them to
-        drop it from the table rather than leaving a false warning behind.
-
-        Uses the AST rather than a line regex: a regex also matched the option
-        name appearing in a *comment*, which made wiring a neighbouring option
-        fail this test for the wrong reason.
+        Uses the AST, not a regex over source lines: the line-matching version
+        failed the moment the word "output" appeared in one of chat_main's own
+        comments, which is the same class of bug it exists to catch.
         """
-        import ast
-        import inspect
-        import textwrap
-
-        src = textwrap.dedent(inspect.getsource(chat_module.chat_main))
-        tree = ast.parse(src)
-        fn = next(
-            n for n in ast.walk(tree)
-            if isinstance(n, ast.FunctionDef) and n.name == "chat_main"
+        wired = set(chat_module._UNWIRED_CHAT_OPTIONS) & _names_read_by_chat_main()
+        assert not wired, (
+            f"now read by chat_main; drop from _UNWIRED_CHAT_OPTIONS so the "
+            f"warning stops lying: {sorted(wired)}"
         )
-        read = {
-            n.id for n in ast.walk(fn)
-            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
-        }
-        for name in chat_module._UNWIRED_CHAT_OPTIONS:
-            assert name not in read, (
-                f"{name} is now read by chat_main; remove it from "
-                f"_UNWIRED_CHAT_OPTIONS so the warning stops lying"
-            )
 
     def test_every_dropped_option_is_named_in_the_table(self):
         """The table must cover the WHOLE gap, not a subset of it.

--- a/src/praisonai-code/tests/unit/test_runtime_agent_parity.py
+++ b/src/praisonai-code/tests/unit/test_runtime_agent_parity.py
@@ -1,0 +1,117 @@
+"""The warm runtime must build the same agent the cold path would.
+
+`praisonai run "<prompt>"` with a daemon up silently forwards to the warm
+runtime. That runtime constructed a bare ``Agent(name, role, goal, llm)``: no
+project-local ``.praisonai/tools/*.py``, and no AGENTS.md/CLAUDE.md subtree
+hook. The agent then returns fluent text and exits 0 having touched nothing --
+which reads as a completed task until you check the filesystem.
+
+``run_main`` already keeps ``--tools``/``--toolset``/``--mcp``/``--instructions``
+runs in-process, so what was missing is exactly the two *implicit*,
+project-scoped sources tested here.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from praisonai_code.runtime import server as server_mod
+from praisonai_code.runtime.server import _apply_cold_path_parity
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A project with a local tool and an AGENTS.md, made the cwd."""
+    tools_dir = tmp_path / ".praisonai" / "tools"
+    tools_dir.mkdir(parents=True)
+    (tools_dir / "shout.py").write_text(
+        "def shout(text: str) -> str:\n"
+        '    """Return TEXT, loudly."""\n'
+        "    return text.upper()\n"
+    )
+    (tmp_path / "AGENTS.md").write_text("# Rules\nAlways use tabs.\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PRAISONAI_ALLOW_LOCAL_TOOLS", "true")
+    return tmp_path
+
+
+def test_project_local_tools_reach_the_runtime_agent(project):
+    config = {"name": "RuntimeAgent", "role": "Assistant", "goal": "Complete the task"}
+
+    _apply_cold_path_parity(config)
+
+    names = [getattr(t, "__name__", str(t)) for t in (config.get("tools") or [])]
+    assert "shout" in names, (
+        f"the daemon-built agent has no project-local tools: {names}"
+    )
+
+
+def test_project_rules_hook_reaches_the_runtime_agent(project):
+    config = {"name": "RuntimeAgent", "role": "Assistant", "goal": "Complete the task"}
+
+    _apply_cold_path_parity(config)
+
+    assert config.get("hooks") is not None, (
+        "AGENTS.md/CLAUDE.md subtree instructions were never wired"
+    )
+
+
+def test_no_rules_opt_out_is_honoured(project, monkeypatch):
+    """PRAISON_NO_RULES must suppress the hook here as it does in-process."""
+    monkeypatch.setenv("PRAISON_NO_RULES", "1")
+    config = {"name": "RuntimeAgent"}
+
+    _apply_cold_path_parity(config)
+
+    assert config.get("hooks") is None
+
+
+def test_local_tools_opt_in_is_honoured(project, monkeypatch):
+    """Loading local tools runs user code; without the opt-in, load nothing."""
+    monkeypatch.delenv("PRAISONAI_ALLOW_LOCAL_TOOLS", raising=False)
+    config = {"name": "RuntimeAgent"}
+
+    _apply_cold_path_parity(config)
+
+    assert not config.get("tools")
+
+
+def test_parity_never_breaks_a_turn(project, monkeypatch):
+    """A failure in the parity wiring must not propagate to the daemon."""
+    import praisonai_code.cli.commands.run as run_mod
+
+    def _boom(*a, **k):
+        raise RuntimeError("discovery exploded")
+
+    monkeypatch.setattr(run_mod, "_auto_discover_project_tools", _boom)
+    monkeypatch.setattr(run_mod, "_wire_subtree_context_hook", _boom)
+
+    config = {"name": "RuntimeAgent"}
+    _apply_cold_path_parity(config)  # must not raise
+    assert config == {"name": "RuntimeAgent"}
+
+
+def _methods_calling(name):
+    """Names of WarmRuntime methods that call ``name``."""
+    tree = ast.parse(Path(server_mod.__file__).read_text())
+    cls = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.ClassDef) and n.name == "WarmRuntime"
+    )
+    found = set()
+    for fn in cls.body:
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                    and node.func.id == name:
+                found.add(fn.name)
+    return found
+
+
+def test_both_agent_builders_are_wired():
+    """The anonymous and per-session builders each construct their own Agent."""
+    callers = _methods_calling("_apply_cold_path_parity")
+    assert "_get_agent" in callers, "the anonymous warm agent is still bare"
+    assert "_get_session_agent" in callers, "the per-session warm agent is still bare"

--- a/src/praisonai-code/tests/unit/test_tui_session_persistence.py
+++ b/src/praisonai-code/tests/unit/test_tui_session_persistence.py
@@ -40,6 +40,24 @@ def store(tmp_path, monkeypatch):
     return session_store
 
 
+@pytest.fixture
+def project_store(tmp_path, monkeypatch):
+    """Isolate the project session store the agent rehydrates from.
+
+    ``apply_cli_session_continuity`` reads this store, not the flat unified one,
+    so ``/import`` must write here for the model to actually see the transcript.
+    """
+    from praisonaiagents.session.store import DefaultSessionStore
+
+    proj_store = DefaultSessionStore(session_dir=str(tmp_path / "project_sessions"))
+    import praisonai_code.cli.state.project_sessions as proj_mod
+
+    monkeypatch.setattr(
+        proj_mod, "get_project_session_store", lambda *a, **k: proj_store
+    )
+    return proj_store
+
+
 def _make_tui(tmp_path, session_id):
     # workspace=tmp_path keeps __init__'s file scan off the real repo tree.
     return AsyncTUI(AsyncTUIConfig(
@@ -98,8 +116,12 @@ def test_a_turn_survives_a_storage_failure(tmp_path, store, monkeypatch):
     tui._persist_turn("hello", "hi")  # must not raise
 
 
-def test_import_reaches_the_model_not_only_the_screen(tmp_path, store):
-    """/import reported "Imported N messages" and answered as if none existed."""
+def test_import_reaches_the_model_not_only_the_screen(tmp_path, store, project_store):
+    """/import reported "Imported N messages" and answered as if none existed.
+
+    The rebuilt agent restores from the *project* store, so the imported turns
+    must land there -- not only in the flat unified store /sessions lists.
+    """
     transcript = tmp_path / "conv.json"
     transcript.write_text(
         '{"session_id": "imported", "messages": ['
@@ -113,11 +135,36 @@ def test_import_reaches_the_model_not_only_the_screen(tmp_path, store):
     assert tui._resume_session_id == "imported", (
         "imported turns never reached the agent-rehydration path"
     )
+    # The store the model actually rehydrates from must hold the transcript.
+    project_history = project_store.get_chat_history("imported")
+    assert "the passphrase is oakleaf" in [
+        m["content"] for m in project_history
+    ], "the model would receive none of the imported conversation"
+    # And the flat store keeps it discoverable to /sessions and /continue.
     saved = store.load("imported")
     assert saved is not None
     assert "the passphrase is oakleaf" in [
         m["content"] for m in saved.get_chat_history()
     ]
+
+
+def test_import_preserves_a_trailing_unpaired_message(tmp_path, store, project_store):
+    """The old pair-stepping loop dropped a trailing/non-alternating message."""
+    transcript = tmp_path / "odd.json"
+    transcript.write_text(
+        '{"session_id": "odd", "messages": ['
+        '{"role": "user", "content": "first"},'
+        '{"role": "assistant", "content": "reply"},'
+        '{"role": "user", "content": "trailing question"}]}'
+    )
+
+    tui = _make_tui(tmp_path, "sess-odd")
+    assert tui._handle_command(f"/import {transcript}") is True
+
+    contents = [m["content"] for m in project_store.get_chat_history("odd")]
+    assert "trailing question" in contents, (
+        "the final unpaired turn was dropped before the model saw it"
+    )
 
 
 @pytest.mark.parametrize("command", ["/clear", "/new"])
@@ -135,6 +182,41 @@ def test_clear_and_new_also_drop_the_models_context(tmp_path, store, command):
         f"conversation it just cleared"
     )
     assert tui._resume_session_id is None
+    # Rotating the session id is what severs the model context: the rebuilt
+    # agent wires continuity from the current id and re-reads its stored turns,
+    # so keeping the id would reload the exact conversation just cleared.
+    assert tui.session_id != "sess-six", (
+        f"{command} kept the session id, so the next prompt would reload the "
+        f"cleared conversation from the project store"
+    )
+
+
+def test_clear_does_not_rehydrate_the_cleared_conversation(
+    tmp_path, store, project_store, monkeypatch
+):
+    """After /clear, a rebuilt agent must not restore the cleared turns.
+
+    The project store still holds the pre-clear turns under the *old* id; the
+    fix rotates ``session_id`` so ``apply_cli_session_continuity`` reads an
+    empty history for the new id instead.
+    """
+    project_store.set_chat_history(
+        "sess-clear",
+        [
+            {"role": "user", "content": "secret is orchid"},
+            {"role": "assistant", "content": "noted"},
+        ],
+    )
+
+    tui = _make_tui(tmp_path, "sess-clear")
+    tui._conversation_history = [{"role": "user", "content": "secret is orchid"}]
+
+    tui._handle_command("/clear")
+
+    # The continuity read for the rotated id must be empty.
+    assert project_store.get_chat_history(tui.session_id) == [], (
+        "the cleared conversation is still reachable under the new session id"
+    )
 
 
 def _source_of(func_name: str):

--- a/src/praisonai-code/tests/unit/test_tui_session_persistence.py
+++ b/src/praisonai-code/tests/unit/test_tui_session_persistence.py
@@ -1,0 +1,188 @@
+"""The interactive TUI must actually save sessions.
+
+Issue #4910 gave the TUI a working resume path: ``/continue`` records
+``_resume_session_id``, and ``_build_agent`` rehydrates the agent from the
+session store so a follow-up prompt is answered *with* the restored
+conversation rather than only redisplaying it.
+
+But nothing in the TUI ever *wrote* a session. A fresh ``praisonai chat``, a
+bare ``praisonai``, or a standalone ``praisonai code`` produced zero saved
+sessions, so ``/sessions`` answered "No saved sessions found.", ``/continue``
+had nothing to continue, and every conversation on the default interactive path
+was lost on exit. The resume machinery worked; there was never anything for it
+to find.
+
+Two stores are involved and both must be populated:
+
+* the flat ``UnifiedSessionStore`` -- what ``/sessions`` lists and
+  ``/continue`` loads;
+* the project session store -- what ``apply_cli_session_continuity`` reads to
+  rehydrate the agent.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from praisonai_code.cli.interactive import async_tui as tui_mod
+from praisonai_code.cli.interactive.async_tui import AsyncTUI, AsyncTUIConfig
+from praisonai_code.cli.session import UnifiedSessionStore
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """Point the TUI's session store at a temp dir, not the user's ~/.praisonai."""
+    session_store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
+    import praisonai_code.cli.session as session_pkg
+
+    monkeypatch.setattr(session_pkg, "get_session_store", lambda: session_store)
+    return session_store
+
+
+def _make_tui(tmp_path, session_id):
+    # workspace=tmp_path keeps __init__'s file scan off the real repo tree.
+    return AsyncTUI(AsyncTUIConfig(
+        session_id=session_id,
+        workspace=str(tmp_path),
+        show_logo=False,
+    ))
+
+
+def test_a_completed_turn_is_written_to_disk(tmp_path, store):
+    tui = _make_tui(tmp_path, "sess-one")
+
+    tui._persist_turn("what is 2+2", "4")
+
+    saved = store.load("sess-one")
+    assert saved is not None, "the turn was never persisted"
+    roles = [(m["role"], m["content"]) for m in saved.get_chat_history()]
+    assert ("user", "what is 2+2") in roles
+    assert ("assistant", "4") in roles
+
+
+def test_the_session_is_then_listed_by_sessions(tmp_path, store):
+    tui = _make_tui(tmp_path, "sess-listed")
+    tui._persist_turn("hello", "hi")
+
+    listed = {s.get("session_id") for s in store.list_sessions()}
+    assert "sess-listed" in listed, (
+        "/sessions would still report 'No saved sessions found.'"
+    )
+
+
+def test_a_persisted_session_can_actually_be_continued(tmp_path, store):
+    """End to end: what one TUI saves, the next one's /continue restores."""
+    writer = _make_tui(tmp_path, "sess-two")
+    writer._persist_turn("my name is Ada", "Nice to meet you, Ada.")
+
+    reader = _make_tui(tmp_path, "sess-three")
+    assert reader._handle_command("/continue") is True
+
+    assert reader.session_id == "sess-two"
+    contents = [m.get("content") for m in reader._conversation_history]
+    assert "my name is Ada" in contents
+    # Issue #4910's contract: the resumed id is recorded so the agent built
+    # next is rehydrated from it rather than starting empty.
+    assert reader._resume_session_id == "sess-two"
+
+
+def test_a_turn_survives_a_storage_failure(tmp_path, store, monkeypatch):
+    """Persistence is best-effort: it must never break the completed turn."""
+    def _boom(session):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(store, "save", _boom)
+    tui = _make_tui(tmp_path, "sess-four")
+
+    tui._persist_turn("hello", "hi")  # must not raise
+
+
+def test_import_reaches_the_model_not_only_the_screen(tmp_path, store):
+    """/import reported "Imported N messages" and answered as if none existed."""
+    transcript = tmp_path / "conv.json"
+    transcript.write_text(
+        '{"session_id": "imported", "messages": ['
+        '{"role": "user", "content": "the passphrase is oakleaf"},'
+        '{"role": "assistant", "content": "Understood."}]}'
+    )
+
+    tui = _make_tui(tmp_path, "sess-five")
+    assert tui._handle_command(f"/import {transcript}") is True
+
+    assert tui._resume_session_id == "imported", (
+        "imported turns never reached the agent-rehydration path"
+    )
+    saved = store.load("imported")
+    assert saved is not None
+    assert "the passphrase is oakleaf" in [
+        m["content"] for m in saved.get_chat_history()
+    ]
+
+
+@pytest.mark.parametrize("command", ["/clear", "/new"])
+def test_clear_and_new_also_drop_the_models_context(tmp_path, store, command):
+    tui = _make_tui(tmp_path, "sess-six")
+    tui._conversation_history = [{"role": "user", "content": "stale turn"}]
+    tui._resume_session_id = "sess-six"
+    tui._agent = object()
+
+    tui._handle_command(command)
+
+    assert tui._conversation_history == []
+    assert tui._agent is None, (
+        f"{command} cleared the screen but kept the agent holding the "
+        f"conversation it just cleared"
+    )
+    assert tui._resume_session_id is None
+
+
+def _source_of(func_name: str):
+    """Parse the module and return the named function's AST node.
+
+    Parses the file rather than using ``inspect.getsource``: some methods embed
+    triple-quoted help text at column 0, which defeats dedent.
+    """
+    module = ast.parse(Path(tui_mod.__file__).read_text())
+    return next(
+        n for n in ast.walk(module)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name == func_name
+    )
+
+
+def _calls_in(func_name: str) -> set:
+    """Names of ``self.<method>()`` calls made inside ``func_name``."""
+    return {
+        node.func.attr
+        for node in ast.walk(_source_of(func_name))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+    }
+
+
+def test_both_turn_loops_are_wired_to_the_store():
+    """Pin the call sites, so persistence cannot be quietly unhooked again."""
+    assert "_persist_turn" in _calls_in("_execute_in_background")
+    assert "_persist_turn" in _calls_in("_run_simple"), (
+        "the no-prompt_toolkit fallback loop still records nothing"
+    )
+
+
+def test_a_fresh_session_is_wired_for_auto_save():
+    """The agent must persist a brand-new session, not only a resumed one.
+
+    Before this, continuity was wired only when ``_resume_session_id`` was set,
+    so a first-ever session wrote nothing -- and therefore could never become a
+    session to resume.
+    """
+    src = _source_of("_build_agent")
+    call = next(
+        n for n in ast.walk(src)
+        if isinstance(n, ast.Call)
+        and getattr(n.func, "id", None) == "apply_cli_session_continuity"
+    )
+    kwargs = {k.arg for k in call.keywords}
+    assert "auto_save" in kwargs, "the agent will restore history but never save it"


### PR DESCRIPTION
An internal multi-agent sweep of `praisonai-code` — 395 files, never previously audited — surfaced 47 findings; **seven survived adversarial refutation, and all seven were re-verified by hand before any code was touched.** Six are in this package and share one shape: *an operation that reports success for work it never performed.* The seventh is in `praisonai-rust` and ships separately.

Each fix below was mutation-checked: the fix was reverted individually and the new test confirmed to fail.

---

### 1. The interactive TUI never saved a session

Issue #4910 gave the TUI a working resume path — `/continue` records `_resume_session_id`, and `_build_agent` rehydrates the agent from the store. But **nothing ever *wrote* a session.** So `/sessions` answered `No saved sessions found.` on every install, `/continue` had nothing to continue, and every conversation on the default interactive path was lost on exit. The resume machinery worked; there was never anything for it to find.

Two stores are involved and both were empty:

| store | read by | was written by |
|---|---|---|
| `UnifiedSessionStore` (flat) | `/sessions`, `/continue` | nothing |
| project session store | `apply_cli_session_continuity` | only on the resume path, without `auto_save` |

`_persist_turn` now writes each completed turn to the first; `_build_agent` wires continuity **with `auto_save` for fresh sessions too**, not only resumed ones — so a first-ever session can become a session to resume. Both turn loops are covered, including the no-`prompt_toolkit` fallback, which had not even been recording turns in `_conversation_history`.

### 2. `/import` restored the screen, not the model

It reported `Imported N messages` and then answered as though none of them existed — which presents to a user as a forgetful model rather than as missing plumbing. `/continue` was fixed for #4910; `/import` was not. It now persists the imported turns and routes through the same resume path.

`/clear` and `/new` had the same shape: they cleared the transcript while leaving the agent holding the conversation the user had just cleared.

### 3. The warm daemon dropped project rules and local tools

`praisonai run "<prompt>"` with a daemon running silently forwards to the warm runtime, which built a bare `Agent(name, role, goal, llm)` — no AGENTS.md/CLAUDE.md subtree hook, no project-local `.praisonai/tools/*.py`. It returned fluent text and exited 0 with nothing touched.

`run_main` already keeps `--tools`/`--toolset`/`--mcp`/`--instructions` runs in-process, so **what was missing is exactly the two *implicit*, project-scoped sources** — and since the runtime descriptor is project-scoped too, the daemon resolves the same ones the client would have. Both agent builders (anonymous and per-session) now apply them.

### 4. `praisonai chat` dropped eight more options than it admitted

The warning named four. Eight further parameters had zero reads:

- **`--file`** and **`--continue`** — both appear in the command's *own docstring examples*
- **`--no-acp`**, **`--no-lsp`** — `code` already passes these to the same config
- `--tools`, `--toolset`, `--user-id`, `--output` — these are the ones whose values `_run_legacy_terminal_chat` consumes: **a function this module defines and never calls**, which is why they read as wired to a grep and are not

The first four are now wired; the last four are declared unwired so the warning stops under-reporting.

### 5. `praisonai code --file` and `--no-autonomy` vanished

Both accepted, both dropped, and `code` had no unwired-option warning at all — so there was no CLI way to disable auto-delegation, and attached files never reached the agent. Both wired. `code_main` now has **zero** unread parameters, which a new AST test pins.

### 6. `browser-tool` reported success for work that never happened

`BrowserBaseTool.run` signals failure by *returning* a value rather than raising, so six of eight subcommands printed it as `Result:` and exited 0:

```
screenshot --output /tmp/shot.png  -> EXIT 0  "Screenshot saved to: /tmp/shot.png"
os.path.exists('/tmp/shot.png')    -> False
click '#x'                         -> EXIT 0  "{'error': 'Unknown action: click'}"
snapshot --output /tmp/snap.txt    -> writes the error dict as page text
```

The `screenshot --output` branch printed "saved" **without ever opening the file** — unconditional, not version-dependent. Results now go through `_require_success`; screenshot actually writes the bytes and fails loudly when the tool returned no image data; the seven never-read flags either reach the tool or are reported as unsupported. Flags left at their defaults are *not* forwarded, so a `praisonai-tools` build with a narrower `run()` keeps working unchanged.

---

### A test that had become the bug it guards

The existing regex pin on `_UNWIRED_CHAT_OPTIONS` matched source *lines*, and had started matching the word "output" inside one of `chat_main`'s own comments — the same class of bug it exists to catch. It is now an AST pin, and a second pin guards the other direction so an option the body ignores cannot go undeclared again.

### Verification

- **48 new tests**, each run against the *unfixed* code first: 15 of the 20 browser-tool tests fail on the original file.
- Every fix mutation-checked by reverting it individually and confirming the test fails.
- Full `praisonai-code` unit suite: **884 passed, 16 pre-existing failures — the identical set as `main`** (hooks/managed-config/train, none in touched areas).

### What the sweep disproved

Recorded because it calibrates the rest: `praisonai-rust` is *not* dead scaffolding (all three crates build; the README quick-start compiles verbatim); `RulesConfig.char_budget`, `LearnConfig.nudge_min_tool_iters` and three `OutputConfig` fields were flagged by a zero-read scan and are all false; `session export --sanitise` is not a gate that cannot fail; `plugins.enable()/disable()` do not raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Browser commands now report failures accurately, support JSON status output, and save screenshots and snapshots to files.
  - Chat and code commands now pass file attachments to the model.
  - Chat can resume sessions with `--continue` or `--session`; interactive sessions are automatically saved and restored.
  - `/clear`, `/new`, and `/import` now reset or restore conversation context correctly.
  - Runtime agents now support project-local tools and project instruction rules.

- **Bug Fixes**
  - `--no-acp`, `--no-lsp`, and code autonomy options now take effect.
  - Missing or unreadable attachments are handled without aborting commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->