### PR TITLE
fix(rust): stop RAG::query and Judge::judge fabricating results

### DIFF
--- a/src/praisonai-rust/praisonai/src/eval/mod.rs
+++ b/src/praisonai-rust/praisonai/src/eval/mod.rs
@@ -779,8 +779,19 @@ impl Judge {
 
     /// Judge an output (placeholder - would use LLM in real implementation).
     pub fn judge(&self, _input: &str, _output: &str, _expected: Option<&str>) -> JudgeResult {
-        // Placeholder implementation
-        JudgeResult::new(0.8, "Placeholder evaluation", true)
+        // Not implemented: no model is consulted and none of the three inputs
+        // is read. This used to return a hardcoded score of 0.8 with
+        // passed=true, ignoring the threshold set by with_threshold() -- a
+        // gate that could not fail, silently passing every output put through
+        // it. The signature returns a bare JudgeResult rather than a Result,
+        // so the honest answer is to fail CLOSED: score 0.0 and passed=false,
+        // with a reasoning string that says why.
+        JudgeResult::new(
+            0.0,
+            "Judge::judge is not implemented: no model is consulted and the \
+             threshold is not applied. Treat this as a failure, not a verdict.",
+            false,
+        )
     }
 }
 
@@ -890,10 +901,18 @@ mod tests {
     }
 
     #[test]
-    fn test_judge() {
+    fn test_judge_fails_closed_while_unimplemented() {
+        // This used to assert `result.passed`, which the hardcoded 0.8/true
+        // placeholder satisfied -- a test of the fake. Until a model is
+        // actually consulted, judging must not report a pass.
         let judge = Judge::new("test-judge").with_threshold(0.5);
         let result = judge.judge("input", "output", Some("expected"));
-        assert!(result.passed);
+        assert!(!result.passed, "an unimplemented judge must not pass an output");
+        assert!(
+            result.reasoning.contains("not implemented"),
+            "the reason must say why: {}",
+            result.reasoning
+        );
     }
 
     #[test]

--- a/src/praisonai-rust/praisonai/src/rag/mod.rs
+++ b/src/praisonai-rust/praisonai/src/rag/mod.rs
@@ -7,6 +7,14 @@
 //! - `Citation` - Source citation
 //! - `SmartRetriever` - Intelligent document retrieval
 //!
+//! # Status
+//!
+//! `RAG::query` is **not implemented**. It returns an error rather than a
+//! result: it previously returned a fabricated answer, a fabricated chunk with
+//! a 0.95 confidence score and a fabricated citation, which a caller could not
+//! distinguish from real retrieval. The surrounding types (chunking, context
+//! packing, citation formatting) are real and usable.
+//!
 //! # Example
 //!
 //! ```ignore
@@ -23,7 +31,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 // =============================================================================
 // CITATION
@@ -490,35 +498,27 @@ impl RAG {
     }
 
     /// Query the RAG pipeline (placeholder)
-    pub fn query(&self, question: &str) -> Result<RAGResult> {
-        // This is a placeholder - actual implementation would:
-        // 1. Retrieve relevant chunks from knowledge base
-        // 2. Build context from chunks
-        // 3. Generate answer with LLM
-        // 4. Extract citations
-
-        let context = ContextPack {
-            chunks: vec![ContextChunk::new(
-                "Sample retrieved content for the query.",
-                "knowledge_base",
-                0.95,
-            )],
-            total_tokens: 50,
-            query: question.to_string(),
-        };
-
-        let mut result = RAGResult::new(
-            format!("Answer to: {} (based on retrieved context)", question),
-            context,
-        );
-
-        result.add_citation(Citation::new(
-            "[1]",
-            "knowledge_base",
-            "Sample retrieved content",
-        ));
-
-        Ok(result)
+    pub fn query(&self, _question: &str) -> Result<RAGResult> {
+        // Retrieval is not implemented yet. This used to return Ok(..) with a
+        // fabricated answer ("Answer to: {question}"), a fabricated chunk
+        // ("Sample retrieved content for the query.") carrying a 0.95
+        // confidence score, and a fabricated citation pointing at
+        // "knowledge_base". A caller had no way to tell that apart from a real
+        // retrieval -- the score and the citation are exactly what one would
+        // inspect to decide whether to trust the answer.
+        //
+        // Failing is the honest answer until this does what its name says:
+        // 1. retrieve relevant chunks from the knowledge base
+        // 2. build context from those chunks
+        // 3. generate an answer with the LLM
+        // 4. extract real citations
+        Err(Error::Config(
+            "RAG::query is not implemented: retrieval, generation and citation \
+             are all unbuilt. It previously returned a fabricated answer with a \
+             0.95-confidence chunk and a citation, which was indistinguishable \
+             from a real result."
+                .to_string(),
+        ))
     }
 
     /// Add a knowledge source
@@ -743,12 +743,16 @@ mod tests {
     }
 
     #[test]
-    fn test_rag_query() {
+    fn test_rag_query_reports_that_it_is_unimplemented() {
+        // This used to assert `!answer.is_empty() && !citations.is_empty()`,
+        // which the fabricated placeholder satisfied. It was a test of the
+        // fake, not of retrieval.
         let rag = RAG::new().build().unwrap();
-        let result = rag.query("What is the answer?").unwrap();
-
-        assert!(!result.answer.is_empty());
-        assert!(!result.citations.is_empty());
+        let err = rag.query("What is the answer?").unwrap_err();
+        assert!(
+            err.to_string().contains("not implemented"),
+            "query must say it is unimplemented, not invent an answer: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The seventh finding from the internal sweep whose other six ship in #4943. This one is in a **published crate**, and is the worst of the set: two functions that invent their answers and return `Ok`.

### `RAG::query` fabricated the answer, the chunk, *and* the citation

```
chunk    "Sample retrieved content for the query."  score 0.95
answer   "Answer to: {question} (based on retrieved context)"
citation [1] knowledge_base                        -> returned Ok(..)
```

The confidence score and the citation are the damning part. They are precisely what a caller inspects to decide whether to trust an answer, and both were invented — a caller doing the responsible thing (checking the score, following the citation) is misled *more* than one who ignores them. It now returns an error naming what is unbuilt.

### `Judge::judge` was a gate that could not fail

It ignored all three of its arguments and returned a hardcoded `(0.8, "Placeholder evaluation", passed=true)` — disregarding its own configured threshold, so no input could ever fail the judge. It now fails **closed**: `JudgeResult::new(0.0, "...not implemented...", false)`.

Failing closed rather than open matters here: an eval gate that silently passes everything is worse than one that is obviously broken, because it is indistinguishable from a green suite.

### Verification

- The existing tests were read first, to confirm they asserted the *fabrication* rather than an intended placeholder contract — they did, which is why they had to be updated alongside.
- `cargo test`: **465 crate tests pass**. `cargo build`: clean.
- `praisonai-rust` had never been audited before this sweep. Worth recording that its first hypothesis — that the crate was dead scaffolding — was **disproved**: all three crates build, and the README quick-start compiles verbatim when copied into an example. The code is real, which is exactly why these two placeholders matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Evaluation no longer reports a passing result when judging is unavailable; it now returns a score of 0 and clearly indicates that evaluation is not implemented.
  - Retrieval queries no longer return fabricated answers or citations. They now report that the retrieval pipeline is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->