### PR TITLE
fix(cli): workflow exit codes, .praisonai path drift, dropped CLI options

### DIFF
--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -1728,11 +1728,29 @@ class AgentFlow:
             # a failure too, even though no exception was raised. Treat it like
             # step_error so on_error flow control and the final status are honored
             # instead of silently reporting the step "completed".
-            step_failed = bool(step_error) or guardrail_failed
+            #
+            # So is an LLM-backed step that produced no output at all. `chat()`
+            # returns None when the underlying call failed and the agent
+            # swallowed the error (an auth 401 is the common case): the engine
+            # already logs "Output is None" a few lines below, so it knows the
+            # step produced nothing — it just used to report the run
+            # "completed" anyway, and every consumer (CLI, API server, Python
+            # callers) was told the run succeeded. Only agent/action steps are
+            # judged this way: a custom `handler` may legitimately return None,
+            # and a skipped step never reaches here.
+            produced_nothing = (
+                output is None
+                and not step_error
+                and not step.handler
+                and (step.agent is not None or bool(step.action))
+            )
+            step_failed = bool(step_error) or guardrail_failed or produced_nothing
             failure_reason = (
                 str(step_error) if step_error
                 else (f"guardrail validation failed: {validation_feedback}"
-                      if guardrail_failed else None)
+                      if guardrail_failed
+                      else ("agent produced no output (None) — the model call "
+                            "most likely failed" if produced_nothing else None))
             )
 
             # Update step status
@@ -1866,6 +1884,26 @@ class AgentFlow:
             "variables": all_variables,
             "status": self.status
         }
+        # Surface *why* a failed run failed. Callers (the CLI included) read
+        # result["error"]; without it a genuine failure printed
+        # "Workflow failed: Unknown error".
+        if self.status == "failed":
+            reasons = [
+                f"{r.get('step')}: {r.get('error')}"
+                for r in results
+                if r.get("status") == "failed" and r.get("error")
+            ]
+            if reasons:
+                final_result["error"] = "; ".join(reasons)
+            else:
+                failed_names = [
+                    str(r.get("step")) for r in results
+                    if r.get("status") == "failed"
+                ]
+                final_result["error"] = (
+                    "step(s) failed: " + ", ".join(failed_names)
+                    if failed_names else "workflow failed"
+                )
         
         # Call on_workflow_complete callback
         if self.on_workflow_complete:

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -1818,13 +1818,19 @@ class AgentFlow:
                 except Exception as e:
                     logger.error(f"Failed to save output to file: {e}")
             
-            # Store result
-            results.append({
+            # Store result. A step that failed under on_error="continue" reaches
+            # here (the on_error="stop" branch above already returned); carry its
+            # failure_reason through so the final result surfaces *why* it failed
+            # rather than the generic "step(s) failed: <name>" fallback.
+            step_record = {
                 "step": step.name,
                 "output": output,
                 "status": self.step_statuses.get(step.name, "completed"),
                 "retries": retry_count
-            })
+            }
+            if step_failed and failure_reason:
+                step_record["error"] = failure_reason
+            results.append(step_record)
             previous_output = output
             
             if verbose:

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -2012,13 +2012,43 @@ class AgentFlow:
                 step_vars = step_result_internal.get("variables", {})
                 all_variables.update(step_vars)
                 
+                # An LLM-backed step that produced nothing is a failure here
+                # too, exactly as in the sequential path: `chat()` returns None
+                # when the model call failed and the agent swallowed the error.
+                # This loop used to mark every non-raising step "completed"
+                # before the manager ever saw it.
+                produced_nothing = (
+                    output is None
+                    and not getattr(step, 'handler', None)
+                    and (getattr(step, 'agent', None) is not None
+                         or bool(getattr(step, 'action', None)))
+                )
+
                 step_result = {
                     "step": step_name,
                     "output": output,
-                    "status": "completed"
+                    "status": "failed" if produced_nothing else "completed"
                 }
                 results.append(step_result)
-                
+
+                if produced_nothing:
+                    failure_reason = (
+                        f"Step '{step_name}' produced no output (None) -- the "
+                        f"model call most likely failed"
+                    )
+                    logger.error(failure_reason)
+                    self.status = "failed"
+                    if hasattr(step, 'status'):
+                        step.status = "failed"
+                    self.step_statuses[step_name] = "failed"
+                    step_result["failure_reason"] = failure_reason
+                    if self.on_step_error:
+                        try:
+                            self.on_step_error(self, step, Exception(failure_reason))
+                        except Exception as callback_e:
+                            logger.error(f"on_step_error callback failed: {callback_e}")
+                    break
+
                 if hasattr(step, 'status'):
                     step.status = "completed"
                 self.step_statuses[step_name] = "completed"
@@ -2077,16 +2107,26 @@ Respond with JSON: {{"approved": true/false, "reason": "Brief explanation"}}
                         output_json=True
                     )
                     
-                    if isinstance(validation_response, str):
-                        import json
-                        try:
-                            decision_data = json.loads(validation_response)
-                        except json.JSONDecodeError:
-                            decision_data = {"approved": True, "reason": "Could not parse response, assuming success"}
-                    elif isinstance(validation_response, dict):
-                        decision_data = validation_response
-                    else:
-                        decision_data = {"approved": True, "reason": "Unknown response format, assuming success"}
+                    # Parse the manager's verdict with the module's own JSON
+                    # helper, which already strips the ```json fences models
+                    # routinely emit. A bare json.loads() raised JSONDecodeError
+                    # on every fenced reply, and the handler then FAILED OPEN --
+                    # turning "approved": false into "assuming success". A
+                    # manager rejection was therefore silently discarded and the
+                    # run reported completed, which is the same class of defect
+                    # as an all-None run reporting success.
+                    decision_data = _parse_json_output(
+                        validation_response, step_name
+                    )
+                    if not isinstance(decision_data, dict):
+                        # Fail CLOSED: an unreadable verdict is not approval.
+                        decision_data = {
+                            "approved": False,
+                            "reason": (
+                                "Manager validation response could not be "
+                                f"parsed: {str(validation_response)[:200]!r}"
+                            ),
+                        }
                     
                     approved = decision_data.get("approved", True)
                     reason = decision_data.get("reason", "No reason provided")
@@ -2112,8 +2152,31 @@ Respond with JSON: {{"approved": true/false, "reason": "Brief explanation"}}
                         break
                         
                 except Exception as e:
-                    logger.warning(f"Manager validation failed for step '{step_name}': {e}. Continuing workflow.")
-                
+                    # The manager is a GATE. If it could not run, it has not
+                    # passed -- reporting "completed successfully" because the
+                    # quality check itself failed is the same lie as approving a
+                    # rejection. This block already fails closed on an
+                    # unparseable verdict two lines up, so failing open here
+                    # would be incoherent. Hierarchical mode is opt-in: a caller
+                    # who asked for manager validation wants it enforced.
+                    failure_reason = (
+                        f"Manager validation could not run for step "
+                        f"'{step_name}': {e}"
+                    )
+                    logger.error(failure_reason)
+                    self.status = "failed"
+                    if hasattr(step, 'status'):
+                        step.status = "failed"
+                    self.step_statuses[step_name] = "failed"
+                    step_result["status"] = "failed"
+                    step_result["failure_reason"] = failure_reason
+                    if self.on_step_error:
+                        try:
+                            self.on_step_error(self, step, e)
+                        except Exception as callback_e:
+                            logger.error(f"on_step_error callback failed: {callback_e}")
+                    break
+
                 previous_output = output
                 
                 # Store output in variables for next step's variable substitution
@@ -2160,6 +2223,10 @@ Respond with JSON: {{"approved": true/false, "reason": "Brief explanation"}}
         
         if failure_reason:
             final_result["failure_reason"] = failure_reason
+            # Also expose it as `error`, the key every caller (the CLI
+            # included) reads. Without it a genuine hierarchical failure
+            # printed "Workflow failed: Unknown error".
+            final_result.setdefault("error", failure_reason)
         
         if self.on_workflow_complete:
             try:

--- a/src/praisonai-agents/tests/unit/workflows/test_workflow_none_output_is_failure.py
+++ b/src/praisonai-agents/tests/unit/workflows/test_workflow_none_output_is_failure.py
@@ -126,3 +126,150 @@ class TestHandlerStepsAreNotJudgedThisWay:
             steps=[Task(name="side-effect", handler=_handler, max_retries=0)],
         )
         assert wf.start("go")["status"] == "completed"
+
+
+class TestHierarchicalManagerVerdictFailsClosed:
+    """A manager rejection must not be silently turned into approval.
+
+    `process="hierarchical"` asks a manager LLM to approve each step and parsed
+    the reply with a bare ``json.loads``. Models routinely fence JSON in
+    ```json ... ```, which raises JSONDecodeError -- and the handler then FAILED
+    OPEN, substituting ``{"approved": True, "reason": "...assuming success"}``.
+
+    So the manager answered `{"approved": false, "reason": "The output is empty
+    and does not address the task."}` and the run still reported "completed":
+    the whole validation feature was a no-op for rejections.
+
+    These use an agent that DOES produce output, so the manager is genuinely
+    consulted and it is the verdict handling under test.
+    """
+
+    def _workflow(self, agent):
+        return Workflow(
+            name="hier",
+            process="hierarchical",
+            steps=[Task(name="haiku", agent=agent, action="write a haiku",
+                        max_retries=0)],
+        )
+
+    def _stub_manager(self, monkeypatch, reply):
+        """Make the manager LLM return `reply` without any network call."""
+        from praisonaiagents.llm import LLM
+
+        monkeypatch.setattr(
+            LLM, "get_response",
+            lambda self, *a, **k: reply,
+            raising=False,
+        )
+
+    def test_a_fenced_rejection_fails_the_run(self, monkeypatch):
+        self._stub_manager(
+            monkeypatch,
+            '```json\n{"approved": false, "reason": "Off topic."}\n```',
+        )
+        result = self._workflow(_RealAgent()).start("go")
+        assert result["status"] == "failed", (
+            "a fenced manager rejection was silently treated as approval"
+        )
+
+    def test_a_bare_rejection_still_fails_the_run(self, monkeypatch):
+        self._stub_manager(
+            monkeypatch, '{"approved": false, "reason": "Off topic."}'
+        )
+        assert self._workflow(_RealAgent()).start("go")["status"] == "failed"
+
+    def test_the_rejection_reason_is_reported(self, monkeypatch):
+        self._stub_manager(
+            monkeypatch,
+            '```json\n{"approved": false, "reason": "Off topic."}\n```',
+        )
+        result = self._workflow(_RealAgent()).start("go")
+        assert "Off topic." in result.get("failure_reason", "")
+
+    def test_a_fenced_approval_still_completes(self, monkeypatch):
+        """The fence fix must work in both directions, not just reject."""
+        self._stub_manager(
+            monkeypatch,
+            '```json\n{"approved": true, "reason": "Looks good."}\n```',
+        )
+        assert self._workflow(_RealAgent()).start("go")["status"] == "completed"
+
+    def test_an_unparseable_verdict_fails_closed(self, monkeypatch):
+        """An unreadable verdict is not approval."""
+        self._stub_manager(monkeypatch, "I could not decide, sorry.")
+        result = self._workflow(_RealAgent()).start("go")
+        assert result["status"] == "failed", (
+            "an unparseable manager verdict was treated as approval"
+        )
+
+
+class TestHierarchicalRunsAreJudgedToo:
+    """`process="hierarchical"` had the reported defect in full.
+
+    Its loop marked every non-raising step "completed" before the manager saw
+    it, and skipped validation entirely when the manager LLM call itself raised
+    -- so with a dead API key the step produced nothing, the gate never ran, and
+    the CLI printed "Workflow completed successfully!" and exited 0.
+    """
+
+    def _workflow(self, agent):
+        return Workflow(
+            name="hier",
+            process="hierarchical",
+            steps=[Task(name="haiku", agent=agent, action="write a haiku",
+                        max_retries=0)],
+        )
+
+    def test_a_step_producing_nothing_fails_the_run(self, monkeypatch):
+        """Reaches the verdict without the manager needing to run at all."""
+        from praisonaiagents.llm import LLM
+
+        def _boom(self, *a, **k):
+            raise AssertionError("the manager must not be consulted")
+
+        monkeypatch.setattr(LLM, "get_response", _boom, raising=False)
+        wf = self._workflow(_NullAgent())
+        result = wf.start("go")
+        assert result["status"] == "failed"
+        # The step itself must be recorded failed too, not merely the run: the
+        # per-step record is what `--save` writes out and what callers read.
+        assert [s_["status"] for s_ in result["steps"]] == ["failed"]
+        assert wf.step_statuses["haiku"] == "failed"
+
+    def test_that_failure_is_reported_under_the_error_key(self, monkeypatch):
+        """The CLI reads `error`; hierarchical only set `failure_reason`."""
+        from praisonaiagents.llm import LLM
+
+        monkeypatch.setattr(
+            LLM, "get_response", lambda self, *a, **k: "", raising=False
+        )
+        result = self._workflow(_NullAgent()).start("go")
+        assert result.get("error"), "a failed run must say why under `error`"
+        assert "haiku" in result["error"]
+
+    def test_a_manager_outage_does_not_report_success(self, monkeypatch):
+        """If the gate cannot run, the gate has not passed."""
+        from praisonaiagents.llm import LLM
+
+        def _raise(self, *a, **k):
+            raise RuntimeError("401 Incorrect API key provided")
+
+        monkeypatch.setattr(LLM, "get_response", _raise, raising=False)
+        result = self._workflow(_RealAgent()).start("go")
+        assert result["status"] == "failed", (
+            "manager validation failed and the run still reported success"
+        )
+        assert "401" in result.get("error", "")
+
+    def test_a_healthy_hierarchical_run_still_completes(self, monkeypatch):
+        """None of this may break a run that genuinely worked."""
+        from praisonaiagents.llm import LLM
+
+        monkeypatch.setattr(
+            LLM, "get_response",
+            lambda self, *a, **k: '{"approved": true, "reason": "Good."}',
+            raising=False,
+        )
+        result = self._workflow(_RealAgent()).start("go")
+        assert result["status"] == "completed"
+        assert "error" not in result

--- a/src/praisonai-agents/tests/unit/workflows/test_workflow_none_output_is_failure.py
+++ b/src/praisonai-agents/tests/unit/workflows/test_workflow_none_output_is_failure.py
@@ -1,0 +1,128 @@
+"""A workflow whose only agent step produced nothing must not report success.
+
+`Agent.chat()` returns ``None`` when the underlying model call failed and the
+agent swallowed the error -- an invalid API key is the common case. The engine
+already logged "Step 'x': Output is None" and then still set
+``status == "completed"``, so `praisonai workflow run` printed
+"Workflow completed successfully!" over a run in which nothing happened, and
+every other consumer of ``Workflow.start()`` (the API server, Python callers)
+was told the same.
+
+The verdict belongs in the engine, not in one CLI: only here is it known
+whether the step was LLM-backed (an output is definitionally expected) or a
+custom ``handler`` (which may legitimately return ``None``).
+"""
+
+from praisonaiagents import Workflow, StepResult
+from praisonaiagents.task.task import Task
+
+
+class _NullAgent:
+    """Stands in for an Agent whose model call failed and returned nothing."""
+
+    name = "Writer"
+
+    def __init__(self):
+        self.calls = 0
+
+    def chat(self, action, **kwargs):
+        self.calls += 1
+        return None
+
+
+class _RealAgent:
+    name = "Writer"
+
+    def chat(self, action, **kwargs):
+        return "a haiku"
+
+
+class TestAgentStepProducingNothingFailsTheRun:
+
+    def test_status_is_failed_when_the_only_agent_step_returns_none(self):
+        agent = _NullAgent()
+        wf = Workflow(
+            name="haiku-flow",
+            steps=[Task(name="haiku", agent=agent, action="Write a haiku", max_retries=0)],
+        )
+        result = wf.start("Write a haiku about testing")
+        assert result["status"] == "failed", (
+            "a run whose only step produced nothing reported success: "
+            f"{result['status']!r}"
+        )
+
+    def test_the_failed_step_is_named_in_the_result(self):
+        wf = Workflow(
+            name="haiku-flow",
+            steps=[Task(name="haiku", agent=_NullAgent(), action="Write a haiku", max_retries=0)],
+        )
+        result = wf.start("go")
+        failed = [s for s in result["steps"] if s.get("status") == "failed"]
+        assert [s["step"] for s in failed] == ["haiku"]
+
+    def test_the_result_carries_a_reason_not_unknown_error(self):
+        wf = Workflow(
+            name="haiku-flow",
+            steps=[Task(name="haiku", agent=_NullAgent(), action="Write a haiku", max_retries=0)],
+        )
+        result = wf.start("go")
+        assert result.get("error"), "a failed run must say why it failed"
+        assert "haiku" in result["error"]
+
+    def test_a_later_step_does_not_run_after_one_produces_nothing(self):
+        """The default on_error is 'stop': don't feed None forward."""
+        second = _RealAgent()
+        ran = []
+
+        def _handler(ctx):
+            ran.append("second")
+            return StepResult(output="second ran")
+
+        wf = Workflow(
+            name="two-step",
+            steps=[
+                Task(name="first", agent=_NullAgent(), action="do it", max_retries=0),
+                Task(name="second", handler=_handler, max_retries=0),
+            ],
+        )
+        result = wf.start("go")
+        assert result["status"] == "failed"
+        assert ran == [], "the workflow kept going after a step produced nothing"
+
+    def test_a_working_agent_step_still_completes(self):
+        """The new verdict must not fail runs that genuinely succeeded."""
+        wf = Workflow(
+            name="haiku-flow",
+            steps=[Task(name="haiku", agent=_RealAgent(), action="Write a haiku", max_retries=0)],
+        )
+        result = wf.start("go")
+        assert result["status"] == "completed"
+        assert result["output"] == "a haiku"
+        assert "error" not in result
+
+
+class TestHandlerStepsAreNotJudgedThisWay:
+    """A custom handler returning None is legitimate -- leave it alone."""
+
+    def test_a_handler_returning_none_still_completes(self):
+        def _handler(ctx):
+            return None
+
+        wf = Workflow(
+            name="handler-flow",
+            steps=[Task(name="side-effect", handler=_handler, max_retries=0)],
+        )
+        result = wf.start("go")
+        assert result["status"] == "completed", (
+            "a handler step legitimately returning None was marked failed"
+        )
+
+    def test_a_handler_returning_a_stepresult_with_no_output_still_completes(self):
+        def _handler(ctx):
+            return StepResult(output=None)
+
+        wf = Workflow(
+            name="handler-flow",
+            steps=[Task(name="side-effect", handler=_handler, max_retries=0)],
+        )
+        assert wf.start("go")["status"] == "completed"

--- a/src/praisonai-agents/tests/unit/workflows/test_workflow_none_output_is_failure.py
+++ b/src/praisonai-agents/tests/unit/workflows/test_workflow_none_output_is_failure.py
@@ -101,6 +101,39 @@ class TestAgentStepProducingNothingFailsTheRun:
         assert "error" not in result
 
 
+class TestContinuedFailureKeepsItsReason:
+    """A None-output step with on_error='continue' must still carry its reason.
+
+    The run continues past the failed step, so it takes the general result path
+    rather than the on_error='stop' branch. That path used to omit the step's
+    error, so the final result fell back to the generic 'step(s) failed: <name>'
+    text instead of the computed 'agent produced no output' diagnostic.
+    """
+
+    def test_continued_none_step_reports_its_reason_not_the_generic_fallback(self):
+        first = Task(
+            name="first", agent=_NullAgent(), action="do it", max_retries=0
+        )
+        first.on_error = "continue"
+        wf = Workflow(
+            name="continue-flow",
+            steps=[
+                first,
+                Task(name="second", agent=_RealAgent(), action="Write a haiku", max_retries=0),
+            ],
+        )
+        result = wf.start("go")
+        assert result["status"] == "failed"
+        failed = [s for s in result["steps"] if s.get("status") == "failed"]
+        assert failed and failed[0]["step"] == "first"
+        assert "produced no output" in (failed[0].get("error") or ""), (
+            "a continued failure lost its diagnostic reason"
+        )
+        assert "produced no output" in result.get("error", ""), (
+            "the final result must surface the real reason, not the fallback"
+        )
+
+
 class TestHandlerStepsAreNotJudgedThisWay:
     """A custom handler returning None is legitimate -- leave it alone."""
 

--- a/src/praisonai-code/praisonai_code/cli/commands/chat.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/chat.py
@@ -275,11 +275,33 @@ def chat_main(
 
     # `resolved_model` was resolved above (before the onboarding gate) so the
     # gate validated the exact model dispatched here — no re-resolution needed.
+    # `--continue` was declared and dropped, so `praisonai chat -c` silently
+    # started a brand-new session. Resolve the last session id the same way the
+    # bare-TUI launch does.
+    resolved_session_id = session_id
+    if continue_session and not resolved_session_id:
+        try:
+            from praisonai_code.cli.state.project_sessions import find_last_session
+
+            resolved_session_id = find_last_session()
+        except Exception:  # noqa: BLE001 - continuity is best-effort
+            resolved_session_id = None
+        if not resolved_session_id:
+            typer.echo(
+                "No previous sessions found. Starting new session.", err=True
+            )
+
     tui_config = AsyncTUIConfig(
         model=resolved_model,
         show_logo=not compact,
         show_status_bar=not compact,
-        session_id=session_id,
+        session_id=resolved_session_id,
+        resume=bool(resolved_session_id) and (continue_session or bool(session_id)),
+        # `--no-acp`/`--no-lsp` were declared and dropped, so the tools they
+        # name loaded anyway; the AsyncTUIConfig fields for them already exist
+        # and `code` already sets them.
+        enable_acp=not no_acp,
+        enable_lsp=not no_lsp,
         workspace=workspace,
         debug=debug,
         autonomy_mode=autonomy,
@@ -407,6 +429,15 @@ _UNWIRED_CHAT_OPTIONS = {
     "ui_backend": "--ui-backend",
     "no_color": "--no-color",
     "theme": "--theme",
+    # These four were declared and dropped without any warning at all -- the
+    # table only covered the four above, so it was a subset of the real gap.
+    # `--continue`, `--no-acp` and `--no-lsp` are now genuinely wired; these
+    # remain unimplemented and say so rather than being accepted in silence.
+    "tools": "--tools",
+    "toolset": "--toolset",
+    "user_id": "--user-id",
+    "file": "--file",
+    "output": "--output",
 }
 
 

--- a/src/praisonai-code/praisonai_code/cli/commands/code.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/code.py
@@ -456,6 +456,10 @@ def code_main(
     args.tools = tools
     args.no_acp = no_acp
     args.no_lsp = no_lsp
+    # `--no-autonomy` was declared here and dropped, while `chat` wires the
+    # identical flag onto AsyncTUIConfig.autonomy_mode -- so `praisonai code
+    # --no-autonomy` ran fully autonomous anyway.
+    args.autonomy = autonomy
     args.resume_session = session_id if session_id else ('last' if continue_session else None)
     # Reasoning effort (mapped to the core thinking_budget) and named agent
     # profile (tools + permission/mode scope), consumed when the agent is built.
@@ -570,6 +574,7 @@ def _run_resident_code(prompt, args, *, plan=False, session_id=None):
         plan_mode=plan,
         enable_acp=not getattr(args, "no_acp", False),
         enable_lsp=not getattr(args, "no_lsp", False),
+        autonomy_mode=getattr(args, "autonomy", True),
         execution=getattr(args, "execution", None),
     )
 

--- a/src/praisonai-code/praisonai_code/cli/commands/config.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/config.py
@@ -30,35 +30,70 @@ def config_list(
         help="Scope to list: all, user, project",
     ),
 ):
-    """List all configuration values."""
+    """List configuration values.
+
+    `--scope` used to be declared and dropped: `--scope user` and
+    `--scope project` produced byte-identical output because the body always
+    printed the fully merged config. It now selects a single layer:
+
+    - ``all`` (default) -- the resolved, merged configuration
+    - ``user``          -- only what the global user config file contributes
+    - ``project``       -- only what this project's config file contributes
+    """
     output = get_output_controller()
-    
+
+    scope = (scope or "all").lower()
+    valid = ("all", "user", "project")
+    if scope not in valid:
+        output.print_error(
+            f"Unknown scope: {scope!r}. Use one of {', '.join(valid)}."
+        )
+        raise typer.Exit(2)
+
     try:
-        # Resolve configuration using new resolver
-        config = resolve_config()
-        config_dict = config.to_dict()
-        
+        if scope == "all":
+            config = resolve_config()
+            config_dict = config.to_dict()
+            sources = config.sources
+            title = "PraisonAI Config"
+        else:
+            resolver = get_resolver()
+            layer = (
+                resolver._load_global_config()
+                if scope == "user"
+                else resolver._load_project_config()
+            ) or {}
+            source = layer.pop("_source", None)
+            config_dict = layer
+            sources = [f"{scope}:{source}"] if source else []
+            title = f"PraisonAI Config ({scope})"
+
         if output.is_json_mode:
             output.print_json(config_dict)
             return
-        
-        output.print_panel("Configuration", title="PraisonAI Config")
-        
-        def print_dict(d, prefix=""):
-            for key, value in d.items():
-                full_key = f"{prefix}.{key}" if prefix else key
-                if isinstance(value, dict):
-                    print_dict(value, full_key)
-                else:
-                    output.print(f"  {full_key} = {value}")
-        
-        print_dict(config_dict)
-        
+
+        output.print_panel("Configuration", title=title)
+
+        if not config_dict:
+            output.print(f"  [dim]no {scope} configuration found[/dim]")
+        else:
+            def print_dict(d, prefix=""):
+                for key, value in d.items():
+                    full_key = f"{prefix}.{key}" if prefix else key
+                    if isinstance(value, dict):
+                        print_dict(value, full_key)
+                    else:
+                        output.print(f"  {full_key} = {value}")
+
+            print_dict(config_dict)
+
         # Show sources if verbose
         if output.is_verbose:
             output.print("\n[dim]Sources:[/dim]")
-            for source in config.sources:
+            for source in sources:
                 output.print(f"  • {source}")
+    except typer.Exit:
+        raise
     except Exception as e:
         output.print_error(f"Failed to load configuration: {e}")
         raise typer.Exit(1)

--- a/src/praisonai-code/praisonai_code/cli/commands/eval.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/eval.py
@@ -19,8 +19,18 @@ def eval_accuracy(
     """Run accuracy evaluation."""
     from praisonai_code._wrapper_bridge import run_wrapper_command
     
-    argv = ['eval', 'accuracy', agent, '--input', input_text, '--expected', expected]
-    
+    # `--iterations` was declared and dropped, so every accuracy run used the
+    # wrapper's default of 1 -- while the `performance` sibling below forwards
+    # the identical option. `--agent` is a named option on the wrapper's parser,
+    # not a positional, so it must be passed as one.
+    argv = [
+        'eval', 'accuracy',
+        '--agent', agent,
+        '--input', input_text,
+        '--expected', expected,
+        '--iterations', str(iterations),
+    ]
+
     run_wrapper_command(argv, feature="eval")
 
 
@@ -32,7 +42,7 @@ def eval_performance(
     """Run performance evaluation."""
     from praisonai_code._wrapper_bridge import run_wrapper_command
     
-    argv = ['eval', 'performance', agent, '--iterations', str(iterations)]
+    argv = ['eval', 'performance', '--agent', agent, '--iterations', str(iterations)]
     
     run_wrapper_command(argv, feature="eval")
 

--- a/src/praisonai-code/praisonai_code/cli/commands/memory.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/memory.py
@@ -67,16 +67,45 @@ def memory_search(
 
 @app.command("clear")
 def memory_clear(
+    target: str = typer.Argument(
+        "short",
+        help="What to clear: 'short' (short-term only) or 'all' (everything)",
+    ),
     user_id: str = typer.Option(None, "--user-id", help="User ID for memory isolation"),
-    force: bool = typer.Option(False, "--force", "-f", help="Force clear without confirmation"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip the confirmation prompt"),
 ):
-    """Clear all memories."""
+    """Clear memories (short-term by default, everything with 'all').
+
+    `--force` used to be declared and dropped: the command wiped memory with no
+    prompt at all while advertising a safety flag. It now confirms first --
+    matching the `memory learn clear` sibling in this same file -- and only
+    `--force` (or a non-interactive stdin) skips the prompt.
+
+    The `all` target was likewise unreachable: the docstring said "Clear all
+    memories" while the command could only ever clear short-term.
+
+    Examples:
+        praisonai memory clear
+        praisonai memory clear all --force
+    """
     from praisonai_code._wrapper_bridge import run_wrapper_command
-    
-    argv = ['memory', 'clear']
+
+    target = (target or "short").lower()
+    if target not in ("short", "all"):
+        typer.echo(f"Unknown target: {target!r}. Use 'short' or 'all'.", err=True)
+        raise typer.Exit(2)
+
+    if not force:
+        scope = "ALL memories" if target == "all" else "short-term memory"
+        who = f" for user {user_id}" if user_id else ""
+        if not typer.confirm(f"Clear {scope}{who}? This cannot be undone."):
+            typer.echo("Cancelled.")
+            raise typer.Exit(1)
+
+    argv = ['memory', 'clear', target]
     if user_id:
         argv.extend(['--user-id', user_id])
-    
+
     run_wrapper_command(argv, feature="memory")
 
 

--- a/src/praisonai-code/praisonai_code/cli/commands/retrieval.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/retrieval.py
@@ -15,6 +15,7 @@ from typing import List, Optional
 from contextlib import contextmanager
 import time
 import sys
+from praisonai_code.cli.configuration.paths import get_knowledge_store_path
 
 app = typer.Typer(
     name="retrieval",
@@ -113,7 +114,7 @@ def index_command(
                     "provider": "chroma",
                     "config": {
                         "collection_name": collection,
-                        "path": f"./.praison/knowledge/{collection}",
+                        "path": get_knowledge_store_path(collection),
                     }
                 }
             }
@@ -226,7 +227,7 @@ def query_command(
                 citations=citations,
                 citations_mode=CitationsMode(citations_mode),
                 vector_store_provider="chroma",
-                persist_path=f"./.praison/knowledge/{collection}",
+                persist_path=get_knowledge_store_path(collection),
                 collection_name=collection,
             )
             
@@ -348,7 +349,7 @@ def search_command(
                 "provider": "chroma",
                 "config": {
                     "collection_name": collection,
-                    "path": f"./.praison/knowledge/{collection}",
+                    "path": get_knowledge_store_path(collection),
                 }
             }
         }

--- a/src/praisonai-code/praisonai_code/cli/commands/serve.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/serve.py
@@ -453,12 +453,23 @@ def serve_ui_gateway(
 
         _mod = import_bot_module("praisonai_bot.integration.gateway_host")
         run_integrated_gateway = getattr(_mod, "run_integrated_gateway")
-        run_integrated_gateway(
-            host=host,
-            port=port,
-            title=title,
-            style=style
-        )
+        kwargs = dict(host=host, port=port, title=title, style=style)
+        # `--agents` was declared (and used in this command's own docstring
+        # example) but never forwarded. Pass it only when supplied, and only
+        # when the gateway host accepts it, so an older praisonai-bot still
+        # starts instead of raising TypeError.
+        if agents_file:
+            import inspect
+
+            if "agents_file" in inspect.signature(run_integrated_gateway).parameters:
+                kwargs["agents_file"] = agents_file
+            else:
+                output.print_error(
+                    "--agents is not supported by the installed praisonai-bot "
+                    "gateway host; upgrade praisonai-bot to use it."
+                )
+                raise typer.Exit(2)
+        run_integrated_gateway(**kwargs)
     except ImportError as e:
         output.print_error(f"UI-Gateway module not available: {e}")
         output.print("Install with: pip install praisonai-bot[gateway]")

--- a/src/praisonai-code/praisonai_code/cli/commands/serve.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/serve.py
@@ -429,6 +429,51 @@ def serve_ui(
         raise typer.Exit(4)
 
 
+def _load_gateway_agents(agents_file: str, output):
+    """Load an agents YAML file into a list of ``Agent`` objects.
+
+    The integrated gateway host forwards ``agents`` (a parsed list) to
+    ``configure_host``; it does not accept a file path. Parse the YAML here and
+    fail loudly (exit 2) on a missing/malformed/empty file rather than silently
+    starting an empty gateway.
+    """
+    import os
+    import yaml
+
+    if not os.path.exists(agents_file):
+        output.print_error(f"Agent file not found: {agents_file}")
+        raise typer.Exit(2)
+    try:
+        with open(agents_file, "r") as f:
+            config = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError) as e:
+        output.print_error(f"Could not read agent file {agents_file}: {e}")
+        raise typer.Exit(2)
+
+    agents_cfg = config.get("agents") if isinstance(config, dict) else None
+    if not isinstance(agents_cfg, list) or not agents_cfg:
+        output.print_error(f"Agent file {agents_file} has no 'agents' list")
+        raise typer.Exit(2)
+
+    from praisonaiagents import Agent
+
+    agents = []
+    for entry in agents_cfg:
+        if not isinstance(entry, dict):
+            output.print_error(
+                f"Agent file {agents_file} contains a non-mapping agent entry"
+            )
+            raise typer.Exit(2)
+        agents.append(
+            Agent(
+                name=entry.get("name", "agent"),
+                instructions=entry.get("instructions", ""),
+                llm=entry.get("llm"),
+            )
+        )
+    return agents
+
+
 @app.command("ui-gateway")
 def serve_ui_gateway(
     host: str = typer.Option("127.0.0.1", "--host", "-h", help="Host to bind to"),
@@ -455,20 +500,11 @@ def serve_ui_gateway(
         run_integrated_gateway = getattr(_mod, "run_integrated_gateway")
         kwargs = dict(host=host, port=port, title=title, style=style)
         # `--agents` was declared (and used in this command's own docstring
-        # example) but never forwarded. Pass it only when supplied, and only
-        # when the gateway host accepts it, so an older praisonai-bot still
-        # starts instead of raising TypeError.
+        # example) but never forwarded. The gateway host forwards **kwargs to
+        # ``configure_host``, which accepts a parsed ``agents`` list (not a
+        # file path), so load the YAML here and pass ``agents=[...]``.
         if agents_file:
-            import inspect
-
-            if "agents_file" in inspect.signature(run_integrated_gateway).parameters:
-                kwargs["agents_file"] = agents_file
-            else:
-                output.print_error(
-                    "--agents is not supported by the installed praisonai-bot "
-                    "gateway host; upgrade praisonai-bot to use it."
-                )
-                raise typer.Exit(2)
+            kwargs["agents"] = _load_gateway_agents(agents_file, output)
         run_integrated_gateway(**kwargs)
     except ImportError as e:
         output.print_error(f"UI-Gateway module not available: {e}")

--- a/src/praisonai-code/praisonai_code/cli/commands/todo.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/todo.py
@@ -27,8 +27,8 @@ def todo_add(
     """Add a todo."""
     from praisonai_code._wrapper_bridge import run_wrapper_command
     
-    argv = ['todo', 'add', task]
-    
+    argv = ['todo', 'add', task, '--priority', priority]
+
     run_wrapper_command(argv, feature="todo")
 
 

--- a/src/praisonai-code/praisonai_code/cli/commands/up.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/up.py
@@ -343,12 +343,16 @@ def up_status(
 
 
 @app.command("logs")
-def up_logs(
-    service: str = typer.Option("all", "--service", help="Service to show logs for (all, langfuse, langflow)"),
-    follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
-    lines: int = typer.Option(50, "--lines", "-n", help="Number of lines to show"),
-):
-    """Show logs from PraisonAI services."""
+def up_logs():
+    """Show logs from PraisonAI services.
+
+    Not implemented. This used to accept --service/--follow/--lines, drop all
+    three, print "not implemented yet" and exit 0 -- so a script piping the
+    output saw success and no logs. It now exits non-zero and does not
+    advertise options it cannot honour.
+    """
     console = Console()
-    console.print("[yellow]Log viewing not implemented yet[/yellow]")
-    console.print("[dim]Use docker logs or check process output directly[/dim]")
+    console.print("[yellow]`praisonai up logs` is not implemented.[/yellow]")
+    console.print("[dim]Use `docker logs <container>` for langfuse/langflow, "
+                  "or check the process output directly.[/dim]")
+    raise typer.Exit(2)

--- a/src/praisonai-code/praisonai_code/cli/config_loader.py
+++ b/src/praisonai-code/praisonai_code/cli/config_loader.py
@@ -62,7 +62,9 @@ class RAGCliConfig:
     
     def to_knowledge_config(self) -> Dict[str, Any]:
         """Convert to knowledge config dict."""
-        path = self.vector_store_path or f"./.praison/knowledge/{self.collection}"
+        from praisonai_code.cli.configuration.paths import get_knowledge_store_path
+
+        path = self.vector_store_path or get_knowledge_store_path(self.collection)
         
         config = {
             "vector_store": {
@@ -416,7 +418,7 @@ def get_config_schema() -> Dict[str, Any]:
         "knowledge": {
             "collection": "Collection/index name (default: 'default')",
             "vector_store_provider": "Vector store provider (default: 'chroma')",
-            "vector_store_path": "Path to vector store (default: './.praison/knowledge/{collection}')",
+            "vector_store_path": "Path to vector store (default: './.praisonai/knowledge/{collection}')",
         },
         "retrieval": {
             "top_k": "Number of results to retrieve (default: 5)",

--- a/src/praisonai-code/praisonai_code/cli/configuration/__init__.py
+++ b/src/praisonai-code/praisonai_code/cli/configuration/__init__.py
@@ -7,7 +7,12 @@ Provides configuration management with TOML support and precedence handling.
 from .loader import ConfigLoader, get_config, load_config
 from .schema import ConfigSchema
 from .paths import (
+    LEGACY_PROJECT_DATA_DIRNAME,
+    PROJECT_DATA_DIRNAME,
     get_config_paths,
+    get_project_data_dir,
+    get_project_data_path,
+    resolve_project_data_path,
     get_user_config_path,
     get_project_config_path,
     get_project_config_dir,
@@ -19,7 +24,12 @@ __all__ = [
     'ConfigSchema',
     'get_config',
     'load_config',
+    'LEGACY_PROJECT_DATA_DIRNAME',
+    'PROJECT_DATA_DIRNAME',
     'get_config_paths',
+    'get_project_data_dir',
+    'get_project_data_path',
+    'resolve_project_data_path',
     'get_user_config_path',
     'get_project_config_path',
     'get_project_config_dir',

--- a/src/praisonai-code/praisonai_code/cli/configuration/paths.py
+++ b/src/praisonai-code/praisonai_code/cli/configuration/paths.py
@@ -161,6 +161,101 @@ def get_project_config_path(project_root: Optional[Path] = None) -> Path:
     return get_project_config_dir(project_root) / "config.toml"
 
 
+# ---------------------------------------------------------------------------
+# Project-local data directory (the one *single* source of truth)
+#
+# Nine CLI features each hard-coded their own ``".praison/<file>"`` literal
+# while the runtime reads ``.praisonai/`` (``praisonaiagents.paths``). That is
+# not a cosmetic inconsistency: ``.praison`` is the FIRST entry of
+# ``_PROJECT_MARKERS``, so the moment one of those features creates
+# ``./.praison/`` in a project whose config lives in ``./.praisonai/``, this
+# module's own ``_config_dirname_for`` flips and the project's
+# ``.praisonai/config.toml`` silently stops being read.
+#
+# Everything project-local must therefore go through these helpers rather than
+# a literal, so the tenth feature cannot drift again.
+# ---------------------------------------------------------------------------
+
+def _canonical_project_dirname() -> str:
+    """The canonical project data directory name (``.praisonai``).
+
+    Taken from ``praisonaiagents.paths.DEFAULT_DIR_NAME`` so the wrapper CLI and
+    the SDK can never disagree; the literal is only a fallback for a standalone
+    ``praisonai-code`` install without the core package.
+    """
+    try:
+        from praisonaiagents.paths import DEFAULT_DIR_NAME
+
+        return DEFAULT_DIR_NAME
+    except Exception:  # noqa: BLE001 - never fail on a missing core package
+        return ".praisonai"
+
+
+#: Canonical project data directory name. Import this instead of writing
+#: ``".praisonai"`` (or, worse, ``".praison"``) anywhere.
+PROJECT_DATA_DIRNAME = _canonical_project_dirname()
+
+#: Legacy project data directory name, kept for *read-only* fallback so an
+#: existing ``./.praison/thinking.json`` is still found after the fix.
+LEGACY_PROJECT_DATA_DIRNAME = ".praison"
+
+
+def get_project_data_dir(project_root: Optional[Path] = None) -> Path:
+    """Return the canonical project data directory (``<root>/.praisonai``).
+
+    Unlike :func:`get_project_config_dir`, this never resolves to the legacy
+    ``.praison`` name: writes must always land where the runtime reads.
+    """
+    root = project_root if project_root is not None else Path.cwd()
+    return Path(root) / PROJECT_DATA_DIRNAME
+
+
+def get_project_data_path(*parts: str, project_root: Optional[Path] = None) -> Path:
+    """Canonical *write* path for a project-local data file.
+
+    ``get_project_data_path("thinking.json")`` -> ``<cwd>/.praisonai/thinking.json``.
+    """
+    return get_project_data_dir(project_root).joinpath(*parts)
+
+
+def resolve_project_data_path(
+    *parts: str, project_root: Optional[Path] = None
+) -> Path:
+    """Canonical *read* path, falling back to the legacy ``.praison`` location.
+
+    Returns the canonical path when it exists, otherwise an existing legacy
+    ``<root>/.praison/<parts>`` (so data written before this fix is still
+    found), otherwise the canonical path again. Reads fall back; writes never
+    do -- use :func:`get_project_data_path` to save.
+    """
+    canonical = get_project_data_path(*parts, project_root=project_root)
+    if canonical.exists():
+        return canonical
+    root = project_root if project_root is not None else Path.cwd()
+    legacy = Path(root).joinpath(LEGACY_PROJECT_DATA_DIRNAME, *parts)
+    if legacy.exists():
+        return legacy
+    return canonical
+
+
+def get_knowledge_store_path(collection: str) -> str:
+    """Default on-disk vector-store location for a knowledge collection.
+
+    ``./.praisonai/knowledge/<collection>``, derived from the one canonical
+    constant. An existing legacy ``./.praison/knowledge/<collection>`` is still
+    used so a collection indexed before this fix is not orphaned.
+
+    Returned as a relative path string because that is what the knowledge
+    config consumers expect, and it must stay relative to whatever directory
+    the command is run from.
+    """
+    canonical = f"./{PROJECT_DATA_DIRNAME}/knowledge/{collection}"
+    legacy = f"./{LEGACY_PROJECT_DATA_DIRNAME}/knowledge/{collection}"
+    if not os.path.exists(canonical) and os.path.exists(legacy):
+        return legacy
+    return canonical
+
+
 def get_state_dir() -> Path:
     """Return the machine-local state directory (MRU model, logs, spill).
 

--- a/src/praisonai-code/praisonai_code/cli/features/compaction.py
+++ b/src/praisonai-code/praisonai_code/cli/features/compaction.py
@@ -24,7 +24,13 @@ class CompactionHandler:
     - Display compaction statistics
     """
     
-    CONFIG_FILE = ".praison/compaction.json"
+    #: Config file name, resolved under the canonical project data
+    #: directory (``.praisonai/``). It used to be a hard-coded
+    #: ``".praison/compaction.json"``, which created a second dot-directory
+    #: that the config loader then preferred over the project's real
+    #: ``.praisonai/config.toml`` (``_PROJECT_MARKERS`` lists
+    #: ``.praison`` first), silently changing which config was read.
+    CONFIG_NAME = "compaction.json"
     
     def __init__(self, verbose: bool = False):
         self.verbose = verbose
@@ -34,8 +40,25 @@ class CompactionHandler:
         return "compaction"
     
     def _get_config_path(self) -> str:
-        """Get path to config file."""
-        return os.path.join(os.getcwd(), self.CONFIG_FILE)
+        """Path to the config file, under the canonical project data dir.
+
+        Reads fall back to an existing legacy ``./.praison/`` file so a
+        setting saved before the fix is still honoured; a save always
+        lands on the canonical ``./.praisonai/`` location.
+        """
+        from praisonai_code.cli.configuration.paths import (
+            resolve_project_data_path,
+        )
+
+        return str(resolve_project_data_path(self.CONFIG_NAME))
+
+    def _get_config_write_path(self) -> str:
+        """Canonical path to save to (never the legacy fallback)."""
+        from praisonai_code.cli.configuration.paths import (
+            get_project_data_path,
+        )
+
+        return str(get_project_data_path(self.CONFIG_NAME))
     
     def _load_config(self) -> Dict[str, Any]:
         """Load config from file."""
@@ -49,8 +72,8 @@ class CompactionHandler:
         return {}
     
     def _save_config(self, config: Dict[str, Any]):
-        """Save config to file."""
-        config_path = self._get_config_path()
+        """Save config to the canonical project data directory."""
+        config_path = self._get_config_write_path()
         os.makedirs(os.path.dirname(config_path), exist_ok=True)
         with open(config_path, 'w') as f:
             json.dump(config, f, indent=2)

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/memory_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/memory_checks.py
@@ -18,20 +18,55 @@ from ..registry import register_check
 
 
 def _find_memory_dirs() -> list:
-    """Find memory storage directories."""
-    locations = [
-        Path.cwd() / ".praison" / "memory",
-        Path.cwd() / ".praison" / "sessions",
+    """Find the memory/session directories the *runtime* actually uses.
+
+    This hard-coded ``~/.praison/...`` and ignored ``PRAISONAI_HOME`` entirely,
+    so with ``PRAISONAI_HOME`` set the runtime stored memory in one place while
+    doctor inspected another -- the same defect as the skills check. The
+    canonical locations come from ``praisonaiagents.paths``, the same helpers
+    the memory store itself resolves through, so the two cannot disagree.
+
+    The legacy ``~/.praison`` entries are kept only as an additional read
+    location, after the canonical ones, so an existing install still reports.
+    """
+    locations = []
+    try:
+        from praisonaiagents.paths import (
+            get_memory_dir,
+            get_project_data_dir,
+            get_sessions_dir,
+        )
+
+        locations = [
+            get_project_data_dir() / "memory",
+            get_project_data_dir() / "sessions",
+            get_memory_dir(),
+            get_sessions_dir(),
+        ]
+    except Exception:  # noqa: BLE001 - core package is optional
+        from praisonai_code.cli.configuration.paths import (
+            PROJECT_DATA_DIRNAME,
+            home_root,
+        )
+
+        locations = [
+            Path.cwd() / PROJECT_DATA_DIRNAME / "memory",
+            Path.cwd() / PROJECT_DATA_DIRNAME / "sessions",
+            home_root() / "memory",
+            home_root() / "sessions",
+        ]
+
+    # Legacy locations, read-only, after the canonical ones.
+    locations += [
         Path.home() / ".praison" / "memory",
         Path.home() / ".praison" / "sessions",
-        Path.home() / ".config" / "praison" / "memory",
     ]
-    
+
     found = []
     for loc in locations:
-        if loc.exists() and loc.is_dir():
+        if loc.exists() and loc.is_dir() and str(loc) not in found:
             found.append(str(loc))
-    
+
     return found
 
 

--- a/src/praisonai-code/praisonai_code/cli/features/doctor/checks/skills_checks.py
+++ b/src/praisonai-code/praisonai_code/cli/features/doctor/checks/skills_checks.py
@@ -17,20 +17,55 @@ from ..registry import register_check
 
 
 def _find_skills_dirs() -> list:
-    """Find skills directories."""
-    locations = [
-        Path.cwd() / ".praison" / "skills",
-        Path.cwd() / ".claude" / "skills",
-        Path.home() / ".praison" / "skills",
-        Path.home() / ".config" / "praison" / "skills",
-    ]
-    
+    """Find the skills directories the *runtime* actually loads from.
+
+    This used to be its own hard-coded list starting at ``./.praison/skills``,
+    while ``praisonai skills list`` loads ``./.praisonai/skills`` (via
+    ``praisonaiagents.paths.get_project_data_dir``). With both directories
+    populated, `skills list` showed one skill and `doctor` reported and
+    validated a different one -- doctor was checking a directory nothing reads,
+    and its empty state told users to create it.
+
+    The locations are now derived from the same ``praisonaiagents.paths``
+    helpers the skill loader itself uses, so the two cannot disagree again.
+    Only the *parent* directories are listed (project, ``.claude``, user):
+    the loader's remote-skill cache entries are individual skills rather than
+    directories of skills, and doctor's per-entry validation walks children.
+    """
+    locations = []
+    try:
+        from praisonaiagents.paths import get_project_data_dir, get_skills_dir
+
+        locations = [
+            get_project_data_dir() / "skills",
+            Path.cwd() / ".claude" / "skills",
+            get_skills_dir(),
+        ]
+    except Exception:  # noqa: BLE001 - core package is optional
+        from praisonai_code.cli.configuration.paths import (
+            PROJECT_DATA_DIRNAME,
+            home_root,
+        )
+
+        locations = [
+            Path.cwd() / PROJECT_DATA_DIRNAME / "skills",
+            Path.cwd() / ".claude" / "skills",
+            home_root() / "skills",
+        ]
+
     found = []
     for loc in locations:
-        if loc.exists() and loc.is_dir():
+        if loc.exists() and loc.is_dir() and str(loc) not in found:
             found.append(str(loc))
-    
+
     return found
+
+
+def _skills_dir_hint() -> str:
+    """The directory to tell users to create -- the one the runtime reads."""
+    from praisonai_code.cli.configuration.paths import PROJECT_DATA_DIRNAME
+
+    return f"{PROJECT_DATA_DIRNAME}/skills/"
 
 
 def _validate_skill_dir(skill_path: Path) -> dict:
@@ -127,7 +162,7 @@ def check_skills_dirs(config: DoctorConfig) -> CheckResult:
             category=CheckCategory.SKILLS,
             status=CheckStatus.SKIP,
             message="No skills directories found (optional)",
-            details="Create .praison/skills/ to add agent skills",
+            details=f"Create {_skills_dir_hint()} to add agent skills",
         )
 
 

--- a/src/praisonai-code/praisonai_code/cli/features/file_history.py
+++ b/src/praisonai-code/praisonai_code/cli/features/file_history.py
@@ -16,7 +16,26 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_HISTORY_DIR = ".praison/history"
+def _default_history_dir() -> str:
+    """Home-level file-history directory, from the SDK's canonical data root.
+
+    Was a hard-coded ``~/.praison/history`` while every other user-level store
+    resolves through ``praisonaiagents.paths.get_data_dir()`` (``~/.praisonai``,
+    honouring ``PRAISONAI_HOME`` and the legacy fallback), so undo history was
+    written somewhere nothing else looked.
+    """
+    try:
+        from praisonaiagents.paths import get_data_dir
+
+        return str(get_data_dir() / "history")
+    except Exception:  # noqa: BLE001 - core package is optional
+        import os as _os
+
+        return _os.path.expanduser("~/.praisonai/history")
+
+
+#: Kept for callers that imported the name; now the canonical location.
+DEFAULT_HISTORY_DIR = _default_history_dir()
 MAX_VERSIONS_PER_FILE = 50
 
 
@@ -67,7 +86,7 @@ class FileHistoryManager:
         storage_dir: Optional[str] = None,
         max_versions: int = MAX_VERSIONS_PER_FILE,
     ):
-        self.storage_dir = storage_dir or os.path.expanduser(f"~/{DEFAULT_HISTORY_DIR}")
+        self.storage_dir = storage_dir or _default_history_dir()
         self.max_versions = max_versions
         self._index: Dict[str, List[FileVersion]] = {}
         self._ensure_storage()

--- a/src/praisonai-code/praisonai_code/cli/features/knowledge.py
+++ b/src/praisonai-code/praisonai_code/cli/features/knowledge.py
@@ -114,13 +114,25 @@ Examples:
         if self._knowledge is None:
             try:
                 from praisonaiagents import Knowledge
+
+                from praisonai_code.cli.configuration.paths import (
+                    resolve_project_data_path,
+                )
                 
                 # Build config based on options
                 config = {
                     "vector_store": {
                         "provider": self.vector_store,
                         "config": {
-                            "path": os.path.join(self.workspace, ".praison", "knowledge")
+                            # Canonical project data dir, via the one shared
+                            # constant. A hard-coded ".praison" here created a
+                            # second dot-directory that the config loader then
+                            # preferred over the project's real ".praisonai".
+                            "path": str(
+                                resolve_project_data_path(
+                                    "knowledge", project_root=self.workspace
+                                )
+                            )
                         }
                     }
                 }

--- a/src/praisonai-code/praisonai_code/cli/features/output_style.py
+++ b/src/praisonai-code/praisonai_code/cli/features/output_style.py
@@ -22,7 +22,13 @@ class OutputStyleHandler:
     - Set output style (concise, detailed, technical, conversational, structured, minimal)
     """
     
-    CONFIG_FILE = ".praison/output.json"
+    #: Config file name, resolved under the canonical project data
+    #: directory (``.praisonai/``). It used to be a hard-coded
+    #: ``".praison/output.json"``, which created a second dot-directory
+    #: that the config loader then preferred over the project's real
+    #: ``.praisonai/config.toml`` (``_PROJECT_MARKERS`` lists
+    #: ``.praison`` first), silently changing which config was read.
+    CONFIG_NAME = "output.json"
     
     def __init__(self, verbose: bool = False):
         self.verbose = verbose
@@ -32,8 +38,25 @@ class OutputStyleHandler:
         return "output"
     
     def _get_config_path(self) -> str:
-        """Get path to config file."""
-        return os.path.join(os.getcwd(), self.CONFIG_FILE)
+        """Path to the config file, under the canonical project data dir.
+
+        Reads fall back to an existing legacy ``./.praison/`` file so a
+        setting saved before the fix is still honoured; a save always
+        lands on the canonical ``./.praisonai/`` location.
+        """
+        from praisonai_code.cli.configuration.paths import (
+            resolve_project_data_path,
+        )
+
+        return str(resolve_project_data_path(self.CONFIG_NAME))
+
+    def _get_config_write_path(self) -> str:
+        """Canonical path to save to (never the legacy fallback)."""
+        from praisonai_code.cli.configuration.paths import (
+            get_project_data_path,
+        )
+
+        return str(get_project_data_path(self.CONFIG_NAME))
     
     def _load_config(self) -> Dict[str, Any]:
         """Load config from file."""
@@ -47,8 +70,8 @@ class OutputStyleHandler:
         return {}
     
     def _save_config(self, config: Dict[str, Any]):
-        """Save config to file."""
-        config_path = self._get_config_path()
+        """Save config to the canonical project data directory."""
+        config_path = self._get_config_write_path()
         os.makedirs(os.path.dirname(config_path), exist_ok=True)
         with open(config_path, 'w') as f:
             json.dump(config, f, indent=2)

--- a/src/praisonai-code/praisonai_code/cli/features/queue/models.py
+++ b/src/praisonai-code/praisonai_code/cli/features/queue/models.py
@@ -10,6 +10,14 @@ from typing import Any, Dict, List, Optional
 import time
 import uuid
 
+from praisonai_code.cli.configuration.paths import PROJECT_DATA_DIRNAME
+
+#: Default queue database, relative to the project root. Derived from the one
+#: canonical project-data directory name instead of a hard-coded
+#: ``".praison/queue.db"``: that literal created a second dot-directory which
+#: the config loader then preferred over the project's real ``.praisonai/``.
+DEFAULT_QUEUE_DB_PATH = f"{PROJECT_DATA_DIRNAME}/queue.db"
+
 
 class RunState(str, Enum):
     """State of a queued run."""
@@ -197,7 +205,7 @@ class QueueConfig:
     
     # Persistence
     enable_persistence: bool = True
-    db_path: str = ".praison/queue.db"
+    db_path: str = DEFAULT_QUEUE_DB_PATH
     
     # Autosave
     autosave_interval_seconds: float = 30.0
@@ -243,7 +251,7 @@ class QueueConfig:
             default_priority=priority,
             default_max_retries=data.get("default_max_retries", 3),
             enable_persistence=data.get("enable_persistence", True),
-            db_path=data.get("db_path", ".praison/queue.db"),
+            db_path=data.get("db_path", DEFAULT_QUEUE_DB_PATH),
             autosave_interval_seconds=data.get("autosave_interval_seconds", 30.0),
             stream_buffer_size=data.get("stream_buffer_size", 1000),
             drop_strategy=data.get("drop_strategy", "oldest"),

--- a/src/praisonai-code/praisonai_code/cli/features/queue/persistence.py
+++ b/src/praisonai-code/praisonai_code/cli/features/queue/persistence.py
@@ -14,7 +14,13 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .models import QueuedRun, RunState, RunPriority, QueueStats
+from .models import (
+    DEFAULT_QUEUE_DB_PATH,
+    QueuedRun,
+    RunState,
+    RunPriority,
+    QueueStats,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,13 +105,26 @@ CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);
 class QueuePersistence:
     """SQLite-backed persistence for the queue system."""
     
-    def __init__(self, db_path: str = ".praison/queue.db"):
+    def __init__(self, db_path: Optional[str] = None):
         """
         Initialize persistence layer.
-        
+
         Args:
-            db_path: Path to SQLite database file.
+            db_path: Path to SQLite database file. Defaults to the canonical
+                project data directory (``.praisonai/queue.db``); an existing
+                queue database at the legacy ``.praison/queue.db`` is still
+                opened so a queue created before the fix is not orphaned.
         """
+        if db_path is None:
+            from praisonai_code.cli.configuration.paths import (
+                LEGACY_PROJECT_DATA_DIRNAME,
+            )
+
+            db_path = DEFAULT_QUEUE_DB_PATH
+            if not os.path.exists(db_path):
+                legacy = os.path.join(LEGACY_PROJECT_DATA_DIRNAME, "queue.db")
+                if os.path.exists(legacy):
+                    db_path = legacy
         self.db_path = db_path
         self._conn: Optional[sqlite3.Connection] = None
         self._lock = threading.Lock()

--- a/src/praisonai-code/praisonai_code/cli/features/thinking.py
+++ b/src/praisonai-code/praisonai_code/cli/features/thinking.py
@@ -62,7 +62,13 @@ class ThinkingHandler:
     - Display usage statistics
     """
     
-    CONFIG_FILE = ".praison/thinking.json"
+    #: Config file name, resolved under the canonical project data
+    #: directory (``.praisonai/``). It used to be a hard-coded
+    #: ``".praison/thinking.json"``, which created a second dot-directory
+    #: that the config loader then preferred over the project's real
+    #: ``.praisonai/config.toml`` (``_PROJECT_MARKERS`` lists
+    #: ``.praison`` first), silently changing which config was read.
+    CONFIG_NAME = "thinking.json"
     
     def __init__(self, verbose: bool = False):
         self.verbose = verbose
@@ -74,8 +80,25 @@ class ThinkingHandler:
         return "thinking"
     
     def _get_config_path(self) -> str:
-        """Get path to config file."""
-        return os.path.join(os.getcwd(), self.CONFIG_FILE)
+        """Path to the config file, under the canonical project data dir.
+
+        Reads fall back to an existing legacy ``./.praison/`` file so a
+        setting saved before the fix is still honoured; a save always
+        lands on the canonical ``./.praisonai/`` location.
+        """
+        from praisonai_code.cli.configuration.paths import (
+            resolve_project_data_path,
+        )
+
+        return str(resolve_project_data_path(self.CONFIG_NAME))
+
+    def _get_config_write_path(self) -> str:
+        """Canonical path to save to (never the legacy fallback)."""
+        from praisonai_code.cli.configuration.paths import (
+            get_project_data_path,
+        )
+
+        return str(get_project_data_path(self.CONFIG_NAME))
     
     def _load_config(self) -> Dict[str, Any]:
         """Load config from file."""
@@ -89,8 +112,8 @@ class ThinkingHandler:
         return {}
     
     def _save_config(self, config: Dict[str, Any]):
-        """Save config to file."""
-        config_path = self._get_config_path()
+        """Save config to the canonical project data directory."""
+        config_path = self._get_config_write_path()
         os.makedirs(os.path.dirname(config_path), exist_ok=True)
         with open(config_path, 'w') as f:
             json.dump(config, f, indent=2)

--- a/src/praisonai-code/praisonai_code/cli/features/todo.py
+++ b/src/praisonai-code/praisonai_code/cli/features/todo.py
@@ -120,6 +120,32 @@ Flag Usage:
         
         return todos
     
+    #: Accepted values for `--priority`, shared by the CLI and this handler.
+    PRIORITIES = ("low", "medium", "high")
+
+    @staticmethod
+    def _extract_priority(args):
+        """Split a `--priority <v>` / `-p <v>` pair out of positional argv.
+
+        Returns ``(remaining_args, priority_or_None)``.
+        """
+        remaining = []
+        priority = None
+        i = 0
+        while i < len(args):
+            arg = args[i]
+            if arg in ("--priority", "-p") and i + 1 < len(args):
+                priority = str(args[i + 1]).lower()
+                i += 2
+                continue
+            if arg.startswith("--priority="):
+                priority = arg.split("=", 1)[1].lower()
+                i += 1
+                continue
+            remaining.append(arg)
+            i += 1
+        return remaining, priority
+
     def action_add(self, args: List[str], **kwargs) -> Dict[str, Any]:
         """
         Add a new todo.
@@ -133,9 +159,25 @@ Flag Usage:
         if not args:
             self.print_status("Usage: praisonai todo add <task>", "error")
             return {}
-        
+
+        # `--priority/-p` arrives inline in argv from the Typer command, which
+        # used to declare the option and never forward it -- so
+        # `todo add "x" --priority high` produced a medium-priority todo.
+        # Pull it out here so it never lands in the task text either.
+        args, inline_priority = self._extract_priority(list(args))
+        if not args:
+            self.print_status("Usage: praisonai todo add <task>", "error")
+            return {}
+
         task = ' '.join(args)
-        priority = kwargs.get('priority', 'medium')
+        priority = inline_priority or kwargs.get('priority') or 'medium'
+        if priority not in self.PRIORITIES:
+            self.print_status(
+                f"Unknown priority: {priority}. Use one of "
+                f"{', '.join(self.PRIORITIES)}.",
+                "error",
+            )
+            return {}
         
         todos = self._load_todos()
         

--- a/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
+++ b/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
@@ -1200,8 +1200,11 @@ class PraisonAI:
                         if '=' in var:
                             key, value = var.split('=', 1)
                             workflow_vars[key] = value
-                self.handle_workflow_command(action, action_args, workflow_vars, args)
-                sys.exit(0)
+                # Propagate the handler's exit code. This used to be a
+                # hard-coded sys.exit(0): a run whose only step failed still
+                # reported success, so a CI job that ran a workflow doing
+                # nothing stayed green.
+                sys.exit(self.handle_workflow_command(action, action_args, workflow_vars, args) or 0)
 
             elif args.command == 'hooks':
                 self._require_agents()

--- a/src/praisonai-code/praisonai_code/cli/unified_schema.py
+++ b/src/praisonai-code/praisonai_code/cli/unified_schema.py
@@ -241,7 +241,11 @@ if BaseModel:
         
         def to_knowledge_config(self) -> Dict[str, Any]:
             """Convert to knowledge config format."""
-            path = self.vector_store_path or f"./.praison/knowledge/{self.collection}"
+            from praisonai_code.cli.configuration.paths import (
+                get_knowledge_store_path,
+            )
+
+            path = self.vector_store_path or get_knowledge_store_path(self.collection)
             
             config = {
                 "vector_store": {

--- a/src/praisonai-code/tests/unit/cli/test_chat_unwired_options.py
+++ b/src/praisonai-code/tests/unit/cli/test_chat_unwired_options.py
@@ -105,23 +105,117 @@ class TestUnwiredChatOptions:
 
         If someone implements one of these, this test fails and tells them to
         drop it from the table rather than leaving a false warning behind.
-        """
-        import inspect
-        import re
 
-        src = inspect.getsource(chat_module.chat_main)
-        body = src[src.index("):"):]
+        Uses the AST rather than a line regex: a regex also matched the option
+        name appearing in a *comment*, which made wiring a neighbouring option
+        fail this test for the wrong reason.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        src = textwrap.dedent(inspect.getsource(chat_module.chat_main))
+        tree = ast.parse(src)
+        fn = next(
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "chat_main"
+        )
+        read = {
+            n.id for n in ast.walk(fn)
+            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+        }
         for name in chat_module._UNWIRED_CHAT_OPTIONS:
-            uses = [
-                line for line in body.splitlines()
-                if re.search(rf"\b{re.escape(name)}\b", line)
-                and "_UNWIRED_CHAT_OPTIONS" not in line
-                and "_warn_about_unwired_options" not in line
-            ]
-            assert not uses, (
+            assert name not in read, (
                 f"{name} is now read by chat_main; remove it from "
                 f"_UNWIRED_CHAT_OPTIONS so the warning stops lying"
             )
+
+    def test_every_dropped_option_is_named_in_the_table(self):
+        """The table must cover the WHOLE gap, not a subset of it.
+
+        It listed four options while nine were silently dropped, so
+        `chat --tools web_search` was accepted, ignored, and never mentioned.
+        Any declared option chat_main never reads must either be wired or be
+        listed here.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        src = textwrap.dedent(inspect.getsource(chat_module.chat_main))
+        fn = next(
+            n for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.FunctionDef) and n.name == "chat_main"
+        )
+        defaults = fn.args.defaults
+        params = fn.args.args[len(fn.args.args) - len(defaults):]
+        declared = [
+            a.arg for a, d in zip(params, defaults)
+            if "typer.Option" in ast.unparse(d) or "typer.Argument" in ast.unparse(d)
+        ]
+        read = {
+            n.id for n in ast.walk(fn)
+            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+        }
+        # `pure` is consumed by the @scopes_no_plugins decorator, which reads it
+        # out of **kwargs rather than from the body.
+        unread = [
+            p for p in declared
+            if p not in read and p != "pure"
+        ]
+        missing = [p for p in unread if p not in chat_module._UNWIRED_CHAT_OPTIONS]
+        assert not missing, (
+            f"chat declares and silently drops {missing}; wire them or add them "
+            f"to _UNWIRED_CHAT_OPTIONS so the user is told"
+        )
+
+
+class TestNewlyWiredOptions:
+    """--continue, --no-acp and --no-lsp were dropped; now they reach the TUI."""
+
+    def test_no_acp_disables_acp_on_the_config(self, monkeypatch):
+        _StubTUI.last_config = None
+        _run(monkeypatch, "--no-acp")
+        assert _StubTUI.last_config.enable_acp is False
+
+    def test_no_lsp_disables_lsp_on_the_config(self, monkeypatch):
+        _StubTUI.last_config = None
+        _run(monkeypatch, "--no-lsp")
+        assert _StubTUI.last_config.enable_lsp is False
+
+    def test_acp_and_lsp_stay_enabled_by_default(self, monkeypatch):
+        _StubTUI.last_config = None
+        _run(monkeypatch)
+        assert _StubTUI.last_config.enable_acp is True
+        assert _StubTUI.last_config.enable_lsp is True
+
+    def test_continue_resolves_the_last_session_onto_the_config(self, monkeypatch):
+        monkeypatch.setattr(
+            "praisonai_code.cli.state.project_sessions.find_last_session",
+            lambda *a, **k: "sess-123",
+        )
+        _StubTUI.last_config = None
+        _run(monkeypatch, "--continue")
+        assert _StubTUI.last_config.session_id == "sess-123"
+        assert _StubTUI.last_config.resume is True
+
+    def test_without_continue_no_session_is_resumed(self, monkeypatch):
+        monkeypatch.setattr(
+            "praisonai_code.cli.state.project_sessions.find_last_session",
+            lambda *a, **k: "sess-123",
+        )
+        _StubTUI.last_config = None
+        _run(monkeypatch)
+        assert _StubTUI.last_config.session_id is None
+        assert _StubTUI.last_config.resume is False
+
+    def test_none_of_them_trigger_the_unwired_warning(self, monkeypatch):
+        monkeypatch.setattr(
+            "praisonai_code.cli.state.project_sessions.find_last_session",
+            lambda *a, **k: "sess-123",
+        )
+        out = _run(monkeypatch, "--no-acp", "--no-lsp", "--continue").output
+        assert "does not implement" not in out
 
 
 class TestWiredCapabilityOptions:

--- a/src/praisonai-code/tests/unit/cli/test_declared_options_are_honoured.py
+++ b/src/praisonai-code/tests/unit/cli/test_declared_options_are_honoured.py
@@ -336,59 +336,118 @@ class TestRecipeJudgeGoal:
 # ---------------------------------------------------------------------------
 
 class TestServeUiGatewayAgents:
+    """`--agents` was declared, used in the command's own docstring example,
+    and never forwarded.
 
-    def _run(self, monkeypatch, args, accepts_agents=True):
+    The contract matters: ``run_integrated_gateway`` takes ``**configure_kwargs``
+    and hands them to ``configure_host``, which declares
+    ``agents: Optional[List[Any]]`` -- a PARSED LIST, not a file path, and not a
+    parameter named ``agents_file``. An earlier attempt at this fix passed
+    ``agents_file=<path>`` behind an ``inspect.signature`` guard, which could
+    never match a ``**kwargs`` function and so rejected the option every time.
+    These tests pin the real contract so that cannot recur.
+    """
+
+    AGENTS_YAML = (
+        "agents:\n"
+        "  - name: Writer\n"
+        "    instructions: You write things\n"
+        "    llm: gpt-4o-mini\n"
+        "  - name: Editor\n"
+        "    instructions: You edit things\n"
+    )
+
+    def _run(self, monkeypatch, args):
         captured = {}
 
-        if accepts_agents:
-            def _run_gateway(host=None, port=None, title=None, style=None,
-                             agents_file=None):
-                captured.update(
-                    host=host, port=port, title=title, style=style,
-                    agents_file=agents_file,
-                )
-        else:
-            def _run_gateway(host=None, port=None, title=None, style=None):
-                captured.update(host=host, port=port, title=title, style=style)
+        def _run_gateway(**kwargs):
+            captured.update(kwargs)
 
         class _Mod:
             run_integrated_gateway = staticmethod(_run_gateway)
 
         monkeypatch.setattr(
-            "praisonai_code._bot_bridge.import_bot_module",
-            lambda name: _Mod,
+            "praisonai_code._bot_bridge.import_bot_module", lambda name: _Mod
         )
         from praisonai_code.cli.commands import serve as serve_module
 
         result = _invoke(_group("ui-gateway", serve_module.serve_ui_gateway), args)
         return result, captured
 
-    def test_the_agents_file_reaches_the_gateway(self, monkeypatch):
+    @pytest.fixture
+    def agents_yaml(self, tmp_path):
+        f = tmp_path / "agents.yaml"
+        f.write_text(self.AGENTS_YAML)
+        return str(f)
+
+    def test_a_parsed_agent_list_reaches_the_gateway(self, monkeypatch, agents_yaml):
         result, captured = self._run(
-            monkeypatch, ["ui-gateway", "--agents", "agents.yaml"]
+            monkeypatch, ["ui-gateway", "--agents", agents_yaml]
         )
         assert result.exit_code == 0, result.output
-        assert captured["agents_file"] == "agents.yaml"
+        assert "agents" in captured, (
+            "the gateway never received the agents; configure_host takes "
+            "`agents`, not `agents_file`"
+        )
+        assert isinstance(captured["agents"], list)
+        assert len(captured["agents"]) == 2
+
+    def test_it_is_a_list_of_agents_not_the_path(self, monkeypatch, agents_yaml):
+        _, captured = self._run(monkeypatch, ["ui-gateway", "--agents", agents_yaml])
+        assert captured.get("agents_file") is None, (
+            "passed a file path under a parameter configure_host does not declare"
+        )
+        assert [a.name for a in captured["agents"]] == ["Writer", "Editor"]
 
     def test_it_is_not_passed_when_not_supplied(self, monkeypatch):
         result, captured = self._run(monkeypatch, ["ui-gateway"])
         assert result.exit_code == 0, result.output
-        assert captured["agents_file"] is None
+        assert "agents" not in captured
 
-    def test_an_older_gateway_that_cannot_take_it_fails_loudly(self, monkeypatch):
-        """Never silently drop it, and never crash with a TypeError."""
-        result, _ = self._run(
-            monkeypatch, ["ui-gateway", "--agents", "agents.yaml"],
-            accepts_agents=False,
+    def test_the_other_options_still_reach_the_gateway(self, monkeypatch):
+        _, captured = self._run(
+            monkeypatch, ["ui-gateway", "--style", "chat", "--title", "My App"]
+        )
+        assert captured["style"] == "chat"
+        assert captured["title"] == "My App"
+
+    def test_a_missing_file_fails_loudly(self, monkeypatch):
+        result, captured = self._run(
+            monkeypatch, ["ui-gateway", "--agents", "/no/such/agents.yaml"]
         )
         assert result.exit_code != 0
+        assert captured == {}, "the gateway was started despite a bad --agents"
 
-    def test_an_older_gateway_still_starts_without_the_option(self, monkeypatch):
-        result, captured = self._run(
-            monkeypatch, ["ui-gateway"], accepts_agents=False
-        )
-        assert result.exit_code == 0, result.output
-        assert captured["style"] == "dashboard"
+    def test_a_file_without_an_agents_list_fails_loudly(self, monkeypatch, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("something_else: 1\n")
+        result, captured = self._run(monkeypatch, ["ui-gateway", "--agents", str(bad)])
+        assert result.exit_code != 0
+        assert captured == {}
+
+    def test_malformed_yaml_fails_loudly(self, monkeypatch, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("agents: [unclosed\n")
+        result, captured = self._run(monkeypatch, ["ui-gateway", "--agents", str(bad)])
+        assert result.exit_code != 0
+        assert captured == {}
+
+    def test_the_real_gateway_host_accepts_the_kwarg_we_send(self):
+        """Pin the contract against the actual praisonai-bot signature.
+
+        A unit test with a stub cannot catch "we pass a kwarg the real function
+        rejects" -- which is exactly how the earlier attempt went wrong.
+        """
+        import inspect
+
+        try:
+            from praisonai_bot.integration.host_app import configure_host
+        except Exception:
+            pytest.skip("praisonai-bot not importable")
+
+        params = inspect.signature(configure_host).parameters
+        assert "agents" in params, "configure_host no longer takes `agents`"
+        assert "agents_file" not in params
 
 
 # ---------------------------------------------------------------------------

--- a/src/praisonai-code/tests/unit/cli/test_declared_options_are_honoured.py
+++ b/src/praisonai-code/tests/unit/cli/test_declared_options_are_honoured.py
@@ -1,0 +1,454 @@
+"""Declared CLI options must do something, or not be declared.
+
+An AST scan found 45 `typer.Option`/`Argument` parameters that never appear in
+their own function body. These are the ones verified by running them: each was
+accepted, validated by typer, and dropped.
+
+Assertions are on behaviour and exit codes, never message text.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+
+def _invoke(app, args, **kwargs):
+    return CliRunner().invoke(app, args, **kwargs)
+
+
+def _group(name, fn):
+    """A Typer app with `fn` registered as `name`.
+
+    A second, inert command is registered too: Typer collapses a single-command
+    app into a bare callback, which would make the command name be parsed as
+    the first argument.
+    """
+    app = typer.Typer()
+    app.command(name)(fn)
+
+    @app.command("__filler")
+    def _filler():  # pragma: no cover - never invoked
+        pass
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# memory clear -- destructive, advertised --force it ignored, and no prompt
+# ---------------------------------------------------------------------------
+
+class TestMemoryClearIsGuarded:
+
+    @pytest.fixture
+    def cleared(self, monkeypatch):
+        """Capture the argv `memory clear` would hand the wrapper."""
+        seen = []
+        monkeypatch.setattr(
+            "praisonai_code._wrapper_bridge.run_wrapper_command",
+            lambda argv, feature=None: seen.append(list(argv)),
+        )
+        return seen
+
+    def _app(self):
+        from praisonai_code.cli.commands import memory as memory_module
+
+        return _group("clear", memory_module.memory_clear)
+
+    def test_without_force_and_without_confirmation_nothing_is_cleared(self, cleared):
+        result = _invoke(self._app(), ["clear", "all"], input="n\n")
+        assert cleared == [], "memory was wiped despite the user declining"
+        assert result.exit_code != 0
+
+    def test_without_force_and_no_stdin_nothing_is_cleared(self, cleared):
+        result = _invoke(self._app(), ["clear", "all"], input="")
+        assert cleared == [], "memory was wiped with no confirmation at all"
+        assert result.exit_code != 0
+
+    def test_confirming_clears(self, cleared):
+        result = _invoke(self._app(), ["clear", "all"], input="y\n")
+        assert result.exit_code == 0, result.output
+        assert cleared and cleared[0][:3] == ["memory", "clear", "all"]
+
+    def test_force_skips_the_prompt(self, cleared):
+        result = _invoke(self._app(), ["clear", "all", "--force"], input="")
+        assert result.exit_code == 0, result.output
+        assert cleared and cleared[0][:3] == ["memory", "clear", "all"]
+
+    def test_force_short_flag_skips_the_prompt(self, cleared):
+        result = _invoke(self._app(), ["clear", "-f"], input="")
+        assert result.exit_code == 0, result.output
+        assert cleared
+
+    def test_the_target_reaches_the_wrapper(self, cleared):
+        """`clear all` was unreachable: the command always cleared short-term."""
+        _invoke(self._app(), ["clear", "all", "-f"], input="")
+        assert cleared[0][2] == "all"
+        cleared.clear()
+        _invoke(self._app(), ["clear", "-f"], input="")
+        assert cleared[0][2] == "short"
+
+    def test_an_unknown_target_is_rejected(self, cleared):
+        result = _invoke(self._app(), ["clear", "banana", "-f"], input="")
+        assert result.exit_code != 0
+        assert cleared == []
+
+    def test_user_id_still_reaches_the_wrapper(self, cleared):
+        _invoke(self._app(), ["clear", "-f", "--user-id", "bob"], input="")
+        assert "--user-id" in cleared[0] and "bob" in cleared[0]
+
+
+# ---------------------------------------------------------------------------
+# todo add --priority
+# ---------------------------------------------------------------------------
+
+class TestTodoAddPriority:
+
+    @pytest.fixture
+    def handler(self, tmp_path):
+        from praisonai_code.cli.features.todo import TodoHandler
+
+        return TodoHandler(workspace=str(tmp_path))
+
+    def test_priority_is_stored(self, handler):
+        todo = handler.action_add(["buy milk", "--priority", "high"])
+        assert todo["priority"] == "high"
+
+    def test_short_flag_is_stored(self, handler):
+        assert handler.action_add(["x", "-p", "low"])["priority"] == "low"
+
+    def test_equals_form_is_stored(self, handler):
+        assert handler.action_add(["x", "--priority=high"])["priority"] == "high"
+
+    def test_the_flag_never_lands_in_the_task_text(self, handler):
+        todo = handler.action_add(["buy milk", "--priority", "high"])
+        assert todo["task"] == "buy milk"
+
+    def test_the_default_is_medium(self, handler):
+        assert handler.action_add(["x"])["priority"] == "medium"
+
+    def test_an_unknown_priority_is_rejected(self, handler):
+        assert handler.action_add(["x", "-p", "urgent"]) == {}
+
+    def test_the_typer_command_forwards_the_option(self, monkeypatch):
+        seen = []
+        monkeypatch.setattr(
+            "praisonai_code._wrapper_bridge.run_wrapper_command",
+            lambda argv, feature=None: seen.append(list(argv)),
+        )
+        from praisonai_code.cli.commands import todo as todo_module
+
+        _invoke(_group("add", todo_module.todo_add),
+                ["add", "buy milk", "--priority", "high"])
+        assert seen and "--priority" in seen[0] and "high" in seen[0]
+
+
+# ---------------------------------------------------------------------------
+# config list --scope
+# ---------------------------------------------------------------------------
+
+class TestConfigListScope:
+
+    def _app(self):
+        from praisonai_code.cli.commands import config as config_module
+
+        return _group("list", config_module.config_list)
+
+    @pytest.fixture
+    def project(self, tmp_path, monkeypatch):
+        """An isolated home + project so both scopes have known content."""
+        monkeypatch.delenv("PRAISONAI_PROJECT", raising=False)
+        monkeypatch.delenv("PRAISONAI_CONFIG", raising=False)
+        monkeypatch.delenv("PRAISONAI_CONFIG_CONTENT", raising=False)
+
+        home = tmp_path / "home"
+        (home / ".praisonai").mkdir(parents=True)
+        (home / ".praisonai" / "config.yaml").write_text(
+            "model:\n  default: from-the-user\n"
+        )
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+
+        proj = tmp_path / "proj"
+        (proj / ".praisonai").mkdir(parents=True)
+        (proj / ".praisonai" / "config.yaml").write_text(
+            "model:\n  default: from-the-project\n"
+        )
+        monkeypatch.chdir(proj)
+
+        # Force a fresh resolver rooted at this cwd.
+        from praisonai_code.cli.configuration import resolver as resolver_module
+
+        resolver_module.get_resolver(proj, reset=True)
+        return proj
+
+    def test_user_and_project_scopes_differ(self, project):
+        user = _invoke(self._app(), ["list", "--scope", "user"]).output
+        proj = _invoke(self._app(), ["list", "--scope", "project"]).output
+        assert user != proj, "--scope user and --scope project are still identical"
+
+    def test_project_scope_shows_the_project_value(self, project):
+        out = _invoke(self._app(), ["list", "--scope", "project"]).output
+        assert "from-the-project" in out
+
+    def test_user_scope_shows_the_user_value_only(self, project):
+        out = _invoke(self._app(), ["list", "--scope", "user"]).output
+        assert "from-the-user" in out
+        assert "from-the-project" not in out
+
+    def test_an_unknown_scope_is_rejected(self, project):
+        assert _invoke(self._app(), ["list", "--scope", "banana"]).exit_code != 0
+
+    def test_all_scope_still_succeeds(self, project):
+        assert _invoke(self._app(), ["list", "--scope", "all"]).exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# eval accuracy -n / --iterations
+# ---------------------------------------------------------------------------
+
+class TestEvalAccuracyIterations:
+
+    def _argv(self, monkeypatch, args):
+        seen = []
+        monkeypatch.setattr(
+            "praisonai_code._wrapper_bridge.run_wrapper_command",
+            lambda argv, feature=None: seen.append(list(argv)),
+        )
+        from praisonai_code.cli.commands import eval as eval_module
+
+        _invoke(_group("accuracy", eval_module.eval_accuracy), args)
+        return seen[0] if seen else []
+
+    def test_iterations_is_forwarded(self, monkeypatch):
+        argv = self._argv(monkeypatch, [
+            "accuracy", "a.yaml", "-i", "2+2", "-e", "4", "-n", "7",
+        ])
+        assert "--iterations" in argv
+        assert argv[argv.index("--iterations") + 1] == "7"
+
+    def test_the_agent_is_passed_as_the_named_option_the_wrapper_parses(
+        self, monkeypatch
+    ):
+        """The wrapper's parser declares --agent; a bare positional was rejected."""
+        argv = self._argv(monkeypatch, [
+            "accuracy", "a.yaml", "-i", "x", "-e", "y",
+        ])
+        assert "--agent" in argv
+        assert argv[argv.index("--agent") + 1] == "a.yaml"
+        assert "a.yaml" not in argv[:2]
+
+    def test_the_wrapper_parser_accepts_what_we_send(self, monkeypatch):
+        """Parse the forwarded argv with the wrapper's own parser."""
+        import argparse
+
+        from praisonai.cli.features.eval import add_eval_parser_subcommands
+
+        argv = self._argv(monkeypatch, [
+            "accuracy", "a.yaml", "-i", "2+2", "-e", "4", "-n", "7",
+        ])
+        parser = argparse.ArgumentParser(prog="praisonai eval")
+        add_eval_parser_subcommands(parser.add_subparsers(dest="eval_type"))
+        parsed = parser.parse_args(argv[1:])
+        assert parsed.iterations == 7
+        assert parsed.agent == "a.yaml"
+
+
+# ---------------------------------------------------------------------------
+# recipe judge --goal
+# ---------------------------------------------------------------------------
+
+class TestRecipeJudgeGoal:
+
+    def test_judge_trace_accepts_an_explicit_goal(self):
+        import inspect
+
+        from praisonai.replay import ContextEffectivenessJudge
+
+        sig = inspect.signature(ContextEffectivenessJudge.judge_trace)
+        assert "recipe_goal" in sig.parameters
+
+    def test_the_explicit_goal_reaches_the_report(self, monkeypatch):
+        from praisonai.replay import ContextEffectivenessJudge
+
+        judge = ContextEffectivenessJudge()
+        # No events -> the report is built from the (empty) agent data, but the
+        # goal must still be the one supplied.
+        report = judge.judge_trace([], session_id="t", recipe_goal="ship the blog")
+        assert report.recipe_goal == "ship the blog"
+
+    def test_without_a_goal_the_report_carries_none(self):
+        from praisonai.replay import ContextEffectivenessJudge
+
+        report = ContextEffectivenessJudge().judge_trace([], session_id="t")
+        assert not report.recipe_goal
+
+    def _run_judge(self, monkeypatch, args):
+        """Invoke `recipe judge` with the reader and judge stubbed out.
+
+        Returns the kwargs the command handed ``judge_trace``.
+        """
+        import praisonai.replay as replay
+
+        captured = {}
+
+        class _Reader:
+            def __init__(self, trace_id):
+                pass
+
+            def get_all(self):
+                return [{"event": "one"}]
+
+        class _Judge:
+            def __init__(self, **kwargs):
+                pass
+
+            def judge_trace(self, events, **kwargs):
+                captured.update(kwargs)
+                return object()
+
+        monkeypatch.setattr(replay, "ContextTraceReader", _Reader)
+        monkeypatch.setattr(replay, "ContextEffectivenessJudge", _Judge)
+        monkeypatch.setattr(replay, "format_judge_report", lambda r: "")
+
+        from praisonai.cli.commands import recipe as recipe_module
+
+        _invoke(_group("judge", recipe_module.recipe_judge), args)
+        return captured
+
+    def test_the_command_passes_its_goal_through(self, monkeypatch):
+        captured = self._run_judge(
+            monkeypatch, ["judge", "run-abc", "--goal", "ship the blog"]
+        )
+        assert captured.get("recipe_goal") == "ship the blog", (
+            "recipe judge still drops --goal"
+        )
+
+    def test_without_the_option_no_goal_is_forced(self, monkeypatch):
+        captured = self._run_judge(monkeypatch, ["judge", "run-abc"])
+        assert not captured.get("recipe_goal")
+
+
+# ---------------------------------------------------------------------------
+# serve ui-gateway --agents (used in the command's own docstring example)
+# ---------------------------------------------------------------------------
+
+class TestServeUiGatewayAgents:
+
+    def _run(self, monkeypatch, args, accepts_agents=True):
+        captured = {}
+
+        if accepts_agents:
+            def _run_gateway(host=None, port=None, title=None, style=None,
+                             agents_file=None):
+                captured.update(
+                    host=host, port=port, title=title, style=style,
+                    agents_file=agents_file,
+                )
+        else:
+            def _run_gateway(host=None, port=None, title=None, style=None):
+                captured.update(host=host, port=port, title=title, style=style)
+
+        class _Mod:
+            run_integrated_gateway = staticmethod(_run_gateway)
+
+        monkeypatch.setattr(
+            "praisonai_code._bot_bridge.import_bot_module",
+            lambda name: _Mod,
+        )
+        from praisonai_code.cli.commands import serve as serve_module
+
+        result = _invoke(_group("ui-gateway", serve_module.serve_ui_gateway), args)
+        return result, captured
+
+    def test_the_agents_file_reaches_the_gateway(self, monkeypatch):
+        result, captured = self._run(
+            monkeypatch, ["ui-gateway", "--agents", "agents.yaml"]
+        )
+        assert result.exit_code == 0, result.output
+        assert captured["agents_file"] == "agents.yaml"
+
+    def test_it_is_not_passed_when_not_supplied(self, monkeypatch):
+        result, captured = self._run(monkeypatch, ["ui-gateway"])
+        assert result.exit_code == 0, result.output
+        assert captured["agents_file"] is None
+
+    def test_an_older_gateway_that_cannot_take_it_fails_loudly(self, monkeypatch):
+        """Never silently drop it, and never crash with a TypeError."""
+        result, _ = self._run(
+            monkeypatch, ["ui-gateway", "--agents", "agents.yaml"],
+            accepts_agents=False,
+        )
+        assert result.exit_code != 0
+
+    def test_an_older_gateway_still_starts_without_the_option(self, monkeypatch):
+        result, captured = self._run(
+            monkeypatch, ["ui-gateway"], accepts_agents=False
+        )
+        assert result.exit_code == 0, result.output
+        assert captured["style"] == "dashboard"
+
+
+# ---------------------------------------------------------------------------
+# up logs -- advertised three options, honoured none, and exited 0
+# ---------------------------------------------------------------------------
+
+class TestUpLogs:
+
+    def _app(self):
+        from praisonai_code.cli.commands import up as up_module
+
+        return _group("logs", up_module.up_logs)
+
+    def test_it_no_longer_reports_success(self):
+        assert _invoke(self._app(), ["logs"]).exit_code != 0
+
+    def test_it_no_longer_advertises_options_it_ignores(self):
+        for flag in ("--service", "--follow", "--lines"):
+            result = _invoke(self._app(), ["logs", flag, "x"])
+            assert result.exit_code != 0, flag
+
+
+# ---------------------------------------------------------------------------
+# code --no-autonomy
+# ---------------------------------------------------------------------------
+
+class TestCodeNoAutonomy:
+
+    def test_the_flag_reaches_the_tui_config(self):
+        import ast
+        import inspect
+        import textwrap
+
+        from praisonai_code.cli.commands import code as code_module
+
+        src = textwrap.dedent(inspect.getsource(code_module.code_main))
+        fn = next(
+            n for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.FunctionDef) and n.name == "code_main"
+        )
+        read = {
+            n.id for n in ast.walk(fn)
+            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+        }
+        assert "autonomy" in read, "code still drops --no-autonomy"
+
+    def test_the_resident_runner_honours_it(self):
+        import argparse
+        import ast
+        import inspect
+        import textwrap
+
+        from praisonai_code.cli.commands import code as code_module
+
+        src = textwrap.dedent(inspect.getsource(code_module._run_resident_code))
+        assert "autonomy_mode=" in src, (
+            "_run_resident_code builds AsyncTUIConfig without autonomy_mode"
+        )
+
+    def test_chat_and_code_agree_on_the_default(self):
+        from praisonai_code.cli.interactive.async_tui import AsyncTUIConfig
+
+        assert AsyncTUIConfig().autonomy_mode is True

--- a/src/praisonai-code/tests/unit/cli/test_project_data_dir_is_one_constant.py
+++ b/src/praisonai-code/tests/unit/cli/test_project_data_dir_is_one_constant.py
@@ -266,3 +266,46 @@ class TestFileHistoryUsesTheSdkDataRoot:
         assert file_history._default_history_dir() == str(
             core_paths.get_data_dir() / "history"
         )
+
+
+class TestDoctorMemoryChecksScanWhatTheRuntimeUses:
+    """`doctor`'s memory check hard-coded ~/.praison and ignored PRAISONAI_HOME.
+
+    Same defect as the skills check: with PRAISONAI_HOME set, the runtime stored
+    memory in one place while doctor inspected another, so the check reported on
+    directories nothing reads (and missed the ones that matter).
+    """
+
+    def test_the_project_memory_dir_is_the_canonical_one(self, project, monkeypatch):
+        monkeypatch.setenv("PRAISONAI_HOME", str(project / "home"))
+        (project / PROJECT_DATA_DIRNAME / "memory").mkdir(parents=True)
+        (project / LEGACY_PROJECT_DATA_DIRNAME / "memory").mkdir(parents=True)
+
+        from praisonai_code.cli.features.doctor.checks import memory_checks
+
+        dirs = memory_checks._find_memory_dirs()
+        assert str(project / PROJECT_DATA_DIRNAME / "memory") in dirs
+        assert str(project / LEGACY_PROJECT_DATA_DIRNAME / "memory") not in dirs
+
+    def test_it_honours_praisonai_home(self, project, monkeypatch):
+        home = project / "home"
+        monkeypatch.setenv("PRAISONAI_HOME", str(home))
+        import praisonaiagents.paths as core_paths
+
+        core_paths._clear_cache()
+        (home / "memory").mkdir(parents=True)
+
+        from praisonai_code.cli.features.doctor.checks import memory_checks
+
+        assert str(home / "memory") in memory_checks._find_memory_dirs(), (
+            "doctor ignored PRAISONAI_HOME and looked at the legacy dir instead"
+        )
+
+    def test_no_duplicates_are_reported(self, project, monkeypatch):
+        monkeypatch.setenv("PRAISONAI_HOME", str(project / "home"))
+        (project / PROJECT_DATA_DIRNAME / "memory").mkdir(parents=True)
+
+        from praisonai_code.cli.features.doctor.checks import memory_checks
+
+        dirs = memory_checks._find_memory_dirs()
+        assert len(dirs) == len(set(dirs))

--- a/src/praisonai-code/tests/unit/cli/test_project_data_dir_is_one_constant.py
+++ b/src/praisonai-code/tests/unit/cli/test_project_data_dir_is_one_constant.py
@@ -1,0 +1,268 @@
+"""Project-local CLI data must live in the one canonical directory.
+
+Nine CLI features each hard-coded ``.praison/<file>`` while the runtime reads
+``.praisonai/`` (``praisonaiagents.paths``). That is not cosmetic: ``.praison``
+is the FIRST entry of ``paths._PROJECT_MARKERS``, so the moment one of those
+features creates ``./.praison/`` in a project whose config lives in
+``./.praisonai/``, ``_config_dirname_for`` flips and the project's real
+``.praisonai/config.toml`` silently stops being read.
+
+Every assertion here is made against the shared constant, never a literal, so a
+future drift back to ``.praison`` fails these tests rather than shipping.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from praisonai_code.cli.configuration.paths import (
+    LEGACY_PROJECT_DATA_DIRNAME,
+    PROJECT_DATA_DIRNAME,
+    get_knowledge_store_path,
+    get_project_data_path,
+    resolve_project_data_path,
+)
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """An empty project directory, as cwd, with no PRAISONAI_PROJECT override."""
+    monkeypatch.delenv("PRAISONAI_PROJECT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestTheConstantItself:
+
+    def test_matches_the_sdk_canonical_dir_name(self):
+        from praisonaiagents.paths import DEFAULT_DIR_NAME
+
+        assert PROJECT_DATA_DIRNAME == DEFAULT_DIR_NAME
+
+    def test_the_legacy_name_is_not_the_canonical_one(self):
+        assert LEGACY_PROJECT_DATA_DIRNAME != PROJECT_DATA_DIRNAME
+
+
+class TestSettingsHandlersWriteToTheCanonicalDir:
+    """thinking / compaction / output-style each owned a `.praison/*.json`."""
+
+    HANDLERS = [
+        ("praisonai_code.cli.features.thinking", "ThinkingHandler"),
+        ("praisonai_code.cli.features.compaction", "CompactionHandler"),
+        ("praisonai_code.cli.features.output_style", "OutputStyleHandler"),
+    ]
+
+    def _handlers(self):
+        import importlib
+
+        for mod_name, cls_name in self.HANDLERS:
+            mod = importlib.import_module(mod_name)
+            yield cls_name, getattr(mod, cls_name)
+
+    def test_save_lands_under_the_canonical_dir(self, project):
+        for name, cls in self._handlers():
+            handler = cls()
+            handler._save_config({"probe": name})
+            written = Path(handler._get_config_write_path())
+            assert written.parent == project / PROJECT_DATA_DIRNAME, name
+            assert written.exists(), name
+
+    def test_no_legacy_directory_is_created(self, project):
+        for name, cls in self._handlers():
+            cls()._save_config({"probe": name})
+        assert not (project / LEGACY_PROJECT_DATA_DIRNAME).exists()
+
+    def test_a_save_round_trips(self, project):
+        for name, cls in self._handlers():
+            handler = cls()
+            handler._save_config({"probe": name})
+            assert handler._load_config() == {"probe": name}, name
+
+    def test_an_existing_legacy_file_is_still_read(self, project):
+        """Data written before the fix must not be orphaned."""
+        for name, cls in self._handlers():
+            handler = cls()
+            legacy = project / LEGACY_PROJECT_DATA_DIRNAME / handler.CONFIG_NAME
+            legacy.parent.mkdir(parents=True, exist_ok=True)
+            legacy.write_text(json.dumps({"legacy": name}))
+            assert handler._load_config() == {"legacy": name}, name
+
+    def test_saving_over_a_legacy_file_writes_the_canonical_one(self, project):
+        for name, cls in self._handlers():
+            handler = cls()
+            legacy = project / LEGACY_PROJECT_DATA_DIRNAME / handler.CONFIG_NAME
+            legacy.parent.mkdir(parents=True, exist_ok=True)
+            legacy.write_text(json.dumps({"legacy": name}))
+            handler._save_config({"fresh": name})
+            canonical = project / PROJECT_DATA_DIRNAME / handler.CONFIG_NAME
+            assert canonical.exists(), name
+            assert json.loads(canonical.read_text()) == {"fresh": name}, name
+
+
+class TestTheProjectConfigIsNoLongerHijacked:
+    """The user-visible consequence: which config.toml gets read."""
+
+    def test_saving_a_setting_does_not_change_the_resolved_project_config(
+        self, project
+    ):
+        (project / PROJECT_DATA_DIRNAME).mkdir()
+        (project / PROJECT_DATA_DIRNAME / "config.toml").write_text(
+            '[model]\ndefault = "from-the-project"\n'
+        )
+
+        from praisonai_code.cli.configuration.loader import ConfigLoader
+        from praisonai_code.cli.features.thinking import ThinkingHandler
+
+        before = ConfigLoader().load().model.default
+        assert before == "from-the-project"
+
+        ThinkingHandler()._save_config({"level": "high"})
+
+        after = ConfigLoader().load().model.default
+        assert after == before, (
+            "saving a thinking budget silently changed which config.toml is read"
+        )
+
+
+class TestQueueDefaults:
+
+    def test_config_default_uses_the_constant(self):
+        from praisonai_code.cli.features.queue.models import (
+            DEFAULT_QUEUE_DB_PATH,
+            QueueConfig,
+        )
+
+        assert DEFAULT_QUEUE_DB_PATH.startswith(PROJECT_DATA_DIRNAME + "/")
+        assert QueueConfig().db_path == DEFAULT_QUEUE_DB_PATH
+
+    def test_from_dict_default_uses_the_constant(self):
+        from praisonai_code.cli.features.queue.models import (
+            DEFAULT_QUEUE_DB_PATH,
+            QueueConfig,
+        )
+
+        assert QueueConfig.from_dict({}).db_path == DEFAULT_QUEUE_DB_PATH
+
+    def test_persistence_default_uses_the_constant(self, project):
+        from praisonai_code.cli.features.queue.models import DEFAULT_QUEUE_DB_PATH
+        from praisonai_code.cli.features.queue.persistence import QueuePersistence
+
+        assert QueuePersistence().db_path == DEFAULT_QUEUE_DB_PATH
+
+    def test_persistence_still_opens_an_existing_legacy_database(self, project):
+        legacy = project / LEGACY_PROJECT_DATA_DIRNAME / "queue.db"
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_bytes(b"")
+
+        from praisonai_code.cli.features.queue.persistence import QueuePersistence
+
+        assert Path(QueuePersistence().db_path).name == "queue.db"
+        assert LEGACY_PROJECT_DATA_DIRNAME in QueuePersistence().db_path
+
+
+class TestKnowledgeStorePath:
+
+    def test_default_is_under_the_canonical_dir(self, project):
+        assert get_knowledge_store_path("docs") == (
+            f"./{PROJECT_DATA_DIRNAME}/knowledge/docs"
+        )
+
+    def test_an_existing_legacy_store_is_still_used(self, project):
+        legacy = project / LEGACY_PROJECT_DATA_DIRNAME / "knowledge" / "docs"
+        legacy.mkdir(parents=True)
+        assert get_knowledge_store_path("docs") == (
+            f"./{LEGACY_PROJECT_DATA_DIRNAME}/knowledge/docs"
+        )
+
+    def test_every_knowledge_consumer_agrees(self, project):
+        """config_loader, unified_schema and retrieval must not diverge."""
+        from praisonai_code.cli.config_loader import RAGCliConfig
+
+        cfg = RAGCliConfig(collection="docs")
+        path = cfg.to_knowledge_config()["vector_store"]["config"]["path"]
+        assert path == get_knowledge_store_path("docs")
+
+    def test_no_source_file_still_hard_codes_the_legacy_knowledge_path(self):
+        import praisonai_code
+
+        root = Path(praisonai_code.__file__).parent
+        offenders = []
+        for py in root.rglob("*.py"):
+            text = py.read_text(errors="ignore")
+            if f'"./{LEGACY_PROJECT_DATA_DIRNAME}/knowledge/' in text:
+                offenders.append(str(py))
+        assert not offenders, offenders
+
+
+class TestDoctorScansWhatTheRuntimeReads:
+    """`doctor` validated `.praison/skills` while the loader reads
+    `.praisonai/skills`, so it reported a different skill than `skills list`."""
+
+    def _make_skill(self, parent, name):
+        d = parent / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: a probe skill\n---\nBody.\n"
+        )
+        return d
+
+    def test_the_project_skills_dir_doctor_finds_is_the_canonical_one(
+        self, project, monkeypatch
+    ):
+        monkeypatch.setenv("PRAISONAI_HOME", str(project / "home"))
+        self._make_skill(project / PROJECT_DATA_DIRNAME / "skills", "newskill")
+        self._make_skill(project / LEGACY_PROJECT_DATA_DIRNAME / "skills", "ghost")
+
+        from praisonai_code.cli.features.doctor.checks import skills_checks
+
+        dirs = skills_checks._find_skills_dirs()
+        assert str(project / PROJECT_DATA_DIRNAME / "skills") in dirs
+        assert str(project / LEGACY_PROJECT_DATA_DIRNAME / "skills") not in dirs
+
+    def test_doctor_and_the_loader_report_the_same_project_skill(
+        self, project, monkeypatch
+    ):
+        monkeypatch.setenv("PRAISONAI_HOME", str(project / "home"))
+        self._make_skill(project / PROJECT_DATA_DIRNAME / "skills", "newskill")
+        self._make_skill(project / LEGACY_PROJECT_DATA_DIRNAME / "skills", "ghost")
+
+        from praisonaiagents.skills.discovery import discover_skills
+
+        from praisonai_code.cli.features.doctor.checks import skills_checks
+
+        loader_names = {s.name for s in discover_skills(include_defaults=True)}
+        doctor_names = set()
+        for d in skills_checks._find_skills_dirs():
+            for child in Path(d).iterdir():
+                if child.is_dir() and (child / "SKILL.md").exists():
+                    doctor_names.add(child.name)
+
+        assert "newskill" in loader_names and "newskill" in doctor_names
+        assert "ghost" not in loader_names, "the loader read the legacy dir"
+        assert "ghost" not in doctor_names, (
+            "doctor validated a skill directory the runtime never reads"
+        )
+
+    def test_the_empty_state_names_the_canonical_dir(self):
+        from praisonai_code.cli.features.doctor.checks import skills_checks
+
+        hint = skills_checks._skills_dir_hint()
+        assert hint.startswith(PROJECT_DATA_DIRNAME + "/")
+        assert not hint.startswith(LEGACY_PROJECT_DATA_DIRNAME + "/")
+
+
+class TestFileHistoryUsesTheSdkDataRoot:
+
+    def test_history_dir_is_under_the_sdk_data_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PRAISONAI_HOME", str(tmp_path / "home"))
+        import praisonaiagents.paths as core_paths
+
+        core_paths._clear_cache()
+
+        from praisonai_code.cli.features import file_history
+
+        assert file_history._default_history_dir() == str(
+            core_paths.get_data_dir() / "history"
+        )

--- a/src/praisonai/praisonai/cli/commands/recipe.py
+++ b/src/praisonai/praisonai/cli/commands/recipe.py
@@ -473,14 +473,22 @@ def recipe_judge(
             max_chunks=max_chunks,
             aggregation_strategy=aggregation,
         )
-        report = judge.judge_trace(events, session_id=trace_id, yaml_file=yaml_file)
+        # `--goal` was declared, documented in this command's own example, and
+        # never passed on, so the judge always evaluated against the goal it
+        # could scrape from --yaml (or "Not specified" when there was none).
+        report = judge.judge_trace(
+            events,
+            session_id=trace_id,
+            yaml_file=yaml_file,
+            recipe_goal=goal,
+        )
         
         # Display report
         print(format_judge_report(report))
         
         # Generate plan if yaml_file provided
         if yaml_file:
-            plan = generate_plan_from_report(report, yaml_file=yaml_file)
+            plan = generate_plan_from_report(report, yaml_file=yaml_file, goal=goal)
             print(plan.format_summary())
             
             if not dry_run:

--- a/src/praisonai/praisonai/cli/legacy/workflow_commands.py
+++ b/src/praisonai/praisonai/cli/legacy/workflow_commands.py
@@ -19,12 +19,18 @@ from praisonai.cli.legacy.framework_run import fw_workflow_module as _fw_workflo
 def handle_workflow_command(self, action: str, action_args: list, variables: dict = None, args=None):
     """
     Handle workflow subcommand actions.
-    
+
     Args:
         action: The workflow action (list, run, create, show)
         action_args: Additional arguments for the action
         variables: Workflow variables for substitution
         args: Parsed command line arguments
+
+    Returns:
+        A process exit code: ``0`` on success, ``1`` when the workflow (or the
+        command itself) failed. Every path used to fall off the end returning
+        ``None`` and the dispatcher hard-coded ``sys.exit(0)``, so a run whose
+        only step failed still reported success to CI.
     """
     try:
         from praisonaiagents import Agent as PraisonAgent
@@ -58,14 +64,13 @@ def handle_workflow_command(self, action: str, action_args: list, variables: dic
         elif action == 'run':
             if not action_args:
                 print("[red]ERROR: Workflow name required. Usage: praisonai workflow run <name>[/red]")
-                return
+                return 1
             workflow_name = action_args[0]
             
             # Check if it's a YAML file
             if workflow_name.endswith(('.yaml', '.yml')) and os.path.exists(workflow_name):
                 # Use new YAML workflow parser
-                self._run_yaml_workflow(workflow_name, action_args, variables, args)
-                return
+                return self._run_yaml_workflow(workflow_name, action_args, variables, args)
             
             # Parse checkpoint/resume flags from the run args. These live in
             # action_args because the markdown run path forwards raw flags.
@@ -178,11 +183,12 @@ def handle_workflow_command(self, action: str, action_args: list, variables: dic
                     print(f"\n[green]✅ Output saved to: {output_file}[/green]")
             else:
                 print(f"[red]❌ Workflow failed: {result.get('error', 'Unknown error')}[/red]")
-                
+                return 1
+
         elif action == 'show':
             if not action_args:
                 print("[red]ERROR: Workflow name required. Usage: praisonai workflow show <name>[/red]")
-                return
+                return 1
             workflow_name = action_args[0]
             workflow = manager.get_workflow(workflow_name)
             if workflow:
@@ -195,11 +201,12 @@ def handle_workflow_command(self, action: str, action_args: list, variables: dic
                     print(f"\n[bold]Variables:[/bold] {workflow.variables}")
             else:
                 print(f"[red]Workflow not found: {workflow_name}[/red]")
-                
+                return 1
+
         elif action == 'create':
             if not action_args:
                 print("[red]ERROR: Workflow name required. Usage: praisonai workflow create <name>[/red]")
-                return
+                return 1
             workflow_name = action_args[0]
             
             # Create a simple template workflow
@@ -218,12 +225,12 @@ def handle_workflow_command(self, action: str, action_args: list, variables: dic
             # Validate a YAML workflow file
             if not action_args:
                 print("[red]ERROR: YAML file required. Usage: praisonai workflow validate <file.yaml>[/red]")
-                return
+                return 1
             yaml_file = action_args[0]
             if not yaml_file.endswith(('.yaml', '.yml')):
                 print("[red]ERROR: File must be a YAML file (.yaml or .yml)[/red]")
-                return
-            self._validate_yaml_workflow(yaml_file)
+                return 1
+            return self._validate_yaml_workflow(yaml_file)
             
         elif action == 'template':
             # Create from template
@@ -232,11 +239,11 @@ def handle_workflow_command(self, action: str, action_args: list, variables: dic
             for i, arg in enumerate(action_args):
                 if arg == '--output' and i + 1 < len(action_args):
                     output_file = action_args[i + 1]
-            self._create_workflow_from_template(template_name, output_file)
-        
+            return self._create_workflow_from_template(template_name, output_file)
+
         elif action == 'auto':
             # Auto-generate workflow from topic
-            self._auto_generate_workflow(action_args)
+            return self._auto_generate_workflow(action_args)
 
         elif action == 'checkpoints':
             # Manage saved workflow checkpoints (list / delete).
@@ -300,12 +307,17 @@ def handle_workflow_command(self, action: str, action_args: list, variables: dic
         else:
             print(f"[red]Unknown workflow action: {action}[/red]")
             print("Use 'praisonai workflow help' for available commands")
-            
+            return 2
+
     except ImportError as e:
         print(f"[red]ERROR: Failed to import workflow module: {e}[/red]")
         print("Make sure praisonaiagents is installed: pip install praisonaiagents")
+        return 1
     except Exception as e:
         print(f"[red]ERROR: Workflow command failed: {e}[/red]")
+        return 1
+
+    return 0
 
 def _run_yaml_workflow(self, yaml_file: str, action_args: list, variables: dict = None, args=None):
     """
@@ -484,6 +496,7 @@ def _run_yaml_workflow(self, yaml_file: str, action_args: list, variables: dict 
         print("\n[bold]Executing workflow...[/bold]\n")
         result = workflow.start(start_input)
         
+        exit_code = 0
         if result.get("status") == "completed":
             print("\n[green]✅ Workflow completed successfully![/green]")
             
@@ -497,6 +510,7 @@ def _run_yaml_workflow(self, yaml_file: str, action_args: list, variables: dict 
                     print(output)
         else:
             print(f"\n[red]❌ Workflow failed: {result.get('error', 'Unknown error')}[/red]")
+            exit_code = 1
         
         # Close trace writer on completion
         if trace_emitter:
@@ -508,7 +522,9 @@ def _run_yaml_workflow(self, yaml_file: str, action_args: list, variables: dict 
         if trace_emitter_token:
             from praisonaiagents.trace.context_events import reset_context_emitter
             reset_context_emitter(trace_emitter_token)
-            
+
+        return exit_code
+
     except FileNotFoundError:
         # Cleanup trace on error
         if trace_emitter:
@@ -519,6 +535,7 @@ def _run_yaml_workflow(self, yaml_file: str, action_args: list, variables: dict 
             from praisonaiagents.trace.context_events import reset_context_emitter
             reset_context_emitter(trace_emitter_token)
         print(f"[red]ERROR: YAML file not found: {yaml_file}[/red]")
+        return 1
     except Exception as e:
         # Cleanup trace on error
         if trace_emitter:
@@ -531,13 +548,18 @@ def _run_yaml_workflow(self, yaml_file: str, action_args: list, variables: dict 
         print(f"[red]ERROR: YAML workflow failed: {e}[/red]")
         import traceback
         traceback.print_exc()
+        return 1
 
 def _validate_yaml_workflow(self, yaml_file: str):
     """
     Validate a YAML workflow file.
-    
+
     Args:
         yaml_file: Path to the YAML workflow file
+
+    Returns:
+        ``0`` when the file parses and validates, ``1`` otherwise (a missing
+        file or a parse error used to print an error and still exit 0).
     """
     try:
         from praisonaiagents.workflows import YAMLWorkflowParser
@@ -550,7 +572,7 @@ def _validate_yaml_workflow(self, yaml_file: str):
         
         if not os.path.exists(yaml_file):
             print(f"[red]ERROR: File not found: {yaml_file}[/red]")
-            return
+            return 1
         
         print(f"[cyan]Validating: {yaml_file}[/cyan]")
         
@@ -593,9 +615,12 @@ def _validate_yaml_workflow(self, yaml_file: str):
                 print(f"   [dim]•[/dim] {suggestion}")
             print()
             print("[dim]Note: Both old and new names work, but canonical names are recommended.[/dim]")
-        
+
+        return 0
+
     except Exception as e:
         print(f"[red]✗ Validation failed: {e}[/red]")
+        return 1
 
 def _get_canonical_suggestions(self, data: dict) -> list:
     """
@@ -675,17 +700,17 @@ def _create_workflow_from_template(self, template_name: str = None, output_file:
         templates = WorkflowHandler.TEMPLATES
     except ImportError:
         print("[red]ERROR: WorkflowHandler not available.[/red]")
-        return
-    
+        return 1
+
     if not template_name:
         print("[red]ERROR: Template name required.[/red]")
         print(f"[cyan]Available templates: {', '.join(templates.keys())}[/cyan]")
-        return
-    
+        return 1
+
     if template_name not in templates:
         print(f"[red]ERROR: Unknown template: {template_name}[/red]")
         print(f"[cyan]Available templates: {', '.join(templates.keys())}[/cyan]")
-        return
+        return 1
     
     # Default output file
     if not output_file:
@@ -694,14 +719,15 @@ def _create_workflow_from_template(self, template_name: str = None, output_file:
     # Check if file exists
     if os.path.exists(output_file):
         print(f"[red]ERROR: File already exists: {output_file}[/red]")
-        return
-    
+        return 1
+
     # Write template
     with open(output_file, 'w') as f:
         f.write(templates[template_name])
-    
+
     print(f"[green]✓ Created workflow: {output_file}[/green]")
     print(f"[cyan]Run with: praisonai workflow run {output_file}[/cyan]")
+    return 0
 
 def _auto_generate_workflow(self, action_args: list):
     """
@@ -734,14 +760,14 @@ def _auto_generate_workflow(self, action_args: list):
     if not topic:
         print('[red]Usage: praisonai workflow auto "topic" --pattern <pattern>[/red]')
         print("[cyan]Patterns: sequential, routing, parallel[/cyan]")
-        return
+        return 1
     
     # Validate pattern
     valid_patterns = ["sequential", "routing", "parallel", "loop", "orchestrator-workers", "evaluator-optimizer"]
     if pattern not in valid_patterns:
         print(f"[red]Unknown pattern: {pattern}[/red]")
         print(f"[cyan]Valid patterns: {', '.join(valid_patterns)}[/cyan]")
-        return
+        return 1
     
     # Default output file
     if not output_file:
@@ -751,8 +777,8 @@ def _auto_generate_workflow(self, action_args: list):
     # Check if file exists
     if os.path.exists(output_file):
         print(f"[red]ERROR: File already exists: {output_file}[/red]")
-        return
-    
+        return 1
+
     print(f"[cyan]Generating {pattern} workflow for: {topic}[/cyan]")
     
     try:
@@ -769,8 +795,11 @@ def _auto_generate_workflow(self, action_args: list):
         
         print(f"[green]✓ Created workflow: {result_path}[/green]")
         print(f"[cyan]Run with: praisonai workflow run {output_file}[/cyan]")
-        
+        return 0
+
     except ImportError:
         print("[red]Auto-generation requires litellm: pip install litellm[/red]")
+        return 1
     except Exception as e:
         print(f"[red]Generation failed: {e}[/red]")
+        return 1

--- a/src/praisonai/praisonai/replay/judge.py
+++ b/src/praisonai/praisonai/replay/judge.py
@@ -2188,6 +2188,7 @@ REASONING: [brief explanation]
         yaml_file: Optional[str] = None,
         evaluate_tools: bool = True,
         evaluate_context_flow: bool = True,
+        recipe_goal: Optional[str] = None,
     ) -> JudgeReport:
         """
         Judge all agents in a trace with YAML-aware evaluation.
@@ -2198,6 +2199,12 @@ REASONING: [brief explanation]
             yaml_file: Optional path to YAML file for context-aware evaluation
             evaluate_tools: Whether to evaluate individual tool calls
             evaluate_context_flow: Whether to evaluate context flow between agents
+            recipe_goal: Explicit overall goal to evaluate against. Overrides the
+                goal extracted from ``yaml_file``, and supplies one when no YAML
+                is given. This is what ``praisonai recipe judge --goal`` passes;
+                the option was previously declared (and used in that command's
+                own docstring example) but never reached the judge, so the goal
+                evaluation silently ran against "Not specified".
             
         Returns:
             JudgeReport with all agent scores, tool evaluations, and recommendations
@@ -2231,13 +2238,16 @@ REASONING: [brief explanation]
                         all_sources.extend(s.get("sources", []))
                     agent_data[agent_name]["knowledge_sources"] = ", ".join(list(set(all_sources))[:5]) or "None"
         
-        # Load YAML info if provided
+        # Load YAML info if provided. An explicitly supplied goal wins over the
+        # one extracted from the YAML.
         yaml_info = None
-        recipe_goal = ""
+        explicit_goal = (recipe_goal or "").strip()
+        recipe_goal = explicit_goal
         input_context = ""  # Additional context from input images/URLs
         if yaml_file:
             yaml_info = _detect_yaml_structure(yaml_file)
-            recipe_goal = yaml_info.get("recipe_goal", "")
+            if not explicit_goal:
+                recipe_goal = yaml_info.get("recipe_goal", "")
             
             # Extract input variables from YAML for image/URL context
             variables = yaml_info.get("variables", {})

--- a/src/praisonai/tests/unit/cli/queue/test_models.py
+++ b/src/praisonai/tests/unit/cli/queue/test_models.py
@@ -161,7 +161,12 @@ class TestQueueConfig:
         assert config.max_concurrent_per_agent == 2
         assert config.max_queue_size == 100
         assert config.enable_persistence
-        assert config.db_path == ".praison/queue.db"
+        # Asserted against the shared constant, not a literal: the default
+        # used to be a hard-coded ".praison/queue.db" while the runtime reads
+        # ".praisonai/".
+        from praisonai_code.cli.features.queue.models import DEFAULT_QUEUE_DB_PATH
+
+        assert config.db_path == DEFAULT_QUEUE_DB_PATH
     
     def test_custom_values(self):
         """Test custom values."""

--- a/src/praisonai/tests/unit/test_workflow_cli_exit_codes.py
+++ b/src/praisonai/tests/unit/test_workflow_cli_exit_codes.py
@@ -1,0 +1,222 @@
+"""`praisonai workflow` must report failure through its exit code.
+
+The whole legacy handler contained zero `sys.exit`/`typer.Exit` calls and the
+dispatcher hard-coded `sys.exit(0)`, so `workflow run` on a workflow whose only
+step failed, and `workflow validate /nonexistent.yaml`, both exited 0. A CI job
+that ran a workflow doing nothing stayed green.
+
+These assert exit codes and return values, never message text.
+"""
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+from praisonai.cli.legacy import workflow_commands
+
+
+class _Host:
+    """Minimal stand-in for the PraisonAI CLI object the handlers bind to."""
+
+    def _run_yaml_workflow(self, *a, **k):
+        return workflow_commands._run_yaml_workflow(self, *a, **k)
+
+    def _validate_yaml_workflow(self, *a, **k):
+        return workflow_commands._validate_yaml_workflow(self, *a, **k)
+
+    def _get_canonical_suggestions(self, data):
+        return workflow_commands._get_canonical_suggestions(self, data)
+
+    def _create_workflow_from_template(self, *a, **k):
+        return workflow_commands._create_workflow_from_template(self, *a, **k)
+
+    def _auto_generate_workflow(self, *a, **k):
+        return workflow_commands._auto_generate_workflow(self, *a, **k)
+
+    def _load_tools(self, spec):
+        return None
+
+
+@pytest.fixture
+def host():
+    return _Host()
+
+
+_GOOD_YAML = """
+name: haiku-flow
+agents:
+  Writer:
+    name: Writer
+    instructions: "You write haiku"
+    llm: gpt-4o-mini
+steps:
+  - name: haiku
+    agent: Writer
+    instruction: "Write a haiku"
+"""
+
+
+@pytest.fixture
+def good_yaml(tmp_path):
+    p = tmp_path / "wf.yaml"
+    p.write_text(_GOOD_YAML)
+    return str(p)
+
+
+class TestValidateExitCode:
+
+    def test_missing_file_returns_nonzero(self, host):
+        assert host._validate_yaml_workflow("/nonexistent-workflow.yaml") != 0
+
+    def test_valid_file_returns_zero(self, host, good_yaml):
+        assert host._validate_yaml_workflow(good_yaml) == 0
+
+    def test_unparseable_file_returns_nonzero(self, host, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("steps:\n  - name: x\n    agent: NotDefined\n")
+        assert host._validate_yaml_workflow(str(bad)) != 0
+
+    def test_handler_propagates_validate_failure(self, host):
+        assert workflow_commands.handle_workflow_command(
+            host, "validate", ["/nonexistent-workflow.yaml"]
+        ) != 0
+
+    def test_handler_propagates_validate_success(self, host, good_yaml):
+        assert workflow_commands.handle_workflow_command(
+            host, "validate", [good_yaml]
+        ) == 0
+
+    def test_non_yaml_extension_returns_nonzero(self, host):
+        assert workflow_commands.handle_workflow_command(
+            host, "validate", ["notes.txt"]
+        ) != 0
+
+    def test_missing_argument_returns_nonzero(self, host):
+        assert workflow_commands.handle_workflow_command(
+            host, "validate", []
+        ) != 0
+
+
+class TestRunExitCode:
+    """A run the engine reports as failed must exit non-zero."""
+
+    def _run(self, host, monkeypatch, yaml_file, status, output=None):
+        class _FakeWorkflow:
+            name = "haiku-flow"
+            description = ""
+            steps = []
+            variables = {}
+            planning = False
+            reasoning = False
+            default_input = ""
+
+            def start(self, *a, **k):
+                res = {"status": status, "output": output, "steps": []}
+                if status != "completed":
+                    res["error"] = "haiku: agent produced no output (None)"
+                return res
+
+        class _FakeManager:
+            def __init__(self, *a, **k):
+                pass
+
+            def load_yaml(self, *a, **k):
+                return _FakeWorkflow()
+
+        import praisonaiagents.workflows as wfmod
+        monkeypatch.setattr(wfmod, "WorkflowManager", _FakeManager, raising=False)
+        return host._run_yaml_workflow(yaml_file, [yaml_file], {}, None)
+
+    def test_failed_run_returns_nonzero(self, host, monkeypatch, good_yaml):
+        assert self._run(host, monkeypatch, good_yaml, "failed") != 0
+
+    def test_completed_run_returns_zero(self, host, monkeypatch, good_yaml):
+        assert self._run(host, monkeypatch, good_yaml, "completed", "a haiku") == 0
+
+    def test_missing_yaml_file_returns_nonzero(self, host):
+        assert host._run_yaml_workflow(
+            "/nonexistent-workflow.yaml", ["/nonexistent-workflow.yaml"], {}, None
+        ) != 0
+
+    def test_run_without_a_name_returns_nonzero(self, host):
+        assert workflow_commands.handle_workflow_command(host, "run", []) != 0
+
+
+class TestOtherActionsExitCode:
+
+    def test_unknown_action_returns_nonzero(self, host):
+        assert workflow_commands.handle_workflow_command(host, "banana", []) != 0
+
+    def test_help_returns_zero(self, host):
+        assert workflow_commands.handle_workflow_command(host, "help", []) == 0
+
+    def test_show_without_a_name_returns_nonzero(self, host):
+        assert workflow_commands.handle_workflow_command(host, "show", []) != 0
+
+    def test_create_without_a_name_returns_nonzero(self, host):
+        assert workflow_commands.handle_workflow_command(host, "create", []) != 0
+
+    def test_template_with_unknown_name_returns_nonzero(self, host):
+        assert workflow_commands.handle_workflow_command(
+            host, "template", ["no-such-template"]
+        ) != 0
+
+    def test_auto_without_a_topic_returns_nonzero(self, host):
+        assert workflow_commands.handle_workflow_command(host, "auto", []) != 0
+
+
+class TestDispatcherPropagatesTheCode:
+    """End-to-end: the shell must see a non-zero code, not just the handler."""
+
+    def _cli(self, *args, cwd=None):
+        """Run the real CLI in a subprocess and read its own exit code.
+
+        Never through a pipe -- `cmd | tail` reports tail's status, which is
+        how this class of defect stays invisible.
+        """
+        import subprocess
+
+        import praisonai
+        import praisonai_code
+        import praisonaiagents
+
+        roots = [
+            os.path.dirname(os.path.dirname(m.__file__))
+            for m in (praisonai, praisonai_code, praisonaiagents)
+        ]
+        env = dict(os.environ)
+        env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(roots))
+        # The legacy CLI takes a different branch when PYTEST_CURRENT_TEST is
+        # set (praison_ai.py `in_test_env`), so the child must not inherit it
+        # or it would not exercise the real command path.
+        env.pop("PYTEST_CURRENT_TEST", None)
+        env.pop("PYTEST_VERSION", None)
+        return subprocess.run(
+            [sys.executable, "-m", "praisonai", "workflow", *args],
+            cwd=cwd, env=env, capture_output=True, text=True, timeout=300,
+        )
+
+    def test_validate_missing_file_exits_nonzero(self, tmp_path):
+        proc = self._cli("validate", "/nonexistent-workflow.yaml", cwd=str(tmp_path))
+        assert proc.returncode != 0, proc.stdout + proc.stderr
+
+    def test_validate_good_file_exits_zero(self, good_yaml, tmp_path):
+        proc = self._cli("validate", good_yaml, cwd=str(tmp_path))
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    def test_list_exits_zero(self, tmp_path):
+        proc = self._cli("list", cwd=str(tmp_path))
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    def test_the_workflow_branch_no_longer_hardcodes_success(self):
+        import inspect
+
+        from praisonai_code.cli.legacy import praison_ai as legacy
+
+        src = inspect.getsource(legacy)
+        assert (
+            "self.handle_workflow_command(action, action_args, workflow_vars, args)\n"
+            "                sys.exit(0)"
+        ) not in src, "the dispatcher still hard-codes sys.exit(0) after a workflow run"


### PR DESCRIPTION
Three classes of silent defect in `src/praisonai` and `src/praisonai-code`. Each was reproduced by running it before the fix, and each is gated by a test that fails without the fix and passes with it.

---

## 1. `praisonai workflow run` reported success when every step failed

**Before** — an invalid API key, one step, nothing produced:

```
[Writer] Authentication failed for openai.
workflows.py:1827 WARNING  ⚠️  Step 'haiku': Output is None.
✅ Workflow completed successfully!
EXIT=0
```

**After:**

```
❌ Workflow failed: haiku: agent produced no output (None) — the model call most likely failed
EXIT=1
```

Two compounding defects, and I fixed both — the exit code alone would have shipped a correct code over a wrong verdict.

### Where the verdict belongs

`Agent.chat()` returns `None` when the model call failed and the agent swallowed the error. `workflows.py` *already* logged `Step 'haiku': Output is None` and then set `status="completed"` anyway.

I put the verdict in the **engine**, not the CLI, for two reasons:

- Only the engine can tell an LLM-backed step (an output is definitionally expected) from a custom `handler` step (which may legitimately return `None`). The CLI sees `{"status": "completed", "output": None}` and cannot distinguish "the agent produced nothing" from "the final output was legitimately empty".
- Every consumer of `Workflow.start()` was being lied to — the API server and Python callers as well as this CLI. A CLI-only judgement leaves the Python API broken.

So an `agent`/`action` step producing `None` is now a step failure, honouring `on_error` like any other failure, which also stops `None` being fed forward into the next step. `handler` steps are untouched, and two tests pin that. A failed result also now carries `error`, which was simply absent — hence the CLI's `Workflow failed: Unknown error`.

### Where the exit code belongs

`grep -c "sys.exit\|SystemExit\|typer.Exit"` over the 111-`print` handler returned **0**, and the legacy dispatcher hard-coded `sys.exit(0)`. So even the `❌ Workflow failed` branch exited 0, and `workflow validate /nonexistent.yaml` printed `ERROR: File not found` and exited 0. The handler and its helpers now return exit codes and the dispatcher propagates them — the same pattern #4927 established for `hooks`.

### Callers that relied on 0

I checked. The only in-repo consumer is `.github/workflows/praisonai-pr-review.yml`, whose last step is `praisonai workflow run .github/praisonai-reviewer.yaml`. That job currently passes unconditionally; it will now fail when the review workflow actually fails — which is the point of the fix. Nothing else in the repo shells out to `praisonai workflow`. `workflow list`/`help`, and a successful `run`/`validate`, still exit 0 (pinned by tests). `workflow help` still exits 2 because Typer rejects it before the legacy path — unchanged from `origin/main`, verified.

### Follow-up: hierarchical mode had the same defect, three more ways

I checked whether the async path inherited the fix. `astart()` delegates to the sync `run()`, so it did — but `process="hierarchical"` is a **separate loop** that had the reported symptom in full. Reproduced end to end with the same dead key:

```
before:  ✅ Workflow completed successfully!                                  EXIT=0
after :  ❌ Workflow failed: Step 'haiku' produced no output (None)           EXIT=1
```

Three independent fail-opens, all in one block:

1. **A manager rejection was silently converted into approval.** The verdict was parsed with a bare `json.loads`; models routinely fence JSON in ` ```json `, which raises `JSONDecodeError`, and the handler substituted `{"approved": True, "reason": "assuming success"}`. Proved against a real call — the manager answered `{"approved": false, "reason": "The output is empty and does not address the task."}` and the run still reported `completed`. Manager validation was a **no-op for rejections** in the common case. Now parsed with this module's own `_parse_json_output` (which already strips those fences), and an unreadable verdict **fails closed**.

2. **A manager outage was treated as a pass.** When the manager LLM call itself raised, validation was skipped with a warning and the run reported success. The manager is a gate: if it could not run, it has not passed. Failing open here would also be incoherent with (1) in the same `try` block. Hierarchical mode is opt-in — a caller who asked for validation gets it enforced.

3. **A step that produced nothing was never judged.** The loop marked every non-raising step `completed` before the manager saw it. The same rule as the sequential path now applies, and the per-step record is marked failed too, since that record is what `--save` writes.

The result now also exposes `error` alongside `failure_reason` — the CLI reads `error`, so a real hierarchical failure printed `Workflow failed: Unknown error`.

Four more mutations. **One initially survived**: forcing the per-step status back to `completed` changed nothing observable, because the run status was still set failed below and no test asserted the step record. I added that assertion rather than record a pass; it now kills the mutation. A healthy hierarchical run still completes, pinned by its own test.

---

## 2. `.praison` vs `.praisonai` — the #4927 hooks-path bug, nine more times

**Proved with both directories populated:**

```
$ praisonai skills list   ->  newskill                       (from .praisonai/skills)
$ praisonai doctor        ->  Found 1 ... /tmp/proj/.praison/skills   (the other one)
```

So `doctor` validated a directory the runtime never reads, and its empty state told users to create it.

### The siblings are not cosmetic

I verified each before changing it, as asked. Four of them (`thinking.json`, `compaction.json`, `output.json`, `queue.db`) have exactly one reader and one writer, so on their own they round-trip fine — my first read was that they were harmless legacy naming. That is wrong, and here is why:

`.praison` is the **first** entry of `paths._PROJECT_MARKERS`, so `_config_dirname_for` prefers it. The moment one of these features creates `./.praison/` in a project whose config lives in `./.praisonai/`, the project's own `config.toml` silently stops being read:

```
BEFORE: from-praisonai-dir
wrote:  /tmp/hijack/.praison/thinking.json      # praisonai thinking set high
AFTER : gpt-4o-mini                             # the project config is gone
```

That is a real cross-component, silent defect, and it is what makes these the same class as #4927 rather than a tidy-up.

### One constant, not nine literals

`PROJECT_DATA_DIRNAME` in `cli/configuration/paths.py`, taken from `praisonaiagents.paths.DEFAULT_DIR_NAME`, plus `get_project_data_path()` (writes, always canonical) and `resolve_project_data_path()` (reads, with a read-only `.praison` fallback so nothing saved before this is orphaned).

Applied to: thinking, compaction, output-style, file-history, the queue db, the knowledge vector-store path, and doctor's skills check. The knowledge path needed all five sites moved together (`config_loader`, `unified_schema`, and three in `retrieval.py`) — moving two would have split the vector store from its readers. `skills_checks` now derives its locations from the same `praisonaiagents.paths` helpers the skill loader uses, so it cannot disagree with the runtime again.

The two documented read-only legacy fallbacks in `configuration/paths.py` and `credentials.py` are **left alone**.

Every assertion in the new test is made against the shared constant, never a literal, so a drift back to `.praison` fails the test rather than shipping.

---

## 3. Declared CLI options that were silently ignored

### `memory clear` — prioritised

A destructive command advertising a `--force` it ignored, with **no confirmation prompt at all**. It now confirms first — matching the `memory learn clear` sibling 170 lines below in the same file — and only `--force` skips it. Its `all` target, named in its own docstring, was unreachable (`memory clear all` → `Got unexpected extra argument`); it is now an argument, so `Clear all memories.` is finally true.

```
$ praisonai memory clear all </dev/null
Clear ALL memories? This cannot be undone. [y/N]: Aborted.   EXIT=1     # memory intact
$ praisonai memory clear all --force
✅ All memory cleared                                        EXIT=0
```

### Also wired

| Command | Was dropped | Now |
|---|---|---|
| `todo add` | `-p/--priority` | `--priority high` → 🔴, `-p low` → 🟢, default 🟡; an unknown value is rejected |
| `config list` | `-s/--scope` | `user` and `project` show their own layer; they are no longer byte-identical |
| `eval accuracy` | `-n/--iterations` | forwarded — **and** `--agent` now passed as the named option the wrapper's parser declares; a bare positional made the whole command fail with `unrecognized arguments: ag.yaml` on `main` |
| `serve ui-gateway` | `-a/--agents` | forwarded when the installed gateway host accepts it, refused loudly when it does not (never silently dropped, never a `TypeError`) |
| `recipe judge` | `-g/--goal` | `judge_trace` grew a `recipe_goal` override that wins over the YAML-extracted one, and the plan generator now gets it too |
| `code` | `--no-autonomy` | reaches `AsyncTUIConfig.autonomy_mode`, as `chat` already did at `chat.py:285` |
| `chat` | `--continue`, `--no-acp`, `--no-lsp` | the config fields already existed and `code` already set them |

### `up logs`

Accepted `--service/--follow/--lines`, honoured none, printed "not implemented yet" and **exited 0**. The three options are removed and it exits non-zero — an option that cannot work should not be advertised, and a command that does nothing should not report success.

### `_UNWIRED_CHAT_OPTIONS`: generalised, not replaced

The mechanism was right; its coverage was not. It listed 4 options while `chat_main` drops 13. Wiring the cheap ones left five that genuinely need features behind them (`--tools`, `--toolset`, `--user-id`, `--file`, `--output`), and those are now listed and warned about instead of accepted in silence.

To stop the table being a subset again, a new test derives the whole dropped set from the AST and fails if any declared option is neither wired nor listed. The existing pinning test moved from a line regex to the AST too — the regex matched an option name appearing in a *comment*, which made wiring a neighbouring option fail it for the wrong reason.

---

## Corrections to my own work in this PR

Two things I got wrong, both caught and both now pinned:

**`serve ui-gateway --agents` — my first fix was broken.** The triage bot's `69769cbdd8` corrected the implementation; I then rewrote my test, which had been asserting my wrong assumption. Verified against praisonai-bot:

```
run_integrated_gateway(*, port, host, static_dir, ui_config, **configure_kwargs)
    -> configure_host(*, ..., agents: Optional[List[Any]] = None, ...)
```

The parameter is `agents` and it takes a **parsed list**. I passed `agents_file=<path>` — wrong name, wrong type — behind an `inspect.signature(...).parameters` guard. That guard **can never match a `**kwargs` function**, so the option was rejected 100% of the time, and my "an older gateway fails loudly" test was asserting the failure path as though it were the compatibility path. It passed for the wrong reason.

The tests now pin the real contract, and I added one that reads the **actual** `configure_host` signature (skipped if praisonai-bot isn't importable). A stub-based unit test structurally cannot catch "we pass a kwarg the real function rejects" — precisely how the first attempt slipped through. Restoring my original broken version turns five tests red.

**A tenth `.praison` site.** Rather than assume, I checked the doctor checks I'd listed as follow-ups. They did not agree:

- `mcp_checks` is **already correct and deliberately so** — canonical `get_mcp_dir()`/`get_project_data_dir()` first, `.praison` below under an explicit "Legacy paths for backward compatibility" comment. Left untouched.
- `memory_checks` hard-coded `~/.praison/...` with no canonical path at all. Reproduced: with `PRAISONAI_HOME` set, `memory add` stored under `/tmp/memproof/.praisonai/memory` while the check reported `['~/.praison/memory', '~/.praison/sessions']` — neither of which the runtime touches. Now resolved through the same `praisonaiagents.paths` helpers the memory store uses. `praisonai doctor` still exits 2 with the same six failing checks as the baseline, so its exit code and check set are unchanged.

## The 15 unverified options — what I actually checked

I checked all of them and fixed none, as instructed:

- **`app.py:751` `version` — false positive.** It carries `callback=version_callback, is_eager=True`, so the AST scan cannot see the read. `praisonai --version` prints `PraisonAI version 4.7.6`. Working.
- **`knowledge.py:331` `verbose` — real.** `knowledge list` and `knowledge list --verbose` are byte-identical (`cmp` confirms).
- **`context.py:84` `agent`, `context.py:144` `threshold`, `docs.py:1065` `write`, `realtime.py:15` `verbose` — real** by AST and by reading the bodies; I did not exercise them end to end.
- **`browser_tool.py` — seven, not one:** `browser status --json`, `browser open --headless`, `browser snapshot --format`, `browser screenshot --format`, `browser click --profile/--double`, `browser type --profile/--submit`, `browser navigate --profile`. All unread.

None are fixed here — each needs its own reproduction, and the mandate was not to act on them blind.

---

## Gates and mutation testing

Every gate was mutation-tested, with an `assert` that the anchor was found before applying (a silent no-op mutation reports a false SURVIVED):

- **(1)** 6 mutations — engine verdict, error reason, CLI validate code, CLI run code, dispatcher `sys.exit(0)` — all killed.
- **(2)** 6 mutations — constant reverted to `.praison`, write path routed through the read resolver, doctor scanning `.praison` again, queue db, knowledge path, file history — all killed.
- **(3)** 12 mutations — all killed.

**Two survived on the first pass and I strengthened the tests rather than record them:**

- Removing `recipe_goal=goal` from the judge call survived, because my test only asserted `goal` appeared as a name-load somewhere in the function — and it still did, via `generate_plan_from_report(..., goal=goal)`. Replaced with a stubbed-judge invocation that asserts the kwarg actually arrives.
- One `memory.py` mutation aborted on an ambiguous anchor, so it never ran. Re-anchored uniquely; it then killed four tests.

Exit codes are read from the command itself, never through a pipe into `tail`. The end-to-end CLI tests run the real command in a subprocess and read `returncode` — with `PYTEST_CURRENT_TEST` stripped from the child env, because `praison_ai.py:972` takes a different branch when it is set.

## Regressions

- `praisonai-code`: 914 passed. Failure set diffed against `origin/main` — identical, except `test_root_commit_stable_across_orphan_branches`, which I reproduced failing then passing on an **untouched** `origin/main` worktree. Pre-existing flake, not mine.
- `praisonai/tests/unit/cli`: 1586 passed, 2 failed — both reproduced on untouched `origin/main`.
- `praisonai-agents` workflows + task + config + conditions + context: 796 passed, 1 failed (`test_placement.py`, reproduced on untouched `origin/main`).
- judge/replay/recipe: 149 passed.

One existing test was updated: `tests/unit/cli/queue/test_models.py` asserted the literal `".praison/queue.db"`. It now asserts against `DEFAULT_QUEUE_DB_PATH`, so it pins the constant rather than the string.

## Left for a follow-up (reported, not changed)

Other `.praison` sites outside the nine named: `features/logs.py` (`~/.praison/logs`), `features/todo.py:31` (`~/.praison` workspace), `features/package.py`, `llm/catalogue.py`, `resolver.py:730`, the interactive history files, and doctor's `mcp_checks`/`memory_checks`/`permissions_checks`/`config_checks`. The home-level ones do not trigger the project-marker hijack, and `job_workflow.py:449` is a read path that never creates the directory — but the doctor checks are very likely the same defect as the skills one and deserve the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workflow steps that produce no output now fail correctly, report useful error details, and return appropriate CLI exit codes.
  - CLI options for sessions, ACP/LSP, autonomy, evaluations, recipe goals, todo priorities, and memory clearing now work as expected.
  - Configuration scopes and knowledge-store paths now resolve consistently.

- **Improvements**
  - Project data uses the canonical `.praisonai` directory while preserving access to legacy data.
  - Memory clearing includes target selection and confirmation safeguards.
  - Gateway agent configuration is validated before use.
  - Unsupported log viewing now clearly reports its unavailable status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

