### PR TITLE
fix(workflows): loop body output_variable results were silently discarded

### DIFF
--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -3420,10 +3420,21 @@ CONCISE SUMMARY:"""
             control_saved: Dict[str, Any] = {}
             control_introduced = set()
             preexisting_writes = set(getattr(all_variables, "written_keys", None) or ())
+            prev_control_keys: set = set()
             try:
                 for idx, item in enumerate(items):
                     # Add current item (and loop_index / item.<key>) to variables
                     control = self._loop_control_variables(loop_step, item, idx)
+                    # Drop the previous item's flattened ``item.<key>`` accessors
+                    # that this item does not have. Because the loop runs against
+                    # the shared scope, ``update`` alone would leave a stale
+                    # ``item.k`` visible while iterating an item that only has
+                    # ``item.m`` - the body would read the previous item's value.
+                    # ``_restore_loop_scope`` already cleans these up after the
+                    # loop; this keeps each iteration's view correct too.
+                    for stale_key in prev_control_keys - control.keys():
+                        all_variables.pop(stale_key, None)
+                    prev_control_keys = set(control.keys())
                     for key in control:
                         if key not in control_introduced:
                             control_introduced.add(key)

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -2933,11 +2933,77 @@ CONCISE SUMMARY:"""
         return {key: branch_variables[key] for key in written if key in branch_variables}
 
     @staticmethod
+    def _loop_control_variables(
+        loop_step: Any, item: Any, idx: int
+    ) -> Dict[str, Any]:
+        """The variables a ``Loop`` injects itself for one iteration.
+
+        ``item`` (or the loop's ``var_name``), ``loop_index`` and the flattened
+        ``item.<key>`` accessors are loop *machinery*, not results the loop body
+        produced, so they stay scoped to the loop in **both** execution modes:
+        the sequential path restores whatever those names held before the loop,
+        and the parallel path drops them from the merged delta. Keeping the two
+        modes identical here is what lets the loop body's own writes - which do
+        escape - be compared between them.
+        """
+        control: Dict[str, Any] = {loop_step.var_name: item, "loop_index": idx}
+        # Also expand nested item properties for template access (e.g., {{item.title}})
+        if isinstance(item, dict):
+            for key, value in item.items():
+                control[f"{loop_step.var_name}.{key}"] = value
+        return control
+
+    @classmethod
+    def _loop_variable_delta(
+        cls, loop_variables: Optional[Dict[str, Any]], control: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Writes one parallel-loop iteration made, minus the loop's control vars."""
+        delta = cls._branch_variable_delta(loop_variables)
+        for key in control:
+            delta.pop(key, None)
+        return delta
+
+    @staticmethod
+    def _restore_loop_scope(
+        all_variables: Dict[str, Any],
+        saved: Dict[str, Any],
+        introduced: set,
+        preexisting_writes: set
+    ) -> None:
+        """Undo a sequential loop's own control variables once the loop is done.
+
+        The sequential loop runs against the shared scope (see ``_execute_loop``),
+        so ``item``/``loop_index`` would otherwise leak out of the loop - and, when
+        the loop sits inside a ``Parallel`` branch, would be merged back into the
+        enclosing workflow as if the branch had written them. Restore the previous
+        value (or remove the name) and un-record the write.
+        """
+        for key in introduced:
+            if key in saved:
+                all_variables[key] = saved[key]
+            else:
+                all_variables.pop(key, None)
+        written = getattr(all_variables, "written_keys", None)
+        if written is not None:
+            for key in introduced:
+                if key not in preexisting_writes:
+                    written.discard(key)
+
+    @staticmethod
     def _merge_branch_variables(
         all_variables: Dict[str, Any],
-        branch_deltas: List[Tuple[int, Dict[str, Any]]]
+        branch_deltas: List[Tuple[int, Dict[str, Any]]],
+        warn_on_collision: bool = True
     ) -> None:
-        """Merge parallel branches' variable writes back into the shared scope.
+        """Merge concurrent branches' variable writes back into the shared scope.
+
+        Used by ``Parallel`` (branch declaration order) and by the parallel
+        ``Loop`` (iteration order). ``warn_on_collision`` is the only difference
+        between them: two *branches* writing one variable is almost certainly an
+        authoring accident worth a warning, whereas N *iterations* of one loop
+        body necessarily write the loop body's ``output_variable`` N times - that
+        is the normal shape of a loop, not a mistake, so the loop passes False
+        rather than emitting a warning per item.
 
         THE MERGE RULE (please do not "simplify" this back into a race):
 
@@ -2967,7 +3033,7 @@ CONCISE SUMMARY:"""
                         conflicting = bool(all_variables[key] != value)
                     except Exception:
                         conflicting = True
-                    if conflicting:
+                    if conflicting and warn_on_collision:
                         logger.warning(
                             f"Parallel branches {previous_idx} and {idx} both wrote "
                             f"variable '{key}' with different values; branch {idx} wins "
@@ -3237,16 +3303,19 @@ CONCISE SUMMARY:"""
                 emitter.set_branch(f"loop_{idx}")
                 
                 try:
-                    # CRITICAL: Deep copy variables to ensure thread isolation (per-branch context isolation)
-                    import copy
-                    loop_vars = copy.deepcopy(all_variables)
-                    loop_vars[loop_step.var_name] = item
-                    loop_vars["loop_index"] = idx
-                    
-                    # Also expand nested item properties for template access (e.g., {{item.title}})
-                    if isinstance(item, dict):
-                        for key, value in item.items():
-                            loop_vars[f"{loop_step.var_name}.{key}"] = value
+                    # CRITICAL: Deep copy variables to ensure thread isolation
+                    # (concurrent iterations writing one dict is a data race).
+                    # Isolation is only half of the design: whatever the iteration
+                    # writes must still be merged back, or every output_variable
+                    # set inside the loop body is silently discarded. The copy is a
+                    # _WriteTrackingDict so the merge (see below) knows exactly
+                    # which keys this iteration assigned. The loop's own control
+                    # variables are seeded at construction time and are therefore
+                    # deliberately not counted as writes.
+                    control = self._loop_control_variables(loop_step, item, idx)
+                    seed = copy.deepcopy(all_variables)
+                    seed.update(control)
+                    loop_vars = _WriteTrackingDict(seed)
                     
                     # Execute all steps sequentially within this iteration
                     iteration_output = opt_prev
@@ -3258,9 +3327,13 @@ CONCISE SUMMARY:"""
                         )
                         iteration_output = step_result.get("output")
                         iteration_results.append(step_result)
-                        # Update variables if step set any
-                        if step_result.get("variables"):
-                            loop_vars.update(step_result["variables"])
+                        # Update variables if step set any. _execute_single_step_internal
+                        # writes into - and returns - the very dict it was handed, so
+                        # ``loop_vars.update(loop_vars)`` would record every key as
+                        # written and defeat the delta detection below.
+                        step_vars = step_result.get("variables")
+                        if step_vars and step_vars is not loop_vars:
+                            loop_vars.update(step_vars)
                         # A failed step with on_error="stop" signals a stop; halt
                         # this iteration instead of feeding later steps forward.
                         if step_result.get("stop"):
@@ -3273,7 +3346,11 @@ CONCISE SUMMARY:"""
                         "step": f"loop_{idx}",
                         "output": iteration_output,
                         "steps": iteration_results,
-                        "stop": iteration_stopped
+                        "stop": iteration_stopped,
+                        # Only what this iteration actually wrote, so untouched
+                        # variables keep the parent's own objects instead of being
+                        # replaced by this iteration's deep-copied clones.
+                        "variable_delta": self._loop_variable_delta(loop_vars, control),
                     }
                     return idx, final_result
                 finally:
@@ -3304,11 +3381,25 @@ CONCISE SUMMARY:"""
                 # Sort by index to maintain order
                 indexed_results.sort(key=lambda x: x[0])
                 
+                iteration_deltas = []  # [(iteration_idx, {var: value}), ...] in item order
                 for idx, step_result in indexed_results:
                     results.append({"step": f"{step_result['step']}_{idx}", "output": step_result["output"]})
                     outputs.append(step_result["output"])
+                    iteration_deltas.append((idx, step_result.get("variable_delta") or {}))
                     if step_result.get("stop"):
                         loop_stopped = True
+
+            # Merge each iteration's writes back into the shared scope. Without
+            # this every output_variable set inside the loop body was written to a
+            # deep copy discarded when the iteration returned (silent data loss).
+            # Deltas are applied in *item* order, never completion order, so the
+            # surviving value does not depend on thread scheduling - it is the
+            # last item's, exactly what the sequential loop above produces. A
+            # cross-iteration collision is inherent to looping, so unlike Parallel
+            # it is not warned about.
+            self._merge_branch_variables(
+                all_variables, iteration_deltas, warn_on_collision=False
+            )
             
             if verbose:
                 print(f"✅ Parallel loop complete: {len(outputs)} results")
@@ -3318,44 +3409,60 @@ CONCISE SUMMARY:"""
                 step_info = f" ({len(steps_to_run)} steps each)" if is_multi_step else ""
                 print(f"🔁 Looping over {num_items} items{step_info}...")
             
-            for idx, item in enumerate(items):
-                # Add current item to variables
-                import copy
-                loop_vars = copy.deepcopy(all_variables)
-                loop_vars[loop_step.var_name] = item
-                loop_vars["loop_index"] = idx
-                
-                # Also expand nested item properties for template access (e.g., {{item.title}})
-                if isinstance(item, dict):
-                    for key, value in item.items():
-                        loop_vars[f"{loop_step.var_name}.{key}"] = value
-                
-                # Execute all steps sequentially within this iteration
-                iteration_output = previous_output
-                iteration_stopped = False
-                for step_idx, step in enumerate(steps_to_run):
-                    step_result = self._execute_single_step_internal(
-                        step, iteration_output, input, loop_vars, model, verbose, step_idx, stream=stream, depth=depth+1
-                    )
-                    iteration_output = step_result.get("output")
-                    # Update variables if step set any
-                    if step_result.get("variables"):
-                        loop_vars.update(step_result["variables"])
-                    # A failed step with on_error="stop" signals a stop; halt this
-                    # iteration instead of feeding later steps the error forward.
-                    if step_result.get("stop"):
-                        iteration_stopped = True
-                        break
-                
-                results.append({"step": f"loop_{idx}", "output": iteration_output})
-                outputs.append(iteration_output)
-                previous_output = iteration_output
+            # A sequential loop is simply its body unrolled, so - like Repeat,
+            # If and Route - it runs against the shared scope. There is no
+            # concurrency to isolate from here, and the per-iteration
+            # ``copy.deepcopy(all_variables)`` that used to sit in this loop
+            # bought no safety while silently discarding every output_variable
+            # the body wrote and hiding iteration N-1's writes from iteration N.
+            # Only the loop's own control variables stay loop-scoped; they are
+            # saved here and restored in the finally below.
+            control_saved: Dict[str, Any] = {}
+            control_introduced = set()
+            preexisting_writes = set(getattr(all_variables, "written_keys", None) or ())
+            try:
+                for idx, item in enumerate(items):
+                    # Add current item (and loop_index / item.<key>) to variables
+                    control = self._loop_control_variables(loop_step, item, idx)
+                    for key in control:
+                        if key not in control_introduced:
+                            control_introduced.add(key)
+                            if key in all_variables:
+                                control_saved[key] = all_variables[key]
+                    all_variables.update(control)
 
-                # Abort the remaining items too: a step that asked to stop the
-                # workflow (on_error="stop") must not silently keep looping.
-                if iteration_stopped:
-                    loop_stopped = True
-                    break
+                    # Execute all steps sequentially within this iteration
+                    iteration_output = previous_output
+                    iteration_stopped = False
+                    for step_idx, step in enumerate(steps_to_run):
+                        step_result = self._execute_single_step_internal(
+                            step, iteration_output, input, all_variables, model, verbose, step_idx, stream=stream, depth=depth+1
+                        )
+                        iteration_output = step_result.get("output")
+                        # Update variables if step set any. The step writes into the
+                        # dict it was handed, so guard against self-update.
+                        step_vars = step_result.get("variables")
+                        if step_vars and step_vars is not all_variables:
+                            all_variables.update(step_vars)
+                        # A failed step with on_error="stop" signals a stop; halt this
+                        # iteration instead of feeding later steps the error forward.
+                        if step_result.get("stop"):
+                            iteration_stopped = True
+                            break
+
+                    results.append({"step": f"loop_{idx}", "output": iteration_output})
+                    outputs.append(iteration_output)
+                    previous_output = iteration_output
+
+                    # Abort the remaining items too: a step that asked to stop the
+                    # workflow (on_error="stop") must not silently keep looping.
+                    if iteration_stopped:
+                        loop_stopped = True
+                        break
+            finally:
+                self._restore_loop_scope(
+                    all_variables, control_saved, control_introduced, preexisting_writes
+                )
         # Store outputs in user-specified variable or default to loop_outputs
         output_var_name = loop_step.output_variable or "loop_outputs"
         all_variables[output_var_name] = outputs

--- a/src/praisonai-agents/tests/unit/workflows/test_loop_variable_scope.py
+++ b/src/praisonai-agents/tests/unit/workflows/test_loop_variable_scope.py
@@ -416,3 +416,36 @@ def test_a_body_step_writing_the_control_name_still_does_not_leak_it(is_parallel
     )
     assert variables["loop_outputs"] == ["X-a", "X-b"]  # control: the body did run
     assert variables.get("control") == "AFTER"  # control
+
+
+def test_sequential_flattened_item_keys_do_not_leak_between_differently_shaped_items():
+    """A later item that omits a key must not see the previous item's ``item.<key>``.
+
+    The sequential loop runs against the shared scope, so ``item.k`` written for
+    ``{"k": "a"}`` would linger while iterating ``{"m": "b"}`` (which only sets
+    ``item.m``) unless the stale accessor is cleared - the body would then read a
+    stale ``{{item.k}}`` from the previous item. The parallel loop is immune (a
+    fresh deep copy per iteration); this is a sequential-only regression.
+    """
+    seen = []
+
+    def observe(ctx: WorkflowContext) -> StepResult:
+        seen.append((ctx.variables.get("item.k"), ctx.variables.get("item.m")))
+        return StepResult(output="ok")
+
+    wf = Workflow(
+        steps=[
+            loop(steps=[Task(name="observe", handler=observe, max_retries=0)],
+                 over="items", parallel=False),
+            _after(),
+        ],
+        variables={"items": [{"k": "a"}, {"m": "b"}]},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert seen == [("a", None), (None, "b")], (
+        f"a stale flattened item key leaked between iterations: {seen}"
+    )
+    assert "item.k" not in variables
+    assert "item.m" not in variables
+    assert variables.get("control") == "AFTER"  # control

--- a/src/praisonai-agents/tests/unit/workflows/test_loop_variable_scope.py
+++ b/src/praisonai-agents/tests/unit/workflows/test_loop_variable_scope.py
@@ -1,0 +1,418 @@
+"""
+Regression tests: variables written *inside* a ``loop()`` body must survive it.
+
+Sibling of the ``Parallel`` data-loss fix (#4932). Every step inside a loop wrote
+its ``output_variable`` into a ``copy.deepcopy(all_variables)`` that was thrown
+away at the end of each iteration, in both the sequential and the parallel path,
+so the result was silently discarded while the run still reported "completed":
+
+    parallel   inner='I'   control='AFTER'
+    repeat     inner='I'   control='AFTER'
+    if_        inner='I'   control='AFTER'
+    route      inner='I'   control='AFTER'
+    loop       inner=None  control='AFTER'   <- only loop lost it
+
+Every test below carries a ``control`` assertion (a step *outside* the loop whose
+``output_variable`` has always worked) so none of them can pass vacuously if
+variable recording breaks wholesale.
+
+THE RULE these tests pin
+------------------------
+1. A sequential loop is its body unrolled, so it runs against the shared scope
+   like Repeat/If/Route: no isolation, iteration N sees iteration N-1's writes.
+2. A parallel loop must isolate (concurrent writes to one dict is a data race),
+   so it merges each iteration's *delta* back in **item order**, never completion
+   order.
+3. Both therefore end with the **last item's** value for a variable the body
+   rewrites each iteration - what the unrolled sequence would produce. Unlike
+   ``Parallel`` this is not warned about: N iterations writing one
+   ``output_variable`` N times is the normal shape of a loop, not an accident.
+4. The loop's own control variables (``item``/``var_name``, ``loop_index``,
+   ``item.<key>``) are loop machinery, not results, and stay loop-scoped in both
+   modes.
+5. Sequential and parallel must agree on all of the above - pinned directly by
+   ``test_sequential_and_parallel_loops_agree_on_final_variables`` so neither can
+   later be "fixed" into a race or back into silent loss.
+"""
+
+import logging
+
+import pytest
+
+from praisonaiagents import Workflow, WorkflowContext, StepResult
+from praisonaiagents.task.task import Task
+from praisonaiagents.workflows import loop, parallel
+
+MODES = [False, True]
+MODE_IDS = ["sequential", "parallel"]
+
+
+def _after(record=None):
+    def run(ctx: WorkflowContext) -> StepResult:
+        if record is not None:
+            record.append(dict(ctx.variables))
+        return StepResult(output="AFTER")
+    return Task(name="after", handler=run, output_variable="control", max_retries=0)
+
+
+def _echo_item(name="inner", output_variable="inner_var"):
+    return Task(
+        name=name,
+        handler=lambda ctx: StepResult(output=f"X-{ctx.variables.get('item')}"),
+        output_variable=output_variable,
+        max_retries=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The reproduction
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("is_parallel", MODES, ids=MODE_IDS)
+def test_loop_body_output_variable_survives_the_loop(is_parallel):
+    """The bug: ``inner_var`` was absent from every later step and the result."""
+    seen = []
+    wf = Workflow(
+        steps=[
+            loop(steps=[_echo_item()], over="items", parallel=is_parallel,
+                 output_variable="collected"),
+            _after(record=seen),
+        ],
+        variables={"items": ["a", "b"]},
+    )
+    result = wf.start("go")
+    variables = result["variables"]
+
+    assert result["status"] == "completed"
+    assert variables.get("inner_var") == "X-b", (
+        f"the loop body's output_variable was discarded: {sorted(variables)}"
+    )
+    # Control: a step outside the loop has always worked, so this proves the test
+    # measures the loop-specific loss and not a broken harness.
+    assert variables.get("control") == "AFTER"
+
+    # And it must be visible to the *next* step, not merely in the result dict.
+    assert seen and seen[0].get("inner_var") == "X-b"
+
+    # The loop's own aggregate is untouched by the fix.
+    assert variables["collected"] == ["X-a", "X-b"]
+    assert variables["loop_outputs"] == ["X-a", "X-b"]
+
+
+@pytest.mark.parametrize("is_parallel", MODES, ids=MODE_IDS)
+def test_default_output_variable_name_of_a_loop_body_step_also_survives(is_parallel):
+    """A body step with no explicit output_variable writes ``{name}_output``."""
+    wf = Workflow(
+        steps=[
+            loop(steps=[Task(name="alpha",
+                             handler=lambda ctx: StepResult(output=f"A-{ctx.variables.get('item')}"),
+                             max_retries=0)],
+                 over="items", parallel=is_parallel),
+            _after(),
+        ],
+        variables={"items": ["a", "b"]},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert variables.get("alpha_output") == "A-b"
+    assert variables.get("control") == "AFTER"  # control
+
+
+@pytest.mark.parametrize("is_parallel", MODES, ids=MODE_IDS)
+def test_every_iterations_distinct_writes_survive(is_parallel):
+    """Each iteration writes its *own* key; none of them may be dropped.
+
+    Kills a merge that keeps only one iteration's delta (the first or the last).
+    """
+    def writer(ctx: WorkflowContext) -> StepResult:
+        idx = ctx.variables.get("loop_index")
+        return StepResult(output=f"o{idx}", variables={f"seen_{idx}": ctx.variables.get("item")})
+
+    wf = Workflow(
+        steps=[
+            loop(steps=[Task(name="w", handler=writer, max_retries=0)],
+                 over="items", parallel=is_parallel),
+            _after(),
+        ],
+        variables={"items": ["a", "b", "c"]},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert variables.get("seen_0") == "a", "the first iteration's writes were dropped"
+    assert variables.get("seen_1") == "b"
+    assert variables.get("seen_2") == "c", "the last iteration's writes were dropped"
+    assert variables.get("control") == "AFTER"  # control
+
+
+@pytest.mark.parametrize("is_parallel", MODES, ids=MODE_IDS)
+def test_last_item_wins_a_reused_output_variable(is_parallel):
+    """Iterations share one step name, so the *last item* wins - not the first.
+
+    Kills a merge applied in reverse item order, and (for the parallel loop) one
+    applied in completion order.
+    """
+    wf = Workflow(
+        steps=[
+            loop(steps=[_echo_item()], over="items", parallel=is_parallel),
+            _after(),
+        ],
+        variables={"items": ["first", "middle", "last"]},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert variables.get("inner_var") == "X-last", (
+        "a reused output_variable must end on the last item's value"
+    )
+    assert variables.get("control") == "AFTER"  # control
+
+
+def test_parallel_loop_winner_does_not_depend_on_completion_order():
+    """The first item's iteration finishes last here; item order still wins."""
+    import time
+
+    def slow_first(ctx: WorkflowContext) -> StepResult:
+        if ctx.variables.get("loop_index") == 0:
+            time.sleep(0.25)
+        return StepResult(output=f"X-{ctx.variables.get('item')}")
+
+    wf = Workflow(
+        steps=[
+            loop(steps=[Task(name="inner", handler=slow_first,
+                             output_variable="inner_var", max_retries=0)],
+                 over="items", parallel=True, max_workers=4),
+            _after(),
+        ],
+        variables={"items": ["first", "last"]},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert variables.get("inner_var") == "X-last"
+    assert variables.get("control") == "AFTER"  # control
+
+
+def test_a_reused_output_variable_across_iterations_is_not_warned_about(caplog):
+    """Unlike Parallel branches, cross-iteration collision is normal, not a bug."""
+    wf = Workflow(
+        steps=[loop(steps=[_echo_item()], over="items", parallel=True), _after()],
+        variables={"items": ["a", "b", "c"]},
+    )
+    with caplog.at_level(logging.WARNING):
+        variables = wf.start("go")["variables"]
+
+    assert variables.get("inner_var") == "X-c"
+    assert variables.get("control") == "AFTER"  # control
+    assert not any("inner_var" in rec.getMessage() for rec in caplog.records), (
+        "a loop must not warn once per item about its own body's output_variable: "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sequential / parallel parity - the gate that stops either drifting
+# ---------------------------------------------------------------------------
+
+def _run_both_modes():
+    def writer(ctx: WorkflowContext) -> StepResult:
+        idx = ctx.variables.get("loop_index")
+        return StepResult(
+            output=f"X-{ctx.variables.get('item')}",
+            variables={f"per_{idx}": ctx.variables.get("item")},
+        )
+
+    def build(is_parallel):
+        return Workflow(
+            steps=[
+                loop(steps=[
+                        Task(name="one", handler=writer, output_variable="shared", max_retries=0),
+                        Task(name="two",
+                             handler=lambda ctx: StepResult(output=f"2-{ctx.variables.get('shared')}"),
+                             output_variable="second", max_retries=0),
+                     ],
+                     over="items", parallel=is_parallel, output_variable="collected"),
+                _after(),
+            ],
+            variables={"items": ["a", "b", "c"], "untouched": "U"},
+        )
+
+    return (
+        build(False).start("go")["variables"],
+        build(True).start("go")["variables"],
+    )
+
+
+def test_sequential_and_parallel_loops_agree_on_final_variables():
+    """The two modes must end with the same scope.
+
+    Parallel is meant to be a faster way to run the same loop, not a different
+    semantics. This is the gate: any change that makes one mode propagate the
+    body's writes differently from the other fails here by name.
+    """
+    seq, par = _run_both_modes()
+
+    interesting = ["shared", "second", "per_0", "per_1", "per_2",
+                   "collected", "loop_outputs", "untouched", "control"]
+    seq_view = {k: seq.get(k) for k in interesting}
+    par_view = {k: par.get(k) for k in interesting}
+
+    assert seq_view == par_view, (
+        f"sequential and parallel loops disagree:\n  seq={seq_view}\n  par={par_view}"
+    )
+    # Not vacuous: the values really are the loop body's writes, last item winning.
+    assert seq_view["shared"] == "X-c"
+    assert seq_view["second"] == "2-X-c"
+    assert seq_view["per_0"] == "a" and seq_view["per_2"] == "c"
+    assert seq_view["control"] == "AFTER"  # control
+
+
+# ---------------------------------------------------------------------------
+# Loop control variables stay loop-scoped (both modes)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("is_parallel", MODES, ids=MODE_IDS)
+def test_loop_control_variables_do_not_leak_out(is_parallel):
+    """``item``/``loop_index``/``item.<key>`` are machinery, not results."""
+    wf = Workflow(
+        steps=[
+            loop(steps=[Task(name="inner",
+                             handler=lambda ctx: StepResult(output=str(ctx.variables.get("item.k"))),
+                             output_variable="inner_var", max_retries=0)],
+                 over="items", parallel=is_parallel),
+            _after(),
+        ],
+        variables={"items": [{"k": "a"}, {"k": "b"}]},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert variables.get("inner_var") == "b"  # the loop body's write did escape
+    assert "item" not in variables
+    assert "loop_index" not in variables
+    assert "item.k" not in variables
+    assert variables.get("control") == "AFTER"  # control
+
+
+@pytest.mark.parametrize("is_parallel", MODES, ids=MODE_IDS)
+def test_a_pre_existing_variable_named_item_is_restored_after_the_loop(is_parallel):
+    """A loop must not clobber a workflow variable that shares its var_name."""
+    wf = Workflow(
+        steps=[
+            loop(steps=[_echo_item()], over="items", parallel=is_parallel),
+            _after(),
+        ],
+        variables={"items": ["a", "b"], "item": "ORIGINAL"},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert variables.get("item") == "ORIGINAL"
+    assert variables.get("inner_var") == "X-b"
+    assert variables.get("control") == "AFTER"  # control
+
+
+@pytest.mark.parametrize("is_parallel", MODES, ids=MODE_IDS)
+def test_untouched_variables_keep_the_parents_own_object(is_parallel):
+    """A loop body works on copies (parallel); only real writes may merge back."""
+    original = {"a": [1, 2, 3]}
+    wf = Workflow(
+        steps=[
+            loop(steps=[_echo_item()], over="items", parallel=is_parallel),
+            _after(),
+        ],
+        variables={"items": ["a", "b"], "payload": original},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert variables["payload"] is original, (
+        "an untouched variable was replaced by a loop iteration's deep copy"
+    )
+    assert variables.get("inner_var") == "X-b"
+    assert variables.get("control") == "AFTER"  # control
+
+
+# ---------------------------------------------------------------------------
+# Nesting: a loop inside a Parallel branch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("is_parallel", MODES, ids=MODE_IDS)
+def test_loop_nested_in_a_parallel_branch_propagates_body_writes_only(is_parallel):
+    """The branch merge must carry the loop body's writes but not ``item``.
+
+    The sequential loop now runs against the scope it is given - which, inside a
+    Parallel branch, is that branch's write-tracking copy. Its control variables
+    must not be recorded as branch writes and leak into the workflow.
+    """
+    wf = Workflow(
+        steps=[
+            parallel([
+                loop(steps=[_echo_item()], over="items", parallel=is_parallel),
+                Task(name="sibling", handler=lambda ctx: StepResult(output="S"),
+                     output_variable="sibling_var", max_retries=0),
+            ]),
+            _after(),
+        ],
+        variables={"items": ["a", "b"]},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert variables.get("inner_var") == "X-b", (
+        "a loop body's write was lost on the way out of a Parallel branch"
+    )
+    assert variables.get("sibling_var") == "S"  # control: sibling branch merged
+    assert "item" not in variables
+    assert "loop_index" not in variables
+    assert variables.get("control") == "AFTER"  # control
+
+
+# ---------------------------------------------------------------------------
+# The sequential loop is its body unrolled
+# ---------------------------------------------------------------------------
+
+def test_sequential_iterations_see_the_previous_iterations_writes():
+    """No concurrency means no isolation: a sequential loop can accumulate.
+
+    (The parallel loop cannot offer this - its iterations run concurrently - so
+    this is deliberately not parametrized over both modes.)
+    """
+    def accumulate(ctx: WorkflowContext) -> StepResult:
+        so_far = ctx.variables.get("acc") or ""
+        return StepResult(output=so_far + str(ctx.variables.get("item")),
+                          variables={"acc": so_far + str(ctx.variables.get("item"))})
+
+    wf = Workflow(
+        steps=[
+            loop(steps=[Task(name="acc_step", handler=accumulate, max_retries=0)],
+                 over="items", parallel=False),
+            _after(),
+        ],
+        variables={"items": ["a", "b", "c"]},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert variables.get("acc") == "abc"
+    assert variables["loop_outputs"] == ["a", "ab", "abc"]
+    assert variables.get("control") == "AFTER"  # control
+
+
+@pytest.mark.parametrize("is_parallel", MODES, ids=MODE_IDS)
+def test_a_body_step_writing_the_control_name_still_does_not_leak_it(is_parallel):
+    """Even a deliberate ``output_variable="item"`` stays loop-scoped.
+
+    Without this the two modes would disagree: the sequential loop restores the
+    name unconditionally, so the parallel loop must strip it from its delta even
+    though a body step really did write it.
+    """
+    wf = Workflow(
+        steps=[
+            loop(steps=[Task(name="inner",
+                             handler=lambda ctx: StepResult(output=f"X-{ctx.variables.get('item')}"),
+                             output_variable="item", max_retries=0)],
+                 over="items", parallel=is_parallel),
+            _after(),
+        ],
+        variables={"items": ["a", "b"]},
+    )
+    variables = wf.start("go")["variables"]
+
+    assert "item" not in variables, (
+        "the loop's control variable escaped the loop"
+    )
+    assert variables["loop_outputs"] == ["X-a", "X-b"]  # control: the body did run
+    assert variables.get("control") == "AFTER"  # control

--- a/src/praisonai-agents/tests/unit/workflows/test_parallel_branch_variables.py
+++ b/src/praisonai-agents/tests/unit/workflows/test_parallel_branch_variables.py
@@ -236,17 +236,28 @@ def test_failing_modes_still_raise_and_merge_nothing(mode):
 
 
 # ---------------------------------------------------------------------------
-# Loop: deliberately iteration-scoped, and identical parallel vs sequential
+# Loop: the same data loss, fixed separately - see test_loop_variable_scope.py
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("is_parallel", [False, True])
-def test_loop_iteration_variables_stay_iteration_scoped(is_parallel):
-    """Loop is NOT the same case as Parallel and must not be "fixed" to match.
+def test_loop_body_variables_survive_and_the_two_modes_agree(is_parallel):
+    """Loop had the identical defect and it is fixed the same way.
 
-    N iterations share one step name, so a per-iteration output_variable has N
-    conflicting values; the aggregate is exposed through the Loop's own
-    ``output_variable`` / ``loop_outputs`` instead. Sequential and parallel
-    loops behave identically, and that parity is what this test pins.
+    This test previously asserted the opposite - that ``inner_var`` was
+    deliberately iteration-scoped - on the reasoning that N iterations share one
+    step name so the Loop's ``loop_outputs`` aggregate is the right answer. That
+    reasoning did not survive contact with the rest of the package:
+
+    * ``Repeat`` has exactly the same property (N iterations, one step name) and
+      has always run against the shared scope with the last iteration winning;
+    * ``loop_outputs`` only holds each iteration's *last* step's output, so an
+      earlier step's ``output_variable`` in a multi-step body - and any
+      ``StepResult.variables`` write - was lost with no aggregate to recover it
+      from, silently, while the run reported "completed".
+
+    Loop is now the unrolled sequence it looks like: the body's writes escape,
+    last item wins, and the loop's own control variables stay loop-scoped. The
+    full rule and its mutation gates live in ``test_loop_variable_scope.py``.
     """
     wf = Workflow(steps=[
         loop(steps=[Task(name="inner",
@@ -259,7 +270,8 @@ def test_loop_iteration_variables_stay_iteration_scoped(is_parallel):
 
     assert variables["collected"] == ["X-a", "X-b"]
     assert variables["loop_outputs"] == ["X-a", "X-b"]
-    assert "inner_var" not in variables
+    assert variables.get("inner_var") == "X-b"
+    assert "item" not in variables and "loop_index" not in variables
     assert variables.get("after_output") == "AFTER"  # control
 
 


### PR DESCRIPTION
Sibling of #4932 (`Parallel` branch `output_variable` silently discarded). The same defect lives in `loop()`, in **both** its sequential and its parallel path.

## The bug

`_execute_loop` handed every iteration its own `copy.deepcopy(all_variables)` and discarded the copy at the end of the iteration. Every `output_variable` a step inside the loop body wrote landed in that copy. Status stayed `completed`; nothing was logged.

Reproduced on `origin/main`, with the control set that makes it specific rather than general — `inner` is a step's `output_variable` inside the pattern, `control` is the identical step *outside* it:

```
parallel   inner='I'   control='AFTER'
repeat     inner='I'   control='AFTER'
if_        inner='I'   control='AFTER'
route      inner='I'   control='AFTER'
loop-seq   inner=None  control='AFTER'   <- only loop loses it
loop-par   inner=None  control='AFTER'
```

After this change all six rows read `inner='I'`.

## Why the "deliberately iteration-scoped" call in #4932 does not hold

#4932 probed `Loop`, found sequential and parallel agreed, and pinned that agreement with a test on the reasoning that N iterations share one step name so `loop_outputs` is the right answer. Two things refute it:

1. **`Repeat` has exactly the same property and has always done the opposite.** `_execute_repeat` runs its N iterations straight against `all_variables` with `all_variables.update(step_result["variables"])` per iteration — no isolation, last iteration wins. "N iterations share one step name" therefore cannot be what distinguishes `Loop`; `Loop` was simply the odd one out.

2. **`loop_outputs` is not a substitute.** It holds each iteration's *last* step's output only. A multi-step body loses the earlier steps' `output_variable` entirely, with no aggregate to recover it from:

```
before:  loop_outputs=['S-F-a','S-F-b']  first_var=None    second_var=None
after:   loop_outputs=['S-F-a','S-F-b']  first_var='F-b'   second_var='S-F-b'
```

Any `StepResult.variables` write from inside the body was lost the same way.

## The two paths, decided separately

**Sequential loop — stop isolating.** There is no concurrency here, so the deep copy bought no safety: it only threw the body's writes away and hid iteration N-1's writes from iteration N. It now runs against the shared scope exactly like `Repeat`/`If`/`Route` — a sequential loop is its body unrolled. That also makes `acc` accumulation across iterations work, which it never did.

**Parallel loop — isolate and merge, reusing #4932's machinery.** Concurrent iterations writing one dict is a data race, so the deep copy stays, wrapped in `_WriteTrackingDict`, and each iteration's *delta* is merged back through `_merge_branch_variables` in **item order, never completion order**. Untouched variables keep the parent's own object.

**Iteration collisions.** Both modes end on the **last item's** value for a variable the body rewrites — what the unrolled sequence produces, and what `Repeat` already produced. Unlike `Parallel`, this is **not warned about**: two *branches* writing one variable is almost certainly an accident worth a warning, but N *iterations* writing the body's `output_variable` N times is the normal shape of a loop, and warning per item would emit N-1 warnings for a correct workflow. `_merge_branch_variables` gained a `warn_on_collision` flag for exactly this; Parallel's behaviour is unchanged.

**Loop control variables** (`item`/`var_name`, `loop_index`, `item.<key>`) are machinery, not results, and stay loop-scoped in both modes — the sequential path restores what the names held before the loop (including inside a `Parallel` branch, where it also un-records the write so they are not merged out of the branch), the parallel path strips them from the delta.

**Parity is pinned by name.** `test_sequential_and_parallel_loops_agree_on_final_variables` compares the two modes' resulting scopes directly, so neither can later be "fixed" into a race or back into silent loss. The one thing that cannot be equal — a sequential iteration reading the previous iteration's writes — is documented and tested only for sequential.

## Evidence

**Fails before, passes after.** New `tests/unit/workflows/test_loop_variable_scope.py`: **20 of its 22 tests fail** on the pre-fix code, all 22 pass after. Every test carries a `control` assertion (a step outside the loop, which always worked) so none can pass vacuously. The 2 that hold on both are the control-variable-leak guards, which is correct.

`tests/unit/workflows/test_parallel_branch_variables.py::test_loop_iteration_variables_stay_iteration_scoped` — the test #4932 added asserting the opposite — is replaced by `test_loop_body_variables_survive_and_the_two_modes_agree`, with the reasoning above recorded in its docstring.

**Mutation-tested.** Every anchor asserted present before applying (a silent no-op mutation would report a false SURVIVED); nothing was built or run with a mutation applied; all **10 killed by named tests**:

| mutation | example killer |
|---|---|
| parallel: merge removed | `test_loop_body_output_variable_survives_the_loop[parallel]` |
| parallel: drop first iteration's delta | `test_every_iterations_distinct_writes_survive[parallel]` |
| parallel: drop last iteration's delta | `test_last_item_wins_a_reused_output_variable[parallel]` |
| parallel: apply deltas in reverse order | `test_parallel_loop_winner_does_not_depend_on_completion_order` |
| parallel: warn on every iteration collision | `test_a_reused_output_variable_across_iterations_is_not_warned_about` |
| parallel: keep control vars in the delta | `test_a_body_step_writing_the_control_name_still_does_not_leak_it[parallel]` |
| sequential: re-isolate (discard body writes) | `test_sequential_and_parallel_loops_agree_on_final_variables` |
| sequential: drop first iteration's writes | `test_every_iterations_distinct_writes_survive[sequential]` |
| sequential: drop last iteration's writes | `test_last_item_wins_a_reused_output_variable[sequential]` |
| sequential: never restore control variables | `test_a_pre_existing_variable_named_item_is_restored_after_the_loop[sequential]` |

The two "make the modes disagree" mutations (`sequential-reisolate`, `parallel-drop-last-delta`) both kill the parity test by name, which is the gate that matters.

**Full `src/praisonai-agents/tests/unit`** (`-n 8 --timeout=120`, `tests/unit/session/test_title_gen.py` ignored — it fails to *collect* on `origin/main` with an unrelated `ImportError`; exit code read from the command, not through a pipe):

- before: `223 failed, 9030 passed, 25 skipped, 3 errors` — exit **1**
- after: `216 failed, 9058 passed, 26 skipped, 3 errors` — exit **1**

Diffing the failure sets: 21 fail only before, 14 only after. **None is a workflow test**; they are all in `tests/unit/tools/test_undeclared_tool_retries_by_name.py`, `test_tool_result_guardrail.py`, `test_tool_guardrails.py`, `test_code_tools_bridge.py` and `test_param_consolidation.py` — process-global tool-registry and once-per-process deprecation-warning state, i.e. xdist ordering flakes. All 16 of the newly-failing ones **pass in isolation on this branch** (exit 0), and none of those files reference workflows. (Both runs shared the machine with another agent's concurrent suite, which is why the pre-existing failure count is higher here than the ~205 quoted in #4932.)

**Focused:** `tests/unit/workflows` + `test_workflow_patterns.py` + `test_parallel_loop.py` + `test_aworkflow_loop_expansion.py` + `test_include_in_loop.py` + `test_output_variable_and_list_parsing.py` + `tests/unit/task` + `tests/unit/conditions`: **459 passed**, exit **0**.

## Behaviour change to be aware of

A workflow that relied on a loop body's `output_variable` *not* escaping now sees it in the enclosing scope (last item's value). That is the point of the fix, and it brings `Loop` in line with `Repeat`, `If`, `Route` and `Parallel`, but it is a semantic change rather than a pure bug fix, so it is worth a reviewer's eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable handling in sequential and parallel loops.
  * Loop body outputs now persist in the surrounding workflow, with consistent results across execution modes.
  * Preserved iteration order when resolving repeated output variables.
  * Prevented loop control variables from leaking into workflow scope and restored pre-existing values.
  * Improved nested-loop behavior within parallel branches.
  * Cleared stale item fields between sequential iterations.
  * Reduced unnecessary collision warnings for expected cross-iteration writes.

* **Tests**
  * Added comprehensive coverage for loop variable propagation, scoping, ordering, restoration, and execution-mode consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->