### PR TITLE
Feat/edenai provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ COHERE_API_KEY=...             # Cohere models
 AZURE_OPENAI_API_KEY=...       # Azure OpenAI
 AZURE_OPENAI_ENDPOINT=...      # Azure OpenAI endpoint
 EVOLINK_API_KEY=...            # EvoLink.AI OpenAI-compatible models. Get yours at https://evolink.ai/dashboard/keys
+EDENAI_API_KEY=...             # Eden AI gateway (OpenAI-compatible, many vendors behind one key)
+# EDENAI_BASE_URL=https://api.edenai.run/v3   # Optional: override the Eden AI endpoint
 
 # === Optional: Memory backends ===
 MEM0_API_KEY=...               # Mem0 memory service

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Powered by 100+ LLMs (OpenAI, Anthropic, Gemini & local models).
 <img src="https://img.shields.io/badge/Cerebras-F05A28?style=flat" alt="Cerebras" />
 <img src="https://img.shields.io/badge/Cohere-39594D?style=flat" alt="Cohere" />
 <img src="https://img.shields.io/badge/OpenRouter-6467F2?style=flat" alt="OpenRouter" />
+<img src="https://img.shields.io/badge/Eden_AI-3A6FF8?style=flat" alt="Eden AI" />
 <img src="https://img.shields.io/badge/Perplexity-20808D?style=flat" alt="Perplexity" />
 <img src="https://img.shields.io/badge/Fireworks-FF6B35?style=flat" alt="Fireworks" />
 <img src="https://img.shields.io/badge/AWS_Bedrock-FF9900?style=flat&logo=amazonaws&logoColor=white" alt="AWS Bedrock" />
@@ -380,7 +381,7 @@ Powered by 100+ LLMs (OpenAI, Anthropic, Gemini & local models).
 </p>
 
 <details>
-<summary><strong>View all 24 providers with examples</strong></summary>
+<summary><strong>View all 25 providers with examples</strong></summary>
 
 | Provider | Example |
 |----------|:-------:|
@@ -397,6 +398,7 @@ Powered by 100+ LLMs (OpenAI, Anthropic, Gemini & local models).
 | Fireworks | [Example](examples/python/providers/fireworks/fireworks_example.py) |
 | Together AI | [Example](examples/python/providers/together/together_ai_example.py) |
 | OpenRouter | [Example](examples/python/providers/openrouter/openrouter_example.py) |
+| Eden AI | [Example](examples/python/providers/edenai/edenai_example.py) |
 | HuggingFace | [Example](examples/python/providers/huggingface/huggingface_example.py) |
 | Azure OpenAI | [Example](examples/python/providers/azure/azure_openai_example.py) |
 | AWS Bedrock | [Example](examples/python/providers/aws/aws_bedrock_example.py) |

--- a/examples/python/providers/edenai/edenai_example.py
+++ b/examples/python/providers/edenai/edenai_example.py
@@ -1,0 +1,50 @@
+"""Basic example of using Eden AI with PraisonAI.
+
+Eden AI is an AI gateway: a single OpenAI-compatible endpoint fronts models from
+many vendors. Select one with ``edenai/<vendor>/<model>`` -- the ``<vendor>/<model>``
+part is Eden AI's own model identifier and is forwarded unchanged, so any model
+Eden AI serves works without a PraisonAI update.
+
+Setup:
+    export EDENAI_API_KEY=your_api_key
+
+Optionally point at a different Eden AI endpoint (defaults to
+https://api.edenai.run/v3):
+
+    export EDENAI_BASE_URL=https://api.edenai.run/v3
+
+EDENAI_API_KEY is required for an Eden AI model. PraisonAI will not fall back to
+OPENAI_API_KEY for these routes, so your OpenAI credential is never sent to
+Eden AI.
+"""
+
+import os
+
+from praisonaiagents import Agent
+
+if not os.getenv("EDENAI_API_KEY"):
+    raise RuntimeError(
+        "EDENAI_API_KEY is not set. Set it before running this example: "
+        "export EDENAI_API_KEY=your_api_key"
+    )
+
+agent = Agent(
+    instructions="You are a helpful assistant",
+    llm="edenai/openai/gpt-4.1-mini",
+)
+
+response = agent.start("Hello! Share one practical AI automation idea.")
+print(response)
+
+
+# Switching vendors is a change of model string -- same key, same endpoint.
+for model in [
+    "edenai/anthropic/claude-sonnet-4-5",
+    "edenai/google/gemini-2.5-flash",
+]:
+    vendor_agent = Agent(
+        instructions="You are a concise technical writer",
+        llm=model,
+    )
+    print(f"\n--- {model} ---")
+    print(vendor_agent.start("Explain quantum entanglement in two sentences."))

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -27,6 +27,13 @@ from ..model_harness.guard import check_model_request
 # Gap 2: Tool call execution imports
 from ..tools.call_executor import ToolCall, create_tool_call_executor
 from ..tools.schema import build_tool_definition
+from .model_providers import (
+    EDENAI_API_KEY_VAR,
+    EDENAI_BASE_URL_VAR,
+    EDENAI_DEFAULT_BASE_URL,
+    EDENAI_ROUTE_PREFIX,
+    is_edenai_model,
+)
 
 
 # Sentinel returned as the "arguments" value when a tool call's argument string
@@ -657,6 +664,14 @@ Respond with ONLY a valid JSON tool call in this format:
         if provider_prefix in {"lm_studio", "lmstudio", "vllm", "hosted_vllm",
                                "llamacpp", "llama_cpp"}:
             return "local"
+        # A gateway route names the gateway, not the vendor in the rest of the
+        # id: "edenai/anthropic/claude-*" is Eden AI serving Claude over
+        # Chat Completions. It must not reach the substring fallback below,
+        # which would hand it the direct Anthropic adapter (streaming disabled)
+        # or the Gemini one (streaming-with-tools disabled). Returning the
+        # gateway id selects DefaultAdapter, i.e. plain OpenAI behaviour.
+        if is_edenai_model(self.model):
+            return "edenai"
         if provider_prefix in {"anthropic", "claude"}:
             return "anthropic"
         if provider_prefix in {"gemini", "google"} and "gemini" in model_lower:
@@ -728,6 +743,17 @@ Respond with ONLY a valid JSON tool call in this format:
         # here made this predicate disagree with the adapter that gets selected.
         if self.model.startswith(("ollama/", "ollama_chat/")):
             return True
+
+        # An explicit gateway route is hosted by definition, so a local
+        # base_url in the environment must not capture it. The
+        # is_hosted_only_model() guard below cannot cover this case: it keys off
+        # closed-weights model *families*, and a gateway route commonly names an
+        # open-weights one ("edenai/mistral/mistral-large-latest") that Ollama
+        # genuinely can serve. Without this, such a route took the Ollama
+        # adapter -- tool results downgraded to natural-language user turns and
+        # tool_calls dropped from the assistant message.
+        if is_edenai_model(self.model):
+            return False
 
         # A base_url says WHERE the server is, not WHAT it serves. Only let it
         # imply Ollama for a model that could plausibly be running locally.
@@ -6048,6 +6074,15 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         model = self.model
         if not isinstance(model, str):
             return model
+        # Eden AI is an OpenAI-compatible gateway litellm has no provider route
+        # for, so "edenai/<vendor>/<model>" goes through litellm's OpenAI client
+        # (_apply_edenai_route supplies the endpoint and credential). litellm
+        # splits only the FIRST path segment, so the "<vendor>/<model>" tail
+        # reaches Eden AI exactly as the user wrote it -- which is Eden AI's own
+        # documented model format. Remove this once litellm routes "edenai"
+        # itself (i.e. once "edenai" appears in litellm.provider_list).
+        if is_edenai_model(model):
+            return f"openai/{model[len(EDENAI_ROUTE_PREFIX):]}"
         # llama.cpp's llama-server speaks OpenAI, but litellm knows no
         # "llama_cpp/" provider -- it raised "LLM Provider NOT provided" and
         # then retried four times before returning None. We accept the prefix
@@ -6068,6 +6103,44 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         if self._detect_provider() != "openai":
             return model
         return f"openai/{model}"
+
+    def _apply_edenai_route(self, params: Dict[str, Any]) -> None:
+        """Point an ``edenai/`` route at Eden AI, and fail closed without its key.
+
+        ``_resolve_openai_compatible_model`` has already rewritten the model to
+        ``openai/...``, which means litellm would otherwise fill in OpenAI's own
+        defaults for it: ``OPENAI_API_KEY`` for the credential and
+        ``OPENAI_BASE_URL``/``OPENAI_API_BASE`` (else api.openai.com) for the
+        endpoint. Measured, with only those two set: the request went to
+        ``http://localhost:11434/v1/chat/completions`` carrying the user's real
+        OpenAI key. So both are resolved explicitly here, and a missing Eden AI
+        key raises instead of falling back -- an Eden AI route must never spend
+        an OpenAI credential.
+
+        Endpoint precedence: an already-resolved ``base_url`` (caller-supplied,
+        or injected by a subscription auth provider) > ``EDENAI_BASE_URL`` >
+        Eden AI's public endpoint. Credential precedence is the same, so
+        ``api_key=`` and ``auth=`` keep working unchanged.
+        """
+        if not is_edenai_model(self.model):
+            return
+        if not params.get("base_url"):
+            params["base_url"] = (
+                (os.getenv(EDENAI_BASE_URL_VAR) or "").strip()
+                or EDENAI_DEFAULT_BASE_URL
+            )
+        if not params.get("api_key"):
+            api_key = (os.getenv(EDENAI_API_KEY_VAR) or "").strip()
+            if not api_key:
+                raise ValueError(
+                    f"{EDENAI_API_KEY_VAR} is required for the Eden AI model "
+                    f"{self.model!r}. Set it to your Eden AI key, or pass "
+                    "api_key=... explicitly. OPENAI_API_KEY is deliberately not "
+                    "used as a fallback: Eden AI is a separate gateway, so doing "
+                    "that would send your OpenAI credential to "
+                    f"{params['base_url']}."
+                )
+            params["api_key"] = api_key
 
     def _guard_format_with_tools(self, params: Dict[str, Any]) -> None:
         """Refuse a combination that makes the model fabricate.
@@ -6151,6 +6224,12 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
         
         # Override with any provided parameters
         params.update(override_params)
+
+        # Resolve Eden AI's endpoint and credential once every other source
+        # (instance, subscription auth, per-call overrides) has been merged, so
+        # any explicit value wins and the fail-closed key check sees the final
+        # state of the request.
+        self._apply_edenai_route(params)
 
         # Resolve temperature from the instance when the caller did not specify
         # one. Public entry points now default temperature to None so a value

--- a/src/praisonai-agents/praisonaiagents/llm/model_providers.py
+++ b/src/praisonai-agents/praisonaiagents/llm/model_providers.py
@@ -74,6 +74,34 @@ def is_hosted_only_model(model_name: str) -> bool:
     return False
 
 
+# Eden AI is an OpenAI-compatible gateway: one endpoint fronts many vendors, and
+# the model id it expects is itself ``<vendor>/<model>``
+# (``anthropic/claude-sonnet-4-5``). litellm has no ``edenai`` provider -- the
+# slug is absent from its provider list -- so an ``edenai/`` route is resolved
+# here and sent through litellm's OpenAI-compatible client instead.
+#
+# Only the prefix is ever matched. Everything after it is forwarded untouched,
+# so this package keeps no catalogue of Eden AI models and needs no change when
+# Eden AI adds a vendor or a model.
+EDENAI_ROUTE_PREFIX = "edenai/"
+EDENAI_API_KEY_VAR = "EDENAI_API_KEY"
+EDENAI_BASE_URL_VAR = "EDENAI_BASE_URL"
+EDENAI_DEFAULT_BASE_URL = "https://api.edenai.run/v3"
+
+
+def is_edenai_model(model_name: str) -> bool:
+    """True if ``model_name`` is routed through the Eden AI gateway.
+
+    Matches the ``edenai/`` route prefix only. The remainder is Eden AI's own
+    ``<vendor>/<model>`` identifier and is deliberately not inspected: the
+    vendor named there is *reached through* Eden AI, not called directly, so it
+    must not be read as a direct Anthropic/Gemini/Ollama route.
+    """
+    if not model_name:
+        return False
+    return model_name.lower().startswith(EDENAI_ROUTE_PREFIX)
+
+
 # The small helper model used for internal auxiliary calls -- memory quality
 # scoring, context compaction, session titling, workflow routing. Historically
 # about a dozen sites resolved this from OPENAI_MODEL_NAME while about twenty

--- a/src/praisonai-agents/praisonaiagents/llm/model_providers.py
+++ b/src/praisonai-agents/praisonaiagents/llm/model_providers.py
@@ -96,8 +96,14 @@ def is_edenai_model(model_name: str) -> bool:
     ``<vendor>/<model>`` identifier and is deliberately not inspected: the
     vendor named there is *reached through* Eden AI, not called directly, so it
     must not be read as a direct Anthropic/Gemini/Ollama route.
+
+    A non-string model is not a route, so it returns ``False`` rather than
+    raising: this runs on every request build, and ``_resolve_openai_compatible_model``
+    guards the same way. Without the type check a duck-typed stand-in made
+    ``startswith`` answer with a truthy object, which read as an Eden AI route
+    and then demanded ``EDENAI_API_KEY``.
     """
-    if not model_name:
+    if not isinstance(model_name, str) or not model_name:
         return False
     return model_name.lower().startswith(EDENAI_ROUTE_PREFIX)
 

--- a/src/praisonai-agents/tests/unit/llm/test_edenai_gateway.py
+++ b/src/praisonai-agents/tests/unit/llm/test_edenai_gateway.py
@@ -1,0 +1,391 @@
+"""Tests for the Eden AI gateway route (``edenai/<vendor>/<model>``).
+
+Eden AI is an OpenAI-compatible gateway: one endpoint fronts many vendors, and
+the model id it expects is itself ``<vendor>/<model>``. LiteLLM has no
+``edenai`` provider, so PraisonAI routes ``edenai/`` through LiteLLM's
+OpenAI-compatible client against Eden AI's endpoint.
+
+Two properties carry most of the risk and are asserted directly:
+
+* The vendor named *inside* an Eden AI id is reached **through** the gateway,
+  so it must not be read as a direct Anthropic/Gemini/Ollama route -- those
+  paths disable streaming or rewrite the message shape.
+* The model reaching LiteLLM is ``openai/...``, so LiteLLM would happily fill
+  in ``OPENAI_API_KEY`` and ``OPENAI_BASE_URL`` for it. The route must resolve
+  both explicitly and fail closed rather than spend an OpenAI credential
+  against api.edenai.run.
+
+No network access and no Eden AI credentials are required.
+"""
+
+import json
+
+import pytest
+
+from praisonaiagents.llm.llm import LLM
+from praisonaiagents.llm.model_providers import is_edenai_model
+
+# Every credential/endpoint variable that could leak into a resolved request.
+_PROVIDER_ENV = (
+    "EDENAI_API_KEY", "EDENAI_BASE_URL",
+    "OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_BASE", "OPENAI_MODEL_NAME",
+    "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "OLLAMA_API_BASE",
+    "OLLAMA_HOST",
+)
+
+EDEN_ROUTES = [
+    "edenai/openai/gpt-4.1-mini",
+    "edenai/anthropic/claude-sonnet-4-5",
+    "edenai/google/gemini-2.5-flash",
+]
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Isolate provider env vars, then supply only an Eden AI key."""
+    for var in _PROVIDER_ENV:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("EDENAI_API_KEY", "eden-test-key")
+
+
+# ---------------------------------------------------------------- recognition
+
+@pytest.mark.parametrize("model", EDEN_ROUTES)
+def test_route_is_recognised_as_edenai(model):
+    assert is_edenai_model(model)
+    assert LLM(model=model)._detect_provider() == "edenai"
+
+
+def test_prefix_match_is_case_insensitive_and_scoped():
+    assert is_edenai_model("EdenAI/openai/gpt-4.1-mini")
+    # Not a route prefix: a vendor or model that merely contains the word.
+    assert not is_edenai_model("openai/edenai-tuned-model")
+    assert not is_edenai_model("edenai")
+    assert not is_edenai_model("")
+
+
+# -------------------------------------------------------- model normalisation
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("edenai/openai/gpt-4.1-mini", "openai/openai/gpt-4.1-mini"),
+        ("edenai/anthropic/claude-sonnet-4-5", "openai/anthropic/claude-sonnet-4-5"),
+        ("edenai/google/gemini-2.5-flash", "openai/google/gemini-2.5-flash"),
+    ],
+)
+def test_model_is_routed_through_the_openai_compatible_client(model, expected):
+    assert LLM(model=model)._build_completion_params()["model"] == expected
+
+
+def test_arbitrary_vendor_and_model_are_forwarded_untouched():
+    """No catalogue: anything after ``edenai/`` is passed through verbatim.
+
+    Eden AI adds vendors and models continuously, so a route naming one this
+    package has never heard of -- at any segment depth -- must still resolve.
+    """
+    for tail in ("acme/some-future-model-v9", "vendor/family/size-42b", "bare-model-id"):
+        params = LLM(model=f"edenai/{tail}")._build_completion_params()
+        assert params["model"] == f"openai/{tail}"
+
+
+# ------------------------------------------------------- endpoint resolution
+
+def test_default_endpoint_is_eden_ai():
+    params = LLM(model="edenai/openai/gpt-4.1-mini")._build_completion_params()
+    assert params["base_url"] == "https://api.edenai.run/v3"
+
+
+def test_edenai_base_url_env_overrides_the_default(monkeypatch):
+    monkeypatch.setenv("EDENAI_BASE_URL", "https://eu.edenai.example/v3")
+    params = LLM(model="edenai/openai/gpt-4.1-mini")._build_completion_params()
+    assert params["base_url"] == "https://eu.edenai.example/v3"
+
+
+def test_explicit_base_url_overrides_the_env_var(monkeypatch):
+    monkeypatch.setenv("EDENAI_BASE_URL", "https://eu.edenai.example/v3")
+    params = LLM(
+        model="edenai/openai/gpt-4.1-mini",
+        base_url="https://api.edenai.run/v3",
+    )._build_completion_params()
+    assert params["base_url"] == "https://api.edenai.run/v3"
+
+
+def test_a_stray_openai_base_url_cannot_redirect_the_route(monkeypatch):
+    """The endpoint is resolved explicitly, so OPENAI_BASE_URL is not consulted."""
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+    params = LLM(model="edenai/openai/gpt-4.1-mini")._build_completion_params()
+    assert params["base_url"] == "https://api.edenai.run/v3"
+
+
+# ----------------------------------------------------- credentials, closed
+
+def test_api_key_comes_from_edenai_api_key():
+    params = LLM(model="edenai/openai/gpt-4.1-mini")._build_completion_params()
+    assert params["api_key"] == "eden-test-key"
+
+
+def test_explicit_api_key_overrides_the_env_var():
+    params = LLM(
+        model="edenai/openai/gpt-4.1-mini", api_key="caller-key"
+    )._build_completion_params()
+    assert params["api_key"] == "caller-key"
+
+
+def test_missing_edenai_key_fails_closed(monkeypatch):
+    monkeypatch.delenv("EDENAI_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="EDENAI_API_KEY"):
+        LLM(model="edenai/openai/gpt-4.1-mini")._build_completion_params()
+
+
+def test_openai_key_is_never_used_as_the_edenai_fallback(monkeypatch):
+    """The security property: an Eden AI route must not spend an OpenAI key.
+
+    The model handed to LiteLLM is ``openai/...``, so LiteLLM's own resolution
+    would fall back to OPENAI_API_KEY. Refusing must happen here, before the
+    request is built, and the refusal must not echo the secret.
+    """
+    monkeypatch.delenv("EDENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real-openai-secret")
+
+    with pytest.raises(ValueError) as exc:
+        LLM(model="edenai/openai/gpt-4.1-mini")._build_completion_params()
+
+    message = str(exc.value)
+    assert "EDENAI_API_KEY" in message
+    assert "sk-real-openai-secret" not in message
+
+
+def test_blank_edenai_key_is_treated_as_missing(monkeypatch):
+    monkeypatch.setenv("EDENAI_API_KEY", "   ")
+    with pytest.raises(ValueError, match="EDENAI_API_KEY"):
+        LLM(model="edenai/openai/gpt-4.1-mini")._build_completion_params()
+
+
+# ------------------------------------ vendor heuristics stay out of the way
+
+@pytest.mark.parametrize("model", EDEN_ROUTES)
+def test_eden_routes_use_the_default_adapter(model):
+    """Not the Anthropic adapter (streaming off) nor the Gemini one."""
+    llm = LLM(model=model)
+    assert type(llm._provider_adapter).__name__ == "DefaultAdapter"
+
+
+def test_eden_claude_route_is_not_the_direct_anthropic_provider():
+    llm = LLM(model="edenai/anthropic/claude-sonnet-4-5")
+    assert llm._detect_provider() == "edenai"
+    assert llm._provider_adapter.supports_streaming() is True
+
+
+def test_eden_gemini_route_is_not_the_direct_gemini_provider():
+    llm = LLM(model="edenai/google/gemini-2.5-flash")
+    assert llm._detect_provider() == "edenai"
+    assert llm._provider_adapter.supports_streaming_with_tools() is True
+
+
+def test_eden_route_is_not_ollama_even_with_a_local_endpoint(monkeypatch):
+    """An open-weights vendor behind Eden AI must not take the Ollama path.
+
+    ``is_hosted_only_model`` deliberately does not cover open-weights families
+    (Ollama really can serve Mistral), so a local ``OPENAI_BASE_URL`` -- the
+    documented local-model recipe -- used to capture this route. The Ollama
+    adapter rewrites tool results into natural-language user turns and drops
+    ``tool_calls`` from the assistant message.
+    """
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+    llm = LLM(model="edenai/mistral/mistral-large-latest")
+
+    assert llm._is_ollama_provider() is False
+    assert llm._detect_provider() == "edenai"
+    assert type(llm._provider_adapter).__name__ == "DefaultAdapter"
+    # The standard OpenAI tool-result shape, not Ollama's "user" rewrite.
+    assert llm._provider_adapter.format_tool_result_message("f", {"ok": 1})["role"] == "tool"
+
+
+# ----------------------------------------------------------- request shape
+
+def test_streaming_is_available_on_the_default_path():
+    llm = LLM(model="edenai/anthropic/claude-sonnet-4-5")
+    assert llm._provider_adapter.supports_streaming() is True
+    assert llm._supports_streaming_tools() is True
+
+
+def test_tools_and_caller_tool_choice_survive_the_route():
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Look up weather",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+        },
+    }]
+    params = LLM(model="edenai/openai/gpt-4.1-mini")._build_completion_params(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=tools,
+        tool_choice="auto",
+    )
+    assert params["tools"] == tools
+    assert params["tool_choice"] == "auto"
+
+
+def test_structured_output_does_not_inject_gemini_native_parameters():
+    """A Gemini model behind Eden AI still speaks OpenAI, not Gemini.
+
+    ``response_mime_type``/``response_schema`` are Gemini-native and would be
+    wrong on Eden AI's OpenAI-shaped endpoint. LiteLLM reports no
+    structured-output capability for a gateway-routed model, so PraisonAI falls
+    back to putting the schema in the prompt -- which is the safe behaviour and
+    the one asserted here.
+    """
+    from pydantic import BaseModel
+
+    class Answer(BaseModel):
+        text: str
+
+    params = LLM(model="edenai/google/gemini-2.5-flash")._build_completion_params(
+        messages=[{"role": "user", "content": "hi"}],
+        output_pydantic=Answer,
+    )
+    assert "response_mime_type" not in params
+    assert "response_schema" not in params
+    # Internal-only parameters never reach the provider.
+    assert "output_pydantic" not in params
+
+
+def test_eden_route_does_not_select_the_responses_api():
+    for model in EDEN_ROUTES:
+        assert LLM(model=model)._supports_responses_api() is False
+
+
+# --------------------------------------------- LiteLLM call construction
+
+def test_resolved_params_produce_the_expected_edenai_request(monkeypatch):
+    """Integration-style: feed the resolved params to LiteLLM, mock the socket.
+
+    Asserts the request LiteLLM actually builds -- URL, bearer token and the
+    ``model`` in the JSON body -- because that body is what Eden AI validates.
+    LiteLLM strips only the first path segment, so the vendor-qualified id must
+    survive intact.
+    """
+    import httpx
+    import litellm
+
+    captured = {}
+
+    def fake_send(self, request, **kwargs):
+        captured["url"] = str(request.url)
+        captured["authorization"] = request.headers.get("authorization")
+        captured["body"] = json.loads(request.content or b"{}")
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "anthropic/claude-sonnet-4-5",
+                "choices": [{
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "hello"},
+                }],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+            },
+        )
+
+    monkeypatch.setattr(httpx.Client, "send", fake_send)
+
+    params = LLM(model="edenai/anthropic/claude-sonnet-4-5")._build_completion_params(
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.2,
+    )
+    response = litellm.completion(**params)
+
+    assert captured["url"] == "https://api.edenai.run/v3/chat/completions"
+    assert captured["authorization"] == "Bearer eden-test-key"
+    assert captured["body"]["model"] == "anthropic/claude-sonnet-4-5"
+    assert response.choices[0].finish_reason == "stop"
+    assert response.usage.total_tokens == 4
+
+
+@pytest.mark.parametrize(
+    "status,expected_category",
+    [(401, "auth"), (429, "rate_limit"), (400, "invalid_request"), (500, "transient")],
+)
+def test_edenai_errors_reuse_the_existing_classifier(monkeypatch, status, expected_category):
+    """Gateway failures need no Eden-specific handling.
+
+    Going out over LiteLLM's OpenAI client means Eden AI's HTTP statuses arrive
+    as the same exception classes every other OpenAI-compatible provider
+    raises, which the existing classifier already routes correctly.
+
+    HTTP 422 -- which Eden AI returns for a malformed request body -- is
+    deliberately absent: LiteLLM retries it once and then returns ``None``
+    instead of raising. That was measured to be identical for a direct
+    ``openai/gpt-4o-mini`` route and for bare ``litellm.completion`` with no
+    PraisonAI involvement, so it is pre-existing LiteLLM behaviour rather than
+    anything this route introduces. Asserting it here would pin a third-party
+    quirk instead of this integration's contract.
+    """
+    import httpx
+    import litellm
+
+    from praisonaiagents.llm.error_classifier import classify_error
+
+    def fake_send(self, request, **kwargs):
+        return httpx.Response(status, request=request, json={"error": {"message": "nope"}})
+
+    monkeypatch.setattr(httpx.Client, "send", fake_send)
+
+    params = LLM(model="edenai/openai/gpt-4.1-mini")._build_completion_params(
+        messages=[{"role": "user", "content": "hi"}],
+        num_retries=0,
+    )
+    with pytest.raises(Exception) as exc:
+        litellm.completion(**params)
+
+    assert classify_error(exc.value).value == expected_category
+
+
+# -------------------------------------------------------------- regression
+
+@pytest.mark.parametrize(
+    "model,expected_provider,expected_model",
+    [
+        ("gpt-4o-mini", "openai", "gpt-4o-mini"),
+        ("openai/gpt-4o", "openai", "openai/gpt-4o"),
+        ("anthropic/claude-3-5-sonnet", "anthropic", "anthropic/claude-3-5-sonnet"),
+        ("gemini/gemini-1.5-flash", "gemini", "gemini/gemini-1.5-flash"),
+        ("ollama/llama3", "ollama", "ollama/llama3"),
+        # A different gateway: deliberately untouched by this change.
+        ("openrouter/anthropic/claude-3.5-sonnet", "anthropic",
+         "openrouter/anthropic/claude-3.5-sonnet"),
+    ],
+)
+def test_direct_and_other_provider_routes_are_unchanged(model, expected_provider, expected_model):
+    """Nothing outside the ``edenai/`` prefix may change behaviour."""
+    llm = LLM(model=model)
+    params = llm._build_completion_params()
+
+    assert llm._detect_provider() == expected_provider
+    assert params["model"] == expected_model
+    # No endpoint or credential is invented for a non-Eden route.
+    assert "base_url" not in params
+    assert "api_key" not in params
+
+
+def test_direct_ollama_detection_still_works(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+    # Explicit prefix, and the env-based detection for a bare open-weights model.
+    assert LLM(model="ollama/llama3")._is_ollama_provider() is True
+    assert LLM(model="mistral-large")._is_ollama_provider() is True
+    # A hosted-only family stays hosted even against a local endpoint.
+    assert LLM(model="gpt-4o")._is_ollama_provider() is False
+
+
+def test_direct_anthropic_and_gemini_heuristics_are_untouched():
+    """The vendor predicates keep their meaning for direct routes."""
+    assert LLM(model="anthropic/claude-3-5-sonnet")._is_anthropic_model() is True
+    assert LLM(model="claude-3-5-sonnet")._is_anthropic_model() is True
+    assert LLM(model="gemini/gemini-1.5-flash")._is_gemini_model() is True
+    assert LLM(model="anthropic/claude-3-5-sonnet")._provider_adapter.supports_streaming() is False

--- a/src/praisonai-agents/tests/unit/llm/test_edenai_gateway.py
+++ b/src/praisonai-agents/tests/unit/llm/test_edenai_gateway.py
@@ -64,6 +64,38 @@ def test_prefix_match_is_case_insensitive_and_scoped():
     assert not is_edenai_model("")
 
 
+@pytest.mark.parametrize(
+    "value",
+    [None, 123, 4.5, True, b"edenai/x", ["edenai/x"], {"model": "edenai/x"}, object()],
+)
+def test_non_string_models_are_not_eden_routes(value):
+    """The predicate runs on every request build, so odd values must not raise.
+
+    ``_resolve_openai_compatible_model`` already guards ``isinstance(model, str)``;
+    this guards the same way and returns a real ``bool``. Before the type check,
+    a duck-typed stand-in answered ``startswith`` with a truthy object, which
+    classified it as an Eden AI route and then demanded ``EDENAI_API_KEY``.
+    """
+    assert is_edenai_model(value) is False
+
+
+def test_a_mock_model_is_not_an_eden_route():
+    """The specific footgun: a mock answers any method with a truthy mock.
+
+    Called out separately from the other non-string values because a test
+    double is the way this would realistically reach the predicate.
+    """
+    from unittest.mock import MagicMock
+
+    assert is_edenai_model(MagicMock()) is False
+
+
+def test_predicate_returns_a_real_bool_on_the_positive_path():
+    """``is`` rather than truthiness, so the ``-> bool`` annotation is enforced."""
+    assert is_edenai_model("edenai/openai/gpt-4.1-mini") is True
+    assert is_edenai_model("openai/gpt-4.1-mini") is False
+
+
 # -------------------------------------------------------- model normalisation
 
 @pytest.mark.parametrize(

--- a/src/praisonai-code/praisonai_code/llm/catalogue.py
+++ b/src/praisonai-code/praisonai_code/llm/catalogue.py
@@ -191,6 +191,7 @@ PROVIDER_KEY_URLS = {
     "gemini": "https://aistudio.google.com/app/apikey",
     "groq": "https://console.groq.com/keys",
     "openrouter": "https://openrouter.ai/keys",
+    "edenai": "https://app.edenai.run/settings/api-keys",
     "mistral": "https://console.mistral.ai/api-keys",
     "deepseek": "https://platform.deepseek.com/api_keys",
     "xai": "https://console.x.ai",
@@ -240,6 +241,10 @@ PROVIDER_ENV_CATALOGUE: Dict[str, tuple] = {
     "together":   (("TOGETHER_API_KEY", "TOGETHERAI_API_KEY"), "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo", "together_ai/"),
     "perplexity": (("PERPLEXITYAI_API_KEY",),         "perplexity/sonar",                     "perplexity/"),
     "fireworks":  (("FIREWORKS_API_KEY", "FIREWORKS_AI_API_KEY"), "fireworks_ai/accounts/fireworks/models/llama-v3p3-70b-instruct", "fireworks_ai/"),
+    # Eden AI is a gateway, so its model ids nest a vendor the same way
+    # OpenRouter's and Together's do. The default below is one representative
+    # model, not a catalogue: any "edenai/<vendor>/<model>" is forwarded as-is.
+    "edenai":     (("EDENAI_API_KEY",),           "edenai/openai/gpt-4.1-mini",           "edenai/"),
 }
 
 

--- a/src/praisonai-code/praisonai_code/llm/credentials.py
+++ b/src/praisonai-code/praisonai_code/llm/credentials.py
@@ -67,6 +67,7 @@ def inject_credentials_into_env() -> bool:
             "groq": "GROQ_API_KEY",
             "cohere": "COHERE_API_KEY",
             "openrouter": "OPENROUTER_API_KEY",
+            "edenai": "EDENAI_API_KEY",
         }
 
         for provider in providers:

--- a/src/praisonai-code/praisonai_code/llm/env.py
+++ b/src/praisonai-code/praisonai_code/llm/env.py
@@ -30,6 +30,10 @@ _PROVIDER_MAP = {
     "cohere/":     ("COHERE_API_KEY",     "https://api.cohere.ai/v1"),
     "openrouter/": ("OPENROUTER_API_KEY", "https://openrouter.ai/api/v1"),
     "ollama/":     ("OLLAMA_API_KEY",     "http://localhost:11434/v1"),
+    # Without this row an "edenai/..." model fell through to the OpenAI
+    # default, so the resolved endpoint was https://api.openai.com/v1 holding an
+    # Eden AI key.
+    "edenai/":     ("EDENAI_API_KEY",     "https://api.edenai.run/v3"),
 }
 
 # Documented, single precedence list. Add new providers here only.
@@ -54,9 +58,11 @@ _KEY_VAR_TO_FALLBACK_PROVIDERS = {
     "GROQ_API_KEY": ("groq",),
     "COHERE_API_KEY": ("cohere",),
     "OPENROUTER_API_KEY": ("openrouter",),
+    "EDENAI_API_KEY": ("edenai",),
 }
 _ALL_FALLBACK_PROVIDERS = (
     "openai", "anthropic", "google", "gemini", "groq", "cohere", "openrouter",
+    "edenai",
 )
 
 # Ordered list of (credential env-var, provider-appropriate default model),

--- a/src/praisonai-code/praisonai_code/llm/env.py
+++ b/src/praisonai-code/praisonai_code/llm/env.py
@@ -39,6 +39,18 @@ _PROVIDER_MAP = {
 # Documented, single precedence list. Add new providers here only.
 _MODEL_VARS = ("MODEL_NAME", "OPENAI_MODEL_NAME")
 _BASE_URL_VARS = ("OPENAI_BASE_URL", "OPENAI_API_BASE", "OLLAMA_API_BASE")
+
+# Provider key env-var → its dedicated base-URL env-var. When a route resolves
+# to one of these providers, only that provider's own base-URL variable may
+# override the endpoint. This keeps the generic OpenAI/Ollama base-URL variables
+# in ``_BASE_URL_VARS`` from silently capturing a gateway route: an ``edenai/``
+# model must never send its ``EDENAI_API_KEY`` to an ``OPENAI_BASE_URL`` the user
+# set for an unrelated OpenAI call. Eden AI is a separate gateway, so its
+# endpoint is resolved from ``EDENAI_BASE_URL`` (then the Eden default) exactly
+# as the agent-runtime path in llm.py does.
+_KEY_VAR_TO_BASE_URL_VAR = {
+    "EDENAI_API_KEY": "EDENAI_BASE_URL",
+}
 # Single source of truth for the terminal fallback model, used only when no
 # explicit model, recency, env override, or provider credential is available.
 # CLI entry points must route through resolve_default_model() rather than
@@ -224,7 +236,18 @@ def resolve_llm_endpoint(
 
     key_var, provider_base = _provider_from_model(model)
 
-    env_base = _first_set(*_BASE_URL_VARS)
+    # A provider with a dedicated gateway (e.g. Eden AI) resolves its endpoint
+    # only from its own base-URL variable, never from the generic OpenAI/Ollama
+    # ones. Otherwise an unrelated OPENAI_BASE_URL override would capture the
+    # route and receive the provider's own credential. Precedence for such a
+    # route: explicit config base_url > <PROVIDER>_BASE_URL > provider default.
+    # For every other route the historical generic precedence is unchanged.
+    dedicated_base_var = _KEY_VAR_TO_BASE_URL_VAR.get(key_var)
+    if dedicated_base_var:
+        env_base = _first_set(dedicated_base_var)
+    else:
+        env_base = _first_set(*_BASE_URL_VARS)
+
     if env_base:
         base_url = env_base
     elif resolved_config and resolved_config.agent.base_url:

--- a/src/praisonai/README.md
+++ b/src/praisonai/README.md
@@ -367,6 +367,7 @@ Powered by 100+ LLMs (OpenAI, Anthropic, Gemini & local models).
 <img src="https://img.shields.io/badge/Cerebras-F05A28?style=flat" alt="Cerebras" />
 <img src="https://img.shields.io/badge/Cohere-39594D?style=flat" alt="Cohere" />
 <img src="https://img.shields.io/badge/OpenRouter-6467F2?style=flat" alt="OpenRouter" />
+<img src="https://img.shields.io/badge/Eden_AI-3A6FF8?style=flat" alt="Eden AI" />
 <img src="https://img.shields.io/badge/Perplexity-20808D?style=flat" alt="Perplexity" />
 <img src="https://img.shields.io/badge/Fireworks-FF6B35?style=flat" alt="Fireworks" />
 <img src="https://img.shields.io/badge/AWS_Bedrock-FF9900?style=flat&logo=amazonaws&logoColor=white" alt="AWS Bedrock" />
@@ -380,7 +381,7 @@ Powered by 100+ LLMs (OpenAI, Anthropic, Gemini & local models).
 </p>
 
 <details>
-<summary><strong>View all 24 providers with examples</strong></summary>
+<summary><strong>View all 25 providers with examples</strong></summary>
 
 | Provider | Example |
 |----------|:-------:|
@@ -397,6 +398,7 @@ Powered by 100+ LLMs (OpenAI, Anthropic, Gemini & local models).
 | Fireworks | [Example](examples/python/providers/fireworks/fireworks_example.py) |
 | Together AI | [Example](examples/python/providers/together/together_ai_example.py) |
 | OpenRouter | [Example](examples/python/providers/openrouter/openrouter_example.py) |
+| Eden AI | [Example](examples/python/providers/edenai/edenai_example.py) |
 | HuggingFace | [Example](examples/python/providers/huggingface/huggingface_example.py) |
 | Azure OpenAI | [Example](examples/python/providers/azure/azure_openai_example.py) |
 | AWS Bedrock | [Example](examples/python/providers/aws/aws_bedrock_example.py) |

--- a/src/praisonai/tests/unit/llm/test_edenai_catalogue.py
+++ b/src/praisonai/tests/unit/llm/test_edenai_catalogue.py
@@ -1,0 +1,160 @@
+"""Tests for Eden AI in the CLI provider catalogue and endpoint resolver.
+
+One ``PROVIDER_ENV_CATALOGUE`` row is what makes ``praisonai auth login edenai``,
+``praisonai setup --provider edenai`` and ``is_configured()`` work, and the
+``env.py`` row is what stops an ``edenai/...`` model from resolving to
+OpenAI's endpoint. Both are asserted here, along with the guarantee that adding
+Eden AI did not disturb the ordered credential precedence the catalogue relies
+on.
+
+No network access and no Eden AI credentials are required.
+"""
+
+import os
+
+import pytest
+
+try:
+    from praisonai_code.llm.catalogue import (
+        PROVIDER_ENV_CATALOGUE,
+        env_vars_for_provider,
+        key_url_for_provider,
+        provider_for_model,
+    )
+    from praisonai_code.llm.env import (
+        default_model_for_available_provider,
+        resolve_llm_endpoint,
+    )
+except ImportError as exc:  # pragma: no cover - matches the sibling env-resolver test
+    pytest.skip(f"Could not import praisonai_code.llm: {exc}", allow_module_level=True)
+
+
+# Every credential/endpoint variable the resolver consults.
+_PROVIDER_ENV = (
+    "EDENAI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
+    "GOOGLE_API_KEY", "GROQ_API_KEY", "COHERE_API_KEY", "OPENROUTER_API_KEY",
+    "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "XAI_API_KEY", "TOGETHER_API_KEY",
+    "TOGETHERAI_API_KEY", "PERPLEXITYAI_API_KEY", "FIREWORKS_API_KEY",
+    "FIREWORKS_AI_API_KEY", "OLLAMA_HOST", "OPENAI_BASE_URL", "OPENAI_API_BASE",
+    "OLLAMA_API_BASE", "MODEL_NAME", "OPENAI_MODEL_NAME",
+)
+
+EDEN_MODEL = "edenai/anthropic/claude-sonnet-4-5"
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in _PROVIDER_ENV:
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------- catalogue
+
+def test_edenai_is_catalogued_with_its_own_key_variable():
+    assert "edenai" in PROVIDER_ENV_CATALOGUE
+    assert env_vars_for_provider("edenai") == ("EDENAI_API_KEY",)
+    # A gateway prefix, so the vendor/model tail stays part of the model id.
+    assert PROVIDER_ENV_CATALOGUE["edenai"][2] == "edenai/"
+
+
+def test_edenai_has_an_onboarding_key_hint():
+    """`praisonai setup` prints this before prompting for a masked key."""
+    assert key_url_for_provider("edenai")
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "edenai/openai/gpt-4.1-mini",
+        "edenai/anthropic/claude-sonnet-4-5",
+        "edenai/google/gemini-2.5-flash",
+        # An unknown vendor still resolves: no model catalogue is consulted.
+        "edenai/acme/some-future-model",
+    ],
+)
+def test_eden_models_map_to_the_edenai_provider(model):
+    assert provider_for_model(model) == "edenai"
+
+
+def test_eden_prefix_does_not_shadow_other_providers():
+    assert provider_for_model("openrouter/openai/gpt-4o-mini") == "openrouter"
+    assert provider_for_model("anthropic/claude-3-5-sonnet") == "anthropic"
+    assert provider_for_model("gpt-4o-mini") == "openai"
+
+
+# -------------------------------------------------------- endpoint resolver
+
+def test_eden_model_resolves_to_the_edenai_endpoint(monkeypatch):
+    """The regression this row exists for.
+
+    Without a catalogue/`_PROVIDER_MAP` entry, an ``edenai/...`` model fell
+    through to the OpenAI default, so the resolver handed back
+    ``https://api.openai.com/v1`` paired with an Eden AI key.
+    """
+    monkeypatch.setenv("EDENAI_API_KEY", "eden-test-key")
+    monkeypatch.setenv("MODEL_NAME", EDEN_MODEL)
+
+    endpoint = resolve_llm_endpoint()
+
+    assert endpoint.model == EDEN_MODEL
+    assert endpoint.base_url == "https://api.edenai.run/v3"
+    assert endpoint.api_key == "eden-test-key"
+
+
+def test_eden_model_does_not_pick_up_an_openai_key(monkeypatch):
+    """An Eden AI model must not be credentialed from OPENAI_API_KEY."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real-openai-secret")
+    monkeypatch.setenv("MODEL_NAME", EDEN_MODEL)
+
+    endpoint = resolve_llm_endpoint()
+
+    assert endpoint.base_url == "https://api.edenai.run/v3"
+    assert endpoint.api_key != "sk-real-openai-secret"
+
+
+def test_only_an_eden_key_infers_an_eden_default_model(monkeypatch):
+    monkeypatch.setenv("EDENAI_API_KEY", "eden-test-key")
+    assert default_model_for_available_provider().startswith("edenai/")
+
+
+# ---------------------------------------------------- credential injection
+
+def test_stored_edenai_credential_is_exported_to_the_environment(monkeypatch, tmp_path):
+    """`praisonai auth login edenai` must reach the runtime.
+
+    The runtime resolves ``EDENAI_API_KEY`` from the environment and cannot
+    read the CLI credential store (that would invert the package tiering), so
+    ``inject_credentials_into_env`` is the seam between the two.
+    """
+    monkeypatch.setenv("PRAISONAI_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    from praisonai_code.cli.configuration.credentials import CredentialStore
+    from praisonai_code.llm.credentials import inject_credentials_into_env
+
+    store = CredentialStore()
+    store.store_credential("edenai", api_key="eden-stored-key")
+    assert "edenai" in [p.lower() for p in store.list_providers()]
+
+    assert inject_credentials_into_env() is True
+    assert os.environ["EDENAI_API_KEY"] == "eden-stored-key"
+
+
+# -------------------------------------------------------------- regression
+
+def test_existing_provider_precedence_is_unchanged(monkeypatch):
+    """Eden AI is appended, so it never outranks an already-configured provider."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("EDENAI_API_KEY", "eden-test-key")
+    assert default_model_for_available_provider() == "gpt-4o-mini"
+
+
+def test_direct_provider_endpoints_are_unchanged(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("MODEL_NAME", "gpt-4o-mini")
+    assert resolve_llm_endpoint().base_url == "https://api.openai.com/v1"
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test")
+    monkeypatch.setenv("MODEL_NAME", "openrouter/openai/gpt-4o-mini")
+    assert resolve_llm_endpoint().base_url == "https://openrouter.ai/api/v1"

--- a/src/praisonai/tests/unit/llm/test_env_resolver.py
+++ b/src/praisonai/tests/unit/llm/test_env_resolver.py
@@ -298,3 +298,58 @@ class TestProviderMapping:
             assert ep.model == "anthropic/claude-3-5-sonnet"
             # Should be None, not any other provider's key
             assert ep.api_key is None
+
+
+class TestEdenAIEndpointPrecedence:
+    """Eden AI is a separate gateway; its endpoint must resolve from
+    EDENAI_BASE_URL (then the Eden default) and never be captured by the
+    generic OPENAI_BASE_URL/OPENAI_API_BASE variables, which would otherwise
+    send the EDENAI_API_KEY to an unrelated OpenAI endpoint."""
+
+    def test_edenai_default_base_url(self):
+        env = {
+            "MODEL_NAME": "edenai/openai/gpt-4.1-mini",
+            "EDENAI_API_KEY": "eden-key",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            ep = resolve_llm_endpoint()
+            assert ep.model == "edenai/openai/gpt-4.1-mini"
+            assert ep.api_key == "eden-key"
+            assert ep.base_url == "https://api.edenai.run/v3"
+
+    def test_edenai_base_url_override(self):
+        env = {
+            "MODEL_NAME": "edenai/openai/gpt-4.1-mini",
+            "EDENAI_API_KEY": "eden-key",
+            "EDENAI_BASE_URL": "https://proxy.internal/eden",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            ep = resolve_llm_endpoint()
+            assert ep.base_url == "https://proxy.internal/eden"
+            assert ep.api_key == "eden-key"
+
+    def test_openai_base_url_does_not_capture_edenai_route(self):
+        env = {
+            "MODEL_NAME": "edenai/openai/gpt-4.1-mini",
+            "EDENAI_API_KEY": "eden-key",
+            "OPENAI_BASE_URL": "http://localhost:11434/v1",
+            "OPENAI_API_BASE": "http://localhost:11434/v1",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            ep = resolve_llm_endpoint()
+            # OpenAI overrides must NOT capture the Eden route.
+            assert ep.base_url == "https://api.edenai.run/v3"
+            assert ep.api_key == "eden-key"
+
+    def test_edenai_route_never_uses_openai_api_key(self):
+        env = {
+            "MODEL_NAME": "edenai/anthropic/claude-sonnet-4-5",
+            "OPENAI_API_KEY": "sk-openai-key",
+            # EDENAI_API_KEY intentionally missing
+        }
+        with patch.dict(os.environ, env, clear=True):
+            ep = resolve_llm_endpoint()
+            assert ep.model == "edenai/anthropic/claude-sonnet-4-5"
+            # Must fail closed: no Eden key means no key, never the OpenAI one.
+            assert ep.api_key is None
+            assert ep.base_url == "https://api.edenai.run/v3"

--- a/src/praisonai/tests/unit/llm/test_env_resolver.py
+++ b/src/praisonai/tests/unit/llm/test_env_resolver.py
@@ -277,6 +277,7 @@ class TestProviderMapping:
             "cohere/": "https://api.cohere.ai/v1",
             "openrouter/": "https://openrouter.ai/api/v1",
             "ollama/": "http://localhost:11434/v1",
+            "edenai/": "https://api.edenai.run/v3",
         }
         
         for prefix, (key_var, base_url) in _PROVIDER_MAP.items():


### PR DESCRIPTION
## Summary

Adds Eden AI as an explicit, OpenAI-compatible gateway provider for the Python Agent/LLM path.

Eden AI is an AI gateway that provides access to multiple AI providers and models through a single API, rather than being a single underlying model provider. This integration allows PraisonAI users to access models from different providers through Eden AI while keeping the existing provider integrations unchanged.

Users can route requests through Eden AI by specifying the `edenai/` prefix:

```python
Agent(llm="edenai/openai/gpt-4.1-mini")
Agent(llm="edenai/anthropic/claude-sonnet-4-5")
Agent(llm="edenai/google/gemini-2.5-flash")
```

The integration is fully opt-in. Existing OpenAI, Anthropic, Gemini, Ollama, and other provider behavior remains unchanged.

## Implementation

* Adds Eden AI provider detection using the `edenai/` prefix.
* Routes `edenai/<vendor>/<model>` through LiteLLM's existing OpenAI-compatible path.
* Forwards the `<vendor>/<model>` identifier without maintaining a hardcoded Eden AI model catalogue.
* Uses `EDENAI_API_KEY` exclusively for Eden AI routes.
* Fails closed when `EDENAI_API_KEY` is missing instead of falling back to `OPENAI_API_KEY`.
* Supports configurable `EDENAI_BASE_URL`, with the following precedence:

  1. Explicit `base_url=`
  2. `EDENAI_BASE_URL`
  3. `https://api.edenai.run/v3`
* Prevents Eden AI routes from being incorrectly detected as Anthropic, Gemini, or Ollama providers.
* Adds Eden AI to CLI/provider credential and environment configuration.
* Recognizes `EDENAI_API_KEY` as a configured provider credential, so Eden AI environments are correctly detected as configured without affecting credential resolution for other providers.
* Adds an Eden AI example and documentation updates.

## Compatibility

The integration does not change the existing OpenAI configuration or `OPENAI_API_KEY` requirement.

For example:

```python
Agent(llm="gpt-4.1-mini")
```

continues through the existing OpenAI path, while:

```python
Agent(llm="edenai/openai/gpt-4.1-mini")
```

explicitly selects Eden AI.

`EDENAI_API_KEY` and `EDENAI_BASE_URL` are only applied to routes using the `edenai/` prefix. Existing provider environment variables and endpoint resolution remain unchanged.

## Testing

Added focused unit and integration-style mocked transport coverage for:

* Eden AI provider detection
* Eden AI model rewriting
* Arbitrary vendor/model identifiers
* API key resolution and precedence
* Credential isolation from `OPENAI_API_KEY`
* Fail-closed behavior when `EDENAI_API_KEY` is missing
* `EDENAI_BASE_URL` resolution and precedence
* Provider detection and Ollama protection
* Streaming
* Tools and `tool_choice`
* Structured-output behavior
* Error handling
* CLI/provider catalogue and credential resolution
* Regression coverage for existing providers

### Test results

* `praisonai-agents` LLM tests: **213 passed, 1 skipped**
* Eden AI gateway tests: **40 passed**
* Broader affected-function/agent tests: **644 passed, 19 skipped**
* PraisonAI catalogue/env tests: **46 passed**
* `praisonai-code` credential/onboarding tests: **100 passed**
* `git diff --check`: passed
* Python compilation checks: passed

One unrelated pre-existing Windows `UnicodeDecodeError` remains in `test_auxiliary_model_default.py`. The failure reproduces on a clean tree and is unrelated to this change.

No new dependency was added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Eden AI as a supported LLM provider through its OpenAI-compatible gateway.
  - Added support for selecting Eden AI vendor and model combinations.
  - Added configurable Eden AI credentials and endpoint settings.
  - Added credential-store integration for Eden AI.
- **Documentation**
  - Updated provider listings, badges, and counts to include Eden AI.
  - Added a Python example demonstrating multiple Eden AI vendor models.
- **Tests**
  - Added coverage for routing, credentials, endpoints, streaming, tools, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->