### PR TITLE
fix(openapi): a body schema without top-level properties sent an empty body

### DIFF
--- a/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
+++ b/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
@@ -68,6 +68,26 @@ def _body_properties(schema: Any) -> Dict[str, Any]:
     return props
 
 
+def _body_is_closed(schema: Any) -> bool:
+    """True when a schema forbids properties it did not declare.
+
+    A body schema with no declared properties is normally treated as
+    free-form so its arguments still pass. But ``additionalProperties: false``
+    means the exact opposite -- the object is closed -- so an empty allow-set
+    there really does forbid everything, and forwarding model-supplied keys
+    would build a request a strict API rejects. ``allOf`` branches are
+    followed because a closed constraint in a composed branch closes the whole.
+    """
+    if not isinstance(schema, dict):
+        return False
+    if schema.get("additionalProperties") is False:
+        return True
+    for sub_schema in schema.get("allOf") or []:
+        if _body_is_closed(sub_schema):
+            return True
+    return False
+
+
 def _body_required(schema: Any) -> List[str]:
     """Required body field names, flattened the same way as the properties.
 
@@ -240,12 +260,16 @@ class OpenAPIOperation:
             # a free-form body -- legal, and common as bare {"type": "object"}
             # or additionalProperties: true -- and filtering against an empty
             # set would send an empty body for every such operation, which is
-            # the silent-drop this filter exists to prevent.
+            # the silent-drop this filter exists to prevent. The one exception
+            # is a *closed* empty schema (additionalProperties: false): that
+            # forbids every property, so an empty allow-set there is honoured
+            # rather than read as free-form.
             allowed = set(_body_properties(self.body_schema))
+            closed = _body_is_closed(self.body_schema)
             for key, value in kwargs.items():
                 if key in consumed or key in _FRAMEWORK_KWARGS:
                     continue
-                if allowed and key not in allowed:
+                if (allowed or closed) and key not in allowed:
                     logger.debug("dropping undeclared body key %r for %s",
                                  key, self.name)
                     continue

--- a/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
+++ b/src/praisonai-agents/praisonaiagents/tools/openapi_toolset.py
@@ -31,6 +31,58 @@ logger = logging.getLogger(__name__)
 _BODY_METHODS = {"post", "put", "patch", "delete"}
 _HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options"}
 
+# Keys the framework injects into a tool call rather than the model supplying
+# them. ``OpenAPIOperation.__call__`` takes ``**kwargs``, which is exactly the
+# signature durable execution inspects before adding an idempotency key, so on
+# the free-form-body path below these must not be swept into the payload.
+_FRAMEWORK_KWARGS = frozenset({
+    "idempotency_key", "_idempotency_key", "run_id", "_run_id",
+    "_tool_call_id", "_agent", "_task_id",
+})
+
+# Composition keywords whose subschemas contribute properties to the parent.
+_COMPOSITION_KEYS = ("allOf", "oneOf", "anyOf")
+
+
+def _body_properties(schema: Any) -> Dict[str, Any]:
+    """Collect a body schema's properties, flattening allOf/oneOf/anyOf.
+
+    Composition is how real specs express "this object, plus those fields", and
+    such a schema carries no top-level ``properties`` at all. Reading only the
+    top level therefore found nothing -- which both hid the body arguments from
+    the model and, on the send side, filtered every one of them out.
+
+    For ``oneOf``/``anyOf`` the union is taken: the caller is describing which
+    arguments a tool *may* accept, and a superset is the useful answer there.
+    """
+    if not isinstance(schema, dict):
+        return {}
+    props: Dict[str, Any] = {}
+    direct = schema.get("properties")
+    if isinstance(direct, dict):
+        props.update(direct)
+    for key in _COMPOSITION_KEYS:
+        for sub_schema in schema.get(key) or []:
+            for name, value in _body_properties(sub_schema).items():
+                props.setdefault(name, value)
+    return props
+
+
+def _body_required(schema: Any) -> List[str]:
+    """Required body field names, flattened the same way as the properties.
+
+    Only ``allOf`` contributes: a field required by just one branch of an
+    ``oneOf`` is not required of the request as a whole.
+    """
+    if not isinstance(schema, dict):
+        return []
+    out: List[str] = list(schema.get("required") or [])
+    for sub_schema in schema.get("allOf") or []:
+        for name in _body_required(sub_schema):
+            if name not in out:
+                out.append(name)
+    return out
+
 
 def _resolve_ref(schema: Any, root: Dict[str, Any], _seen: Optional[set] = None) -> Any:
     """Expand local ``$ref`` pointers against the document.
@@ -183,11 +235,19 @@ class OpenAPIOperation:
             # durable-execution ``idempotency_key`` added for ``**kwargs``
             # callables) into the request, breaking strict APIs and any schema
             # with ``additionalProperties: false``.
-            props = (self.body_schema.get("properties")
-                     if isinstance(self.body_schema, dict) else None) or {}
-            allowed = set(props)
+            # A schema that declares properties (directly or through
+            # allOf/oneOf/anyOf) is the filter. A schema that declares none is
+            # a free-form body -- legal, and common as bare {"type": "object"}
+            # or additionalProperties: true -- and filtering against an empty
+            # set would send an empty body for every such operation, which is
+            # the silent-drop this filter exists to prevent.
+            allowed = set(_body_properties(self.body_schema))
             for key, value in kwargs.items():
-                if key in consumed or key not in allowed:
+                if key in consumed or key in _FRAMEWORK_KWARGS:
+                    continue
+                if allowed and key not in allowed:
+                    logger.debug("dropping undeclared body key %r for %s",
+                                 key, self.name)
                     continue
                 body[key] = value
 
@@ -390,11 +450,11 @@ class OpenAPIToolset:
         if body_param:
             # Swagger 2: expose the body as one named object argument.
             properties.setdefault(body_param, body_schema or {"type": "object"})
-        elif isinstance(body_schema, dict) and body_schema.get("properties"):
-            for key, value in body_schema["properties"].items():
+        elif isinstance(body_schema, dict):
+            for key, value in _body_properties(body_schema).items():
                 properties.setdefault(key, value)
-            required.extend(r for r in (body_schema.get("required") or [])
-                            if r not in required)
+            required.extend(r for r in _body_required(body_schema)
+                            if r not in required and r in properties)
 
         schema: Dict[str, Any] = {"type": "object", "properties": properties}
         if required:

--- a/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
+++ b/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
@@ -381,6 +381,24 @@ class TestBodySchemasWithoutTopLevelProperties:
                            "properties": {"name": {"type": "string"}}})
         assert tool.build_request(name="Rex", hallucinated="x")["json"] == {"name": "Rex"}
 
+    def test_a_closed_empty_schema_forbids_all_keys(self):
+        """additionalProperties:false with no properties is closed, not free-form.
+
+        A free-form body forwards its arguments; a closed empty object permits
+        only an empty object, so model-supplied keys must be dropped rather
+        than sent to a strict API that would reject them.
+        """
+        tool = self._tool({"type": "object", "additionalProperties": False})
+        assert "json" not in tool.build_request(hallucinated="x")
+
+    def test_a_closed_allof_branch_closes_the_whole_body(self):
+        """A closed constraint composed via allOf closes the whole body."""
+        tool = self._tool({"allOf": [
+            {"type": "object", "properties": {"name": {"type": "string"}}},
+            {"type": "object", "additionalProperties": False},
+        ]})
+        assert tool.build_request(name="Rex", hallucinated="x")["json"] == {"name": "Rex"}
+
     def test_a_self_referential_composition_does_not_hang(self):
         toolset = OpenAPIToolset(spec_dict={
             "openapi": "3.0.0",

--- a/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
+++ b/src/praisonai-agents/tests/unit/tools/test_openapi_toolset.py
@@ -300,3 +300,95 @@ class TestCredentialedRequestsStayOnOrigin:
         request = op.build_request(id="42", q="x")
         assert request["url"] == "https://api.example.com/v1/pets/42"
         assert request["params"] == {"q": "x"}
+
+
+class TestBodySchemasWithoutTopLevelProperties:
+    """A body schema need not declare `properties` at the top level.
+
+    Filtering arguments against the declared properties stops framework
+    metadata and model hallucinations reaching a strict API. But reading only
+    ``schema["properties"]`` finds nothing for two legal and common shapes --
+    a free-form object, and a schema composed with allOf/oneOf/anyOf -- and an
+    empty allow-set filtered out *every* argument. Those operations advertised
+    no body arguments at all and then POSTed an empty body: accepted,
+    discarded, reported as success.
+
+    allOf is the standard way real specs say "this object, plus those fields",
+    so this covered a large share of real-world POST/PUT operations.
+    """
+
+    @staticmethod
+    def _tool(schema):
+        return OpenAPIToolset(spec_dict={
+            "openapi": "3.0.0",
+            "servers": [{"url": "https://api.example.com"}],
+            "paths": {"/pets": {"post": {
+                "operationId": "createPet",
+                "requestBody": {"content": {"application/json": {"schema": schema}}},
+            }}},
+        }).get_tools()[0]
+
+    @pytest.mark.parametrize("schema", [
+        {"type": "object"},
+        {"type": "object", "additionalProperties": True},
+    ], ids=["bare-object", "additionalProperties"])
+    def test_a_free_form_body_still_sends_its_arguments(self, schema):
+        assert self._tool(schema).build_request(name="Rex")["json"] == {"name": "Rex"}
+
+    def test_a_free_form_body_still_excludes_framework_keys(self):
+        """The filter's actual purpose must survive the free-form path."""
+        request = self._tool({"type": "object"}).build_request(
+            name="Rex", idempotency_key="abc-123")
+        assert request["json"] == {"name": "Rex"}
+
+    def test_an_allof_schemas_properties_are_advertised_and_sent(self):
+        tool = self._tool({"allOf": [
+            {"type": "object", "properties": {"name": {"type": "string"}},
+             "required": ["name"]},
+            {"type": "object", "properties": {"age": {"type": "integer"}}},
+        ]})
+        assert set(tool.input_schema["properties"]) >= {"name", "age"}
+        assert tool.input_schema["required"] == ["name"]
+        assert tool.build_request(name="Rex", age=3)["json"] == {"name": "Rex", "age": 3}
+
+    def test_a_oneof_schema_advertises_the_union(self):
+        tool = self._tool({"oneOf": [
+            {"type": "object", "properties": {"name": {"type": "string"}}},
+            {"type": "object", "properties": {"tag": {"type": "string"}}},
+        ]})
+        assert set(tool.input_schema["properties"]) >= {"name", "tag"}
+        assert tool.build_request(name="Rex")["json"] == {"name": "Rex"}
+
+    def test_a_oneof_branch_requirement_is_not_required_of_the_request(self):
+        """A field required by only one branch is not required overall."""
+        tool = self._tool({"oneOf": [
+            {"type": "object", "properties": {"name": {"type": "string"}},
+             "required": ["name"]},
+            {"type": "object", "properties": {"tag": {"type": "string"}}},
+        ]})
+        assert "name" not in tool.input_schema.get("required", [])
+
+    def test_a_nested_allof_is_flattened(self):
+        tool = self._tool({"allOf": [
+            {"allOf": [{"type": "object", "properties": {"deep": {"type": "string"}}}]},
+        ]})
+        assert "deep" in tool.input_schema["properties"]
+        assert tool.build_request(deep="v")["json"] == {"deep": "v"}
+
+    def test_a_declared_schema_still_filters_undeclared_keys(self):
+        """The regression guard: declaring properties must still restrict."""
+        tool = self._tool({"type": "object",
+                           "properties": {"name": {"type": "string"}}})
+        assert tool.build_request(name="Rex", hallucinated="x")["json"] == {"name": "Rex"}
+
+    def test_a_self_referential_composition_does_not_hang(self):
+        toolset = OpenAPIToolset(spec_dict={
+            "openapi": "3.0.0",
+            "servers": [{"url": "https://api.example.com"}],
+            "components": {"schemas": {"Node": {
+                "allOf": [{"type": "object",
+                           "properties": {"child": {"$ref": "#/components/schemas/Node"}}}]}}},
+            "paths": {"/n": {"post": {"operationId": "mk", "requestBody": {"content": {
+                "application/json": {"schema": {"$ref": "#/components/schemas/Node"}}}}}}},
+        })
+        assert "child" in toolset.get_tools()[0].input_schema["properties"]


### PR DESCRIPTION
Found while validating that the OpenAPI fixes from #4933 and #4955 actually hold on merged `main`. They do — but the argument filter added in #4933 has an edge case that covers a large share of real specs.

### What happens

The filter restricts the JSON body to the schema's declared properties, so framework metadata and model hallucinations do not reach a strict API. It reads `schema["properties"]` only. **Two legal and common shapes have nothing there**, so `allowed` comes out empty and every argument is filtered away — and the operation also advertises no body arguments, so the model is never told what to send:

| body schema | advertises | body sent |
|---|---|---|
| `{"type": "object"}` | `[]` | `None` |
| `{"type": "object", "additionalProperties": true}` | `[]` | `None` |
| `allOf: [...]` | `[]` | `None` |
| `oneOf: [...]` | `[]` | `None` |
| `{"properties": {...}}` | `["name"]` | `{"name": "Rex"}` ✅ |

A `POST` reaching the server with an empty body and reporting success — the same silent drop the filter was added to prevent.

**`allOf` is the standard way specs compose schemas** ("this object, plus those fields"), so this is not an exotic corner.

### The fix

`_body_properties` flattens `allOf`/`oneOf`/`anyOf` recursively and is used on **both** sides — to advertise the arguments, and as the allow-set when sending. An empty allow-set now means *free-form* rather than *allow nothing*, so arguments pass, while framework-injected keys (`idempotency_key` et al) stay excluded on that path too.

`_body_required` flattens only `allOf`: a field required by one branch of a `oneOf` is not required of the request as a whole.

Recursion terminates on self-referential schemas via the existing `$ref` cycle break, which is covered by a test.

### Verification

- Reproduced against merged `main`, not against a stale branch.
- 9 new tests, covering both shapes in both directions, plus the regression guard that a schema which *does* declare properties still filters undeclared keys.
- All three parts mutation-checked by reverting each individually: restoring the empty-allow-set drop fails 3, removing composition flattening fails 4, removing the framework-key exclusion fails 1.
- Suite: 678 passed, the same 5 pre-existing failures as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OpenAPI request bodies using composed schemas such as `allOf`, `oneOf`, and `anyOf`.
  * Free-form request bodies now correctly include supported input fields.
  * Closed request body schemas no longer forward undeclared input fields.
  * Framework-generated fields are excluded from request bodies.
  * Required fields are reported more accurately for composed schemas.

* **Tests**
  * Added coverage for free-form, nested, composed, self-referential, and closed request body schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->