### PR TITLE
test(chat): --continue tests read the developer's real session store

### DIFF
--- a/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
+++ b/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
@@ -139,13 +139,39 @@ def test_profiled_chat_still_receives_the_attachment(tmp_path, tui, monkeypatch)
 # --continue
 # --------------------------------------------------------------------------
 
-def test_chat_continue_resumes_the_last_session(tmp_path, tui, monkeypatch):
+@pytest.fixture
+def sessions(tmp_path, monkeypatch):
+    """Isolate BOTH session stores `--continue` consults.
+
+    It prefers the canonical project store (``find_last_session``) and falls
+    back to the flat unified store. Stubbing only the latter left these tests
+    reading the developer's real ``~/.praisonai`` -- they passed or failed
+    depending on whose machine ran them, and asserted against a live session id.
+
+    Returns a setter so a test states the last session id it wants, rather than
+    inheriting whatever happens to be on disk.
+    """
     from praisonai_code.cli.session import UnifiedSessionStore
     import praisonai_code.cli.session as session_pkg
+    import praisonai_code.cli.state.project_sessions as project_sessions
 
     store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
-    store.get_or_create("earlier-one")
     monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
+
+    def set_last(session_id):
+        monkeypatch.setattr(
+            project_sessions, "find_last_session",
+            lambda *a, **k: session_id, raising=False,
+        )
+        if session_id:
+            store.get_or_create(session_id)
+
+    set_last(None)          # default: no history anywhere
+    return set_last
+
+
+def test_chat_continue_resumes_the_last_session(tui, sessions):
+    sessions("earlier-one")
 
     _invoke(chat_module.chat_main, ["hi", "--continue"])
 
@@ -154,26 +180,33 @@ def test_chat_continue_resumes_the_last_session(tmp_path, tui, monkeypatch):
     )
 
 
-def test_an_explicit_session_beats_continue(tmp_path, tui, monkeypatch):
+def test_continue_falls_back_to_the_unified_store(tui, sessions, tmp_path,
+                                                  monkeypatch):
+    """The project store is preferred, but must not be the only one tried."""
     from praisonai_code.cli.session import UnifiedSessionStore
     import praisonai_code.cli.session as session_pkg
+    import praisonai_code.cli.state.project_sessions as project_sessions
 
-    store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
-    store.get_or_create("earlier-one")
+    store = UnifiedSessionStore(session_dir=tmp_path / "unified")
+    store.get_or_create("only-in-unified")
     monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
+    monkeypatch.setattr(project_sessions, "find_last_session",
+                        lambda *a, **k: None, raising=False)
+
+    _invoke(chat_module.chat_main, ["hi", "--continue"])
+
+    assert tui.last_config.session_id == "only-in-unified"
+
+
+def test_an_explicit_session_beats_continue(tui, sessions):
+    sessions("earlier-one")
 
     _invoke(chat_module.chat_main, ["hi", "--continue", "--session", "chosen"])
 
     assert tui.last_config.session_id == "chosen"
 
 
-def test_continue_with_no_history_says_so_and_carries_on(tmp_path, tui, monkeypatch):
-    from praisonai_code.cli.session import UnifiedSessionStore
-    import praisonai_code.cli.session as session_pkg
-
-    store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
-    monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
-
+def test_continue_with_no_history_says_so_and_carries_on(tui, sessions):
     result = _invoke(chat_module.chat_main, ["hi", "--continue"])
 
     assert result.exit_code == 0

--- a/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
+++ b/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
@@ -198,6 +198,30 @@ def test_continue_falls_back_to_the_unified_store(tui, sessions, tmp_path,
     assert tui.last_config.session_id == "only-in-unified"
 
 
+def test_project_store_wins_over_the_unified_fallback(tui, tmp_path, monkeypatch):
+    """Both stores hold a session -- the canonical project one must be chosen.
+
+    The fallback exists only for when the project index is empty; if the order
+    ever reversed, ``--continue`` would resume the wrong conversation. Distinct
+    ids in each store make that regression fail here instead of silently passing.
+    """
+    from praisonai_code.cli.session import UnifiedSessionStore
+    import praisonai_code.cli.session as session_pkg
+    import praisonai_code.cli.state.project_sessions as project_sessions
+
+    store = UnifiedSessionStore(session_dir=tmp_path / "unified")
+    store.get_or_create("from-unified")
+    monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
+    monkeypatch.setattr(project_sessions, "find_last_session",
+                        lambda *a, **k: "from-project", raising=False)
+
+    _invoke(chat_module.chat_main, ["hi", "--continue"])
+
+    assert tui.last_config.session_id == "from-project", (
+        "--continue resumed the unified fallback while the project store had one"
+    )
+
+
 def test_an_explicit_session_beats_continue(tui, sessions):
     sessions("earlier-one")
 


### PR DESCRIPTION
Found while validating that the merged sweep fixes still hold on `main`. They do — but two tests I added in #4943 fail there, and **the reason is worse than the failure**.

`--continue` was improved after #4943 merged: it now prefers the canonical project session store (`find_last_session`) and falls back to the flat unified store. My tests stubbed **only the unified one**.

So `find_last_session` ran unmocked:

```
find_last_session()  ->  'sess-123'        # a real session, from ~/.praisonai
ls ~/.praisonai/sessions | wc -l  ->  4510
```

The assertion was comparing against whatever conversation the developer last had. That makes the tests machine-dependent — they pass or fail on live user state and assert against data nobody wrote for them. A test that *reads* real user data is the same class of mistake as a probe that *writes* it.

### The fix

A `sessions` fixture isolates both stores and returns a setter, so each test states the last session id it wants rather than inheriting one. It also adds a case nothing covered: **the unified-store fallback**. The project store is preferred, but must not be the only one tried.

### Verification

- Both paths mutation-checked: disabling the `--continue` resolution fails 3 tests, removing the unified fallback fails 1.
- Confirmed the tests no longer touch `~/.praisonai` (4,510 real session files, unchanged).
- Suite: **970 passed, 11 pre-existing failures** unchanged from `main`.

### One note for anyone reproducing the suite

Three `TestRecipeJudgeGoal` failures and five `test_cli_surface_defects` hooks failures are **not** real: `praisonai-code`'s tests import `praisonaiagents` *and* the `praisonai` wrapper, and both resolve from site-packages unless their source trees are on `PYTHONPATH`. With a stale copy the count is 20; with all three packages from the same commit it is 11. Worth knowing before chasing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for the chat `--continue` option.
  - Verified fallback behavior when project session history is unavailable.
  - Confirmed project session history takes precedence when multiple histories exist.
  - Improved test isolation by preventing reliance on local user session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->