### PR TITLE
fix(identity): creating an orphan branch could reassign the project id

### DIFF
--- a/src/praisonai-code/praisonai_code/cli/utils/project.py
+++ b/src/praisonai-code/praisonai_code/cli/utils/project.py
@@ -119,23 +119,76 @@ def get_git_root_commit(path: Optional[str] = None) -> Optional[str]:
     cwd = git_root if git_root else (Path(path) if path else Path.cwd())
     # Enumerate root commits across *all* refs (not just those reachable from
     # HEAD) so switching between unmerged orphan branches doesn't change the
-    # selected root commit and silently orphan session history. Choosing the
-    # lexicographically smallest SHA keeps the identity deterministic regardless
-    # of ref ordering or the currently checked-out branch.
-    out = _git_output(['rev-list', '--max-parents=0', '--all'], cwd)
+    # selected root commit and silently orphan session history.
+    #
+    # The choice among them must be stable as the repo GAINS roots, which
+    # picking the lexicographically smallest SHA is not: creating an orphan
+    # branch adds a root, and roughly half the time that new SHA sorts below
+    # the existing one -- reassigning the project id and orphaning exactly the
+    # history this is meant to protect. Measured at 10/20 on fresh repos.
+    #
+    # The oldest root is stable instead: a root created later cannot become the
+    # oldest. Ties (same commit second, common in scripted setups) fall back to
+    # the smallest SHA so the result stays deterministic.
+    out = _git_output(
+        ['log', '--max-parents=0', '--all', '--format=%ct %H'], cwd)
     if not out:
         # No refs yet (e.g. detached/unborn); fall back to HEAD's roots if any.
-        out = _git_output(['rev-list', '--max-parents=0', 'HEAD'], cwd)
+        out = _git_output(
+            ['log', '--max-parents=0', 'HEAD', '--format=%ct %H'], cwd)
     if not out:
         return None
-    roots = [line.strip() for line in out.splitlines() if line.strip()]
+    roots = []
+    for line in out.splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) != 2:
+            continue
+        stamp, sha = parts
+        try:
+            roots.append((int(stamp), sha))
+        except ValueError:
+            # Unparseable timestamp: keep the commit, but sort it last so it
+            # only wins when nothing else is available.
+            roots.append((1 << 62, sha))
     if not roots:
         return None
-    return min(roots)
+    available = {sha for _, sha in roots}
+    chosen = min(roots)[1]
+
+    # Pin the choice on first resolve. Preferring the oldest root already stops
+    # a *later* orphan branch from winning, but two roots created in the same
+    # second tie and fall back to the SHA -- which flips about half the time.
+    # A pinned SHA cannot drift at all. Re-choose only if the pinned commit is
+    # no longer a root here (history rewritten, or a shallow/partial clone).
+    pinned_path = _git_meta_path(path, "praisonai-root-commit")
+    if pinned_path is not None:
+        try:
+            if pinned_path.exists():
+                pinned = pinned_path.read_text(encoding="utf-8").strip()
+                if pinned in available:
+                    return pinned
+            else:
+                # Exclusive create, like the cached id below: concurrent first
+                # runs must agree rather than each pinning its own choice.
+                try:
+                    with open(pinned_path, "x", encoding="utf-8") as fh:
+                        fh.write(chosen)
+                except FileExistsError:
+                    other = pinned_path.read_text(encoding="utf-8").strip()
+                    if other in available:
+                        return other
+                except OSError:
+                    pass
+        except OSError:
+            pass
+    return chosen
 
 
-def _cached_id_path(path: Optional[str] = None) -> Optional[Path]:
-    """Return the path to the persisted project-id file inside ``.git``."""
+def _git_meta_path(path: Optional[str], name: str) -> Optional[Path]:
+    """Return ``<git-common-dir>/<name>`` for the repo containing ``path``.
+
+    ``--git-common-dir`` so every worktree of a repo shares one file.
+    """
     git_root = get_git_root(path)
     if not git_root:
         return None
@@ -147,7 +200,12 @@ def _cached_id_path(path: Optional[str] = None) -> Optional[Path]:
     git_dir_path = Path(git_dir)
     if not git_dir_path.is_absolute():
         git_dir_path = (git_root / git_dir_path).resolve()
-    return git_dir_path / "praisonai-project"
+    return git_dir_path / name
+
+
+def _cached_id_path(path: Optional[str] = None) -> Optional[Path]:
+    """Return the path to the persisted project-id file inside ``.git``."""
+    return _git_meta_path(path, "praisonai-project")
 
 
 def get_or_create_cached_id(path: Optional[str] = None) -> Optional[str]:

--- a/src/praisonai-code/praisonai_code/cli/utils/project.py
+++ b/src/praisonai-code/praisonai_code/cli/utils/project.py
@@ -167,6 +167,12 @@ def get_git_root_commit(path: Optional[str] = None) -> Optional[str]:
                 pinned = pinned_path.read_text(encoding="utf-8").strip()
                 if pinned in available:
                     return pinned
+                # A pin naming a commit that is no longer a root here (rewritten
+                # history, shallow/partial clone) can't be trusted. Re-pin the
+                # freshly chosen root so subsequent resolves stay stable rather
+                # than recomputing -- and flipping on same-second ties -- every
+                # time. Atomic replace keeps concurrent healers agreeing.
+                _atomic_write(pinned_path, chosen)
             else:
                 # Exclusive create, like the cached id below: concurrent first
                 # runs must agree rather than each pinning its own choice.
@@ -177,11 +183,32 @@ def get_git_root_commit(path: Optional[str] = None) -> Optional[str]:
                     other = pinned_path.read_text(encoding="utf-8").strip()
                     if other in available:
                         return other
+                    _atomic_write(pinned_path, chosen)
                 except OSError:
                     pass
         except OSError:
             pass
     return chosen
+
+
+def _atomic_write(target: Path, content: str) -> None:
+    """Best-effort atomic overwrite of ``target`` with ``content``.
+
+    Writes to a unique temp file in the same directory and ``os.replace``s it
+    into place so a concurrent reader never sees a half-written pin and racing
+    healers converge on one file rather than corrupting each other. Failures are
+    swallowed: the caller already has the value it will return.
+    """
+    tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp, target)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
 
 
 def _git_meta_path(path: Optional[str], name: str) -> Optional[Path]:

--- a/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
+++ b/src/praisonai-code/tests/unit/cli/test_chat_code_option_wiring.py
@@ -139,13 +139,39 @@ def test_profiled_chat_still_receives_the_attachment(tmp_path, tui, monkeypatch)
 # --continue
 # --------------------------------------------------------------------------
 
-def test_chat_continue_resumes_the_last_session(tmp_path, tui, monkeypatch):
+@pytest.fixture
+def sessions(tmp_path, monkeypatch):
+    """Isolate BOTH session stores `--continue` consults.
+
+    It prefers the canonical project store (``find_last_session``) and falls
+    back to the flat unified store. Stubbing only the latter left these tests
+    reading the developer's real ``~/.praisonai`` -- they passed or failed
+    depending on whose machine ran them, and asserted against a live session id.
+
+    Returns a setter so a test states the last session id it wants, rather than
+    inheriting whatever happens to be on disk.
+    """
     from praisonai_code.cli.session import UnifiedSessionStore
     import praisonai_code.cli.session as session_pkg
+    import praisonai_code.cli.state.project_sessions as project_sessions
 
     store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
-    store.get_or_create("earlier-one")
     monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
+
+    def set_last(session_id):
+        monkeypatch.setattr(
+            project_sessions, "find_last_session",
+            lambda *a, **k: session_id, raising=False,
+        )
+        if session_id:
+            store.get_or_create(session_id)
+
+    set_last(None)          # default: no history anywhere
+    return set_last
+
+
+def test_chat_continue_resumes_the_last_session(tui, sessions):
+    sessions("earlier-one")
 
     _invoke(chat_module.chat_main, ["hi", "--continue"])
 
@@ -154,26 +180,33 @@ def test_chat_continue_resumes_the_last_session(tmp_path, tui, monkeypatch):
     )
 
 
-def test_an_explicit_session_beats_continue(tmp_path, tui, monkeypatch):
+def test_continue_falls_back_to_the_unified_store(tui, sessions, tmp_path,
+                                                  monkeypatch):
+    """The project store is preferred, but must not be the only one tried."""
     from praisonai_code.cli.session import UnifiedSessionStore
     import praisonai_code.cli.session as session_pkg
+    import praisonai_code.cli.state.project_sessions as project_sessions
 
-    store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
-    store.get_or_create("earlier-one")
+    store = UnifiedSessionStore(session_dir=tmp_path / "unified")
+    store.get_or_create("only-in-unified")
     monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
+    monkeypatch.setattr(project_sessions, "find_last_session",
+                        lambda *a, **k: None, raising=False)
+
+    _invoke(chat_module.chat_main, ["hi", "--continue"])
+
+    assert tui.last_config.session_id == "only-in-unified"
+
+
+def test_an_explicit_session_beats_continue(tui, sessions):
+    sessions("earlier-one")
 
     _invoke(chat_module.chat_main, ["hi", "--continue", "--session", "chosen"])
 
     assert tui.last_config.session_id == "chosen"
 
 
-def test_continue_with_no_history_says_so_and_carries_on(tmp_path, tui, monkeypatch):
-    from praisonai_code.cli.session import UnifiedSessionStore
-    import praisonai_code.cli.session as session_pkg
-
-    store = UnifiedSessionStore(session_dir=tmp_path / "sessions")
-    monkeypatch.setattr(session_pkg, "get_session_store", lambda: store)
-
+def test_continue_with_no_history_says_so_and_carries_on(tui, sessions):
     result = _invoke(chat_module.chat_main, ["hi", "--continue"])
 
     assert result.exit_code == 0

--- a/src/praisonai-code/tests/unit/test_project_identity.py
+++ b/src/praisonai-code/tests/unit/test_project_identity.py
@@ -295,3 +295,30 @@ def test_a_pin_naming_a_vanished_commit_is_not_trusted(tmp_path):
     (pin / "praisonai-root-commit").write_text("0" * 40)
 
     assert get_git_root_commit(str(repo)) == real_root
+
+
+@requires_git
+def test_a_vanished_pin_is_repaired_not_merely_ignored(tmp_path):
+    """A stale pin must be *rewritten*, not just distrusted.
+
+    If a dead pin were only ignored, every later resolve would recompute the
+    root -- reintroducing the same-second tie-break flip the pin exists to
+    prevent. So the first resolve must heal the pin to the freshly chosen root,
+    restoring persistent stability rather than leaving recomputation forever.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "f.txt").write_text("x")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    real_root = get_git_root_commit(str(repo))
+
+    pin_file = project_mod._git_meta_path(str(repo), "praisonai-root-commit")
+    assert pin_file is not None
+    pin_file.write_text("0" * 40)
+
+    # First resolve after the pin went stale re-chooses...
+    assert get_git_root_commit(str(repo)) == real_root
+    # ...and repairs the pin on disk so it is trusted from now on.
+    assert pin_file.read_text(encoding="utf-8").strip() == real_root

--- a/src/praisonai-code/tests/unit/test_project_identity.py
+++ b/src/praisonai-code/tests/unit/test_project_identity.py
@@ -14,11 +14,22 @@ import pytest
 
 from praisonai_code.cli.utils import project as project_mod
 from praisonai_code.cli.utils.project import (
+    get_git_root_commit,
     get_legacy_project_id,
     get_project_id,
     normalize_git_remote,
     resolve_project_identity,
 )
+
+
+def _git_out(cwd, *args):
+    """Like ``_git`` but returns stdout (``_git`` discards it)."""
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True,
+        env={**os.environ,
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"},
+    ).stdout
 
 
 def _git(cwd, *args):
@@ -205,3 +216,82 @@ def test_get_project_id_returns_only_hash(tmp_path, monkeypatch):
         project_mod, "resolve_project_identity", lambda path=None: ("abcd1234", "path")
     )
     assert get_project_id(str(tmp_path)) == "abcd1234"
+
+
+@requires_git
+def test_root_commit_choice_is_pinned_not_recomputed(tmp_path):
+    """Identity must survive the repo *gaining* a root commit.
+
+    The selection used to be ``min()`` over every root SHA. That is stable for
+    a fixed set of roots but not as the set grows: creating an orphan branch
+    adds a root, and about half the time the new SHA sorts below the original
+    (measured 10/20 on fresh repos), silently reassigning the project id and
+    orphaning the very session history the selection exists to protect. This
+    test failed roughly one run in two.
+
+    Preferring the oldest root fixes the common case but not two roots created
+    in the same second -- routine in scripted setup -- so the resolved SHA is
+    pinned in the git common dir on first use.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "f.txt").write_text("x")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+
+    original_root = _git_out(repo, "rev-list", "--max-parents=0", "--all").strip()
+    first = get_git_root_commit(str(repo))
+    assert first == original_root
+
+    # Ten orphan branches: with the old min(), at least one new root sorting
+    # below the original is near-certain.
+    for i in range(10):
+        _git(repo, "checkout", "--orphan", f"orphan{i}")
+        (repo / f"g{i}.txt").write_text(str(i))
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", f"orphan{i}")
+        assert get_git_root_commit(str(repo)) == original_root, (
+            f"identity changed after adding orphan branch {i}"
+        )
+
+
+@requires_git
+def test_the_pin_is_shared_by_every_worktree(tmp_path):
+    """A linked worktree must resolve the same identity as its main checkout.
+
+    The pin lives in ``--git-common-dir`` for this reason; a per-worktree
+    ``.git`` file would give each worktree its own project id.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "f.txt").write_text("x")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    main_id, _ = resolve_project_identity(str(repo))
+
+    linked = tmp_path / "linked"
+    _git(repo, "worktree", "add", "-b", "wt", str(linked))
+    linked_id, _ = resolve_project_identity(str(linked))
+
+    assert linked_id == main_id
+
+
+@requires_git
+def test_a_pin_naming_a_vanished_commit_is_not_trusted(tmp_path):
+    """A rewritten history must re-choose rather than return a dead SHA."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "f.txt").write_text("x")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    real_root = get_git_root_commit(str(repo))
+
+    pin = Path(_git_out(repo, "rev-parse", "--git-common-dir").strip())
+    if not pin.is_absolute():
+        pin = (repo / pin).resolve()
+    (pin / "praisonai-root-commit").write_text("0" * 40)
+
+    assert get_git_root_commit(str(repo)) == real_root


### PR DESCRIPTION
Found while validating that this sweep's fixes hold on `main`: a test failed that had **not** failed before the work started. It turned out not to be a regression — it is flaky on every commit I tried, at roughly one run in two — and **the flakiness is a real defect, not a bad test**.

### What happens

Project identity is derived from the repository's root commit, enumerated across all refs so that switching between unmerged orphan branches does not change it. The code's own comment says exactly that. The selection was `min()` over the root SHAs — deterministic for a *fixed* set of roots, but not as the set **grows**. Creating an orphan branch adds a root, and about half the time the new SHA sorts below the existing one:

```
FLIP: 10 / 20   SAME: 10 / 20     (fresh repos: init, then --orphan)
```

When it flips, the project id changes and **every session filed under the old id is orphaned** — the precise outcome the all-refs enumeration exists to prevent.

### Why two changes were needed

Preferring the **oldest** root fixes the common case: a root created later cannot become the oldest. It does **not** fix two roots created in the same second — routine in scripted setup and in tests. They tie, fall back to the SHA, and flip again. Measured **2 failures in 12 runs** with oldest-root alone.

So the resolved SHA is also **pinned** in the git common dir on first use, using the same exclusive-create pattern the cached id already uses so concurrent first runs agree rather than each pinning its own choice. `--git-common-dir` means every worktree of a repo shares one pin. A pin naming a commit that is no longer a root here (rewritten history, shallow clone) is not trusted, and the choice is remade.

`_cached_id_path` now delegates to the same helper rather than repeating the git-dir resolution.

### Verification

- **20 consecutive runs** of the previously-flaky test now pass (was ~50%).
- Three new tests: ten successive orphan branches, worktree sharing, and a pin naming a vanished commit.
- All three parts mutation-checked — restoring `min()` fails 1; removing the pin fails **5 of 6 runs** (the one pass is the coin flip); trusting a stale pin fails 1.
- Suite: **974 passed, 10 failures — the identical set** to `592e1c3667`, the commit before any of this sweep's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Project identity now remains consistent across linked worktrees and is preserved even when repository history changes.
  - Stale or invalid project metadata is automatically corrected, improving reliability when commits or branches are removed.
  - Session continuation now correctly falls back when project history is unavailable, while explicitly selected sessions take precedence.
  - Chat and code options for file attachments and runtime controls are now reliably applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->