### PR TITLE
fix: circuit breaker counted every outcome twice; trust lookup failed open

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
@@ -2047,7 +2047,18 @@ Write the complete compiled report:"""
                 # NOT counted as tool failures (same exclusions the sync wrapper
                 # applies in _execute_tool_with_circuit_breaker_impl), so a gated
                 # tool never trips the breaker.
-                breaker_record = getattr(self, '_circuit_breaker_record', None)
+                #
+                # Only when the breaker wrapper did not already run. When
+                # ``breaker`` is set, ``breaker.acall`` above has already called
+                # _on_success/_on_failure for this invocation, and recording
+                # again counted every outcome twice -- halving the configured
+                # failure_threshold (a breaker set to 5 opened after 3) and, on
+                # the success side, closing a HALF_OPEN circuit in half the
+                # required successes.
+                breaker_record = (
+                    getattr(self, '_circuit_breaker_record', None)
+                    if breaker is None else None
+                )
                 if breaker_record is not None:
                     is_breaker_failure = (
                         isinstance(result, dict)
@@ -2099,13 +2110,18 @@ Write the complete compiled report:"""
                 logging.error(f"Error executing {function_name}: {str(e)}", exc_info=True)
                 # Circuit breaker (failure on raised exception) — a raised tool
                 # exception is a failure just like an error-dict result, and the
-                # sync path's ``breaker.call`` counts it. Record it here so the
-                # breaker still opens after repeated raises; otherwise the
-                # post-invoke record block above is skipped and raised failures
-                # never trip the breaker. Approval/permission/policy/guardrail
-                # denials surface as error dicts (handled above), not raises, so
-                # this path only ever sees genuine tool failures.
-                breaker_record = getattr(self, '_circuit_breaker_record', None)
+                # sync path's ``breaker.call`` counts it. Approval/permission/
+                # policy/guardrail denials surface as error dicts (handled
+                # above), not raises, so this path only ever sees genuine tool
+                # failures.
+                #
+                # Again only when the breaker wrapper did not run: ``acall``
+                # records the failure and re-raises, so the exception arriving
+                # here has already been counted once.
+                breaker_record = (
+                    getattr(self, '_circuit_breaker_record', None)
+                    if breaker is None else None
+                )
                 if breaker_record is not None:
                     breaker_record(function_name, False)
                 # Record the failed invocation so repeated identical failures

--- a/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
@@ -2029,6 +2029,24 @@ Write the complete compiled report:"""
                         # Fall through (not return) so the loop guard records this
                         # timeout as a failure — repeated timeouts must accumulate
                         # toward the BLOCK/HALT thresholds like any other failure.
+                        #
+                        # A timeout cancels the awaited ``_invoke_guarded``; the
+                        # cancellation surfaces inside ``breaker.acall`` as
+                        # ``asyncio.CancelledError`` (a BaseException, not
+                        # Exception), so ``acall`` never ran ``_on_failure`` for
+                        # it. The fall-through breaker-record block below only
+                        # runs when ``breaker is None``, so without recording it
+                        # here a repeatedly timing-out tool would never open the
+                        # circuit. Record the one failure directly on the breaker
+                        # (the block below stays disabled, so it is counted once).
+                        if breaker is not None:
+                            try:
+                                breaker._on_failure()
+                            except Exception:
+                                logging.debug(
+                                    "Failed to record tool timeout on circuit breaker",
+                                    exc_info=True,
+                                )
                         result = {
                             "error": f"Tool timed out after {tool_timeout}s",
                             "timeout": True,

--- a/src/praisonai-agents/praisonaiagents/tools/trust.py
+++ b/src/praisonai-agents/praisonaiagents/tools/trust.py
@@ -14,8 +14,11 @@ Usage:
     # Returns wrapped content for external tools, unchanged for trusted tools
 """
 
+import logging
 from enum import Enum
 from typing import Union
+
+logger = logging.getLogger(__name__)
 
 
 class ToolTrustLevel(str, Enum):
@@ -24,8 +27,14 @@ class ToolTrustLevel(str, Enum):
     EXTERNAL = "external"  # Results originate outside the agent's control
 
 
-# Tools that fetch external content and need security wrapping
-EXTERNAL_TOOL_NAMES = frozenset({
+# Tools that fetch external content and need security wrapping.
+#
+# A mutable set, mutated in place by ``add_external_tool``. It was a frozenset
+# that the adder *rebound*, so any module holding a reference imported earlier
+# ("from .trust import EXTERNAL_TOOL_NAMES") kept the pre-registration copy and
+# went on treating the tool as trusted. Nothing in-tree held such a reference
+# yet, but this is a security boundary and that is a bad way to find out.
+EXTERNAL_TOOL_NAMES = set({
     # Web search tools
     "internet_search", "duckduckgo", "tavily_search", "exa_search",
     "searxng_search", "web_search",
@@ -63,6 +72,15 @@ INLINE_REQUEST_NOTICE = (
 
 # Minimum content length to trigger wrapping (avoid overhead for short results)
 MIN_CONTENT_LENGTH_FOR_WRAPPING = 32
+
+# Bound at module level rather than imported inside the lookup, so callers can
+# see (and tests can patch) the dependency, and so "no registry available" is
+# distinguishable from "the registry raised while answering" -- which must not
+# be treated the same way on a trust decision.
+try:  # pragma: no cover - exercised via the fallback below
+    from .registry import get_registry
+except Exception:  # pragma: no cover
+    get_registry = None  # type: ignore[assignment]
 
 
 def wrap_if_external(tool_name: str, result: Union[str, dict, list, None]) -> Union[str, dict, list, None]:
@@ -166,14 +184,31 @@ def _is_tool_external(tool_name: str) -> bool:
         return True
     
     # Then check registry metadata (for MCP tools and others)
-    try:
-        from .registry import get_registry
-        registry = get_registry()
-        trust_level = registry.get_trust_level(tool_name)
-        return trust_level == ToolTrustLevel.EXTERNAL
-    except Exception:
-        # Registry not available or raised, fall back to hardcoded list only
+    if get_registry is None:
+        # No registry in this build: the hardcoded list is the whole answer.
         return False
+    try:
+        registry = get_registry()
+    except Exception:
+        logger.debug("tool registry unavailable; using the hardcoded list only",
+                     exc_info=True)
+        return False
+
+    try:
+        trust_level = registry.get_trust_level(tool_name)
+    except Exception:
+        # The registry exists and failed to answer. Fail CLOSED: the caller
+        # (agent/tool_execution.py) uses this to decide whether to fence tool
+        # output against prompt injection, so guessing "trusted" here lets an
+        # untrusted result reach the model unfenced. Over-fencing a trusted
+        # tool costs a wrapper; under-fencing an external one is the bug the
+        # fence exists to prevent.
+        logger.warning(
+            "trust lookup for %r failed; treating it as external", tool_name,
+            exc_info=True,
+        )
+        return True
+    return trust_level == ToolTrustLevel.EXTERNAL
 
 
 def is_external_tool(tool_name: str) -> bool:
@@ -193,14 +228,14 @@ def add_external_tool(tool_name: str) -> None:
     """
     Add a tool name to the external tools set.
     
-    Note: This modifies a frozenset by creating a new one.
-    For dynamic registration, consider using ToolRegistry metadata instead.
+    Mutates the set in place, so a module that imported ``EXTERNAL_TOOL_NAMES``
+    before the call sees the addition too. For dynamic registration, consider
+    using ToolRegistry metadata instead.
     
     Args:
         tool_name: Name of the tool to mark as external
     """
-    global EXTERNAL_TOOL_NAMES
-    EXTERNAL_TOOL_NAMES = EXTERNAL_TOOL_NAMES | frozenset({tool_name})
+    EXTERNAL_TOOL_NAMES.add(tool_name)
 
 
 def get_system_prompt_addition() -> str:

--- a/src/praisonai-agents/tests/unit/test_circuit_breaker.py
+++ b/src/praisonai-agents/tests/unit/test_circuit_breaker.py
@@ -154,7 +154,36 @@ class TestCircuitBreaker:
         # Next call should be rejected
         with pytest.raises(CircuitBreakerException):
             await breaker.acall(failing_async_func)
-    
+
+    @pytest.mark.asyncio
+    async def test_acall_cancelled_by_wait_for_does_not_record(self):
+        """A wait_for timeout cancels acall without counting a failure.
+
+        ``acall`` catches ``except Exception``; the cancellation delivered by
+        ``asyncio.wait_for`` is ``asyncio.CancelledError`` (a BaseException),
+        so ``_on_failure`` never runs. This is *why* the async tool path in
+        ``execution_mixin`` must record the timeout on the breaker itself --
+        otherwise a repeatedly timing-out tool would never open the circuit.
+        This test pins the underlying behaviour so that reasoning stays true.
+        """
+        breaker = CircuitBreaker(
+            "timeout_service", CircuitBreakerConfig(failure_threshold=1)
+        )
+
+        async def slow():
+            await asyncio.sleep(10)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(breaker.acall(slow), timeout=0.05)
+
+        # The breaker did NOT count the cancellation as a failure.
+        assert breaker.stats.failure_count == 0
+        assert breaker.state == CircuitState.CLOSED
+
+        # Recording it explicitly (as the mixin now does) opens the circuit.
+        breaker._on_failure()
+        assert breaker.state == CircuitState.OPEN
+
     def test_health_check_functionality(self):
         """Test health check integration."""
         health_check_call_count = 0

--- a/src/praisonai-agents/tests/unit/tools/test_tool_resolution_repair.py
+++ b/src/praisonai-agents/tests/unit/tools/test_tool_resolution_repair.py
@@ -101,18 +101,55 @@ def test_runtime_valueerror_omits_parameter_hint():
 
 
 def test_unknown_tool_message_reaches_model_via_public_path():
+    """An unresolvable tool name must reach the model *without* ending the run.
+
+    This asserted ``pytest.raises(ToolExecutionError)`` until #4446 made a tool
+    error dict flow back as a normal tool result rather than a fatal error, so
+    the model can see it and retry. The unknown-tool dict is covered by that,
+    and rightly: ToolExecutionError is terminal and non-retryable
+    (agent/execution_mixin.py lets it propagate "to stop the run instead of
+    retrying or swallowing it into an error dict"), so raising here would kill
+    the run at the exact moment the runtime has just handed the model the list
+    of names it could have used -- defeating the self-repair #3309 added.
+
+    So the contract is the message and the inventory, not the exception.
+    """
     def web_search(query: str) -> str:
         """Search the web."""
         return query
 
+    agent = _make_agent([web_search])
+
+    result = agent.execute_tool("totally_made_up_tool", {})
+
+    assert isinstance(result, dict), (
+        "an unknown tool must return an error result the model can act on, "
+        "not raise a terminal ToolExecutionError"
+    )
+    assert "not found" in result["error"]
+    assert "web_search" in result["error"]
+    # The inventory is the actionable half: it is what lets the model retry
+    # with a real name instead of guessing again.
+    assert result["available_tools"] == ["web_search"]
+
+
+def test_an_unknown_tool_does_not_end_the_run():
+    """Pin the #4446 contract directly, so a 'fix' cannot quietly undo it."""
     from praisonaiagents.errors import ToolExecutionError
+
+    def web_search(query: str) -> str:
+        """Search the web."""
+        return query
 
     agent = _make_agent([web_search])
 
-    with pytest.raises(ToolExecutionError) as exc:
+    try:
         agent.execute_tool("totally_made_up_tool", {})
-    assert "not found" in str(exc.value)
-    assert "web_search" in str(exc.value)
+    except ToolExecutionError as exc:  # pragma: no cover - the regression
+        pytest.fail(
+            "unknown tool raised a terminal ToolExecutionError, ending the run "
+            f"instead of letting the model retry: {exc}"
+        )
 
 
 def test_bind_failure_parameter_hint_reaches_model_via_public_path():

--- a/src/praisonai-agents/tests/unit/tools/test_trust_system.py
+++ b/src/praisonai-agents/tests/unit/tools/test_trust_system.py
@@ -13,6 +13,7 @@ import pytest
 import json
 from unittest.mock import patch, MagicMock
 
+import praisonaiagents.tools.trust as trust_module
 from praisonaiagents.tools.trust import (
     wrap_if_external, 
     wrap_request_payload,
@@ -295,3 +296,61 @@ class TestSecurityScenarios:
         content_lines = wrapped.split('\n')[1:-1]
         content = '\n'.join(content_lines)
         assert EXTERNAL_CONTENT_FENCE_CLOSE not in content
+
+class TestTrustLookupFailsClosed:
+    """A trust decision that cannot be made must not default to 'trusted'.
+
+    ``agent/tool_execution.py`` calls ``is_external_tool`` to decide whether to
+    fence a tool result against prompt injection. The registry lookup used to
+    sit under a blanket ``except Exception: return False``, so a registry that
+    existed and *failed to answer* was indistinguishable from one that said
+    "trusted" -- and an external tool's output reached the model unfenced.
+
+    Over-fencing a trusted tool costs a wrapper. Under-fencing an external one
+    is the thing the wrapper exists to prevent.
+    """
+
+    def test_a_registry_that_raises_is_treated_as_external(self, monkeypatch):
+        class Boom:
+            def get_trust_level(self, name):
+                raise RuntimeError("registry backend down")
+
+        monkeypatch.setattr(trust_module, "get_registry", lambda: Boom())
+        assert is_external_tool("some_mcp_tool") is True
+
+    def test_a_registry_that_cannot_be_constructed_falls_back_to_the_list(
+        self, monkeypatch
+    ):
+        """Distinct from the above: no registry at all is not a failed lookup.
+
+        With no registry the hardcoded list is the whole answer, so an unknown
+        tool is trusted -- otherwise every ordinary function tool would be
+        fenced.
+        """
+        def _unavailable():
+            raise RuntimeError("no registry in this build")
+
+        monkeypatch.setattr(trust_module, "get_registry", _unavailable)
+        assert is_external_tool("some_plain_tool") is False
+        # The hardcoded list still applies.
+        assert is_external_tool("internet_search") is True
+
+    def test_no_registry_binding_at_all_still_works(self, monkeypatch):
+        monkeypatch.setattr(trust_module, "get_registry", None)
+        assert is_external_tool("some_plain_tool") is False
+        assert is_external_tool("internet_search") is True
+
+
+class TestExternalRegistrationIsVisibleToEarlierImporters:
+    """``add_external_tool`` must mutate the set, not rebind the module global.
+
+    It replaced the frozenset with a new one, so a module that had already done
+    ``from .trust import EXTERNAL_TOOL_NAMES`` kept the pre-registration copy
+    and went on treating the tool as trusted.
+    """
+
+    def test_a_reference_taken_before_the_call_sees_the_addition(self):
+        held = trust_module.EXTERNAL_TOOL_NAMES  # as an importer would hold it
+        add_external_tool("late_registered_scraper")
+        assert "late_registered_scraper" in held
+        assert is_external_tool("late_registered_scraper")

--- a/src/praisonai-agents/tests/unit/tools/test_trust_system.py
+++ b/src/praisonai-agents/tests/unit/tools/test_trust_system.py
@@ -349,6 +349,20 @@ class TestExternalRegistrationIsVisibleToEarlierImporters:
     and went on treating the tool as trusted.
     """
 
+    @pytest.fixture(autouse=True)
+    def _restore_external_tool_names(self):
+        # The set is now mutated in place, so a registration here would leak
+        # into every later test and make ``is_external_tool`` order-dependent
+        # (AGENTS.md §4.6: deterministic tests). Snapshot and restore its
+        # contents in place -- restoring the *same object*, not a rebind, so an
+        # importer's held reference stays valid.
+        snapshot = set(trust_module.EXTERNAL_TOOL_NAMES)
+        try:
+            yield
+        finally:
+            trust_module.EXTERNAL_TOOL_NAMES.clear()
+            trust_module.EXTERNAL_TOOL_NAMES.update(snapshot)
+
     def test_a_reference_taken_before_the_call_sees_the_addition(self):
         held = trust_module.EXTERNAL_TOOL_NAMES  # as an importer would hold it
         add_external_tool("late_registered_scraper")

--- a/src/praisonai-code/tests/unit/test_project_identity.py
+++ b/src/praisonai-code/tests/unit/test_project_identity.py
@@ -305,6 +305,7 @@ def test_a_vanished_pin_is_repaired_not_merely_ignored(tmp_path):
     root -- reintroducing the same-second tie-break flip the pin exists to
     prevent. So the first resolve must heal the pin to the freshly chosen root,
     restoring persistent stability rather than leaving recomputation forever.
+    Once re-chosen, adding a later root must not change the pinned identity.
     """
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -322,3 +323,10 @@ def test_a_vanished_pin_is_repaired_not_merely_ignored(tmp_path):
     assert get_git_root_commit(str(repo)) == real_root
     # ...and repairs the pin on disk so it is trusted from now on.
     assert pin_file.read_text(encoding="utf-8").strip() == real_root
+
+    # Adding a later root must not change the (now-valid) pinned identity.
+    _git(repo, "checkout", "--orphan", "later")
+    (repo / "g.txt").write_text("y")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "later")
+    assert get_git_root_commit(str(repo)) == real_root


### PR DESCRIPTION
Four tests had been red on `main`. Checking each rather than assuming they were stale: **three were real defects**, and the fourth encoded a contract a later PR deliberately replaced.

---

### 1. The async circuit breaker halved its own threshold

`breaker.acall` records success/failure for the invocation — and then a second block recorded the same outcome *again* through `_circuit_breaker_record`. That block predates the `acall` wrapper (#4281); its comment still describes it as covering a path `acall` now covers.

```
call 1: recorded=2   call 2: recorded=4   call 3: recorded=6  -> OPEN
                                          threshold=5
```

Every outcome counted twice, so a breaker configured `failure_threshold=5` **opened after 3** — a flaky tool cut off at roughly half the configured tolerance. The success side is affected too: a `HALF_OPEN` circuit closes in half the required successes, re-admitting traffic to a still-broken tool.

Both blocks now run only when the `acall` wrapper did not (`breaker is None`). One failure per call; the breaker opens at exactly 5, and the 6th call short-circuits.

### 2. A trust lookup that *failed* was treated as "trusted"

`_is_tool_external` wrapped the registry call in a blanket `except Exception: return False`, so a registry that existed and **failed to answer** was indistinguishable from one that answered "trusted".

`agent/tool_execution.py:242` uses exactly this to decide whether to fence tool output against prompt injection — so an external tool's result reached the model **unfenced**. It now fails closed. "No registry at all" stays distinct from "the registry raised", otherwise every ordinary function tool would be fenced.

Over-fencing a trusted tool costs a wrapper; under-fencing an external one is the thing the wrapper exists to prevent.

### 3. `add_external_tool` rebound the module global

It replaced the frozenset rather than mutating it, so any module holding a reference imported earlier kept the pre-registration copy and went on treating the tool as trusted. Nothing in-tree holds such a reference *yet* — a bad way to find out about a security boundary. Now a set, mutated in place.

### 4. The fourth test was stale — and "fixing" it would have been a regression

`test_unknown_tool_message_reaches_model_via_public_path` asserted the public path raises `ToolExecutionError` for an unknown tool. It passed when written. Bisecting found `1a677bf1c0` (#4446), which made tool error dicts flow back as a normal result *"letting the model see the error and retry"*.

That is right here. `ToolExecutionError` is **terminal and non-retryable** — `execution_mixin` lets it propagate *"to stop the run instead of ... swallowing it into an error dict"*. Raising would kill the run at the exact moment the runtime has just handed the model the list of names it could have used, defeating the self-repair #3309 added.

So the test now asserts the message **and the inventory**, and a second test pins that it must *not* raise, so a future "fix" cannot quietly undo #4446.

---

### Verification

- 5 new tests: 3 for the fail-closed lookup, 1 for in-place registration, 1 pinning the non-raising contract.
- Each production fix mutation-checked by reverting it individually. The fail-open fix was initially caught by **nothing** — I added the test that catches it before shipping.
- Suite: **683 passed, 0 failures** in `tools`/`security` (was 4 failures).
- The remaining `test_spawn_announce` failures are pre-existing on clean `main` and covered by #4961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unknown tools now return actionable error details, allowing runs to continue instead of terminating immediately.
  - Circuit breakers now accurately track timed-out tool calls and avoid counting outcomes twice, improving protection against repeated failures.
  - Tool trust checks now fail closed when registry lookups encounter errors, while preserving fallback behavior when no registry is available.
  - External tool registrations are now reflected consistently across the application.
  - Repaired project identity pins remain stable when new repository roots are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->