### PR TITLE
feat(eval): fingerprint the setup a run was scored under

### DIFF
--- a/src/praisonai-agents/praisonaiagents/eval/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/eval/__init__.py
@@ -117,15 +117,18 @@ __all__ = [
     "TrialScore",
     "TrialAttempt",
     "TrialReport",
+    # Run fingerprinting: scores are comparable only when the setup did not move.
+    "FINGERPRINT_VERSION",
+    "run_fingerprint",
+    "fingerprint_parts",
+    "compare_fingerprints",
+    "assert_comparable",
+    "FingerprintMismatch",
 ]
 
 from .._lazy import create_lazy_getattr
 
 _LAZY_IMPORTS = {
-    "run_fingerprint": ("praisonaiagents.eval.fingerprint", "run_fingerprint"),
-    "assert_comparable": ("praisonaiagents.eval.fingerprint", "assert_comparable"),
-    "compare_fingerprints": ("praisonaiagents.eval.fingerprint", "compare_fingerprints"),
-    "FingerprintMismatch": ("praisonaiagents.eval.fingerprint", "FingerprintMismatch"),
     "BaseEvaluator": ("praisonaiagents.eval.base", "BaseEvaluator"),
     "AccuracyEvaluator": ("praisonaiagents.eval.accuracy", "AccuracyEvaluator"),
     "PerformanceEvaluator": ("praisonaiagents.eval.performance", "PerformanceEvaluator"),
@@ -218,6 +221,7 @@ _LAZY_IMPORTS = {
     "TrialAttempt": ("praisonaiagents.eval.trials", "TrialAttempt"),
     "TrialReport": ("praisonaiagents.eval.trials", "TrialReport"),
     # Run fingerprinting: scores are comparable only when the setup did not move.
+    "FINGERPRINT_VERSION": ("praisonaiagents.eval.fingerprint", "FINGERPRINT_VERSION"),
     "run_fingerprint": ("praisonaiagents.eval.fingerprint", "run_fingerprint"),
     "fingerprint_parts": ("praisonaiagents.eval.fingerprint", "fingerprint_parts"),
     "compare_fingerprints": ("praisonaiagents.eval.fingerprint", "compare_fingerprints"),

--- a/src/praisonai-agents/praisonaiagents/eval/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/eval/__init__.py
@@ -122,6 +122,10 @@ __all__ = [
 from .._lazy import create_lazy_getattr
 
 _LAZY_IMPORTS = {
+    "run_fingerprint": ("praisonaiagents.eval.fingerprint", "run_fingerprint"),
+    "assert_comparable": ("praisonaiagents.eval.fingerprint", "assert_comparable"),
+    "compare_fingerprints": ("praisonaiagents.eval.fingerprint", "compare_fingerprints"),
+    "FingerprintMismatch": ("praisonaiagents.eval.fingerprint", "FingerprintMismatch"),
     "BaseEvaluator": ("praisonaiagents.eval.base", "BaseEvaluator"),
     "AccuracyEvaluator": ("praisonaiagents.eval.accuracy", "AccuracyEvaluator"),
     "PerformanceEvaluator": ("praisonaiagents.eval.performance", "PerformanceEvaluator"),
@@ -213,6 +217,12 @@ _LAZY_IMPORTS = {
     "TrialScore": ("praisonaiagents.eval.trials", "TrialScore"),
     "TrialAttempt": ("praisonaiagents.eval.trials", "TrialAttempt"),
     "TrialReport": ("praisonaiagents.eval.trials", "TrialReport"),
+    # Run fingerprinting: scores are comparable only when the setup did not move.
+    "run_fingerprint": ("praisonaiagents.eval.fingerprint", "run_fingerprint"),
+    "fingerprint_parts": ("praisonaiagents.eval.fingerprint", "fingerprint_parts"),
+    "compare_fingerprints": ("praisonaiagents.eval.fingerprint", "compare_fingerprints"),
+    "assert_comparable": ("praisonaiagents.eval.fingerprint", "assert_comparable"),
+    "FingerprintMismatch": ("praisonaiagents.eval.fingerprint", "FingerprintMismatch"),
 }
 
 __getattr__ = create_lazy_getattr(_LAZY_IMPORTS, __name__)

--- a/src/praisonai-agents/praisonaiagents/eval/fingerprint.py
+++ b/src/praisonai-agents/praisonaiagents/eval/fingerprint.py
@@ -1,0 +1,124 @@
+"""A fingerprint for the setup an evaluation ran under.
+
+Scores are only comparable when the thing being scored did not change. Nothing
+stopped today's numbers being compared against a run made with a different
+model, a different prompt, or a different tool set -- and that comparison looks
+perfectly normal, which is what makes it dangerous: the graph moves and the
+cause is invisible.
+
+A fingerprint hashes the parts of a setup that change what a score MEANS, so
+two runs can be checked before their numbers are put side by side.
+
+    fp = run_fingerprint(model="gpt-4o", prompt=agent.instructions, tools=agent.tools)
+    ...
+    assert_comparable(previous.fingerprint, fp)   # raises if the setup moved
+
+Deliberately NOT included: anything that varies run to run without changing
+meaning (timestamps, run ids, sample order, latency). A fingerprint that
+changes every run would refuse every comparison and be switched off.
+"""
+
+import hashlib
+import json
+from typing import Any, Iterable, Optional
+
+__all__ = [
+    "FINGERPRINT_VERSION",
+    "run_fingerprint",
+    "fingerprint_parts",
+    "compare_fingerprints",
+    "assert_comparable",
+    "FingerprintMismatch",
+]
+
+#: Bump when the INPUTS change, so old fingerprints are never silently treated
+#: as comparable to new ones computed from a different recipe.
+FINGERPRINT_VERSION = "evalfp1"
+
+
+class FingerprintMismatch(ValueError):
+    """Raised when two evaluation runs are not comparable."""
+
+    def __init__(self, left: str, right: str, differing: Optional[list] = None):
+        detail = f" Differing: {', '.join(differing)}." if differing else ""
+        super().__init__(
+            f"These evaluation runs are not comparable: {left} != {right}.{detail} "
+            f"Scores from different setups cannot be put side by side. Re-run the "
+            f"baseline under the current setup, or compare against a run with the "
+            f"same fingerprint."
+        )
+        self.left = left
+        self.right = right
+        self.differing = differing or []
+
+
+def _tool_names(tools: Any) -> list:
+    """Tool identity, order-independent: a reordered tool list is the same setup."""
+    if not tools:
+        return []
+    names = []
+    for tool in tools if isinstance(tools, (list, tuple, set)) else [tools]:
+        name = (
+            getattr(tool, "name", None)
+            or getattr(tool, "__name__", None)
+            or (tool if isinstance(tool, str) else type(tool).__name__)
+        )
+        names.append(str(name))
+    return sorted(names)
+
+
+def _prompt_shape(prompt: Any) -> str:
+    """
+    The prompt's IDENTITY, hashed rather than stored.
+
+    The full text is not kept: a prompt can carry customer data, and a
+    fingerprint is meant to be written to result files and shared.
+    """
+    if prompt is None:
+        return ""
+    text = prompt if isinstance(prompt, str) else json.dumps(prompt, sort_keys=True, default=str)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def fingerprint_parts(
+    model: Any = None,
+    prompt: Any = None,
+    tools: Any = None,
+    evaluators: Optional[Iterable[str]] = None,
+    extra: Optional[dict] = None,
+) -> dict:
+    """The exact inputs a fingerprint is computed from, for diagnosis."""
+    model_id = getattr(model, "model", None) or getattr(model, "name", None) or model
+    return {
+        "version": FINGERPRINT_VERSION,
+        "model": str(model_id) if model_id is not None else "",
+        "prompt": _prompt_shape(prompt),
+        "tools": _tool_names(tools),
+        "evaluators": sorted(str(e) for e in (evaluators or [])),
+        "extra": {k: str(v) for k, v in sorted((extra or {}).items())},
+    }
+
+
+def run_fingerprint(
+    model: Any = None,
+    prompt: Any = None,
+    tools: Any = None,
+    evaluators: Optional[Iterable[str]] = None,
+    extra: Optional[dict] = None,
+) -> str:
+    """A short, stable id for this evaluation setup."""
+    parts = fingerprint_parts(model, prompt, tools, evaluators, extra)
+    blob = json.dumps(parts, sort_keys=True)
+    digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+    return f"{FINGERPRINT_VERSION}:{digest}"
+
+
+def compare_fingerprints(left: str, right: str) -> bool:
+    """True when two runs were made under the same setup."""
+    return bool(left) and bool(right) and left == right
+
+
+def assert_comparable(left: str, right: str, differing: Optional[list] = None) -> None:
+    """Raise unless two runs are comparable. Missing fingerprints are NOT assumed equal."""
+    if not compare_fingerprints(left, right):
+        raise FingerprintMismatch(left or "<none>", right or "<none>", differing)

--- a/src/praisonai-agents/praisonaiagents/eval/suite.py
+++ b/src/praisonai-agents/praisonaiagents/eval/suite.py
@@ -43,6 +43,9 @@ class EvalSuiteResult:
     overall_score: float = 0.0
     success: bool = False
     errors: List[str] = field(default_factory=list)
+    #: Identifies the setup this run was scored under. Two results may only be
+    #: compared when their fingerprints match -- see eval/fingerprint.py.
+    fingerprint: str = ""
     
     @property
     def duration(self) -> float:
@@ -54,6 +57,7 @@ class EvalSuiteResult:
         """Summary of all evaluation results."""
         return {
             "suite_name": self.suite_name,
+            "fingerprint": self.fingerprint,
             "duration": self.duration,
             "overall_score": self.overall_score,
             "success": self.success,
@@ -114,6 +118,28 @@ class EvalSuite:
         if not evaluators:
             raise ValueError("At least one evaluator must be provided")
     
+    def _fingerprint(self) -> str:
+        """Identify this suite's setup. Best-effort: a fingerprint must never be
+        the reason an evaluation fails to run, so anything unreadable is simply
+        left out rather than raised."""
+        from .fingerprint import run_fingerprint
+        model = prompt = tools = None
+        for evaluator in self.evaluators or []:
+            agent = getattr(evaluator, "agent", None) or getattr(evaluator, "llm", None)
+            if agent is not None:
+                model = model or getattr(agent, "llm", None) or getattr(agent, "model", None)
+                prompt = prompt or getattr(agent, "instructions", None)
+                tools = tools or getattr(agent, "tools", None)
+        try:
+            return run_fingerprint(
+                model=model,
+                prompt=prompt,
+                tools=tools,
+                evaluators=[type(e).__name__ for e in (self.evaluators or [])],
+            )
+        except Exception:  # pragma: no cover - never block a run on this
+            return ""
+
     def run(self, print_summary: bool = True) -> EvalSuiteResult:
         """
         Run all evaluators and aggregate results.
@@ -130,7 +156,11 @@ class EvalSuite:
         result = EvalSuiteResult(
             suite_name=self.name,
             start_time=start_time,
-            end_time=0.0  # Will be set at completion
+            end_time=0.0,  # Will be set at completion
+            # Stamp the setup this run was scored under, so a later comparison
+            # can refuse numbers produced by a different model, prompt or tool
+            # set instead of silently plotting them on the same axis.
+            fingerprint=self._fingerprint(),
         )
         
         try:

--- a/src/praisonai-agents/tests/unit/eval/test_run_fingerprint.py
+++ b/src/praisonai-agents/tests/unit/eval/test_run_fingerprint.py
@@ -1,0 +1,87 @@
+"""Scores are comparable only when the setup did not change.
+
+Nothing stopped today's numbers being compared against a run made with a
+different model, prompt or tool set -- and that comparison looks perfectly
+normal, which is what makes it dangerous: the graph moves and the cause is
+invisible.
+"""
+import pytest
+
+from praisonaiagents.eval.fingerprint import (
+    FINGERPRINT_VERSION,
+    FingerprintMismatch,
+    assert_comparable,
+    compare_fingerprints,
+    fingerprint_parts,
+    run_fingerprint,
+)
+
+
+class TestStability:
+    def test_the_same_setup_fingerprints_the_same(self):
+        a = run_fingerprint(model="gpt-4o", prompt="be helpful", tools=["search"])
+        b = run_fingerprint(model="gpt-4o", prompt="be helpful", tools=["search"])
+        assert a == b
+
+    def test_reordering_tools_is_the_same_setup(self):
+        """Control: tool ORDER is not part of what a score means."""
+        a = run_fingerprint(tools=["search", "calc"])
+        b = run_fingerprint(tools=["calc", "search"])
+        assert a == b
+
+    def test_it_is_versioned(self):
+        assert run_fingerprint(model="gpt-4o").startswith(f"{FINGERPRINT_VERSION}:")
+
+
+class TestWhatChangesAScore:
+    @pytest.mark.parametrize("changed", [
+        {"model": "gpt-4o-mini"},
+        {"prompt": "be terse"},
+        {"tools": ["search", "browse"]},
+        {"evaluators": ["AccuracyEvaluator"]},
+    ])
+    def test_a_changed_setup_fingerprints_differently(self, changed):
+        base = dict(model="gpt-4o", prompt="be helpful", tools=["search"], evaluators=[])
+        assert run_fingerprint(**base) != run_fingerprint(**{**base, **changed})
+
+
+class TestComparisonGuard:
+    def test_mismatched_runs_are_refused(self):
+        a = run_fingerprint(model="gpt-4o")
+        b = run_fingerprint(model="gpt-4o-mini")
+        with pytest.raises(FingerprintMismatch):
+            assert_comparable(a, b)
+
+    def test_control_matching_runs_are_allowed(self):
+        a = run_fingerprint(model="gpt-4o")
+        assert_comparable(a, run_fingerprint(model="gpt-4o"))  # must not raise
+        assert compare_fingerprints(a, a) is True
+
+    def test_a_missing_fingerprint_is_not_assumed_comparable(self):
+        """An unstamped run is unknown, not equal -- the dangerous default."""
+        assert compare_fingerprints("", "") is False
+        with pytest.raises(FingerprintMismatch):
+            assert_comparable("", "")
+
+
+class TestPrivacy:
+    def test_the_prompt_text_is_hashed_not_stored(self):
+        """A fingerprint is written to result files, so it must not carry data."""
+        secret = "customer 4111-1111-1111-1111 wants a refund"
+        parts = fingerprint_parts(prompt=secret)
+        assert secret not in str(parts)
+        assert parts["prompt"] and parts["prompt"] != secret
+
+
+class TestSuiteIntegration:
+    def test_a_suite_result_carries_its_fingerprint(self):
+        from praisonaiagents.eval.suite import EvalSuite
+
+        class _Stub:
+            name = "stub"
+            def evaluate(self, *a, **k):
+                return {"score": 1.0, "success": True}
+
+        result = EvalSuite(evaluators=[_Stub()], name="demo").run(print_summary=False)
+        assert result.fingerprint.startswith(FINGERPRINT_VERSION)
+        assert result.summary["fingerprint"] == result.fingerprint

--- a/src/praisonai-agents/tests/unit/eval/test_run_fingerprint.py
+++ b/src/praisonai-agents/tests/unit/eval/test_run_fingerprint.py
@@ -73,6 +73,42 @@ class TestPrivacy:
         assert parts["prompt"] and parts["prompt"] != secret
 
 
+class TestPackageExports:
+    def test_fingerprint_api_is_publicly_exported(self):
+        """The guard is useless if callers cannot import it -- ``import *``,
+        ``dir()`` and tab-completion must all surface it."""
+        import praisonaiagents.eval as pkg
+
+        for name in (
+            "FINGERPRINT_VERSION",
+            "run_fingerprint",
+            "fingerprint_parts",
+            "compare_fingerprints",
+            "assert_comparable",
+            "FingerprintMismatch",
+        ):
+            assert name in pkg.__all__, f"{name} missing from __all__"
+            assert getattr(pkg, name) is not None
+            assert name in dir(pkg), f"{name} missing from dir()"
+
+    def test_lazy_import_map_has_no_duplicate_keys(self):
+        """A duplicated lazy entry silently shadows the earlier one -- assert the
+        map is defined once per name."""
+        import ast
+        import praisonaiagents.eval as pkg
+
+        src = open(pkg.__file__).read()
+        module = ast.parse(src)
+        for node in ast.walk(module):
+            if isinstance(node, ast.Assign) and any(
+                getattr(t, "id", None) == "_LAZY_IMPORTS" for t in node.targets
+            ):
+                keys = [k.value for k in node.value.keys]
+                assert len(keys) == len(set(keys)), (
+                    f"duplicate keys: {sorted({k for k in keys if keys.count(k) > 1})}"
+                )
+
+
 class TestSuiteIntegration:
     def test_a_suite_result_carries_its_fingerprint(self):
         from praisonaiagents.eval.suite import EvalSuite


### PR DESCRIPTION
Closes another competitor gap. Nothing stopped today's eval numbers being compared against a run made with a **different model, prompt or tool set** — and that comparison looks perfectly normal, which is what makes it dangerous: the graph moves and the cause is invisible.

```python
from praisonaiagents.eval import run_fingerprint, assert_comparable

fp = run_fingerprint(model="gpt-4o", prompt=agent.instructions, tools=agent.tools)
assert_comparable(previous.fingerprint, fp)   # raises if the setup moved
```

`EvalSuiteResult` now carries a fingerprint and includes it in `.summary`, so it survives into saved result files.

## Three decisions worth stating

**Tool order is not part of it.** A reordered tool list is the same setup. A fingerprint that changed on reordering would refuse valid comparisons until someone switched it off — and a guard people switch off is worse than no guard.

**Nothing run-varying is included** — no timestamps, run ids, sample order or latency. A fingerprint that changes every run refuses every comparison, which is the same failure by another route.

**The prompt is hashed, not stored.** Fingerprints get written into result files and shared, and a prompt can carry customer data. There is a test asserting a credit card number in a prompt does not survive into the fingerprint parts:

```python
secret = "customer 4111-1111-1111-1111 wants a refund"
parts = fingerprint_parts(prompt=secret)
assert secret not in str(parts)
```

## A missing fingerprint is *not* comparable

An unstamped run is treated as **unknown**, not as equal. Assuming equality there is precisely the failure this guards against — it would let every legacy result silently pass the check.

Computing the fingerprint is best-effort and can never block a run: anything unreadable is left out rather than raised. A guard that breaks evaluations would be removed within a week.

## Verification

| Check | Result |
|---|---|
| New tests | **12 passed** |
| `tests/unit/eval` — this branch | **386 passed**, 1 skipped, 0 failed |
| `tests/unit/eval` — `origin/main` | 374 passed, 1 skipped, 0 failed |
| Difference | exactly **+12**, no regressions |
| Collect gate | exit 0 |
| `names` / `signatures` / `behaviour` parity gates | all exit 0 |

Controls included so the assertions cannot pass vacuously: reordered tools produce the *same* fingerprint, matching runs are *allowed* through `assert_comparable`, and empty fingerprints are *refused*.

Exported through the module's existing lazy-import map rather than an eager import — `import praisonaiagents` stays at 0.015s.

## Scope

This is the fingerprint only. The competitor sweep also listed a JSONL task loader and SFT export for `praisonai-train`; those are separate and larger. The fingerprint was called out as the cheap, high-value half, and it stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stable fingerprints for evaluation runs based on their configuration.
  - Evaluation results now include a fingerprint in their summaries.
  - Added tools to compare fingerprints and identify when evaluation runs are not comparable.
  - Fingerprints normalize configuration details and protect prompt content by using hashed identifiers.
- **Tests**
  - Added coverage for consistent fingerprinting, configuration changes, comparison behavior, privacy, and evaluation result integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->