### PR TITLE
test(code): ten tests were reading the developer's machine, not the code

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
@@ -2052,6 +2052,20 @@ Write the complete compiled report:"""
                             "timeout": True,
                             "_praison_retryable": False,
                         }
+                        # wait_for cancels breaker.acall, so its except-clause never
+                        # ran and the breaker did NOT count this outcome. The
+                        # post-execution breaker_record below is skipped whenever a
+                        # breaker exists (to avoid double-counting the outcomes the
+                        # breaker already saw) — but a cancelled acall saw nothing.
+                        # Record the timeout here so repeated timeouts still open the
+                        # circuit; guard the call so a plain instance without a
+                        # breaker record (breaker fell back to direct invocation)
+                        # doesn't raise.
+                        if breaker is not None:
+                            _timeout_record = getattr(
+                                self, '_circuit_breaker_record', None)
+                            if _timeout_record is not None:
+                                _timeout_record(function_name, False)
                 else:
                     try:
                         result = await _invoke_guarded()

--- a/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
+++ b/src/praisonai-agents/praisonaiagents/agent/execution_mixin.py
@@ -2052,20 +2052,6 @@ Write the complete compiled report:"""
                             "timeout": True,
                             "_praison_retryable": False,
                         }
-                        # wait_for cancels breaker.acall, so its except-clause never
-                        # ran and the breaker did NOT count this outcome. The
-                        # post-execution breaker_record below is skipped whenever a
-                        # breaker exists (to avoid double-counting the outcomes the
-                        # breaker already saw) — but a cancelled acall saw nothing.
-                        # Record the timeout here so repeated timeouts still open the
-                        # circuit; guard the call so a plain instance without a
-                        # breaker record (breaker fell back to direct invocation)
-                        # doesn't raise.
-                        if breaker is not None:
-                            _timeout_record = getattr(
-                                self, '_circuit_breaker_record', None)
-                            if _timeout_record is not None:
-                                _timeout_record(function_name, False)
                 else:
                     try:
                         result = await _invoke_guarded()

--- a/src/praisonai-agents/tests/unit/tools/test_async_tool_retry_parity.py
+++ b/src/praisonai-agents/tests/unit/tools/test_async_tool_retry_parity.py
@@ -201,6 +201,38 @@ def test_async_breaker_opens_after_raised_exceptions():
     assert not any(r.get("circuit_open") for r in results[:5])
 
 
+def test_async_breaker_opens_after_timeouts():
+    """A tool that keeps *timing out* must also open the breaker. ``wait_for``
+    cancels ``breaker.acall``, so the breaker never saw the outcome and the
+    post-execution record block is skipped whenever a breaker exists — leaving
+    repeated timeouts uncounted. The timeout branch records the failure itself
+    so five timeouts open the circuit and the sixth short-circuits.
+    """
+    import time
+
+    def slow(x: str = "") -> str:
+        time.sleep(0.5)
+        return "done"
+
+    agent = Agent(name="t", instructions="x", tools=[slow])
+    # ToolConfig.timeout is int-seconds; set the resolved attribute directly to
+    # a sub-second value so the test stays fast while exercising the same path.
+    agent._tool_timeout = 0.05
+
+    async def _drive():
+        results = []
+        for _ in range(6):
+            results.append(
+                await agent._execute_tool_async_impl("slow", {}, None, None)
+            )
+        return results
+
+    results = asyncio.run(_drive())
+    assert results[-1].get("circuit_open") is True
+    assert all(r.get("timeout") for r in results[:5])
+    assert not any(r.get("circuit_open") for r in results[:5])
+
+
 def test_async_breaker_is_per_instance():
     """One agent's open breaker must not trip a distinct agent's same-named
     tool — the breaker key is instance-scoped (``tool_{id(self)}_{name}``)."""

--- a/src/praisonai-code/praisonai_code/cli/utils/project.py
+++ b/src/praisonai-code/praisonai_code/cli/utils/project.py
@@ -183,6 +183,7 @@ def get_git_root_commit(path: Optional[str] = None) -> Optional[str]:
                     other = pinned_path.read_text(encoding="utf-8").strip()
                     if other in available:
                         return other
+                    # Racing writer pinned a now-stale commit; refresh as above.
                     _atomic_write(pinned_path, chosen)
                 except OSError:
                     pass

--- a/src/praisonai-code/tests/unit/conftest.py
+++ b/src/praisonai-code/tests/unit/conftest.py
@@ -28,6 +28,18 @@ CONFIG_ENV_VARS = (
     "PRAISONAI_TELEMETRY",
 )
 
+# Read by ``_load_env_user_config`` (not ``_load_env_config``), so the AST guard
+# in test_config_env_isolation.py does not police these. They stand in for the
+# whole user-config layer: an exported ``PRAISONAI_CONFIG_CONTENT`` (inline blob)
+# or ``PRAISONAI_CONFIG`` (explicit path) would suppress file discovery and feed
+# the developer's own config into resolution -- the same machine-dependence the
+# fixture exists to prevent. Kept in a separate tuple so the two guards stay
+# distinct: one polices the environment layer, this covers the user-config layer.
+CONFIG_USER_ENV_VARS = (
+    "PRAISONAI_CONFIG_CONTENT",
+    "PRAISONAI_CONFIG",
+)
+
 
 @pytest.fixture
 def isolated_config_env(monkeypatch):
@@ -39,6 +51,10 @@ def isolated_config_env(monkeypatch):
     ``config.sources`` gained an "environment" entry and the resolved model
     became whatever they had set. The tests passed or failed per machine, and
     on CI (where nothing is exported) the gap was invisible.
+
+    ``_load_env_user_config`` reads PRAISONAI_CONFIG_CONTENT / PRAISONAI_CONFIG,
+    which likewise override file discovery with the developer's own config, so
+    they are scrubbed too.
     """
-    for name in CONFIG_ENV_VARS:
+    for name in CONFIG_ENV_VARS + CONFIG_USER_ENV_VARS:
         monkeypatch.delenv(name, raising=False)

--- a/src/praisonai-code/tests/unit/conftest.py
+++ b/src/praisonai-code/tests/unit/conftest.py
@@ -1,0 +1,44 @@
+"""Shared fixtures for the praisonai-code unit tests."""
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+# Every environment variable ConfigResolver folds into its "environment" layer.
+# Kept in sync with the resolver by test_config_env_isolation.py, which parses
+# the resolver and fails if a new one appears that is not listed here.
+CONFIG_ENV_VARS = (
+    "MODEL_NAME",
+    "OPENAI_MODEL_NAME",
+    "PRAISONAI_MODEL",
+    "PRAISONAI_PROVIDER",
+    "OPENAI_BASE_URL",
+    "OPENAI_API_BASE",
+    "PRAISONAI_BASE_URL",
+    "PRAISONAI_OUTPUT_FORMAT",
+    "PRAISONAI_COLOR",
+    "PRAISONAI_VERBOSE",
+    "PRAISONAI_QUIET",
+    "PRAISONAI_MANAGED_CONFIG_URL",
+    "PRAISONAI_MANAGED_CONFIG_DIR",
+    "PRAISONAI_MANAGED_CONFIG_TIMEOUT",
+    "PRAISONAI_STRICT_CONFIG",
+    "PRAISONAI_TELEMETRY",
+)
+
+
+@pytest.fixture
+def isolated_config_env(monkeypatch):
+    """Hide the developer's shell from ConfigResolver.
+
+    ``_load_env_config`` folds MODEL_NAME / OPENAI_MODEL_NAME and friends into
+    an "environment" layer. Anyone who exports those -- which is the normal way
+    to use this tool -- made config tests assert against their own shell:
+    ``config.sources`` gained an "environment" entry and the resolved model
+    became whatever they had set. The tests passed or failed per machine, and
+    on CI (where nothing is exported) the gap was invisible.
+    """
+    for name in CONFIG_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)

--- a/src/praisonai-code/tests/unit/test_config_env_isolation.py
+++ b/src/praisonai-code/tests/unit/test_config_env_isolation.py
@@ -1,0 +1,98 @@
+"""Config tests must not read the developer's shell.
+
+``ConfigResolver._load_env_config`` folds MODEL_NAME / OPENAI_MODEL_NAME and
+friends into an "environment" layer. Exporting those is the normal way to use
+this tool, so config tests were asserting against whoever ran them: seven were
+red on this machine and green on CI, where nothing is exported. Machine-
+dependent tests are worse than missing ones -- they train you to ignore a red
+suite.
+
+The ``isolated_config_env`` fixture scrubs them. This module keeps that list
+honest by reading the resolver: a variable added there and not listed here
+would silently reopen the leak.
+"""
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+from praisonai_code.cli.configuration import resolver as resolver_mod
+from praisonai_code.cli.configuration.resolver import ConfigResolver
+
+from .conftest import CONFIG_ENV_VARS
+
+
+def _env_vars_read_by_load_env_config():
+    """Env-var names read by ``_load_env_config``.
+
+    Matches the ``("VAR_NAME", ["section", "key"])`` mapping shape and direct
+    ``os.environ.get("VAR")`` calls. Deliberately not "every uppercase string
+    in the function": the bare suffixes in ``env_var.endswith(("COLOR",
+    "VERBOSE", "QUIET"))`` are not variables, and counting them would make this
+    guard demand that the fixture scrub names that do not exist.
+    """
+    tree = ast.parse(Path(resolver_mod.__file__).read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name == "_load_env_config"
+    )
+    names = set()
+    for node in ast.walk(fn):
+        # ("VAR", [...]) mapping entries
+        if (isinstance(node, ast.Tuple) and node.elts
+                and isinstance(node.elts[0], ast.Constant)
+                and isinstance(node.elts[0].value, str)
+                and len(node.elts) == 2
+                and isinstance(node.elts[1], (ast.List, ast.Tuple))):
+            names.add(node.elts[0].value)
+        # os.environ.get("VAR") / os.environ["VAR"]
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+                and node.args[0].value.isupper()):
+            names.add(node.args[0].value)
+    return names
+
+
+def test_the_fixture_covers_every_variable_the_resolver_reads():
+    read = _env_vars_read_by_load_env_config()
+    # Only names that look like env vars, not the config keys they map to.
+    candidates = {n for n in read if n.isupper()}
+    missing = sorted(candidates - set(CONFIG_ENV_VARS))
+    assert not missing, (
+        "ConfigResolver reads these and isolated_config_env does not scrub "
+        f"them, so config tests will read the developer's shell: {missing}"
+    )
+
+
+def test_resolution_is_unaffected_by_an_exported_model(monkeypatch,
+                                                       isolated_config_env,
+                                                       tmp_path):
+    """The regression itself: an exported model must not reach the resolver."""
+    monkeypatch.setenv("MODEL_NAME", "some-exported-model")
+    monkeypatch.setenv("OPENAI_MODEL_NAME", "another-exported-model")
+    # The fixture ran first; re-setting them here proves the *test* controls
+    # the environment rather than inheriting it, and that a test which wants
+    # the variable can still have it.
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    config = ConfigResolver(cwd=tmp_path).resolve()
+    assert "environment" in config.sources
+    assert config.agent.model in (
+        "some-exported-model", "another-exported-model",
+    )
+
+
+def test_without_the_export_there_is_no_environment_layer(isolated_config_env,
+                                                          monkeypatch, tmp_path):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    config = ConfigResolver(cwd=tmp_path).resolve()
+    assert config.sources == ["defaults"], (
+        "an environment layer appeared with nothing exported -- the fixture "
+        "is missing a variable the resolver reads"
+    )

--- a/src/praisonai-code/tests/unit/test_config_env_isolation.py
+++ b/src/praisonai-code/tests/unit/test_config_env_isolation.py
@@ -21,7 +21,7 @@ import pytest
 from praisonai_code.cli.configuration import resolver as resolver_mod
 from praisonai_code.cli.configuration.resolver import ConfigResolver
 
-from .conftest import CONFIG_ENV_VARS
+from .conftest import CONFIG_ENV_VARS, CONFIG_USER_ENV_VARS
 
 
 def _env_vars_read_by_load_env_config():
@@ -95,4 +95,44 @@ def test_without_the_export_there_is_no_environment_layer(isolated_config_env,
     assert config.sources == ["defaults"], (
         "an environment layer appeared with nothing exported -- the fixture "
         "is missing a variable the resolver reads"
+    )
+
+
+def test_the_fixture_covers_the_user_config_env_vars():
+    """The user-config layer (``_load_env_user_config``) reads these via module
+    constants, so the AST guard above cannot see them. Pin them against the
+    resolver's own constants so a rename there fails here rather than silently
+    reopening the leak.
+    """
+    read = {resolver_mod.CONFIG_CONTENT_ENV, resolver_mod.CONFIG_PATH_ENV}
+    missing = sorted(read - set(CONFIG_USER_ENV_VARS))
+    assert not missing, (
+        "ConfigResolver reads these user-config env vars and "
+        f"isolated_config_env does not scrub them: {missing}"
+    )
+
+
+@pytest.fixture
+def _export_user_config(monkeypatch):
+    """Export a user-config blob *before* ``isolated_config_env`` runs.
+
+    Ordering matters: a fixture listed earlier in a test's parameter list is
+    set up first, so this stands in for the developer's already-exported shell
+    that the isolation fixture must scrub. Setting it inside the test (after the
+    fixture) would instead prove the test controls its own environment, which is
+    the opposite assertion.
+    """
+    monkeypatch.setenv("PRAISONAI_CONFIG_CONTENT", '{"model": "leaked-model"}')
+
+
+def test_an_exported_user_config_does_not_reach_the_resolver(_export_user_config,
+                                                             isolated_config_env,
+                                                             monkeypatch,
+                                                             tmp_path):
+    """A pre-existing PRAISONAI_CONFIG_CONTENT export must not survive the fixture."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    config = ConfigResolver(cwd=tmp_path).resolve()
+    assert config.sources == ["defaults"], (
+        "an exported user-config blob leaked into resolution -- the fixture "
+        "did not scrub PRAISONAI_CONFIG_CONTENT"
     )

--- a/src/praisonai-code/tests/unit/test_config_interpolation_provenance.py
+++ b/src/praisonai-code/tests/unit/test_config_interpolation_provenance.py
@@ -15,6 +15,10 @@ import pytest
 from praisonai_code.cli.utils.env_utils import interpolate
 from praisonai_code.cli.configuration.resolver import ConfigResolver
 
+# Every test here resolves config, so none of them may see the
+# developer's exported MODEL_NAME/OPENAI_MODEL_NAME et al.
+pytestmark = pytest.mark.usefixtures("isolated_config_env")
+
 
 def test_interpolate_env_and_dollar_forms(monkeypatch):
     monkeypatch.setenv("MY_TOKEN", "secret123")

--- a/src/praisonai-code/tests/unit/test_managed_config_layer.py
+++ b/src/praisonai-code/tests/unit/test_managed_config_layer.py
@@ -14,6 +14,12 @@ import json
 
 from praisonai_code.cli.configuration.resolver import ConfigResolver
 
+# Every test here resolves config, so none of them may see the
+# developer's exported MODEL_NAME/OPENAI_MODEL_NAME et al.
+import pytest
+
+pytestmark = pytest.mark.usefixtures("isolated_config_env")
+
 
 def _write_managed_dir(base, body: str):
     d = base / "managed"

--- a/src/praisonai-code/tests/unit/test_run_subtree_context.py
+++ b/src/praisonai-code/tests/unit/test_run_subtree_context.py
@@ -130,8 +130,17 @@ def test_custom_agent_verbose_maps_to_output_preset(monkeypatch):
         verbose=True,
     )
 
-    real_params = set(inspect.signature(RealAgent.__init__).parameters)
-    assert set(captured) <= real_params
+    # Construct a real Agent with exactly these kwargs. Checking them against
+    # the signature does not work in either direction: Agent.__init__ takes
+    # **kwargs, so ``inspect.signature().bind`` accepts even the ``verbose``
+    # this test exists to catch, while a "subset of named parameters" check
+    # rejects legitimate extras like ``auto_save`` (stored as an attribute by
+    # the session wiring). Only the constructor knows -- it validates kwargs
+    # itself and raises for names that have moved.
+    try:
+        RealAgent(**{**captured, "llm": captured.get("llm") or "gpt-4o-mini"})
+    except TypeError as exc:  # pragma: no cover - the regression
+        pytest.fail(f"the real Agent constructor rejects these kwargs: {exc}")
     assert "verbose" not in captured
     assert captured["output"] == "verbose"
 

--- a/src/praisonai-code/tests/unit/test_standalone_stub_commands.py
+++ b/src/praisonai-code/tests/unit/test_standalone_stub_commands.py
@@ -62,7 +62,6 @@ def test_run_wrapper_command_exits_one_without_traceback(monkeypatch):
         ("memory", ["show"]),
         ("skills", ["list"]),
         ("hooks", ["list"]),
-        ("rules", ["list"]),
         ("eval", ["accuracy", "agent", "--input", "x", "--expected", "y"]),
         ("package", ["list"]),
         ("templates", ["list"]),
@@ -90,6 +89,38 @@ def test_stub_command_no_traceback_standalone(monkeypatch, module_name, argv):
     assert "Traceback" not in result.output
     assert "argparse_builder" not in result.output
     assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("module_name,argv", [
+    ("rules", ["list"]),
+])
+def test_natively_migrated_commands_work_without_the_wrapper(
+    monkeypatch, tmp_path, module_name, argv
+):
+    """Commands made *native* to praisonai-code must succeed standalone.
+
+    ``rules`` sat in the stub table above, which asserts exit 1, until
+    448b7bb912 made it native (#4337) -- and the table was never updated, so
+    this had been red ever since. It is the opposite assertion now: the point
+    of that change is that the command works with no wrapper installed.
+
+    HOME is redirected because the command reads the user's real rules
+    directory otherwise, which made the outcome depend on whose machine ran it.
+    """
+    typer_testing = pytest.importorskip("typer.testing")
+    import praisonai_code._wrapper_bridge as bridge
+
+    monkeypatch.setattr(bridge, "wrapper_available", lambda: False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    module = __import__(
+        f"praisonai_code.cli.commands.{module_name}", fromlist=["app"]
+    )
+    result = typer_testing.CliRunner().invoke(module.app, argv)
+
+    assert "Traceback" not in result.output
+    assert result.exit_code == 0, result.output
 
 
 def test_no_legacy_main_reentry_in_stub_modules():

--- a/src/praisonai-code/tests/unit/test_train_command_routing.py
+++ b/src/praisonai-code/tests/unit/test_train_command_routing.py
@@ -74,11 +74,79 @@ def test_train_command_reaches_trainer_not_direct_prompt(monkeypatch, tmp_path):
     assert calls["config"] is not None
     assert calls["config"]["dataset"] == [{"name": str(dataset)}]
     assert calls["config"]["model_name"] == "llama-3.1"
-    # The trainer subprocess was actually dispatched.
+    # The trainer subprocess was actually dispatched, at the module the
+    # dispatcher chose for this environment.
     assert calls["train_argv"] is not None
-    assert "praisonai_train.train.llm.trainer" in calls["train_argv"]
+    assert any(
+        a in calls["train_argv"]
+        for a in ("praisonai_train.train.llm.trainer",
+                  "praisonai.train.llm.trainer")
+    ), calls["train_argv"]
     assert "train" in calls["train_argv"]
 
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+
+@pytest.mark.parametrize("available,expected", [
+    (True, "praisonai_train.train.llm.trainer"),
+    (False, "praisonai.train.llm.trainer"),
+])
+def test_the_trainer_module_follows_the_installed_package(
+    monkeypatch, tmp_path, available, expected
+):
+    """Which trainer module is invoked must follow ``train_package_available``.
+
+    ``praisonai_train`` is the owner package since the C10 extraction;
+    ``praisonai.train.*`` is a compatibility shim. The dispatcher picks the
+    owner when it is importable and the shim otherwise -- correct, but the
+    assertion above only ever exercised whichever branch the *developer's*
+    environment happened to select, so it was red on a checkout without
+    ``praisonai-train`` on the path and green with it. Both branches are now
+    driven explicitly.
+    """
+    pa = _load_module()
+    try:
+        from praisonai_code._wrapper_bridge import import_wrapper_module
+        import_wrapper_module("praisonai.cli.legacy.dispatch.argparse_builder")
+    except ImportError as exc:  # pragma: no cover - depends on optional wrapper
+        pytest.skip(f"wrapper argparse builder unavailable: {exc}")
+
+    calls = {"train_argv": None}
+
+    monkeypatch.setattr(pa, "TRAIN_AVAILABLE", True)
+    monkeypatch.setattr(pa.PraisonAI, "handle_direct_prompt",
+                        lambda self, *a, **k: "PROMPTED")
+    monkeypatch.setattr(pa, "stream_subprocess",
+                        lambda cmd, env=None: calls.__setitem__("train_argv", list(cmd)))
+    monkeypatch.setattr(pa, "_get_generate_config",
+                        lambda: (lambda **kw: {"model_name": kw.get("model_name") or ""}))
+    # Imported inside the dispatch function from _train_bridge, so it must
+    # be patched at its source module rather than on the loaded module.
+    import praisonai_code._train_bridge as train_bridge
+    monkeypatch.setattr(train_bridge, "train_package_available",
+                        lambda: available)
+
+    import subprocess as _sp
+    monkeypatch.setattr(
+        _sp, "check_output",
+        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+
+    dataset = tmp_path / "my_sft.jsonl"
+    dataset.write_text('{"instruction": "x"}\n')
+    monkeypatch.chdir(tmp_path)
+
+    import sys as _sys
+    monkeypatch.setattr(
+        _sys, "argv",
+        ["praisonai", "train", "--dataset", str(dataset), "--model", "llama-3.1"],
+    )
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    pa.PraisonAI().main()
+
+    assert calls["train_argv"] is not None
+    assert expected in calls["train_argv"], calls["train_argv"]


### PR DESCRIPTION
The `praisonai-code` unit suite had **ten reds on main**. I checked each rather than assuming. None was a code defect — every one was a test consulting something outside its own control, so it passed or failed per machine and was green on CI, where none of it is set.

That is worse than a missing test: it trains you to ignore a red suite.

---

### Seven — the developer's exported model leaked into the config resolver

`ConfigResolver._load_env_config` folds `MODEL_NAME` / `OPENAI_MODEL_NAME` / `PRAISONAI_MODEL` and friends into an `"environment"` layer. Exporting those is the normal way to use this tool, so:

```
assert ['defaults', 'environment'] == ['defaults']
assert 'gpt-4o-mini' == 'claude-3-5-sonnet'
```

Both `MODEL_NAME` and `OPENAI_MODEL_NAME` were set here, which is why unsetting either alone changed nothing.

A new `tests/unit/conftest.py` provides `isolated_config_env`, and the two affected modules opt in with a module-level `usefixtures` mark. **`test_config_env_isolation.py` keeps the scrub list honest** by parsing `_load_env_config` — a variable added there and not listed would silently reopen the leak. It reads only the `("VAR", [path])` mapping entries and `os.environ.get` calls, *not* every uppercase string: the bare suffixes in `endswith(("COLOR", "VERBOSE", "QUIET"))` are not variables, and counting them would make the guard demand the fixture scrub names that don't exist.

### One — the trainer assertion depended on which packages were installed

The dispatcher prefers `praisonai_train` (the owner package since the C10 extraction) and falls back to the `praisonai.train.*` shim. **That code is correct.** The test asserted the owner branch without controlling the condition, so it was red on a checkout without `praisonai-train` on the path and green with it. Both branches are now driven explicitly, by patching `train_package_available` at `_train_bridge` — where the dispatch function imports it from.

### One — a command migrated to native was still listed as a stub

The stub table asserts exit 1 without the wrapper. `448b7bb912` made `rules` **native** to standalone praisonai-code (#4337) and the table was never updated, so this had been red ever since. It's the opposite assertion now — the point of that change is that it works with no wrapper — and `HOME` is redirected, because it was otherwise listing the developer's real rules.

### One — a signature check that couldn't see through `**kwargs`

`test_custom_agent_verbose_maps_to_output_preset` asserted the captured kwargs are a subset of `Agent.__init__`'s named parameters. `Agent` takes `**kwargs` and stores extras as attributes, so a legitimate `auto_save` (set by the session wiring) was flagged.

Binding against the signature is no better — `**kwargs` accepts even the `verbose` this test exists to catch. **Only the constructor knows**: it validates kwargs itself and raises for names that have moved. The test now constructs a real `Agent`. Mutation-checked — re-introducing `agent_config["verbose"]` fails it.

---

### Verification

Suite: **989 passed, 0 failed, 0 errors** (was 10 failed). Every fix verified with the developer's environment variables still exported, which is the condition that produced the reds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Circuit breakers now handle tool timeouts correctly, preventing premature openings or closures while still opening after repeated timeouts.
  - Unknown tools now return actionable errors with available tool names instead of terminating execution.
  - External-tool trust checks now fail closed when registry lookups fail, improving safety.
  - The `rules` command now runs successfully as a native `praisonai-code` command without requiring a wrapper.
  - Git root identification remains stable across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->