### PR TITLE
fix(core): make four accepted-and-ignored config knobs real

### DIFF
--- a/src/praisonai-agents/AGENTS.md
+++ b/src/praisonai-agents/AGENTS.md
@@ -514,7 +514,7 @@ agent = Agent(
     name="assistant",
     llm="gpt-4o-mini",
     memory=MemoryConfig(provider="chroma", use_long_term=True),
-    hooks=HooksConfig(before_tool=[my_validator]),
+    hooks=HooksConfig(on_tool_call=my_tool_logger, middleware=[my_validator]),
     guardrail=my_guardrail
 )
 ```

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -1362,7 +1362,18 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
                 _hooks_list = _hooks_config
             elif isinstance(_hooks_config, HooksConfig):
                 step_callback = _hooks_config.on_step
-                _hooks_list = _hooks_config.middleware or []
+                _hooks_list = list(_hooks_config.middleware or [])
+                # Route on_step / on_tool_call onto the SAME middleware chain
+                # that already powers ``hooks=[...]`` (MiddlewareManager). Both
+                # keys used to be stored-and-never-called, so the TypeError that
+                # advertises them ("Valid keys: on_step, on_tool_call,
+                # middleware") promised behaviour that did not exist.
+                if _hooks_config.on_step is not None or _hooks_config.on_tool_call is not None:
+                    from ..hooks.middleware import as_step_hook, as_tool_call_hook
+                    if _hooks_config.on_step is not None:
+                        _hooks_list.append(as_step_hook(_hooks_config.on_step))
+                    if _hooks_config.on_tool_call is not None:
+                        _hooks_list.append(as_tool_call_hook(_hooks_config.on_tool_call))
         
         # ─────────────────────────────────────────────────────────────────────
         # Resolve SKILLS param - FAST PATH
@@ -2570,6 +2581,18 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
         
         # Store ExecutionConfig for context compaction policy access
         self.execution = _exec_config
+
+        # ExecutionConfig(code_execution=True) actually grants the capability.
+        # Before this, the flag only set ``self.allow_code_execution`` and no
+        # code tool was ever produced, so the knob was accepted and ignored.
+        #
+        # The tool is named ``execute_code``, which is registered "critical" in
+        # approval/registry.py, so it is approval-gated under every preset but
+        # ``"full"`` — the privilege-escalation problem that got the old
+        # ``sandbox=``-injects-tools behaviour reverted does not apply here, and
+        # unlike ``sandbox=`` this is an explicit opt-in by the caller.
+        if allow_code_execution:
+            self._attach_code_execution_tools(code_execution_mode, _exec_config)
         # Async-safe chat_history with dual-lock protection
         self.__chat_history_state = AsyncSafeState([])
         
@@ -4030,6 +4053,45 @@ Summary:"""
             return f"Agent {self._agent_index}"
         return "Agent"
     
+    def _attach_code_execution_tools(self, code_execution_mode: str, exec_config: Any) -> None:
+        """Give the model a code-execution tool for ``code_execution=True``.
+
+        ``code_mode`` is a real switch, not a label:
+
+        * ``"safe"``  -> subprocess isolation, no tool access from the code.
+        * ``"unsafe"`` -> same process, restricted builtins, and the
+          ``code_tools_allow`` allow-list injected as callable tool proxies.
+
+        Both expose one tool named ``execute_code``, which the approval registry
+        classes as "critical", so it stays gated under every preset but "full".
+        """
+        from ..tools.python_tools import build_code_execution_tools
+
+        code_tools = bool(getattr(exec_config, "code_tools", False))
+        allowed = list(getattr(exec_config, "code_tools_allow", None) or [])
+        if code_tools and code_execution_mode != "unsafe":
+            import warnings
+            warnings.warn(
+                "ExecutionConfig(code_tools=True) needs code_mode='unsafe': in "
+                "'safe' mode the code runs in a separate process and cannot "
+                "reach the agent's tools, so code_tools_allow is ignored.",
+                UserWarning,
+                stacklevel=3,
+            )
+            code_tools = False
+
+        # An unknown code_mode raises out of here rather than silently
+        # producing nothing, which is the failure this whole change is about.
+        new_tools = build_code_execution_tools(
+            code_mode=code_execution_mode,
+            allowed_tools=allowed if code_tools else [],
+        )
+
+        existing = {getattr(t, "__name__", None) for t in (self.tools or [])}
+        self.tools = list(self.tools or []) + [
+            t for t in new_tools if getattr(t, "__name__", None) not in existing
+        ]
+
     def _init_autonomy(self, autonomy: Any, verification_hooks: Optional[List[Any]] = None) -> None:
         """Initialize autonomy features (agent-centric escalation/doom-loop).
         

--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -4080,11 +4080,28 @@ Summary:"""
             )
             code_tools = False
 
+        # In unsafe mode the allow-list must resolve against ONLY the tools this
+        # agent was granted, never the process-global registry (which can hold
+        # plugin/entry-point tools the agent was never given). Build a private
+        # registry from self.tools and pass it down so code-mode inherits the
+        # agent's exact tool boundary.
+        scoped_registry = None
+        if code_tools and code_execution_mode == "unsafe":
+            from ..tools.registry import ToolRegistry
+            scoped_registry = ToolRegistry()
+            for t in (self.tools or []):
+                if callable(t) or hasattr(t, "name"):
+                    try:
+                        scoped_registry.register(t)
+                    except Exception:
+                        pass
+
         # An unknown code_mode raises out of here rather than silently
         # producing nothing, which is the failure this whole change is about.
         new_tools = build_code_execution_tools(
             code_mode=code_execution_mode,
             allowed_tools=allowed if code_tools else [],
+            registry=scoped_registry,
         )
 
         existing = {getattr(t, "__name__", None) for t in (self.tools or [])}

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -838,7 +838,68 @@ class AgentTeam(SpawnAnnounceProtocol):
         The class was renamed from `AgentManager` to `AgentTeam` in v1.0.
         `AgentManager` and `Agents` remain as silent aliases for backward compatibility.
     """
-    
+
+    @staticmethod
+    def _adapt_single_agent_execution_config(execution, multi_agent_cls):
+        """Accept the single-agent ``ExecutionConfig`` on a team, loudly.
+
+        ``ExecutionConfig`` is exported at the package top level;
+        ``MultiAgentExecutionConfig`` is not, so ``AgentTeam(execution=
+        ExecutionConfig(max_iter=99))`` is an easy and natural mistake. It used
+        to be resolved against the wrong class and silently discarded whole.
+
+        Shared fields are carried over (``max_iter``; ``max_retry_limit`` ->
+        ``max_retries``) and a ``UserWarning`` names the right class and lists
+        any settings that have no team-level counterpart.
+        """
+        if execution is None or multi_agent_cls is None:
+            return execution
+        if isinstance(execution, multi_agent_cls):
+            return execution
+        try:
+            from ..config.feature_configs import ExecutionConfig
+        except ImportError:
+            return execution
+        if not isinstance(execution, ExecutionConfig):
+            return execution
+
+        import warnings
+        from dataclasses import fields as _dc_fields
+
+        defaults = ExecutionConfig()
+        carried = {
+            "max_iter": execution.max_iter,
+            "max_retries": execution.max_retry_limit,
+        }
+        shared = {"max_iter", "max_retry_limit"}
+
+        def _is_set(name):
+            # A user object with an exotic __eq__ must not blow up the warning
+            # path; treat an uncomparable value as explicitly set.
+            try:
+                return getattr(execution, name) != getattr(defaults, name)
+            except Exception:
+                return True
+
+        dropped = sorted(
+            f.name for f in _dc_fields(execution)
+            if f.name not in shared and _is_set(f.name)
+        )
+        message = (
+            "AgentTeam(execution=...) expects MultiAgentExecutionConfig, not the "
+            "single-agent ExecutionConfig. max_iter and max_retry_limit were "
+            "carried over; pass MultiAgentExecutionConfig(max_iter=..., "
+            "max_retries=...) at the team level and ExecutionConfig(...) to the "
+            "individual Agent(...) instances."
+        )
+        if dropped:
+            message += (
+                " These settings have no team-level counterpart and were "
+                f"ignored: {', '.join(dropped)}."
+            )
+        warnings.warn(message, UserWarning, stacklevel=3)
+        return multi_agent_cls(**carried)
+
     def __init__(
         self,
         agents,
@@ -988,6 +1049,14 @@ class AgentTeam(SpawnAnnounceProtocol):
         # Resolve EXECUTION param using canonical resolver
         # Supports: None, str preset, list [preset, overrides], Config, dict
         # ─────────────────────────────────────────────────────────────────────
+        # The top-level-exported ``ExecutionConfig`` is the *single-agent* class;
+        # this container's own class is ``MultiAgentExecutionConfig``. Passing
+        # the exported one used to be resolved against the wrong class and
+        # dropped whole - including ``max_iter``, which both classes define -
+        # with no error and no warning. Adapt the shared fields and say so.
+        execution = self._adapt_single_agent_execution_config(
+            execution, MultiAgentExecutionConfig
+        )
         _exec_config = resolve(
             value=execution,
             param_name="execution",

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -850,7 +850,11 @@ class AgentTeam(SpawnAnnounceProtocol):
 
         Shared fields are carried over (``max_iter``; ``max_retry_limit`` ->
         ``max_retries``) and a ``UserWarning`` names the right class and lists
-        any settings that have no team-level counterpart.
+        any settings that have no team-level counterpart. A shared field is only
+        carried when the caller actually changed it, so the team keeps its own
+        defaults for anything left untouched (``ExecutionConfig.max_retry_limit``
+        defaults to 2, but the team default ``max_retries`` is 5 — an
+        ``ExecutionConfig(max_iter=99)`` must not silently drop team retries).
         """
         if execution is None or multi_agent_cls is None:
             return execution
@@ -867,10 +871,6 @@ class AgentTeam(SpawnAnnounceProtocol):
         from dataclasses import fields as _dc_fields
 
         defaults = ExecutionConfig()
-        carried = {
-            "max_iter": execution.max_iter,
-            "max_retries": execution.max_retry_limit,
-        }
         shared = {"max_iter", "max_retry_limit"}
 
         def _is_set(name):
@@ -880,6 +880,14 @@ class AgentTeam(SpawnAnnounceProtocol):
                 return getattr(execution, name) != getattr(defaults, name)
             except Exception:
                 return True
+
+        # Only carry a shared field when the caller changed it; otherwise let
+        # the team config keep its own (different) default.
+        carried = {}
+        if _is_set("max_iter"):
+            carried["max_iter"] = execution.max_iter
+        if _is_set("max_retry_limit"):
+            carried["max_retries"] = execution.max_retry_limit
 
         dropped = sorted(
             f.name for f in _dc_fields(execution)

--- a/src/praisonai-agents/praisonaiagents/config/feature_configs.py
+++ b/src/praisonai-agents/praisonaiagents/config/feature_configs.py
@@ -1372,10 +1372,14 @@ class HooksConfig:
             middleware=[my_middleware],
         ))
     """
-    # Step callback
+    # Step callback: invoked once per agent step (one model call) with the
+    # ``ModelResponse`` for that step. Routed onto the ``after_model``
+    # middleware slot; the return value is ignored.
     on_step: Optional[Callable] = None
     
-    # Tool call callback
+    # Tool call callback: invoked before every tool the agent executes with the
+    # ``ToolRequest`` (``.tool_name`` / ``.arguments``). Routed onto the
+    # ``before_tool`` middleware slot; the return value is ignored.
     on_tool_call: Optional[Callable] = None
     
     # Middleware list

--- a/src/praisonai-agents/praisonaiagents/context/store.py
+++ b/src/praisonai-agents/praisonaiagents/context/store.py
@@ -463,7 +463,23 @@ _global_store: Optional[ContextStoreImpl] = None
 _store_lock = threading.Lock()
 
 def get_global_store(validate_schema: bool = False) -> ContextStoreImpl:
-    """Get or create global context store."""
+    """Get or create the process-local context store.
+
+    IMPORTANT - what this is *not*:
+
+    * It is an **in-memory singleton scoped to the current process**. It is not
+      persisted and it is not shared with any other process, so a separate CLI
+      invocation can never observe a store an agent run populated.
+    * **Nothing in the agent runtime writes to it.** ``Agent.chat_history`` and
+      the session/memory subsystems keep their own state; this store is an
+      opt-in structure that a caller must populate itself via
+      ``get_mutator(agent_id).append(...)`` + ``commit()`` or
+      :meth:`ContextStoreImpl.add_shared_context`.
+
+    A freshly obtained store is therefore always empty. Callers that report on
+    it (stats/compaction/export) must say so rather than reporting success on
+    an empty store.
+    """
     global _global_store
     
     with _store_lock:

--- a/src/praisonai-agents/praisonaiagents/context/store.py
+++ b/src/praisonai-agents/praisonaiagents/context/store.py
@@ -468,17 +468,20 @@ def get_global_store(validate_schema: bool = False) -> ContextStoreImpl:
     IMPORTANT - what this is *not*:
 
     * It is an **in-memory singleton scoped to the current process**. It is not
-      persisted and it is not shared with any other process, so a separate CLI
-      invocation can never observe a store an agent run populated.
+      *automatically* persisted and it is not shared with any other process, so
+      a separate CLI invocation can never observe a store an agent run
+      populated; sharing across processes requires explicit
+      :meth:`ContextStoreImpl.snapshot` / :meth:`ContextStoreImpl.restore`.
     * **Nothing in the agent runtime writes to it.** ``Agent.chat_history`` and
       the session/memory subsystems keep their own state; this store is an
       opt-in structure that a caller must populate itself via
       ``get_mutator(agent_id).append(...)`` + ``commit()`` or
       :meth:`ContextStoreImpl.add_shared_context`.
 
-    A freshly obtained store is therefore always empty. Callers that report on
-    it (stats/compaction/export) must say so rather than reporting success on
-    an empty store.
+    A store is therefore empty when first created and only holds what a caller
+    put in it during this process; the same singleton is returned on later
+    calls, so it may already contain data. Callers that report on it
+    (stats/compaction/export) must not report success on an empty store.
     """
     global _global_store
     

--- a/src/praisonai-agents/praisonaiagents/hooks/middleware.py
+++ b/src/praisonai-agents/praisonaiagents/hooks/middleware.py
@@ -29,6 +29,8 @@ Usage:
     agent = Agent(name="Test", hooks=[add_context, retry_on_error])
 """
 
+import asyncio
+import inspect
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Generic
 from functools import wraps
@@ -291,6 +293,28 @@ def wrap_tool_call(func: WrapToolCallFn) -> WrapToolCallFn:
     return func
 
 
+def _invoke_observer(callback: Callable[[Any], Any], arg: Any) -> None:
+    """Call an observer callback, awaiting it if it returns a coroutine.
+
+    ``HooksConfig(on_step=...)`` / ``on_tool_call=...`` accept any ``Callable``,
+    so an ``async def`` is permitted. Calling it synchronously would create a
+    coroutine that is never awaited (a silent no-op plus a RuntimeWarning), so a
+    returned coroutine is drained here: run to completion on a fresh loop when
+    none is running, otherwise scheduled on the running loop. The return value
+    is always ignored — these are observers.
+    """
+    result = callback(arg)
+    if inspect.iscoroutine(result):
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is not None:
+            loop.create_task(result)
+        else:
+            asyncio.run(result)
+
+
 def as_step_hook(callback: Callable[[Any], Any]) -> AfterModelFn:
     """Adapt a plain ``on_step`` callback into an ``after_model`` middleware hook.
 
@@ -303,7 +327,7 @@ def as_step_hook(callback: Callable[[Any], Any]) -> AfterModelFn:
 
     @after_model
     def _on_step(response: ModelResponse) -> ModelResponse:
-        callback(response)
+        _invoke_observer(callback, response)
         return response
 
     _on_step.__name__ = getattr(callback, "__name__", "on_step")
@@ -322,7 +346,7 @@ def as_tool_call_hook(callback: Callable[[Any], Any]) -> BeforeToolFn:
 
     @before_tool
     def _on_tool_call(request: ToolRequest) -> ToolRequest:
-        callback(request)
+        _invoke_observer(callback, request)
         return request
 
     _on_tool_call.__name__ = getattr(callback, "__name__", "on_tool_call")

--- a/src/praisonai-agents/praisonaiagents/hooks/middleware.py
+++ b/src/praisonai-agents/praisonaiagents/hooks/middleware.py
@@ -291,6 +291,44 @@ def wrap_tool_call(func: WrapToolCallFn) -> WrapToolCallFn:
     return func
 
 
+def as_step_hook(callback: Callable[[Any], Any]) -> AfterModelFn:
+    """Adapt a plain ``on_step`` callback into an ``after_model`` middleware hook.
+
+    ``HooksConfig(on_step=...)`` advertises "called once per agent step". An
+    agent step is one model call, so the callback is routed onto the existing
+    ``after_model`` middleware slot: it is invoked with the :class:`ModelResponse`
+    for the step and its return value is ignored (the response passes through
+    unchanged, so an observer can never corrupt the run).
+    """
+
+    @after_model
+    def _on_step(response: ModelResponse) -> ModelResponse:
+        callback(response)
+        return response
+
+    _on_step.__name__ = getattr(callback, "__name__", "on_step")
+    return _on_step
+
+
+def as_tool_call_hook(callback: Callable[[Any], Any]) -> BeforeToolFn:
+    """Adapt a plain ``on_tool_call`` callback into a ``before_tool`` hook.
+
+    ``HooksConfig(on_tool_call=...)`` is routed onto the existing ``before_tool``
+    middleware slot, so it fires for every tool the agent executes (sync and
+    async paths both run through :class:`MiddlewareManager`). The callback
+    receives the :class:`ToolRequest`; its return value is ignored so the
+    request passes through unchanged.
+    """
+
+    @before_tool
+    def _on_tool_call(request: ToolRequest) -> ToolRequest:
+        callback(request)
+        return request
+
+    _on_tool_call.__name__ = getattr(callback, "__name__", "on_tool_call")
+    return _on_tool_call
+
+
 def get_hook_type(func: Callable) -> Optional[str]:
     """Get the hook type of a decorated function."""
     return getattr(func, '_hook_type', None)

--- a/src/praisonai-agents/praisonaiagents/tools/python_tools.py
+++ b/src/praisonai-agents/praisonaiagents/tools/python_tools.py
@@ -289,14 +289,19 @@ def safe_execute():
         
         # Execute user code (use safe_globals as both globals AND locals
         # so function defs can see each other)
-        compiled_code = compile(user_code, '<string>', 'exec')
+        # Split off a trailing expression statement BEFORE executing so it runs
+        # exactly once; exec-then-re-eval ran `print(x)` (and any trailing call)
+        # twice.
+        _last_expr = None
+        if tree.body and isinstance(tree.body[-1], ast.Expr):
+            _last_expr = tree.body.pop()
+        compiled_code = compile(tree, '<string>', 'exec')
         exec(compiled_code, safe_globals)
         
         # Try to get result from last expression
-        tree = ast.parse(user_code)
-        if tree.body and isinstance(tree.body[-1], ast.Expr):
+        if _last_expr is not None:
             result = eval(
-                compile(ast.Expression(tree.body[-1].value), '<string>', 'eval'),
+                compile(ast.Expression(_last_expr.value), '<string>', 'eval'),
                 safe_globals
             )
         
@@ -641,24 +646,29 @@ def _execute_code_direct(
         stderr_buffer = io.StringIO()
 
         try:
-            # Compile code with restricted mode
-            compiled_code = compile(code, '<string>', 'exec')
+            # Split off a trailing expression statement BEFORE executing, so
+            # it is evaluated exactly once. Executing the whole module and then
+            # re-eval'ing the last expression ran it twice: `print(x)` printed
+            # twice, and in code mode a trailing `my_tool(...)` called the tool
+            # twice (doubling its side effects).
+            import ast
+            tree = ast.parse(code)
+            last_expr = None
+            if tree.body and isinstance(tree.body[-1], ast.Expr):
+                last_expr = tree.body.pop()
+            compiled_code = compile(tree, '<string>', 'exec')
+            compiled_expr = (
+                compile(ast.Expression(last_expr.value), '<string>', 'eval')
+                if last_expr is not None else None
+            )
 
             # Execute with output capture
             with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
                 exec(compiled_code, globals_dict, locals_dict)
-
-                # Get last expression value if any
-                import ast
-                tree = ast.parse(code)
-                if tree.body and isinstance(tree.body[-1], ast.Expr):
-                    result = eval(
-                        compile(ast.Expression(tree.body[-1].value), '<string>', 'eval'),
-                        globals_dict,
-                        locals_dict
-                    )
-                else:
-                    result = None
+                result = (
+                    eval(compiled_expr, globals_dict, locals_dict)
+                    if compiled_expr is not None else None
+                )
 
             # Get output
             stdout = stdout_buffer.getvalue()
@@ -963,6 +973,74 @@ class PythonTools:
 
 # Lazy accessors for optional-dep tools (PythonTools requires black/pylint/autopep8)
 # execute_code is already a standalone function above — always available.
+
+# ──────────────────────────────────────────────────────────────────────
+# Agent-facing code-execution tool factory
+# ──────────────────────────────────────────────────────────────────────
+
+def _build_unsafe_execute_code(allowed_tools: List[str], timeout: int = 30):
+    """Build the in-process ``execute_code`` tool for ``code_mode="unsafe"``."""
+
+    @require_approval(risk_level="critical")
+    def execute_code(code: str) -> Dict[str, Any]:
+        """Execute Python code in this process and return its output.
+
+        Runs with restricted builtins but WITHOUT process isolation, and the
+        agent's allow-listed tools are callable from the code by bare name.
+
+        Args:
+            code: Python code to execute.
+
+        Returns:
+            Dict with ``result``, ``stdout``, ``stderr`` and ``success``.
+        """
+        return execute_code_with_tools(
+            code, allowed_tools=allowed_tools, timeout=timeout
+        )
+
+    return execute_code
+
+
+def build_code_execution_tools(
+    code_mode: str = "safe",
+    allowed_tools: Optional[List[str]] = None,
+    timeout: int = 30,
+) -> List[Any]:
+    """Return the code-execution tools for ``ExecutionConfig(code_execution=True)``.
+
+    This is the production entry point that makes the ``code_execution`` flag
+    real. Both modes expose a single tool literally named ``execute_code``, which
+    is registered "critical" in :mod:`praisonaiagents.approval.registry`, so the
+    tool the model gains is approval-gated by every preset except ``"full"``.
+
+    ``code_mode`` decides what that tool actually does, so the security-shaped
+    knob is not decorative:
+
+    * ``"safe"`` (default) — subprocess isolation with resource limits and a
+      clean environment (``execute_code(..., sandbox_mode="sandbox")``). Tools
+      are NOT reachable from the code: they live in the parent process.
+    * ``"unsafe"`` — same-process execution with restricted builtins, no
+      isolation, and the ``allowed_tools`` allow-list injected as callable
+      proxies (each proxy call still passes the approval gate).
+
+    Args:
+        code_mode: ``"safe"`` or ``"unsafe"``.
+        allowed_tools: Tool names callable from code; only honoured in
+            ``"unsafe"`` mode. Empty/None exposes no tools.
+        timeout: Per-execution timeout in seconds.
+
+    Returns:
+        A one-element list holding the ``execute_code`` tool.
+    """
+    if code_mode not in ("safe", "unsafe"):
+        raise ValueError(
+            f"Unknown code_mode {code_mode!r}; expected 'safe' or 'unsafe'."
+        )
+    if code_mode == "unsafe":
+        return [_build_unsafe_execute_code(list(allowed_tools or []), timeout=timeout)]
+    return [execute_code]
+
+
 def _get_python_tools():
     """Lazy-init PythonTools (requires black/pylint/autopep8)."""
     global _python_tools_instance

--- a/src/praisonai-agents/praisonaiagents/tools/python_tools.py
+++ b/src/praisonai-agents/praisonaiagents/tools/python_tools.py
@@ -978,8 +978,16 @@ class PythonTools:
 # Agent-facing code-execution tool factory
 # ──────────────────────────────────────────────────────────────────────
 
-def _build_unsafe_execute_code(allowed_tools: List[str], timeout: int = 30):
-    """Build the in-process ``execute_code`` tool for ``code_mode="unsafe"``."""
+def _build_unsafe_execute_code(
+    allowed_tools: List[str], timeout: int = 30, registry: Optional[Any] = None
+):
+    """Build the in-process ``execute_code`` tool for ``code_mode="unsafe"``.
+
+    ``registry`` scopes which tools the allow-list can resolve. The agent passes
+    a registry built from its own granted tools so code-mode cannot reach a
+    globally-registered tool (e.g. a plugin entry-point tool) the agent was
+    never given; omitting it falls back to the global registry.
+    """
 
     @require_approval(risk_level="critical")
     def execute_code(code: str) -> Dict[str, Any]:
@@ -995,7 +1003,7 @@ def _build_unsafe_execute_code(allowed_tools: List[str], timeout: int = 30):
             Dict with ``result``, ``stdout``, ``stderr`` and ``success``.
         """
         return execute_code_with_tools(
-            code, allowed_tools=allowed_tools, timeout=timeout
+            code, allowed_tools=allowed_tools, timeout=timeout, registry=registry
         )
 
     return execute_code
@@ -1005,6 +1013,7 @@ def build_code_execution_tools(
     code_mode: str = "safe",
     allowed_tools: Optional[List[str]] = None,
     timeout: int = 30,
+    registry: Optional[Any] = None,
 ) -> List[Any]:
     """Return the code-execution tools for ``ExecutionConfig(code_execution=True)``.
 
@@ -1021,7 +1030,11 @@ def build_code_execution_tools(
       are NOT reachable from the code: they live in the parent process.
     * ``"unsafe"`` — same-process execution with restricted builtins, no
       isolation, and the ``allowed_tools`` allow-list injected as callable
-      proxies (each proxy call still passes the approval gate).
+      proxies (each proxy call still passes the approval gate). Because the code
+      runs in this process, ``timeout`` is NOT enforced in unsafe mode — a
+      runaway loop can block the worker. This is why unsafe mode is opt-in and
+      approval-gated "critical"; use ``"safe"`` (subprocess) when the timeout
+      must be a hard guarantee.
 
     Args:
         code_mode: ``"safe"`` or ``"unsafe"``.
@@ -1037,8 +1050,32 @@ def build_code_execution_tools(
             f"Unknown code_mode {code_mode!r}; expected 'safe' or 'unsafe'."
         )
     if code_mode == "unsafe":
-        return [_build_unsafe_execute_code(list(allowed_tools or []), timeout=timeout)]
-    return [execute_code]
+        return [
+            _build_unsafe_execute_code(
+                list(allowed_tools or []), timeout=timeout, registry=registry
+            )
+        ]
+
+    # Safe mode: bind the configured timeout to the tool the model sees, so a
+    # model call that passes only ``code`` still gets the caller's timeout
+    # rather than execute_code's 30s default. The default timeout returns the
+    # module-level tool unchanged so its identity is preserved for callers.
+    if timeout == 30:
+        return [execute_code]
+
+    def execute_code_timed(code: str) -> Dict[str, Any]:
+        """Execute Python code in an isolated subprocess and return its output.
+
+        Args:
+            code: Python code to execute.
+
+        Returns:
+            Dict with ``result``, ``stdout``, ``stderr`` and ``success``.
+        """
+        return execute_code(code, timeout=timeout)
+
+    execute_code_timed.__name__ = "execute_code"
+    return [execute_code_timed]
 
 
 def _get_python_tools():

--- a/src/praisonai-agents/praisonaiagents/tools/tool_proxy.py
+++ b/src/praisonai-agents/praisonaiagents/tools/tool_proxy.py
@@ -88,7 +88,12 @@ def serve_tool_call(
     subject to the same policy as an in-process one — never a weaker path.
     """
     allowed_set = frozenset(allowed)
-    resolved_registry = registry or get_registry()
+    # ``registry is not None`` (not truthiness): an empty ToolRegistry is a
+    # meaningful, deliberate boundary ("this agent granted no tools"), and
+    # ToolRegistry is falsy when empty (__len__), so ``registry or ...`` would
+    # silently fall back to the process-global registry and leak un-granted
+    # tools into code mode.
+    resolved_registry = registry if registry is not None else get_registry()
     if name not in allowed_set:
         raise PermissionError(f"tool '{name}' is not allowed from code")
     tool = resolved_registry.get(name)
@@ -232,7 +237,9 @@ class ToolProxy:
         registry: Optional[ToolRegistry] = None,
     ) -> None:
         allowed_set = frozenset(allowed)
-        resolved_registry = registry or get_registry()
+        # ``is not None`` so an explicitly-passed empty (agent-scoped) registry
+        # is honoured rather than falling back to the global one.
+        resolved_registry = registry if registry is not None else get_registry()
 
         def _getter(name: str) -> Callable[..., Any]:
             return _make_proxy(name, allowed_set, resolved_registry)
@@ -280,7 +287,9 @@ def build_tool_namespace(
     ``tools.fetch(...)`` form via :class:`ToolProxy`.
     """
     allowed_set = frozenset(allowed)
-    resolved_registry = registry or get_registry()
+    # ``is not None`` so an explicitly-passed empty (agent-scoped) registry is
+    # honoured rather than falling back to the global one.
+    resolved_registry = registry if registry is not None else get_registry()
     namespace: Dict[str, Callable[..., Any]] = {}
     for name in sorted(allowed_set):
         try:

--- a/src/praisonai-agents/tests/unit/test_accepted_and_ignored_config.py
+++ b/src/praisonai-agents/tests/unit/test_accepted_and_ignored_config.py
@@ -21,6 +21,27 @@ from praisonaiagents.config import HooksConfig
 from praisonaiagents.config.feature_configs import MultiAgentExecutionConfig
 
 
+@pytest.fixture(autouse=True)
+def _restore_approval_state():
+    """Keep approval backend + context from leaking between tests.
+
+    Several tests here install an ``AutoApproveBackend`` to exercise the
+    approval-gated ``execute_code`` tool. Without this the backend (and any
+    sticky per-tool approval) would bleed into later tests in the same process
+    and silently auto-approve their gates -- violating the deterministic-tests
+    invariant.
+    """
+    from praisonaiagents.approval import get_approval_registry, clear_approval_context
+
+    registry = get_approval_registry()
+    previous = registry.get_backend()
+    try:
+        yield
+    finally:
+        registry.set_backend(previous)
+        clear_approval_context()
+
+
 # ---------------------------------------------------------------------------
 # 1. HooksConfig callbacks actually fire
 # ---------------------------------------------------------------------------
@@ -120,7 +141,11 @@ def test_code_execution_tool_is_approval_gated_as_critical():
 
 def test_code_mode_changes_what_the_tool_can_do():
     """'unsafe' must mean something: in-process, with the agent's tools reachable."""
-    from praisonaiagents.approval import get_approval_registry, AutoApproveBackend
+    from praisonaiagents.approval import (
+        get_approval_registry,
+        AutoApproveBackend,
+        clear_approval_context,
+    )
     from praisonaiagents.tools.registry import get_registry
 
     def code_mode_probe() -> str:
@@ -128,17 +153,21 @@ def test_code_mode_changes_what_the_tool_can_do():
         return "PROBE-OK"
 
     get_registry().register(code_mode_probe)
-    previous = get_approval_registry()._backend if hasattr(get_approval_registry(), "_backend") else None
+    previous = get_approval_registry().get_backend()
     get_approval_registry().set_backend(AutoApproveBackend())
     try:
         safe = Agent(
             name="SafeCoder",
             instructions="test",
+            tools=[code_mode_probe],
             execution=ExecutionConfig(code_execution=True),
         )
         unsafe = Agent(
             name="UnsafeCoder",
             instructions="test",
+            # The tool is GRANTED to the agent; code mode may only reach the
+            # agent's own tools, never the process-global registry.
+            tools=[code_mode_probe],
             execution=ExecutionConfig(
                 code_execution=True,
                 code_mode="unsafe",
@@ -147,11 +176,13 @@ def test_code_mode_changes_what_the_tool_can_do():
             ),
         )
         code = "print(code_mode_probe())"
-        safe_result = safe.tools[0](code)
-        unsafe_result = unsafe.tools[0](code)
+        safe_exec = next(t for t in safe.tools if getattr(t, "__name__", None) == "execute_code")
+        unsafe_exec = next(t for t in unsafe.tools if getattr(t, "__name__", None) == "execute_code")
+        safe_result = safe_exec(code)
+        unsafe_result = unsafe_exec(code)
     finally:
-        if previous is not None:
-            get_approval_registry().set_backend(previous)
+        get_approval_registry().set_backend(previous)
+        clear_approval_context()
 
     assert unsafe_result["success"] is True
     assert "PROBE-OK" in unsafe_result["stdout"]
@@ -159,14 +190,81 @@ def test_code_mode_changes_what_the_tool_can_do():
     assert "PROBE-OK" not in (safe_result.get("stdout") or "")
 
 
+def test_unsafe_code_mode_cannot_reach_tools_the_agent_was_not_granted():
+    """A globally-registered tool NOT in the agent's tools must be unreachable.
+
+    code_tools_allow is a per-run filter, not a grant: the tool must also be one
+    the agent itself holds, or unsafe code mode would escape the agent's tool
+    boundary and reach plugin/entry-point tools it was never given.
+    """
+    from praisonaiagents.approval import (
+        get_approval_registry,
+        AutoApproveBackend,
+        clear_approval_context,
+    )
+    from praisonaiagents.tools.registry import get_registry
+
+    def ungranted_global_tool() -> str:
+        """Registered globally but never handed to the agent."""
+        return "LEAK"
+
+    get_registry().register(ungranted_global_tool)
+    previous = get_approval_registry().get_backend()
+    get_approval_registry().set_backend(AutoApproveBackend())
+    try:
+        agent = Agent(
+            name="ScopedCoder",
+            instructions="test",
+            # NB: ungranted_global_tool is NOT in tools=[...]
+            execution=ExecutionConfig(
+                code_execution=True,
+                code_mode="unsafe",
+                code_tools=True,
+                code_tools_allow=["ungranted_global_tool"],
+            ),
+        )
+        execute = next(
+            t for t in agent.tools if getattr(t, "__name__", None) == "execute_code"
+        )
+        result = execute("print(ungranted_global_tool())")
+    finally:
+        get_approval_registry().set_backend(previous)
+        clear_approval_context()
+
+    assert result["success"] is False
+    assert "LEAK" not in (result.get("stdout") or "")
+
+
+def test_async_on_step_callback_is_awaited_not_dropped():
+    """An async on_step callback must actually run, not be discarded silently."""
+    from praisonaiagents.hooks.middleware import as_step_hook
+
+    ran = {"called": False}
+
+    async def on_step(_response):
+        ran["called"] = True
+
+    hook = as_step_hook(on_step)
+    hook(object())  # sync invocation path (no running loop)
+    assert ran["called"] is True
+
+
 def test_code_execution_runs_a_trailing_expression_exactly_once():
     """exec-then-re-eval used to run a trailing expression statement twice."""
     from praisonaiagents.approval import get_approval_registry, AutoApproveBackend
     from praisonaiagents.tools.python_tools import execute_code, execute_code_with_tools
 
-    get_approval_registry().set_backend(AutoApproveBackend())
-    assert execute_code("print(7)")["stdout"] == "7\n"
-    assert execute_code_with_tools("print(7)")["stdout"] == "7\n"
+    from praisonaiagents.approval import clear_approval_context
+
+    registry = get_approval_registry()
+    previous = registry.get_backend()
+    registry.set_backend(AutoApproveBackend())
+    try:
+        assert execute_code("print(7)")["stdout"] == "7\n"
+        assert execute_code_with_tools("print(7)")["stdout"] == "7\n"
+    finally:
+        registry.set_backend(previous)
+        clear_approval_context()
 
 
 def test_unknown_code_mode_is_rejected():
@@ -205,6 +303,39 @@ def test_team_accepts_single_agent_execution_config_and_warns():
     assert team.max_iter == 99, "max_iter was silently dropped"
     messages = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
     assert any("MultiAgentExecutionConfig" in m for m in messages), messages
+
+
+def test_team_keeps_its_retry_default_when_execution_config_untouched():
+    """An ExecutionConfig(max_iter=99) must not drag the team's retries down.
+
+    ExecutionConfig.max_retry_limit defaults to 2; MultiAgentExecutionConfig
+    .max_retries defaults to 5. Carrying the untouched single-agent default
+    would silently reduce team retries, so it must be left alone.
+    """
+    agent = Agent(name="TeamRetryMember", instructions="test")
+
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        team = AgentTeam(agents=[agent], execution=ExecutionConfig(max_iter=99))
+
+    default_team = AgentTeam(
+        agents=[Agent(name="DefaultRetryMember", instructions="test")],
+        execution=MultiAgentExecutionConfig(max_iter=99),
+    )
+    assert team.max_retries == default_team.max_retries
+
+
+def test_team_carries_retry_when_explicitly_set():
+    agent = Agent(name="ExplicitRetryMember", instructions="test")
+
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        team = AgentTeam(
+            agents=[agent],
+            execution=ExecutionConfig(max_iter=7, max_retry_limit=9),
+        )
+
+    assert team.max_retries == 9
 
 
 def test_team_warning_names_the_fields_it_cannot_carry():

--- a/src/praisonai-agents/tests/unit/test_accepted_and_ignored_config.py
+++ b/src/praisonai-agents/tests/unit/test_accepted_and_ignored_config.py
@@ -1,0 +1,232 @@
+"""Regression tests for config knobs that were accepted and then ignored.
+
+Each test here fails on the pre-fix code:
+
+* ``HooksConfig(on_step=..., on_tool_call=...)`` -- both callbacks were stored
+  and never invoked, while the TypeError for an unknown key advertised them.
+* ``ExecutionConfig(code_execution=True)`` -- set ``allow_code_execution`` and
+  produced no tool, so the agent gained no capability; ``code_mode`` was a
+  security-shaped label with no behaviour behind it.
+* ``AgentTeam(execution=ExecutionConfig(...))`` -- the top-level-exported
+  single-agent config was resolved against ``MultiAgentExecutionConfig`` and
+  dropped whole, silently, including the ``max_iter`` both classes define.
+"""
+
+import warnings
+
+import pytest
+
+from praisonaiagents import Agent, AgentTeam, ExecutionConfig
+from praisonaiagents.config import HooksConfig
+from praisonaiagents.config.feature_configs import MultiAgentExecutionConfig
+
+
+# ---------------------------------------------------------------------------
+# 1. HooksConfig callbacks actually fire
+# ---------------------------------------------------------------------------
+
+def _adder(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+def test_hooks_config_on_tool_call_fires_on_every_tool():
+    seen = []
+    agent = Agent(
+        name="HookToolAgent",
+        instructions="test",
+        tools=[_adder],
+        hooks=HooksConfig(on_tool_call=seen.append),
+    )
+
+    assert agent.execute_tool("_adder", {"a": 1, "b": 2}) == 3
+
+    assert len(seen) == 1, "on_tool_call was never invoked"
+    assert seen[0].tool_name == "_adder"
+    assert seen[0].arguments == {"a": 1, "b": 2}
+
+
+def test_hooks_config_on_step_fires_once_per_model_call():
+    seen = []
+    agent = Agent(
+        name="HookStepAgent",
+        instructions="test",
+        hooks=HooksConfig(on_step=seen.append),
+    )
+    agent._chat_completion_with_retry_core = lambda *a, **k: "hello"
+
+    out = agent._chat_completion_with_retry([{"role": "user", "content": "hi"}])
+
+    assert out == "hello", "on_step must not change the model result"
+    assert len(seen) == 1, "on_step was never invoked"
+    assert seen[0].content == "hello"
+
+
+def test_hooks_config_middleware_still_works_alongside_callbacks():
+    from praisonaiagents.hooks import before_tool
+
+    order = []
+
+    @before_tool
+    def mw(request):
+        order.append("middleware")
+        return request
+
+    agent = Agent(
+        name="HookBothAgent",
+        instructions="test",
+        tools=[_adder],
+        hooks=HooksConfig(on_tool_call=lambda r: order.append("on_tool_call"), middleware=[mw]),
+    )
+    agent.execute_tool("_adder", {"a": 1, "b": 1})
+
+    assert order == ["middleware", "on_tool_call"]
+
+
+# ---------------------------------------------------------------------------
+# 2. ExecutionConfig(code_execution=True) grants a real capability
+# ---------------------------------------------------------------------------
+
+def _tool_names(agent):
+    return [getattr(t, "__name__", None) for t in (agent.tools or [])]
+
+
+def test_code_execution_flag_adds_a_code_tool():
+    plain = Agent(name="NoCode", instructions="test")
+    coder = Agent(
+        name="Coder",
+        instructions="test",
+        execution=ExecutionConfig(code_execution=True),
+    )
+
+    assert _tool_names(plain) == []
+    assert "execute_code" in _tool_names(coder), (
+        "ExecutionConfig(code_execution=True) produced no code tool"
+    )
+    assert coder.allow_code_execution is True
+
+
+def test_code_execution_tool_is_approval_gated_as_critical():
+    from praisonaiagents.approval import get_risk_level
+
+    coder = Agent(
+        name="CoderGated",
+        instructions="test",
+        execution=ExecutionConfig(code_execution=True),
+    )
+    tool = next(t for t in coder.tools if getattr(t, "__name__", None) == "execute_code")
+    assert getattr(tool, "_requires_approval", False) or get_risk_level("execute_code") == "critical"
+
+
+def test_code_mode_changes_what_the_tool_can_do():
+    """'unsafe' must mean something: in-process, with the agent's tools reachable."""
+    from praisonaiagents.approval import get_approval_registry, AutoApproveBackend
+    from praisonaiagents.tools.registry import get_registry
+
+    def code_mode_probe() -> str:
+        """Return a marker string."""
+        return "PROBE-OK"
+
+    get_registry().register(code_mode_probe)
+    previous = get_approval_registry()._backend if hasattr(get_approval_registry(), "_backend") else None
+    get_approval_registry().set_backend(AutoApproveBackend())
+    try:
+        safe = Agent(
+            name="SafeCoder",
+            instructions="test",
+            execution=ExecutionConfig(code_execution=True),
+        )
+        unsafe = Agent(
+            name="UnsafeCoder",
+            instructions="test",
+            execution=ExecutionConfig(
+                code_execution=True,
+                code_mode="unsafe",
+                code_tools=True,
+                code_tools_allow=["code_mode_probe"],
+            ),
+        )
+        code = "print(code_mode_probe())"
+        safe_result = safe.tools[0](code)
+        unsafe_result = unsafe.tools[0](code)
+    finally:
+        if previous is not None:
+            get_approval_registry().set_backend(previous)
+
+    assert unsafe_result["success"] is True
+    assert "PROBE-OK" in unsafe_result["stdout"]
+    # Safe mode runs in a subprocess where the parent's tools do not exist.
+    assert "PROBE-OK" not in (safe_result.get("stdout") or "")
+
+
+def test_code_execution_runs_a_trailing_expression_exactly_once():
+    """exec-then-re-eval used to run a trailing expression statement twice."""
+    from praisonaiagents.approval import get_approval_registry, AutoApproveBackend
+    from praisonaiagents.tools.python_tools import execute_code, execute_code_with_tools
+
+    get_approval_registry().set_backend(AutoApproveBackend())
+    assert execute_code("print(7)")["stdout"] == "7\n"
+    assert execute_code_with_tools("print(7)")["stdout"] == "7\n"
+
+
+def test_unknown_code_mode_is_rejected():
+    with pytest.raises(ValueError, match="code_mode"):
+        Agent(
+            name="BadMode",
+            instructions="test",
+            execution=ExecutionConfig(code_execution=True, code_mode="turbo"),
+        )
+
+
+def test_code_tools_without_unsafe_mode_warns():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Agent(
+            name="CodeToolsSafe",
+            instructions="test",
+            execution=ExecutionConfig(
+                code_execution=True, code_tools=True, code_tools_allow=["x"]
+            ),
+        )
+    assert any("code_mode='unsafe'" in str(w.message) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# 3. AgentTeam(execution=ExecutionConfig(...)) is no longer swallowed
+# ---------------------------------------------------------------------------
+
+def test_team_accepts_single_agent_execution_config_and_warns():
+    agent = Agent(name="TeamMember", instructions="test")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        team = AgentTeam(agents=[agent], execution=ExecutionConfig(max_iter=99))
+
+    assert team.max_iter == 99, "max_iter was silently dropped"
+    messages = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+    assert any("MultiAgentExecutionConfig" in m for m in messages), messages
+
+
+def test_team_warning_names_the_fields_it_cannot_carry():
+    agent = Agent(name="TeamMember2", instructions="test")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        AgentTeam(agents=[agent], execution=ExecutionConfig(max_iter=5, max_rpm=30))
+
+    messages = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+    assert any("max_rpm" in m for m in messages), messages
+
+
+def test_team_with_correct_config_does_not_warn():
+    agent = Agent(name="TeamMember3", instructions="test")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        team = AgentTeam(agents=[agent], execution=MultiAgentExecutionConfig(max_iter=42))
+
+    assert team.max_iter == 42
+    assert not [
+        w for w in caught
+        if issubclass(w.category, UserWarning) and "MultiAgentExecutionConfig" in str(w.message)
+    ]

--- a/src/praisonai/praisonai/cli/commands/context.py
+++ b/src/praisonai/praisonai/cli/commands/context.py
@@ -169,8 +169,16 @@ def context_compact(
         store = get_global_store()
         stats = store.get_stats()
 
+        # Compaction only cleans per-agent history; shared context is not
+        # compactable, so a store without agent history has nothing to compact.
         if not stats.get("agents"):
-            typer.echo(_EMPTY_STORE_MESSAGE)
+            if stats.get("shared_context_size"):
+                typer.echo(
+                    "The context store holds only shared context, which has no "
+                    "per-agent history to compact. Nothing was done."
+                )
+            else:
+                typer.echo(_EMPTY_STORE_MESSAGE)
             raise typer.Exit(1)
 
         if dry_run:
@@ -217,7 +225,11 @@ def context_export(
         
         store = get_global_store()
 
-        if not store.get_stats().get("agents"):
+        # Export serialises per-agent history AND shared context, so a store
+        # holding only shared context is still exportable and must not be
+        # rejected as empty.
+        stats = store.get_stats()
+        if not stats.get("agents") and not stats.get("shared_context_size"):
             typer.echo(_EMPTY_STORE_MESSAGE)
             raise typer.Exit(1)
 

--- a/src/praisonai/praisonai/cli/commands/context.py
+++ b/src/praisonai/praisonai/cli/commands/context.py
@@ -13,6 +13,18 @@ import typer
 
 app = typer.Typer(help="Context management")
 
+# ``praisonaiagents.context.get_global_store()`` is an in-memory, PROCESS-LOCAL
+# singleton. Nothing in the agent runtime writes to it, and even if something
+# did, a separate ``praisonai`` CLI process could never see it. These commands
+# must therefore never report success on an empty store - that is exactly the
+# "did nothing, said it worked" failure they used to produce.
+_EMPTY_STORE_MESSAGE = (
+    "The context store is empty in this process.\n"
+    "praisonaiagents.context.get_global_store() is an in-memory, process-local "
+    "store: it is not populated by agent runs, and a CLI process can never see "
+    "another process's store. Nothing was done."
+)
+
 
 @app.command("show")
 def context_show(
@@ -156,7 +168,11 @@ def context_compact(
         
         store = get_global_store()
         stats = store.get_stats()
-        
+
+        if not stats.get("agents"):
+            typer.echo(_EMPTY_STORE_MESSAGE)
+            raise typer.Exit(1)
+
         if dry_run:
             typer.echo("[Dry Run] Current store stats:")
             typer.echo(f"  Agents: {stats['agent_count']}")
@@ -165,13 +181,19 @@ def context_compact(
                 typer.echo(f"  {agent_id}: {agent_stats['message_count']} messages, {agent_stats['effective_count']} effective")
         else:
             # Cleanup orphaned parents for all agents
+            cleaned = 0
             for agent_id in stats.get("agents", {}).keys():
                 if agent and agent_id != agent:
                     continue
                 store.cleanup_agent(agent_id)
+                cleaned += 1
                 typer.echo(f"Cleaned up agent: {agent_id}")
-            
-            typer.echo("Compaction complete.")
+
+            if cleaned:
+                typer.echo(f"Compaction complete ({cleaned} agent(s)).")
+            else:
+                typer.echo(f"No agent matching {agent!r} in the context store; nothing compacted.")
+                raise typer.Exit(1)
             
     except ImportError as e:
         typer.echo(f"Error: Context module not available: {e}", err=True)
@@ -194,7 +216,11 @@ def context_export(
         from pathlib import Path
         
         store = get_global_store()
-        
+
+        if not store.get_stats().get("agents"):
+            typer.echo(_EMPTY_STORE_MESSAGE)
+            raise typer.Exit(1)
+
         if format == "json":
             data = store.snapshot()
             output_path = Path(output)

--- a/src/praisonai/tests/unit/cli/test_context_store_honesty.py
+++ b/src/praisonai/tests/unit/cli/test_context_store_honesty.py
@@ -1,0 +1,68 @@
+"""`praisonai context compact/export` must not report success on an empty store.
+
+``praisonaiagents.context.get_global_store()`` is an in-memory, process-local
+singleton that the agent runtime never populates, so in a fresh CLI process it
+is always empty. The commands used to iterate zero agents and print
+"Compaction complete." -- success reported for work that did not happen.
+"""
+
+import pytest
+
+typer_testing = pytest.importorskip("typer.testing")
+CliRunner = typer_testing.CliRunner
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _empty_store():
+    store = pytest.importorskip("praisonaiagents.context")
+    store.reset_global_store()
+    yield
+    store.reset_global_store()
+
+
+def _app():
+    from praisonai.cli.commands.context import app
+    return app
+
+
+def test_compact_does_not_claim_success_on_an_empty_store(runner):
+    result = runner.invoke(_app(), ["compact"])
+
+    assert "Compaction complete" not in result.output, result.output
+    assert "process-local" in result.output, result.output
+    assert result.exit_code == 1
+
+
+def test_compact_dry_run_reports_the_empty_store(runner):
+    result = runner.invoke(_app(), ["compact", "--dry-run"])
+
+    assert "process-local" in result.output, result.output
+    assert result.exit_code == 1
+
+
+def test_export_does_not_write_a_file_for_an_empty_store(runner, tmp_path):
+    target = tmp_path / "ctx.json"
+    result = runner.invoke(_app(), ["export", str(target)])
+
+    assert not target.exists(), "exported a file for a store with no content"
+    assert "process-local" in result.output, result.output
+    assert result.exit_code == 1
+
+
+def test_compact_still_works_when_the_store_has_content(runner):
+    from praisonaiagents.context import get_global_store
+
+    mutator = get_global_store().get_mutator("agent-1")
+    mutator.append({"role": "user", "content": "hi"})
+    mutator.commit()
+
+    result = runner.invoke(_app(), ["compact"])
+
+    assert result.exit_code == 0, result.output
+    assert "Compaction complete" in result.output
+    assert "agent-1" in result.output

--- a/src/praisonai/tests/unit/cli/test_context_store_honesty.py
+++ b/src/praisonai/tests/unit/cli/test_context_store_honesty.py
@@ -66,3 +66,31 @@ def test_compact_still_works_when_the_store_has_content(runner):
     assert result.exit_code == 0, result.output
     assert "Compaction complete" in result.output
     assert "agent-1" in result.output
+
+
+def test_export_writes_a_shared_context_only_store(runner, tmp_path):
+    """A store holding only shared context is still exportable (snapshot()
+    serialises shared_context), so export must not reject it as empty."""
+    from praisonaiagents.context import get_global_store
+
+    get_global_store().add_shared_context({"role": "system", "content": "shared"})
+
+    target = tmp_path / "ctx.json"
+    result = runner.invoke(_app(), ["export", str(target)])
+
+    assert result.exit_code == 0, result.output
+    assert target.exists(), "shared-context-only store was rejected as empty"
+
+
+def test_compact_reports_shared_only_store_honestly(runner):
+    """Compaction cleans per-agent history only; a shared-context-only store
+    has nothing to compact and must say so rather than claim success."""
+    from praisonaiagents.context import get_global_store
+
+    get_global_store().add_shared_context({"role": "system", "content": "shared"})
+
+    result = runner.invoke(_app(), ["compact"])
+
+    assert result.exit_code == 1, result.output
+    assert "Compaction complete" not in result.output
+    assert "shared context" in result.output


### PR DESCRIPTION
## Four settings that were accepted and then ignored

All four were reproduced by running code on `origin/main` before being touched, and each fix ships with a test that fails before it and passes after. Every gate was mutation-tested: the fix was reverted and a **named** test confirmed red (9 mutations, 9 killed, every anchor asserted present before it was applied).

### 1. `Agent(hooks=HooksConfig(...))` — two of three advertised keys were inert

```
agent.step_callback -> <function on_step>     # assigned, never called
on_tool_call fired  -> 0                      # never read at all
TypeError           -> "Valid keys: on_step, on_tool_call, middleware."
```

`on_step` was stored on `self.step_callback`, which has no call site anywhere in the package. `on_tool_call` was never read. The `TypeError` for an unknown key promised both.

Fixed by routing both onto the middleware chain that already powers `hooks=[...]` (`MiddlewareManager`), rather than building anything new: `on_step` -> `after_model` (fires once per model call, with the `ModelResponse`), `on_tool_call` -> `before_tool` (fires for every tool, with the `ToolRequest`). Both are observers: the return value is ignored, so a callback cannot corrupt the run. `middleware=[...]` and `hooks=HookRegistry()` are unchanged.

### 2. `ExecutionConfig(code_execution=True)` did nothing — **wired**, not deleted

```
plain tools: []   code tools: []   allow_code_execution: True
```

Decision: **wire it.** The capability is already built, tested and security-reviewed (`execute_code`, `execute_code_with_tools`, `ToolProxy`/`build_tool_namespace`, the subprocess executor). Deleting the flag would also mean deleting `Agent(allow_code_execution=...)`'s deprecation path and the `allow_code_execution`/`code_execution_mode` fields that `config/loader.py` serialises — a much larger break for callers who wrote the flag expecting it to work. And the existing comment in `agent.py` that reverted the old `sandbox=`-injects-tools behaviour says exactly what the fix should be: *"Giving the model a sandboxed execution tool should be an explicit act by the caller, the way MCP() is."* `ExecutionConfig(code_execution=True)` **is** that explicit act.

The tool is literally named `execute_code`, which `approval/registry.py` already classes `"critical"`, so it is approval-gated under every preset but `"full"` — the privilege-escalation objection that killed the `sandbox=` injection does not apply.

`code_mode` now decides behaviour rather than labelling it:

| `code_mode` | isolation | tools reachable from the code |
|---|---|---|
| `"safe"` (default) | subprocess, resource limits, clean env | no |
| `"unsafe"` | same process, restricted builtins | yes, `code_tools_allow` via proxies (each still approval-gated) |

Proved by running the same source in both:

```
SAFE  : success=False  stdout=''
UNSAFE: success=True   stdout='PROBE-OK\n'
```

An unknown `code_mode` now raises instead of silently producing nothing; `code_tools=True` without `code_mode="unsafe"` warns rather than being quietly ignored.

**Bug found while wiring:** both code executors ran `exec(whole module)` and then re-`eval`'d a trailing expression statement, so `print(x)` printed twice and, in code mode, a trailing `my_tool(...)` would have called the tool **twice**. Pre-existing on `origin/main` (`baseline stdout: '1\n1\n'`) but only reachable in production once the flag works, so it is fixed here: the trailing expression is split off before `exec` and evaluated once.

### 3. `AgentTeam(execution=ExecutionConfig(...))` was silently swallowed

```
correct type -> max_iter: 99   wrong type -> max_iter: 10 (default)   warnings: []
```

`ExecutionConfig` is the one exported at the package top level; `MultiAgentExecutionConfig` is not. Passing the exported one resolved against the wrong class and dropped everything, including the `max_iter` both classes define.

Accepting both is the kinder fix, so shared fields are carried over (`max_iter`; `max_retry_limit` -> `max_retries`) **and** a `UserWarning` names the right class and lists the settings that have no team-level counterpart:

> `... These settings have no team-level counterpart and were ignored: code_execution, max_rpm.`

Passing the correct class stays silent.

### 4. `ContextStoreImpl` is never populated — **made honest**, not wired

Decision: **make it honest.** `get_global_store()` is an in-memory singleton scoped to one process. `praisonai context compact` runs in a *different* process, so no amount of runtime wiring could make it see an agent's history — wiring cannot fix the reported symptom. It would also duplicate every agent's history into a second global structure with no in-process reader.

So the store is documented for what it is, and the CLI stops reporting success for work it did not do: `compact` and `export` on an empty store now print what happened and exit non-zero instead of printing "Compaction complete." over zero agents. `compact` with real content still works and still says so.

## Verification

* **Package unit suite, baseline vs branch, same runner** (6 xdist workers, `--timeout=60`): `208 failed / 9195 passed` on `origin/main` vs `206 failed / 9209 passed` on this branch. The failure sets differ in both directions (11 in / 13 out) — including 13 tests that "pass" on the branch and fail on main, which this change plainly did not fix. That churn is pre-existing cross-test pollution: all 11 "new" failures pass in **both** worktrees when run in isolation (`51 passed` each). Failure-neutral.
* **Mutation testing**: 9 mutations, 9 killed, each by a named test; the un-mutated control is green; the working tree was verified restored afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable safe and unsafe code execution with approval gates, allowed-tool controls, and custom timeouts for safe execution.
  - Hook callbacks now work alongside middleware, including asynchronous callbacks.
  - Improved compatibility when configuring team execution settings.

- **Bug Fixes**
  - Prevented unauthorized tools from being accessible during code execution.
  - Prevented trailing code expressions from running twice.
  - Context commands now accurately report empty or shared-only stores and validate compaction requests.

- **Documentation**
  - Updated hook configuration examples and clarified callback, timeout, and context-store behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->