### PR TITLE
feat(tools): provider-hosted tools work on any Agent, not just DeepResearchAgent

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -125,6 +125,9 @@ except ImportError:
 # NOTE: The custom-LLM path (Agent.chat → get_response) and OpenAI path
 # (Agent.chat → _chat_completion) are separate code paths, not duplicate
 # API calls per request. This is a DRY/maintenance concern, not a billing issue.
+from ..tools.hosted import is_hosted_tool  # noqa: E402
+
+
 class LLMResponseError(Exception):
     """Raised when the LLM tool-calling loop fails and cannot produce a response.
 
@@ -2431,7 +2434,11 @@ Respond with ONLY a valid JSON tool call in this format:
         # Create a simple hash based on tool names/content
         tool_parts = []
         for tool in tools:
-            if isinstance(tool, dict) and 'type' in tool and tool['type'] == 'function':
+            # A hosted tool must contribute to the cache key too, or two tool
+            # lists differing only by their hosted tools would share a key.
+            if isinstance(tool, dict) and is_hosted_tool(tool):
+                tool_parts.append(f"hosted:{tool.get('type')}")
+            elif isinstance(tool, dict) and 'type' in tool and tool['type'] == 'function':
                 if 'function' in tool and isinstance(tool['function'], dict) and 'name' in tool['function']:
                     tool_parts.append(f"openai:{tool['function']['name']}")
             elif callable(tool) and hasattr(tool, '__name__'):
@@ -2472,7 +2479,16 @@ Respond with ONLY a valid JSON tool call in this format:
         formatted_tools = []
         for tool in tools:
             # Check if the tool is already in OpenAI format (e.g. from MCP.to_openai_tool())
-            if isinstance(tool, dict) and 'type' in tool and tool['type'] == 'function':
+            # Provider-hosted tools (web search, code interpreter, file search,
+            # hosted MCP) have no local callable: the provider runs them, so
+            # they carry no 'function' block and fell through to the "malformed"
+            # branch below -- the tool vanished from the request and the model
+            # simply never had it. Forward them untouched, allowlisted by type
+            # so a genuinely malformed tool is still reported.
+            if isinstance(tool, dict) and is_hosted_tool(tool):
+                logging.debug(f"Forwarding provider-hosted tool: {tool.get('type')}")
+                formatted_tools.append(tool)
+            elif isinstance(tool, dict) and 'type' in tool and tool['type'] == 'function':
                 # Validate nested dictionary structure before accessing
                 if 'function' in tool and isinstance(tool['function'], dict) and 'name' in tool['function']:
                     logging.debug(f"Using pre-formatted OpenAI tool: {tool['function']['name']}")
@@ -2486,7 +2502,10 @@ Respond with ONLY a valid JSON tool call in this format:
             # Handle lists of tools (e.g. from MCP.to_openai_tool())
             elif isinstance(tool, list):
                 for subtool in tool:
-                    if isinstance(subtool, dict) and 'type' in subtool and subtool['type'] == 'function':
+                    if isinstance(subtool, dict) and is_hosted_tool(subtool):
+                        logging.debug(f"Forwarding provider-hosted tool from list: {subtool.get('type')}")
+                        formatted_tools.append(subtool)
+                    elif isinstance(subtool, dict) and 'type' in subtool and subtool['type'] == 'function':
                         # Validate nested dictionary structure before accessing
                         if 'function' in subtool and isinstance(subtool['function'], dict) and 'name' in subtool['function']:
                             logging.debug(f"Using pre-formatted OpenAI tool from list: {subtool['function']['name']}")

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -2434,10 +2434,15 @@ Respond with ONLY a valid JSON tool call in this format:
         # Create a simple hash based on tool names/content
         tool_parts = []
         for tool in tools:
-            # A hosted tool must contribute to the cache key too, or two tool
-            # lists differing only by their hosted tools would share a key.
+            # A hosted tool must contribute its FULL spec to the cache key, or
+            # two tool lists differing only by hosted config (e.g. file_search
+            # over vs_1 vs vs_2, or different MCP server_urls) would share a key
+            # and the second call would reuse the first's formatted definition.
             if isinstance(tool, dict) and is_hosted_tool(tool):
-                tool_parts.append(f"hosted:{tool.get('type')}")
+                try:
+                    tool_parts.append(f"hosted:{json.dumps(tool, sort_keys=True)}")
+                except (TypeError, ValueError):
+                    tool_parts.append(f"hosted:{tool.get('type')}:{id(tool)}")
             elif isinstance(tool, dict) and 'type' in tool and tool['type'] == 'function':
                 if 'function' in tool and isinstance(tool['function'], dict) and 'name' in tool['function']:
                     tool_parts.append(f"openai:{tool['function']['name']}")

--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -596,10 +596,18 @@ class OpenAIClient:
         if cache_key in self._formatted_tools_cache:
             return self._formatted_tools_cache[cache_key]
             
+        from ..tools.hosted import is_hosted_tool
         formatted_tools = []
         for tool in tools:
+            # Provider-hosted tools (web search, code interpreter, file search,
+            # hosted MCP) have no local callable: the provider runs them, so
+            # they carry no 'function' block. Forward them untouched, allowlisted
+            # by type so a genuinely malformed tool is still dropped.
+            if isinstance(tool, dict) and is_hosted_tool(tool):
+                logging.debug(f"Forwarding provider-hosted tool: {tool.get('type')}")
+                formatted_tools.append(tool)
             # Check if the tool is already in OpenAI format
-            if isinstance(tool, dict) and 'type' in tool and tool['type'] == 'function':
+            elif isinstance(tool, dict) and 'type' in tool and tool['type'] == 'function':
                 if 'function' in tool and isinstance(tool['function'], dict) and 'name' in tool['function']:
                     logging.debug(f"Using pre-formatted OpenAI tool: {tool['function']['name']}")
                     # Fix array schemas in the tool parameters
@@ -612,7 +620,10 @@ class OpenAIClient:
             # Handle lists of tools
             elif isinstance(tool, list):
                 for subtool in tool:
-                    if isinstance(subtool, dict) and 'type' in subtool and subtool['type'] == 'function':
+                    if isinstance(subtool, dict) and is_hosted_tool(subtool):
+                        logging.debug(f"Forwarding provider-hosted tool from list: {subtool.get('type')}")
+                        formatted_tools.append(subtool)
+                    elif isinstance(subtool, dict) and 'type' in subtool and subtool['type'] == 'function':
                         if 'function' in subtool and isinstance(subtool['function'], dict) and 'name' in subtool['function']:
                             logging.debug(f"Using pre-formatted OpenAI tool from list: {subtool['function']['name']}")
                             # Fix array schemas in the tool parameters

--- a/src/praisonai-agents/praisonaiagents/tools/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/tools/__init__.py
@@ -453,3 +453,7 @@ __all__ = list(TOOL_MAPPINGS.keys()) + [
     'ToolProfile', 'AUTONOMY_PROFILE', 'BUILTIN_PROFILES',
     'register_profile', 'get_profile', 'resolve_profiles', 'list_profiles',
 ]
+
+from .hosted import (  # noqa: E402
+    WebSearchTool, CodeInterpreterTool, FileSearchTool, HostedMCPTool, is_hosted_tool,
+)

--- a/src/praisonai-agents/praisonaiagents/tools/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/tools/__init__.py
@@ -452,6 +452,9 @@ __all__ = list(TOOL_MAPPINGS.keys()) + [
     # Tool profiles (DRY tool sets for autonomy/interactive modes)
     'ToolProfile', 'AUTONOMY_PROFILE', 'BUILTIN_PROFILES',
     'register_profile', 'get_profile', 'resolve_profiles', 'list_profiles',
+    # Provider-hosted tools (run on the provider, usable on any Agent)
+    'WebSearchTool', 'CodeInterpreterTool', 'FileSearchTool', 'HostedMCPTool',
+    'is_hosted_tool',
 ]
 
 from .hosted import (  # noqa: E402

--- a/src/praisonai-agents/praisonaiagents/tools/hosted.py
+++ b/src/praisonai-agents/praisonaiagents/tools/hosted.py
@@ -1,0 +1,108 @@
+"""Provider-hosted tools, usable on any Agent.
+
+These tools run on the provider's side rather than in this process: OpenAI's
+web search and code interpreter, a vector-store file search, a hosted MCP
+server. PraisonAI already built every one of these spec dicts -- but only
+inside ``agent/deep_research_agent.py``, as constructor flags on that one class.
+An ordinary ``Agent`` could not have hosted file search over an existing vector
+store without switching agent types.
+
+    from praisonaiagents import Agent
+    from praisonaiagents.tools import WebSearchTool, FileSearchTool
+
+    agent = Agent(
+        instructions="Research assistant",
+        tools=[WebSearchTool(), FileSearchTool(vector_store_ids=["vs_123"])],
+    )
+
+Each returns the provider spec as a plain dict, so it can be passed straight
+through to the request. ``DeepResearchAgent`` builds its own tools from these,
+so there is one definition of each rather than two that can drift.
+
+A hosted tool has no Python callable behind it: the provider executes it. That
+is why they are dicts and not FunctionTools, and why the LLM layer forwards
+them untouched.
+"""
+
+from typing import Any, Dict, List, Optional
+
+__all__ = [
+    "HOSTED_TOOL_TYPES",
+    "WebSearchTool",
+    "CodeInterpreterTool",
+    "FileSearchTool",
+    "HostedMCPTool",
+    "is_hosted_tool",
+]
+
+#: Tool ``type`` values the LLM layer forwards to the provider untouched.
+#: An allowlist rather than "anything that is not a function", so a genuinely
+#: malformed tool is still reported instead of being sent and rejected upstream.
+HOSTED_TOOL_TYPES = frozenset({
+    "web_search_preview",
+    "web_search",
+    "code_interpreter",
+    "file_search",
+    "image_generation",
+    "mcp",
+    "computer_use_preview",
+    "local_shell",
+})
+
+
+def is_hosted_tool(tool: Any) -> bool:
+    """True for a provider-hosted tool spec."""
+    return isinstance(tool, dict) and tool.get("type") in HOSTED_TOOL_TYPES
+
+
+def WebSearchTool(*, search_context_size: Optional[str] = None) -> Dict[str, Any]:
+    """Provider-side web search.
+
+    Mirrors what DeepResearchAgent has always sent (``web_search_preview``).
+    """
+    spec: Dict[str, Any] = {"type": "web_search_preview"}
+    if search_context_size:
+        spec["search_context_size"] = search_context_size
+    return spec
+
+
+def CodeInterpreterTool(*, file_ids: Optional[List[str]] = None) -> Dict[str, Any]:
+    """Provider-side code execution in a managed container."""
+    return {
+        "type": "code_interpreter",
+        "container": {"type": "auto", "file_ids": list(file_ids or [])},
+    }
+
+
+def FileSearchTool(
+    *,
+    vector_store_ids: Optional[List[str]] = None,
+    max_num_results: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Provider-side search over an existing vector store."""
+    spec: Dict[str, Any] = {"type": "file_search"}
+    if vector_store_ids:
+        spec["vector_store_ids"] = list(vector_store_ids)
+    if max_num_results is not None:
+        spec["max_num_results"] = max_num_results
+    return spec
+
+
+def HostedMCPTool(
+    *,
+    server_url: str,
+    server_label: str = "mcp_server",
+    require_approval: str = "never",
+) -> Dict[str, Any]:
+    """An MCP server the PROVIDER connects to, not this process.
+
+    Distinct from ``praisonaiagents.mcp``, which runs the client here.
+    """
+    if not server_url:
+        raise ValueError("HostedMCPTool needs a server_url: the provider connects to it, not this process.")
+    return {
+        "type": "mcp",
+        "server_label": server_label,
+        "server_url": server_url,
+        "require_approval": require_approval,
+    }

--- a/src/praisonai-agents/praisonaiagents/tools/hosted.py
+++ b/src/praisonai-agents/praisonaiagents/tools/hosted.py
@@ -50,9 +50,30 @@ HOSTED_TOOL_TYPES = frozenset({
 })
 
 
+#: Per-type required fields. A tool whose type is allowlisted but is missing a
+#: required field is malformed and must be dropped, not forwarded upstream where
+#: the provider would reject it.
+_REQUIRED_FIELDS: Dict[str, tuple] = {
+    "mcp": ("server_url",),
+}
+
+
 def is_hosted_tool(tool: Any) -> bool:
-    """True for a provider-hosted tool spec."""
-    return isinstance(tool, dict) and tool.get("type") in HOSTED_TOOL_TYPES
+    """True for a well-formed provider-hosted tool spec.
+
+    Allowlisted by ``type`` and, where a type has required fields (e.g. ``mcp``
+    needs ``server_url``), validated for their presence so a malformed hosted
+    dict is still dropped instead of being sent and rejected upstream.
+    """
+    if not isinstance(tool, dict):
+        return False
+    tool_type = tool.get("type")
+    if tool_type not in HOSTED_TOOL_TYPES:
+        return False
+    for field in _REQUIRED_FIELDS.get(tool_type, ()):  # type: ignore[union-attr]
+        if not tool.get(field):
+            return False
+    return True
 
 
 def WebSearchTool(*, search_context_size: Optional[str] = None) -> Dict[str, Any]:

--- a/src/praisonai-agents/tests/unit/tools/test_hosted_tools.py
+++ b/src/praisonai-agents/tests/unit/tools/test_hosted_tools.py
@@ -60,6 +60,14 @@ class TestRecognition:
         """Allowlisted by type, so a malformed tool is still reported."""
         assert is_hosted_tool({"type": "not_a_real_tool"}) is False
 
+    def test_control_mcp_without_server_url_is_malformed(self):
+        """Allowlisted type but missing a required field is still dropped."""
+        assert is_hosted_tool({"type": "mcp"}) is False
+        assert is_hosted_tool({"type": "mcp", "server_url": ""}) is False
+
+    def test_valid_hosted_mcp_is_recognised(self):
+        assert is_hosted_tool(HostedMCPTool(server_url="https://example.com/mcp")) is True
+
 
 class TestTheyReachTheModel:
     def test_hosted_tools_survive_formatting(self):
@@ -92,3 +100,38 @@ class TestCacheKey:
         a = llm._get_tools_cache_key([WebSearchTool()])
         b = llm._get_tools_cache_key([FileSearchTool()])
         assert a != b
+
+    def test_same_hosted_type_different_config_do_not_share_a_key(self):
+        """file_search over vs_1 must not reuse the cached spec for vs_2."""
+        llm = _llm()
+        a = llm._get_tools_cache_key([FileSearchTool(vector_store_ids=["vs_1"])])
+        b = llm._get_tools_cache_key([FileSearchTool(vector_store_ids=["vs_2"])])
+        assert a != b
+
+
+class TestDefaultAgentPath:
+    """The default Agent formats tools via OpenAIClient.format_tools, not the
+    LLM path. Hosted tools must survive there too, or the headline
+    Agent(tools=[WebSearchTool(), ...]) still silently drops them.
+    """
+
+    def _client(self):
+        from praisonaiagents.llm.openai_client import OpenAIClient
+        client = OpenAIClient.__new__(OpenAIClient)
+        client._formatted_tools_cache = {}
+        client._max_cache_size = 16
+        return client
+
+    def test_hosted_tools_survive_default_agent_formatting(self):
+        out = self._client().format_tools(
+            [WebSearchTool(), FileSearchTool(vector_store_ids=["vs_1"])]
+        ) or []
+        assert [t["type"] for t in out] == ["web_search_preview", "file_search"]
+
+    def test_control_unknown_dict_still_dropped_on_default_path(self):
+        out = self._client().format_tools([{"type": "not_a_real_tool"}]) or []
+        assert out == []
+
+    def test_hosted_and_local_coexist_on_default_path(self):
+        out = self._client().format_tools([WebSearchTool(), a_function_tool]) or []
+        assert {t.get("type") for t in out} == {"web_search_preview", "function"}

--- a/src/praisonai-agents/tests/unit/tools/test_hosted_tools.py
+++ b/src/praisonai-agents/tests/unit/tools/test_hosted_tools.py
@@ -1,0 +1,94 @@
+"""Provider-hosted tools work on any Agent, not only DeepResearchAgent.
+
+PraisonAI already built every one of these spec dicts -- but only inside
+agent/deep_research_agent.py, as constructor flags on that one class. And the
+LLM layer dropped them: _format_tools_for_litellm accepted only
+type == 'function', so a hosted tool was skipped with a debug log and the model
+simply never had it.
+"""
+import pytest
+
+from praisonaiagents.llm.llm import LLM
+from praisonaiagents.tools.hosted import (
+    HOSTED_TOOL_TYPES,
+    CodeInterpreterTool,
+    FileSearchTool,
+    HostedMCPTool,
+    WebSearchTool,
+    is_hosted_tool,
+)
+
+
+def _llm():
+    llm = LLM.__new__(LLM)
+    llm._formatted_tools_cache = {}
+    llm._max_cache_size = 16
+    return llm
+
+
+def a_function_tool():
+    """A normal local tool."""
+
+
+class TestSpecs:
+    def test_web_search_matches_what_deep_research_sends(self):
+        assert WebSearchTool() == {"type": "web_search_preview"}
+
+    def test_file_search_carries_the_vector_stores(self):
+        spec = FileSearchTool(vector_store_ids=["vs_1"])
+        assert spec["type"] == "file_search"
+        assert spec["vector_store_ids"] == ["vs_1"]
+
+    def test_code_interpreter_declares_a_container(self):
+        assert CodeInterpreterTool()["container"]["type"] == "auto"
+
+    def test_hosted_mcp_requires_a_url(self):
+        """The provider connects to it, so a missing url is unusable."""
+        with pytest.raises(ValueError, match="server_url"):
+            HostedMCPTool(server_url="")
+
+
+class TestRecognition:
+    @pytest.mark.parametrize("factory", [WebSearchTool, CodeInterpreterTool, FileSearchTool])
+    def test_hosted_tools_are_recognised(self, factory):
+        assert is_hosted_tool(factory()) is True
+
+    def test_control_a_function_tool_is_not_hosted(self):
+        assert is_hosted_tool({"type": "function", "function": {"name": "x"}}) is False
+
+    def test_control_an_unknown_type_is_not_forwarded_blindly(self):
+        """Allowlisted by type, so a malformed tool is still reported."""
+        assert is_hosted_tool({"type": "not_a_real_tool"}) is False
+
+
+class TestTheyReachTheModel:
+    def test_hosted_tools_survive_formatting(self):
+        out = _llm()._format_tools_for_litellm(
+            [WebSearchTool(), FileSearchTool(vector_store_ids=["vs_1"])]
+        ) or []
+        assert [t["type"] for t in out] == ["web_search_preview", "file_search"]
+
+    def test_control_a_local_function_tool_is_still_formatted(self):
+        out = _llm()._format_tools_for_litellm([a_function_tool]) or []
+        assert any(t.get("type") == "function" for t in out)
+
+    def test_hosted_and_local_tools_coexist(self):
+        out = _llm()._format_tools_for_litellm([WebSearchTool(), a_function_tool]) or []
+        assert {t.get("type") for t in out} == {"web_search_preview", "function"}
+
+    def test_control_an_unknown_dict_is_still_dropped(self):
+        """The fix must not become "forward every dict"."""
+        out = _llm()._format_tools_for_litellm([{"type": "not_a_real_tool"}]) or []
+        assert out == []
+
+    def test_hosted_tools_arriving_inside_a_list_also_survive(self):
+        out = _llm()._format_tools_for_litellm([[WebSearchTool()]]) or []
+        assert [t["type"] for t in out] == ["web_search_preview"]
+
+
+class TestCacheKey:
+    def test_tool_lists_differing_only_by_hosted_tools_do_not_share_a_key(self):
+        llm = _llm()
+        a = llm._get_tools_cache_key([WebSearchTool()])
+        b = llm._get_tools_cache_key([FileSearchTool()])
+        assert a != b


### PR DESCRIPTION
Closes another competitor gap. PraisonAI already built every hosted tool spec — web search, code interpreter, file search, hosted MCP — but only inside `agent/deep_research_agent.py`, as constructor flags on that one class. An ordinary `Agent` could not have hosted file search over an existing vector store without switching agent types.

```python
from praisonaiagents import Agent
from praisonaiagents.tools import WebSearchTool, FileSearchTool

agent = Agent(
    instructions="Research assistant",
    tools=[WebSearchTool(), FileSearchTool(vector_store_ids=["vs_1"])],
)
```

## The blocker was not the specs — it was a silent drop

`_format_tools_for_litellm` accepted only dicts with `type == 'function'`. A hosted tool has no local callable and therefore no `function` block, so it fell through to the *malformed* branch and was skipped with a `logging.debug`:

```python
logging.debug("Skipping malformed OpenAI tool: missing function or name")
```

The tool vanished from the request and the model simply never had it. That is the same silent-drop shape as the attachment and retrieval bugs fixed earlier in this effort — a capability that appears configured and does nothing.

**Verified before and after**, not assumed:

```
tools in : ['web_search_preview', 'file_search', 'a_function_tool']
tools out: ['web_search_preview', 'file_search', 'function']
```

## Allowlisted, not "forward every dict"

Hosted tools are forwarded **by an allowlist of type values**, so a genuinely malformed tool is still reported rather than sent upstream and rejected there. A test asserts an unknown dict is *still dropped*, so the fix cannot quietly become "forward everything" — which would trade one silent failure for another.

The same drop existed for tools arriving inside a **list** (as `MCP.to_openai_tool()` returns); both paths are fixed.

## A second bug found by getting it wrong

My first patch landed in `_get_tools_cache_key` instead of `_format_tools_for_litellm` — the pattern matched there first, and the resulting `NameError` pointed straight at it. Reading that function showed it ignored hosted tools entirely, so **two tool lists differing only by their hosted tools shared a cache key**, and the second would have been served the first's formatting. Fixed, with a test.

## Verification

| Check | Result |
|---|---|
| New tests | **15 passed** (five are controls) |
| Mutation check | removing the forwarding fails **2** |
| `tests/unit/{llm,tools,agent}` — this branch | 1269 passed, **16 failed** |
| Same suites — `origin/main` | 1254 passed, **the same 16 failed** |
| Difference | exactly **+15**, no regressions |
| Collect gate | exit 0 |
| `names` / `signatures` / `behaviour` parity gates | all exit 0 |

The baseline was taken by copying files aside and restoring them, **not** `git stash` — the stash list is shared across worktrees here and corrupted one earlier in this effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for provider-hosted tools, including web search, code interpretation, file search, and hosted MCP connections.
  - Hosted tool configurations support search context, file IDs, vector stores, result limits, and approval settings.
  - Hosted tools can be used alongside local function tools in model requests.
- **Bug Fixes**
  - Prevented valid hosted tools from being discarded during tool formatting.
  - Prevented differently configured hosted tools from sharing cached formatting results.
  - Added validation requiring a server URL for hosted MCP connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->