### PR TITLE
feat(knowledge): load sources from S3, GCS and Azure blob storage

### DIFF
--- a/src/praisonai-agents/praisonaiagents/knowledge/cloud.py
+++ b/src/praisonai-agents/praisonaiagents/knowledge/cloud.py
@@ -22,7 +22,7 @@ the exact pip command rather than failing later inside the provider.
 import os
 import tempfile
 from typing import Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 __all__ = [
     "CLOUD_SCHEMES",
@@ -39,35 +39,60 @@ class CloudSourceError(RuntimeError):
     """Raised when a cloud source cannot be resolved."""
 
 
+def _is_azure_blob_host(hostname: Optional[str]) -> bool:
+    """True only for a genuine Azure Blob authority, not arbitrary URL text.
+
+    Matched on the parsed hostname so a normal https URL that merely mentions
+    ``.blob.core.windows.net`` in its path or query cannot be misrouted here.
+    """
+    return bool(hostname) and hostname.lower().endswith(".blob.core.windows.net")
+
+
 def is_cloud_source(source: str) -> bool:
     """True for a URI this module can fetch."""
     if not isinstance(source, str):
         return False
-    scheme = urlparse(source.strip()).scheme.lower()
+    parsed = urlparse(source.strip())
+    scheme = parsed.scheme.lower()
     if scheme in CLOUD_SCHEMES:
         return True
-    return scheme in ("http", "https") and ".blob.core.windows.net" in source
+    return scheme in ("http", "https") and _is_azure_blob_host(parsed.hostname)
 
 
 def parse_cloud_uri(source: str) -> Tuple[str, str, str]:
-    """Split a cloud URI into (provider, container, key)."""
+    """Split a cloud URI into (provider, container, key).
+
+    Object keys are percent-decoded, because provider SDKs expect the literal
+    object name -- ``handbook%20v2.pdf`` must look up ``handbook v2.pdf``.
+    For Azure the account named by the URL is bound to the download (see
+    :func:`_parse_cloud_uri_full`); this helper keeps the public 3-tuple shape.
+    """
+    provider, container, key, _account = _parse_cloud_uri_full(source)
+    return provider, container, key
+
+
+def _parse_cloud_uri_full(source: str) -> Tuple[str, str, str, Optional[str]]:
+    """Like :func:`parse_cloud_uri` but also returns the Azure account, if any."""
     parsed = urlparse(source.strip())
     scheme = parsed.scheme.lower()
 
     if scheme == "s3":
-        return "s3", parsed.netloc, parsed.path.lstrip("/")
+        return "s3", parsed.netloc, unquote(parsed.path.lstrip("/")), None
     if scheme in ("gs", "gcs"):
-        return "gcs", parsed.netloc, parsed.path.lstrip("/")
+        return "gcs", parsed.netloc, unquote(parsed.path.lstrip("/")), None
     if scheme in ("az", "abfs"):
         # az://container/blob -- the account comes from the connection string
-        return "azure", parsed.netloc, parsed.path.lstrip("/")
-    if scheme in ("http", "https") and ".blob.core.windows.net" in source:
+        return "azure", parsed.netloc, unquote(parsed.path.lstrip("/")), None
+    if scheme in ("http", "https") and _is_azure_blob_host(parsed.hostname):
+        # The account is the first label of the host; bind it to the download
+        # so a URL for account A is never served from the configured account B.
+        account = parsed.hostname.split(".", 1)[0]
         parts = parsed.path.lstrip("/").split("/", 1)
         if len(parts) != 2:
             raise CloudSourceError(
                 f"Azure blob URL must include a container and a blob name: {source}"
             )
-        return "azure", parts[0], parts[1]
+        return "azure", parts[0], unquote(parts[1]), account
 
     raise CloudSourceError(
         f"Not a supported cloud source: {source!r}. "
@@ -98,19 +123,45 @@ def _download_gcs(bucket: str, key: str, dest: str) -> None:
     storage.Client().bucket(bucket).blob(key).download_to_filename(dest)
 
 
-def _download_azure(container: str, key: str, dest: str) -> None:
-    try:
-        from azure.storage.blob import BlobServiceClient  # type: ignore
-    except ImportError as exc:
-        raise _missing("azure-storage-blob", "Azure blob") from exc
+def _azure_client(account: Optional[str]):
+    """Build a BlobServiceClient bound to the account named by the URL.
+
+    A URL for account A must never be served from account B. When the URL
+    names an account we address that account's endpoint (using
+    ``AZURE_STORAGE_CONNECTION_STRING`` only if it belongs to the same
+    account, else ``DefaultAzureCredential`` / anonymous). Without a URL
+    account (``az://`` form) the connection string account is used.
+    """
+    from azure.storage.blob import BlobServiceClient  # type: ignore
+
     conn = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+    if account:
+        account_url = f"https://{account}.blob.core.windows.net"
+        if conn and f"AccountName={account};" in conn:
+            return BlobServiceClient.from_connection_string(conn)
+        try:
+            from azure.identity import DefaultAzureCredential  # type: ignore
+
+            return BlobServiceClient(account_url, credential=DefaultAzureCredential())
+        except ImportError:
+            return BlobServiceClient(account_url)
     if not conn:
         raise CloudSourceError(
             "Azure blob sources need AZURE_STORAGE_CONNECTION_STRING in the environment."
         )
-    client = BlobServiceClient.from_connection_string(conn)
+    return BlobServiceClient.from_connection_string(conn)
+
+
+def _download_azure(container: str, key: str, dest: str, account: Optional[str] = None) -> None:
+    try:
+        import azure.storage.blob  # type: ignore  # noqa: F401
+    except ImportError as exc:
+        raise _missing("azure-storage-blob", "Azure blob") from exc
+    client = _azure_client(account)
+    # Stream into the file instead of readall() so a large blob is not held
+    # whole in process memory.
     with open(dest, "wb") as handle:
-        handle.write(client.get_blob_client(container, key).download_blob().readall())
+        client.get_blob_client(container, key).download_blob().readinto(handle)
 
 
 _DOWNLOADERS = {"s3": _download_s3, "gcs": _download_gcs, "azure": _download_azure}
@@ -122,7 +173,7 @@ def fetch_cloud_source(source: str, dest_dir: Optional[str] = None) -> str:
     The local name keeps the object's extension, because the readers dispatch
     on it -- a PDF fetched to an extension-less temp file would be read as plain text.
     """
-    provider, container, key = parse_cloud_uri(source)
+    provider, container, key, account = _parse_cloud_uri_full(source)
     if not container or not key:
         raise CloudSourceError(
             f"Cloud source must name a container and an object: {source!r}"
@@ -134,7 +185,10 @@ def fetch_cloud_source(source: str, dest_dir: Optional[str] = None) -> str:
     dest = os.path.join(directory, os.path.basename(key) or f"object{suffix}")
 
     try:
-        _DOWNLOADERS[provider](container, key, dest)
+        if provider == "azure":
+            _download_azure(container, key, dest, account)
+        else:
+            _DOWNLOADERS[provider](container, key, dest)
     except CloudSourceError:
         raise
     except Exception as exc:

--- a/src/praisonai-agents/praisonaiagents/knowledge/cloud.py
+++ b/src/praisonai-agents/praisonaiagents/knowledge/cloud.py
@@ -1,0 +1,147 @@
+"""Load knowledge sources from cloud object storage.
+
+`Knowledge` could only read local disk. `detect_source_kind()` already
+classified `s3://` and `gs://` as URLs, but nothing fetched them -- so a bucket
+path was handed to an HTTP fetcher that cannot speak those schemes. Anyone with
+documents in a bucket had to download them by hand first.
+
+This resolves a cloud URI to a local temporary file and hands it to the readers
+that already exist, rather than reimplementing PDF/DOCX parsing per provider:
+
+    Knowledge(sources=["s3://my-bucket/handbook.pdf"])
+
+Supported: ``s3://`` (boto3), ``gs://`` (google-cloud-storage), and
+``az://account/container/blob`` or ``https://<account>.blob.core.windows.net/...``
+(azure-storage-blob).
+
+Each SDK is optional and imported only when a URI of that scheme is used, so
+installing PraisonAI does not pull three cloud SDKs. A missing SDK raises with
+the exact pip command rather than failing later inside the provider.
+"""
+
+import os
+import tempfile
+from typing import Optional, Tuple
+from urllib.parse import urlparse
+
+__all__ = [
+    "CLOUD_SCHEMES",
+    "CloudSourceError",
+    "is_cloud_source",
+    "parse_cloud_uri",
+    "fetch_cloud_source",
+]
+
+CLOUD_SCHEMES = ("s3", "gs", "gcs", "az", "abfs")
+
+
+class CloudSourceError(RuntimeError):
+    """Raised when a cloud source cannot be resolved."""
+
+
+def is_cloud_source(source: str) -> bool:
+    """True for a URI this module can fetch."""
+    if not isinstance(source, str):
+        return False
+    scheme = urlparse(source.strip()).scheme.lower()
+    if scheme in CLOUD_SCHEMES:
+        return True
+    return scheme in ("http", "https") and ".blob.core.windows.net" in source
+
+
+def parse_cloud_uri(source: str) -> Tuple[str, str, str]:
+    """Split a cloud URI into (provider, container, key)."""
+    parsed = urlparse(source.strip())
+    scheme = parsed.scheme.lower()
+
+    if scheme == "s3":
+        return "s3", parsed.netloc, parsed.path.lstrip("/")
+    if scheme in ("gs", "gcs"):
+        return "gcs", parsed.netloc, parsed.path.lstrip("/")
+    if scheme in ("az", "abfs"):
+        # az://container/blob -- the account comes from the connection string
+        return "azure", parsed.netloc, parsed.path.lstrip("/")
+    if scheme in ("http", "https") and ".blob.core.windows.net" in source:
+        parts = parsed.path.lstrip("/").split("/", 1)
+        if len(parts) != 2:
+            raise CloudSourceError(
+                f"Azure blob URL must include a container and a blob name: {source}"
+            )
+        return "azure", parts[0], parts[1]
+
+    raise CloudSourceError(
+        f"Not a supported cloud source: {source!r}. "
+        f"Supported schemes: {', '.join(CLOUD_SCHEMES)}, or an Azure blob URL."
+    )
+
+
+def _missing(package: str, provider: str) -> CloudSourceError:
+    return CloudSourceError(
+        f"Reading {provider} sources needs the `{package}` package. "
+        f"Install it with: pip install {package}"
+    )
+
+
+def _download_s3(bucket: str, key: str, dest: str) -> None:
+    try:
+        import boto3  # type: ignore
+    except ImportError as exc:
+        raise _missing("boto3", "s3://") from exc
+    boto3.client("s3").download_file(bucket, key, dest)
+
+
+def _download_gcs(bucket: str, key: str, dest: str) -> None:
+    try:
+        from google.cloud import storage  # type: ignore
+    except ImportError as exc:
+        raise _missing("google-cloud-storage", "gs://") from exc
+    storage.Client().bucket(bucket).blob(key).download_to_filename(dest)
+
+
+def _download_azure(container: str, key: str, dest: str) -> None:
+    try:
+        from azure.storage.blob import BlobServiceClient  # type: ignore
+    except ImportError as exc:
+        raise _missing("azure-storage-blob", "Azure blob") from exc
+    conn = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+    if not conn:
+        raise CloudSourceError(
+            "Azure blob sources need AZURE_STORAGE_CONNECTION_STRING in the environment."
+        )
+    client = BlobServiceClient.from_connection_string(conn)
+    with open(dest, "wb") as handle:
+        handle.write(client.get_blob_client(container, key).download_blob().readall())
+
+
+_DOWNLOADERS = {"s3": _download_s3, "gcs": _download_gcs, "azure": _download_azure}
+
+
+def fetch_cloud_source(source: str, dest_dir: Optional[str] = None) -> str:
+    """Download a cloud object to a local file and return its path.
+
+    The local name keeps the object's extension, because the readers dispatch
+    on it -- a PDF fetched to an extension-less temp file would be read as plain text.
+    """
+    provider, container, key = parse_cloud_uri(source)
+    if not container or not key:
+        raise CloudSourceError(
+            f"Cloud source must name a container and an object: {source!r}"
+        )
+
+    suffix = os.path.splitext(key)[1]
+    directory = dest_dir or tempfile.mkdtemp(prefix="praisonai-kb-")
+    os.makedirs(directory, exist_ok=True)
+    dest = os.path.join(directory, os.path.basename(key) or f"object{suffix}")
+
+    try:
+        _DOWNLOADERS[provider](container, key, dest)
+    except CloudSourceError:
+        raise
+    except Exception as exc:
+        raise CloudSourceError(
+            f"Could not fetch {source!r}: {type(exc).__name__}: {exc}"
+        ) from exc
+
+    if not os.path.exists(dest):
+        raise CloudSourceError(f"Fetch reported success but wrote no file for {source!r}")
+    return dest

--- a/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
+++ b/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
@@ -50,6 +50,9 @@ class CustomMemory:
 # MongoDBMemory has been moved to adapters/mongodb_adapter.py
 # This maintains backward compatibility while following protocol-driven architecture
 
+from .cloud import is_cloud_source, fetch_cloud_source  # noqa: E402
+
+
 class Knowledge:
     def __init__(self, config=None, verbose=None):
         self._config = config
@@ -525,6 +528,24 @@ class Knowledge:
                 else:
                     all_extensions.append(exts)
             all_extensions = tuple(all_extensions)
+
+            # Cloud object storage (s3://, gs://, az://, Azure blob URL).
+            # Checked BEFORE the http branch, because an Azure blob URL is https
+            # and would otherwise be handed to the web fetcher. The object is
+            # downloaded to a local temp file and then read by the SAME readers
+            # as any local file, so PDF/DOCX parsing is not reimplemented per
+            # provider.
+            if isinstance(input_path, str) and is_cloud_source(input_path):
+                self._log(f"Fetching cloud source: {input_path}")
+                local_path = fetch_cloud_source(input_path)
+                result = self._process_single_input(
+                    local_path, user_id, agent_id, run_id, metadata
+                )
+                # Keep the ORIGINAL uri in metadata: the temp path is meaningless
+                # to anyone reading a citation later.
+                if isinstance(result, dict):
+                    result.setdefault('source', input_path)
+                return result
 
             # Check if input is URL
             if isinstance(input_path, str) and (input_path.startswith('http://') or input_path.startswith('https://')):

--- a/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
+++ b/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import logging
 from praisonaiagents._logging import get_logger
 from datetime import datetime
@@ -537,14 +538,21 @@ class Knowledge:
             # provider.
             if isinstance(input_path, str) and is_cloud_source(input_path):
                 self._log(f"Fetching cloud source: {input_path}")
-                local_path = fetch_cloud_source(input_path)
-                result = self._process_single_input(
-                    local_path, user_id, agent_id, run_id, metadata
-                )
-                # Keep the ORIGINAL uri in metadata: the temp path is meaningless
-                # to anyone reading a citation later.
+                # Download into a TemporaryDirectory so the fetched document is
+                # removed after indexing rather than accumulating on disk.
+                with tempfile.TemporaryDirectory(prefix="praisonai-kb-") as tmp_dir:
+                    local_path = fetch_cloud_source(input_path, dest_dir=tmp_dir)
+                    # Persist the ORIGINAL uri in the stored chunk metadata, not
+                    # the temp filename -- a temp path is meaningless in a
+                    # citation, and two objects with the same basename would
+                    # otherwise be indistinguishable.
+                    cloud_metadata = dict(metadata or {})
+                    cloud_metadata['source'] = input_path
+                    result = self._process_single_input(
+                        local_path, user_id, agent_id, run_id, cloud_metadata
+                    )
                 if isinstance(result, dict):
-                    result.setdefault('source', input_path)
+                    result['source'] = input_path
                 return result
 
             # Check if input is URL

--- a/src/praisonai-agents/tests/unit/knowledge/test_cloud_sources.py
+++ b/src/praisonai-agents/tests/unit/knowledge/test_cloud_sources.py
@@ -34,6 +34,13 @@ class TestRecognition:
         """Control: an ordinary URL must still go to the web fetcher."""
         assert is_cloud_source(uri) is False
 
+    def test_control_blob_text_in_query_is_not_an_azure_host(self):
+        """A normal https URL that merely mentions the Azure host in its query
+        must not be misrouted to the cloud branch."""
+        assert is_cloud_source(
+            "https://example.com/doc.pdf?x=.blob.core.windows.net"
+        ) is False
+
 
 class TestParsing:
     def test_s3_splits_into_bucket_and_key(self):
@@ -51,6 +58,16 @@ class TestParsing:
     def test_an_unsupported_scheme_is_refused_by_name(self):
         with pytest.raises(CloudSourceError, match="Not a supported cloud source"):
             parse_cloud_uri("ftp://host/file.pdf")
+
+    def test_percent_encoded_object_names_are_decoded(self):
+        """SDKs expect the literal object name, so %20 must become a space."""
+        _provider, _container, key = parse_cloud_uri(
+            "https://acct.blob.core.windows.net/docs/handbook%20v2.pdf"
+        )
+        assert key == "handbook v2.pdf"
+
+    def test_s3_key_is_also_decoded(self):
+        assert parse_cloud_uri("s3://b/a%20b.pdf") == ("s3", "b", "a b.pdf")
 
 
 class TestFetching:
@@ -107,3 +124,49 @@ class TestFetching:
 
         with pytest.raises(CloudSourceError, match="wrote no file"):
             fetch_cloud_source("s3://bucket/a.pdf", dest_dir=str(tmp_path))
+
+    def test_azure_streams_into_the_file_and_binds_the_url_account(
+        self, tmp_path, monkeypatch
+    ):
+        """Azure downloads must stream (readinto) rather than buffer the whole
+        blob, and address the account named by the URL, not the env account."""
+        seen = {}
+
+        class _Downloader:
+            def readinto(self, handle):
+                handle.write(b"streamed")
+
+        class _BlobClient:
+            def download_blob(self):
+                return _Downloader()
+
+        class _BSC:
+            def __init__(self, account_url=None, credential=None):
+                seen["account_url"] = account_url
+
+            @classmethod
+            def from_connection_string(cls, conn):
+                seen["from_conn"] = conn
+                return cls()
+
+            def get_blob_client(self, container, key):
+                seen["container"], seen["key"] = container, key
+                return _BlobClient()
+
+        blob_mod = types.ModuleType("azure.storage.blob")
+        blob_mod.BlobServiceClient = _BSC
+        azure_pkg = types.ModuleType("azure")
+        storage_pkg = types.ModuleType("azure.storage")
+        monkeypatch.setitem(sys.modules, "azure", azure_pkg)
+        monkeypatch.setitem(sys.modules, "azure.storage", storage_pkg)
+        monkeypatch.setitem(sys.modules, "azure.storage.blob", blob_mod)
+        monkeypatch.setitem(sys.modules, "azure.identity", None)
+        monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+
+        path = fetch_cloud_source(
+            "https://accta.blob.core.windows.net/docs/handbook.pdf",
+            dest_dir=str(tmp_path),
+        )
+        assert open(path, "rb").read() == b"streamed"
+        assert seen["account_url"] == "https://accta.blob.core.windows.net"
+        assert (seen["container"], seen["key"]) == ("docs", "handbook.pdf")

--- a/src/praisonai-agents/tests/unit/knowledge/test_cloud_sources.py
+++ b/src/praisonai-agents/tests/unit/knowledge/test_cloud_sources.py
@@ -1,0 +1,109 @@
+"""Knowledge sources can live in cloud object storage.
+
+Knowledge could only read local disk. detect_source_kind() already classified
+s3:// and gs:// as URLs, but nothing fetched them -- so a bucket path was handed
+to an HTTP fetcher that cannot speak those schemes.
+"""
+import os
+import sys
+import types
+import pytest
+
+from praisonaiagents.knowledge.cloud import (
+    CloudSourceError,
+    fetch_cloud_source,
+    is_cloud_source,
+    parse_cloud_uri,
+)
+
+
+class TestRecognition:
+    @pytest.mark.parametrize("uri", [
+        "s3://bucket/doc.pdf",
+        "gs://bucket/doc.pdf",
+        "az://container/doc.pdf",
+        "https://acct.blob.core.windows.net/container/doc.pdf",
+    ])
+    def test_cloud_uris_are_recognised(self, uri):
+        assert is_cloud_source(uri) is True
+
+    @pytest.mark.parametrize("uri", [
+        "/local/doc.pdf", "doc.pdf", "https://example.com/doc.pdf", "", None,
+    ])
+    def test_control_non_cloud_sources_are_not_claimed(self, uri):
+        """Control: an ordinary URL must still go to the web fetcher."""
+        assert is_cloud_source(uri) is False
+
+
+class TestParsing:
+    def test_s3_splits_into_bucket_and_key(self):
+        assert parse_cloud_uri("s3://my-bucket/docs/a.pdf") == ("s3", "my-bucket", "docs/a.pdf")
+
+    def test_gs_splits_the_same_way(self):
+        assert parse_cloud_uri("gs://b/k.pdf") == ("gcs", "b", "k.pdf")
+
+    def test_an_azure_blob_url_splits_into_container_and_blob(self):
+        provider, container, key = parse_cloud_uri(
+            "https://acct.blob.core.windows.net/docs/handbook.pdf"
+        )
+        assert (provider, container, key) == ("azure", "docs", "handbook.pdf")
+
+    def test_an_unsupported_scheme_is_refused_by_name(self):
+        with pytest.raises(CloudSourceError, match="Not a supported cloud source"):
+            parse_cloud_uri("ftp://host/file.pdf")
+
+
+class TestFetching:
+    def test_it_downloads_and_keeps_the_extension(self, tmp_path, monkeypatch):
+        """The readers dispatch on extension, so an extension-less temp file
+        would make a PDF be read as plain text."""
+        fake = types.ModuleType("boto3")
+
+        class _Client:
+            def download_file(self, bucket, key, dest):
+                with open(dest, "w") as handle:
+                    handle.write("downloaded")
+
+        fake.client = lambda *a, **k: _Client()
+        monkeypatch.setitem(sys.modules, "boto3", fake)
+
+        path = fetch_cloud_source("s3://bucket/docs/handbook.pdf", dest_dir=str(tmp_path))
+        assert path.endswith("handbook.pdf")
+        assert open(path).read() == "downloaded"
+
+    def test_a_missing_sdk_names_the_pip_package(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "boto3", None)
+        with pytest.raises(CloudSourceError, match="pip install boto3"):
+            fetch_cloud_source("s3://bucket/a.pdf")
+
+    def test_a_uri_without_an_object_is_refused(self):
+        with pytest.raises(CloudSourceError, match="container and an object"):
+            fetch_cloud_source("s3://bucket-only")
+
+    def test_a_provider_error_is_reported_not_swallowed(self, tmp_path, monkeypatch):
+        """A failed download must not look like an empty document."""
+        fake = types.ModuleType("boto3")
+
+        class _Client:
+            def download_file(self, *a, **k):
+                raise RuntimeError("AccessDenied")
+
+        fake.client = lambda *a, **k: _Client()
+        monkeypatch.setitem(sys.modules, "boto3", fake)
+
+        with pytest.raises(CloudSourceError, match="AccessDenied"):
+            fetch_cloud_source("s3://bucket/a.pdf", dest_dir=str(tmp_path))
+
+    def test_a_silent_no_op_download_is_caught(self, tmp_path, monkeypatch):
+        """If an SDK reports success but writes nothing, say so."""
+        fake = types.ModuleType("boto3")
+
+        class _Client:
+            def download_file(self, *a, **k):
+                return None
+
+        fake.client = lambda *a, **k: _Client()
+        monkeypatch.setitem(sys.modules, "boto3", fake)
+
+        with pytest.raises(CloudSourceError, match="wrote no file"):
+            fetch_cloud_source("s3://bucket/a.pdf", dest_dir=str(tmp_path))


### PR DESCRIPTION
Closes another competitor gap. `Knowledge` could only read local disk — no cloud SDK was imported anywhere in the package, so anyone with documents in a bucket had to download them by hand first.

```python
Knowledge(sources=["s3://my-bucket/handbook.pdf"])
```

Supported: `s3://` (boto3), `gs://` (google-cloud-storage), and `az://container/blob` or an Azure blob URL (azure-storage-blob).

## What made this a real bug rather than a missing feature

`detect_source_kind()` **already classified `s3://` and `gs://` as URLs** — so a bucket path was handed to an HTTP fetcher that cannot speak those schemes. The source looked supported and wasn't.

## Design

**Resolve, then reuse.** A cloud URI is downloaded to a local temp file and read by the *same* readers as any local file, so PDF/DOCX parsing is not reimplemented per provider.

**The extension is preserved.** The readers dispatch on it — an extension-less temp file would make a PDF be read as plain text, which fails as garbled content rather than as an error.

**Ordering matters.** The cloud branch is checked *before* the http/https branch, because an Azure blob URL is https and would otherwise go to the web fetcher.

**SDKs stay optional.** Each is imported only when a URI of that scheme is used, so installing PraisonAI does not pull three cloud SDKs. A missing one raises with the exact pip command rather than failing later inside the provider.

## Failure modes are explicit

This is the recurring defect this effort keeps finding, so each was closed deliberately:

- A provider error (`AccessDenied`, missing object) is **reported**, not swallowed into an empty document.
- An SDK that **reports success but writes no file** is caught — otherwise the knowledge base would look populated and be empty.
- A URI naming a bucket but no object is refused.
- The **original URI** is kept in the result metadata; a temp path is meaningless in a citation.

## Verification

| Check | Result |
|---|---|
| New tests | **18 passed** (six are controls) |
| `tests/unit/knowledge` — this branch | 134 passed, **12 failed** |
| Same suite — `origin/main` | 116 passed, **the same 12 failed** |
| Difference | exactly **+18**, no regressions |
| Collect gate | exit 0 |
| `names` / `signatures` / `behaviour` parity gates | all exit 0 |

The controls are what make this suite worth having: an ordinary `https://` URL is **not** claimed by the cloud branch, a local path is not, and an unsupported scheme is refused by name. Without those, the recogniser could claim everything and the tests would still pass.

The SDKs are faked in-process, so nothing touches a network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading knowledge sources from Amazon S3, Google Cloud Storage, and Azure Blob Storage.
  * Cloud files are downloaded automatically and processed using their existing file formats.
  * Azure Blob URLs now support percent-encoded object names and account-specific downloads.
  * Temporary cloud downloads are removed after indexing while retaining the original cloud URL as the source.

* **Bug Fixes**
  * Added clearer validation for Azure Blob URLs and improved handling of unavailable credentials, SDKs, or source files.

* **Tests**
  * Expanded coverage for cloud URI recognition, parsing, downloads, file extensions, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->