### PR TITLE
feat(agentos): read endpoints for runs, sessions and approvals

### DIFF
--- a/src/praisonai/praisonai/app/agentos.py
+++ b/src/praisonai/praisonai/app/agentos.py
@@ -13,6 +13,16 @@ import os
 from praisonaiagents import AgentOSConfig, AgentOSProtocol
 
 
+def _run_to_dict(record: Any) -> Dict[str, Any]:
+    """A RunRecord as JSON. Uses whatever the record exposes rather than
+    assuming a shape, so a ledger with extra fields is not silently truncated."""
+    if hasattr(record, "as_dict"):
+        return record.as_dict()
+    if hasattr(record, "__dict__"):
+        return {k: v for k, v in vars(record).items() if not k.startswith("_")}
+    return {"run": str(record)}
+
+
 class AgentOS:
     """
     Production platform for deploying AI agents as web services.
@@ -166,6 +176,100 @@ class AgentOS:
         async def health():
             return {"status": "healthy"}
         
+        # ── Read endpoints ────────────────────────────────────────────────
+        # AgentOS could list agents and take a chat turn, and nothing else. A
+        # session could not be replayed, a run inspected, or a pending approval
+        # seen over HTTP, even though the protocols to expose all three already
+        # existed. These are READ-only on purpose: mutating a run over HTTP is a
+        # much larger design question than surfacing one.
+        #
+        # Each returns 503 with what to configure when its store is absent.
+        # Returning an empty list would be indistinguishable from "no runs yet",
+        # which is the failure this codebase keeps finding.
+
+        def _unavailable(what: str, how: str):
+            raise HTTPException(
+                status_code=503,
+                detail=f"{what} is not available: {how}",
+            )
+
+        @app.get(f"{self.config.api_prefix}/runs")
+        async def list_runs(limit: int = 50):
+            ledger = getattr(self, "run_ledger", None)
+            if ledger is None:
+                _unavailable(
+                    "Run history",
+                    "no run ledger is configured on this AgentOS instance. "
+                    "Attach a praisonaiagents.runs.SQLiteRunLedger as `run_ledger`.",
+                )
+            records = ledger.list_all(limit=limit)
+            return {"runs": [_run_to_dict(r) for r in records], "count": len(records)}
+
+        @app.get(f"{self.config.api_prefix}/runs/{{run_id}}")
+        async def get_run(run_id: str):
+            ledger = getattr(self, "run_ledger", None)
+            if ledger is None:
+                _unavailable(
+                    "Run history",
+                    "no run ledger is configured on this AgentOS instance.",
+                )
+            record = ledger.get(run_id)
+            if record is None:
+                raise HTTPException(status_code=404, detail=f"No run {run_id!r}")
+            return _run_to_dict(record)
+
+        @app.get(f"{self.config.api_prefix}/sessions")
+        async def list_sessions(limit: int = 20):
+            store = getattr(self, "session_store", None)
+            if store is None or not hasattr(store, "recent"):
+                _unavailable(
+                    "Session history",
+                    "no session store is configured on this AgentOS instance. "
+                    "Attach a praisonaiagents.session store as `session_store`.",
+                )
+            summaries = store.recent(limit=limit)
+            return {
+                "sessions": [
+                    s.as_dict() if hasattr(s, "as_dict") else dict(s) for s in summaries
+                ],
+                "count": len(summaries),
+            }
+
+        @app.get(f"{self.config.api_prefix}/sessions/{{session_id}}")
+        async def get_session(session_id: str, limit: int = 100):
+            store = getattr(self, "session_store", None)
+            if store is None:
+                _unavailable(
+                    "Session history",
+                    "no session store is configured on this AgentOS instance.",
+                )
+            if hasattr(store, "session_exists") and not store.session_exists(session_id):
+                raise HTTPException(status_code=404, detail=f"No session {session_id!r}")
+            return {
+                "session_id": session_id,
+                "messages": store.get_chat_history(session_id, limit),
+            }
+
+        @app.get(f"{self.config.api_prefix}/approvals")
+        async def list_approvals():
+            try:
+                from praisonaiagents.approval import get_approval_registry
+            except ImportError:
+                _unavailable("Approvals", "praisonaiagents.approval is not installed.")
+            registry = get_approval_registry()
+            requirements = getattr(registry, "_requirements", None)
+            if requirements is None:
+                _unavailable(
+                    "Approvals",
+                    "this build's approval registry exposes no requirement listing.",
+                )
+            return {
+                "requirements": [
+                    {"tool": tool, "agent": agent, "risk_level": str(level)}
+                    for (tool, agent), level in requirements.items()
+                ]
+            }
+
         @app.get(f"{self.config.api_prefix}/agents")
         async def list_agents():
             return {

--- a/src/praisonai/praisonai/app/agentos.py
+++ b/src/praisonai/praisonai/app/agentos.py
@@ -149,7 +149,7 @@ class AgentOS:
     
     def _register_routes(self, app: Any) -> None:
         """Register API routes."""
-        from fastapi import HTTPException
+        from fastapi import HTTPException, Query
         from pydantic import BaseModel
         
         class ChatRequest(BaseModel):
@@ -194,7 +194,7 @@ class AgentOS:
             )
 
         @app.get(f"{self.config.api_prefix}/runs")
-        async def list_runs(limit: int = 50):
+        async def list_runs(limit: int = Query(50, ge=1, le=500)):
             ledger = getattr(self, "run_ledger", None)
             if ledger is None:
                 _unavailable(
@@ -219,7 +219,7 @@ class AgentOS:
             return _run_to_dict(record)
 
         @app.get(f"{self.config.api_prefix}/sessions")
-        async def list_sessions(limit: int = 20):
+        async def list_sessions(limit: int = Query(20, ge=1, le=200)):
             store = getattr(self, "session_store", None)
             if store is None or not hasattr(store, "recent"):
                 _unavailable(
@@ -236,14 +236,20 @@ class AgentOS:
             }
 
         @app.get(f"{self.config.api_prefix}/sessions/{{session_id}}")
-        async def get_session(session_id: str, limit: int = 100):
+        async def get_session(session_id: str, limit: int = Query(100, ge=1, le=500)):
             store = getattr(self, "session_store", None)
             if store is None:
                 _unavailable(
                     "Session history",
                     "no session store is configured on this AgentOS instance.",
                 )
-            if hasattr(store, "session_exists") and not store.session_exists(session_id):
+            if hasattr(store, "session_exists"):
+                if not store.session_exists(session_id):
+                    raise HTTPException(status_code=404, detail=f"No session {session_id!r}")
+            elif not store.get_chat_history(session_id, limit):
+                # Stores without session_exists cannot distinguish an unknown
+                # session from an empty one; treat an empty transcript as absent
+                # rather than returning a healthy-looking 200 for a bad id.
                 raise HTTPException(status_code=404, detail=f"No session {session_id!r}")
             return {
                 "session_id": session_id,
@@ -257,18 +263,35 @@ class AgentOS:
             except ImportError:
                 _unavailable("Approvals", "praisonaiagents.approval is not installed.")
             registry = get_approval_registry()
-            requirements = getattr(registry, "_requirements", None)
-            if requirements is None:
+
+            # The registry stores approval requirements across four fields --
+            # global tools plus per-agent overrides -- rather than a single
+            # dict. Reading the public accessors (is_required/get_risk_level)
+            # keeps this decoupled from that private shape. Fall back to the
+            # attributes only to enumerate which (agent, tool) pairs exist.
+            global_tools = getattr(registry, "_required_tools", None)
+            agent_tools = getattr(registry, "_agent_required_tools", None)
+            if global_tools is None and agent_tools is None:
                 _unavailable(
                     "Approvals",
                     "this build's approval registry exposes no requirement listing.",
                 )
-            return {
-                "requirements": [
-                    {"tool": tool, "agent": agent, "risk_level": str(level)}
-                    for (tool, agent), level in requirements.items()
-                ]
-            }
+
+            requirements = []
+            for tool in sorted(global_tools or ()):
+                requirements.append({
+                    "tool": tool,
+                    "agent": None,
+                    "risk_level": registry.get_risk_level(tool),
+                })
+            for agent, tools in (agent_tools or {}).items():
+                for tool in sorted(tools):
+                    requirements.append({
+                        "tool": tool,
+                        "agent": agent,
+                        "risk_level": registry.get_risk_level(tool, agent),
+                    })
+            return {"requirements": requirements}
 
         @app.get(f"{self.config.api_prefix}/agents")
         async def list_agents():

--- a/src/praisonai/tests/unit/app/test_agentos_read_endpoints.py
+++ b/src/praisonai/tests/unit/app/test_agentos_read_endpoints.py
@@ -1,0 +1,103 @@
+"""AgentOS can be inspected over HTTP.
+
+It could list agents and take a chat turn, and nothing else: a session could not
+be replayed, a run inspected, or a pending approval seen -- even though the
+protocols to expose all three already existed.
+"""
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from praisonai.app.agentos import AgentOS  # noqa: E402
+
+
+def _client(**attrs):
+    os_ = AgentOS(agents=[], name="demo")
+    for key, value in attrs.items():
+        setattr(os_, key, value)
+    return TestClient(os_.get_app())
+
+
+class FakeRun:
+    def __init__(self, run_id, status="done"):
+        self.run_id = run_id
+        self.status = status
+        self.agent = "researcher"
+
+
+class FakeLedger:
+    def __init__(self, runs):
+        self._runs = runs
+
+    def list_all(self, limit=200):
+        return self._runs[:limit]
+
+    def get(self, run_id):
+        return next((r for r in self._runs if r.run_id == run_id), None)
+
+
+class FakeSessionStore:
+    def __init__(self, history):
+        self._history = history
+
+    def recent(self, limit=10):
+        return [{"session_id": "s1", "messages": len(self._history)}][:limit]
+
+    def session_exists(self, session_id):
+        return session_id == "s1"
+
+    def get_chat_history(self, session_id, max_messages=None):
+        return self._history
+
+
+class TestMissingStoresFailLoudly:
+    """503 rather than [] -- an empty list is indistinguishable from 'none yet'."""
+
+    @pytest.mark.parametrize("path", ["/api/runs", "/api/sessions"])
+    def test_absent_store_returns_503_naming_what_to_configure(self, path):
+        response = _client().get(path)
+        assert response.status_code == 503
+        assert "configured" in response.json()["detail"]
+
+    def test_control_pre_existing_routes_are_unchanged(self):
+        client = _client()
+        assert client.get("/health").status_code == 200
+        assert client.get("/api/agents").status_code == 200
+
+
+class TestRuns:
+    def test_runs_are_listed_when_a_ledger_is_attached(self):
+        client = _client(run_ledger=FakeLedger([FakeRun("r1"), FakeRun("r2")]))
+        body = client.get("/api/runs").json()
+        assert body["count"] == 2
+        assert {r["run_id"] for r in body["runs"]} == {"r1", "r2"}
+
+    def test_a_single_run_can_be_fetched(self):
+        client = _client(run_ledger=FakeLedger([FakeRun("r1")]))
+        assert client.get("/api/runs/r1").json()["run_id"] == "r1"
+
+    def test_an_unknown_run_is_404_not_an_empty_object(self):
+        client = _client(run_ledger=FakeLedger([FakeRun("r1")]))
+        assert client.get("/api/runs/nope").status_code == 404
+
+    def test_limit_is_honoured(self):
+        client = _client(run_ledger=FakeLedger([FakeRun(f"r{i}") for i in range(5)]))
+        assert client.get("/api/runs?limit=2").json()["count"] == 2
+
+
+class TestSessions:
+    def test_a_session_can_be_replayed(self):
+        history = [{"role": "user", "content": "hi"}]
+        client = _client(session_store=FakeSessionStore(history))
+        body = client.get("/api/sessions/s1").json()
+        assert body["session_id"] == "s1"
+        assert body["messages"] == history
+
+    def test_an_unknown_session_is_404(self):
+        client = _client(session_store=FakeSessionStore([]))
+        assert client.get("/api/sessions/nope").status_code == 404
+
+    def test_sessions_are_listed(self):
+        client = _client(session_store=FakeSessionStore([{"role": "user", "content": "hi"}]))
+        assert client.get("/api/sessions").json()["count"] == 1

--- a/src/praisonai/tests/unit/app/test_agentos_read_endpoints.py
+++ b/src/praisonai/tests/unit/app/test_agentos_read_endpoints.py
@@ -101,3 +101,50 @@ class TestSessions:
     def test_sessions_are_listed(self):
         client = _client(session_store=FakeSessionStore([{"role": "user", "content": "hi"}]))
         assert client.get("/api/sessions").json()["count"] == 1
+
+    def test_store_without_session_exists_treats_empty_history_as_404(self):
+        # A store that cannot answer session_exists must not report an unknown
+        # id as a healthy 200 with an empty transcript.
+        client = _client(session_store=HistoryOnlyStore({"s1": [{"role": "user", "content": "hi"}]}))
+        assert client.get("/api/sessions/s1").status_code == 200
+        assert client.get("/api/sessions/nope").status_code == 404
+
+
+class TestBoundedLimits:
+    """Client-controlled limits are bounded -- a negative value must not remove
+    the SQL LIMIT (SQLite treats LIMIT -1 as unlimited)."""
+
+    @pytest.mark.parametrize(
+        "path", ["/api/runs?limit=-1", "/api/runs?limit=0", "/api/runs?limit=99999"]
+    )
+    def test_out_of_range_run_limit_is_rejected(self, path):
+        client = _client(run_ledger=FakeLedger([FakeRun("r1")]))
+        assert client.get(path).status_code == 422
+
+    def test_out_of_range_session_limit_is_rejected(self):
+        client = _client(session_store=FakeSessionStore([]))
+        assert client.get("/api/sessions?limit=-1").status_code == 422
+
+
+class TestApprovals:
+    def test_configured_requirements_are_listed(self):
+        from praisonaiagents.approval import get_approval_registry
+
+        registry = get_approval_registry()
+        registry.add_requirement("delete_file", risk_level="high")
+        try:
+            body = _client().get("/api/approvals").json()
+            tools = {r["tool"]: r["risk_level"] for r in body["requirements"]}
+            assert tools.get("delete_file") == "high"
+        finally:
+            registry.remove_requirement("delete_file")
+
+
+class HistoryOnlyStore:
+    """A session store that exposes only get_chat_history (no session_exists)."""
+
+    def __init__(self, histories):
+        self._histories = histories
+
+    def get_chat_history(self, session_id, max_messages=None):
+        return self._histories.get(session_id, [])


### PR DESCRIPTION
Closes another competitor gap. AgentOS could list agents and take a chat turn, and nothing else — a session could not be replayed, a run inspected, or a pending approval seen over HTTP, **even though the protocols to expose all three already existed** (`runs/sqlite_ledger.py`, `session/`, `approval/registry.py`).

Four routes become nine:

```
GET /api/runs?limit=50        GET /api/runs/{run_id}
GET /api/sessions?limit=20    GET /api/sessions/{session_id}
GET /api/approvals
```

**Read-only on purpose.** Mutating a run over HTTP is a much larger design question than surfacing one, and the audit that found this gap explicitly recommended taking the slice rather than building the whole 20-router control plane.

## The decision worth reviewing

A missing store returns **503 naming what to configure**, not an empty list:

```
/api/runs      -> 503  Run history is not available: no run ledger is configured…
/api/sessions  -> 503  Session history is not available: no session store is configured…
```

An empty list is indistinguishable from "no runs yet". An operator debugging a missing run would get a healthy-looking `{"runs": [], "count": 0}` and conclude the run never happened — the exact silent-failure shape this effort keeps finding, and the one that made the retrieval, attachment and hosted-tool bugs expensive. An unknown run or session is **404** rather than an empty object, for the same reason.

`_run_to_dict` serialises via the record's own `as_dict`/`__dict__` rather than a hardcoded field list, so a ledger carrying extra fields is not silently truncated on the way out.

## Verification

| Check | Result |
|---|---|
| New tests | **10 passed**, against a real FastAPI `TestClient` |
| Pre-existing routes | `/health` and `/api/agents` still **200** |
| `names` / `signatures` / `behaviour` parity gates | all exit 0 |

Two of the ten are controls — the existing routes still answer, and `limit=` is honoured rather than accepted and ignored.

## Pre-existing conditions, stated so they are not mistaken for regressions

`src/praisonai/tests/unit` collects **5742 tests with 6 errors**, all in unrelated modules (`cli`, `code`, `compute`, `scheduler`, `langflow`) and all present before this change. The suite also exits non-zero on an interpreter-shutdown logging crash in `Agent.__del__` (`ValueError: I/O operation on closed file`) that predates this branch — worth its own fix, but not this one's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only API endpoints for viewing run history and session history.
  * Added endpoints for reviewing approval requirements.
  * Added support for retrieving individual runs and sessions, with configurable result limits.

* **Bug Fixes**
  * APIs now return clear errors when records are missing or required stores and integrations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->