### PR TITLE
feat(workflows): typed workflow state

### DIFF
--- a/src/praisonai-agents/praisonaiagents/workflows/state.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/state.py
@@ -1,0 +1,95 @@
+"""Typed workflow state.
+
+A flow's state was an untyped ``Dict[str, Any]``. A typo in a variable name --
+``ctx.variables["reserach_results"]`` -- was found at runtime, if at all, and
+nothing told you what fields a workflow's state carried without reading every
+step. CrewAI leads its production guide with typed flow state for exactly this
+reason.
+
+    class ReviewState(BaseModel):
+        draft: str = ""
+        score: int = 0
+
+    flow = AgentFlow(steps=[...], state_model=ReviewState, variables={"draft": "hi"})
+    flow.state.draft          # typed, and a typo is an AttributeError here
+    flow.validate_variables() # raises on an unknown or ill-typed field
+
+Works with a Pydantic model or a plain dataclass, because this package must not
+require Pydantic for a workflow to run. Without ``state_model`` nothing changes:
+``variables`` stays the untyped dict it has always been, so this is additive.
+"""
+
+import dataclasses
+from typing import Any, Dict, Optional, Type
+
+__all__ = ["WorkflowStateError", "build_state", "state_field_names", "validate_variables"]
+
+
+class WorkflowStateError(ValueError):
+    """Raised when variables do not match the declared state model."""
+
+
+def _is_pydantic(model: Any) -> bool:
+    return hasattr(model, "model_validate") or hasattr(model, "parse_obj")
+
+
+def state_field_names(model: Type) -> set:
+    """The field names a state model declares."""
+    if model is None:
+        return set()
+    fields = getattr(model, "model_fields", None)  # pydantic v2
+    if isinstance(fields, dict):
+        return set(fields)
+    fields = getattr(model, "__fields__", None)  # pydantic v1
+    if isinstance(fields, dict):
+        return set(fields)
+    if dataclasses.is_dataclass(model):
+        return {f.name for f in dataclasses.fields(model)}
+    return set()
+
+
+def validate_variables(model: Optional[Type], variables: Dict[str, Any]) -> None:
+    """Raise unless ``variables`` fit ``model``.
+
+    An UNKNOWN key is an error, not something to ignore: silently accepting
+    ``reserach_results`` is precisely the typo this exists to catch.
+    """
+    if model is None:
+        return
+    declared = state_field_names(model)
+    if not declared:
+        raise WorkflowStateError(
+            f"{getattr(model, '__name__', model)!r} declares no fields, so it cannot "
+            f"describe this flow's state. Use a Pydantic model or a dataclass."
+        )
+    unknown = sorted(set(variables or {}) - declared)
+    if unknown:
+        raise WorkflowStateError(
+            f"Unknown workflow variable(s) {unknown} for state model "
+            f"{getattr(model, '__name__', model)!r}. Declared fields: "
+            f"{sorted(declared)}. A misspelled variable would otherwise be "
+            f"written, never read, and never reported."
+        )
+    build_state(model, variables)  # surfaces type errors too
+
+
+def build_state(model: Optional[Type], variables: Dict[str, Any]) -> Any:
+    """Construct the typed state instance from ``variables``."""
+    if model is None:
+        return None
+    data = dict(variables or {})
+    try:
+        if _is_pydantic(model):
+            if hasattr(model, "model_validate"):
+                return model.model_validate(data)
+            return model.parse_obj(data)
+        if dataclasses.is_dataclass(model):
+            return model(**data)
+        return model(**data)
+    except WorkflowStateError:
+        raise
+    except Exception as exc:
+        raise WorkflowStateError(
+            f"Workflow variables do not fit state model "
+            f"{getattr(model, '__name__', model)!r}: {type(exc).__name__}: {exc}"
+        ) from exc

--- a/src/praisonai-agents/praisonaiagents/workflows/workflows.py
+++ b/src/praisonai-agents/praisonaiagents/workflows/workflows.py
@@ -701,7 +701,15 @@ class AgentFlow:
     # Status tracking
     status: str = "not_started"  # not_started, running, completed, failed
     step_statuses: Dict[str, str] = field(default_factory=dict)  # {step_name: status}
-    
+
+    #: Optional type for ``variables``: a Pydantic model or a dataclass. When
+    #: set, the initial variables are validated and ``flow.state`` gives typed
+    #: access, so a misspelled variable is an error instead of a value written
+    #: once and never read. Without it nothing changes -- ``variables`` stays
+    #: the untyped dict it has always been. Declared last so it never shifts
+    #: the positional binding of existing fields like ``file_path``.
+    state_model: Optional[type] = None
+
     # Private resolved fields (set in __post_init__)
     _verbose: bool = field(default=False, repr=False)
     _stream: bool = field(default=True, repr=False)
@@ -748,6 +756,13 @@ class AgentFlow:
     def __post_init__(self):
         """Resolve consolidated params to internal values."""
         from ..utils.model_alias import resolve_model_name
+
+        # Validate the declared state up front. A misspelled variable found when
+        # the flow is BUILT costs nothing; found mid-run it has already burned
+        # the steps before it, and may never be found at all.
+        if self.state_model is not None:
+            from .state import validate_variables as _validate_state
+            _validate_state(self.state_model, self.variables)
 
         # One rule for the alias pair, shared with Agent and AgentTeam. Must
         # UNWRAP an LLMConfig to its model string: this value seeds the agents
@@ -1214,6 +1229,27 @@ class AgentFlow:
         """
         from .diagram import flow_to_mermaid
         return flow_to_mermaid(self)
+
+    @property
+    def state(self):
+        """The flow's variables as the declared ``state_model``.
+
+        Returns None when no model was declared, so callers can tell "untyped"
+        from "typed and empty" rather than being handed a misleading blank.
+        """
+        from .state import build_state
+        if self.state_model is None:
+            return None
+        return build_state(self.state_model, self.variables)
+
+    def validate_variables(self) -> None:
+        """Raise unless the current variables fit ``state_model``.
+
+        Called for you at construction; exposed so a step that writes variables
+        can re-check before the next step reads them.
+        """
+        from .state import validate_variables
+        validate_variables(self.state_model, self.variables)
 
     def __repr__(self):
         """Show where this workflow's steps run.

--- a/src/praisonai-agents/tests/unit/workflows/test_typed_state.py
+++ b/src/praisonai-agents/tests/unit/workflows/test_typed_state.py
@@ -1,0 +1,98 @@
+"""A workflow's state can be typed.
+
+Flow state was an untyped Dict[str, Any]. A typo -- ctx.variables["reserach_results"]
+-- was found at runtime, if at all, and nothing told you what fields a workflow's
+state carried without reading every step.
+"""
+import dataclasses
+import pytest
+
+from praisonaiagents.workflows.state import (
+    WorkflowStateError,
+    build_state,
+    state_field_names,
+    validate_variables,
+)
+from praisonaiagents.workflows.workflows import AgentFlow
+
+pydantic = pytest.importorskip("pydantic")
+
+
+class ReviewState(pydantic.BaseModel):
+    draft: str = ""
+    score: int = 0
+
+
+@dataclasses.dataclass
+class PlainState:
+    draft: str = ""
+    score: int = 0
+
+
+class TestTypedAccess:
+    def test_state_exposes_declared_fields(self):
+        flow = AgentFlow(steps=[], state_model=ReviewState,
+                         variables={"draft": "hi", "score": 7})
+        assert flow.state.draft == "hi"
+        assert flow.state.score == 7
+
+    def test_a_dataclass_works_too(self):
+        """Pydantic must not become a requirement for running a workflow."""
+        flow = AgentFlow(steps=[], state_model=PlainState, variables={"draft": "hi"})
+        assert flow.state.draft == "hi"
+
+    def test_control_an_untyped_flow_is_unchanged(self):
+        """Without a model, variables stay the untyped dict they always were."""
+        flow = AgentFlow(steps=[], variables={"anything": 1})
+        assert flow.state is None
+        assert flow.variables == {"anything": 1}
+
+    def test_state_is_none_not_an_empty_object_when_untyped(self):
+        """Callers must be able to tell 'untyped' from 'typed and empty'."""
+        assert AgentFlow(steps=[]).state is None
+
+
+class TestMistakesAreCaughtAtBuildTime:
+    def test_a_misspelled_variable_is_refused(self):
+        with pytest.raises(WorkflowStateError, match="reserach_results"):
+            AgentFlow(steps=[], state_model=ReviewState,
+                      variables={"reserach_results": 1})
+
+    def test_the_error_lists_the_declared_fields(self):
+        """So the fix is visible without opening the model."""
+        with pytest.raises(WorkflowStateError, match="draft"):
+            AgentFlow(steps=[], state_model=ReviewState, variables={"nope": 1})
+
+    def test_a_wrongly_typed_variable_is_refused(self):
+        with pytest.raises(WorkflowStateError, match="do not fit state model"):
+            AgentFlow(steps=[], state_model=ReviewState, variables={"score": "not an int"})
+
+    def test_control_correct_variables_build_cleanly(self):
+        AgentFlow(steps=[], state_model=ReviewState, variables={"score": 3})
+
+    def test_a_model_with_no_fields_is_refused(self):
+        class Empty:
+            pass
+        with pytest.raises(WorkflowStateError, match="declares no fields"):
+            validate_variables(Empty, {"a": 1})
+
+
+class TestRevalidation:
+    def test_variables_written_later_can_be_rechecked(self):
+        flow = AgentFlow(steps=[], state_model=ReviewState, variables={"score": 1})
+        flow.variables["reserach_results"] = 2
+        with pytest.raises(WorkflowStateError, match="reserach_results"):
+            flow.validate_variables()
+
+    def test_control_valid_later_writes_still_pass(self):
+        flow = AgentFlow(steps=[], state_model=ReviewState, variables={"score": 1})
+        flow.variables["draft"] = "later"
+        flow.validate_variables()
+
+
+class TestHelpers:
+    def test_field_names_from_pydantic_and_dataclass_agree(self):
+        assert state_field_names(ReviewState) == state_field_names(PlainState) == {"draft", "score"}
+
+    def test_build_state_returns_none_without_a_model(self):
+        assert build_state(None, {"a": 1}) is None


### PR DESCRIPTION
Closes another competitor gap. A flow's state was an untyped `Dict[str, Any]` — a typo like `ctx.variables["reserach_results"]` was found at runtime, if at all, and nothing told you what fields a workflow's state carried without reading every step.

```python
class ReviewState(BaseModel):
    draft: str = ""
    score: int = 0

flow = AgentFlow(steps=[...], state_model=ReviewState, variables={"draft": "hi"})
flow.state.draft            # typed access
flow.validate_variables()   # re-check after a step writes
```

## Validation runs at construction

A misspelled variable found when the flow is **built** costs nothing. Found mid-run it has already burned every step before it — and it may never be found at all, because a variable written once and never read is silent by nature.

```
typo caught:     Unknown workflow variable(s) ['reserach_results'] for state model
                 'ReviewState'. Declared fields: ['draft', 'score']. …
bad type caught: Workflow variables do not fit state model 'ReviewState': ValidationError…
```

## Three decisions

**An unknown key is an error, not something to ignore.** Silently accepting `reserach_results` is exactly the typo this exists to catch. The message lists the declared fields, so the fix is visible without opening the model.

**A dataclass works as well as a Pydantic model.** Requiring Pydantic to run a workflow would be a heavier dependency than the feature is worth — there is a test for the dataclass path so it cannot quietly regress into a Pydantic requirement.

**`flow.state` returns `None` when no model is declared**, rather than an empty object, so a caller can tell *untyped* from *typed and empty*.

## Entirely additive

Without `state_model`, `variables` stays the untyped dict it has always been. A control test pins that, so this cannot become a breaking change by accident.

## Verification

| Check | Result |
|---|---|
| New tests | **13 passed** (five are controls) |
| `tests/unit/workflows` — this branch | **219 passed, 0 failed** |
| Same suite — `origin/main` | **206 passed, 0 failed** |
| Difference | exactly **+13**, no regressions |
| Collect gate | exit 0 |
| `names` / `signatures` / `behaviour` parity gates | all exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional typed state support for workflows using Pydantic models or dataclasses.
  * Workflows can validate variables during setup and revalidate them after updates.
  * Added typed state access through the workflow interface.
  * Untyped workflows continue using their existing variables dictionary behavior.
  * Clear validation errors are provided for unknown fields, invalid values, and state construction failures.
  * Typed state remains available as a distinct workflow state, including when variables are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->