### PR TITLE
feat(agent): export an Agent or team back to a config dict

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/serialize.py
+++ b/src/praisonai-agents/praisonaiagents/agent/serialize.py
@@ -15,6 +15,16 @@ is exported by NAME, because a callable cannot survive a round trip through
 JSON and pretending otherwise would produce a config that imports as a
 different agent. ``tools_resolvable`` says whether the names could be rebound,
 so a caller is told rather than left to discover it.
+
+Scope, stated plainly so a caller is not surprised: this exports the scalar
+constructor arguments that are JSON-safe and round-trip cleanly (identity, the
+model, and simple flags). It does not yet serialise the grouped feature-config
+objects (``output=``, ``reflection=``, ``execution=`` ...) -- those are rich
+dataclasses, not scalars, and rebuilding them faithfully is a separate,
+larger piece of work. An agent that relies on a customised grouped config will
+round-trip to one carrying that config's *defaults*, not the original. That is
+a known limit of v1, named here rather than hidden, in the same spirit as
+``tools_resolvable``.
 """
 
 from typing import Any, Callable, Dict, List, Optional
@@ -39,6 +49,7 @@ AGENT_CONFIG_VERSION = 1
 #: imported. Hardcoding the list alone produced exactly that.
 _AGENT_FIELDS = (
     "name", "role", "goal", "backstory", "instructions", "llm",
+    "reasoning_effort",
     "self_reflect", "max_reflect", "min_reflect", "respect_context_window",
     "max_iter", "reasoning_steps", "markdown", "stream", "verbose",
 )
@@ -147,12 +158,23 @@ def agent_from_dict(
 
 
 def team_to_dict(team: Any) -> Dict[str, Any]:
-    """An AgentTeam as a config dict, members included."""
+    """An AgentTeam as a config dict, members included.
+
+    A team's *members* export cleanly; its **task graph** does not yet. Tasks
+    carry agent bindings, ordering, and context wiring whose faithful
+    serialisation -- and a matching importer -- is a larger piece of work than
+    this v1. Rather than emit half a task graph that would import wrong, ``tasks``
+    are omitted and ``tasks_included`` reports whether any were dropped, so the
+    caller is told rather than handed a team that silently forgot its work.
+    """
     if team is None:
         raise SerializationError("Cannot export None as a team config.")
+    tasks = getattr(team, "tasks", None)
+    had_tasks = bool(tasks)
     return {
         "version": AGENT_CONFIG_VERSION,
         "name": getattr(team, "name", None),
         "process": getattr(team, "process", None),
         "agents": [agent_to_dict(a) for a in (getattr(team, "agents", None) or [])],
+        "tasks_included": not had_tasks,
     }

--- a/src/praisonai-agents/praisonaiagents/agent/serialize.py
+++ b/src/praisonai-agents/praisonaiagents/agent/serialize.py
@@ -1,0 +1,158 @@
+"""Export an Agent or AgentTeam back to a config dict.
+
+Config flowed one way. ``workflows/yaml_parser.py`` builds agents FROM YAML, and
+nothing exported them back -- so you could not build a team in Python and hand
+it to the visual builder, diff two team configs, or check into review what a
+programmatically-assembled team actually became. This is the missing half of a
+pipeline that already exists.
+
+    blob = agent_to_dict(agent)         # JSON-safe
+    same = agent_from_dict(blob)        # an equivalent Agent
+
+What is deliberately NOT exported: anything that is a live object rather than
+configuration -- an open session, a memory store, a resolved LLM client. A tool
+is exported by NAME, because a callable cannot survive a round trip through
+JSON and pretending otherwise would produce a config that imports as a
+different agent. ``tools_resolvable`` says whether the names could be rebound,
+so a caller is told rather than left to discover it.
+"""
+
+from typing import Any, Callable, Dict, List, Optional
+
+__all__ = [
+    "AGENT_CONFIG_VERSION",
+    "SerializationError",
+    "agent_to_dict",
+    "agent_from_dict",
+    "team_to_dict",
+]
+
+AGENT_CONFIG_VERSION = 1
+
+#: Candidate fields worth carrying. Deliberately a list rather than "everything
+#: on the object": an Agent holds runtime state (clients, caches, sessions) that
+#: is meaningless -- and sometimes unserialisable -- in a config.
+#:
+#: Intersected with the CONSTRUCTOR SIGNATURE at export time, so an attribute
+#: that still exists on the instance but is no longer a constructor argument
+#: (several moved into `output=`) is not exported into a config that cannot be
+#: imported. Hardcoding the list alone produced exactly that.
+_AGENT_FIELDS = (
+    "name", "role", "goal", "backstory", "instructions", "llm",
+    "self_reflect", "max_reflect", "min_reflect", "respect_context_window",
+    "max_iter", "reasoning_steps", "markdown", "stream", "verbose",
+)
+
+
+def _constructor_fields(agent_cls: type) -> set:
+    """The subset of _AGENT_FIELDS this build's constructor still accepts."""
+    import inspect
+    try:
+        params = inspect.signature(agent_cls.__init__).parameters
+    except (TypeError, ValueError):  # pragma: no cover - exotic callables
+        return set(_AGENT_FIELDS)
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        # **kwargs alone is not proof it is accepted: this class validates and
+        # raises on unknown keys, so trust the named parameters only.
+        pass
+    return {f for f in _AGENT_FIELDS if f in params}
+
+
+class SerializationError(ValueError):
+    """Raised when a config cannot be exported or rebuilt."""
+
+
+def _tool_name(tool: Any) -> Optional[str]:
+    for attr in ("name", "__name__"):
+        value = getattr(tool, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    if isinstance(tool, str):
+        return tool
+    return None
+
+
+def agent_to_dict(agent: Any) -> Dict[str, Any]:
+    """An Agent as a JSON-safe config dict."""
+    if agent is None:
+        raise SerializationError("Cannot export None as an agent config.")
+
+    allowed = _constructor_fields(type(agent))
+    config: Dict[str, Any] = {"version": AGENT_CONFIG_VERSION}
+    for field in sorted(allowed):
+        if not hasattr(agent, field):
+            continue
+        value = getattr(agent, field)
+        if value is None:
+            continue
+        # An LLM object rather than a model string: keep its identity, not the
+        # client. A resolved client cannot be rebuilt from JSON anyway.
+        if field == "llm" and not isinstance(value, str):
+            value = getattr(value, "model", None) or getattr(value, "name", None) or str(value)
+        config[field] = value
+
+    tools = getattr(agent, "tools", None) or []
+    names = [_tool_name(t) for t in tools]
+    config["tools"] = [n for n in names if n]
+    # Say plainly whether the tools survived as names. A config whose tools
+    # cannot be rebound imports as an agent that silently cannot act.
+    config["tools_resolvable"] = all(n is not None for n in names)
+    return config
+
+
+def agent_from_dict(
+    config: Dict[str, Any],
+    *,
+    tool_registry: Optional[Dict[str, Callable]] = None,
+    agent_cls: Optional[type] = None,
+) -> Any:
+    """Rebuild an Agent from ``agent_to_dict`` output.
+
+    ``tool_registry`` maps exported tool names back to callables. Without it an
+    agent is rebuilt WITHOUT tools, and that is reported rather than assumed --
+    an agent that silently lost its tools looks like an agent that chose not to
+    use them.
+    """
+    if not isinstance(config, dict):
+        raise SerializationError(f"Agent config must be a dict; got {type(config).__name__}")
+
+    version = config.get("version", AGENT_CONFIG_VERSION)
+    if version != AGENT_CONFIG_VERSION:
+        raise SerializationError(
+            f"Agent config is version {version!r}, this build reads {AGENT_CONFIG_VERSION}."
+        )
+
+    if agent_cls is None:
+        from .agent import Agent as agent_cls  # type: ignore
+
+    kwargs = {k: v for k, v in config.items() if k in _constructor_fields(agent_cls)}
+
+    wanted: List[str] = list(config.get("tools") or [])
+    if wanted:
+        if tool_registry is None:
+            raise SerializationError(
+                f"This config declares tools {wanted} but no tool_registry was given, "
+                f"so they cannot be rebound. Pass tool_registry={{name: callable}}, or "
+                f"strip 'tools' from the config if a tool-less agent is intended."
+            )
+        missing = [n for n in wanted if n not in tool_registry]
+        if missing:
+            raise SerializationError(
+                f"tool_registry is missing {missing}. Rebuilding without them would "
+                f"produce an agent that silently cannot act."
+            )
+        kwargs["tools"] = [tool_registry[n] for n in wanted]
+
+    return agent_cls(**kwargs)
+
+
+def team_to_dict(team: Any) -> Dict[str, Any]:
+    """An AgentTeam as a config dict, members included."""
+    if team is None:
+        raise SerializationError("Cannot export None as a team config.")
+    return {
+        "version": AGENT_CONFIG_VERSION,
+        "name": getattr(team, "name", None),
+        "process": getattr(team, "process", None),
+        "agents": [agent_to_dict(a) for a in (getattr(team, "agents", None) or [])],
+    }

--- a/src/praisonai-agents/tests/unit/agent/test_config_round_trip.py
+++ b/src/praisonai-agents/tests/unit/agent/test_config_round_trip.py
@@ -41,6 +41,14 @@ class TestRoundTrip:
         rebuilt = agent_from_dict(blob, tool_registry={"search": search})
         assert [t.__name__ for t in rebuilt.tools] == ["search"]
 
+    def test_reasoning_effort_is_a_current_param_and_must_survive(self):
+        """reasoning_effort is a live constructor arg (Issue #4452); dropping it
+        silently would round-trip a 'high' agent back to the default."""
+        agent = Agent(name="R", instructions="x", llm="gpt-4o", reasoning_effort="high")
+        blob = agent_to_dict(agent)
+        assert blob["reasoning_effort"] == "high"
+        assert agent_from_dict(blob).reasoning_effort == "high"
+
 
 class TestItRefusesToLoseThings:
     def test_tools_without_a_registry_are_refused(self):
@@ -94,3 +102,22 @@ class TestTeams:
         blob = team_to_dict(FakeTeam())
         assert blob["name"] == "ops"
         assert [a["name"] for a in blob["agents"]] == ["A", "B"]
+
+    def test_a_taskless_team_reports_tasks_included(self):
+        class FakeTeam:
+            name = "ops"
+            process = "sequential"
+            agents = [Agent(name="A", instructions="x", llm="gpt-4o")]
+
+        assert team_to_dict(FakeTeam())["tasks_included"] is True
+
+    def test_a_team_with_tasks_reports_them_as_not_included(self):
+        """The task graph is not serialised in v1; the flag says so plainly
+        rather than letting a diff or builder assume the work came across."""
+        class FakeTeam:
+            name = "ops"
+            process = "sequential"
+            agents = [Agent(name="A", instructions="x", llm="gpt-4o")]
+            tasks = {0: object()}
+
+        assert team_to_dict(FakeTeam())["tasks_included"] is False

--- a/src/praisonai-agents/tests/unit/agent/test_config_round_trip.py
+++ b/src/praisonai-agents/tests/unit/agent/test_config_round_trip.py
@@ -1,0 +1,96 @@
+"""An Agent can be exported to config and rebuilt.
+
+Config flowed one way: workflows/yaml_parser.py builds agents FROM YAML and
+nothing exported them back, so a team assembled in Python could not be handed to
+the visual builder or diffed against another.
+"""
+import json
+import pytest
+
+from praisonaiagents import Agent
+from praisonaiagents.agent.serialize import (
+    AGENT_CONFIG_VERSION,
+    SerializationError,
+    agent_from_dict,
+    agent_to_dict,
+    team_to_dict,
+)
+
+
+def search(q: str) -> str:
+    """Search the web."""
+    return "result"
+
+
+class TestRoundTrip:
+    def test_identity_survives(self):
+        agent = Agent(name="Researcher", role="Analyst", instructions="be thorough", llm="gpt-4o")
+        rebuilt = agent_from_dict(agent_to_dict(agent))
+        assert (rebuilt.name, rebuilt.role, rebuilt.llm) == ("Researcher", "Analyst", "gpt-4o")
+
+    def test_the_config_is_json_safe(self):
+        """It has to survive a file or an HTTP body to be worth anything."""
+        agent = Agent(name="R", instructions="x", llm="gpt-4o", tools=[search])
+        json.dumps(agent_to_dict(agent))
+
+    def test_tools_are_exported_by_name_and_can_be_rebound(self):
+        agent = Agent(name="R", instructions="x", llm="gpt-4o", tools=[search])
+        blob = agent_to_dict(agent)
+        assert blob["tools"] == ["search"]
+        assert blob["tools_resolvable"] is True
+        rebuilt = agent_from_dict(blob, tool_registry={"search": search})
+        assert [t.__name__ for t in rebuilt.tools] == ["search"]
+
+
+class TestItRefusesToLoseThings:
+    def test_tools_without_a_registry_are_refused(self):
+        """Rebuilding tool-less would look like an agent that chose not to act."""
+        blob = agent_to_dict(Agent(name="R", instructions="x", llm="gpt-4o", tools=[search]))
+        with pytest.raises(SerializationError, match="tool_registry"):
+            agent_from_dict(blob)
+
+    def test_a_registry_missing_a_tool_is_refused_by_name(self):
+        blob = agent_to_dict(Agent(name="R", instructions="x", llm="gpt-4o", tools=[search]))
+        with pytest.raises(SerializationError, match="search"):
+            agent_from_dict(blob, tool_registry={"other": search})
+
+    def test_control_a_tool_less_agent_needs_no_registry(self):
+        blob = agent_to_dict(Agent(name="R", instructions="x", llm="gpt-4o"))
+        assert agent_from_dict(blob).name == "R"
+
+    def test_a_config_from_another_version_is_refused(self):
+        blob = agent_to_dict(Agent(name="R", instructions="x", llm="gpt-4o"))
+        blob["version"] = AGENT_CONFIG_VERSION + 1
+        with pytest.raises(SerializationError, match="version"):
+            agent_from_dict(blob)
+
+    def test_exporting_none_is_refused(self):
+        with pytest.raises(SerializationError):
+            agent_to_dict(None)
+
+
+class TestOnlyConstructorArguments:
+    def test_the_export_contains_nothing_the_constructor_rejects(self):
+        """The first draft exported attributes that had moved into output=,
+        producing a config that could not be imported."""
+        agent = Agent(name="R", instructions="x", llm="gpt-4o")
+        blob = agent_to_dict(agent)
+        agent_from_dict(blob)  # must not raise
+
+    def test_runtime_state_is_not_exported(self):
+        blob = agent_to_dict(Agent(name="R", instructions="x", llm="gpt-4o"))
+        for leaked in ("chat_history", "_session", "memory", "knowledge"):
+            assert leaked not in blob
+
+
+class TestTeams:
+    def test_a_team_exports_its_members(self):
+        class FakeTeam:
+            name = "ops"
+            process = "sequential"
+            agents = [Agent(name="A", instructions="x", llm="gpt-4o"),
+                      Agent(name="B", instructions="x", llm="gpt-4o")]
+
+        blob = team_to_dict(FakeTeam())
+        assert blob["name"] == "ops"
+        assert [a["name"] for a in blob["agents"]] == ["A", "B"]


### PR DESCRIPTION
Closes another competitor gap. Config flowed **one way**: `workflows/yaml_parser.py` builds agents *from* YAML and nothing exported them back — so you could not build a team in Python and hand it to the visual builder, diff two team configs, or put into review what a programmatically-assembled team actually became.

```python
blob = agent_to_dict(agent)                               # JSON-safe
same = agent_from_dict(blob, tool_registry={"search": search})
```

## The field set is derived from the constructor, not hardcoded

The first draft used a fixed list and exported attributes that still exist on the instance but have **moved into `output=`** (`verbose`, `stream`, `markdown`, `self_reflect`, …). The result imported as:

```
TypeError: Agent.__init__() got unexpected keyword argument(s): markdown, max_iter, …
```

An export that cannot be imported is worse than no export — it looks like a working config right up until someone tries to use it. Intersecting with the live signature means the exporter cannot drift from the constructor again.

## Refusals, each because the silent version loses something quietly

| Refused | Because otherwise… |
|---|---|
| Tools present, no `tool_registry` | rebuilding tool-less produces an agent that looks like it *chose* not to act |
| Registry missing a tool | the tool is dropped silently rather than named |
| Config from another version | half-imports into an incompatible build |

`tools_resolvable` records whether every tool survived as a name, so a caller is **told** rather than left to discover it. Runtime state — clients, caches, sessions, memory — is deliberately not exported, and a test asserts none of it leaks in.

## Why module functions rather than `Agent.to_dict()`

The methods were written first. The **signatures gate correctly flagged them** as a new Python/TypeScript method divergence requiring the recorded baseline to grow:

```
Agent.to_dict: a new methods divergence, not in the recorded baseline.
```

Growing a parity baseline for two convenience aliases is a poor trade when `agent_to_dict(agent)` is equally usable, so the methods were removed and **parity stays flat**. The gate did its job; I took the option that doesn't add debt.

## Verification

| Check | Result |
|---|---|
| New tests | **11 passed** (two are controls) |
| `tests/unit/agent` — this branch | 450 passed, **3 failed** |
| Same suite — `origin/main` | 439 passed, **the same 3 failed** |
| Difference | exactly **+11**, no regressions |
| Collect gate | exit 0 |
| `names` / `signatures` / `behaviour` parity gates | all exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON-safe configuration export and import for agents and teams.
  * Agent configurations preserve supported settings and can reconnect tools through a registry.
  * Team exports include member information and indicate whether task details were included.
  * Added validation for unsupported versions, invalid configurations, and unavailable tools.

* **Tests**
  * Added coverage for configuration round trips, JSON compatibility, tool restoration, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->