### PR TITLE
fix(config): seven config classes for public parameters were not importable

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -880,6 +880,14 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
                     "streaming moved into output=; use "
                     "output=OutputConfig(stream=True)."
                 ),
+                "tool_retry_policy": (
+                    "tool retry moved into tool_config=; use "
+                    "tool_config=ToolConfig(retry_policy=RetryPolicy(...))."
+                ),
+                "tool_timeout": (
+                    "tool timeout moved into tool_config=; use "
+                    "tool_config=ToolConfig(timeout=...)."
+                ),
             }
             _hint = "".join(
                 f"\n  {name}: {_HINTS[name]}" for name in sorted(_unknown) if name in _HINTS

--- a/src/praisonai-agents/praisonaiagents/config/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/config/__init__.py
@@ -37,6 +37,17 @@ __all__ = [
     "WebConfig",
     "OutputConfig",
     "ExecutionConfig",
+    # Configuration objects for public parameters that were defined in
+    # feature_configs but never exported here, so the usage their own
+    # docstrings show -- Agent(tool_config=ToolConfig(...)) -- could not be
+    # written with the natural import.
+    "ToolConfig",
+    "AutonomyConfig",
+    "LearnConfig",
+    "MultiAgentExecutionConfig",
+    "MultiAgentHooksConfig",
+    "MultiAgentMemoryConfig",
+    "MultiAgentOutputConfig",
     "PreCompactionMemoryFlushConfig",
     "TemplateConfig",
     "CachingConfig",
@@ -127,6 +138,13 @@ _MODULE_MAP = {
     "WebConfig": "feature_configs",
     "OutputConfig": "feature_configs",
     "ExecutionConfig": "feature_configs",
+    "ToolConfig": "feature_configs",
+    "AutonomyConfig": "feature_configs",
+    "LearnConfig": "feature_configs",
+    "MultiAgentExecutionConfig": "feature_configs",
+    "MultiAgentHooksConfig": "feature_configs",
+    "MultiAgentMemoryConfig": "feature_configs",
+    "MultiAgentOutputConfig": "feature_configs",
     "PreCompactionMemoryFlushConfig": "feature_configs",
     "TemplateConfig": "feature_configs",
     "CachingConfig": "feature_configs",

--- a/src/praisonai-agents/tests/unit/config/test_public_config_exports.py
+++ b/src/praisonai-agents/tests/unit/config/test_public_config_exports.py
@@ -1,0 +1,86 @@
+"""Every config class a public parameter accepts must be importable.
+
+``ToolConfig``'s own docstring shows ``Agent(tool_config=ToolConfig())``, but
+it was defined in ``feature_configs`` and never listed in
+``praisonaiagents.config.__all__`` -- so the documented usage could not be
+written with the natural import, while its siblings (``ExecutionConfig``,
+``OutputConfig``, ...) could. Six others were in the same position, all of them
+backing a public parameter of ``Agent`` or ``PraisonAIAgents``.
+
+This pins the rule rather than the list, so a config added for a new parameter
+cannot be left unexported.
+"""
+
+import inspect
+
+import pytest
+
+import praisonaiagents.config as config_pkg
+from praisonaiagents import Agent, PraisonAIAgents
+from praisonaiagents.config import feature_configs
+
+
+# Parameter name -> the config class callers are expected to pass.
+_AGENT_PARAM_CONFIGS = {
+    "tool_config": "ToolConfig",
+    "autonomy": "AutonomyConfig",
+    "learn": "LearnConfig",
+    "output": "OutputConfig",
+    "memory": "MemoryConfig",
+    "knowledge": "KnowledgeConfig",
+}
+_TEAM_PARAM_CONFIGS = {
+    "execution": "MultiAgentExecutionConfig",
+    "hooks": "MultiAgentHooksConfig",
+    "memory": "MultiAgentMemoryConfig",
+    "output": "MultiAgentOutputConfig",
+}
+
+
+def _exported(name):
+    return name in getattr(config_pkg, "__all__", ()) and hasattr(config_pkg, name)
+
+
+@pytest.mark.parametrize("param,cls", sorted(_AGENT_PARAM_CONFIGS.items()))
+def test_agent_parameter_configs_are_importable(param, cls):
+    assert param in inspect.signature(Agent.__init__).parameters, (
+        f"Agent no longer takes {param!r}; update this table"
+    )
+    assert _exported(cls), (
+        f"Agent({param}=...) expects {cls}, which is not importable from "
+        f"praisonaiagents.config"
+    )
+
+
+@pytest.mark.parametrize("param,cls", sorted(_TEAM_PARAM_CONFIGS.items()))
+def test_team_parameter_configs_are_importable(param, cls):
+    assert param in inspect.signature(PraisonAIAgents.__init__).parameters, (
+        f"PraisonAIAgents no longer takes {param!r}; update this table"
+    )
+    assert _exported(cls), (
+        f"PraisonAIAgents({param}=...) expects {cls}, which is not importable "
+        f"from praisonaiagents.config"
+    )
+
+
+def test_every_exported_name_actually_resolves():
+    """__all__ is lazily resolved, so a typo there fails only on first access."""
+    unresolvable = []
+    for name in getattr(config_pkg, "__all__", ()):
+        try:
+            getattr(config_pkg, name)
+        except Exception as exc:  # pragma: no cover - the regression
+            unresolvable.append(f"{name} ({type(exc).__name__})")
+    assert not unresolvable, f"listed in __all__ but not importable: {unresolvable}"
+
+
+def test_the_documented_usage_actually_runs():
+    """The line from ToolConfig's own docstring must work end to end."""
+    from praisonaiagents.config import ToolConfig
+    from praisonaiagents.tools.retry import RetryPolicy
+
+    agent = Agent(
+        name="t", role="r", goal="g", llm="gpt-4o-mini",
+        tool_config=ToolConfig(retry_policy=RetryPolicy(max_attempts=5)),
+    )
+    assert agent is not None

--- a/src/praisonai-agents/tests/unit/config/test_public_config_exports.py
+++ b/src/praisonai-agents/tests/unit/config/test_public_config_exports.py
@@ -84,3 +84,43 @@ def test_the_documented_usage_actually_runs():
         tool_config=ToolConfig(retry_policy=RetryPolicy(max_attempts=5)),
     )
     assert agent is not None
+
+
+def _config_classes_named_in(annotation):
+    """Every ``*Config`` class name referenced by a parameter's annotation.
+
+    Annotations here are forward-ref strings inside ``Union`` / ``Optional``
+    (e.g. ``Optional[Union[bool, 'ToolConfig']]``). Walk the annotation's own
+    text so the check needs no import of the target and follows the signature
+    itself -- a new config-backed parameter is picked up without editing a list.
+    """
+    import re
+
+    text = annotation if isinstance(annotation, str) else str(annotation)
+    return {
+        name
+        for name in re.findall(r"[A-Za-z_][A-Za-z0-9_]*", text)
+        if name.endswith("Config") and hasattr(feature_configs, name)
+    }
+
+
+@pytest.mark.parametrize("owner", [Agent, PraisonAIAgents])
+def test_config_classes_in_signatures_are_all_exported(owner):
+    """Completeness guard: derive from annotations, not a hand-kept table.
+
+    The parametrized tables above only assert the parameters already known.
+    This walks *every* parameter's annotation, so a future config-backed
+    parameter whose class is left unexported fails here even if nobody updates
+    the tables -- the exact regression this module exists to prevent.
+    """
+    missing = {}
+    for param in inspect.signature(owner.__init__).parameters.values():
+        if param.annotation is inspect.Parameter.empty:
+            continue
+        for cls in _config_classes_named_in(param.annotation):
+            if not _exported(cls):
+                missing.setdefault(param.name, set()).add(cls)
+    assert not missing, (
+        f"{owner.__name__} parameters reference config classes defined in "
+        f"feature_configs but not importable from praisonaiagents.config: {missing}"
+    )

--- a/src/praisonai-agents/tests/unit/session/test_bot_session_persistence.py
+++ b/src/praisonai-agents/tests/unit/session/test_bot_session_persistence.py
@@ -7,6 +7,8 @@ per-user session isolation instead of in-memory-only storage.
 
 import asyncio
 import tempfile
+
+import pytest
 from typing import Any, Dict, List
 
 from praisonaiagents.session.store import DefaultSessionStore
@@ -39,21 +41,23 @@ class TestBotSessionManagerWithStore:
     """Tests for BotSessionManager using persistent session store."""
     
     def _make_manager(self, tmpdir: str, platform: str = "test"):
-        """Create a BotSessionManager with a persistent store."""
-        # Import here to test the refactored version
-        import sys
-        import os
-        # Add wrapper path so we can import _session
-        wrapper_path = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
-                os.path.dirname(os.path.abspath(__file__))
-            )))),
-            "praisonai", "praisonai", "bots"
-        )
-        if wrapper_path not in sys.path:
-            sys.path.insert(0, wrapper_path)
-        
-        from _session import BotSessionManager
+        """Create a BotSessionManager with a persistent store.
+
+        Imported as a package rather than by pushing a directory onto sys.path.
+        The old helper walked five levels up to ``praisonai/praisonai/bots`` and
+        imported a bare ``_session``; the bots code has since moved to the
+        ``praisonai-bot`` package, that directory no longer exists, and all
+        eleven tests in this class had been failing with
+        ``ModuleNotFoundError: No module named '_session'`` ever since.
+
+        Skipped rather than failed when the optional package is absent, so a
+        checkout without it reports "not installed" instead of a bare import
+        error that reads like a broken test.
+        """
+        BotSessionManager = pytest.importorskip(
+            "praisonai_bot.bots._session",
+            reason="praisonai-bot is not installed",
+        ).BotSessionManager
         store = DefaultSessionStore(session_dir=tmpdir)
         return BotSessionManager(store=store, platform=platform)
     
@@ -179,18 +183,10 @@ class TestBotSessionManagerWithStore:
     
     def test_backward_compat_no_store(self):
         """BotSessionManager must still work without a store (in-memory fallback)."""
-        import sys
-        import os
-        wrapper_path = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
-                os.path.dirname(os.path.abspath(__file__))
-            )))),
-            "praisonai", "praisonai", "bots"
-        )
-        if wrapper_path not in sys.path:
-            sys.path.insert(0, wrapper_path)
-        
-        from _session import BotSessionManager
+        BotSessionManager = pytest.importorskip(
+            "praisonai_bot.bots._session",
+            reason="praisonai-bot is not installed",
+        ).BotSessionManager
         # No store parameter = backward compatible in-memory mode
         mgr = BotSessionManager()
         agent = FakeAgent()

--- a/src/praisonai-agents/tests/unit/session/test_hierarchy.py
+++ b/src/praisonai-agents/tests/unit/session/test_hierarchy.py
@@ -417,24 +417,50 @@ class TestHierarchicalSessionStore:
         assert final_session.messages[2].content == "Message 2"
         assert final_session.messages[3].content == "Response 2"
     
-    def test_cache_performance_with_unchanged_files(self):
-        """
-        Test that performance optimization works - reads from cache when file hasn't changed.
+    def test_reads_are_fresh_and_leave_the_cache_valid(self):
+        """``get_extended_session`` reads from disk every time, by design.
+
+        This asserted ``session2 is session1`` -- that a second read returns the
+        same cached object -- until #1781 and #1785 made the getter always
+        reload. Those were not tidying: the stale extended cache could **wipe
+        session messages**, and went stale on cross-instance writes. Returning
+        the cached object again would reintroduce exactly that.
+
+        So identity is not the contract. What must hold is that a second read
+        sees the same data, and that the fresh read leaves the cache and its
+        mtime in sync rather than invalidating them.
         """
         session_id = self.store.create_session(title="Cache Test")
         self.store.add_message(session_id, "user", "Test message")
-        
-        # First read - loads from disk and caches
+
         session1 = self.store.get_extended_session(session_id)
         assert len(session1.messages) == 1
-        
-        # Second read should use cache (file hasn't changed)
-        # We can't easily test this directly, but we can verify the cache is valid
         assert self.store._is_cache_valid(session_id) is True
-        
+
         session2 = self.store.get_extended_session(session_id)
         assert len(session2.messages) == 1
-        assert session2 is session1  # Should be same cached object
+        assert session2.session_id == session1.session_id
+        assert [m.content for m in session2.messages] == [
+            m.content for m in session1.messages
+        ]
+        # Re-reading keeps the cache coherent instead of leaving it stale.
+        assert self.store._is_cache_valid(session_id) is True
+
+    def test_a_write_from_another_store_instance_is_seen(self):
+        """The reason the cache is bypassed (#1785): cross-instance writes.
+
+        A second store object writing to the same directory must be visible to
+        the first, which a cached object would hide.
+        """
+        session_id = self.store.create_session(title="Cross Instance")
+        self.store.add_message(session_id, "user", "first")
+        assert len(self.store.get_extended_session(session_id).messages) == 1
+
+        other = type(self.store)(session_dir=self.store.session_dir)
+        other.add_message(session_id, "user", "second")
+
+        seen = self.store.get_extended_session(session_id)
+        assert [m.content for m in seen.messages] == ["first", "second"]
     
     def test_force_reload_bypasses_cache(self):
         """Test that force_reload=True always loads from disk."""

--- a/src/praisonai-agents/tests/unit/test_tool_decorator_retry.py
+++ b/src/praisonai-agents/tests/unit/test_tool_decorator_retry.py
@@ -2,6 +2,7 @@
 Tests for @tool(retry_policy=...) decorator functionality.
 """
 from praisonaiagents import tool, Agent
+from praisonaiagents.config import ToolConfig
 from praisonaiagents.tools.retry import RetryPolicy
 
 
@@ -47,7 +48,7 @@ class TestToolDecoratorRetryPolicy:
             name="test_agent",
             instructions="Test agent",
             tools=[special_tool],
-            tool_retry_policy=agent_retry_policy
+            tool_config=ToolConfig(retry_policy=agent_retry_policy)
         )
         
         # Should get tool-level policy (higher precedence)
@@ -78,7 +79,7 @@ class TestToolDecoratorRetryPolicy:
             name="test_agent",
             instructions="Test agent",
             tools=[tool_a, tool_b, tool_c],
-            tool_retry_policy=agent_policy
+            tool_config=ToolConfig(retry_policy=agent_policy)
         )
         
         # Tool A should use its own policy

--- a/src/praisonai-agents/tests/unit/test_tool_retry_agentic.py
+++ b/src/praisonai-agents/tests/unit/test_tool_retry_agentic.py
@@ -2,16 +2,29 @@
 Real agentic test for tool retry policy - agent actually runs and calls LLM with retrying tools.
 This satisfies the AGENTS.md requirement (§9.4) for real agentic testing.
 """
+import os
+
 import pytest
 import time
 from unittest.mock import patch
 
 from praisonaiagents import Agent, tool
+from praisonaiagents.config import ToolConfig
 from praisonaiagents.tools.retry import RetryPolicy
 
 
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY") == "not-needed",
+    reason="Requires OpenAI API Key",
+)
 class TestRetryPolicyAgentic:
-    """Real agentic tests where the agent calls LLM and uses retrying tools."""
+    """Real agentic tests where the agent calls LLM and uses retrying tools.
+
+    These genuinely call the model (AGENTS.md 9.4) but live under tests/unit
+    with no gate, so running the unit suite issued live API calls and failed on
+    any machine without a key. Gated with the same condition
+    test_circuit_breaker.py already uses.
+    """
     
     def test_agent_with_flaky_tool_real_llm(self):
         """
@@ -48,7 +61,7 @@ class TestRetryPolicyAgentic:
             name="research_assistant",
             instructions="You are a helpful research assistant. When asked to search for information, use the flaky_web_search tool. Be concise in your response.",
             tools=[flaky_web_search],
-            tool_retry_policy=retry_policy
+            tool_config=ToolConfig(retry_policy=retry_policy)
         )
         
         # Mock time.sleep to speed up test
@@ -89,7 +102,7 @@ class TestRetryPolicyAgentic:
             name="data_analyst", 
             instructions="You are a data analyst. If you cannot access the database, explain what happened and suggest alternatives. Keep it brief.",
             tools=[restricted_database_query],
-            tool_retry_policy=retry_policy
+            tool_config=ToolConfig(retry_policy=retry_policy)
         )
         
         # ✅ REAL agent call with actual LLM interaction
@@ -141,7 +154,7 @@ class TestRetryPolicyAgentic:
             name="api_client",
             instructions="You help users get information. Try the primary_api first. If it fails completely, you can try fallback_api. Be brief.",
             tools=[primary_api, fallback_api],
-            tool_retry_policy=agent_retry_policy
+            tool_config=ToolConfig(retry_policy=agent_retry_policy)
         )
         
         with patch('time.sleep'):
@@ -185,7 +198,7 @@ class TestRetryPolicyAgentic:
             name="weather_assistant",
             instructions="You provide weather information using the async_weather_api tool. Keep responses concise.",
             tools=[async_weather_api],
-            tool_retry_policy=retry_policy
+            tool_config=ToolConfig(retry_policy=retry_policy)
         )
         
         with patch('time.sleep'), patch('asyncio.sleep'):


### PR DESCRIPTION
`ToolConfig`'s own docstring shows the intended usage:

```python
Agent(tool_config=ToolConfig(timeout=60, retry_policy=RetryPolicy(...)))
```

**That line could not be written.** `ToolConfig` is defined in `feature_configs` and was never listed in `praisonaiagents.config.__all__`, while its siblings (`ExecutionConfig`, `OutputConfig`, `MemoryConfig`, …) are. Six more were in the same position — every one backing a **public parameter**:

| parameter | class | | parameter | class |
|---|---|---|---|---|
| `Agent(tool_config=)` | `ToolConfig` | | `PraisonAIAgents(execution=)` | `MultiAgentExecutionConfig` |
| `Agent(autonomy=)` | `AutonomyConfig` | | `PraisonAIAgents(hooks=)` | `MultiAgentHooksConfig` |
| `Agent(learn=)` | `LearnConfig` | | `PraisonAIAgents(memory=)` | `MultiAgentMemoryConfig` |
| | | | `PraisonAIAgents(output=)` | `MultiAgentOutputConfig` |

All seven now go through the same lazy map the others use.

A new test **pins the rule rather than the list** — for each public parameter, the config class it accepts must be importable — so a config added for a new parameter cannot be left behind. It also walks `__all__` and resolves every name, because the lazy loader means a typo there surfaces only on first access.

### How this surfaced, and two more gaps along the way

Six tests failed with `Agent.__init__() got unexpected keyword argument(s): tool_retry_policy`. Retry has moved onto `tool_config`; updating the tests to the current API is what exposed the missing export.

- **The error gave no migration hint.** `Agent`'s unknown-kwarg error names the replacement for `verbose` and `stream`, but said nothing for the tool ones — a bare "unexpected keyword argument" with no clue it had moved. `tool_retry_policy` and `tool_timeout` now carry the same hint:

  ```
  tool_retry_policy: tool retry moved into tool_config=; use
    tool_config=ToolConfig(retry_policy=RetryPolicy(...)).
  ```

- **Live LLM calls were hiding in `tests/unit`.** `TestRetryPolicyAgentic` genuinely calls the model (AGENTS.md §9.4) but sat ungated, so running the unit suite issued real API calls and failed outright without a key. Gated with the same condition `test_circuit_breaker.py` already uses.

### Verification

- `tests/unit/config`: **333 passed**.
- The live-LLM module now reports **4 skipped** instead of 4 failed with no key present.
- Mutation-checked: un-exporting `ToolConfig` fails the new guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added public configuration options for tools, autonomy, learning, multi-agent execution, hooks, memory, and output settings.
  - Added clearer guidance when unsupported tool retry or timeout options are provided, directing users to configure them through `tool_config`.

- **Bug Fixes**
  - Improved session data consistency so updates made through another session store are visible on subsequent reads.

- **Tests**
  - Expanded coverage for configuration exports, tool retry settings, and session persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->