### PR TITLE
fix(knowledge): index() reported success after failing to index every file

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agent/agent.py
+++ b/src/praisonai-agents/praisonaiagents/agent/agent.py
@@ -880,6 +880,14 @@ class Agent(GoalLoopMixin, SteeringMixin, SandboxMixin, SkillReviewMixin, Unifie
                     "streaming moved into output=; use "
                     "output=OutputConfig(stream=True)."
                 ),
+                "tool_retry_policy": (
+                    "tool retry moved into tool_config=; use "
+                    "tool_config=ToolConfig(retry_policy=RetryPolicy(...))."
+                ),
+                "tool_timeout": (
+                    "tool timeout moved into tool_config=; use "
+                    "tool_config=ToolConfig(timeout=...)."
+                ),
             }
             _hint = "".join(
                 f"\n  {name}: {_HINTS[name]}" for name in sorted(_unknown) if name in _HINTS

--- a/src/praisonai-agents/praisonaiagents/config/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/config/__init__.py
@@ -37,6 +37,17 @@ __all__ = [
     "WebConfig",
     "OutputConfig",
     "ExecutionConfig",
+    # Configuration objects for public parameters that were defined in
+    # feature_configs but never exported here, so the usage their own
+    # docstrings show -- Agent(tool_config=ToolConfig(...)) -- could not be
+    # written with the natural import.
+    "ToolConfig",
+    "AutonomyConfig",
+    "LearnConfig",
+    "MultiAgentExecutionConfig",
+    "MultiAgentHooksConfig",
+    "MultiAgentMemoryConfig",
+    "MultiAgentOutputConfig",
     "PreCompactionMemoryFlushConfig",
     "TemplateConfig",
     "CachingConfig",
@@ -127,6 +138,13 @@ _MODULE_MAP = {
     "WebConfig": "feature_configs",
     "OutputConfig": "feature_configs",
     "ExecutionConfig": "feature_configs",
+    "ToolConfig": "feature_configs",
+    "AutonomyConfig": "feature_configs",
+    "LearnConfig": "feature_configs",
+    "MultiAgentExecutionConfig": "feature_configs",
+    "MultiAgentHooksConfig": "feature_configs",
+    "MultiAgentMemoryConfig": "feature_configs",
+    "MultiAgentOutputConfig": "feature_configs",
     "PreCompactionMemoryFlushConfig": "feature_configs",
     "TemplateConfig": "feature_configs",
     "CachingConfig": "feature_configs",

--- a/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
+++ b/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
@@ -958,6 +958,17 @@ class Knowledge:
             indexed_at=datetime.now().isoformat(),
         )
         
+        # ``success`` was never assigned, so it kept the dataclass default of
+        # True no matter what happened: a run where every file failed to embed
+        # still returned success=True with files_indexed=0 and each failure
+        # sitting in ``errors``, and a caller doing ``if result.success`` went on
+        # believing the corpus was indexed.
+        #
+        # A partial failure counts. Losing one file out of ten from a knowledge
+        # base is precisely the kind of loss that should not be silent, and the
+        # caller still has ``errors`` and ``total_files`` for the detail.
+        result.success = not result.errors
+
         # Store corpus stats for later retrieval
         self._corpus_stats = result.corpus_stats
         

--- a/src/praisonai-agents/tests/unit/config/test_public_config_exports.py
+++ b/src/praisonai-agents/tests/unit/config/test_public_config_exports.py
@@ -1,0 +1,86 @@
+"""Every config class a public parameter accepts must be importable.
+
+``ToolConfig``'s own docstring shows ``Agent(tool_config=ToolConfig())``, but
+it was defined in ``feature_configs`` and never listed in
+``praisonaiagents.config.__all__`` -- so the documented usage could not be
+written with the natural import, while its siblings (``ExecutionConfig``,
+``OutputConfig``, ...) could. Six others were in the same position, all of them
+backing a public parameter of ``Agent`` or ``PraisonAIAgents``.
+
+This pins the rule rather than the list, so a config added for a new parameter
+cannot be left unexported.
+"""
+
+import inspect
+
+import pytest
+
+import praisonaiagents.config as config_pkg
+from praisonaiagents import Agent, PraisonAIAgents
+from praisonaiagents.config import feature_configs
+
+
+# Parameter name -> the config class callers are expected to pass.
+_AGENT_PARAM_CONFIGS = {
+    "tool_config": "ToolConfig",
+    "autonomy": "AutonomyConfig",
+    "learn": "LearnConfig",
+    "output": "OutputConfig",
+    "memory": "MemoryConfig",
+    "knowledge": "KnowledgeConfig",
+}
+_TEAM_PARAM_CONFIGS = {
+    "execution": "MultiAgentExecutionConfig",
+    "hooks": "MultiAgentHooksConfig",
+    "memory": "MultiAgentMemoryConfig",
+    "output": "MultiAgentOutputConfig",
+}
+
+
+def _exported(name):
+    return name in getattr(config_pkg, "__all__", ()) and hasattr(config_pkg, name)
+
+
+@pytest.mark.parametrize("param,cls", sorted(_AGENT_PARAM_CONFIGS.items()))
+def test_agent_parameter_configs_are_importable(param, cls):
+    assert param in inspect.signature(Agent.__init__).parameters, (
+        f"Agent no longer takes {param!r}; update this table"
+    )
+    assert _exported(cls), (
+        f"Agent({param}=...) expects {cls}, which is not importable from "
+        f"praisonaiagents.config"
+    )
+
+
+@pytest.mark.parametrize("param,cls", sorted(_TEAM_PARAM_CONFIGS.items()))
+def test_team_parameter_configs_are_importable(param, cls):
+    assert param in inspect.signature(PraisonAIAgents.__init__).parameters, (
+        f"PraisonAIAgents no longer takes {param!r}; update this table"
+    )
+    assert _exported(cls), (
+        f"PraisonAIAgents({param}=...) expects {cls}, which is not importable "
+        f"from praisonaiagents.config"
+    )
+
+
+def test_every_exported_name_actually_resolves():
+    """__all__ is lazily resolved, so a typo there fails only on first access."""
+    unresolvable = []
+    for name in getattr(config_pkg, "__all__", ()):
+        try:
+            getattr(config_pkg, name)
+        except Exception as exc:  # pragma: no cover - the regression
+            unresolvable.append(f"{name} ({type(exc).__name__})")
+    assert not unresolvable, f"listed in __all__ but not importable: {unresolvable}"
+
+
+def test_the_documented_usage_actually_runs():
+    """The line from ToolConfig's own docstring must work end to end."""
+    from praisonaiagents.config import ToolConfig
+    from praisonaiagents.tools.retry import RetryPolicy
+
+    agent = Agent(
+        name="t", role="r", goal="g", llm="gpt-4o-mini",
+        tool_config=ToolConfig(retry_policy=RetryPolicy(max_attempts=5)),
+    )
+    assert agent is not None

--- a/src/praisonai-agents/tests/unit/knowledge/test_adapters.py
+++ b/src/praisonai-agents/tests/unit/knowledge/test_adapters.py
@@ -289,6 +289,12 @@ class TestChromaKnowledgeAdapterWhereFilters:
 
         adapter = ChromaKnowledgeAdapter.__new__(ChromaKnowledgeAdapter)
         adapter.collection = MagicMock()
+        # __init__ is bypassed to avoid a real chromadb client, so every
+        # attribute the methods under test read must be supplied here.
+        # ``_embedder`` was added to __init__ later (so an agent that had
+        # selected a local embedder stopped being silently routed to
+        # OpenAI) and these tests began failing with AttributeError.
+        adapter._embedder = {}
         adapter.collection.query.return_value = {
             "ids": [[]],
             "documents": [[]],

--- a/src/praisonai-agents/tests/unit/knowledge/test_directory_ingestion.py
+++ b/src/praisonai-agents/tests/unit/knowledge/test_directory_ingestion.py
@@ -30,6 +30,10 @@ def _make_knowledge_or_skip():
 
 
 @requires_knowledge
+@pytest.mark.live  # embeds every chunk through the configured provider:
+# a real network call. Unmarked, `pytest tests/unit` issued live embedding
+# requests and failed on any key lacking access to the default model. CI
+# sets PRAISONAI_LIVE_TESTS=0 (tests/conftest.py), so these skip there.
 class TestDirectoryIngestion:
     """Test that directories are properly processed and file contents stored."""
     
@@ -141,6 +145,10 @@ class TestDirectoryIngestion:
 
 
 @requires_knowledge
+@pytest.mark.live  # embeds every chunk through the configured provider:
+# a real network call. Unmarked, `pytest tests/unit` issued live embedding
+# requests and failed on any key lacking access to the default model. CI
+# sets PRAISONAI_LIVE_TESTS=0 (tests/conftest.py), so these skip there.
 class TestContextBuilderUsesText:
     """Test that context builder injects text, not paths."""
     

--- a/src/praisonai-agents/tests/unit/knowledge/test_embedding_failure.py
+++ b/src/praisonai-agents/tests/unit/knowledge/test_embedding_failure.py
@@ -20,6 +20,12 @@ def _make_adapter():
     adapter = ChromaKnowledgeAdapter.__new__(ChromaKnowledgeAdapter)
     adapter.collection = MagicMock()
     adapter.client = MagicMock()
+    # __init__ is bypassed, so every attribute the methods under test read must
+    # be supplied here. ``_embedder`` was added to __init__ later (so an agent
+    # that had selected a local embedder stopped being silently routed to
+    # OpenAI) and these tests began failing with AttributeError before they
+    # reached the assertions they exist for.
+    adapter._embedder = {}
     return adapter
 
 

--- a/src/praisonai-agents/tests/unit/knowledge/test_index_result_reports_failure.py
+++ b/src/praisonai-agents/tests/unit/knowledge/test_index_result_reports_failure.py
@@ -1,0 +1,89 @@
+"""``Knowledge.index()`` must not report success when nothing was indexed.
+
+``IndexResult.success`` defaults to True and ``index()`` never assigned it. So a
+run in which every file failed to embed still returned:
+
+    IndexResult(success=True, files_indexed=0, chunks_created=0,
+                errors=['/tmp/.../test.txt: Failed to generate embedding ...'])
+
+Each failure was collected in ``errors`` and then contradicted by the flag a
+caller actually branches on. ``if result.success:`` went on believing the corpus
+was indexed.
+
+Embedding is mocked here rather than marked ``live``, so the contract is
+verified in CI instead of skipped with the tests that need a real provider.
+"""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from praisonaiagents.knowledge import Knowledge
+from praisonaiagents.knowledge.models import AddResult
+
+
+def _knowledge_with_add(add_impl):
+    """A Knowledge whose store add() behaves as given, with no real backend."""
+    knowledge = Knowledge.__new__(Knowledge)
+    knowledge._corpus_stats = None
+    knowledge._config = {}
+    return knowledge, patch.object(Knowledge, "add", side_effect=add_impl)
+
+
+def test_success_is_false_when_every_file_fails():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "a.txt"), "w") as fh:
+            fh.write("content")
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("Failed to generate embedding (model=...)")
+
+        with patch.object(Knowledge, "add", side_effect=boom):
+            result = Knowledge().index(tmpdir)
+
+        assert result.files_indexed == 0
+        assert result.errors, "the failure was not recorded at all"
+        assert result.success is False, (
+            "reported success while indexing nothing and recording "
+            f"{len(result.errors)} error(s)"
+        )
+
+
+def test_success_is_false_on_a_partial_failure():
+    """Losing one file out of several must not be reported as success.
+
+    A knowledge base quietly missing a document is the failure mode this whole
+    result object exists to surface.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for name in ("good.txt", "bad.txt"):
+            with open(os.path.join(tmpdir, name), "w") as fh:
+                fh.write("content")
+
+        def sometimes(*args, **kwargs):
+            target = args[0] if args else kwargs.get("file_path", "")
+            if "bad" in str(target):
+                raise RuntimeError("Failed to generate embedding (model=...)")
+            return AddResult(id="1", success=True)
+
+        with patch.object(Knowledge, "add", side_effect=sometimes):
+            result = Knowledge().index(tmpdir)
+
+        assert len(result.errors) == 1
+        assert result.success is False
+
+
+def test_success_is_true_when_nothing_failed():
+    """The guard must not become a blanket False."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "a.txt"), "w") as fh:
+            fh.write("content")
+
+        with patch.object(Knowledge, "add",
+                          return_value=AddResult(id="1", success=True)):
+            result = Knowledge().index(tmpdir)
+
+        assert result.errors == []
+        assert result.success is True

--- a/src/praisonai-agents/tests/unit/knowledge/test_indexing.py
+++ b/src/praisonai-agents/tests/unit/knowledge/test_indexing.py
@@ -6,6 +6,8 @@ Tests IndexResult, CorpusStats, incremental indexing, and .praisonignore support
 
 import os
 import tempfile
+
+import pytest
 import time
 
 
@@ -280,6 +282,10 @@ class TestFileTracker:
             assert tracker2.has_changed(test_file) is False
 
 
+@pytest.mark.live  # embeds every chunk through the configured provider:
+# a real network call. Unmarked, `pytest tests/unit` issued live embedding
+# requests and failed on any key lacking access to the default model. CI
+# sets PRAISONAI_LIVE_TESTS=0 (tests/conftest.py), so these skip there.
 class TestKnowledgeIndex:
     """Tests for Knowledge.index() method."""
     

--- a/src/praisonai-agents/tests/unit/knowledge/test_indexing.py
+++ b/src/praisonai-agents/tests/unit/knowledge/test_indexing.py
@@ -282,12 +282,16 @@ class TestFileTracker:
             assert tracker2.has_changed(test_file) is False
 
 
-@pytest.mark.live  # embeds every chunk through the configured provider:
-# a real network call. Unmarked, `pytest tests/unit` issued live embedding
-# requests and failed on any key lacking access to the default model. CI
-# sets PRAISONAI_LIVE_TESTS=0 (tests/conftest.py), so these skip there.
 class TestKnowledgeIndex:
-    """Tests for Knowledge.index() method."""
+    """Tests for Knowledge.index() method.
+
+    The methods that actually index embed every chunk through the configured
+    provider — a real network call. Unmarked, `pytest tests/unit` issued live
+    embedding requests and failed on any key lacking access to the default
+    model, so those carry the repo's ``live`` marker (tests/conftest.py) and
+    skip unless PRAISONAI_LIVE_TESTS=1. The deterministic API-contract check
+    below only inspects the class and stays in the default suite.
+    """
     
     def test_knowledge_has_index_method(self):
         """Knowledge should have an index() method."""
@@ -295,6 +299,7 @@ class TestKnowledgeIndex:
         
         assert hasattr(Knowledge, "index")
     
+    @pytest.mark.live
     def test_index_returns_result(self):
         """Knowledge.index() should return IndexResult."""
         from praisonaiagents.knowledge import Knowledge
@@ -311,6 +316,7 @@ class TestKnowledgeIndex:
             assert isinstance(result, IndexResult)
             assert result.files_indexed >= 1
     
+    @pytest.mark.live
     def test_incremental_index(self):
         """Knowledge.index() should support incremental indexing."""
         from praisonaiagents.knowledge import Knowledge
@@ -340,6 +346,7 @@ class TestKnowledgeIndex:
             assert result3.files_indexed == 1
             assert result3.files_skipped == 1
     
+    @pytest.mark.live
     def test_index_respects_ignore_patterns(self):
         """Knowledge.index() should respect exclude_glob patterns."""
         from praisonaiagents.knowledge import Knowledge
@@ -365,6 +372,7 @@ class TestKnowledgeIndex:
             # Should only index main.txt (*.log files excluded)
             assert result.files_indexed == 1
     
+    @pytest.mark.live
     def test_index_with_include_exclude_globs(self):
         """Knowledge.index() should support include/exclude globs."""
         from praisonaiagents.knowledge import Knowledge
@@ -400,6 +408,7 @@ class TestKnowledgeIndex:
             )
             assert result.files_indexed == 1
     
+    @pytest.mark.live
     def test_get_corpus_stats(self):
         """Knowledge should provide corpus stats."""
         from praisonaiagents.knowledge import Knowledge

--- a/src/praisonai-agents/tests/unit/session/test_bot_session_persistence.py
+++ b/src/praisonai-agents/tests/unit/session/test_bot_session_persistence.py
@@ -7,6 +7,8 @@ per-user session isolation instead of in-memory-only storage.
 
 import asyncio
 import tempfile
+
+import pytest
 from typing import Any, Dict, List
 
 from praisonaiagents.session.store import DefaultSessionStore
@@ -39,21 +41,23 @@ class TestBotSessionManagerWithStore:
     """Tests for BotSessionManager using persistent session store."""
     
     def _make_manager(self, tmpdir: str, platform: str = "test"):
-        """Create a BotSessionManager with a persistent store."""
-        # Import here to test the refactored version
-        import sys
-        import os
-        # Add wrapper path so we can import _session
-        wrapper_path = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
-                os.path.dirname(os.path.abspath(__file__))
-            )))),
-            "praisonai", "praisonai", "bots"
-        )
-        if wrapper_path not in sys.path:
-            sys.path.insert(0, wrapper_path)
-        
-        from _session import BotSessionManager
+        """Create a BotSessionManager with a persistent store.
+
+        Imported as a package rather than by pushing a directory onto sys.path.
+        The old helper walked five levels up to ``praisonai/praisonai/bots`` and
+        imported a bare ``_session``; the bots code has since moved to the
+        ``praisonai-bot`` package, that directory no longer exists, and all
+        eleven tests in this class had been failing with
+        ``ModuleNotFoundError: No module named '_session'`` ever since.
+
+        Skipped rather than failed when the optional package is absent, so a
+        checkout without it reports "not installed" instead of a bare import
+        error that reads like a broken test.
+        """
+        BotSessionManager = pytest.importorskip(
+            "praisonai_bot.bots._session",
+            reason="praisonai-bot is not installed",
+        ).BotSessionManager
         store = DefaultSessionStore(session_dir=tmpdir)
         return BotSessionManager(store=store, platform=platform)
     
@@ -179,18 +183,10 @@ class TestBotSessionManagerWithStore:
     
     def test_backward_compat_no_store(self):
         """BotSessionManager must still work without a store (in-memory fallback)."""
-        import sys
-        import os
-        wrapper_path = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
-                os.path.dirname(os.path.abspath(__file__))
-            )))),
-            "praisonai", "praisonai", "bots"
-        )
-        if wrapper_path not in sys.path:
-            sys.path.insert(0, wrapper_path)
-        
-        from _session import BotSessionManager
+        BotSessionManager = pytest.importorskip(
+            "praisonai_bot.bots._session",
+            reason="praisonai-bot is not installed",
+        ).BotSessionManager
         # No store parameter = backward compatible in-memory mode
         mgr = BotSessionManager()
         agent = FakeAgent()

--- a/src/praisonai-agents/tests/unit/session/test_hierarchy.py
+++ b/src/praisonai-agents/tests/unit/session/test_hierarchy.py
@@ -417,24 +417,50 @@ class TestHierarchicalSessionStore:
         assert final_session.messages[2].content == "Message 2"
         assert final_session.messages[3].content == "Response 2"
     
-    def test_cache_performance_with_unchanged_files(self):
-        """
-        Test that performance optimization works - reads from cache when file hasn't changed.
+    def test_reads_are_fresh_and_leave_the_cache_valid(self):
+        """``get_extended_session`` reads from disk every time, by design.
+
+        This asserted ``session2 is session1`` -- that a second read returns the
+        same cached object -- until #1781 and #1785 made the getter always
+        reload. Those were not tidying: the stale extended cache could **wipe
+        session messages**, and went stale on cross-instance writes. Returning
+        the cached object again would reintroduce exactly that.
+
+        So identity is not the contract. What must hold is that a second read
+        sees the same data, and that the fresh read leaves the cache and its
+        mtime in sync rather than invalidating them.
         """
         session_id = self.store.create_session(title="Cache Test")
         self.store.add_message(session_id, "user", "Test message")
-        
-        # First read - loads from disk and caches
+
         session1 = self.store.get_extended_session(session_id)
         assert len(session1.messages) == 1
-        
-        # Second read should use cache (file hasn't changed)
-        # We can't easily test this directly, but we can verify the cache is valid
         assert self.store._is_cache_valid(session_id) is True
-        
+
         session2 = self.store.get_extended_session(session_id)
         assert len(session2.messages) == 1
-        assert session2 is session1  # Should be same cached object
+        assert session2.session_id == session1.session_id
+        assert [m.content for m in session2.messages] == [
+            m.content for m in session1.messages
+        ]
+        # Re-reading keeps the cache coherent instead of leaving it stale.
+        assert self.store._is_cache_valid(session_id) is True
+
+    def test_a_write_from_another_store_instance_is_seen(self):
+        """The reason the cache is bypassed (#1785): cross-instance writes.
+
+        A second store object writing to the same directory must be visible to
+        the first, which a cached object would hide.
+        """
+        session_id = self.store.create_session(title="Cross Instance")
+        self.store.add_message(session_id, "user", "first")
+        assert len(self.store.get_extended_session(session_id).messages) == 1
+
+        other = type(self.store)(session_dir=self.store.session_dir)
+        other.add_message(session_id, "user", "second")
+
+        seen = self.store.get_extended_session(session_id)
+        assert [m.content for m in seen.messages] == ["first", "second"]
     
     def test_force_reload_bypasses_cache(self):
         """Test that force_reload=True always loads from disk."""

--- a/src/praisonai-agents/tests/unit/test_tool_decorator_retry.py
+++ b/src/praisonai-agents/tests/unit/test_tool_decorator_retry.py
@@ -2,6 +2,7 @@
 Tests for @tool(retry_policy=...) decorator functionality.
 """
 from praisonaiagents import tool, Agent
+from praisonaiagents.config import ToolConfig
 from praisonaiagents.tools.retry import RetryPolicy
 
 
@@ -47,7 +48,7 @@ class TestToolDecoratorRetryPolicy:
             name="test_agent",
             instructions="Test agent",
             tools=[special_tool],
-            tool_retry_policy=agent_retry_policy
+            tool_config=ToolConfig(retry_policy=agent_retry_policy)
         )
         
         # Should get tool-level policy (higher precedence)
@@ -78,7 +79,7 @@ class TestToolDecoratorRetryPolicy:
             name="test_agent",
             instructions="Test agent",
             tools=[tool_a, tool_b, tool_c],
-            tool_retry_policy=agent_policy
+            tool_config=ToolConfig(retry_policy=agent_policy)
         )
         
         # Tool A should use its own policy

--- a/src/praisonai-agents/tests/unit/test_tool_retry_agentic.py
+++ b/src/praisonai-agents/tests/unit/test_tool_retry_agentic.py
@@ -2,8 +2,6 @@
 Real agentic test for tool retry policy - agent actually runs and calls LLM with retrying tools.
 This satisfies the AGENTS.md requirement (§9.4) for real agentic testing.
 """
-import os
-
 import pytest
 import time
 from unittest.mock import patch
@@ -13,17 +11,15 @@ from praisonaiagents.config import ToolConfig
 from praisonaiagents.tools.retry import RetryPolicy
 
 
-@pytest.mark.skipif(
-    not os.getenv("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY") == "not-needed",
-    reason="Requires OpenAI API Key",
-)
+@pytest.mark.live
 class TestRetryPolicyAgentic:
     """Real agentic tests where the agent calls LLM and uses retrying tools.
 
-    These genuinely call the model (AGENTS.md 9.4) but live under tests/unit
-    with no gate, so running the unit suite issued live API calls and failed on
-    any machine without a key. Gated with the same condition
-    test_circuit_breaker.py already uses.
+    These genuinely call the model (AGENTS.md 9.4) but live under tests/unit,
+    so running the unit suite issued live API calls. Gated with the repo's
+    ``live`` marker (tests/conftest.py) so ``PRAISONAI_LIVE_TESTS=1`` is the
+    single explicit opt-in — a key merely being present no longer routes real
+    billable requests through the default unit run.
     """
     
     def test_agent_with_flaky_tool_real_llm(self):

--- a/src/praisonai-agents/tests/unit/test_tool_retry_agentic.py
+++ b/src/praisonai-agents/tests/unit/test_tool_retry_agentic.py
@@ -2,16 +2,29 @@
 Real agentic test for tool retry policy - agent actually runs and calls LLM with retrying tools.
 This satisfies the AGENTS.md requirement (§9.4) for real agentic testing.
 """
+import os
+
 import pytest
 import time
 from unittest.mock import patch
 
 from praisonaiagents import Agent, tool
+from praisonaiagents.config import ToolConfig
 from praisonaiagents.tools.retry import RetryPolicy
 
 
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY") == "not-needed",
+    reason="Requires OpenAI API Key",
+)
 class TestRetryPolicyAgentic:
-    """Real agentic tests where the agent calls LLM and uses retrying tools."""
+    """Real agentic tests where the agent calls LLM and uses retrying tools.
+
+    These genuinely call the model (AGENTS.md 9.4) but live under tests/unit
+    with no gate, so running the unit suite issued live API calls and failed on
+    any machine without a key. Gated with the same condition
+    test_circuit_breaker.py already uses.
+    """
     
     def test_agent_with_flaky_tool_real_llm(self):
         """
@@ -48,7 +61,7 @@ class TestRetryPolicyAgentic:
             name="research_assistant",
             instructions="You are a helpful research assistant. When asked to search for information, use the flaky_web_search tool. Be concise in your response.",
             tools=[flaky_web_search],
-            tool_retry_policy=retry_policy
+            tool_config=ToolConfig(retry_policy=retry_policy)
         )
         
         # Mock time.sleep to speed up test
@@ -89,7 +102,7 @@ class TestRetryPolicyAgentic:
             name="data_analyst", 
             instructions="You are a data analyst. If you cannot access the database, explain what happened and suggest alternatives. Keep it brief.",
             tools=[restricted_database_query],
-            tool_retry_policy=retry_policy
+            tool_config=ToolConfig(retry_policy=retry_policy)
         )
         
         # ✅ REAL agent call with actual LLM interaction
@@ -141,7 +154,7 @@ class TestRetryPolicyAgentic:
             name="api_client",
             instructions="You help users get information. Try the primary_api first. If it fails completely, you can try fallback_api. Be brief.",
             tools=[primary_api, fallback_api],
-            tool_retry_policy=agent_retry_policy
+            tool_config=ToolConfig(retry_policy=agent_retry_policy)
         )
         
         with patch('time.sleep'):
@@ -185,7 +198,7 @@ class TestRetryPolicyAgentic:
             name="weather_assistant",
             instructions="You provide weather information using the async_weather_api tool. Keep responses concise.",
             tools=[async_weather_api],
-            tool_retry_policy=retry_policy
+            tool_config=ToolConfig(retry_policy=retry_policy)
         )
         
         with patch('time.sleep'), patch('asyncio.sleep'):


### PR DESCRIPTION
`IndexResult.success` defaults to `True` and `Knowledge.index()` **never assigned it**. Each per-file failure was appended to `result.errors` and then contradicted by the one flag a caller actually branches on:

```
IndexResult(success=True, files_indexed=0, chunks_created=0,
            errors=['/tmp/.../test.txt: Failed to generate embedding ...'])
```

So `if result.success:` went on believing the corpus was indexed while nothing had been stored — the same shape as the six defects in #4943.

`success` is now `not result.errors`. **A partial failure counts**: a knowledge base quietly missing one document out of ten is exactly the loss this result object exists to surface, and the caller still has `errors` and `total_files` for the detail.

Three **mocked** tests pin it — total failure, partial failure, and a guard that it doesn't become a blanket `False`. Mocked rather than marked `live`, so the contract is checked in CI rather than skipped.

### Two more causes behind the twelve reds in this directory

**Five** — `test_adapters.py` and `test_embedding_failure.py` build `ChromaKnowledgeAdapter` through `__new__` to avoid a real chromadb client, then set only `collection`. `_embedder` was added to `__init__` later — itself a real fix, so an agent that had selected a local embedder stopped being silently routed to OpenAI — and these began failing with `AttributeError` *before reaching the assertions they exist for*. The bypassing helpers now supply it, with a note saying why.

**Two (+5 more)** — `TestKnowledgeIndex`, `TestDirectoryIngestion` and `TestContextBuilderUsesText` embed every chunk through the configured provider, a real network call, and carried no marker. So `pytest tests/unit` issued live embedding requests and failed on any key without access to the default model. Marked with the repo's existing `live` gate (`tests/conftest.py`), **per class rather than per file** so the pure dataclass and ignore-matcher tests keep running — 11 skipped, not 30.

### Verification

- `tests/unit/knowledge`: **121 passed, 11 skipped** (was 12 failed).
- Mutation-checked: reverting the `success` assignment fails 2 of the 3 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration classes are now available directly through the public configuration package.
  * Clearer “Did you mean?” guidance is provided for tool retry and timeout settings.

* **Bug Fixes**
  * Knowledge indexing now reports failure when any file cannot be embedded, accurately reflecting partial and complete failures.

* **Tests**
  * Improved coverage for public configuration imports and indexing outcomes.
  * Live and optional-package tests now skip safely when required services or packages are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->