### PR TITLE
fix(mcp): CLI printed literal [bold] tags instead of formatted text

### DIFF
--- a/src/praisonai-mcp/praisonai_mcp/mcp_server/cli.py
+++ b/src/praisonai-mcp/praisonai_mcp/mcp_server/cli.py
@@ -386,7 +386,7 @@ Run PraisonAI as an MCP server for Claude Desktop, Cursor, Windsurf, and other M
                 print(f"    {desc}\n")
             
             if next_cursor:
-                print(f"[dim]More results available. Use --cursor {next_cursor}[/dim]\n")
+                self._print_rich(f"[dim]More results available. Use --cursor {next_cursor}[/dim]\n")
             
             return self.EXIT_SUCCESS
             
@@ -526,7 +526,7 @@ Run PraisonAI as an MCP server for Claude Desktop, Cursor, Windsurf, and other M
                 print(f"    {desc}\n")
             
             if next_cursor:
-                print(f"[dim]More results available. Use --cursor {next_cursor}[/dim]\n")
+                self._print_rich(f"[dim]More results available. Use --cursor {next_cursor}[/dim]\n")
             
             return self.EXIT_SUCCESS
             
@@ -564,10 +564,10 @@ Run PraisonAI as an MCP server for Claude Desktop, Cursor, Windsurf, and other M
                 return self.EXIT_SUCCESS
             
             self._print_rich(f"\n[bold cyan]Tool: {tool.name}[/bold cyan]\n")
-            print(f"[bold]Description:[/bold] {tool.description}")
+            self._print_rich(f"[bold]Description:[/bold] {tool.description}")
             
             annotations = schema.get("annotations", {})
-            print("\n[bold]Annotations:[/bold]")
+            self._print_rich("\n[bold]Annotations:[/bold]")
             print(f"  • readOnlyHint: {annotations.get('readOnlyHint', False)}")
             print(f"  • destructiveHint: {annotations.get('destructiveHint', True)}")
             print(f"  • idempotentHint: {annotations.get('idempotentHint', False)}")
@@ -583,7 +583,7 @@ Run PraisonAI as an MCP server for Claude Desktop, Cursor, Windsurf, and other M
             required = input_schema.get("required", []) or []
             
             if props:
-                print("\n[bold]Parameters:[/bold]")
+                self._print_rich("\n[bold]Parameters:[/bold]")
                 for param_name, param_info in props.items():
                     req = " (required)" if param_name in required else ""
                     ptype = param_info.get("type", "any")
@@ -643,7 +643,7 @@ Run PraisonAI as an MCP server for Claude Desktop, Cursor, Windsurf, and other M
                 print("No resources registered")
                 return self.EXIT_SUCCESS
             
-            print(f"\n[bold]Available MCP Resources ({len(resources)}):[/bold]\n")
+            self._print_rich(f"\n[bold]Available MCP Resources ({len(resources)}):[/bold]\n")
             for res in resources:
                 uri = res.get("uri", "unknown")
                 desc = res.get("description", "No description")
@@ -670,7 +670,7 @@ Run PraisonAI as an MCP server for Claude Desktop, Cursor, Windsurf, and other M
                 print("No prompts registered")
                 return self.EXIT_SUCCESS
             
-            print(f"\n[bold]Available MCP Prompts ({len(prompts)}):[/bold]\n")
+            self._print_rich(f"\n[bold]Available MCP Prompts ({len(prompts)}):[/bold]\n")
             for prompt in prompts:
                 name = prompt.get("name", "unknown")
                 desc = prompt.get("description", "No description")
@@ -718,7 +718,7 @@ Run PraisonAI as an MCP server for Claude Desktop, Cursor, Windsurf, and other M
                 f.write(config_json)
             self._print_success(f"Config written to {parsed.output}")
         else:
-            print(f"\n[bold]{parsed.client} Configuration:[/bold]\n")
+            self._print_rich(f"\n[bold]{parsed.client} Configuration:[/bold]\n")
             print(config_json)
             print()
         
@@ -861,25 +861,25 @@ Run PraisonAI as an MCP server for Claude Desktop, Cursor, Windsurf, and other M
             skip_mark = "[yellow]\u25cb[/yellow]" if unicode_ok else "[yellow][--][/yellow]"
             fail_mark = "[red]\u2717[/red]" if unicode_ok else "[red][X][/red]"
 
-            print("\n[bold cyan]PraisonAI MCP Server Health Check[/bold cyan]\n")
+            self._print_rich("\n[bold cyan]PraisonAI MCP Server Health Check[/bold cyan]\n")
 
-            print(f"[bold]Protocol Version:[/bold] {PROTOCOL_VERSION}")
-            print(f"[bold]Supported Versions:[/bold] {', '.join(SUPPORTED_VERSIONS)}")
+            self._print_rich(f"[bold]Protocol Version:[/bold] {PROTOCOL_VERSION}")
+            self._print_rich(f"[bold]Supported Versions:[/bold] {', '.join(SUPPORTED_VERSIONS)}")
             print()
 
-            print("[bold]Registered Components:[/bold]")
+            self._print_rich("[bold]Registered Components:[/bold]")
             print(f"  {bullet} Tools: {len(tools)}")
             print(f"  {bullet} Resources: {len(resources)}")
             print(f"  {bullet} Prompts: {len(prompts)}")
             print()
 
-            print("[bold]Environment:[/bold]")
+            self._print_rich("[bold]Environment:[/bold]")
             for key, present in env_checks.items():
                 status = ok_mark if present else skip_mark
                 print(f"  {status} {key}")
             print()
 
-            print("[bold]Dependencies:[/bold]")
+            self._print_rich("[bold]Dependencies:[/bold]")
             for dep, available in deps.items():
                 status = ok_mark if available else fail_mark
                 print(f"  {status} {dep}")
@@ -891,7 +891,7 @@ Run PraisonAI as an MCP server for Claude Desktop, Cursor, Windsurf, and other M
                 self._print_error("Missing required dependencies. Install with: pip install praisonai[mcp]")
                 return self.EXIT_ERROR
             else:
-                print("[yellow]Warning: No API keys configured. Some tools may not work.[/yellow]")
+                self._print_rich("[yellow]Warning: No API keys configured. Some tools may not work.[/yellow]")
 
             return self.EXIT_SUCCESS
 

--- a/src/praisonai-mcp/praisonai_mcp/mcp_server/recipe_cli.py
+++ b/src/praisonai-mcp/praisonai_mcp/mcp_server/recipe_cli.py
@@ -280,7 +280,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                     print("No recipes found")
                     return self.EXIT_SUCCESS
                 
-                print(f"\n[bold]Available Recipes ({len(recipes)}):[/bold]\n")
+                self._print_rich(f"\n[bold]Available Recipes ({len(recipes)}):[/bold]\n")
                 for recipe in recipes:
                     print(f"  • {recipe.name} (v{recipe.version})")
                     print(f"    {recipe.description}")
@@ -306,7 +306,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                         print("No recipes found")
                         return self.EXIT_SUCCESS
                     
-                    print(f"\n[bold]Available Recipes ({len(templates)}):[/bold]\n")
+                    self._print_rich(f"\n[bold]Available Recipes ({len(templates)}):[/bold]\n")
                     for template in templates:
                         print(f"  • {template.name}")
                         if template.description:
@@ -378,12 +378,12 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                     self._print_error(f"Recipe '{parsed.recipe_name}' has validation errors")
                 
                 if errors:
-                    print("\n[bold red]Errors:[/bold red]")
+                    self._print_rich("\n[bold red]Errors:[/bold red]")
                     for error in errors:
                         print(f"  ✗ {error}")
                 
                 if warnings:
-                    print("\n[bold yellow]Warnings:[/bold yellow]")
+                    self._print_rich("\n[bold yellow]Warnings:[/bold yellow]")
                     for warning in warnings:
                         print(f"  ⚠ {warning}")
             
@@ -437,11 +437,11 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
             if parsed.json:
                 self._print_json(result)
             else:
-                print(f"\n[bold cyan]Recipe: {parsed.recipe_name}[/bold cyan]\n")
+                self._print_rich(f"\n[bold cyan]Recipe: {parsed.recipe_name}[/bold cyan]\n")
                 
                 if "metadata" in result:
                     meta = result["metadata"]
-                    print("[bold]Metadata:[/bold]")
+                    self._print_rich("[bold]Metadata:[/bold]")
                     print(f"  Version: {meta.get('version', 'unknown')}")
                     print(f"  Description: {meta.get('description', 'N/A')}")
                     if meta.get('tags'):
@@ -450,7 +450,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                 
                 if "tools" in result:
                     tools = result["tools"]
-                    print(f"[bold]Tools ({len(tools)}):[/bold]")
+                    self._print_rich(f"[bold]Tools ({len(tools)}):[/bold]")
                     for tool in tools:
                         print(f"  • {tool['name']}")
                         print(f"    {tool.get('description', 'No description')}")
@@ -458,7 +458,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                 
                 if "resources" in result:
                     resources = result["resources"]
-                    print(f"[bold]Resources ({len(resources)}):[/bold]")
+                    self._print_rich(f"[bold]Resources ({len(resources)}):[/bold]")
                     for res in resources:
                         print(f"  • {res['uri']}")
                         print(f"    {res.get('description', 'No description')}")
@@ -466,7 +466,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                 
                 if "prompts" in result:
                     prompts = result["prompts"]
-                    print(f"[bold]Prompts ({len(prompts)}):[/bold]")
+                    self._print_rich(f"[bold]Prompts ({len(prompts)}):[/bold]")
                     for prompt in prompts:
                         print(f"  • {prompt['name']}")
                         print(f"    {prompt.get('description', 'No description')}")
@@ -551,7 +551,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                 f.write(config_json)
             self._print_success(f"Config written to {parsed.output}")
         else:
-            print(f"\n[bold]{parsed.client} Configuration for {parsed.recipe_name}:[/bold]\n")
+            self._print_rich(f"\n[bold]{parsed.client} Configuration for {parsed.recipe_name}:[/bold]\n")
             print(config_json)
             print()
         
@@ -611,7 +611,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                     "expires_at": api_key.expires_at,
                 })
             else:
-                print("\n[bold green]Generated API Key:[/bold green]")
+                self._print_rich("\n[bold green]Generated API Key:[/bold green]")
                 print(f"  Key: {raw_key}")
                 print(f"  ID: {api_key.key_id}")
                 if api_key.name:
@@ -620,7 +620,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                     print(f"  Scopes: {', '.join(api_key.scopes)}")
                 if api_key.expires_at:
                     print(f"  Expires: {api_key.expires_at}")
-                print("\n[yellow]Save this key securely - it cannot be retrieved later.[/yellow]")
+                self._print_rich("\n[yellow]Save this key securely - it cannot be retrieved later.[/yellow]")
             
             return self.EXIT_SUCCESS
             
@@ -683,7 +683,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
             if parsed.json:
                 self._print_json(config.to_dict())
             else:
-                print(f"\n[bold]OIDC Configuration for {parsed.issuer}:[/bold]\n")
+                self._print_rich(f"\n[bold]OIDC Configuration for {parsed.issuer}:[/bold]\n")
                 print(f"  Issuer: {config.issuer}")
                 print(f"  Authorization: {config.authorization_endpoint}")
                 print(f"  Token: {config.token_endpoint}")
@@ -749,7 +749,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
                     print("No tasks found")
                     return self.EXIT_SUCCESS
                 
-                print(f"\n[bold]Tasks ({len(tasks)}):[/bold]\n")
+                self._print_rich(f"\n[bold]Tasks ({len(tasks)}):[/bold]\n")
                 for task in tasks:
                     print(f"  • {task.id} [{task.state.value}]")
                     print(f"    Method: {task.method}")
@@ -787,7 +787,7 @@ Serve PraisonAI recipes as MCP servers for Claude Desktop, Cursor, Windsurf, and
             if parsed.json:
                 self._print_json(task.to_dict())
             else:
-                print(f"\n[bold]Task: {task.id}[/bold]\n")
+                self._print_rich(f"\n[bold]Task: {task.id}[/bold]\n")
                 print(f"  State: {task.state.value}")
                 print(f"  Method: {task.method}")
                 print(f"  Created: {task.created_at}")

--- a/src/praisonai-mcp/tests/unit/test_cli_rich_markup.py
+++ b/src/praisonai-mcp/tests/unit/test_cli_rich_markup.py
@@ -1,0 +1,63 @@
+"""Rich markup must never reach the user as literal [bold]...[/bold] text.
+
+Both MCP CLIs define a ``_print_rich`` helper that renders markup when Rich is
+installed and strips the tags when it is not. A bare ``print()`` carrying markup
+bypasses that helper, so the user sees the raw tags.
+"""
+import io
+import re
+import contextlib
+from pathlib import Path
+
+import pytest
+
+MARKUP = re.compile(r"\[/?(?:bold|red|green|yellow|cyan|dim|blue|magenta)[^\]]*\]")
+CLI_FILES = [
+    Path(__file__).resolve().parents[2] / "praisonai_mcp" / "mcp_server" / "cli.py",
+    Path(__file__).resolve().parents[2] / "praisonai_mcp" / "mcp_server" / "recipe_cli.py",
+]
+
+
+def _bare_markup_prints(path: Path):
+    """Lines calling the builtin print() with Rich markup in the argument."""
+    hits = []
+    for i, line in enumerate(path.read_text().splitlines(), 1):
+        stripped = line.lstrip()
+        if stripped.startswith("print(") and MARKUP.search(line):
+            hits.append(f"{path.name}:{i}: {stripped[:90]}")
+    return hits
+
+
+@pytest.mark.parametrize("path", CLI_FILES, ids=lambda p: p.name)
+def test_no_bare_print_of_rich_markup(path):
+    """Static guard: markup must go through _print_rich, not builtin print."""
+    assert path.exists(), f"missing {path}"
+    hits = _bare_markup_prints(path)
+    assert not hits, (
+        f"{len(hits)} bare print() call(s) carry Rich markup and will show "
+        "literal tags to the user:\n  " + "\n  ".join(hits)
+    )
+
+
+def test_control_probe_detector_actually_matches():
+    """Control: the detector must fire on a known-bad line, else the scan is vacuous."""
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+        fh.write('print(f"[bold]x[/bold]")\n')
+        tmp = Path(fh.name)
+    try:
+        assert len(_bare_markup_prints(tmp)) == 1
+    finally:
+        tmp.unlink()
+
+
+def test_list_recipes_output_has_no_literal_markup():
+    """Runtime: real command output must not contain literal Rich tags."""
+    from praisonai_mcp.mcp_server.recipe_cli import RecipeMCPCLI
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        RecipeMCPCLI().cmd_list_recipes([])
+    out = buf.getvalue()
+    leaked = MARKUP.findall(out)
+    assert not leaked, f"literal Rich tags shown to user: {leaked[:6]}\n---\n{out[:400]}"


### PR DESCRIPTION
## The bug

Both MCP CLIs define a `_print_rich` helper that renders Rich markup when Rich is installed and strips the tags when it is not. **30 call sites bypassed it** and called the builtin `print()` with markup in the string, so users saw the raw tags.

The files were already inconsistent with themselves: `cli.py` routed three sites through the helper (lines 374, 514, 566) and fifteen others through bare `print`.

## Reproduced on origin/main with the real command

Before:
```
[bold]Available Recipes (3):[/bold]

  • my-joke-template (v1.0.0)
    Generate jokes on any topic
```

After:
```
Available Recipes (3):

  • my-joke-template (v1.0.0)
    Generate jokes on any topic
```

## The change

All 30 sites were single-argument `print()` calls inside CLI methods, so each becomes `self._print_rich(...)` with no other change. 15 in `cli.py`, 15 in `recipe_cli.py`; 30 insertions, 30 deletions.

## Tests — `tests/unit/test_cli_rich_markup.py`

- **Runtime**: asserts real `cmd_list_recipes` output contains no literal Rich tags.
- **Static guard**: no bare `print()` carrying markup may be reintroduced in either file.
- **Control probe**: proves the detector fires on a known-bad line — without it the static scan would pass vacuously.

The runtime test matters because the static one alone could pass on empty output; rendered content is confirmed intact (still lists all 3 recipes).

## Verification

- **3 failed before / 4 passed after**, judged by **process exit code**, not a summary line.
- **Mutation testing**: restoring one bare `print` is killed by both the static and runtime tests (exit 1). Guarded with `assert old in s` so the mutation could not silently no-op and report a false SURVIVED.
- **Failure-neutral**: the same 6 tests fail on pristine `origin/main` (auth/adapter, unrelated to printing) — 210 passed baseline vs 214 with these tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line output when Rich formatting is unavailable.
  * Rich formatting tags are no longer displayed as literal text in CLI responses.
  * Updated recipe and MCP command output to consistently render clean, readable headings.

* **Tests**
  * Added coverage to verify that Rich markup does not leak into displayed command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->