### PR TITLE
fix(knowledge): clear reported success when nothing was cleared

### DIFF
--- a/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
+++ b/src/praisonai-agents/praisonaiagents/knowledge/knowledge.py
@@ -469,14 +469,21 @@ class Knowledge:
                 f"{type(self.memory).__name__} does not support delete_all()"
             )
 
-    def reset(self):
-        """Reset all memories."""
+    def reset(self) -> bool:
+        """Reset all memories.
+
+        Returns:
+            True if the backend actually reset, False if it has no ``reset``
+            and the call was a no-op. Callers that report this operation to a
+            user must not claim success on a False return: nothing was erased.
+        """
         if hasattr(self.memory, "reset"):
             self.memory.reset()
-        else:
-            logger.warning(
-                f"{type(self.memory).__name__} does not support reset(); no-op"
-            )
+            return True
+        logger.warning(
+            f"{type(self.memory).__name__} does not support reset(); no-op"
+        )
+        return False
 
     def normalize_content(self, content):
         """Normalize content for consistent storage."""

--- a/src/praisonai-mcp/praisonai_mcp/mcp_server/adapters/knowledge.py
+++ b/src/praisonai-mcp/praisonai_mcp/mcp_server/adapters/knowledge.py
@@ -74,8 +74,16 @@ def register_knowledge_tools() -> None:
             from praisonaiagents.knowledge import Knowledge
 
             knowledge = Knowledge()
-            knowledge.reset()
-            return "Knowledge cleared"
+            # reset() returns False when the configured backend has no reset():
+            # it warns and no-ops. Reporting "cleared" there would tell the user
+            # a destructive operation succeeded when nothing was erased.
+            if knowledge.reset():
+                return "Knowledge cleared"
+            backend = type(getattr(knowledge, "memory", None)).__name__
+            return (
+                f"Error: knowledge was NOT cleared - the configured backend "
+                f"({backend}) does not support reset()"
+            )
         except ImportError:
             return "Error: Knowledge module not available"
         except Exception as e:

--- a/src/praisonai-mcp/tests/mcp_server/test_knowledge_clear_honesty.py
+++ b/src/praisonai-mcp/tests/mcp_server/test_knowledge_clear_honesty.py
@@ -1,0 +1,85 @@
+"""`praisonai.knowledge.clear` must not claim success when nothing was cleared.
+
+``Knowledge.reset()`` deliberately no-ops (with a warning) when the configured
+memory backend has no ``reset``. The MCP tool called it and returned the fixed
+string "Knowledge cleared" regardless, so a user asking to clear a knowledge
+base was told the destructive operation succeeded when it had not run at all.
+"""
+import pytest
+
+pytest.importorskip("praisonaiagents")
+
+
+@pytest.fixture
+def isolated_registry():
+    import praisonai_mcp.mcp_server.registry as reg
+    from praisonai_mcp.mcp_server.registry import MCPToolRegistry, MCPResourceRegistry
+
+    saved_tool, saved_resource = reg._tool_registry, reg._resource_registry
+    reg._tool_registry = MCPToolRegistry()
+    reg._resource_registry = MCPResourceRegistry()
+    try:
+        yield reg
+    finally:
+        reg._tool_registry, reg._resource_registry = saved_tool, saved_resource
+
+
+def _tool(reg, name):
+    tool = reg._tool_registry.get(name)
+    assert tool is not None, f"tool not registered: {name}"
+    return tool.handler
+
+
+class _BackendWithoutReset:
+    """A memory backend that cannot be reset (e.g. ChromaKnowledgeAdapter)."""
+
+
+class _BackendWithReset:
+    def __init__(self):
+        self.was_reset = False
+
+    def reset(self):
+        self.was_reset = True
+
+
+def _fake_knowledge_cls(backend):
+    """A Knowledge stand-in reusing the REAL Knowledge.reset implementation."""
+    from praisonaiagents.knowledge import Knowledge
+
+    class _FakeKnowledge:
+        def __init__(self):
+            self.memory = backend
+
+        reset = Knowledge.reset
+
+    return _FakeKnowledge
+
+
+def _run_clear(monkeypatch, isolated_registry, backend):
+    import praisonaiagents.knowledge as kmod
+    from praisonai_mcp.mcp_server.adapters.knowledge import register_knowledge_tools
+
+    monkeypatch.setattr(kmod, "Knowledge", _fake_knowledge_cls(backend))
+    register_knowledge_tools()
+    return _tool(isolated_registry, "praisonai.knowledge.clear")()
+
+
+def test_clear_does_not_claim_success_when_backend_cannot_reset(
+    monkeypatch, isolated_registry
+):
+    backend = _BackendWithoutReset()
+    out = _run_clear(monkeypatch, isolated_registry, backend)
+    assert "cleared" not in out.lower() or "not" in out.lower(), (
+        "tool reported a destructive operation as done when the backend "
+        f"silently no-opped; returned: {out!r}"
+    )
+
+
+def test_clear_still_reports_success_when_it_really_clears(
+    monkeypatch, isolated_registry
+):
+    """Control: the honest path must still confirm a real clear."""
+    backend = _BackendWithReset()
+    out = _run_clear(monkeypatch, isolated_registry, backend)
+    assert backend.was_reset, "control backend was never reset - test is vacuous"
+    assert "cleared" in out.lower(), f"real clear should be confirmed; got {out!r}"


### PR DESCRIPTION
## The bug

`Knowledge.reset()` deliberately no-ops when the configured memory backend has no `reset()` — it logs a warning and returns. The MCP tool `praisonai.knowledge.clear` called it and then returned the fixed string `"Knowledge cleared"` **regardless**.

So a user who asked to clear a knowledge base was told a destructive operation had succeeded when it had never run.

This is worse than a wording nit: the false confirmation is on a **destructive path**, so a user could believe sensitive material was erased when it is still stored.

## Reproduced against the real `Knowledge.reset` implementation

```
WARNING  _BackendWithoutReset does not support reset(); no-op
tool returned: 'Knowledge cleared'
```

After:

```
'Error: knowledge was NOT cleared - the configured backend
 (ChromaKnowledgeAdapter) does not support reset()'
```

## Changes

- **`Knowledge.reset()`** returns `True` when the backend actually reset, `False` when the call was a no-op. Returning a value is backward compatible — existing callers that ignore it are unaffected.
- **`knowledge_clear()`** reports honestly and names the backend that refused.

## Tests — `tests/mcp_server/test_knowledge_clear_honesty.py`

- A no-op backend must not be reported as cleared.
- **Control**: a backend that really resets must still be confirmed — and the control asserts the backend was *actually* reset, so it cannot pass vacuously.

## Verification

- **1 failed before / 2 passed after**, judged by **process exit code**.
- **Mutation testing**, each guarded by an `assert target in source` so a mutation could not silently no-op and report a false SURVIVED:
  - `reset()` always returning `True` → **killed**
  - the tool ignoring the return value (`if True or knowledge.reset()`) → **killed**
  - anchor run on unmutated code passed first, and the restored tree re-verified green.
- **Failure-neutral**: praisonai-mcp 216 passed baseline → 218 with these tests, both exit 0. The praisonai-agents knowledge/memory selection has an **identical failure set** vs pristine `origin/main` (13 pre-existing, 704 passed) — verified by diffing the sorted failure lists, not just comparing counts.

### Note on the 6 "failures" this investigation started from

They were **environmental**, not real: a stale installed `praisonaiagents` in site-packages lacking `oauth_provider`. With the repo SDK on `PYTHONPATH` all 32 pass. Only the honesty bug above survived scrutiny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Knowledge clearing now accurately reports whether the configured backend supports reset operations.
  * Users receive an error message when knowledge cannot be cleared, instead of an incorrect success confirmation.
  * Successful resets continue to report “Knowledge cleared.”

* **Tests**
  * Added coverage for both supported and unsupported backend reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->