### PR TITLE
fix(hooks): emit SCHEDULE_ADD and SCHEDULE_REMOVE from the schedule store

### DIFF
--- a/src/praisonai-agents/praisonaiagents/hooks/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/hooks/__init__.py
@@ -83,6 +83,8 @@ __all__ = [
     "GatewayStartInput",
     "GatewayStopInput",
     "ScheduleTriggerInput",
+    "ScheduleAddInput",
+    "ScheduleRemoveInput",
     "JobCompletedInput",
     # Middleware types
     "InvocationContext",
@@ -156,6 +158,8 @@ _LAZY_GROUPS = {
         'GatewayStartInput': ('praisonaiagents.hooks.events', 'GatewayStartInput'),
         'GatewayStopInput': ('praisonaiagents.hooks.events', 'GatewayStopInput'),
         'ScheduleTriggerInput': ('praisonaiagents.hooks.events', 'ScheduleTriggerInput'),
+        'ScheduleAddInput': ('praisonaiagents.hooks.events', 'ScheduleAddInput'),
+        'ScheduleRemoveInput': ('praisonaiagents.hooks.events', 'ScheduleRemoveInput'),
         'JobCompletedInput': ('praisonaiagents.hooks.events', 'JobCompletedInput'),
     },
     'middleware_types': {

--- a/src/praisonai-agents/praisonaiagents/hooks/events.py
+++ b/src/praisonai-agents/praisonaiagents/hooks/events.py
@@ -462,6 +462,61 @@ class ScheduleTriggerInput(HookInput):
 
 
 @dataclass
+class ScheduleAddInput(HookInput):
+    """Input for SCHEDULE_ADD hooks (a scheduled job was persisted).
+
+    Emitted by the schedule store, which is the single point every author
+    path funnels through: the agent-callable ``schedule_add`` tool, the
+    ``praisonai schedule add`` CLI, and the gateway's config reconciler.
+    """
+    job_name: str = ""
+    job_id: str = ""
+    schedule: str = ""
+    message: str = ""
+    agent_id: str = ""
+    principal: str = ""
+    enabled: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        base = super().to_dict()
+        base.update({
+            "job_name": self.job_name,
+            "job_id": self.job_id,
+            "schedule": self.schedule,
+            "message": self.message[:500] if self.message else "",
+            "agent_id": self.agent_id,
+            "principal": self.principal,
+            "enabled": self.enabled,
+        })
+        return base
+
+
+@dataclass
+class ScheduleRemoveInput(HookInput):
+    """Input for SCHEDULE_REMOVE hooks (a scheduled job was deleted).
+
+    Emitted by the schedule store for every deletion path — the
+    agent-callable ``schedule_remove`` tool, ``praisonai schedule
+    remove``/``delete`` (which delete by id, not name), and the automatic
+    cleanup of a spent ``delete_after_run`` one-shot.
+    """
+    job_name: str = ""
+    job_id: str = ""
+    schedule: str = ""
+    principal: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        base = super().to_dict()
+        base.update({
+            "job_name": self.job_name,
+            "job_id": self.job_id,
+            "schedule": self.schedule,
+            "principal": self.principal,
+        })
+        return base
+
+
+@dataclass
 class JobCompletedInput(HookInput):
     """Input for JOB_COMPLETED hooks (a background job finished).
 

--- a/src/praisonai-agents/praisonaiagents/scheduler/config_store.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/config_store.py
@@ -16,6 +16,7 @@ from typing import Dict, Iterator, List, Optional
 
 from .models import ScheduleJob, RunRecord
 from .due import is_due as _is_due, resolve_schedule_timezone
+from .hook_emit import emit_schedule_add, emit_schedule_remove
 
 logger = get_logger(__name__)
 
@@ -72,6 +73,9 @@ class ConfigYamlScheduleStore:
                 raise ValueError(f"Job '{job.id}' already exists")
             self._jobs[job.id] = job
             self._save()
+        # Emit SCHEDULE_ADD outside the store locks: a hook must never be able
+        # to deadlock the cross-process file lock by calling back in.
+        emit_schedule_add(job)
 
     def get(self, job_id: str) -> Optional[ScheduleJob]:
         with self._lock:
@@ -131,15 +135,18 @@ class ConfigYamlScheduleStore:
             self._save()
 
     def remove(self, job_id: str) -> bool:
+        removed = None
         with self._lock, self._file_lock():
             self._reload_locked()
             if job_id in self._jobs:
-                del self._jobs[job_id]
+                removed = self._jobs.pop(job_id)
                 # Drop any per-job scratchpad so a deleted job leaves no state.
                 self._job_state.pop(job_id, None)
                 self._save()
-                return True
+        if removed is None:
             return False
+        emit_schedule_remove(removed)
+        return True
 
     def remove_by_name(self, name: str, principal: Optional[str] = None) -> bool:
         """Remove a job by name, optionally scoped to ``principal``.
@@ -149,17 +156,21 @@ class ConfigYamlScheduleStore:
         automation by guessing its name. ``None`` (the default) preserves the
         pre-scoping global removal.
         """
+        removed = None
         with self._lock, self._file_lock():
             self._reload_locked()
             for jid, job in list(self._jobs.items()):
                 if job.name == name:
                     if principal is not None and job.principal != principal:
                         continue
-                    del self._jobs[jid]
+                    removed = self._jobs.pop(jid)
                     self._job_state.pop(jid, None)
                     self._save()
-                    return True
+                    break
+        if removed is None:
             return False
+        emit_schedule_remove(removed)
+        return True
 
     # ── atomic claim / lease ──────────────────────────────────────────
 
@@ -187,6 +198,10 @@ class ConfigYamlScheduleStore:
         not see the job in their returned list.
         """
         claimed: List[ScheduleJob] = []
+        # One-shots auto-deleted by this claim. Emitted after the lock below;
+        # a later ``remove(job.id)`` by the runner is then a no-op, so a spent
+        # one-shot yields exactly one SCHEDULE_REMOVE.
+        auto_removed: List[ScheduleJob] = []
         with self._lock, self._file_lock():
             # Re-read from disk so we observe cross-process claims/leases.
             self._reload_locked()
@@ -210,7 +225,7 @@ class ConfigYamlScheduleStore:
                 changed = True
                 if job.delete_after_run:
                     # One-shot: remove now so no competitor re-claims it.
-                    del self._jobs[job.id]
+                    auto_removed.append(self._jobs.pop(job.id))
                     self._job_state.pop(job.id, None)
             if changed:
                 if not self._save():
@@ -221,7 +236,10 @@ class ConfigYamlScheduleStore:
                     # fires a duplicate. Drop the claim so it is retried cleanly.
                     for job in claimed:
                         self._held_leases.pop(job.id, None)
+                    # The deletion was never persisted — do not announce it.
                     return []
+        for job in auto_removed:
+            emit_schedule_remove(job)
         return claimed
 
     def complete(self, job_id: str, owner_id: str) -> None:

--- a/src/praisonai-agents/praisonaiagents/scheduler/hook_emit.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/hook_emit.py
@@ -1,0 +1,153 @@
+"""Lifecycle hook emission for schedule mutations.
+
+``HookEvent.SCHEDULE_ADD`` / ``HookEvent.SCHEDULE_REMOVE`` are emitted from the
+schedule store because the store is the one point every author/deleter path
+funnels through:
+
+* the agent-callable ``schedule_add`` / ``schedule_remove`` tools,
+* ``praisonai schedule add`` (delegates to the tool) and ``praisonai schedule
+  remove`` / ``delete`` (call ``store.remove(job_id)`` directly),
+* the gateway's ``config.yaml`` schedule reconciler,
+* the automatic cleanup of a spent ``delete_after_run`` one-shot.
+
+Emitting per-call-site instead would have silently missed most of those.
+
+Everything here is best-effort: a hook must never break, slow down, or roll
+back the mutation it observes, and there is no measurable cost when nothing is
+registered (a single ``has_hooks`` dictionary lookup).
+"""
+
+import asyncio
+import os
+import time
+from typing import Any, Optional, Set
+
+from praisonaiagents._logging import get_logger
+
+logger = get_logger(__name__)
+
+# Strong references to in-flight fire-and-forget hook tasks. Without this the
+# event loop only holds a weak reference and a task may be garbage-collected
+# before it completes (see asyncio.create_task docs). Mirrors the gateway's
+# ``praisonai_bot.bots._protocol_mixin`` emitter.
+_PENDING_HOOK_TASKS: Set[Any] = set()
+
+
+def _on_hook_task_done(task: Any) -> None:
+    """Drop the finished task and log any swallowed coroutine exception."""
+    _PENDING_HOOK_TASKS.discard(task)
+    try:
+        exc = task.exception()
+    except Exception:  # noqa: BLE001 — cancelled or loop teardown; nothing to log
+        return
+    if exc is not None:
+        logger.debug("schedule hook task error (non-fatal): %s", exc)
+
+
+def describe_schedule(schedule: Any) -> str:
+    """Render a job's schedule as a short, stable, human-readable token."""
+    try:
+        kind = getattr(schedule, "kind", "")
+        if kind == "every" and getattr(schedule, "every_seconds", None):
+            return f"every {schedule.every_seconds}s"
+        if kind == "cron" and getattr(schedule, "cron_expr", None):
+            return f"cron:{schedule.cron_expr}"
+        if kind == "at" and getattr(schedule, "at", None):
+            return f"at:{schedule.at}"
+        return str(kind or "")
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+def _dispatch(event: Any, input_data: Any, registry: Any) -> None:
+    """Run hooks for ``event``, working in both sync and async contexts.
+
+    ``HookRunner.execute_sync`` raises inside a running event loop, so when one
+    is detected the coroutine is scheduled fire-and-forget instead. Never
+    raises to the caller.
+    """
+    from ..hooks.runner import HookRunner
+
+    runner = HookRunner(registry)
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None and loop.is_running():
+        task = loop.create_task(runner.execute(event, input_data))
+        _PENDING_HOOK_TASKS.add(task)
+        task.add_done_callback(_on_hook_task_done)
+    else:
+        runner.execute_sync(event, input_data)
+
+
+def _registry_for(event: Any) -> Optional[Any]:
+    """Return the default hook registry only when it has hooks for ``event``."""
+    from ..hooks.registry import get_default_registry
+
+    registry = get_default_registry()
+    return registry if registry.has_hooks(event) else None
+
+
+def emit_schedule_add(job: Any) -> None:
+    """Fire ``SCHEDULE_ADD`` for a newly persisted job (best-effort)."""
+    try:
+        from ..hooks.types import HookEvent
+
+        registry = _registry_for(HookEvent.SCHEDULE_ADD)
+        if registry is None:
+            return
+
+        from ..hooks.events import ScheduleAddInput
+
+        _dispatch(
+            HookEvent.SCHEDULE_ADD,
+            ScheduleAddInput(
+                session_id="",
+                cwd=os.getcwd(),
+                event_name=HookEvent.SCHEDULE_ADD.value,
+                timestamp=str(time.time()),
+                agent_name=getattr(job, "agent_id", None) or "scheduler",
+                job_name=getattr(job, "name", "") or "",
+                job_id=str(getattr(job, "id", "") or ""),
+                schedule=describe_schedule(getattr(job, "schedule", None)),
+                message=getattr(job, "message", "") or "",
+                agent_id=getattr(job, "agent_id", "") or "",
+                principal=getattr(job, "principal", "") or "",
+                enabled=bool(getattr(job, "enabled", True)),
+            ),
+            registry,
+        )
+    except Exception:  # noqa: BLE001 — observability must never break the store
+        logger.debug("SCHEDULE_ADD hook emit failed (non-fatal)", exc_info=True)
+
+
+def emit_schedule_remove(job: Any) -> None:
+    """Fire ``SCHEDULE_REMOVE`` for a job that was actually deleted."""
+    try:
+        from ..hooks.types import HookEvent
+
+        registry = _registry_for(HookEvent.SCHEDULE_REMOVE)
+        if registry is None:
+            return
+
+        from ..hooks.events import ScheduleRemoveInput
+
+        _dispatch(
+            HookEvent.SCHEDULE_REMOVE,
+            ScheduleRemoveInput(
+                session_id="",
+                cwd=os.getcwd(),
+                event_name=HookEvent.SCHEDULE_REMOVE.value,
+                timestamp=str(time.time()),
+                agent_name=getattr(job, "agent_id", None) or "scheduler",
+                job_name=getattr(job, "name", "") or "",
+                job_id=str(getattr(job, "id", "") or ""),
+                schedule=describe_schedule(getattr(job, "schedule", None)),
+                principal=getattr(job, "principal", "") or "",
+            ),
+            registry,
+        )
+    except Exception:  # noqa: BLE001 — observability must never break the store
+        logger.debug("SCHEDULE_REMOVE hook emit failed (non-fatal)", exc_info=True)

--- a/src/praisonai-agents/praisonaiagents/scheduler/store.py
+++ b/src/praisonai-agents/praisonaiagents/scheduler/store.py
@@ -15,6 +15,7 @@ from typing import Dict, Iterator, List, Optional
 
 from .models import ScheduleJob, RunRecord
 from .due import is_due as _is_due
+from .hook_emit import emit_schedule_add, emit_schedule_remove
 
 logger = get_logger(__name__)
 
@@ -60,6 +61,9 @@ class FileScheduleStore:
                 raise ValueError(f"Job '{job.id}' already exists")
             self._jobs[job.id] = job
             self._save()
+        # Emit SCHEDULE_ADD outside the store locks: a hook must never be able
+        # to deadlock the cross-process file lock by calling back in.
+        emit_schedule_add(job)
 
     def get(self, job_id: str) -> Optional[ScheduleJob]:
         with self._lock:
@@ -119,13 +123,16 @@ class FileScheduleStore:
             self._save()
 
     def remove(self, job_id: str) -> bool:
+        removed = None
         with self._lock, self._file_lock():
             self._reload_locked()
             if job_id in self._jobs:
-                del self._jobs[job_id]
+                removed = self._jobs.pop(job_id)
                 self._save()
-                return True
+        if removed is None:
             return False
+        emit_schedule_remove(removed)
+        return True
 
     def remove_by_name(self, name: str, principal: Optional[str] = None) -> bool:
         """Remove a job by name, optionally scoped to ``principal``.
@@ -135,16 +142,20 @@ class FileScheduleStore:
         automation by guessing its name. ``None`` (the default) preserves the
         pre-scoping global removal.
         """
+        removed = None
         with self._lock, self._file_lock():
             self._reload_locked()
             for jid, job in list(self._jobs.items()):
                 if job.name == name:
                     if principal is not None and job.principal != principal:
                         continue
-                    del self._jobs[jid]
+                    removed = self._jobs.pop(jid)
                     self._save()
-                    return True
+                    break
+        if removed is None:
             return False
+        emit_schedule_remove(removed)
+        return True
 
     # ── atomic claim / lease ──────────────────────────────────────────
 
@@ -172,6 +183,10 @@ class FileScheduleStore:
         not see the job in their returned list.
         """
         claimed: List[ScheduleJob] = []
+        # One-shots auto-deleted by this claim. Emitted after the lock below;
+        # a later ``remove(job.id)`` by the runner is then a no-op, so a spent
+        # one-shot yields exactly one SCHEDULE_REMOVE.
+        auto_removed: List[ScheduleJob] = []
         with self._lock, self._file_lock():
             # Re-read from disk so we observe cross-process claims/leases.
             self._reload_locked()
@@ -195,7 +210,7 @@ class FileScheduleStore:
                 changed = True
                 if job.delete_after_run:
                     # One-shot: remove now so no competitor re-claims it.
-                    del self._jobs[job.id]
+                    auto_removed.append(self._jobs.pop(job.id))
             if changed:
                 if not self._save():
                     # The lease/last_run_at advance was NOT persisted (full
@@ -205,7 +220,10 @@ class FileScheduleStore:
                     # fires a duplicate. Drop the claim so it is retried cleanly.
                     for job in claimed:
                         self._held_leases.pop(job.id, None)
+                    # The deletion was never persisted — do not announce it.
                     return []
+        for job in auto_removed:
+            emit_schedule_remove(job)
         return claimed
 
     def complete(self, job_id: str, owner_id: str) -> None:

--- a/src/praisonai-agents/tests/unit/test_schedule_lifecycle_hooks.py
+++ b/src/praisonai-agents/tests/unit/test_schedule_lifecycle_hooks.py
@@ -1,0 +1,344 @@
+"""Tests for SCHEDULE_ADD / SCHEDULE_REMOVE hook emission.
+
+``HookEvent.SCHEDULE_ADD`` and ``HookEvent.SCHEDULE_REMOVE`` were declared in
+``praisonaiagents/hooks/types.py`` but never emitted by any production code
+path, so a plugin registering on them was silent forever. (The *strings*
+``"schedule_add"``/``"schedule_remove"`` do appear in production, but only as
+agent tool names in TOOL_MAPPINGS / profiles / tool_search — not emissions.)
+
+These tests pin the emission to the canonical schedule mutation point: the
+schedule store, which every author path funnels through — the agent-callable
+``schedule_add``/``schedule_remove`` tools, the ``praisonai schedule
+add/remove/delete`` CLI, the gateway config reconciler, and the one-shot
+``delete_after_run`` cleanup.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from praisonaiagents.hooks import HookEvent, HookRegistry, HookResult
+from praisonaiagents.hooks.registry import get_default_registry, set_default_registry
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+class _Recorder:
+    """Install a fresh default registry recording the events under test."""
+
+    def __init__(self, *events):
+        self.events = events
+        self.fired = []
+        self.payloads = []
+        self._saved = None
+
+    def __enter__(self):
+        self._saved = get_default_registry()
+        reg = HookRegistry()
+
+        def _make(name):
+            def _h(ev):
+                self.fired.append(name)
+                self.payloads.append(ev.to_dict())
+                return HookResult.allow()
+            return _h
+
+        for evt in self.events:
+            reg.on(evt)(_make(evt.value))
+        set_default_registry(reg)
+        return self
+
+    def __exit__(self, *exc):
+        set_default_registry(self._saved)
+        return False
+
+
+@pytest.fixture
+def tool_store(tmp_path):
+    """A temp FileScheduleStore wired into the schedule tools + core default."""
+    from praisonaiagents.tools import schedule_tools
+    from praisonaiagents import scheduler as _scheduler
+    from praisonaiagents.scheduler.store import FileScheduleStore
+
+    saved_tool_store = schedule_tools._store_instance
+    try:
+        saved_default = _scheduler.get_default_store()
+    except Exception:
+        saved_default = None
+
+    store = FileScheduleStore(store_dir=str(tmp_path))
+    schedule_tools.set_store(store)
+    try:
+        yield store
+    finally:
+        schedule_tools._store_instance = saved_tool_store
+        try:
+            _scheduler.set_default_store(saved_default)
+        except Exception:
+            pass
+
+
+def _job(name="nightly", seconds=3600, **kw):
+    from praisonaiagents.scheduler.models import Schedule, ScheduleJob
+
+    return ScheduleJob(
+        name=name,
+        schedule=Schedule(kind="every", every_seconds=seconds),
+        message="do the thing",
+        **kw,
+    )
+
+
+# ── event input types ────────────────────────────────────────────────────────
+
+class TestScheduleMutationInputTypes:
+    def test_input_types_importable(self):
+        from praisonaiagents.hooks import ScheduleAddInput, ScheduleRemoveInput
+
+        assert ScheduleAddInput is not None
+        assert ScheduleRemoveInput is not None
+
+    def test_schedule_add_to_dict(self):
+        from praisonaiagents.hooks import ScheduleAddInput
+
+        ev = ScheduleAddInput(
+            session_id="",
+            cwd=".",
+            event_name=HookEvent.SCHEDULE_ADD.value,
+            timestamp="0",
+            job_name="nightly",
+            job_id="42",
+            schedule="every 3600s",
+            message="do the thing",
+            principal="alice",
+        )
+        d = ev.to_dict()
+        assert d["job_name"] == "nightly"
+        assert d["job_id"] == "42"
+        assert d["schedule"] == "every 3600s"
+        assert d["message"] == "do the thing"
+        assert d["principal"] == "alice"
+
+    def test_schedule_remove_to_dict(self):
+        from praisonaiagents.hooks import ScheduleRemoveInput
+
+        ev = ScheduleRemoveInput(
+            session_id="",
+            cwd=".",
+            event_name=HookEvent.SCHEDULE_REMOVE.value,
+            timestamp="0",
+            job_name="nightly",
+            job_id="42",
+            principal="alice",
+        )
+        d = ev.to_dict()
+        assert d["job_name"] == "nightly"
+        assert d["job_id"] == "42"
+        assert d["principal"] == "alice"
+
+
+# ── the agent-callable tool path ─────────────────────────────────────────────
+
+class TestScheduleToolsEmit:
+    def test_schedule_add_tool_fires_hook(self, tool_store):
+        from praisonaiagents.tools.schedule_tools import schedule_add
+
+        with _Recorder(HookEvent.SCHEDULE_ADD) as rec:
+            out = schedule_add(name="nightly", schedule="*/30m", message="check email")
+
+        assert "added" in out, out
+        assert rec.fired == ["schedule_add"]
+        payload = rec.payloads[0]
+        assert payload["job_name"] == "nightly"
+        assert payload["job_id"]
+        assert payload["message"] == "check email"
+
+    def test_schedule_remove_tool_fires_hook(self, tool_store):
+        from praisonaiagents.tools.schedule_tools import schedule_add, schedule_remove
+
+        schedule_add(name="nightly", schedule="*/30m", message="check email")
+        with _Recorder(HookEvent.SCHEDULE_REMOVE) as rec:
+            out = schedule_remove(name="nightly")
+
+        assert "removed" in out, out
+        assert rec.fired == ["schedule_remove"]
+        assert rec.payloads[0]["job_name"] == "nightly"
+
+    def test_failed_add_does_not_fire(self, tool_store):
+        """A duplicate-name rejection is not an add — nothing may be emitted."""
+        from praisonaiagents.tools.schedule_tools import schedule_add
+
+        schedule_add(name="nightly", schedule="*/30m")
+        with _Recorder(HookEvent.SCHEDULE_ADD) as rec:
+            out = schedule_add(name="nightly", schedule="*/30m")
+
+        assert "already exists" in out, out
+        assert rec.fired == []
+
+    def test_missing_remove_does_not_fire(self, tool_store):
+        from praisonaiagents.tools.schedule_tools import schedule_remove
+
+        with _Recorder(HookEvent.SCHEDULE_REMOVE) as rec:
+            out = schedule_remove(name="does-not-exist")
+
+        assert "not found" in out, out
+        assert rec.fired == []
+
+
+# ── the store itself (CLI `schedule remove`, gateway reconciler, one-shots) ──
+
+class TestFileScheduleStoreEmits:
+    def test_store_add_fires(self, tmp_path):
+        from praisonaiagents.scheduler.store import FileScheduleStore
+
+        store = FileScheduleStore(store_dir=str(tmp_path))
+        with _Recorder(HookEvent.SCHEDULE_ADD) as rec:
+            store.add(_job())
+        assert rec.fired == ["schedule_add"]
+
+    def test_store_remove_by_id_fires(self, tmp_path):
+        """`praisonai schedule remove/delete` removes by id, not by name."""
+        from praisonaiagents.scheduler.store import FileScheduleStore
+
+        store = FileScheduleStore(store_dir=str(tmp_path))
+        job = _job()
+        store.add(job)
+        with _Recorder(HookEvent.SCHEDULE_REMOVE) as rec:
+            assert store.remove(job.id) is True
+        assert rec.fired == ["schedule_remove"]
+        assert rec.payloads[0]["job_id"] == job.id
+        assert rec.payloads[0]["job_name"] == "nightly"
+
+    def test_store_remove_by_name_fires(self, tmp_path):
+        from praisonaiagents.scheduler.store import FileScheduleStore
+
+        store = FileScheduleStore(store_dir=str(tmp_path))
+        store.add(_job(name="weekly"))
+        with _Recorder(HookEvent.SCHEDULE_REMOVE) as rec:
+            assert store.remove_by_name("weekly") is True
+        assert rec.fired == ["schedule_remove"]
+        assert rec.payloads[0]["job_name"] == "weekly"
+
+    def test_no_op_remove_does_not_fire(self, tmp_path):
+        from praisonaiagents.scheduler.store import FileScheduleStore
+
+        store = FileScheduleStore(store_dir=str(tmp_path))
+        with _Recorder(HookEvent.SCHEDULE_REMOVE) as rec:
+            assert store.remove("nope") is False
+            assert store.remove_by_name("nope") is False
+        assert rec.fired == []
+
+    def test_principal_scoped_skip_does_not_fire(self, tmp_path):
+        """A cross-tenant remove that legitimately removes nothing is silent."""
+        from praisonaiagents.scheduler.store import FileScheduleStore
+
+        store = FileScheduleStore(store_dir=str(tmp_path))
+        store.add(_job(name="alices", principal="alice"))
+        with _Recorder(HookEvent.SCHEDULE_REMOVE) as rec:
+            assert store.remove_by_name("alices", principal="bob") is False
+        assert rec.fired == []
+
+
+class TestOneShotAutoDelete:
+    """A spent ``delete_after_run`` job is deleted inside ``claim_due``,
+    bypassing ``remove()`` entirely — it must still announce itself, exactly
+    once (the runner's later ``remove(job.id)`` finds nothing)."""
+
+    def test_claim_due_auto_delete_fires_once(self, tmp_path):
+        from praisonaiagents.scheduler.store import FileScheduleStore
+        from praisonaiagents.scheduler.runner import ScheduleRunner
+
+        store = FileScheduleStore(store_dir=str(tmp_path))
+        job = _job(name="one-shot", seconds=1)
+        job.delete_after_run = True
+        job.last_run_at = None
+        store.add(job)
+
+        with _Recorder(HookEvent.SCHEDULE_REMOVE) as rec:
+            claimed = store.claim_due(now=time.time() + 5, owner_id="w1")
+            assert [j.id for j in claimed] == [job.id]
+            # The runner's post-run cleanup must not double-announce it.
+            assert store.remove(job.id) is False
+
+        assert rec.fired == ["schedule_remove"]
+        assert rec.payloads[0]["job_name"] == "one-shot"
+        assert ScheduleRunner is not None  # cleanup path lives here
+
+    def test_recurring_claim_does_not_fire(self, tmp_path):
+        from praisonaiagents.scheduler.store import FileScheduleStore
+
+        store = FileScheduleStore(store_dir=str(tmp_path))
+        job = _job(name="recurring", seconds=1)
+        store.add(job)
+        with _Recorder(HookEvent.SCHEDULE_REMOVE) as rec:
+            assert store.claim_due(now=time.time() + 5, owner_id="w1")
+        assert rec.fired == []
+
+
+class TestConfigYamlScheduleStoreEmits:
+    def test_config_store_add_and_remove_fire(self, tmp_path):
+        from praisonaiagents.scheduler.config_store import ConfigYamlScheduleStore
+
+        store = ConfigYamlScheduleStore(config_path=str(tmp_path / "config.yaml"))
+        job = _job(name="from-config")
+        with _Recorder(HookEvent.SCHEDULE_ADD, HookEvent.SCHEDULE_REMOVE) as rec:
+            store.add(job)
+            assert store.remove(job.id) is True
+        assert rec.fired == ["schedule_add", "schedule_remove"]
+
+
+# ── async safety and zero-overhead ───────────────────────────────────────────
+
+class TestEmissionSafety:
+    def test_fires_inside_a_running_event_loop(self, tmp_path):
+        """`HookRunner.execute_sync` raises in a running loop — emission must not."""
+        from praisonaiagents.scheduler.store import FileScheduleStore
+
+        store = FileScheduleStore(store_dir=str(tmp_path))
+
+        async def _run():
+            with _Recorder(HookEvent.SCHEDULE_ADD) as rec:
+                store.add(_job())
+                # fire-and-forget task scheduled on the running loop
+                current = asyncio.current_task()
+                pending = [
+                    t for t in asyncio.all_tasks() if t is not current and not t.done()
+                ]
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
+                return list(rec.fired)
+
+        assert asyncio.run(_run()) == ["schedule_add"]
+
+    def test_no_hooks_registered_is_a_silent_noop(self, tmp_path):
+        from praisonaiagents.scheduler.store import FileScheduleStore
+
+        saved = get_default_registry()
+        set_default_registry(HookRegistry())
+        try:
+            store = FileScheduleStore(store_dir=str(tmp_path))
+            job = _job()
+            store.add(job)  # must not raise
+            assert store.remove(job.id) is True
+        finally:
+            set_default_registry(saved)
+
+    def test_a_raising_hook_never_breaks_the_mutation(self, tmp_path):
+        from praisonaiagents.scheduler.store import FileScheduleStore
+
+        saved = get_default_registry()
+        reg = HookRegistry()
+
+        @reg.on(HookEvent.SCHEDULE_ADD)
+        def _boom(_ev):
+            raise RuntimeError("plugin exploded")
+
+        set_default_registry(reg)
+        try:
+            store = FileScheduleStore(store_dir=str(tmp_path))
+            job = _job()
+            store.add(job)
+            assert store.get(job.id) is not None
+        finally:
+            set_default_registry(saved)


### PR DESCRIPTION
## Summary

Five `HookEvent` members were reported as declared-but-never-emitted. I re-verified each on `origin/main` (`be1961a2`). **Three are already emitted**; two genuinely were not, and this PR fixes those two. No constant is deleted — every one of the five has a real lifecycle point.

| Event | Status on main | Emission site |
|---|---|---|
| `GATEWAY_START` | already emitted | `BotOS.start()` → `praisonai_bot/bots/botos.py:358` → `fire_gateway_start` |
| `GATEWAY_STOP` | already emitted | `BotOS.stop()` → `praisonai_bot/bots/botos.py:1466` → `fire_gateway_stop` |
| `SCHEDULE_TRIGGER` | already emitted | `BotOS._execute_schedule_job()` → `praisonai_bot/bots/botos.py:781` → `fire_schedule_trigger` |
| `SCHEDULE_ADD` | **never emitted** | **new:** `FileScheduleStore.add` / `ConfigYamlScheduleStore.add` |
| `SCHEDULE_REMOVE` | **never emitted** | **new:** both stores' `remove` / `remove_by_name`, plus the one-shot auto-delete inside `claim_due` |

The original report's grep was scoped to `src/praisonai-agents/`; the gateway emissions live in `src/praisonai-bot/`.

### The name collision (confirmed, not an emission)

`"schedule_add"` / `"schedule_remove"` do appear in production, but only as **agent tool names** — `praisonaiagents/tools/__init__.py` (TOOL_MAPPINGS), `tools/profiles.py`, `tools/tool_search.py`, `bots/config.py`, `praisonai_bot/bots/_defaults.py`, `praisonai_code/cli/commands/tracker.py`. None reaches `HookRunner`. Control probes on every scan: `message_received` (must be non-zero) hit; `zzz_control_nonexistent` (must be zero) empty.

## Why the store, not the tool

Emitting from `schedule_add` / `schedule_remove` alone would have missed most real mutations. The store is the one chokepoint every path funnels through:

* the agent-callable `schedule_add` / `schedule_remove` tools;
* `praisonai schedule add` (delegates to the tool) and `praisonai schedule remove` / `delete` — which call `store.remove(job_id)` **by id, never the tool**;
* the gateway's `config.yaml` reconciler (`config_loader.py` `store.add` and `_prune_removed_config_jobs` → `store.remove`);
* the automatic cleanup of a spent `delete_after_run` one-shot, which is deleted **inside `claim_due()`** and never passes through `remove()` at all.

Both store implementations in the repo (`FileScheduleStore`, `ConfigYamlScheduleStore`) are covered.

## Emission discipline

Emission is observability-only and cannot change program behaviour:

* fired **after** the store's `threading.RLock` *and* cross-process file lock are released, so a hook calling back into the store cannot deadlock it;
* skipped entirely when nothing is registered (one `has_hooks` dict lookup);
* loop-aware — `HookRunner.execute_sync` raises inside a running event loop, so a running loop gets a strong-referenced `create_task` instead (same pattern as `praisonai_bot/bots/_protocol_mixin.py::_emit`);
* a raising hook is swallowed and never rolls back the mutation.

Nothing is emitted for a non-event: a duplicate-name add rejection, a no-op remove, a cross-tenant `remove_by_name` that matched nothing, or a one-shot deletion whose persist failed and was rolled back. A spent one-shot fires exactly once (the runner's later `remove(job.id)` finds nothing).

New payload types `ScheduleAddInput` / `ScheduleRemoveInput` follow `ScheduleTriggerInput`.

## Test evidence

New suite: `src/praisonai-agents/tests/unit/test_schedule_lifecycle_hooks.py` (18 tests).

**Before** — on unmodified `origin/main`, judged by process exit code:

```
$ python -m pytest tests/unit/test_schedule_lifecycle_hooks.py -p no:randomly -q
EXIT=1
10 failed, 6 passed in 0.40s

FAILED ...::TestScheduleToolsEmit::test_schedule_add_tool_fires_hook
    assert rec.fired == ["schedule_add"]
E   AssertionError: assert [] == ['schedule_add']
FAILED ...::TestFileScheduleStoreEmits::test_store_remove_by_id_fires
    assert rec.fired == ["schedule_remove"]
E   AssertionError: assert [] == ['schedule_remove']
FAILED ...::TestConfigYamlScheduleStoreEmits::test_config_store_add_and_remove_fire
FAILED ...::TestEmissionSafety::test_fires_inside_a_running_event_loop
   (+6 more)
```

The 6 that passed before are the negative controls (must-not-fire cases) — they anchor the suite so a no-op change cannot look green.

**After:**

```
$ python -m pytest tests/unit/test_schedule_lifecycle_hooks.py -p no:randomly -q
EXIT=0
18 passed in 0.34s
```

### Mutation testing (anchor asserted before each mutation; all restored)

| # | Mutation | Result |
|---|---|---|
| M0 | none (anchor) | exit 0, 18 passed |
| M1 | drop `emit_schedule_add` in `FileScheduleStore.add` | **killed** — exit 1, 3 failed |
| M2 | drop `emit_schedule_remove` in `FileScheduleStore.remove` | **killed** — exit 1, 3 failed |
| M3 | emit even when nothing was removed (drop the `None` guard) | **killed** — exit 1, 3 failed |
| M4 | drop both emissions in `ConfigYamlScheduleStore` | **killed** — exit 1, 1 failed |
| M5 | force `execute_sync` in a running loop (break async path) | **killed** — exit 1, 1 failed |
| M7 | drop the one-shot auto-delete emission in `claim_due` | **killed** — exit 1, 1 failed |
| M8 | fire for every claimed job, not just one-shots | **killed** — exit 1, 1 failed |
| M6 | restore | exit 0, 18 passed |

### End-to-end verification of the three already-emitted events

Driven against **worktree source** (`PYTHONPATH` pinned, since `praisonai_bot` otherwise resolves to site-packages):

```
$ PYTHONPATH=src/praisonai-bot:src/praisonai-agents python verify_gw.py
praisonai_bot from: .../hooks-lifecycle/src/praisonai-bot/praisonai_bot/__init__.py
FIRED: ['gateway_start', 'gateway_stop']            # BotOS.start() / BotOS.stop()
EXIT=0

$ PYTHONPATH=... python verify_trigger.py           # BotOS._execute_schedule_job()
FIRED: [{... 'event_name': HookEvent.SCHEDULE_TRIGGER, 'job_name': 'nightly', ...}]
EXIT=0
```

### Regression

Full `tests/unit` suite, this branch vs. unmodified `origin/main` in a clean baseline worktree:

```
branch:    277 failed, 9146 passed, 27 skipped
baseline:  277 failed, 9128 passed, 27 skipped
FAILED-id set diff: empty in both directions   (+18 = the new tests)
```

The 277 reds are pre-existing on `main` (largely network/API-key dependent). Parity gates checked locally: `generate_parity_tracker.py --check` ✓, `parity.behaviour --check` ✓ (12 options, unchanged); the signatures gate needs `typescript` installed locally and could not be run — it curates no scheduler or hook surface in `surface.yaml`.

## Not verified

* The gateway `config.yaml` reconciler and `praisonai schedule` CLI paths are covered by *reading* that they call `store.add` / `store.remove`, plus the store-level tests — not by driving the CLI or a live gateway.
* Multi-process behaviour (two tickers racing `claim_due`) is not exercised; the emission sits outside the file lock, so a hook cannot deadlock it, but that is argued from the code, not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle notifications when schedules are created or removed.
  * Schedule notifications include relevant job, timing, ownership, and status details.
  * One-time schedules now notify listeners when automatically removed after execution.

* **Reliability**
  * Schedule changes continue to succeed even if a notification handler fails.
  * Notifications are skipped when no handlers are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->