### PR TITLE
fix(bot): Windows autostart wrote a %APPDATA% directory into the repo

### DIFF
--- a/src/praisonai-bot/praisonai_bot/daemon/windows.py
+++ b/src/praisonai-bot/praisonai_bot/daemon/windows.py
@@ -30,8 +30,32 @@ def _python_executable() -> str:
 
 
 def _startup_folder() -> str:
-    """Get the Windows startup folder path."""
+    """Get the Windows startup folder path.
+
+    ``APPDATA`` is read from the environment directly rather than relying on
+    ``os.path.expandvars``, which only expands ``%VAR%`` syntax on Windows.
+    The expandvars form is kept as the fallback so behaviour on Windows with
+    APPDATA set is unchanged.
+    """
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        return os.path.join(
+            appdata, "Microsoft", "Windows", "Start Menu", "Programs", "Startup"
+        )
     return os.path.expandvars(r"%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup")
+
+
+def _startup_folder_is_usable(folder: str) -> bool:
+    """True only when the ``%VAR%`` placeholders actually expanded.
+
+    ``os.path.expandvars`` expands ``%VAR%`` only on Windows, and even there
+    leaves the text untouched when the variable is unset. Writing to the
+    unexpanded string creates a directory literally named ``%APPDATA%``
+    relative to the current directory -- inside the repository when tests run
+    there -- and that path is invalid on Windows, so committing it breaks
+    checkout for everyone.
+    """
+    return "%" not in folder
 
 
 def _startup_script_path() -> str:
@@ -69,6 +93,14 @@ def _create_scheduled_task(config_path: str) -> Dict[str, Any]:
     single, well-formed quoting level and is reused for both install paths.
     """
     startup_folder = _startup_folder()
+    if not _startup_folder_is_usable(startup_folder):
+        # Guarded before the write: this path creates the wrapper script first
+        # and only then calls schtasks, so off Windows it would leave a literal
+        # "%APPDATA%\..." directory behind before failing.
+        raise RuntimeError(
+            "startup folder path still contains an unexpanded variable "
+            f"({startup_folder!r}); refusing to create it."
+        )
     os.makedirs(startup_folder, exist_ok=True)
     script_path = _startup_script_path()
     with open(script_path, "w") as f:
@@ -103,6 +135,15 @@ def _create_startup_folder_entry(config_path: str) -> Dict[str, Any]:
     """Create a startup folder entry as fallback."""
     try:
         startup_folder = _startup_folder()
+        if not _startup_folder_is_usable(startup_folder):
+            return {
+                "ok": False,
+                "error": (
+                    "startup folder path still contains an unexpanded variable "
+                    f"({startup_folder!r}); refusing to create it. This happens "
+                    "off Windows, or when APPDATA is unset."
+                ),
+            }
         os.makedirs(startup_folder, exist_ok=True)
         
         script_content = _generate_startup_script(config_path)
@@ -140,6 +181,10 @@ def install(config_path: str = "bot.yaml", **kwargs: Any) -> Dict[str, Any]:
     }
 
 
+class _SkipStartupRemoval(Exception):
+    """Internal: startup-script removal is not applicable here."""
+
+
 def uninstall() -> Dict[str, Any]:
     """Uninstall the Windows service/startup item."""
     results = []
@@ -161,6 +206,11 @@ def uninstall() -> Dict[str, Any]:
     
     # Try to remove startup script
     try:
+        if not _startup_folder_is_usable(_startup_folder()):
+            results.append(
+                "Startup script location unresolved (unexpanded variable); skipped"
+            )
+            raise _SkipStartupRemoval
         script_path = _startup_script_path()
         if os.path.exists(script_path):
             os.remove(script_path)

--- a/src/praisonai-bot/tests/unit/daemon/test_daemon_dispatch.py
+++ b/src/praisonai-bot/tests/unit/daemon/test_daemon_dispatch.py
@@ -92,7 +92,7 @@ def test_get_daemon_status_routes_to_systemd(mock_systemd_status, mock_detect):
 
 
 @patch('praisonai_bot.daemon.windows.subprocess.run')
-def test_windows_scheduled_task_command_is_well_formed(mock_run):
+def test_windows_scheduled_task_command_is_well_formed(mock_run, tmp_path, monkeypatch):
     """Test Windows scheduled task command format is valid.
 
     The task action (/TR) points at the generated ``.cmd`` wrapper rather than
@@ -101,6 +101,11 @@ def test_windows_scheduled_task_command_is_well_formed(mock_run):
     wrapper itself owns the ``--config`` invocation and the exit-78 mapping.
     """
     mock_run.return_value = MagicMock(stdout="ok")
+
+    # Point APPDATA at a temp dir: this test drives the real write path, and
+    # without this it created a literal "%APPDATA%\..." directory in the repo
+    # (an invalid path on Windows, which broke actions/checkout once committed).
+    monkeypatch.setenv("APPDATA", str(tmp_path))
 
     from praisonai_bot.daemon.windows import (
         _create_scheduled_task,

--- a/src/praisonai-bot/tests/unit/daemon/test_windows_autostart_offplatform.py
+++ b/src/praisonai-bot/tests/unit/daemon/test_windows_autostart_offplatform.py
@@ -1,0 +1,55 @@
+"""The Windows autostart installer must not write into the working tree.
+
+`_startup_folder()` uses `os.path.expandvars(r"%APPDATA%\\...")`. `%VAR%` syntax
+is only expanded on Windows, so off Windows the string stays literal and
+`os.makedirs()` created a `%APPDATA%\\Microsoft\\...` directory relative to the
+current directory -- inside the repo when tests run there.
+
+That path is invalid on Windows, so once committed it broke `actions/checkout`
+for the whole repository before any test could run.
+"""
+import os
+
+import pytest
+
+pytest.importorskip("praisonai_bot")
+
+
+def _has_unexpanded_var(path: str) -> bool:
+    return "%" in path
+
+
+@pytest.mark.skipif(os.name == "nt", reason="off-Windows behaviour under test")
+def test_startup_entry_refuses_when_path_is_unexpanded(tmp_path, monkeypatch):
+    from praisonai_bot.daemon.windows import _create_startup_folder_entry
+
+    monkeypatch.chdir(tmp_path)
+    result = _create_startup_folder_entry(str(tmp_path / "config.yaml"))
+
+    assert result["ok"] is False, (
+        f"installer claimed success off Windows: {result!r}"
+    )
+
+    stray = [p for p in tmp_path.rglob("*") if _has_unexpanded_var(p.name)]
+    assert not stray, f"wrote a directory with an unexpanded variable: {stray}"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="off-Windows behaviour under test")
+def test_running_the_daemon_tests_leaves_no_percent_paths(tmp_path, monkeypatch):
+    """Control: the whole install path, not just the one helper."""
+    from praisonai_bot.daemon.windows import install
+
+    monkeypatch.chdir(tmp_path)
+    try:
+        install(str(tmp_path / "config.yaml"))
+    except Exception:
+        pass  # failing is fine off Windows; writing junk is not
+
+    stray = [p for p in tmp_path.rglob("*") if _has_unexpanded_var(p.name)]
+    assert not stray, f"install path wrote unexpanded-variable dirs: {stray}"
+
+
+def test_control_detector_matches_a_known_bad_name():
+    """Control probe: without this, the scans above could pass vacuously."""
+    assert _has_unexpanded_var("%APPDATA%")
+    assert not _has_unexpanded_var("Startup")


### PR DESCRIPTION
## The bug

`_startup_folder()` used `os.path.expandvars(r"%APPDATA%\...")`. `%VAR%` syntax is **only expanded on Windows**, so off Windows the string stayed literal and the install path called `os.makedirs()` on it — creating a directory named `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup` relative to the current directory, i.e. **inside the repository** when tests run there.

That path is invalid on Windows. Once such a file is committed, `actions/checkout` fails before any test runs:

```
error: invalid path 'src/praisonai-bot/%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup/PraisonAIGateway.cmd'
The process 'git.exe' failed with exit code 128
```

That is exactly what happened on #4994, where a `git add -A` swept the directory up. **One developer running the bot tests on macOS can break Windows CI for everyone.**

## Reproduced on clean main

```
pytest tests/unit/cli/test_gateway_install.py tests/unit/daemon/test_daemon_dispatch.py
27 passed        # exit 0 — all green
```
…and the directory is left behind. The vector is `test_windows_scheduled_task_command_is_well_formed`, which mocks `subprocess.run` and drives the real write path on a non-Windows host.

## Changes

- **`_startup_folder()`** reads `APPDATA` from the environment directly, so the path resolves on any platform when it is set. The `expandvars` form is kept as the fallback, so Windows behaviour with `APPDATA` set is unchanged.
- **Both write sites** refuse when the path still contains an unexpanded `%`. The scheduled-task path needed its own guard because it writes the wrapper script *before* calling `schtasks` — so it polluted the tree and only then failed. Guarding only the obvious site left the bug alive; the end-to-end test caught that.
- **`uninstall()`** reports the location as unresolved instead of guessing.
- **The offending test** points `APPDATA` at `tmp_path`, keeping its actual intent (command formatting) while writing nowhere near the repo.

## Tests — `tests/unit/daemon/test_windows_autostart_offplatform.py`

- the helper must refuse rather than create the directory
- the full `install()` path must leave no unexpanded-variable directories
- a **control probe** asserting the detector matches a known-bad name — without it both scans could pass vacuously

## Verification

- **2 failed before / 3 passed after**, judged by **process exit code**.
- **Three mutations** — dropping either guard, and ignoring the `APPDATA` env var — **all killed**. Each guarded by an `assert target in source` so a mutation could not silently no-op and report a false SURVIVED; anchor green before and after each.
- **Failure-neutral**: full `praisonai-bot tests/unit` is 4 failed / 2207 passed on pristine `main`, and 4 failed / 2210 passed here (+3 new). Failure-set **diff empty in both directions** — compared as sets, not counts.
- After the full suite runs, `git status` shows **no `%APPDATA%` path**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)