### PR TITLE
fix(cli): an emoji in claw's help crashes cp1252 consoles again

### DIFF
--- a/src/praisonai-bot/praisonai_bot/cli/commands/claw.py
+++ b/src/praisonai-bot/praisonai_bot/cli/commands/claw.py
@@ -13,7 +13,14 @@ from typing import Optional
 
 import typer
 
-app = typer.Typer(help="🦞 PraisonAI Dashboard (full UI)")
+# No emoji in the Typer help: this string is what `praisonai --help`
+# prints, and U+1F99E raises UnicodeEncodeError on a cp1252 console
+# (Windows). #2699 removed emoji from praisonai-code's help strings for
+# exactly this reason; the lazily-loaded bot command overrides the clean
+# text registered in praisonai_code/cli/app.py, so it reintroduced one
+# whenever praisonai-bot is installed. Runtime output below is
+# unaffected -- only the help surface has to survive cp1252.
+app = typer.Typer(help="PraisonAI Dashboard (full UI)")
 
 CLAW_DIR = Path.home() / ".praisonai" / "claw"
 DEFAULT_APP = CLAW_DIR / "app.py"

--- a/src/praisonai-code/tests/unit/test_code_print_json.py
+++ b/src/praisonai-code/tests/unit/test_code_print_json.py
@@ -145,7 +145,11 @@ def test_code_print_uses_supported_agent_kwargs_and_workspace_tools(monkeypatch,
     assert captured["output"] == "minimal"
     assert captured["tools"]
     assert captured["workspace"] == str(tmp_path)
-    assert captured["tool_groups"] == ["acp", "edit", "search", "lsp"]
+    # "mcp" joined the default groups in #4965, which made MCP tools reachable
+    # from `code -p` like any other group. The list is pinned in full (rather
+    # than loosened to a subset) so a group silently appearing or disappearing
+    # from the headless path still fails here.
+    assert captured["tool_groups"] == ["acp", "edit", "search", "lsp", "mcp"]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Three tests went red on `main` today, from two of this afternoon's merges. Found while re-basing another branch; they are not caused by it.

### `praisonai --help` emits U+1F99E again

```
│ claw          🦞 PraisonAI Dashboard (full UI)                               │
```

That raises `UnicodeEncodeError` on a cp1252 console (Windows). **#2699 removed emoji from `praisonai-code`'s help strings for exactly this reason**, and the two guard tests for it are still in place.

The regression path is worth noting: the `claw` entry is **lazily loaded from `praisonai_bot`**, whose own `typer.Typer(help="🦞 …")` overrides the clean text registered in `praisonai_code/cli/app.py`. So the emoji returns for anyone who has `praisonai-bot` installed — and CI, which doesn't, stays green while the tests fail locally. A guard that only holds when the optional package is absent isn't guarding much.

Only the Typer **help** string changes; the command's runtime output keeps its emoji, since that is not what `--help` has to survive.

### `test_code_print_json` pinned a stale tool-group list

It expected `["acp", "edit", "search", "lsp"]`. #4965 added `"mcp"`, so the headless `code -p` path now passes five. Updated — and deliberately kept as an **exact** list rather than loosened to a subset, so a group silently appearing or disappearing from that path still fails here.

### Verification

`test_help_encoding` 4 passed, `test_code_print_json` 23 passed — all three previously failing on clean `origin/main`. The remaining 10 failures in that suite are the ones #4972 addresses; this branch doesn't carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Claw command-line help text to avoid console encoding failures on Windows.
* **Tests**
  * Updated coverage to verify that MCP tools are included in the default headless tool groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->