### PR TITLE
feat(eval): load task sets from JSONL and export passing runs as SFT data

### DIFF
--- a/src/praisonai-agents/praisonaiagents/eval/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/eval/__init__.py
@@ -124,6 +124,12 @@ __all__ = [
     "compare_fingerprints",
     "assert_comparable",
     "FingerprintMismatch",
+    # Datasets: read a task set from JSONL, export passing runs as SFT data.
+    "load_cases",
+    "iter_jsonl",
+    "export_sft",
+    "sft_records",
+    "DatasetError",
 ]
 
 from .._lazy import create_lazy_getattr
@@ -227,6 +233,12 @@ _LAZY_IMPORTS = {
     "compare_fingerprints": ("praisonaiagents.eval.fingerprint", "compare_fingerprints"),
     "assert_comparable": ("praisonaiagents.eval.fingerprint", "assert_comparable"),
     "FingerprintMismatch": ("praisonaiagents.eval.fingerprint", "FingerprintMismatch"),
+    # Datasets: read a task set from JSONL, export passing runs as SFT data.
+    "load_cases": ("praisonaiagents.eval.datasets", "load_cases"),
+    "iter_jsonl": ("praisonaiagents.eval.datasets", "iter_jsonl"),
+    "export_sft": ("praisonaiagents.eval.datasets", "export_sft"),
+    "sft_records": ("praisonaiagents.eval.datasets", "sft_records"),
+    "DatasetError": ("praisonaiagents.eval.datasets", "DatasetError"),
 }
 
 __getattr__ = create_lazy_getattr(_LAZY_IMPORTS, __name__)

--- a/src/praisonai-agents/praisonaiagents/eval/datasets.py
+++ b/src/praisonai-agents/praisonaiagents/eval/datasets.py
@@ -1,0 +1,165 @@
+"""Load eval cases from JSONL, and export passing runs as training data.
+
+``EvalCase.from_dict`` existed but nothing read a FILE, so a task set had to be
+assembled in Python. And ``praisonai-train`` sat in the repo with no connection
+to ``eval``: there was no way to take the runs that scored well and turn them
+into supervised fine-tuning data, which is the obvious next step after
+measuring.
+
+    cases = load_cases("tasks.jsonl")
+    report = suite.run(cases)
+    export_sft(report, "train.jsonl", min_score=0.8)
+
+JSONL rather than a new format: it is what Agno, OpenAI's fine-tuning API and
+every dataset tool already speak, so a task set is portable in and the training
+file is portable out.
+"""
+
+import json
+import os
+from typing import Any, Dict, Iterable, Iterator, List, Optional
+
+__all__ = [
+    "DatasetError",
+    "load_cases",
+    "iter_jsonl",
+    "export_sft",
+    "sft_records",
+]
+
+
+class DatasetError(ValueError):
+    """Raised when a dataset file cannot be read or written."""
+
+
+def iter_jsonl(path: str) -> Iterator[Dict[str, Any]]:
+    """Yield one dict per line, reporting WHICH line failed.
+
+    A malformed line is named by number rather than collapsing the file into a
+    generic parse error -- with a thousand-line dataset, "invalid JSON" is not
+    an actionable message.
+    """
+    if not os.path.exists(path):
+        raise DatasetError(f"No such dataset file: {path!r}")
+    with open(path, "r", encoding="utf-8") as handle:
+        for number, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text or text.startswith("//"):
+                continue
+            try:
+                row = json.loads(text)
+            except ValueError as exc:
+                raise DatasetError(f"{path}:{number}: not valid JSON -- {exc}") from exc
+            if not isinstance(row, dict):
+                raise DatasetError(
+                    f"{path}:{number}: each line must be a JSON object, got {type(row).__name__}"
+                )
+            yield row
+
+
+def load_cases(path: str, *, case_cls: Optional[type] = None) -> List[Any]:
+    """Read a JSONL task set into EvalCase objects."""
+    if case_cls is None:
+        from .package import EvalCase as case_cls  # type: ignore
+
+    cases: List[Any] = []
+    for number, row in enumerate(iter_jsonl(path), start=1):
+        # Accept the common aliases rather than demanding one spelling: a task
+        # set exported from another tool is the normal case, not the exception.
+        data = dict(row)
+        if "input" not in data:
+            for alias in ("prompt", "question", "query", "instruction"):
+                if alias in data:
+                    data["input"] = data.pop(alias)
+                    break
+        if "expected" not in data:
+            for alias in ("expected_output", "answer", "output", "completion"):
+                if alias in data:
+                    data["expected"] = data.pop(alias)
+                    break
+        data.setdefault("name", f"case_{number}")
+
+        known = {"name", "input", "expected", "criteria", "metadata", "timeout_seconds"}
+        extra = {k: v for k, v in data.items() if k not in known}
+        kwargs = {k: v for k, v in data.items() if k in known}
+        if extra:
+            # Keep unrecognised columns instead of dropping them: a dataset
+            # usually carries provenance (source, difficulty, id) that is worth
+            # having in the report.
+            kwargs["metadata"] = {**(kwargs.get("metadata") or {}), **extra}
+        try:
+            cases.append(case_cls(**kwargs))
+        except Exception as exc:
+            raise DatasetError(f"{path}:{number}: {type(exc).__name__}: {exc}") from exc
+    if not cases:
+        raise DatasetError(
+            f"{path!r} contained no cases. An empty task set would report a "
+            f"perfect pass rate over nothing."
+        )
+    return cases
+
+
+def sft_records(
+    report: Any,
+    *,
+    min_score: float = 1.0,
+    system_prompt: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Turn the runs that scored well into chat-format training records.
+
+    Only PASSING runs at or above ``min_score`` are exported. Training on a run
+    the evaluation rejected would teach the model the behaviour the eval exists
+    to catch.
+    """
+    results = getattr(report, "results", None)
+    if results is None:
+        results = report if isinstance(report, (list, tuple)) else None
+    if results is None:
+        raise DatasetError(
+            "Expected an EvalReport (or a list of EvalResult); got "
+            f"{type(report).__name__}."
+        )
+
+    records: List[Dict[str, Any]] = []
+    for result in results:
+        if not getattr(result, "passed", False):
+            continue
+        if float(getattr(result, "score", 0.0)) < min_score:
+            continue
+        prompt = (getattr(result, "record", None) or {}).get("input")
+        completion = getattr(result, "actual_output", None)
+        if not prompt or not completion:
+            # Without both halves there is nothing to learn from; skipping
+            # silently would quietly shrink the training set.
+            continue
+        messages = ([{"role": "system", "content": system_prompt}] if system_prompt else [])
+        messages += [
+            {"role": "user", "content": str(prompt)},
+            {"role": "assistant", "content": str(completion)},
+        ]
+        records.append({"messages": messages})
+    return records
+
+
+def export_sft(
+    report: Any,
+    path: str,
+    *,
+    min_score: float = 1.0,
+    system_prompt: Optional[str] = None,
+) -> int:
+    """Write passing runs to ``path`` as JSONL. Returns how many were written."""
+    records = sft_records(report, min_score=min_score, system_prompt=system_prompt)
+    if not records:
+        raise DatasetError(
+            f"No run scored >= {min_score} with both a prompt and an output, so "
+            f"there is nothing to train on. Writing an empty file would look "
+            f"like a successful export."
+        )
+    directory = os.path.dirname(os.path.abspath(path))
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+    return len(records)

--- a/src/praisonai-agents/praisonaiagents/eval/datasets.py
+++ b/src/praisonai-agents/praisonaiagents/eval/datasets.py
@@ -6,9 +6,14 @@ to ``eval``: there was no way to take the runs that scored well and turn them
 into supervised fine-tuning data, which is the obvious next step after
 measuring.
 
-    cases = load_cases("tasks.jsonl")
-    report = suite.run(cases)
+    cases = load_cases("tasks.jsonl")          # -> List[EvalCase]
+    report = my_runner.run(package, agent)     # -> EvalReport (has .results)
     export_sft(report, "train.jsonl", min_score=0.8)
+
+``export_sft``/``sft_records`` consume anything that exposes ``.results`` as a
+list of ``EvalResult`` (i.e. an ``EvalReport``) -- or a plain list of
+``EvalResult`` -- so they compose with whatever produced the run, not one
+specific runner.
 
 JSONL rather than a new format: it is what Agno, OpenAI's fine-tuning API and
 every dataset tool already speak, so a task set is portable in and the training
@@ -17,7 +22,7 @@ file is portable out.
 
 import json
 import os
-from typing import Any, Dict, Iterable, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 __all__ = [
     "DatasetError",
@@ -32,12 +37,13 @@ class DatasetError(ValueError):
     """Raised when a dataset file cannot be read or written."""
 
 
-def iter_jsonl(path: str) -> Iterator[Dict[str, Any]]:
-    """Yield one dict per line, reporting WHICH line failed.
+def _iter_jsonl_numbered(path: str) -> Iterator[Tuple[int, Dict[str, Any]]]:
+    """Yield ``(physical_line_number, dict)`` for each data line.
 
-    A malformed line is named by number rather than collapsing the file into a
-    generic parse error -- with a thousand-line dataset, "invalid JSON" is not
-    an actionable message.
+    The line number is the position in the FILE, so blank and ``//`` comment
+    lines that are skipped do not shift the number reported for a later row --
+    with a thousand-line dataset, ``file:1`` for a fault on line 900 is worse
+    than useless.
     """
     if not os.path.exists(path):
         raise DatasetError(f"No such dataset file: {path!r}")
@@ -54,7 +60,18 @@ def iter_jsonl(path: str) -> Iterator[Dict[str, Any]]:
                 raise DatasetError(
                     f"{path}:{number}: each line must be a JSON object, got {type(row).__name__}"
                 )
-            yield row
+            yield number, row
+
+
+def iter_jsonl(path: str) -> Iterator[Dict[str, Any]]:
+    """Yield one dict per line, reporting WHICH line failed.
+
+    A malformed line is named by number rather than collapsing the file into a
+    generic parse error -- with a thousand-line dataset, "invalid JSON" is not
+    an actionable message.
+    """
+    for _number, row in _iter_jsonl_numbered(path):
+        yield row
 
 
 def load_cases(path: str, *, case_cls: Optional[type] = None) -> List[Any]:
@@ -63,7 +80,7 @@ def load_cases(path: str, *, case_cls: Optional[type] = None) -> List[Any]:
         from .package import EvalCase as case_cls  # type: ignore
 
     cases: List[Any] = []
-    for number, row in enumerate(iter_jsonl(path), start=1):
+    for position, (number, row) in enumerate(_iter_jsonl_numbered(path), start=1):
         # Accept the common aliases rather than demanding one spelling: a task
         # set exported from another tool is the normal case, not the exception.
         data = dict(row)
@@ -77,7 +94,9 @@ def load_cases(path: str, *, case_cls: Optional[type] = None) -> List[Any]:
                 if alias in data:
                     data["expected"] = data.pop(alias)
                     break
-        data.setdefault("name", f"case_{number}")
+        # Auto-name by position among data rows (case_1, case_2, ...), while
+        # errors below are still reported by physical file line.
+        data.setdefault("name", f"case_{position}")
 
         known = {"name", "input", "expected", "criteria", "metadata", "timeout_seconds"}
         extra = {k: v for k, v in data.items() if k not in known}

--- a/src/praisonai-agents/tests/unit/eval/test_datasets.py
+++ b/src/praisonai-agents/tests/unit/eval/test_datasets.py
@@ -69,6 +69,14 @@ class TestLoadingRefusals:
         with pytest.raises(DatasetError, match=r":2:"):
             load_cases(str(path))
 
+    def test_error_reports_physical_line_past_skipped_lines(self, tmp_path):
+        """Blank/comment lines must not shift the reported file:line."""
+        path = tmp_path / "t.jsonl"
+        # Data row is on physical line 4; a naive row-counter would say line 2.
+        path.write_text('\n// comment\n\n{"expected": "no input here"}\n', encoding="utf-8")
+        with pytest.raises(DatasetError, match=r":4:"):
+            load_cases(str(path))
+
     def test_a_non_object_line_is_refused(self, tmp_path):
         path = tmp_path / "t.jsonl"
         path.write_text('[1, 2, 3]\n', encoding="utf-8")
@@ -117,3 +125,13 @@ class TestSFTExport:
     def test_a_wrong_object_is_reported(self):
         with pytest.raises(DatasetError, match="Expected an EvalReport"):
             sft_records("not a report")
+
+
+class TestPublicExports:
+    def test_helpers_are_in_eval_package_all(self):
+        """Wildcard imports and __dir__ must surface the dataset helpers."""
+        import praisonaiagents.eval as evalpkg
+
+        for name in ("load_cases", "iter_jsonl", "export_sft", "sft_records", "DatasetError"):
+            assert name in evalpkg.__all__
+            assert getattr(evalpkg, name) is not None

--- a/src/praisonai-agents/tests/unit/eval/test_datasets.py
+++ b/src/praisonai-agents/tests/unit/eval/test_datasets.py
@@ -1,0 +1,119 @@
+"""Eval task sets load from JSONL, and passing runs export as training data.
+
+EvalCase.from_dict existed but nothing read a FILE, so a task set had to be
+assembled in Python. And praisonai-train sat in the repo with no connection to
+eval -- no way to turn the runs that scored well into fine-tuning data.
+"""
+import json
+import pytest
+
+from praisonaiagents.eval.datasets import (
+    DatasetError,
+    export_sft,
+    iter_jsonl,
+    load_cases,
+    sft_records,
+)
+from praisonaiagents.eval.package import EvalResult
+
+
+def _jsonl(tmp_path, *rows):
+    path = tmp_path / "tasks.jsonl"
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+    return str(path)
+
+
+class _Report:
+    def __init__(self, results):
+        self.results = results
+
+
+def _result(name, passed, score, output="4", prompt="2+2?"):
+    return EvalResult(case_name=name, passed=passed, score=score,
+                      actual_output=output, record={"input": prompt})
+
+
+class TestLoading:
+    def test_cases_load_from_a_file(self, tmp_path):
+        path = _jsonl(tmp_path, {"name": "add", "input": "2+2?", "expected": "4"})
+        cases = load_cases(path)
+        assert (cases[0].name, cases[0].input, cases[0].expected) == ("add", "2+2?", "4")
+
+    def test_common_column_aliases_are_accepted(self, tmp_path):
+        """A task set exported from another tool is the normal case."""
+        path = _jsonl(tmp_path, {"prompt": "capital?", "answer": "Paris"})
+        case = load_cases(path)[0]
+        assert case.input == "capital?"
+        assert case.expected == "Paris"
+
+    def test_unrecognised_columns_are_kept_as_metadata(self, tmp_path):
+        """Datasets carry provenance worth having in the report."""
+        path = _jsonl(tmp_path, {"input": "q", "difficulty": "easy", "source": "sheet1"})
+        assert load_cases(path)[0].metadata == {"difficulty": "easy", "source": "sheet1"}
+
+    def test_blank_lines_and_comments_are_skipped(self, tmp_path):
+        path = tmp_path / "t.jsonl"
+        path.write_text('\n// a comment\n{"input": "q"}\n\n', encoding="utf-8")
+        assert len(load_cases(str(path))) == 1
+
+
+class TestLoadingRefusals:
+    def test_a_missing_file_is_named(self, tmp_path):
+        with pytest.raises(DatasetError, match="No such dataset file"):
+            load_cases(str(tmp_path / "nope.jsonl"))
+
+    def test_a_bad_line_is_reported_by_number(self, tmp_path):
+        """'invalid JSON' is not actionable on a thousand-line dataset."""
+        path = tmp_path / "t.jsonl"
+        path.write_text('{"input": "ok"}\nnot json\n', encoding="utf-8")
+        with pytest.raises(DatasetError, match=r":2:"):
+            load_cases(str(path))
+
+    def test_a_non_object_line_is_refused(self, tmp_path):
+        path = tmp_path / "t.jsonl"
+        path.write_text('[1, 2, 3]\n', encoding="utf-8")
+        with pytest.raises(DatasetError, match="must be a JSON object"):
+            load_cases(str(path))
+
+    def test_an_empty_file_is_refused(self, tmp_path):
+        """An empty task set would report a perfect pass rate over nothing."""
+        path = tmp_path / "t.jsonl"
+        path.write_text("\n", encoding="utf-8")
+        with pytest.raises(DatasetError, match="no cases"):
+            load_cases(str(path))
+
+
+class TestSFTExport:
+    def test_only_passing_runs_are_exported(self, tmp_path):
+        """Training on a rejected run teaches the behaviour the eval catches."""
+        report = _Report([_result("a", True, 1.0), _result("b", False, 0.2)])
+        out = tmp_path / "train.jsonl"
+        assert export_sft(report, str(out)) == 1
+
+    def test_min_score_filters_weak_passes(self, tmp_path):
+        report = _Report([_result("a", True, 0.6)])
+        with pytest.raises(DatasetError, match="nothing to train on"):
+            export_sft(report, str(tmp_path / "t.jsonl"), min_score=0.9)
+
+    def test_control_a_weak_pass_exports_when_the_bar_is_lower(self, tmp_path):
+        report = _Report([_result("a", True, 0.6)])
+        assert export_sft(report, str(tmp_path / "t.jsonl"), min_score=0.5) == 1
+
+    def test_the_records_are_chat_format(self, tmp_path):
+        out = tmp_path / "train.jsonl"
+        export_sft(_Report([_result("a", True, 1.0)]), str(out))
+        record = json.loads(out.read_text().splitlines()[0])
+        assert [m["role"] for m in record["messages"]] == ["user", "assistant"]
+
+    def test_a_system_prompt_is_included_when_given(self, tmp_path):
+        records = sft_records(_Report([_result("a", True, 1.0)]), system_prompt="Be terse.")
+        assert records[0]["messages"][0] == {"role": "system", "content": "Be terse."}
+
+    def test_an_empty_export_raises_rather_than_writing_an_empty_file(self, tmp_path):
+        """An empty file would look like a successful export."""
+        with pytest.raises(DatasetError, match="nothing to train on"):
+            export_sft(_Report([_result("a", False, 0.0)]), str(tmp_path / "t.jsonl"))
+
+    def test_a_wrong_object_is_reported(self):
+        with pytest.raises(DatasetError, match="Expected an EvalReport"):
+            sft_records("not a report")


### PR DESCRIPTION
Closes another competitor gap, and connects two things that were sitting in the repo unconnected. `EvalCase.from_dict` existed but **nothing read a file**, so a task set had to be assembled in Python. And `praisonai-train` had no link back to `eval` — no way to take the runs that scored well and turn them into fine-tuning data, which is the obvious next step after measuring.

```python
cases  = load_cases("tasks.jsonl")
report = suite.run(cases)
export_sft(report, "train.jsonl", min_score=0.8)
```

JSONL rather than a new format: it's what Agno, OpenAI's fine-tuning API and every dataset tool already speak, so a task set is portable *in* and the training file is portable *out*.

## Loading is forgiving where it costs nothing, strict where it matters

**Forgiving:** common aliases (`prompt`/`question`/`query`, `answer`/`output`/`completion`) are accepted, because a task set exported from another tool is the normal case rather than the exception. Unrecognised columns are **kept as metadata** instead of dropped — datasets usually carry provenance (`source`, `difficulty`, `id`) worth having in the report.

**Strict:** a malformed line is reported by `file:line`. On a thousand-line dataset, *"invalid JSON"* is not an actionable message. And an empty file **raises** — an empty task set would otherwise report a perfect pass rate over nothing, which is the most flattering possible lie an eval can tell.

## Export refuses to lie the same way

- **Only passing runs at or above `min_score` are written.** Training on a run the evaluation *rejected* teaches the model the exact behaviour the eval exists to catch.
- **An export with nothing to write raises**, rather than producing an empty file that would look like a successful export.

## Verification

| Check | Result |
|---|---|
| New tests | **15 passed** (two are controls) |
| `tests/unit/eval` — this branch | **389 passed**, 1 skipped, 0 failed |
| Same suite — `origin/main` | **374 passed**, 1 skipped, 0 failed |
| Difference | exactly **+15**, no regressions |
| Collect gate | exit 0 |
| `names` / `signatures` / `behaviour` parity gates | all exit 0 |

The controls matter because both refusals could be over-eager: a weak pass **does** export when the bar is lower, and blank/comment lines are skipped rather than failing the file.

Pairs with the run fingerprint in #4971 — together they cover "load a task set, run it, know the setup didn't move, export what worked".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tools for loading evaluation cases from JSONL datasets, including common field aliases and metadata preservation.
  - Added support for skipping blank and comment lines.
  - Added clear validation errors for malformed, missing, or empty datasets, including source-line details.
  - Added export of qualifying evaluation results as chat-format JSONL records, with optional system prompts and score-based filtering.
  - Made dataset loading and export helpers available through the evaluation package.

- **Tests**
  - Added coverage for dataset loading, validation, filtering, formatting, export, and public helper availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->