### PR TITLE
feat(agents): a team can resume instead of restarting

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -2925,34 +2925,66 @@ class AgentTeam(SpawnAnnounceProtocol):
         }
 
     def _task_set_fingerprint(self) -> str:
-        """Identify this team's task SET, so a checkpoint cannot cross teams."""
+        """Identify this team's task SET, so a checkpoint cannot cross teams.
+
+        Covers the fields that change what a task actually *does* -- its name,
+        full description, the agent that runs it, and its expected output. A
+        truncated description or a name-only fingerprint would let a materially
+        changed task keep the same fingerprint, so a restore would mark the
+        changed task completed and skip the new work.
+        """
         import hashlib
         parts = []
         for task_id in sorted(self.tasks, key=lambda k: str(k)):
             task = self.tasks[task_id]
+            agent = getattr(task, "agent", None)
+            agent_name = getattr(agent, "name", None) or getattr(agent, "display_name", None) or ""
             parts.append("|".join([
                 str(task_id),
                 str(getattr(task, "name", "") or ""),
-                str(getattr(task, "description", "") or "")[:200],
+                str(getattr(task, "description", "") or ""),
+                str(agent_name),
+                str(getattr(task, "expected_output", "") or ""),
             ]))
         blob = "\n".join(parts)
         return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+    @staticmethod
+    def _json_safe(value: Any, fallback: Any = None) -> Any:
+        """Return ``value`` if it survives a JSON round-trip, else ``fallback``.
+
+        A nested ``datetime``/``set``/``bytes``/custom object inside a dict or
+        list result reaches the JSON encoder and fails the durable write, losing
+        the WHOLE checkpoint rather than one field. Probing each field here keeps
+        the rest of the checkpoint intact when one field is not portable.
+        """
+        try:
+            json.dumps(value)
+            return value
+        except (TypeError, ValueError):
+            return fallback
 
     def _serialisable_task_state(self) -> Dict[str, Any]:
         """``_snapshot_task_state`` reduced to what survives JSON.
 
         A task result may be a TaskOutput object; only its text is portable, and
         a half-serialised object that fails to write would lose the whole
-        checkpoint rather than one field.
+        checkpoint rather than one field. Nested non-JSON values inside a dict or
+        list result, or inside task variables, are dropped the same way.
         """
         snapshot = {}
         for task_id, state in self._snapshot_task_state().items():
             result = state.get("result")
             if result is not None and not isinstance(result, (str, int, float, bool, dict, list)):
                 result = getattr(result, "raw", None) or str(result)
+            # A dict/list result may still carry a nested non-JSON value; fall
+            # back to its string form rather than forfeiting the checkpoint.
+            if isinstance(result, (dict, list)):
+                result = self._json_safe(result, fallback=str(result))
             variables = state.get("variables")
             if not isinstance(variables, dict):
                 variables = {}
+            variables = self._json_safe(variables, fallback={})
             snapshot[str(task_id)] = {
                 "status": state.get("status"),
                 "result": result,
@@ -2980,13 +3012,50 @@ class AgentTeam(SpawnAnnounceProtocol):
                 continue
             task.status = state.get("status") or getattr(task, "status", "not started")
             if state.get("result") is not None:
-                task.result = state["result"]
+                # The checkpoint reduced a TaskOutput to text; a remaining task
+                # that consumes this predecessor through workflow dependencies or
+                # task.context reads result.raw (see process.py). Restoring a bare
+                # string would raise AttributeError there, so rebuild a minimal
+                # TaskOutput carrying the text instead.
+                task.result = self._result_from_serialised(task, state["result"])
             if state.get("retry_count") is not None:
                 task.retry_count = state["retry_count"]
             if state.get("variables"):
                 task.variables = state["variables"]
             restored += 1
         return restored
+
+    @staticmethod
+    def _result_from_serialised(task: Any, value: Any) -> Any:
+        """Rebuild a ``TaskOutput`` from a checkpointed result string.
+
+        Consumers of a completed task read ``task.result.raw`` (dependency
+        context, routing decisions). A restored plain string has no ``.raw``, so
+        wrap it in a minimal ``TaskOutput`` preserving the text. A non-string
+        (already a structured/portable value) is returned unchanged so nothing is
+        lost. If ``TaskOutput`` cannot be constructed, fall back to the raw value
+        rather than failing the whole restore.
+        """
+        if not isinstance(value, str):
+            return value
+        try:
+            from ..main import TaskOutput
+        except Exception:
+            try:
+                from ..output.models import TaskOutput
+            except Exception:
+                return value
+        try:
+            agent = getattr(task, "agent", None)
+            agent_name = getattr(agent, "name", None) or getattr(agent, "display_name", None) or ""
+            return TaskOutput(
+                description=str(getattr(task, "description", "") or ""),
+                raw=value,
+                agent=str(agent_name),
+                output_format="RAW",
+            )
+        except Exception:
+            return value
 
     def save_session_state(self, session_id: str, include_memory: bool = True) -> bool:
         """Persist team session state for deterministic resume (Issue #3635).

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -2910,7 +2910,83 @@ class AgentTeam(SpawnAnnounceProtocol):
             "state": state_copy,
             "agents": [agent.display_name for agent in self.agents],
             "process": self.process,
+            # Task status and outputs, so a resumed team can SKIP work it has
+            # already done. Without these the payload carried only the shared
+            # _state dict, and a team that died on task 9 of 12 restarted from
+            # task 1 -- re-paying for eight completed tasks. The snapshot helper
+            # already existed for in-memory batch resets; this makes it durable.
+            "tasks": self._serialisable_task_state(),
+            # Task keys are POSITIONAL (0, 1, 2...), so a checkpoint from a
+            # different team would restore by index and put task 3's output on a
+            # different task 3 -- a resume that looks successful and is wrong.
+            # The YAML workflow path already guards this with a definition
+            # fingerprint; this is the same idea for a team.
+            "tasks_fingerprint": self._task_set_fingerprint(),
         }
+
+    def _task_set_fingerprint(self) -> str:
+        """Identify this team's task SET, so a checkpoint cannot cross teams."""
+        import hashlib
+        parts = []
+        for task_id in sorted(self.tasks, key=lambda k: str(k)):
+            task = self.tasks[task_id]
+            parts.append("|".join([
+                str(task_id),
+                str(getattr(task, "name", "") or ""),
+                str(getattr(task, "description", "") or "")[:200],
+            ]))
+        blob = "\n".join(parts)
+        return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+    def _serialisable_task_state(self) -> Dict[str, Any]:
+        """``_snapshot_task_state`` reduced to what survives JSON.
+
+        A task result may be a TaskOutput object; only its text is portable, and
+        a half-serialised object that fails to write would lose the whole
+        checkpoint rather than one field.
+        """
+        snapshot = {}
+        for task_id, state in self._snapshot_task_state().items():
+            result = state.get("result")
+            if result is not None and not isinstance(result, (str, int, float, bool, dict, list)):
+                result = getattr(result, "raw", None) or str(result)
+            variables = state.get("variables")
+            if not isinstance(variables, dict):
+                variables = {}
+            snapshot[str(task_id)] = {
+                "status": state.get("status"),
+                "result": result,
+                "retry_count": state.get("retry_count"),
+                "variables": variables,
+            }
+        return snapshot
+
+    def _restore_serialised_task_state(self, snapshot: Dict[str, Any]) -> int:
+        """Re-apply a persisted task snapshot. Returns how many tasks matched.
+
+        Tasks absent from this team are skipped rather than invented: a
+        checkpoint from a DIFFERENT team definition must not silently
+        half-restore, which would look like a resume and behave like a fresh run.
+        """
+        restored = 0
+        for task_id, state in (snapshot or {}).items():
+            task = self.tasks.get(task_id)
+            if task is None:
+                for key, candidate in self.tasks.items():
+                    if str(key) == str(task_id):
+                        task = candidate
+                        break
+            if task is None:
+                continue
+            task.status = state.get("status") or getattr(task, "status", "not started")
+            if state.get("result") is not None:
+                task.result = state["result"]
+            if state.get("retry_count") is not None:
+                task.retry_count = state["retry_count"]
+            if state.get("variables"):
+                task.variables = state["variables"]
+            restored += 1
+        return restored
 
     def save_session_state(self, session_id: str, include_memory: bool = True) -> bool:
         """Persist team session state for deterministic resume (Issue #3635).
@@ -2980,6 +3056,24 @@ class AgentTeam(SpawnAnnounceProtocol):
                 if isinstance(state_data, dict) and "state" in state_data:
                     with self._state_lock:
                         self._state.update(state_data["state"])
+                    # Completed tasks come back with their status and output, so
+                    # the process layer's "skip anything already completed" logic
+                    # sees them as done instead of re-running them.
+                    saved_fp = state_data.get("tasks_fingerprint")
+                    if saved_fp and saved_fp != self._task_set_fingerprint():
+                        # Shared state is still restored -- it is keyed by name
+                        # and safe -- but task outputs are NOT, because matching
+                        # them by position across a changed task set would skip
+                        # the wrong work.
+                        logging.warning(
+                            "Team session %s was saved against a different task set; "
+                            "shared state restored but task outputs were not, so no "
+                            "task will be wrongly skipped. Re-run from the start, or "
+                            "resume with the team definition that saved it.",
+                            session_id,
+                        )
+                        return True
+                    self._restore_serialised_task_state(state_data.get("tasks") or {})
                     return True
         except Exception as e:
             logger.debug(f"Durable team session restore failed for {session_id}: {e}")

--- a/src/praisonai-agents/tests/unit/agents/test_team_checkpoint_resume.py
+++ b/src/praisonai-agents/tests/unit/agents/test_team_checkpoint_resume.py
@@ -57,7 +57,9 @@ class TestRestore:
         target = _team(agent)
         assert target._restore_serialised_task_state(payload["tasks"]) == 2
         assert target.tasks[first].status == "completed"
-        assert target.tasks[first].result == "FIRST DONE"
+        # Restored as a TaskOutput, not a bare string, so downstream consumers
+        # that read result.raw (dependency context, routing) keep working.
+        assert target.tasks[first].result.raw == "FIRST DONE"
 
     def test_control_an_unfinished_task_is_not_marked_done(self, agent):
         source = _team(agent)
@@ -85,3 +87,78 @@ class TestFingerprint:
         """Task keys are positional, so without this a checkpoint from another
         team would put task 3's output onto a different task 3."""
         assert list(_team(agent).tasks) == [0, 1]
+
+    def test_a_changed_task_agent_changes_the_fingerprint(self, agent):
+        """A different agent means a different task; the fingerprint must move
+        so a restore cannot mark the changed task completed and skip it."""
+        other = Agent(name="other", instructions="y", llm="gpt-4o")
+        a = _team(agent)
+        b = _team(agent)
+        for t in b.tasks.values():
+            t.agent = other
+        assert a._task_set_fingerprint() != b._task_set_fingerprint()
+
+    def test_a_changed_expected_output_changes_the_fingerprint(self, agent):
+        a = _team(agent)
+        b = _team(agent)
+        for t in b.tasks.values():
+            t.expected_output = "SOMETHING ELSE"
+        assert a._task_set_fingerprint() != b._task_set_fingerprint()
+
+    def test_a_late_description_change_is_not_missed(self, agent):
+        """The old fingerprint truncated the description at 200 chars, so a
+        change past that point was invisible. The full description is hashed."""
+        a = _team(agent)
+        b = _team(agent)
+        for t in b.tasks.values():
+            t.description = ("x" * 300) + "CHANGED"
+        c = _team(agent)
+        for t in c.tasks.values():
+            t.description = ("x" * 300) + "DIFFERENT"
+        assert b._task_set_fingerprint() != c._task_set_fingerprint()
+
+
+class TestDurability:
+    def test_a_nested_non_json_result_does_not_lose_the_checkpoint(self, agent):
+        """A datetime inside a dict result would fail the JSON write and lose
+        the WHOLE checkpoint; it must degrade to text for that field only."""
+        import datetime
+        import json
+
+        team = _team(agent)
+        first = list(team.tasks)[0]
+        second = list(team.tasks)[1]
+        team.tasks[first].status = "completed"
+        team.tasks[first].result = {"when": datetime.datetime(2020, 1, 1)}
+        team.tasks[second].status = "completed"
+        team.tasks[second].result = "PLAIN"
+
+        payload = team._team_state_payload("s1")
+        # The whole payload must be JSON-writable; nothing is forfeited.
+        json.dumps(payload)
+        assert payload["tasks"][str(second)]["result"] == "PLAIN"
+
+    def test_a_non_json_variable_does_not_lose_the_checkpoint(self, agent):
+        import json
+
+        team = _team(agent)
+        first = list(team.tasks)[0]
+        team.tasks[first].variables = {"bad": {object()}}
+        payload = team._team_state_payload("s1")
+        json.dumps(payload)
+        assert payload["tasks"][str(first)]["variables"] == {}
+
+
+class TestRestoredType:
+    def test_a_restored_result_exposes_raw(self, agent):
+        """process.py reads prev_task.result.raw; a bare string would raise
+        AttributeError, so the restore must rebuild a TaskOutput."""
+        source = _team(agent)
+        first = list(source.tasks)[0]
+        source.tasks[first].status = "completed"
+        source.tasks[first].result = "DONE TEXT"
+        payload = source._team_state_payload("s1")
+
+        target = _team(agent)
+        target._restore_serialised_task_state(payload["tasks"])
+        assert target.tasks[first].result.raw == "DONE TEXT"

--- a/src/praisonai-agents/tests/unit/agents/test_team_checkpoint_resume.py
+++ b/src/praisonai-agents/tests/unit/agents/test_team_checkpoint_resume.py
@@ -1,0 +1,87 @@
+"""A team that dies part-way can resume instead of restarting.
+
+save_session_state persisted only the shared _state dict -- no task status, no
+task outputs -- so a team that died on task 9 of 12 restarted from task 1 and
+re-paid for eight completed tasks. Step-level resume existed, but only on the
+YAML workflow path, which AgentTeam cannot reach.
+"""
+import pytest
+
+from praisonaiagents import Agent, AgentTeam, Task
+
+
+@pytest.fixture
+def agent():
+    return Agent(name="w", instructions="x", llm="gpt-4o")
+
+
+def _team(agent, names=("t1", "t2")):
+    return AgentTeam(
+        agents=[agent],
+        tasks=[Task(name=n, description=f"d-{n}", expected_output="e", agent=agent) for n in names],
+    )
+
+
+class TestPayload:
+    def test_task_status_and_output_are_persisted(self, agent):
+        team = _team(agent)
+        first = list(team.tasks)[0]
+        team.tasks[first].status = "completed"
+        team.tasks[first].result = "FIRST DONE"
+
+        payload = team._team_state_payload("s1")
+        assert "tasks" in payload
+        saved = payload["tasks"][str(first)]
+        assert saved["status"] == "completed"
+        assert saved["result"] == "FIRST DONE"
+
+    def test_a_task_output_object_is_reduced_to_something_portable(self, agent):
+        """A half-serialised object would lose the whole checkpoint, not one field."""
+        class Output:
+            raw = "TEXT"
+
+        team = _team(agent)
+        first = list(team.tasks)[0]
+        team.tasks[first].result = Output()
+        assert team._team_state_payload("s1")["tasks"][str(first)]["result"] == "TEXT"
+
+
+class TestRestore:
+    def test_completed_work_comes_back(self, agent):
+        source = _team(agent)
+        first = list(source.tasks)[0]
+        source.tasks[first].status = "completed"
+        source.tasks[first].result = "FIRST DONE"
+        payload = source._team_state_payload("s1")
+
+        target = _team(agent)
+        assert target._restore_serialised_task_state(payload["tasks"]) == 2
+        assert target.tasks[first].status == "completed"
+        assert target.tasks[first].result == "FIRST DONE"
+
+    def test_control_an_unfinished_task_is_not_marked_done(self, agent):
+        source = _team(agent)
+        payload = source._team_state_payload("s1")
+        target = _team(agent)
+        target._restore_serialised_task_state(payload["tasks"])
+        assert all(t.status != "completed" for t in target.tasks.values())
+
+    def test_unknown_tasks_are_skipped_not_invented(self, agent):
+        target = _team(agent)
+        assert target._restore_serialised_task_state({"99": {"status": "completed"}}) == 0
+
+
+class TestFingerprint:
+    def test_the_same_task_set_fingerprints_the_same(self, agent):
+        assert _team(agent)._task_set_fingerprint() == _team(agent)._task_set_fingerprint()
+
+    def test_a_different_task_set_differs(self, agent):
+        assert _team(agent)._task_set_fingerprint() != _team(agent, names=("x", "y"))._task_set_fingerprint()
+
+    def test_the_payload_carries_it(self, agent):
+        assert _team(agent)._team_state_payload("s1")["tasks_fingerprint"]
+
+    def test_it_is_why_positional_keys_are_safe(self, agent):
+        """Task keys are positional, so without this a checkpoint from another
+        team would put task 3's output onto a different task 3."""
+        assert list(_team(agent).tasks) == [0, 1]


### PR DESCRIPTION
Closes another competitor gap. `save_session_state` persisted only the shared `_state` dict — **no task status, no task outputs** — so a team that died on task 9 of 12 restarted from task 1 and re-paid for eight completed tasks.

Step-level resume already existed, with a definition fingerprint and everything, but **only on the YAML workflow path**, which `AgentTeam` cannot reach. The audit called this ~80% built in the wrong module, and that was right.

## What changed

The durable payload now carries per-task status, output, retry count and variables, and `restore_session_state` re-applies them — so the process layer's existing *"skip anything already completed"* logic sees finished work as finished. `_snapshot_task_state` already existed for in-memory batch resets; this makes it durable rather than inventing a second representation that could drift.

A `TaskOutput` object is reduced to its text before writing: a half-serialised object that failed to write would lose the **whole checkpoint** rather than one field.

## The guard that took longest to get right

Task keys are **positional** (`0, 1, 2…`), not ids.

I only noticed because a scratch run restored **2 tasks into a completely fresh team** from another team's payload. That looked like success and was wrong — a checkpoint from a different task set would put task 3's output onto a *different* task 3, producing a resume that looks fine and silently skips the wrong work.

The payload now carries a **task-set fingerprint**. On mismatch it restores the shared state (safe — keyed by name) while **refusing the task outputs**, with a warning saying exactly that. This mirrors the `definition_fingerprint` the YAML path already uses, rather than inventing a new mechanism.

Unknown task ids are skipped rather than invented, so a partial mismatch cannot half-restore.

## Verification

| Check | Result |
|---|---|
| New tests | **9 passed** (two are controls) |
| `tests/unit/{agents,task}` — this branch | **259 passed, 0 failed** |
| Same suites — `origin/main` | **250 passed, 0 failed** |
| Difference | exactly **+9**, no regressions |
| Collect gate | exit 0 |
| `names` / `signatures` / `behaviour` parity gates | all exit 0 |

The controls matter because both failure modes here are *silent*: an unfinished task must not come back marked done, and an unknown task id must restore nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team sessions now save task progress, results, retry counts, variables, and shared state for checkpoint and resume workflows.
  * Saved task progress is restored only when it matches the current task set, preventing incorrect tasks from being skipped.
  * Checkpoints now remain usable when task results or variables contain values that cannot be represented directly in JSON.

* **Bug Fixes**
  * Improved session recovery when task definitions change by retaining shared state while avoiding incompatible task restoration.
  * Restored task results now remain accessible through their standard output fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->