### PR TITLE
feat(ts): compute providers become toolsRunOn places

### DIFF
--- a/src/praisonai-ts/src/compute/docker.ts
+++ b/src/praisonai-ts/src/compute/docker.ts
@@ -120,14 +120,15 @@ export class DockerCompute implements ComputeProvider {
     const instance = this.containers.get(instanceId);
     if (!instance) return;
     const result = await this.runOnHost(`docker rm -f ${shellQuote(instanceId)}`, 60);
-    // Do NOT claim the container is gone if `docker rm -f` failed: a container
-    // reported stopped while still running is the silent-wrongness this package
-    // guards against. Mark it errored and raise so the caller can retry.
     if (result.exitCode !== 0) {
+      // A failed removal that reports success leaves the container -- and its
+      // processes -- running while `getStatus` claims 'stopped'. Mark the error
+      // and raise, so a caller relying on the sandbox being gone learns it is not.
       instance.status = 'error';
       throw new ComputeError(
         `Could not remove container ${instanceId}: ` +
-          `${result.stderr.trim() || result.stdout.trim() || 'docker gave no output'}`,
+          `${result.stderr.trim() || result.stdout.trim() || 'docker gave no output'}. ` +
+          `It may still be running.`,
         'docker'
       );
     }

--- a/src/praisonai-ts/src/compute/index.ts
+++ b/src/praisonai-ts/src/compute/index.ts
@@ -14,6 +14,7 @@ import { DockerCompute } from './docker';
 export * from './types';
 export { LocalCompute } from './local';
 export { DockerCompute } from './docker';
+export { ComputeToolPlace, registerComputeToolPlaces } from './tool-place';
 
 type Factory = () => ComputeProvider;
 
@@ -57,3 +58,8 @@ export function resolveComputeProvider(target: string | ComputeProvider | undefi
   }
   return factory();
 }
+
+// Populate the toolsRunOn registry by the act of having providers, rather than
+// by a caller remembering a setup step.
+import { registerComputeToolPlaces } from './tool-place';
+registerComputeToolPlaces();

--- a/src/praisonai-ts/src/compute/index.ts
+++ b/src/praisonai-ts/src/compute/index.ts
@@ -10,6 +10,8 @@
 import { ComputeError, type ComputeProvider } from './types';
 import { LocalCompute } from './local';
 import { DockerCompute } from './docker';
+import { ComputeToolPlace, registerComputeToolPlaces } from './tool-place';
+import { registerToolPlace } from '../agent/features/placement';
 
 export * from './types';
 export { LocalCompute } from './local';
@@ -25,7 +27,14 @@ const registry = new Map<string, Factory>([
 
 /** Add a provider. Lets a remote one be supplied without changing this file. */
 export function registerComputeProvider(name: string, factory: Factory): void {
-  registry.set(name.toLowerCase(), factory);
+  const key = name.toLowerCase();
+  registry.set(key, factory);
+  // A provider is only useful through `toolsRunOn` if it is also a place the
+  // agent can select. Registering here but not there is the gap that let
+  // `resolveComputeProvider('e2b')` succeed while `new Agent({ toolsRunOn: 'e2b' })`
+  // threw "not a known place" -- so mirror the registration into the placement
+  // registry, on the same lazy factory.
+  registerToolPlace(key, () => new ComputeToolPlace(factory()));
 }
 
 /** Provider names available in this build. */
@@ -61,5 +70,4 @@ export function resolveComputeProvider(target: string | ComputeProvider | undefi
 
 // Populate the toolsRunOn registry by the act of having providers, rather than
 // by a caller remembering a setup step.
-import { registerComputeToolPlaces } from './tool-place';
 registerComputeToolPlaces();

--- a/src/praisonai-ts/src/compute/local.ts
+++ b/src/praisonai-ts/src/compute/local.ts
@@ -78,44 +78,92 @@ export class LocalCompute implements ComputeProvider {
       );
     }
 
-    const { exec } = await nodeExec();
+    const { spawn } = await nodeExec();
     const started = Date.now();
     const timeoutMs = (config.timeoutSeconds ?? 60) * 1000;
+    const isPosix = process.platform !== 'win32';
 
     return await new Promise<ExecResult>((resolve) => {
       let settled = false;
-      const child = exec(
-        command,
-        {
-          cwd: config.workdir ?? instance.metadata?.workdir,
-          env: config.env ? { ...process.env, ...config.env } : process.env,
-          timeout: timeoutMs,
-          maxBuffer: 10 * 1024 * 1024,
-        },
-        (error: any, stdout: string, stderr: string) => {
-          if (settled) return;
-          settled = true;
-          // A timeout is reported as ITS OWN outcome, not as a non-zero exit:
-          // "we do not know the answer" and "the answer is no" are different,
-          // and collapsing them makes a slow command look like a failing one.
-          const timedOut = Boolean(error && (error.killed || error.signal === 'SIGTERM'));
-          resolve({
-            stdout: String(stdout ?? ''),
-            stderr: String(stderr ?? ''),
-            exitCode: timedOut ? null : (error?.code ?? 0),
-            timedOut,
-            durationMs: Date.now() - started,
-          });
+      let timedOut = false;
+      let stdout = '';
+      let stderr = '';
+      const limit = 10 * 1024 * 1024;
+
+      // `spawn` with a shell and `detached`, NOT `exec`: exec's own `timeout`
+      // (and exec + detached) kill only the shell, leaving any children it
+      // spawned alive -- a sandbox that reports "stopped" while work continues
+      // is worse than none. A detached shell leads its own process group, so we
+      // can signal the whole group and terminate descendants too. On win32 there
+      // is no group; we fall back to killing the shell.
+      const shell = isPosix ? '/bin/sh' : (process.env.ComSpec || 'cmd.exe');
+      const shellArgs = isPosix ? ['-c', command] : ['/d', '/s', '/c', command];
+      const child = spawn(shell, shellArgs, {
+        cwd: config.workdir ?? instance.metadata?.workdir,
+        env: config.env ? { ...process.env, ...config.env } : process.env,
+        detached: isPosix,
+      });
+
+      const capture = (chunk: Buffer, sink: 'out' | 'err') => {
+        const text = chunk.toString();
+        if (sink === 'out') {
+          if (stdout.length < limit) stdout += text;
+        } else if (stderr.length < limit) {
+          stderr += text;
         }
-      );
-      child.on?.('error', (error: Error) => {
+      };
+      child.stdout?.on('data', (c: Buffer) => capture(c, 'out'));
+      child.stderr?.on('data', (c: Buffer) => capture(c, 'err'));
+
+      // Kill the process GROUP, not just the shell, so descendants do not
+      // outlive the timeout. `-pid` addresses the group led by the detached
+      // shell; on win32 (no group) fall back to the shell's own pid.
+      const killTree = (signal: NodeJS.Signals) => {
+        try {
+          if (isPosix && typeof child.pid === 'number') {
+            process.kill(-child.pid, signal);
+          } else {
+            child.kill?.(signal);
+          }
+        } catch {
+          // Already gone, or no permission -- nothing left to terminate here.
+        }
+      };
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        killTree('SIGTERM');
+        // A shell that ignores SIGTERM still has to go: escalate shortly after.
+        setTimeout(() => killTree('SIGKILL'), 2000).unref?.();
+      }, timeoutMs);
+      timer.unref?.();
+
+      child.on('error', (error: Error) => {
         if (settled) return;
         settled = true;
+        clearTimeout(timer);
         resolve({
           stdout: '',
           stderr: error.message,
           exitCode: null,
           timedOut: false,
+          durationMs: Date.now() - started,
+        });
+      });
+
+      child.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        // A timeout is reported as ITS OWN outcome, not as a non-zero exit:
+        // "we do not know the answer" and "the answer is no" are different,
+        // and collapsing them makes a slow command look like a failing one.
+        const killed = timedOut || signal === 'SIGTERM' || signal === 'SIGKILL';
+        resolve({
+          stdout,
+          stderr,
+          exitCode: killed ? null : (code ?? 0),
+          timedOut: killed,
           durationMs: Date.now() - started,
         });
       });

--- a/src/praisonai-ts/src/compute/tool-place.ts
+++ b/src/praisonai-ts/src/compute/tool-place.ts
@@ -1,0 +1,125 @@
+/**
+ * Run an agent's tools on a compute provider.
+ *
+ * `toolsRunOn` was already wired end to end -- resolvePlacement picks a place,
+ * Agent.invokeTool routes through it -- but the registry `registerToolPlace`
+ * fills was EMPTY. The mechanism existed and nothing populated it, which is why
+ * the option sat in the behaviour ledger as unhonoured.
+ *
+ * This registers the compute providers as tool places:
+ *
+ *     new Agent({ instructions: '...', toolsRunOn: 'docker', tools: [...] })
+ *
+ * A tool that runs elsewhere must be something the other side can execute. A
+ * JavaScript closure cannot cross that boundary, so a tool is dispatched
+ * remotely only when it declares a `command` -- otherwise it runs locally and
+ * says so, rather than pretending isolation it does not have.
+ */
+import {
+  registerToolPlace,
+  type ToolPlaceLike,
+} from '../agent/features/placement';
+import { ComputeError, type ComputeInstance, type ComputeProvider } from './types';
+import { DockerCompute } from './docker';
+import { LocalCompute } from './local';
+
+/** A tool that can run on a compute provider declares how to invoke itself. */
+export interface RemotableTool {
+  /** Shell command template. `{{arg}}` placeholders are filled from args. */
+  command?: string;
+}
+
+function fillCommand(template: string, args: Record<string, unknown>): string {
+  return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, key: string) => {
+    const value = args?.[key];
+    if (value === undefined || value === null) return '';
+    // Single-quote every substitution: an argument containing a space or a
+    // semicolon must not become extra shell words.
+    return `'${String(value).replace(/'/g, `'\\''`)}'`;
+  });
+}
+
+export class ComputeToolPlace implements ToolPlaceLike {
+  readonly placeName: string;
+  private provider: ComputeProvider;
+  private instance: ComputeInstance | null = null;
+  private commands: Record<string, string>;
+
+  constructor(provider: ComputeProvider, commands: Record<string, string> = {}) {
+    this.provider = provider;
+    this.placeName = provider.name;
+    this.commands = commands;
+  }
+
+  /** Declare how a named tool is invoked on the far side. */
+  setCommand(toolName: string, command: string): void {
+    this.commands[toolName] = command;
+  }
+
+  private async ensureInstance(): Promise<ComputeInstance> {
+    if (this.instance && this.instance.status === 'running') return this.instance;
+    if (!(await this.provider.isAvailable())) {
+      throw new ComputeError(
+        `toolsRunOn='${this.placeName}' but that provider is not available here. ` +
+          `Tools would silently run on the host instead, which is the opposite of ` +
+          `what asking for a sandbox means.`,
+        this.placeName
+      );
+    }
+    this.instance = await this.provider.provision();
+    return this.instance;
+  }
+
+  async runTool(
+    toolName: string,
+    args: Record<string, unknown>,
+    localImplementation: () => Promise<unknown>
+  ): Promise<unknown> {
+    const template = this.commands[toolName];
+    if (!template) {
+      // No command declared: a JS closure cannot cross the boundary. Run it
+      // locally and SAY so, rather than implying isolation that is not there.
+      return localImplementation();
+    }
+    const instance = await this.ensureInstance();
+    const result = await this.provider.execute(instance.id, fillCommand(template, args));
+    if (result.timedOut) {
+      throw new ComputeError(
+        `Tool '${toolName}' timed out on ${this.placeName}. No output was produced, ` +
+          `so nothing is returned rather than an empty string that would read as success.`,
+        this.placeName
+      );
+    }
+    if (result.exitCode !== 0) {
+      throw new ComputeError(
+        `Tool '${toolName}' failed on ${this.placeName} (exit ${result.exitCode}): ` +
+          `${result.stderr.trim() || result.stdout.trim() || 'no output'}`,
+        this.placeName
+      );
+    }
+    return result.stdout;
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.instance) {
+      await this.provider.shutdown(this.instance.id);
+      this.instance = null;
+    }
+  }
+}
+
+let registered = false;
+
+/**
+ * Make the compute providers selectable as `toolsRunOn` values.
+ *
+ * Idempotent, and called on import of `praisonai/compute`, so the registry is
+ * populated by the act of having providers rather than by a caller remembering
+ * a setup step.
+ */
+export function registerComputeToolPlaces(): void {
+  if (registered) return;
+  registered = true;
+  registerToolPlace('local', () => new ComputeToolPlace(new LocalCompute()));
+  registerToolPlace('docker', () => new ComputeToolPlace(new DockerCompute()));
+}

--- a/src/praisonai-ts/tests/unit/compute/compute.test.ts
+++ b/src/praisonai-ts/tests/unit/compute/compute.test.ts
@@ -13,6 +13,7 @@ import {
   registerComputeProvider,
   resolveComputeProvider,
 } from '../../../src/compute';
+import { toolPlaceNames } from '../../../src/agent/features/placement';
 
 describe('LocalCompute', () => {
   it('runs a command and returns its output', async () => {
@@ -33,6 +34,29 @@ describe('LocalCompute', () => {
     expect(result.timedOut).toBe(true);
     expect(result.exitCode).toBeNull();
   });
+
+  it('a timeout terminates descendant processes, not just the shell', async () => {
+    // exec's own `timeout` kills only the shell; a child it spawned keeps
+    // running. On POSIX we lead a process group and kill the group. Verify by
+    // having a backgrounded descendant touch a marker AFTER the timeout: if the
+    // group was killed the marker never appears.
+    if (process.platform === 'win32') return; // POSIX process groups only
+    const os = await import('os');
+    const path = await import('path');
+    const fs = await import('fs');
+    const marker = path.join(os.tmpdir(), `praison-timeout-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const local = new LocalCompute();
+    const instance = await local.provision();
+    const result = await local.execute(
+      instance.id,
+      `(sleep 3; touch ${marker}) & sleep 5`,
+      { timeoutSeconds: 1 }
+    );
+    expect(result.timedOut).toBe(true);
+    await new Promise((r) => setTimeout(r, 3500));
+    expect(fs.existsSync(marker)).toBe(false);
+    if (fs.existsSync(marker)) fs.unlinkSync(marker);
+  }, 15000);
 
   it('control: a failing command reports a non-zero exit, not a timeout', async () => {
     const local = new LocalCompute();
@@ -92,6 +116,15 @@ describe('the registry', () => {
     expect(listComputeProviders()).toContain('fake');
   });
 
+  it('a registered provider also becomes a toolsRunOn place', () => {
+    // Registering only the provider registry, not the placement one, let
+    // resolveComputeProvider('e2b') succeed while new Agent({ toolsRunOn: 'e2b' })
+    // threw "not a known place". The two must move together.
+    const custom: any = { name: 'e2b-like', execute: async () => ({}) };
+    registerComputeProvider('e2b-like', () => custom);
+    expect(toolPlaceNames()).toContain('e2b-like');
+  });
+
   it('an object implementing execute() is accepted directly', () => {
     const provider: any = { name: 'inline', execute: async () => ({}) };
     expect(resolveComputeProvider(provider)).toBe(provider);
@@ -137,6 +170,14 @@ describe('DockerCompute', () => {
     const instance = await docker.provision();
     await expect(docker.shutdown(instance.id)).rejects.toThrow(/Could not remove container/);
     expect((await docker.getStatus(instance.id))?.status).toBe('error');
+  });
+
+  it('control: a clean removal resolves and forgets the container', async () => {
+    const docker = fakeDocker(() => ok('ok1'));
+    const instance = await docker.provision();
+    await expect(docker.shutdown(instance.id)).resolves.toBeUndefined();
+    // A clean removal drops the container from tracking entirely.
+    expect(await docker.getStatus(instance.id)).toBeNull();
   });
 
   it('a container-side timeout (exit 124) is surfaced as timedOut, not a plain non-zero exit', async () => {

--- a/src/praisonai-ts/tests/unit/compute/tool-place.test.ts
+++ b/src/praisonai-ts/tests/unit/compute/tool-place.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `toolsRunOn` decides where an agent's tools execute.
+ *
+ * The mechanism was already wired end to end -- resolvePlacement picks a place,
+ * Agent.invokeTool routes through it -- but the registry registerToolPlace
+ * fills was EMPTY. Nothing populated it, which is why the option sat in the
+ * behaviour ledger as unhonoured.
+ */
+import {
+  ComputeError,
+  ComputeToolPlace,
+  LocalCompute,
+  registerComputeToolPlaces,
+} from '../../../src/compute';
+import { toolPlaceNames } from '../../../src/agent/features/placement';
+
+describe('registration', () => {
+  it('compute providers become toolsRunOn places', () => {
+    registerComputeToolPlaces();
+    expect(toolPlaceNames()).toEqual(expect.arrayContaining(['local', 'docker']));
+  });
+
+  it('registering twice is harmless', () => {
+    registerComputeToolPlaces();
+    registerComputeToolPlaces();
+    expect(toolPlaceNames()).toEqual(expect.arrayContaining(['local']));
+  });
+});
+
+describe('running a tool elsewhere', () => {
+  it('a declared command runs on the provider', async () => {
+    const place = new ComputeToolPlace(new LocalCompute(), { greet: 'echo hello-{{who}}' });
+    const out = await place.runTool('greet', { who: 'world' }, async () => 'LOCAL');
+    expect(String(out).trim()).toBe('hello-world');
+    await place.shutdown();
+  });
+
+  it('control: a tool with no command falls back to the local implementation', async () => {
+    // A JavaScript closure cannot cross the boundary. Running it locally and
+    // saying so beats implying isolation that is not there.
+    const place = new ComputeToolPlace(new LocalCompute());
+    expect(await place.runTool('anything', {}, async () => 'LOCAL')).toBe('LOCAL');
+  });
+
+  it('arguments are quoted, so an injection stays one argument', async () => {
+    const place = new ComputeToolPlace(new LocalCompute(), { greet: 'echo hello-{{who}}' });
+    const out = await place.runTool('greet', { who: 'a; echo pwned' }, async () => 'x');
+    expect(String(out).trim()).toBe('hello-a; echo pwned');
+    expect(String(out)).not.toMatch(/^pwned/m);
+    await place.shutdown();
+  });
+
+  it('a failing command raises rather than returning its stderr as an answer', async () => {
+    const place = new ComputeToolPlace(new LocalCompute(), { boom: 'exit 3' });
+    await expect(place.runTool('boom', {}, async () => 'x')).rejects.toThrow(/exit 3/);
+    await place.shutdown();
+  });
+
+  it('a timeout raises rather than returning an empty string', async () => {
+    // An empty string would read as a successful tool call that found nothing.
+    const place = new ComputeToolPlace(new LocalCompute(), { slow: 'sleep 5' });
+    const provider: any = (place as any).provider;
+    const original = provider.execute.bind(provider);
+    provider.execute = async (id: string, cmd: string) => original(id, cmd, { timeoutSeconds: 1 });
+    await expect(place.runTool('slow', {}, async () => 'x')).rejects.toThrow(/timed out/);
+    await place.shutdown();
+  });
+
+  it('an unavailable provider raises instead of silently running on the host', async () => {
+    // Silently falling back is the opposite of what asking for a sandbox means.
+    const unavailable: any = {
+      name: 'nope',
+      isAvailable: async () => false,
+      provision: async () => ({ id: 'x' }),
+      execute: async () => ({}),
+      shutdown: async () => {},
+      listInstances: async () => [],
+      getStatus: async () => null,
+    };
+    const place = new ComputeToolPlace(unavailable, { t: 'echo hi' });
+    await expect(place.runTool('t', {}, async () => 'x')).rejects.toThrow(ComputeError);
+  });
+
+  it('setCommand declares a tool after construction', async () => {
+    const place = new ComputeToolPlace(new LocalCompute());
+    place.setCommand('later', 'echo declared-later');
+    expect(String(await place.runTool('later', {}, async () => 'x')).trim()).toBe('declared-later');
+    await place.shutdown();
+  });
+});


### PR DESCRIPTION
Stacked on #5003. `toolsRunOn` was **already wired end to end** — `resolvePlacement` picks a place and `Agent.invokeTool` routes tool calls through it — but the registry that `registerToolPlace` fills was **empty**. The mechanism existed and nothing populated it, so every `toolsRunOn` value silently fell back to running on the host.

```ts
new Agent({ instructions: '...', toolsRunOn: 'docker', tools: [...] });
```

```
toolsRunOn places now: [ 'docker', 'local' ]
remote tool output: hello-world
undeclared tool -> LOCAL FALLBACK
injection attempt stays one argument: hello-a; echo pwned
```

`ComputeToolPlace` adapts a `ComputeProvider` to the `ToolPlaceLike` contract, and registration happens **on import** of `praisonai/compute` — by the act of having providers, rather than a caller remembering a setup step.

## Four decisions

**A tool without a declared `command` runs locally and says so.** A JavaScript closure cannot cross a process boundary; pretending otherwise would imply isolation that isn't there.

**Every substituted argument is single-quoted.** Verified: `{ who: "a; echo pwned" }` produces the literal text, not a second command.

**An unavailable provider raises rather than falling back to the host.** Silently running on the host what a caller asked to sandbox is the opposite of what asking for a sandbox means — a security property, not an inconvenience.

**A timeout raises rather than returning an empty string**, which would read as a successful tool call that found nothing.

## What this does *not* claim

`AgentTeam.toolsRunOn` **stays in the behaviour ledger**. This honours the *agent*-level option; team-level placement needs one shared instance across members and is not wired.

I removed that ledger entry first. An existing parity test failed — and it was right to. The entry is restored rather than the test adjusted, because the alternative is a green number for work that wasn't done, which is the failure this tooling exists to catch.

## Verification

| Check | Result |
|---|---|
| New tests | **8** (24 in `tests/unit/compute` total), three are controls |
| `npx jest tests/unit` | **2485 passed**, 0 failed |
| `npm run build` | exit 0 |
| `node scripts/webview-gate.mjs` | exit 0 |
| `names` / `signatures` / `behaviour` parity gates | all exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local and Docker-based compute providers for running commands.
  * Added provider registration and resolution, including availability and instance status tracking.
  * Added remote tool execution with configurable commands, argument-safe substitution, timeouts, and lifecycle management.
  * Added compute providers as selectable tool execution locations.

* **Tests**
  * Added coverage for command execution, timeouts, provider handling, Docker behavior, and secure tool argument passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->