### PR TITLE
fix(openai_client): resolve string tool names instead of dropping them

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -986,12 +986,59 @@ class OpenAIClient:
             logging.error(f"Error generating tool definition: {e}")
             return None
     
+    @staticmethod
+    def _lookup_by_name(name: str) -> Any:
+        """This module's globals first, then __main__, which is where a script's
+        own tools live."""
+        found = globals().get(name)
+        if found is None:
+            import __main__
+            found = getattr(__main__, name, None)
+        return found
+
     def _generate_tool_definition_from_name(self, function_name: str) -> Optional[Dict]:
-        """Generate a tool definition from a function name."""
-        # This is a placeholder - in agent.py this would look up the function
-        # For now, return None as the actual implementation would need access to the function
-        logging.debug(f"Tool definition generation from name '{function_name}' requires function reference")
-        return None
+        """Resolve a tool named by a string and build its definition.
+
+        format_tools() documents string function names as a supported format,
+        and this returned None unconditionally, so every such tool was dropped
+        from the request with no error and nothing above debug level. The same
+        name works on the LiteLLM path, which is what made it hard to see.
+
+        Resolution order matches LLM._generate_tool_definition: the shared tool
+        registry first, then a `<name>_definition` dict, then the function
+        itself.
+        """
+        tool = None
+        try:
+            from ..tools.registry import get_registry
+            tool = get_registry().get(function_name)
+        except ImportError:
+            logging.debug("Tool registry not available, falling back to globals/__main__")
+        except Exception as e:
+            logging.debug(f"Tool registry lookup failed for '{function_name}': {e}")
+
+        if tool is not None:
+            if hasattr(tool, 'get_schema'):
+                # A BaseTool declares its own schema, which honours an @tool
+                # name= override and excludes injected parameters.
+                return tool.get_schema()
+            if not callable(tool):
+                logging.debug(f"Tool '{function_name}' in registry is not callable")
+                return None
+            return self._generate_tool_definition(tool)
+
+        logging.debug(f"Tool '{function_name}' not in registry, falling back to globals/__main__")
+
+        tool_def = self._lookup_by_name(f"{function_name}_definition")
+        if tool_def:
+            return tool_def
+
+        func = self._lookup_by_name(function_name)
+        if not callable(func):
+            logging.debug(f"Function '{function_name}' not found or not callable")
+            return None
+
+        return self._generate_tool_definition(func)
     
     def process_stream_response(
         self,

--- a/src/praisonai-agents/praisonaiagents/llm/openai_client.py
+++ b/src/praisonai-agents/praisonaiagents/llm/openai_client.py
@@ -591,9 +591,13 @@ class OpenAIClient:
         if not tools:
             return None
         
-        # Check cache first
-        cache_key = self._get_tools_cache_key(tools)
-        if cache_key in self._formatted_tools_cache:
+        # String tool names resolve against the mutable tool registry and the
+        # process globals/__main__, so a cached result could advertise an
+        # obsolete schema after the tool is re-registered. Only cache when every
+        # tool is a stable, self-describing form (dict/callable/list).
+        cacheable = not any(isinstance(tool, str) for tool in tools)
+        cache_key = self._get_tools_cache_key(tools) if cacheable else None
+        if cacheable and cache_key in self._formatted_tools_cache:
             return self._formatted_tools_cache[cache_key]
             
         from ..tools.hosted import is_hosted_tool
@@ -661,9 +665,9 @@ class OpenAIClient:
                 logging.error(f"Tools are not JSON serializable: {e}")
                 return None
         
-        # Cache the result
+        # Cache the result (skipped for string tools, see above)
         result = formatted_tools if formatted_tools else None
-        if result is not None and len(self._formatted_tools_cache) < self._max_cache_size:
+        if cacheable and result is not None and len(self._formatted_tools_cache) < self._max_cache_size:
             self._formatted_tools_cache[cache_key] = result
                 
         return result
@@ -1020,8 +1024,22 @@ class OpenAIClient:
         if tool is not None:
             if hasattr(tool, 'get_schema'):
                 # A BaseTool declares its own schema, which honours an @tool
-                # name= override and excludes injected parameters.
-                return tool.get_schema()
+                # name= override and excludes injected parameters. Normalise the
+                # parameters exactly as LLM._generate_tool_definition does so the
+                # registry path and the callable path emit identical, provider-safe
+                # schemas (array 'items' fix) without mutating the tool's schema.
+                tool_def = tool.get_schema()
+                if (
+                    isinstance(tool_def, dict)
+                    and isinstance(tool_def.get("function"), dict)
+                    and isinstance(tool_def["function"].get("parameters"), dict)
+                ):
+                    tool_def = tool_def.copy()
+                    tool_def["function"] = tool_def["function"].copy()
+                    tool_def["function"]["parameters"] = self._fix_array_schemas(
+                        tool_def["function"]["parameters"]
+                    )
+                return tool_def
             if not callable(tool):
                 logging.debug(f"Tool '{function_name}' in registry is not callable")
                 return None

--- a/src/praisonai-agents/tests/unit/llm/test_openai_client_string_tools.py
+++ b/src/praisonai-agents/tests/unit/llm/test_openai_client_string_tools.py
@@ -1,0 +1,100 @@
+"""A tool named by a string must reach the model on the OpenAI-native path.
+
+`OpenAIClient.format_tools()` documents string function names as a supported
+tool format, and `_generate_tool_definition_from_name` returned None
+unconditionally. The string branch is
+
+    tool_def = self._generate_tool_definition_from_name(tool)
+    if tool_def:
+        formatted_tools.append(tool_def)
+
+so the tool was dropped from the request with no exception and nothing above
+`logging.debug`. The model was simply never offered it, and `Agent(tools=[...])`
+with the same name worked on the LiteLLM path -- same code, different dispatch,
+different behaviour.
+"""
+import os
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from praisonaiagents.llm.openai_client import OpenAIClient
+from praisonaiagents.tools.registry import get_registry
+
+
+def get_weather(city: str) -> str:
+    """Return the weather for a city."""
+    return f"sunny in {city}"
+
+
+@pytest.fixture
+def client():
+    return OpenAIClient(api_key="sk-test-not-real")
+
+
+@pytest.fixture
+def registered_tool():
+    registry = get_registry()
+    registry.register(get_weather, name="get_weather", overwrite=True)
+    yield "get_weather"
+
+
+def _names(tools):
+    return [t["function"]["name"] for t in (tools or [])]
+
+
+def test_string_tool_from_the_registry_reaches_the_model(client, registered_tool):
+    formatted = client.format_tools([registered_tool])
+
+    assert _names(formatted) == ["get_weather"]
+    assert formatted[0]["type"] == "function"
+    assert "city" in formatted[0]["function"]["parameters"]["properties"]
+
+
+def test_string_tool_matches_the_callable_form(client, registered_tool):
+    by_name = client.format_tools([registered_tool])
+    by_callable = client.format_tools([get_weather])
+
+    # The two entry points documented by format_tools must agree; they did not,
+    # because one of them produced nothing at all.
+    assert by_name == by_callable
+
+
+def test_string_tool_resolved_from_main(client, monkeypatch):
+    # A script's own tools live in __main__, not in the registry, and the
+    # LiteLLM path already falls back there.
+    import __main__
+
+    monkeypatch.setattr(__main__, "lookup_from_main", get_weather, raising=False)
+    get_registry().unregister("lookup_from_main")
+
+    formatted = client.format_tools(["lookup_from_main"])
+
+    assert _names(formatted) == ["get_weather"]
+
+
+def test_explicit_definition_dict_wins(client, monkeypatch):
+    import __main__
+
+    definition = {
+        "type": "function",
+        "function": {
+            "name": "hand_written",
+            "description": "supplied by the caller",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    }
+    monkeypatch.setattr(__main__, "hand_written_definition", definition, raising=False)
+    get_registry().unregister("hand_written")
+
+    assert client.format_tools(["hand_written"]) == [definition]
+
+
+def test_unknown_string_tool_is_still_dropped(client):
+    # Unchanged behaviour, and deliberately so: a name that resolves to nothing
+    # cannot be turned into a schema. This pins that the fix did not start
+    # inventing definitions.
+    get_registry().unregister("no_such_tool_anywhere")
+
+    assert client.format_tools(["no_such_tool_anywhere"]) in (None, [])

--- a/src/praisonai-agents/tests/unit/llm/test_openai_client_string_tools.py
+++ b/src/praisonai-agents/tests/unit/llm/test_openai_client_string_tools.py
@@ -13,11 +13,9 @@ so the tool was dropped from the request with no exception and nothing above
 with the same name worked on the LiteLLM path -- same code, different dispatch,
 different behaviour.
 """
-import os
+import contextlib
 
 import pytest
-
-os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
 
 from praisonaiagents.llm.openai_client import OpenAIClient
 from praisonaiagents.tools.registry import get_registry
@@ -30,14 +28,51 @@ def get_weather(city: str) -> str:
 
 @pytest.fixture
 def client():
+    # The fixture always passes an explicit key, so nothing here should touch
+    # the process-wide OPENAI_API_KEY and leak a fake credential into unrelated
+    # tests that exercise the no-key path.
     return OpenAIClient(api_key="sk-test-not-real")
+
+
+@contextlib.contextmanager
+def _registry_name(name, tool):
+    """Register ``name`` for the test and restore the registry afterwards.
+
+    get_registry() is a process-global singleton, so a test that overwrites or
+    removes an entry without restoring it makes later tests depend on execution
+    order. Snapshot the prior entry and put it back on exit.
+    """
+    registry = get_registry()
+    previous = registry._tools.get(name)
+    registry.register(tool, name=name, overwrite=True)
+    try:
+        yield name
+    finally:
+        if previous is not None:
+            registry._tools[name] = previous
+        else:
+            registry.unregister(name)
+
+
+@contextlib.contextmanager
+def _registry_absent(name):
+    """Ensure ``name`` is unregistered for the test and restore it afterwards."""
+    registry = get_registry()
+    previous = registry._tools.get(name)
+    registry.unregister(name)
+    try:
+        yield name
+    finally:
+        if previous is not None:
+            registry._tools[name] = previous
+        else:
+            registry.unregister(name)
 
 
 @pytest.fixture
 def registered_tool():
-    registry = get_registry()
-    registry.register(get_weather, name="get_weather", overwrite=True)
-    yield "get_weather"
+    with _registry_name("get_weather", get_weather) as name:
+        yield name
 
 
 def _names(tools):
@@ -67,9 +102,8 @@ def test_string_tool_resolved_from_main(client, monkeypatch):
     import __main__
 
     monkeypatch.setattr(__main__, "lookup_from_main", get_weather, raising=False)
-    get_registry().unregister("lookup_from_main")
-
-    formatted = client.format_tools(["lookup_from_main"])
+    with _registry_absent("lookup_from_main"):
+        formatted = client.format_tools(["lookup_from_main"])
 
     assert _names(formatted) == ["get_weather"]
 
@@ -86,15 +120,34 @@ def test_explicit_definition_dict_wins(client, monkeypatch):
         },
     }
     monkeypatch.setattr(__main__, "hand_written_definition", definition, raising=False)
-    get_registry().unregister("hand_written")
-
-    assert client.format_tools(["hand_written"]) == [definition]
+    with _registry_absent("hand_written"):
+        assert client.format_tools(["hand_written"]) == [definition]
 
 
 def test_unknown_string_tool_is_still_dropped(client):
     # Unchanged behaviour, and deliberately so: a name that resolves to nothing
     # cannot be turned into a schema. This pins that the fix did not start
     # inventing definitions.
-    get_registry().unregister("no_such_tool_anywhere")
+    with _registry_absent("no_such_tool_anywhere"):
+        assert client.format_tools(["no_such_tool_anywhere"]) in (None, [])
 
-    assert client.format_tools(["no_such_tool_anywhere"]) in (None, [])
+
+def test_string_tool_is_not_cached_across_registry_changes(client):
+    # A string name resolves against the mutable registry, so a re-registration
+    # between two format_tools() calls must reach the model as the new schema,
+    # never a stale cached one.
+    def get_weather(city: str, unit: str) -> str:
+        """Return the weather for a city in a given unit."""
+        return f"sunny in {city} ({unit})"
+
+    with _registry_name("get_weather", get_weather):
+        first = client.format_tools(["get_weather"])
+        assert set(first[0]["function"]["parameters"]["properties"]) == {"city", "unit"}
+
+        def get_weather(city: str) -> str:  # noqa: F811 - deliberate re-definition
+            """Return the weather for a city."""
+            return f"sunny in {city}"
+
+        get_registry().register(get_weather, name="get_weather", overwrite=True)
+        second = client.format_tools(["get_weather"])
+        assert set(second[0]["function"]["parameters"]["properties"]) == {"city"}


### PR DESCRIPTION
Addresses **item 1 only** of #5013 — `OpenAIClient.format_tools()` silently dropping every string-named tool. Items 2 (`astart()` ignoring `planning=True`) and 3 (Ollama tool chaining in the async/streaming loops) are untouched and want their own PRs; they are in different files and reviewing them together would be worse for everyone.

## The bug

`_generate_tool_definition_from_name` was a stub returning `None` unconditionally, and the caller is a truthiness check:

```python
elif isinstance(tool, str):
    tool_def = self._generate_tool_definition_from_name(tool)
    if tool_def:
        formatted_tools.append(tool_def)
```

So the tool vanished — no exception, no warning, nothing above `logging.debug`. The model was simply never offered it, and the identical name works on the LiteLLM path, which is what makes it a bad hour to debug.

## The fix

The stub is replaced by the resolution `LLM._generate_tool_definition` already does, so the two copies of "resolve a tool" now agree:

1. the shared tool registry, honouring a `BaseTool`'s own `get_schema()` (which respects an `@tool name=` override and excludes injected parameters)
2. a `<name>_definition` dict
3. the function itself

each looked for in this module's globals and then `__main__`, where a script's own tools actually live. Schema building goes through the existing `_generate_tool_definition`, so `"get_weather"` and `get_weather` produce byte-identical output rather than two schemas that drift.

## Verified — red before green

`tests/unit/llm/test_openai_client_string_tools.py`, five tests. With only the production file stashed and the tests left in place:

```
$ git stash push -- praisonaiagents/llm/openai_client.py
$ python -m pytest tests/unit/llm/test_openai_client_string_tools.py -q
FAILED ...::test_string_tool_from_the_registry_reaches_the_model
FAILED ...::test_string_tool_matches_the_callable_form
FAILED ...::test_string_tool_resolved_from_main
FAILED ...::test_explicit_definition_dict_wins
4 failed, 1 passed

$ git stash pop
$ python -m pytest tests/unit/llm/test_openai_client_string_tools.py -q
5 passed
```

The one that passes both ways is `test_unknown_string_tool_is_still_dropped`, and it is there on purpose: a name that resolves to nothing cannot become a schema, so that behaviour must not change. It pins that the fix did not start inventing definitions.

## No regressions

The whole `tests/unit/llm` suite, before and after:

| | failed | passed |
| --- | --- | --- |
| pristine `main` (with my new test file present, hence 4 of these are mine) | 43 | 125 |
| this branch | **39** | **129** |

Exactly four move, and they are the four above. The 39 remaining failures are pre-existing on `main` — mostly `test_stream_tools_reach_the_model.py` — and I have not touched them.

## Note

This PR was written with AI assistance. I understand the change and can defend or revise it; the numbers above are runs I did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - String-named tools are now correctly resolved and formatted for OpenAI requests.
  - Registered tools and available callable definitions are recognized, while unknown or invalid tool names continue to be skipped.

- **Tests**
  - Added coverage for registry resolution, callable-tool parity, fallback lookup, explicit definition precedence, and unknown tool handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->