### PR TITLE
fix(agents): astart() honours planning=True

### DIFF
--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -1,6 +1,7 @@
 import os
 import time
 import json
+import re
 import logging
 import contextlib
 import contextvars
@@ -36,6 +37,11 @@ except ImportError:
 _RUN_LOCK_INIT_GUARD = threading.Lock()
 
 # Task status constants
+def _strip_rich_markup(text: str) -> str:
+    """Rich tags mean nothing in a log line."""
+    return re.sub(r"\[/?[a-z0-9 ]+\]", "", text)
+
+
 class TaskStatus(Enum):
     """Enumeration for task status values to ensure consistency"""
     COMPLETED = "completed"
@@ -2147,8 +2153,15 @@ class AgentTeam(SpawnAnnounceProtocol):
                         task.context = []
                     task.context.append(content)
 
-        await self.arun_all_tasks()
-        
+        # The sync path branches on self.planning in both of its arms; this one
+        # did not, so a team built with planning=True and driven through
+        # astart() -- which is every async/server entry point -- silently
+        # skipped plan generation, the todo list and the approval gate.
+        if self.planning:
+            await self._arun_with_planning()
+        else:
+            await self.arun_all_tasks()
+
         # Get results
         results = {
             "task_status": self.get_all_tasks_status(),
@@ -3840,6 +3853,163 @@ class AgentTeam(SpawnAnnounceProtocol):
             return result
         return False
     
+    def _plan_note(self, console, message: str) -> None:
+        """Report on plan construction: to the console when the sync path
+        supplies one, to the log otherwise, so the async path is not forced to
+        own a Rich console it never prints to."""
+        if console is not None:
+            console.print(message)
+        else:
+            logger.warning(_strip_rich_markup(message))
+
+    def _restore_tasks_after_plan(self, original_tasks: dict) -> None:
+        """Keep plan-step tasks and results under _plan_tasks for introspection,
+        then put the caller's own task set back as the canonical self.tasks.
+
+        Shared with the async path, which would otherwise leave a team holding
+        the plan's tasks instead of the ones it was built with.
+        """
+        self._plan_tasks = self.tasks
+        self.tasks = original_tasks
+        with self._task_id_lock:
+            self.task_id_counter = (
+                max(original_tasks.keys()) + 1 if original_tasks else 0
+            )
+
+    def _apply_plan(self, plan, console=None) -> dict:
+        """Replace the task list with one Task per plan step, and hand back the
+        original one so the caller can restore it when execution is done.
+
+        Extracted from _run_with_planning so the sync and async planning paths
+        build the same tasks. Each Task inherits memory, callbacks, guardrails,
+        retries and structured output from whichever original task shared its
+        agent, and a step's dependencies become task context so results chain.
+        """
+        from ..task import Task
+
+        # Step 4: Create proper Task objects from plan steps
+        
+        # Map agent names to agent instances
+        agent_map = {agent.display_name: agent for agent in self.agents}
+        
+        # Store original tasks and create new tasks from plan
+        original_tasks = self.tasks.copy()
+        self.tasks = {}
+        with self._task_id_lock:
+            self.task_id_counter = 0
+        
+        # Create Task objects from plan steps
+        plan_tasks = []
+        step_to_task = {}  # Map step_id to task for context chaining
+        
+        for i, step in enumerate(plan.steps):
+            # Get the appropriate agent
+            agent = agent_map.get(step.agent, self.agents[0] if self.agents else None)
+            
+            if not agent:
+                self._plan_note(console, f"[yellow]⚠️ No agent found for '{step.agent}', using first available[/yellow]")
+                agent = self.agents[0] if self.agents else None
+            
+            if not agent:
+                self._plan_note(console, f"[red]❌ No agents available for step: {step.description}[/red]")
+                continue
+            
+            # Build context from dependencies (previous task results)
+            context = []
+            for dep_id in step.dependencies:
+                # Convert step_X format to actual step index
+                if dep_id.startswith("step_"):
+                    try:
+                        dep_index = int(dep_id.split("_")[1])
+                        if dep_index < len(plan_tasks):
+                            context.append(plan_tasks[dep_index])
+                    except (ValueError, IndexError):
+                        pass
+                elif dep_id in step_to_task:
+                    context.append(step_to_task[dep_id])
+            
+            # Find matching original task for additional config (memory, callbacks, etc.)
+            original_task = None
+            for orig_task in original_tasks.values():
+                if orig_task.agent and orig_task.agent.display_name == agent.display_name:
+                    original_task = orig_task
+                    break
+            
+            # Create Task with full features from original task if available
+            task = Task(
+                description=step.description,
+                expected_output=f"Complete: {step.description}",
+                agent=agent,
+                name=f"Plan Step {i + 1}",
+                tools=agent.tools if agent.tools else [],
+                context=context if context else None,
+                # Inherit from original task if available
+                memory=original_task.memory if original_task else None,
+                on_task_complete=original_task.callback if original_task else None,
+                guardrails=original_task.guardrail if original_task else None,
+                max_retries=original_task.max_retries if original_task else 3,
+                output_json=original_task.output_json if original_task else None,
+                output_pydantic=original_task.output_pydantic if original_task else None,
+                config=original_task.config if original_task else {}
+            )
+            
+            # Add task to our task list
+            task_id = self.add_task(task)
+            plan_tasks.append(task)
+            step_to_task[step.id] = task
+
+        return original_tasks
+        
+
+    async def _arun_with_planning(self):
+        """The async counterpart of _run_with_planning.
+
+        Same five steps -- plan, approve, todo list, build tasks from the plan,
+        execute -- sharing _apply_plan with the sync path so the two cannot
+        build different tasks from the same plan. The Rich console output is
+        the one thing left out: it is display-only, and this path is what the
+        headless and server entry points use.
+        """
+        plan = await self._create_plan(
+            request=" AND ".join(task.description for task in self.tasks.values())
+        )
+
+        if not plan:
+            logger.warning("Planning failed, falling back to normal execution")
+            await self.arun_all_tasks()
+            return
+
+        if not self.auto_approve_plan:
+            approved = await self._request_approval(plan)
+            if not approved:
+                logger.info("Plan rejected. Aborting execution.")
+                return
+        else:
+            plan.approve()
+
+        from ..planning import TodoList
+        self._todo_list = TodoList.from_plan(plan)
+
+        try:
+            from ..trace.protocol import get_default_emitter, ActionEvent
+
+            emitter = get_default_emitter()
+            if emitter and emitter.enabled:
+                emitter.emit(ActionEvent(
+                    event_type="plan_created",
+                    timestamp=time.time(),
+                    agent_name="PlanningAgent",
+                    metadata={"plan": self._todo_list.to_markdown()}
+                ))
+        except Exception:
+            pass
+
+        original_tasks = self._apply_plan(plan)
+        try:
+            await self.arun_all_tasks()
+        finally:
+            self._restore_tasks_after_plan(original_tasks)
+
     def _run_with_planning(self):
         """
         Run tasks with planning mode enabled.
@@ -3918,78 +4088,8 @@ class AgentTeam(SpawnAnnounceProtocol):
         except Exception:
             pass
         
-        # Step 4: Create proper Task objects from plan steps
-        console.print("\n[bold blue]🚀 EXECUTION PHASE[/bold blue]\n")
-        
-        # Map agent names to agent instances
-        agent_map = {agent.display_name: agent for agent in self.agents}
-        
-        # Store original tasks and create new tasks from plan
-        original_tasks = self.tasks.copy()
-        self.tasks = {}
-        with self._task_id_lock:
-            self.task_id_counter = 0
-        
-        # Create Task objects from plan steps
-        plan_tasks = []
-        step_to_task = {}  # Map step_id to task for context chaining
-        
-        for i, step in enumerate(plan.steps):
-            # Get the appropriate agent
-            agent = agent_map.get(step.agent, self.agents[0] if self.agents else None)
-            
-            if not agent:
-                console.print(f"[yellow]⚠️ No agent found for '{step.agent}', using first available[/yellow]")
-                agent = self.agents[0] if self.agents else None
-            
-            if not agent:
-                console.print(f"[red]❌ No agents available for step: {step.description}[/red]")
-                continue
-            
-            # Build context from dependencies (previous task results)
-            context = []
-            for dep_id in step.dependencies:
-                # Convert step_X format to actual step index
-                if dep_id.startswith("step_"):
-                    try:
-                        dep_index = int(dep_id.split("_")[1])
-                        if dep_index < len(plan_tasks):
-                            context.append(plan_tasks[dep_index])
-                    except (ValueError, IndexError):
-                        pass
-                elif dep_id in step_to_task:
-                    context.append(step_to_task[dep_id])
-            
-            # Find matching original task for additional config (memory, callbacks, etc.)
-            original_task = None
-            for orig_task in original_tasks.values():
-                if orig_task.agent and orig_task.agent.display_name == agent.display_name:
-                    original_task = orig_task
-                    break
-            
-            # Create Task with full features from original task if available
-            task = Task(
-                description=step.description,
-                expected_output=f"Complete: {step.description}",
-                agent=agent,
-                name=f"Plan Step {i + 1}",
-                tools=agent.tools if agent.tools else [],
-                context=context if context else None,
-                # Inherit from original task if available
-                memory=original_task.memory if original_task else None,
-                on_task_complete=original_task.callback if original_task else None,
-                guardrails=original_task.guardrail if original_task else None,
-                max_retries=original_task.max_retries if original_task else 3,
-                output_json=original_task.output_json if original_task else None,
-                output_pydantic=original_task.output_pydantic if original_task else None,
-                config=original_task.config if original_task else {}
-            )
-            
-            # Add task to our task list
-            task_id = self.add_task(task)
-            plan_tasks.append(task)
-            step_to_task[step.id] = task
-        
+        original_tasks = self._apply_plan(plan, console)
+
         # Step 5: Execute tasks using the proper Task execution system
         for i, (task_id, task) in enumerate(self.tasks.items()):
             # Update todo list progress
@@ -4030,14 +4130,7 @@ class AgentTeam(SpawnAnnounceProtocol):
         console.print(f"[dim]Progress: [{'█' * 30}] 100%[/dim]")
         console.print(f"[green]Completed {completed_count}/{len(self.tasks)} tasks![/green]\n")
         
-        # Keep plan-step tasks/results under _plan_tasks for introspection,
-        # then restore the user's original task set as the canonical self.tasks.
-        self._plan_tasks = self.tasks
-        self.tasks = original_tasks
-        with self._task_id_lock:
-            self.task_id_counter = (
-                max(original_tasks.keys()) + 1 if original_tasks else 0
-            )
+        self._restore_tasks_after_plan(original_tasks)
 
     # Resource Lifecycle Management
     def close(self) -> None:

--- a/src/praisonai-agents/praisonaiagents/agents/agents.py
+++ b/src/praisonai-agents/praisonaiagents/agents/agents.py
@@ -4004,9 +4004,32 @@ class AgentTeam(SpawnAnnounceProtocol):
         except Exception:
             pass
 
-        original_tasks = self._apply_plan(plan)
+        # _apply_plan mutates self.tasks and the id counter before returning, so
+        # snapshot first and guard the whole apply/execute in try/finally: a
+        # plan that raises mid-construction must not leave the team holding a
+        # half-built task set for every later run.
+        original_tasks = self.tasks.copy()
         try:
-            await self.arun_all_tasks()
+            self._apply_plan(plan)
+
+            # Execute plan-step tasks directly rather than via arun_all_tasks:
+            # _apply_plan builds no next_tasks links, so under process="workflow"
+            # the workflow walker would stop after the first step. Iterating the
+            # tasks in order matches the sync path and also lets the todo list
+            # advance in lockstep, which arun_all_tasks would not do.
+            for i, task_id in enumerate(list(self.tasks.keys())):
+                if self._todo_list and i < len(self._todo_list.items):
+                    self._todo_list.start(self._todo_list.items[i].id)
+                try:
+                    await self.arun_task(task_id)
+                    if (
+                        self.tasks[task_id].status == "completed"
+                        and self._todo_list
+                        and i < len(self._todo_list.items)
+                    ):
+                        self._todo_list.complete(self._todo_list.items[i].id)
+                except Exception as e:
+                    logger.error(f"Error executing plan task {task_id}: {e}")
         finally:
             self._restore_tasks_after_plan(original_tasks)
 
@@ -4088,49 +4111,55 @@ class AgentTeam(SpawnAnnounceProtocol):
         except Exception:
             pass
         
-        original_tasks = self._apply_plan(plan, console)
+        # Snapshot before _apply_plan mutates self.tasks so a construction
+        # failure cannot leave the team holding a half-built plan task set.
+        original_tasks = self.tasks.copy()
+        try:
+            self._apply_plan(plan, console)
 
-        # Step 5: Execute tasks using the proper Task execution system
-        for i, (task_id, task) in enumerate(self.tasks.items()):
-            # Update todo list progress
-            if i < len(self._todo_list.items):
-                item = self._todo_list.items[i]
-                
-                # Display progress bar
-                progress = self._todo_list.progress
-                bar_length = 30
-                filled = int(bar_length * progress)
-                bar = "█" * filled + "░" * (bar_length - filled)
-                console.print(f"[dim]Progress: [{bar}] {progress * 100:.0f}%[/dim]")
-                
-                console.print(f"\n[bold]📌 Step {i + 1}/{len(self.tasks)}:[/bold] {task.description[:60]}...")
-                console.print(f"[dim]   Agent: {task.agent.display_name if task.agent else 'Unknown'}[/dim]")
-                
-                # Mark as in progress
-                self._todo_list.start(item.id)
-            
-            # Execute using the full Task execution system
-            # This includes: memory, callbacks, guardrails, structured output, retry logic
-            try:
-                self.run_task(task_id)
-                
-                if task.status == "completed":
-                    if i < len(self._todo_list.items):
-                        self._todo_list.complete(self._todo_list.items[i].id)
-                    console.print("[green]   ✅ Completed[/green]")
-                else:
-                    console.print(f"[yellow]   ⚠️ Task status: {task.status}[/yellow]")
-            except Exception as e:
-                console.print(f"[red]   ❌ Error: {e}[/red]")
-                logger.error(f"Error executing plan task {task_id}: {e}")
-        
-        # Final progress
-        completed_count = len([t for t in self.tasks.values() if t.status == "completed"])
-        console.print(f"\n[bold green]🎉 EXECUTION COMPLETE[/bold green]")
-        console.print(f"[dim]Progress: [{'█' * 30}] 100%[/dim]")
-        console.print(f"[green]Completed {completed_count}/{len(self.tasks)} tasks![/green]\n")
-        
-        self._restore_tasks_after_plan(original_tasks)
+            console.print("\n[bold blue]🚀 EXECUTION PHASE[/bold blue]\n")
+
+            # Step 5: Execute tasks using the proper Task execution system
+            for i, (task_id, task) in enumerate(self.tasks.items()):
+                # Update todo list progress
+                if i < len(self._todo_list.items):
+                    item = self._todo_list.items[i]
+
+                    # Display progress bar
+                    progress = self._todo_list.progress
+                    bar_length = 30
+                    filled = int(bar_length * progress)
+                    bar = "█" * filled + "░" * (bar_length - filled)
+                    console.print(f"[dim]Progress: [{bar}] {progress * 100:.0f}%[/dim]")
+
+                    console.print(f"\n[bold]📌 Step {i + 1}/{len(self.tasks)}:[/bold] {task.description[:60]}...")
+                    console.print(f"[dim]   Agent: {task.agent.display_name if task.agent else 'Unknown'}[/dim]")
+
+                    # Mark as in progress
+                    self._todo_list.start(item.id)
+
+                # Execute using the full Task execution system
+                # This includes: memory, callbacks, guardrails, structured output, retry logic
+                try:
+                    self.run_task(task_id)
+
+                    if task.status == "completed":
+                        if i < len(self._todo_list.items):
+                            self._todo_list.complete(self._todo_list.items[i].id)
+                        console.print("[green]   ✅ Completed[/green]")
+                    else:
+                        console.print(f"[yellow]   ⚠️ Task status: {task.status}[/yellow]")
+                except Exception as e:
+                    console.print(f"[red]   ❌ Error: {e}[/red]")
+                    logger.error(f"Error executing plan task {task_id}: {e}")
+
+            # Final progress
+            completed_count = len([t for t in self.tasks.values() if t.status == "completed"])
+            console.print(f"\n[bold green]🎉 EXECUTION COMPLETE[/bold green]")
+            console.print(f"[dim]Progress: [{'█' * 30}] 100%[/dim]")
+            console.print(f"[green]Completed {completed_count}/{len(self.tasks)} tasks![/green]\n")
+        finally:
+            self._restore_tasks_after_plan(original_tasks)
 
     # Resource Lifecycle Management
     def close(self) -> None:

--- a/src/praisonai-agents/tests/unit/agents/test_astart_honours_planning.py
+++ b/src/praisonai-agents/tests/unit/agents/test_astart_honours_planning.py
@@ -1,0 +1,178 @@
+"""astart() must honour planning=True, as start() already does.
+
+`planning` gates a built feature: a plan from a PlanningAgent, a TodoList, and
+an approval gate before anything runs. `_start_impl` branches on it in both of
+its arms. `_astart_impl` did not mention `self.planning` at all and went
+straight to `arun_all_tasks()`, so every async entry point -- workflows,
+gateway protocols, the AGUI stream, the eval judge, autoagents -- ran the raw
+task list as though planning had never been set, with no error and no
+difference in the return shape.
+"""
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from praisonaiagents.agents.agents import PraisonAIAgents
+
+
+class _Recorder:
+    """A PraisonAIAgents with the execution and planning seams stubbed out, so
+    the test observes which path was taken and nothing talks to a model."""
+
+    def __init__(self, agents, planning, plan=None, approved=True):
+        self.calls = []
+        self.plan = plan
+        self.approved = approved
+        self.agents = agents
+
+
+@pytest.fixture
+def team(monkeypatch):
+    def build(planning, plan=object(), approved=True):
+        instance = PraisonAIAgents.__new__(PraisonAIAgents)
+        instance.planning = planning
+        instance.auto_approve_plan = approved
+        instance.tasks = {}
+        instance.calls = []
+
+        async def arun_all_tasks():
+            instance.calls.append("arun_all_tasks")
+
+        async def _arun_with_planning():
+            instance.calls.append("_arun_with_planning")
+
+        instance.arun_all_tasks = arun_all_tasks
+        instance._arun_with_planning = _arun_with_planning
+        instance.get_all_tasks_status = lambda: {}
+        instance.get_task_result = lambda _id: None
+        return instance
+
+    return build
+
+
+@pytest.mark.asyncio
+async def test_astart_runs_the_planning_path_when_planning_is_on(team):
+    agents = team(planning=True)
+
+    await agents._astart_impl()
+
+    assert agents.calls == ["_arun_with_planning"]
+
+
+@pytest.mark.asyncio
+async def test_astart_runs_tasks_directly_when_planning_is_off(team):
+    agents = team(planning=False)
+
+    await agents._astart_impl()
+
+    assert agents.calls == ["arun_all_tasks"]
+
+
+@pytest.mark.asyncio
+async def test_planning_falls_back_to_plain_execution_when_no_plan(team):
+    # A PlanningAgent that returns nothing must not strand the run.
+    agents = team(planning=True)
+    ran = []
+
+    async def _create_plan(request=None, context=None):
+        ran.append(("plan", request))
+        return None
+
+    async def arun_all_tasks():
+        ran.append("arun_all_tasks")
+
+    agents._create_plan = _create_plan
+    agents.arun_all_tasks = arun_all_tasks
+
+    await PraisonAIAgents._arun_with_planning(agents)
+
+    assert ran[-1] == "arun_all_tasks"
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_plan_runs_nothing(team):
+    agents = team(planning=True, approved=False)
+    agents.auto_approve_plan = False
+    ran = []
+
+    class _Plan:
+        steps = []
+
+        def approve(self):
+            ran.append("approve")
+
+    async def _create_plan(request=None, context=None):
+        return _Plan()
+
+    async def _request_approval(plan):
+        ran.append("asked")
+        return False
+
+    async def arun_all_tasks():
+        ran.append("arun_all_tasks")
+
+    agents._create_plan = _create_plan
+    agents._request_approval = _request_approval
+    agents.arun_all_tasks = arun_all_tasks
+
+    await PraisonAIAgents._arun_with_planning(agents)
+
+    # Asked, refused, and stopped. The approval gate is the point of the
+    # feature, so running anyway would be worse than not planning at all.
+    assert ran == ["asked"]
+
+
+def test_the_plan_to_task_builder_is_shared_by_both_paths():
+    # Both planning paths must build tasks the same way; the async one was
+    # proposed without this, which would have planned and then run the original
+    # tasks instead of the plan's steps.
+    import inspect
+
+    sync_src = inspect.getsource(PraisonAIAgents._run_with_planning)
+    async_src = inspect.getsource(PraisonAIAgents._arun_with_planning)
+
+    assert "_apply_plan" in sync_src
+    assert "_apply_plan" in async_src
+
+
+@pytest.mark.asyncio
+async def test_the_original_task_set_is_put_back_after_a_planned_run(team):
+    # _apply_plan swaps self.tasks for the plan's steps. The sync path restored
+    # the caller's tasks afterwards; the async path has to as well, or a team
+    # comes back from astart() holding tasks it never defined.
+    agents = team(planning=True)
+    original = {0: SimpleNamespace(description="the caller's task")}
+    agents.tasks = dict(original)
+    ran = []
+
+    class _Plan:
+        name = "a plan"
+        steps = []
+
+        def approve(self):
+            pass
+
+    async def _create_plan(request=None, context=None):
+        return _Plan()
+
+    def _apply_plan(plan, console=None):
+        previous = agents.tasks
+        agents.tasks = {0: SimpleNamespace(description="a plan step")}
+        return previous
+
+    async def arun_all_tasks():
+        ran.append(dict(agents.tasks))
+
+    agents._create_plan = _create_plan
+    agents._apply_plan = _apply_plan
+    agents.arun_all_tasks = arun_all_tasks
+    agents._task_id_lock = __import__("threading").Lock()
+
+    await PraisonAIAgents._arun_with_planning(agents)
+
+    assert [t.description for t in ran[0].values()] == ["a plan step"]  # ran the plan
+    assert agents.tasks == original                                     # gave the original back
+    assert [t.description for t in agents._plan_tasks.values()] == ["a plan step"]

--- a/src/praisonai-agents/tests/unit/agents/test_astart_honours_planning.py
+++ b/src/praisonai-agents/tests/unit/agents/test_astart_honours_planning.py
@@ -160,15 +160,17 @@ async def test_the_original_task_set_is_put_back_after_a_planned_run(team):
 
     def _apply_plan(plan, console=None):
         previous = agents.tasks
-        agents.tasks = {0: SimpleNamespace(description="a plan step")}
+        agents.tasks = {0: SimpleNamespace(description="a plan step", status="completed")}
         return previous
 
-    async def arun_all_tasks():
+    async def arun_task(task_id):
+        # The plan's steps are executed one at a time; record what self.tasks
+        # held at execution so the test can prove the plan ran, not the original.
         ran.append(dict(agents.tasks))
 
     agents._create_plan = _create_plan
     agents._apply_plan = _apply_plan
-    agents.arun_all_tasks = arun_all_tasks
+    agents.arun_task = arun_task
     agents._task_id_lock = __import__("threading").Lock()
 
     await PraisonAIAgents._arun_with_planning(agents)
@@ -176,3 +178,97 @@ async def test_the_original_task_set_is_put_back_after_a_planned_run(team):
     assert [t.description for t in ran[0].values()] == ["a plan step"]  # ran the plan
     assert agents.tasks == original                                     # gave the original back
     assert [t.description for t in agents._plan_tasks.values()] == ["a plan step"]
+
+
+@pytest.mark.asyncio
+async def test_every_plan_step_runs_and_the_todo_list_advances(team):
+    # The async path must execute each plan step (not just the first, as it
+    # would under process="workflow" without next_tasks links) and mark the
+    # matching todo items done as it goes -- parity with the sync path.
+    agents = team(planning=True)
+    agents.tasks = {0: SimpleNamespace(description="the caller's task")}
+
+    class _Plan:
+        name = "a plan"
+        steps = []
+
+        def approve(self):
+            pass
+
+    class _Item:
+        def __init__(self, _id):
+            self.id = _id
+            self.state = "pending"
+
+    class _Todo:
+        def __init__(self):
+            self.items = [_Item("a"), _Item("b"), _Item("c")]
+
+        def start(self, _id):
+            next(i for i in self.items if i.id == _id).state = "in_progress"
+
+        def complete(self, _id):
+            next(i for i in self.items if i.id == _id).state = "done"
+
+    executed = []
+
+    async def _create_plan(request=None, context=None):
+        return _Plan()
+
+    def _apply_plan(plan, console=None):
+        previous = agents.tasks
+        agents.tasks = {
+            n: SimpleNamespace(description=f"step {n}", status="completed")
+            for n in range(3)
+        }
+        agents._todo_list = _Todo()
+        return previous
+
+    async def arun_task(task_id):
+        executed.append(task_id)
+
+    agents._create_plan = _create_plan
+    agents._apply_plan = _apply_plan
+    agents.arun_task = arun_task
+    agents._task_id_lock = __import__("threading").Lock()
+
+    await PraisonAIAgents._arun_with_planning(agents)
+
+    assert executed == [0, 1, 2]                                  # every step ran
+    assert [i.state for i in agents._todo_list.items] == [
+        "done",
+        "done",
+        "done",
+    ]  # the todo list advanced
+
+
+@pytest.mark.asyncio
+async def test_a_plan_that_fails_to_apply_restores_the_original_tasks(team):
+    # _apply_plan mutates self.tasks; if it raises mid-construction the caller
+    # must not be left holding a half-built plan task set.
+    agents = team(planning=True)
+    original = {0: SimpleNamespace(description="the caller's task")}
+    agents.tasks = dict(original)
+
+    class _Plan:
+        name = "a plan"
+        steps = []
+
+        def approve(self):
+            pass
+
+    async def _create_plan(request=None, context=None):
+        return _Plan()
+
+    def _apply_plan(plan, console=None):
+        agents.tasks = {}  # publish a partial set, then fail
+        raise ValueError("bad plan step")
+
+    agents._create_plan = _create_plan
+    agents._apply_plan = _apply_plan
+    agents._task_id_lock = __import__("threading").Lock()
+
+    with pytest.raises(ValueError):
+        await PraisonAIAgents._arun_with_planning(agents)
+
+    assert agents.tasks == original  # restored despite the failure


### PR DESCRIPTION
Addresses **item 2 only** of #5013 — `AgentManager.astart()` silently ignoring `planning=True`. Item 1 is #5014; item 3 is untouched.

`_start_impl` branches on `self.planning` in both of its arms. `_astart_impl` never mentioned it:

```python
await self.arun_all_tasks()   # self.planning is never checked
```

So a team built with `planning=True` and driven through `astart()` — workflows, gateway protocols, the AGUI stream, the eval judge, autoagents, `execution_mixin` — skipped plan generation, the todo list and the **approval gate**, with no error, no log line and no difference in the return shape.

## One deliberate departure from the shape in the issue

The suggested `_arun_with_planning` ends with:

```python
self._todo_list = TodoList.from_plan(plan)
await self.arun_all_tasks()
```

That plans, and then runs the *original* tasks. `_run_with_planning`'s Step 4 rebuilds `self.tasks` as one `Task` per plan step before executing, so the sync and async paths would have produced a plan and then executed different work — a subtler version of the same bug.

So instead of duplicating those ~80 lines, they come out of `_run_with_planning` into two shared helpers:

- **`_apply_plan(plan, console=None)`** — builds one `Task` per plan step, inheriting memory, callbacks, guardrails, retries and structured output from whichever original task shared its agent, and turning step dependencies into task context. Returns the caller's original task dict. The sync path passes its Rich console and prints exactly as before; the async path passes nothing and the two warnings go to the log.
- **`_restore_tasks_after_plan(original_tasks)`** — puts the caller's task set back and parks the plan's under `_plan_tasks`. The async path calls it in a `finally`, so a failing task cannot leave a team holding tasks it never defined.

`_run_with_planning`'s behaviour is unchanged: same construction, same console output, same restore, now via the helpers.

## Verified — red before green

`tests/unit/agents/test_astart_honours_planning.py`, six tests. Production file stashed, tests left in place:

```
$ git stash push -- praisonaiagents/agents/agents.py
$ python -m pytest tests/unit/agents/test_astart_honours_planning.py -q
AttributeError: type object 'AgentTeam' has no attribute '_arun_with_planning'
4 failed, 1 passed

$ git stash pop
$ python -m pytest tests/unit/agents/test_astart_honours_planning.py -q
6 passed
```

They cover: planning on takes the planning path; planning off does not; a `PlanningAgent` that returns no plan falls back to plain execution instead of stranding the run; **a rejected plan runs nothing at all** (the approval gate is the point, so running anyway would be worse than not planning); both paths go through `_apply_plan`; and the original task set comes back afterwards while the plan's tasks stay reachable as `_plan_tasks`.

## No regressions

`tests/unit/agents`, before and after:

| | failed | passed |
| --- | --- | --- |
| pristine `main` (my new test file present, so 4 of these are mine) | 5 | 150 |
| this branch | **1** | **155** |

The one remaining failure is `test_team_default_llm.py::test_team_llm_fills_in_members_without_a_model`, which fails on pristine `main` too — it wants `praisonaiagents[llm]` installed.

## Note

This PR was written with AI assistance. I understand the change and can defend or revise it; the numbers above are runs I did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Asynchronous agent runs now support planning workflows, including plan creation, approval, progress tracking, and planned task execution.
  - Planned tasks now execute individually, ensuring all steps run correctly in workflow mode.
  - Todo items advance as planned tasks complete.
  - Original tasks are restored after planned execution, including when errors occur during plan application.

- **Bug Fixes**
  - Log messages no longer display Rich markup, improving readability.
  - Synchronous and asynchronous planning now follow consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->