### PR TITLE
fix(cli): derive output budget from model limits

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/llm/__init__.py
@@ -87,6 +87,10 @@ def __getattr__(name):
             from .model_capabilities import supports_streaming_with_tools
             _lazy_cache[name] = supports_streaming_with_tools
             return supports_streaming_with_tools
+        elif name == "max_output_tokens":
+            from .model_capabilities import max_output_tokens
+            _lazy_cache[name] = max_output_tokens
+            return max_output_tokens
         elif name == "ModelRouter":
             from .model_router import ModelRouter
             _lazy_cache[name] = ModelRouter

--- a/src/praisonai-agents/praisonaiagents/llm/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/llm/__init__.py
@@ -247,6 +247,7 @@ __all__ = [
     "process_stream_chunks",
     "supports_structured_outputs",
     "supports_streaming_with_tools",
+    "max_output_tokens",
     "ModelRouter",
     "ModelProfile",
     "TaskComplexity",

--- a/src/praisonai-agents/praisonaiagents/llm/model_capabilities.py
+++ b/src/praisonai-agents/praisonaiagents/llm/model_capabilities.py
@@ -86,7 +86,11 @@ def max_output_tokens(model_name: str) -> Optional[int]:
         info = _model_info(litellm, model_name)
         if not info:
             return None
-        value = info.get("max_output_tokens") or info.get("max_tokens")
+        # LiteLLM's ``max_tokens`` field is the model context window.  It is
+        # intentionally not a fallback here: using it as an output ceiling
+        # can send provider-invalid completion limits.  Only the explicit
+        # output-limit field is safe for this accessor.
+        value = info.get("max_output_tokens")
         if isinstance(value, bool) or value is None:
             return None
         value = int(value)

--- a/src/praisonai-agents/praisonaiagents/llm/model_capabilities.py
+++ b/src/praisonai-agents/praisonaiagents/llm/model_capabilities.py
@@ -26,6 +26,7 @@ Sources:
 """
 
 from functools import lru_cache
+from typing import Any, Dict, Optional
 
 from ._litellm_loader import get_litellm as _get_litellm
 
@@ -36,6 +37,62 @@ def _base_model_name(model_name: str) -> str:
     if "/" in name:
         name = name.split("/", 1)[1]
     return name
+
+
+def _model_info(litellm: Any, model_name: str) -> Optional[Dict[str, Any]]:
+    """Best-effort lookup of LiteLLM metadata for ``model_name``.
+
+    Newer LiteLLM releases expose ``get_model_info`` while older releases
+    expose the same records through ``model_cost``.  Keep both lookups lazy so
+    lean installs retain the existing optional-dependency behaviour.
+    """
+    getter = getattr(litellm, "get_model_info", None)
+    if getter is not None:
+        try:
+            info = getter(model=model_name)
+            if isinstance(info, dict):
+                return info
+        except Exception:
+            pass
+
+    model_cost = getattr(litellm, "model_cost", None)
+    if not isinstance(model_cost, dict):
+        return None
+    candidates = [model_name.lower(), _base_model_name(model_name)]
+    if "/" in model_name:
+        candidates.append(model_name.rsplit("/", 1)[-1].lower())
+    for candidate in candidates:
+        info = model_cost.get(candidate)
+        if isinstance(info, dict):
+            return info
+    return None
+
+
+@lru_cache(maxsize=256)
+def max_output_tokens(model_name: str) -> Optional[int]:
+    """Return LiteLLM's known maximum output tokens for a model.
+
+    ``None`` means the model is unknown or LiteLLM is unavailable.  The
+    accessor is intentionally best-effort: callers can preserve their current
+    defaults when metadata is missing without making model resolution fail.
+    """
+    if not model_name:
+        return None
+
+    litellm = _get_litellm()
+    if litellm is None:
+        return None
+    try:
+        info = _model_info(litellm, model_name)
+        if not info:
+            return None
+        value = info.get("max_output_tokens") or info.get("max_tokens")
+        if isinstance(value, bool) or value is None:
+            return None
+        value = int(value)
+        return value if value > 0 else None
+    except (TypeError, ValueError, OverflowError):
+        return None
 
 
 def _fallback_supports_structured_outputs(model_name: str) -> bool:

--- a/src/praisonai-agents/tests/test_model_capabilities_fallback.py
+++ b/src/praisonai-agents/tests/test_model_capabilities_fallback.py
@@ -159,4 +159,14 @@ def test_max_output_tokens_unknown_or_invalid_is_none():
     )
     with patch.object(mc, "_get_litellm", return_value=fake):
         assert mc.max_output_tokens("unknown-model") is None
+
+
+def test_max_output_tokens_does_not_treat_context_limit_as_output_limit():
+    mc.max_output_tokens.cache_clear()
+    fake = SimpleNamespace(
+        get_model_info=lambda *, model: {"max_tokens": 128000}
+    )
+    with patch.object(mc, "_get_litellm", return_value=fake):
+        assert mc.max_output_tokens("unknown-model") is None
+    mc.max_output_tokens.cache_clear()
     mc.max_output_tokens.cache_clear()

--- a/src/praisonai-agents/tests/test_model_capabilities_fallback.py
+++ b/src/praisonai-agents/tests/test_model_capabilities_fallback.py
@@ -40,6 +40,7 @@ def _clear_caches():
         mc.supports_parallel_function_calling,
         mc.supports_web_search,
         mc.supports_prompt_caching,
+        mc.max_output_tokens,
     ):
         fn.cache_clear()
 
@@ -126,3 +127,36 @@ def test_empty_model_name_is_false():
         assert mc.supports_web_search("") is False
         assert mc.supports_prompt_caching("") is False
     _clear_caches()
+
+
+def test_max_output_tokens_uses_litellm_model_info():
+    _clear_caches()
+    fake = SimpleNamespace(
+        get_model_info=lambda *, model: {
+            "max_output_tokens": 8192,
+            "max_tokens": 16384,
+        }
+    )
+    with patch.object(mc, "_get_litellm", return_value=fake):
+        assert mc.max_output_tokens("anthropic/claude-test") == 8192
+    mc.max_output_tokens.cache_clear()
+
+
+def test_max_output_tokens_falls_back_to_model_cost():
+    mc.max_output_tokens.cache_clear()
+    fake = SimpleNamespace(
+        model_cost={"gpt-test": {"max_output_tokens": 4096}}
+    )
+    with patch.object(mc, "_get_litellm", return_value=fake):
+        assert mc.max_output_tokens("openai/gpt-test") == 4096
+    mc.max_output_tokens.cache_clear()
+
+
+def test_max_output_tokens_unknown_or_invalid_is_none():
+    mc.max_output_tokens.cache_clear()
+    fake = SimpleNamespace(
+        get_model_info=lambda *, model: {"max_output_tokens": "not-a-number"}
+    )
+    with patch.object(mc, "_get_litellm", return_value=fake):
+        assert mc.max_output_tokens("unknown-model") is None
+    mc.max_output_tokens.cache_clear()

--- a/src/praisonai-code/praisonai_code/cli/commands/run.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/run.py
@@ -61,7 +61,16 @@ def _resolve_max_tokens(
         f"clamping to {ceiling}"
     )
     if output is not None:
-        if getattr(output, "is_json_mode", False) and hasattr(output, "print_json"):
+        output_mode = getattr(getattr(output, "mode", None), "value", None)
+        if output_mode == "stream-json" and hasattr(output, "emit_event"):
+            # stream-json is an NDJSON protocol: never use print_json(), whose
+            # indentation emits a multi-line object and corrupts framing.
+            output.emit_event(
+                "warning",
+                message=message,
+                data={"code": "max_tokens_clamped"},
+            )
+        elif getattr(output, "is_json_mode", False) and hasattr(output, "print_json"):
             # ``print_warning`` intentionally suppresses human text in JSON
             # mode. Emit a structured diagnostic so automation can see that
             # the requested value was lowered without corrupting stderr.
@@ -1445,6 +1454,27 @@ def run_main(
     if target:  # Only check if we actually have something to run
         import sys
         from praisonai_code.llm.credentials import ensure_configured_or_onboard
+
+        # A custom agent may declare its model in frontmatter. Resolve that
+        # model before deriving the default output budget; otherwise an omitted
+        # ``--model`` is budgeted at the generic 16k fallback and then attached
+        # to the frontmatter model, which can have a different ceiling.
+        if agent and model is None:
+            try:
+                from praisonai_code.cli.features.custom_definitions import (
+                    load_agent_from_name,
+                )
+
+                _preview_config = load_agent_from_name(agent)
+                _preview_llm = (_preview_config or {}).get("llm")
+                if isinstance(_preview_llm, dict):
+                    _preview_llm = _preview_llm.get("model")
+                if isinstance(_preview_llm, str) and _preview_llm.strip():
+                    model = _preview_llm.strip()
+            except Exception:
+                # The normal custom-agent load below reports missing/invalid
+                # definitions; preview is only for model-aware budgeting.
+                pass
 
         _headless = (not sys.stdin.isatty()) or output.is_json_mode
         model = ensure_configured_or_onboard(model=model, interactive=not _headless)

--- a/src/praisonai-code/praisonai_code/cli/commands/run.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/run.py
@@ -1451,6 +1451,11 @@ def run_main(
     # generator resolve each agent against its own ceiling. Prompt/custom-agent
     # paths use the resolved top-level model here.
     is_yaml_target = bool(target and _is_yaml_file(target))
+    # Loading a named custom definition performs a complete discovery pass
+    # (including opt-in local tool modules). Keep the preview result so the
+    # execution path does not discover and execute the same definitions twice.
+    preloaded_agent_config = None
+    custom_agent_model = None
     if target or agent or command:  # Any execution surface may need model/budget resolution
         import sys
         from praisonai_code.llm.credentials import ensure_configured_or_onboard
@@ -1466,24 +1471,39 @@ def run_main(
                 )
 
                 _preview_config = load_agent_from_name(agent)
+                preloaded_agent_config = _preview_config
                 _preview_llm = (_preview_config or {}).get("llm")
                 if isinstance(_preview_llm, dict):
-                    _preview_llm = _preview_llm.get("model")
-                if isinstance(_preview_llm, str) and _preview_llm.strip():
-                    model = _preview_llm.strip()
+                    custom_agent_model = _preview_llm.get("model")
+                else:
+                    custom_agent_model = _preview_llm
+                if isinstance(custom_agent_model, str):
+                    custom_agent_model = custom_agent_model.strip() or None
             except Exception:
                 # The normal custom-agent load below reports missing/invalid
                 # definitions; preview is only for model-aware budgeting.
                 pass
 
         _headless = (not sys.stdin.isatty()) or output.is_json_mode
-        model = ensure_configured_or_onboard(model=model, interactive=not _headless)
+        # A frontmatter model is used for credential checks and budget
+        # resolution, but must not be passed as a synthetic ``--model``
+        # override: doing so replaces a mapping-valued LLM spec and discards
+        # endpoint, credentials, sampling, and retry options.
+        credential_model = model or custom_agent_model
+        resolved_model = ensure_configured_or_onboard(
+            model=credential_model, interactive=not _headless
+        )
+        if not (agent and model is None and custom_agent_model):
+            model = resolved_model
         # A YAML file is a workflow target only when no named custom agent or
         # command is selected. In the latter cases the file is merely the
         # prompt/argument source and the named definition still needs its own
         # model-aware budget resolution.
         if not is_yaml_target or agent or command:
-            max_tokens = _resolve_max_tokens(model, max_tokens, output=output)
+            budget_model = custom_agent_model or model
+            max_tokens = _resolve_max_tokens(
+                budget_model, max_tokens, output=output
+            )
 
     # Worktree isolation runs the agent in a chdir'd worktree in-process; the
     # warm runtime is a separate process whose cwd we can't redirect, so reject
@@ -1549,7 +1569,11 @@ def run_main(
     # Handle custom agent or command
     if agent:
         from praisonai_code.cli.features.custom_definitions import load_agent_from_name
-        agent_config = load_agent_from_name(agent)
+        agent_config = (
+            preloaded_agent_config
+            if preloaded_agent_config is not None
+            else load_agent_from_name(agent)
+        )
         if not agent_config:
             output.print_error(f"Agent '{agent}' not found")
             raise typer.Exit(1)
@@ -1932,6 +1956,7 @@ def _run_from_file(
             args.cli_project_sessions = bool(session_id or auto_save_name)
             args.output = output_mode
             args.max_tokens = max_tokens
+            args._max_tokens_explicit = max_tokens is not None
             if effective_approval:
                 args.approval = effective_approval
             if approve_all_tools:
@@ -2251,6 +2276,7 @@ def _run_prompt(
         args.tools = tools
         args.toolset = toolset
         args.max_tokens = max_tokens
+        args._max_tokens_explicit = max_tokens is not None
         args.web_search = False
         args.web_fetch = False
         args.prompt_caching = False
@@ -2448,6 +2474,7 @@ def _run_from_file_profiled(
         args.cli_project_sessions = bool(session_id or auto_save_name)
         args.output = output_mode
         args.max_tokens = max_tokens
+        args._max_tokens_explicit = max_tokens is not None
         if approval:
             args.approval = approval
         if approve_all_tools:
@@ -2656,9 +2683,17 @@ def _run_custom_agent(
     try:
         from praisonaiagents import Agent
         
-        # Override model if specified
+        # Override only the model field when the definition supplies a full
+        # LLM mapping. Replacing the mapping wholesale would discard endpoint,
+        # credentials, sampling, retry, and provider-specific options.
         if model:
-            agent_config["llm"] = model
+            if isinstance(agent_config.get("llm"), dict):
+                agent_config["llm"] = {
+                    **agent_config["llm"],
+                    "model": model,
+                }
+            else:
+                agent_config["llm"] = model
         agent_config["llm"] = _llm_spec_with_max_tokens(
             agent_config.get("llm"), model, max_tokens
         )

--- a/src/praisonai-code/praisonai_code/cli/commands/run.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/run.py
@@ -1451,7 +1451,7 @@ def run_main(
     # generator resolve each agent against its own ceiling. Prompt/custom-agent
     # paths use the resolved top-level model here.
     is_yaml_target = bool(target and _is_yaml_file(target))
-    if target:  # Only check if we actually have something to run
+    if target or agent or command:  # Any execution surface may need model/budget resolution
         import sys
         from praisonai_code.llm.credentials import ensure_configured_or_onboard
 
@@ -1478,7 +1478,11 @@ def run_main(
 
         _headless = (not sys.stdin.isatty()) or output.is_json_mode
         model = ensure_configured_or_onboard(model=model, interactive=not _headless)
-        if not is_yaml_target:
+        # A YAML file is a workflow target only when no named custom agent or
+        # command is selected. In the latter cases the file is merely the
+        # prompt/argument source and the named definition still needs its own
+        # model-aware budget resolution.
+        if not is_yaml_target or agent or command:
             max_tokens = _resolve_max_tokens(model, max_tokens, output=output)
 
     # Worktree isolation runs the agent in a chdir'd worktree in-process; the

--- a/src/praisonai-code/praisonai_code/cli/commands/run.py
+++ b/src/praisonai-code/praisonai_code/cli/commands/run.py
@@ -20,6 +20,72 @@ app = typer.Typer(help="Run agents")
 _FRAMEWORK_HELP = "Framework: praisonai, crewai, autogen"
 
 _ALLOW_LOCAL_TOOLS_ENV = "PRAISONAI_ALLOW_LOCAL_TOOLS"
+DEFAULT_MAX_TOKENS = 16000
+
+
+def _resolve_max_tokens(
+    model: Optional[str],
+    requested: Optional[int],
+    *,
+    output: Any = None,
+) -> int:
+    """Resolve the output budget against the selected model's known limit.
+
+    LiteLLM metadata is optional and best-effort. Unknown models retain the
+    historical default, while an omitted budget uses the known model limit and
+    an explicit oversized value is capped with a diagnostic.
+    """
+    explicit = requested is not None
+    value = DEFAULT_MAX_TOKENS if requested is None else requested
+    if not model or value <= 0:
+        return value
+
+    try:
+        from praisonaiagents.llm.model_capabilities import max_output_tokens
+
+        ceiling = max_output_tokens(model)
+    except Exception:
+        ceiling = None
+
+    if not ceiling or ceiling <= 0:
+        return value
+    if not explicit:
+        # A known limit is authoritative.  Returning the full ceiling avoids
+        # retaining the historical 16k cap on models that can emit more.
+        return ceiling
+    if value <= ceiling:
+        return value
+
+    message = (
+        f"--max-tokens {value} exceeds {model}'s output limit ({ceiling}); "
+        f"clamping to {ceiling}"
+    )
+    if output is not None:
+        if getattr(output, "is_json_mode", False) and hasattr(output, "print_json"):
+            # ``print_warning`` intentionally suppresses human text in JSON
+            # mode. Emit a structured diagnostic so automation can see that
+            # the requested value was lowered without corrupting stderr.
+            output.print_json({"warning": message, "code": "max_tokens_clamped"})
+        else:
+            output.print_warning(message)
+    return ceiling
+
+
+def _llm_spec_with_max_tokens(
+    llm_spec: Any,
+    model: Optional[str],
+    max_tokens: Optional[int],
+) -> Any:
+    """Add a resolved output budget to an LLM spec without losing options."""
+    if max_tokens is None:
+        return llm_spec
+    spec = dict(llm_spec) if isinstance(llm_spec, dict) else {}
+    if not spec.get("model"):
+        spec["model"] = llm_spec if isinstance(llm_spec, str) else model
+    if not spec.get("model"):
+        return llm_spec
+    spec["max_tokens"] = max_tokens
+    return spec
 
 
 def _run_succeeded(result: Any) -> bool:
@@ -1158,7 +1224,7 @@ def run_main(
     tools: Optional[str] = typer.Option(None, "--tools", "-t", help="Comma-separated tool names (e.g. web_search,github) or a tools.py file path"),
     toolset: Optional[str] = typer.Option(None, "--toolset", help="Named toolset groups (comma-separated, e.g., web,files)"),
     allow_local_tools: bool = typer.Option(False, "--allow-local-tools", help="Load project-local .praisonai/tools/*.py (equivalent to PRAISONAI_ALLOW_LOCAL_TOOLS=true)"),
-    max_tokens: int = typer.Option(16000, "--max-tokens", help="Maximum output tokens"),
+    max_tokens: Optional[int] = typer.Option(None, "--max-tokens", help="Maximum output tokens (defaults to the known model limit; 16000 when unknown)"),
     profile: bool = typer.Option(False, "--profile", help="Enable CLI profiling (timing breakdown)"),
     profile_deep: bool = typer.Option(False, "--profile-deep", help="Enable deep profiling (cProfile stats, higher overhead)"),
     output_mode: Optional[str] = typer.Option(None, "--output", "-o", help="Output mode: silent (default), actions, verbose, json, stream"),
@@ -1371,12 +1437,19 @@ def run_main(
     # identically instead of dead-ending on a raw provider error. Headless
     # (non-TTY / --output json) fails fast with the actionable hint; interactive
     # offers the wizard and re-checks.
+    # YAML agents may select a different model (or an explicit per-agent
+    # max_tokens), so leave their raw option untouched and let the YAML
+    # generator resolve each agent against its own ceiling. Prompt/custom-agent
+    # paths use the resolved top-level model here.
+    is_yaml_target = bool(target and _is_yaml_file(target))
     if target:  # Only check if we actually have something to run
         import sys
         from praisonai_code.llm.credentials import ensure_configured_or_onboard
 
         _headless = (not sys.stdin.isatty()) or output.is_json_mode
         model = ensure_configured_or_onboard(model=model, interactive=not _headless)
+        if not is_yaml_target:
+            max_tokens = _resolve_max_tokens(model, max_tokens, output=output)
 
     # Worktree isolation runs the agent in a chdir'd worktree in-process; the
     # warm runtime is a separate process whose cwd we can't redirect, so reject
@@ -1614,6 +1687,7 @@ def run_main(
                 approve_all_tools=approve_all_tools,
                 approval_timeout=approval_timeout,
                 output_mode=output_mode,
+                max_tokens=max_tokens,
             )
         else:
             # Profiling for direct prompt
@@ -1631,6 +1705,7 @@ def run_main(
                 approval=approval,
                 approve_all_tools=approve_all_tools,
                 approval_timeout=approval_timeout,
+                max_tokens=max_tokens,
             )
         return
     
@@ -1724,7 +1799,7 @@ def _run_from_file(
     trace: bool = False,
     memory: bool = False,
     tools: Optional[str] = None,
-    max_tokens: int = 16000,
+    max_tokens: Optional[int] = None,
     output_mode: Optional[str] = None,
     continue_session: bool = False,
     session: Optional[str] = None,
@@ -1812,6 +1887,7 @@ def _run_from_file(
             or effective_approval
             or approve_all_tools
             or output_mode
+            or max_tokens is not None
         ):
             class Args:
                 pass
@@ -1821,6 +1897,7 @@ def _run_from_file(
             args.resume_session = session_id
             args.cli_project_sessions = bool(session_id or auto_save_name)
             args.output = output_mode
+            args.max_tokens = max_tokens
             if effective_approval:
                 args.approval = effective_approval
             if approve_all_tools:
@@ -1979,6 +2056,10 @@ def _run_prompt(
         runtime_eligible = (
             (no_save or stateful_attach)
             and thinking_budget is None
+            # The warm runtime API has no per-request output-budget field. A
+            # resolved non-default budget must stay in-process so it cannot be
+            # silently replaced by the runtime's own default.
+            and max_tokens == DEFAULT_MAX_TOKENS
             and not isolated
             and not append_system_prompt
             and not image
@@ -2021,6 +2102,9 @@ def _run_prompt(
             }
             if model:
                 agent_config["llm"] = model
+            agent_config["llm"] = _llm_spec_with_max_tokens(
+                agent_config.get("llm"), model, max_tokens
+            )
             
             # Resolve approval backend if specified
             if approval:
@@ -2252,6 +2336,7 @@ def _run_from_file_profiled(
     approve_all_tools: bool = False,
     approval_timeout: Optional[str] = None,
     output_mode: Optional[str] = None,
+    max_tokens: Optional[int] = None,
 ):
     """Run agents from a YAML file with profiling enabled."""
     from praisonai_code.cli.features.cli_profiler import (
@@ -2319,7 +2404,7 @@ def _run_from_file_profiled(
     # the same ``args`` the legacy YAML path reads, so a profiled YAML run is
     # permission-gated identically to the non-profiled path instead of silently
     # dropping the deny policy.
-    if session_id or auto_save_name or approval or approve_all_tools or output_mode:
+    if session_id or auto_save_name or approval or approve_all_tools or output_mode or max_tokens is not None:
         class Args:
             pass
         
@@ -2328,6 +2413,7 @@ def _run_from_file_profiled(
         args.resume_session = session_id
         args.cli_project_sessions = bool(session_id or auto_save_name)
         args.output = output_mode
+        args.max_tokens = max_tokens
         if approval:
             args.approval = approval
         if approve_all_tools:
@@ -2539,6 +2625,9 @@ def _run_custom_agent(
         # Override model if specified
         if model:
             agent_config["llm"] = model
+        agent_config["llm"] = _llm_spec_with_max_tokens(
+            agent_config.get("llm"), model, max_tokens
+        )
 
         # Compose the agent's toolset: frontmatter ``tools:`` (name strings)
         # + explicit --tools/--toolset + auto-discovered project-local
@@ -2734,6 +2823,7 @@ def _run_prompt_profiled(
     approval: Optional[str] = None,
     approve_all_tools: bool = False,
     approval_timeout: Optional[str] = None,
+    max_tokens: Optional[int] = None,
 ):
     """Run a direct prompt with profiling enabled."""
     from praisonai_code.cli.features.cli_profiler import (
@@ -2770,6 +2860,9 @@ def _run_prompt_profiled(
     }
     if model:
         agent_config["llm"] = model
+    agent_config["llm"] = _llm_spec_with_max_tokens(
+        agent_config.get("llm"), model, max_tokens
+    )
 
     # Thread the approval backend (e.g. --plan -> PermissionMode.PLAN) into the
     # profiled agent so a read-only planning run stays read-only under

--- a/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
+++ b/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
@@ -2053,6 +2053,10 @@ class PraisonAI:
         if output_mode is not None:
             cli_config['output'] = output_mode
 
+        max_tokens = getattr(self.args, 'max_tokens', None)
+        if max_tokens is not None:
+            cli_config['max_tokens'] = max_tokens
+
         # Extract handoff configuration for YAML CLI parity
         handoff = getattr(self.args, 'handoff', None)
         if handoff:

--- a/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
+++ b/src/praisonai-code/praisonai_code/cli/legacy/praison_ai.py
@@ -2056,6 +2056,12 @@ class PraisonAI:
         max_tokens = getattr(self.args, 'max_tokens', None)
         if max_tokens is not None:
             cli_config['max_tokens'] = max_tokens
+        # Newer callers mark whether the CLI option was explicitly supplied;
+        # retain that bit so YAML agent-level budgets are not shadowed by a
+        # parser default of 16000.
+        explicit_max_tokens = getattr(self.args, '_max_tokens_explicit', None)
+        if explicit_max_tokens is not None:
+            cli_config['_max_tokens_explicit'] = bool(explicit_max_tokens)
 
         # Extract handoff configuration for YAML CLI parity
         handoff = getattr(self.args, 'handoff', None)

--- a/src/praisonai-code/tests/unit/test_model_output_budget.py
+++ b/src/praisonai-code/tests/unit/test_model_output_budget.py
@@ -1,0 +1,62 @@
+"""Tests for model-aware ``run --max-tokens`` resolution."""
+
+from types import SimpleNamespace
+
+from praisonai_code.cli.commands import run as run_command
+
+
+def test_default_budget_is_capped_to_known_model_limit(monkeypatch):
+    monkeypatch.setattr(
+        "praisonaiagents.llm.model_capabilities.max_output_tokens",
+        lambda model: 8192,
+    )
+
+    assert run_command._resolve_max_tokens("provider/model", None) == 8192
+
+
+def test_default_budget_uses_large_known_model_limit(monkeypatch):
+    monkeypatch.setattr(
+        "praisonaiagents.llm.model_capabilities.max_output_tokens",
+        lambda model: 32768,
+    )
+
+    assert run_command._resolve_max_tokens("provider/model", None) == 32768
+
+
+def test_explicit_budget_is_capped_with_warning(monkeypatch):
+    monkeypatch.setattr(
+        "praisonaiagents.llm.model_capabilities.max_output_tokens",
+        lambda model: 8192,
+    )
+    warnings = []
+    output = SimpleNamespace(print_warning=warnings.append)
+
+    assert run_command._resolve_max_tokens(
+        "provider/model", 12000, output=output
+    ) == 8192
+    assert warnings == [
+        "--max-tokens 12000 exceeds provider/model's output limit (8192); "
+        "clamping to 8192"
+    ]
+
+
+def test_unknown_model_preserves_historical_default(monkeypatch):
+    monkeypatch.setattr(
+        "praisonaiagents.llm.model_capabilities.max_output_tokens",
+        lambda model: None,
+    )
+
+    assert run_command._resolve_max_tokens("unknown/model", None) == 16000
+
+
+def test_llm_spec_budget_preserves_existing_options():
+    spec = {"model": "provider/model", "temperature": 0.2}
+
+    resolved = run_command._llm_spec_with_max_tokens(spec, None, 4096)
+
+    assert resolved == {
+        "model": "provider/model",
+        "temperature": 0.2,
+        "max_tokens": 4096,
+    }
+    assert spec == {"model": "provider/model", "temperature": 0.2}

--- a/src/praisonai-code/tests/unit/test_model_output_budget.py
+++ b/src/praisonai-code/tests/unit/test_model_output_budget.py
@@ -86,3 +86,45 @@ def test_llm_spec_budget_preserves_existing_options():
         "max_tokens": 4096,
     }
     assert spec == {"model": "provider/model", "temperature": 0.2}
+
+
+def test_yaml_budget_resolution_preserves_nested_llm_value(monkeypatch):
+    from praisonai.framework_adapters.praisonai_adapter import (
+        _build_agent_llm_spec,
+        _requested_output_budget,
+        _resolve_output_budget,
+    )
+
+    monkeypatch.setattr(
+        "praisonaiagents.llm.model_capabilities.max_output_tokens",
+        lambda model: 8192,
+    )
+    details = {
+        "llm": {
+            "model": "provider/model",
+            "temperature": 0.2,
+            "max_tokens": 2048,
+        }
+    }
+
+    # A legacy parser default must not shadow an explicit nested YAML value.
+    assert _requested_output_budget(details, {"max_tokens": 16000}) == 2048
+    assert _resolve_output_budget("provider/model", 2048) == 2048
+    spec = _build_agent_llm_spec(details["llm"], "provider/model", 2048)
+    assert spec == {
+        "model": "provider/model",
+        "temperature": 0.2,
+        "max_tokens": 2048,
+    }
+
+
+def test_yaml_explicit_cli_budget_wins_over_nested_value():
+    from praisonai.framework_adapters.praisonai_adapter import (
+        _requested_output_budget,
+    )
+
+    details = {"llm": {"model": "provider/model", "max_tokens": 2048}}
+    assert _requested_output_budget(
+        details,
+        {"max_tokens": 4096, "_max_tokens_explicit": True},
+    ) == 4096

--- a/src/praisonai-code/tests/unit/test_model_output_budget.py
+++ b/src/praisonai-code/tests/unit/test_model_output_budget.py
@@ -40,6 +40,32 @@ def test_explicit_budget_is_capped_with_warning(monkeypatch):
     ]
 
 
+def test_explicit_budget_warning_is_single_ndjson_event_in_stream_mode(monkeypatch):
+    monkeypatch.setattr(
+        "praisonaiagents.llm.model_capabilities.max_output_tokens",
+        lambda model: 8192,
+    )
+    events = []
+    output = SimpleNamespace(
+        mode=SimpleNamespace(value="stream-json"),
+        emit_event=lambda *args, **kwargs: events.append((args, kwargs)),
+        is_json_mode=True,
+    )
+
+    assert run_command._resolve_max_tokens(
+        "provider/model", 12000, output=output
+    ) == 8192
+    assert events == [
+        (
+            ("warning",),
+            {
+                "message": "--max-tokens 12000 exceeds provider/model's output limit (8192); clamping to 8192",
+                "data": {"code": "max_tokens_clamped"},
+            },
+        )
+    ]
+
+
 def test_unknown_model_preserves_historical_default(monkeypatch):
     monkeypatch.setattr(
         "praisonaiagents.llm.model_capabilities.max_output_tokens",

--- a/src/praisonai/praisonai/agents_generator.py
+++ b/src/praisonai/praisonai/agents_generator.py
@@ -729,7 +729,7 @@ class AgentsGenerator:
                 break
 
         # Handle agent-level overrides using unified approach
-        agent_level_fields = ['tool_timeout', 'tool_retry_policy', 'planning_tools', 'autonomy', 'planning', 'web', 'web_fetch']
+        agent_level_fields = ['tool_timeout', 'tool_retry_policy', 'planning_tools', 'autonomy', 'planning', 'web', 'web_fetch', 'max_tokens']
         agent_overrides = {k: v for k, v in cli_config.items() if k in agent_level_fields}
 
         if "tool_retry_policy" in agent_overrides:

--- a/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
@@ -438,6 +438,18 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
             # Resolve approval configuration
             agent_approval = self._resolve_agent_approval(details, config)
             
+            # Preserve the complete YAML LLM mapping (endpoint, credentials,
+            # sampling, retries, and provider-specific options) while adding
+            # the resolved model/budget fields. Rebuilding from only ``model``
+            # silently discarded those settings.
+            raw_llm_spec = details.get('llm')
+            if isinstance(raw_llm_spec, dict):
+                agent_llm = dict(raw_llm_spec)
+            else:
+                agent_llm = {}
+            agent_llm['model'] = agent_model
+            agent_llm['max_tokens'] = resolved_max_tokens
+
             # Create basic agent (pass both tools and toolsets)
             agent_kwargs = {
                 'name': role_filled,
@@ -445,10 +457,7 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
                 'goal': goal_filled,
                 'backstory': backstory_filled,
                 'instructions': details.get('instructions'),
-                'llm': {
-                    'model': agent_model,
-                    'max_tokens': resolved_max_tokens,
-                },
+                'llm': agent_llm,
                 'allow_delegation': details.get('allow_delegation', False),
                 'tools': agent_tool_list,
                 'toolsets': agent_toolsets,

--- a/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
@@ -16,6 +16,37 @@ from .base import BaseFrameworkAdapter
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_MAX_TOKENS = 16000
+
+
+def _resolve_output_budget(model: str, requested: Any = None) -> Optional[int]:
+    """Resolve a YAML agent budget against LiteLLM's model ceiling."""
+    try:
+        value = _DEFAULT_MAX_TOKENS if requested is None else int(requested)
+    except (TypeError, ValueError, OverflowError):
+        logger.warning("Ignoring invalid max_tokens=%r for model %r", requested, model)
+        value = _DEFAULT_MAX_TOKENS
+    if not model or value <= 0:
+        return value
+    try:
+        from praisonaiagents.llm.model_capabilities import max_output_tokens
+
+        ceiling = max_output_tokens(model)
+    except Exception:
+        ceiling = None
+    if not ceiling or ceiling <= 0:
+        return value
+    if value > ceiling:
+        if requested is not None:
+            logger.warning(
+                "max_tokens=%s exceeds %s's output limit (%s); clamping to %s",
+                value, model, ceiling, ceiling,
+            )
+        return ceiling
+    # An omitted YAML budget follows the model's full known ceiling, including
+    # ceilings above the historical 16k default.
+    return ceiling if requested is None else value
+
 
 class PraisonAIAdapter(BaseFrameworkAdapter):
     """
@@ -345,7 +376,17 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
             return llm_config[0]['model']
         return "gpt-4o-mini"
 
-    def _build_agents_and_tasks(self, config, topic, tools_dict, agent_callback, task_callback, model_name, agent_tool_wrap_resolver=None):
+    def _build_agents_and_tasks(
+        self,
+        config,
+        topic,
+        tools_dict,
+        agent_callback,
+        task_callback,
+        model_name,
+        agent_tool_wrap_resolver=None,
+        cli_config: Optional[Dict[str, Any]] = None,
+    ):
         """Build agents and tasks from configuration."""
         from praisonaiagents import Agent as PraisonAgent, Task as PraisonTask
         from ._config_builder import build_agent_specs
@@ -378,6 +419,18 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
             
             # Resolve per-agent LLM model
             agent_model = self._resolve_agent_model(details, model_name)
+
+            # CLI max_tokens is an explicit global override when present;
+            # otherwise honour each YAML agent's own value and resolve an
+            # omitted value from that agent's model ceiling.
+            requested_max_tokens = (
+                (cli_config or {}).get("max_tokens")
+                if "max_tokens" in (cli_config or {})
+                else details.get("max_tokens")
+            )
+            resolved_max_tokens = _resolve_output_budget(
+                agent_model, requested_max_tokens
+            )
             
             # Resolve per-agent runtime configuration
             agent_runtime = self._resolve_agent_runtime(details, config)
@@ -392,7 +445,10 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
                 'goal': goal_filled,
                 'backstory': backstory_filled,
                 'instructions': details.get('instructions'),
-                'llm': agent_model,
+                'llm': {
+                    'model': agent_model,
+                    'max_tokens': resolved_max_tokens,
+                },
                 'allow_delegation': details.get('allow_delegation', False),
                 'tools': agent_tool_list,
                 'toolsets': agent_toolsets,
@@ -780,6 +836,7 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
             agents, tasks = self._build_agents_and_tasks(
                 config, topic, tools_dict, agent_callback, task_callback, model_name,
                 agent_tool_wrap_resolver=agent_tool_wrap_resolver,
+                cli_config=cli_config,
             )
 
             # Resolve CLI session continuity (--continue/--session/--fork) that the

--- a/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
@@ -19,12 +19,43 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MAX_TOKENS = 16000
 
 
+def _active_correlation_id() -> Optional[str]:
+    """Return the current workflow id for budget diagnostics when available."""
+    try:
+        from praisonaiagents.trace.context_events import get_context_emitter
+
+        session_id = getattr(get_context_emitter(), "_session_id", None)
+        if session_id:
+            return str(session_id)
+    except Exception:
+        pass
+    try:
+        from praisonaiagents.session.context import get_session_context
+
+        context = get_session_context()
+        for field in ("thread_id", "chat_id", "user_id"):
+            value = getattr(context, field, None)
+            if value:
+                return str(value)
+    except Exception:
+        pass
+    return None
+
+
 def _resolve_output_budget(model: str, requested: Any = None) -> Optional[int]:
     """Resolve a YAML agent budget against LiteLLM's model ceiling."""
     try:
         value = _DEFAULT_MAX_TOKENS if requested is None else int(requested)
     except (TypeError, ValueError, OverflowError):
-        logger.warning("Ignoring invalid max_tokens=%r for model %r", requested, model)
+        correlation_id = _active_correlation_id()
+        logger.warning(
+            "Ignoring invalid max_tokens=%r for model %r",
+            requested,
+            model,
+            extra={"extra_data": {"correlation_id": correlation_id}}
+            if correlation_id
+            else {},
+        )
         value = _DEFAULT_MAX_TOKENS
     if not model or value <= 0:
         return value
@@ -38,14 +69,30 @@ def _resolve_output_budget(model: str, requested: Any = None) -> Optional[int]:
         return value
     if value > ceiling:
         if requested is not None:
+            correlation_id = _active_correlation_id()
             logger.warning(
                 "max_tokens=%s exceeds %s's output limit (%s); clamping to %s",
                 value, model, ceiling, ceiling,
+                extra={"extra_data": {"correlation_id": correlation_id}}
+                if correlation_id
+                else {},
             )
         return ceiling
     # An omitted YAML budget follows the model's full known ceiling, including
     # ceilings above the historical 16k default.
     return ceiling if requested is None else value
+
+
+def _build_agent_llm_spec(
+    raw_llm_spec: Any,
+    model: str,
+    max_tokens: Optional[int],
+) -> Dict[str, Any]:
+    """Overlay resolved model/budget fields without dropping YAML options."""
+    spec = dict(raw_llm_spec) if isinstance(raw_llm_spec, dict) else {}
+    spec["model"] = model
+    spec["max_tokens"] = max_tokens
+    return spec
 
 
 class PraisonAIAdapter(BaseFrameworkAdapter):
@@ -442,13 +489,9 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
             # sampling, retries, and provider-specific options) while adding
             # the resolved model/budget fields. Rebuilding from only ``model``
             # silently discarded those settings.
-            raw_llm_spec = details.get('llm')
-            if isinstance(raw_llm_spec, dict):
-                agent_llm = dict(raw_llm_spec)
-            else:
-                agent_llm = {}
-            agent_llm['model'] = agent_model
-            agent_llm['max_tokens'] = resolved_max_tokens
+            agent_llm = _build_agent_llm_spec(
+                details.get('llm'), agent_model, resolved_max_tokens
+            )
 
             # Create basic agent (pass both tools and toolsets)
             agent_kwargs = {

--- a/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
+++ b/src/praisonai/praisonai/framework_adapters/praisonai_adapter.py
@@ -95,6 +95,40 @@ def _build_agent_llm_spec(
     return spec
 
 
+def _requested_output_budget(
+    details: Dict[str, Any], cli_config: Optional[Dict[str, Any]] = None
+) -> Any:
+    """Select the raw per-agent budget before model-ceiling resolution.
+
+    An explicit CLI value wins over YAML. When the CLI option is omitted,
+    preserve the agent-level value and then a nested ``llm.max_tokens`` value;
+    the latter must not be mistaken for an omitted budget and overwritten by
+    the model ceiling. Older callers may pass the parser's historical 16k
+    default without an explicitness marker, so that value is treated as an
+    omission when a YAML value is available.
+    """
+    details = details or {}
+    cli = cli_config or {}
+    marker = cli.get("_max_tokens_explicit")
+    cli_value = cli.get("max_tokens")
+    if marker is None:
+        marker = (
+            "max_tokens" in cli
+            and cli_value is not None
+            and cli_value != _DEFAULT_MAX_TOKENS
+        )
+    if marker:
+        return cli_value
+
+    agent_value = details.get("max_tokens")
+    if agent_value is not None:
+        return agent_value
+    llm_spec = details.get("llm")
+    if isinstance(llm_spec, dict):
+        return llm_spec.get("max_tokens")
+    return None
+
+
 class PraisonAIAdapter(BaseFrameworkAdapter):
     """
     Adapter for running PraisonAI agents natively using praisonaiagents.
@@ -468,13 +502,10 @@ class PraisonAIAdapter(BaseFrameworkAdapter):
             agent_model = self._resolve_agent_model(details, model_name)
 
             # CLI max_tokens is an explicit global override when present;
-            # otherwise honour each YAML agent's own value and resolve an
-            # omitted value from that agent's model ceiling.
-            requested_max_tokens = (
-                (cli_config or {}).get("max_tokens")
-                if "max_tokens" in (cli_config or {})
-                else details.get("max_tokens")
-            )
+            # otherwise honour each YAML agent's own value (including a nested
+            # ``llm.max_tokens``) and resolve an omitted value from that
+            # agent's model ceiling.
+            requested_max_tokens = _requested_output_budget(details, cli_config)
             resolved_max_tokens = _resolve_output_budget(
                 agent_model, requested_max_tokens
             )

--- a/src/praisonai/tests/unit/test_model_output_budget_adapter.py
+++ b/src/praisonai/tests/unit/test_model_output_budget_adapter.py
@@ -1,0 +1,33 @@
+"""Regression tests for YAML model-aware output budgets."""
+
+from praisonai.framework_adapters.praisonai_adapter import (
+    _build_agent_llm_spec,
+    _resolve_output_budget,
+)
+
+
+def test_yaml_budget_uses_output_ceiling_for_omitted_value(monkeypatch):
+    monkeypatch.setattr(
+        "praisonaiagents.llm.model_capabilities.max_output_tokens",
+        lambda model: 8192,
+    )
+
+    assert _resolve_output_budget("provider/model") == 8192
+    assert _resolve_output_budget("provider/model", 12000) == 8192
+
+
+def test_yaml_llm_spec_preserves_provider_options():
+    raw = {
+        "model": "provider/model",
+        "temperature": 0.2,
+        "api_base": "http://localhost:11434",
+        "retry": {"max_attempts": 2},
+    }
+
+    resolved = _build_agent_llm_spec(raw, "provider/model", 4096)
+
+    assert resolved == {
+        **raw,
+        "max_tokens": 4096,
+    }
+    assert resolved is not raw


### PR DESCRIPTION
## Summary\n\nFixes #5017 by resolving the CLI output-token budget from LiteLLM model metadata. Known model ceilings now replace the fixed default, explicit oversized values are clamped with a diagnostic, and unknown models retain the 16000 fallback across direct, YAML, custom-agent, and profiled paths.\n\nThe core accessor is lazy and optional; YAML agents receive per-model budgets without changing explicit values that fit.\n\n## Verification\n\n- 11 model-capability tests passed\n- 43 CLI budget/YAML/outcome tests passed with the monorepo package paths\n- Python compileall and git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-aware output token limits for CLI runs and agent configurations.
  * Automatically uses known model ceilings, caps explicit values when needed, and applies a fallback for unknown models.
  * Propagates resolved limits through YAML workflows, profiles, custom agents, and framework integrations.

* **Bug Fixes**
  * Preserves existing language model options while applying token limits.
  * Rejects invalid, boolean, and fractional token-limit values safely.
  * Provides warnings when requested limits exceed model capabilities.

* **Tests**
  * Added coverage for model resolution, fallback behavior, metadata validation, precedence, and token-limit clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->