### PR TITLE
fix(llm): preserve Ollama tool result chaining across async and stream

### DIFF
--- a/src/praisonai-agents/praisonaiagents/llm/adapters/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/llm/adapters/__init__.py
@@ -10,7 +10,50 @@ and integrates with Gap 2 (parallel tool execution).
 
 from ..protocols import LLMProviderAdapterProtocol
 import json
+import logging
 from typing import Dict, Any, List, Optional
+
+_logger = logging.getLogger(__name__)
+
+
+def resolve_ollama_chained_arguments(
+    arguments: Dict[str, Any],
+    tool_result_mapping: Dict[str, Any],
+    *,
+    correlation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve exact Ollama function-name references without coercing values.
+
+    Weak local models sometimes emit the name of an earlier function as a
+    later argument.  Keep the complete result (including mappings, lists,
+    negative numbers, and decimals) so the destination tool receives exactly
+    what the first tool returned.
+    """
+    if not tool_result_mapping:
+        return arguments
+    resolved = dict(arguments)
+    for arg_name, arg_value in resolved.items():
+        if isinstance(arg_value, str) and arg_value in tool_result_mapping:
+            replacement = tool_result_mapping[arg_value]
+            resolved[arg_name] = replacement
+            extra = {"correlation_id": correlation_id} if correlation_id else {}
+            _logger.debug(
+                "[OLLAMA_FIX] Replaced %s with a prior result in %s arguments",
+                arg_value,
+                arg_name,
+                extra=extra,
+            )
+    return resolved
+
+
+def record_ollama_tool_result(
+    tool_result_mapping: Dict[str, Any],
+    function_name: str,
+    tool_result: Any,
+) -> None:
+    """Record an Ollama tool result exactly as returned by the callback."""
+    if function_name:
+        tool_result_mapping[function_name] = tool_result
 
 
 def collapse_union_param_types(tools):
@@ -100,6 +143,25 @@ class DefaultAdapter:
         """Hosted providers get the schema untouched -- they support all of it."""
         return tools
 
+    def resolve_chained_arguments(
+        self,
+        arguments: Dict[str, Any],
+        tool_result_mapping: Dict[str, Any],
+        *,
+        correlation_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Provider hook for same-turn tool-result references."""
+        return arguments
+
+    def record_tool_result(
+        self,
+        tool_result_mapping: Dict[str, Any],
+        function_name: str,
+        tool_result: Any,
+    ) -> None:
+        """Provider hook for recording results used by later tool calls."""
+        return None
+
     def supports_prompt_caching(self) -> bool:
         return False
     
@@ -178,6 +240,25 @@ class OllamaAdapter(DefaultAdapter):
     def supports_streaming_with_tools(self) -> bool:
         # Ollama doesn't reliably support streaming with tools
         return False
+
+    def resolve_chained_arguments(
+        self,
+        arguments: Dict[str, Any],
+        tool_result_mapping: Dict[str, Any],
+        *,
+        correlation_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        return resolve_ollama_chained_arguments(
+            arguments, tool_result_mapping, correlation_id=correlation_id
+        )
+
+    def record_tool_result(
+        self,
+        tool_result_mapping: Dict[str, Any],
+        function_name: str,
+        tool_result: Any,
+    ) -> None:
+        record_ollama_tool_result(tool_result_mapping, function_name, tool_result)
     
     
     

--- a/src/praisonai-agents/praisonaiagents/llm/adapters/__init__.py
+++ b/src/praisonai-agents/praisonaiagents/llm/adapters/__init__.py
@@ -52,8 +52,21 @@ def record_ollama_tool_result(
     tool_result: Any,
 ) -> None:
     """Record an Ollama tool result exactly as returned by the callback."""
-    if function_name:
-        tool_result_mapping[function_name] = tool_result
+    if not function_name:
+        return
+    # The agent executor represents failures as an ``error`` mapping (or a
+    # one-item list containing one). Never feed that diagnostic back as a
+    # successful value to a dependent call in the same turn.
+    if isinstance(tool_result, dict) and tool_result.get("error"):
+        return
+    if (
+        isinstance(tool_result, list)
+        and tool_result
+        and isinstance(tool_result[0], dict)
+        and tool_result[0].get("error")
+    ):
+        return
+    tool_result_mapping[function_name] = tool_result
 
 
 def collapse_union_param_types(tools):

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -2082,10 +2082,24 @@ Respond with ONLY a valid JSON tool call in this format:
                 logging.debug(f"[OLLAMA_FIX] Filtered arguments: {filtered_args}")
                 
             return filtered_args
-            
+
         except Exception as e:
             logging.debug(f"[OLLAMA_FIX] Error validating arguments for {function_name}: {e}")
             return arguments
+
+    def _filter_ollama_dispatch_arguments(
+        self, function_name: str, arguments: Dict[str, Any], available_tools: List
+    ) -> Dict[str, Any]:
+        """Re-validate arguments after same-turn result substitution.
+
+        The streaming fallback resolves dependent arguments immediately before
+        each sequential dispatch. Keep this wrapper separate so the source has
+        one obvious pre-dispatch filter per streaming/fallback phase while the
+        post-substitution pass still enforces the target signature.
+        """
+        return self._validate_and_filter_ollama_arguments(
+            function_name, arguments, available_tools
+        )
 
     def _handle_ollama_sequential_logic(self, iteration_count: int, accumulated_tool_results: List[Any], 
                                       response_text: str, messages: List[Dict]) -> tuple:
@@ -4587,9 +4601,14 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                     _tool_call.arguments, ollama_tool_result_mapping
                                 )
                                 # The batch-preparation filter above has
-                                # already removed unknown keys. Chained
-                                # substitution changes values only, so no
-                                # second filtering pass is needed here.
+                                # already removed unknown keys. Re-validate
+                                # after substitution so dependent values follow
+                                # the same signature contract as other paths.
+                                _tool_call.arguments = self._filter_ollama_dispatch_arguments(
+                                    _tool_call.function_name,
+                                    _tool_call.arguments,
+                                    tools,
+                                )
                                 _result = executor.execute_batch(
                                     [_tool_call], execute_tool_fn,
                                     timeout_ms=self.tool_timeout_ms,

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -4750,12 +4750,14 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     is_ollama = self._is_ollama_provider()
                     fallback_iterations = 0
                     tool_call_count = 0
-                    ollama_tool_result_mapping = {}
                     last_tool_call_fingerprint = None
                     stall_reason = None
                     max_fallback_iterations = kwargs.pop("max_iterations", self.max_iter)
                     while fallback_iterations < max_fallback_iterations:
                         fallback_iterations += 1
+                        # Chaining references are scoped to one assistant turn;
+                        # do not let a later turn reuse an earlier result.
+                        ollama_tool_result_mapping = {}
                         response = self._completion_with_retry(
                             **self._build_completion_params(
                                 messages=messages,
@@ -5105,7 +5107,6 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             final_response_text = ""
             stored_reasoning_content = None  # Store reasoning content from tool execution
             accumulated_tool_results = []  # Store all tool results across iterations
-            ollama_tool_result_mapping: Dict[str, Any] = {}
             # Structured stop reason (unified with the OpenAI-native path).
             self._last_stop_reason = "completed"
 
@@ -5125,6 +5126,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 response_text = ""
                 reasoning_content = None
                 tool_calls = []
+                # Chaining references are scoped to one assistant turn;
+                # do not let a later turn reuse an earlier result.
+                ollama_tool_result_mapping: Dict[str, Any] = {}
                 
                 # ── Responses API path (async) ──────────────────────────
                 if self._supports_responses_api():

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -4594,7 +4594,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                     timeout_ms=self.tool_timeout_ms,
                                 )
                                 tool_results.extend(_result)
-                                if _result:
+                                if _result and _result[0].error is None:
                                     self._record_ollama_tool_result(
                                         ollama_tool_result_mapping,
                                         _tool_call.function_name,
@@ -4609,11 +4609,12 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 for _tool_call, _result in zip(
                                     tool_calls_batch, tool_results
                                 ):
-                                    self._record_ollama_tool_result(
-                                        ollama_tool_result_mapping,
-                                        _tool_call.function_name,
-                                        _result.result,
-                                    )
+                                    if _result.error is None:
+                                        self._record_ollama_tool_result(
+                                            ollama_tool_result_mapping,
+                                            _tool_call.function_name,
+                                            _result.result,
+                                        )
                         _batch_elapsed = _perf_counter() - _batch_started
                         
                         for tool_result in tool_results:

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -5486,12 +5486,12 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             _call_plan.append(('error', self._tool_parse_error_message(function_name, tool_call_id)))
                             continue
 
-                        # Validate and filter arguments for Ollama provider
+                        # Validate and filter arguments for Ollama provider.
+                        # In the sequential Ollama path, defer resolution and
+                        # validation until immediately before dispatch; this
+                        # lets a later call consume an earlier result from the
+                        # same assistant turn.
                         if is_ollama and tools:
-                            # In the sequential Ollama path, defer resolution
-                            # and validation until immediately before dispatch;
-                            # this lets a later call consume an earlier result
-                            # from the same assistant turn.
                             if parallel_tool_calls:
                                 arguments = self._resolve_ollama_chained_args(
                                     arguments, ollama_tool_result_mapping
@@ -5500,7 +5500,6 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                     function_name, arguments, tools
                                 )
 
-                        _call_plan.append(('call', function_name, arguments, tool_call_id))
                         if is_ollama and not parallel_tool_calls:
                             arguments = self._resolve_ollama_chained_args(
                                 arguments, ollama_tool_result_mapping
@@ -5509,7 +5508,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 arguments = self._validate_and_filter_ollama_arguments(
                                     function_name, arguments, tools
                                 )
-                            _call_plan[-1] = ('call', function_name, arguments, tool_call_id)
+
+                        _call_plan.append(('call', function_name, arguments, tool_call_id))
+                        if is_ollama and not parallel_tool_calls:
                             _batch_results.append(await _dispatch_async_tool(
                                 execute_tool_fn,
                                 function_name,

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1771,6 +1771,40 @@ Respond with ONLY a valid JSON tool call in this format:
             adapter = OllamaAdapter()
         return adapter.format_tool_result_message(function_name, tool_result)
 
+    @staticmethod
+    def _resolve_ollama_chained_args(
+        arguments: Dict[str, Any],
+        tool_result_mapping: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Replace Ollama's function-name references with prior tool results."""
+        if not tool_result_mapping:
+            return arguments
+        for arg_name, arg_value in list(arguments.items()):
+            if isinstance(arg_value, str) and arg_value in tool_result_mapping:
+                arguments[arg_name] = tool_result_mapping[arg_value]
+                logging.debug(
+                    "[OLLAMA_FIX] Replaced %s with %s in %s arguments",
+                    arg_value,
+                    tool_result_mapping[arg_value],
+                    arg_name,
+                )
+        return arguments
+
+    @staticmethod
+    def _record_ollama_tool_result(
+        tool_result_mapping: Dict[str, Any],
+        function_name: str,
+        tool_result: Any,
+    ) -> None:
+        """Record a tool result in the form weak Ollama models can chain."""
+        if isinstance(tool_result, (int, float)):
+            tool_result_mapping[function_name] = tool_result
+        elif isinstance(tool_result, str):
+            match = re.search(r"\b(\d+)\b", tool_result)
+            tool_result_mapping[function_name] = (
+                int(match.group(1)) if match else tool_result
+            )
+
     def _try_append_multimodal_tool_result(
         self,
         messages: List[Dict[str, Any]],
@@ -3751,13 +3785,9 @@ Respond with ONLY a valid JSON tool call in this format:
                             # Validate and filter arguments for Ollama provider
                             if is_ollama and tools:
                                 # First check if any argument references a previous tool result
-                                if is_ollama and tool_result_mapping:
-                                    # Replace function names with their results in arguments
-                                    for arg_name, arg_value in list(arguments.items()):
-                                        if isinstance(arg_value, str) and arg_value in tool_result_mapping:
-                                            # Replace function name with its result
-                                            arguments[arg_name] = tool_result_mapping[arg_value]
-                                            logging.debug(f"[OLLAMA_FIX] Replaced {arg_value} with {tool_result_mapping[arg_value]} in {function_name} arguments")
+                                arguments = self._resolve_ollama_chained_args(
+                                    arguments, tool_result_mapping
+                                )
                                 
                                 arguments = self._validate_and_filter_ollama_arguments(function_name, arguments, tools)
 
@@ -3795,16 +3825,9 @@ Respond with ONLY a valid JSON tool call in this format:
                             
                             # For Ollama, store the result for potential chaining
                             if is_ollama:
-                                # Extract numeric value from result if it contains one
-                                if isinstance(tool_result, (int, float)):
-                                    tool_result_mapping[function_name] = tool_result
-                                elif isinstance(tool_result, str):
-                                    import re
-                                    match = re.search(r'\b(\d+)\b', tool_result)
-                                    if match:
-                                        tool_result_mapping[function_name] = int(match.group(1))
-                                    else:
-                                        tool_result_mapping[function_name] = tool_result
+                                self._record_ollama_tool_result(
+                                    tool_result_mapping, function_name, tool_result
+                                )
 
                             if verbose:
                                 display_message = f"Agent {agent_name} called function '{function_name}' with arguments: {arguments}\n"
@@ -4373,6 +4396,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                 try:
                     tool_calls = []
                     response_text = ""
+                    ollama_tool_result_mapping: Dict[str, Any] = {}
                     consecutive_errors = 0
                     max_consecutive_errors = 3  # Fallback to non-streaming after 3 consecutive errors
                     
@@ -4501,8 +4525,15 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             # different function, and dispatching those calls the
                             # user's tool with parameters it never declared.
                             if is_ollama and tools:
-                                arguments = self._validate_and_filter_ollama_arguments(
-                                    function_name, arguments, tools)
+                                # In the sequential Ollama path, resolve and
+                                # validate immediately before each dispatch so
+                                # same-turn results are available to later calls.
+                                if parallel_tool_calls:
+                                    arguments = self._resolve_ollama_chained_args(
+                                        arguments, ollama_tool_result_mapping
+                                    )
+                                    arguments = self._validate_and_filter_ollama_arguments(
+                                        function_name, arguments, tools)
                             tool_calls_batch.append(ToolCall(
                                 function_name=function_name,
                                 arguments=arguments, 
@@ -4521,10 +4552,47 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         # here; use a distinct alias.
                         from time import perf_counter as _perf_counter
                         _batch_started = _perf_counter()
-                        tool_results = executor.execute_batch(
-                            tool_calls_batch, execute_tool_fn,
-                            timeout_ms=self.tool_timeout_ms,
-                        )
+                        if is_ollama and not parallel_tool_calls:
+                            # Ollama models commonly emit a later call whose
+                            # argument is the name of an earlier call. Execute
+                            # these calls one at a time so each result can be
+                            # resolved before the next dispatch.
+                            tool_results = []
+                            for _tool_call in tool_calls_batch:
+                                _tool_call.arguments = self._resolve_ollama_chained_args(
+                                    _tool_call.arguments, ollama_tool_result_mapping
+                                )
+                                if tools:
+                                    _tool_call.arguments = self._validate_and_filter_ollama_arguments(
+                                        _tool_call.function_name,
+                                        _tool_call.arguments,
+                                        tools,
+                                    )
+                                _result = executor.execute_batch(
+                                    [_tool_call], execute_tool_fn,
+                                    timeout_ms=self.tool_timeout_ms,
+                                )
+                                tool_results.extend(_result)
+                                if _result:
+                                    self._record_ollama_tool_result(
+                                        ollama_tool_result_mapping,
+                                        _tool_call.function_name,
+                                        _result[0].result,
+                                    )
+                        else:
+                            tool_results = executor.execute_batch(
+                                tool_calls_batch, execute_tool_fn,
+                                timeout_ms=self.tool_timeout_ms,
+                            )
+                            if is_ollama:
+                                for _tool_call, _result in zip(
+                                    tool_calls_batch, tool_results
+                                ):
+                                    self._record_ollama_tool_result(
+                                        ollama_tool_result_mapping,
+                                        _tool_call.function_name,
+                                        _result.result,
+                                    )
                         _batch_elapsed = _perf_counter() - _batch_started
                         
                         for tool_result in tool_results:
@@ -4640,6 +4708,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     is_ollama = self._is_ollama_provider()
                     fallback_iterations = 0
                     tool_call_count = 0
+                    ollama_tool_result_mapping = {}
                     last_tool_call_fingerprint = None
                     stall_reason = None
                     max_fallback_iterations = kwargs.pop("max_iterations", self.max_iter)
@@ -4736,6 +4805,9 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                             # different function, and dispatching those calls the
                             # user's tool with parameters it never declared.
                             if is_ollama and tools:
+                                arguments = self._resolve_ollama_chained_args(
+                                    arguments, ollama_tool_result_mapping
+                                )
                                 arguments = self._validate_and_filter_ollama_arguments(
                                     function_name, arguments, tools)
                             try:
@@ -4746,6 +4818,12 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 logging.warning(
                                     f"Tool '{function_name}' failed: {tool_error}")
                                 tool_result = {"error": str(tool_error)}
+                            if is_ollama:
+                                self._record_ollama_tool_result(
+                                    ollama_tool_result_mapping,
+                                    function_name,
+                                    tool_result,
+                                )
                             try:
                                 _get_display_functions()['execute_sync_callback'](
                                     'tool_call',
@@ -4985,6 +5063,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
             final_response_text = ""
             stored_reasoning_content = None  # Store reasoning content from tool execution
             accumulated_tool_results = []  # Store all tool results across iterations
+            ollama_tool_result_mapping: Dict[str, Any] = {}
             # Structured stop reason (unified with the OpenAI-native path).
             self._last_stop_reason = "completed"
 
@@ -5354,6 +5433,7 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                     # parallel_tool_calls is set) while preserving call order.
                     _call_plan = []  # ('error', msg) | ('call', fn, args, tc_id)
                     _dispatch_specs = []
+                    _batch_results = []
                     for tool_call in tool_calls:
                         # Handle both object and dict access patterns
                         is_ollama = self._is_ollama_provider()
@@ -5366,12 +5446,46 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
 
                         # Validate and filter arguments for Ollama provider
                         if is_ollama and tools:
-                            arguments = self._validate_and_filter_ollama_arguments(function_name, arguments, tools)
+                            # In the sequential Ollama path, defer resolution
+                            # and validation until immediately before dispatch;
+                            # this lets a later call consume an earlier result
+                            # from the same assistant turn.
+                            if parallel_tool_calls:
+                                arguments = self._resolve_ollama_chained_args(
+                                    arguments, ollama_tool_result_mapping
+                                )
+                                arguments = self._validate_and_filter_ollama_arguments(
+                                    function_name, arguments, tools
+                                )
 
                         _call_plan.append(('call', function_name, arguments, tool_call_id))
-                        _dispatch_specs.append((function_name, arguments, tool_call_id))
+                        if is_ollama and not parallel_tool_calls:
+                            arguments = self._resolve_ollama_chained_args(
+                                arguments, ollama_tool_result_mapping
+                            )
+                            if tools:
+                                arguments = self._validate_and_filter_ollama_arguments(
+                                    function_name, arguments, tools
+                                )
+                            _call_plan[-1] = ('call', function_name, arguments, tool_call_id)
+                            _batch_results.append(await _dispatch_async_tool(
+                                execute_tool_fn,
+                                function_name,
+                                arguments,
+                                tool_call_id,
+                                iteration_count,
+                            ))
+                            self._record_ollama_tool_result(
+                                ollama_tool_result_mapping, function_name,
+                                _batch_results[-1],
+                            )
+                        else:
+                            _dispatch_specs.append((function_name, arguments, tool_call_id))
 
-                    _batch_results = await _dispatch_tool_batch(_dispatch_specs, iteration_count)
+                    if not (is_ollama and not parallel_tool_calls):
+                        _batch_results = await _dispatch_tool_batch(
+                            _dispatch_specs, iteration_count
+                        )
                     _result_iter = iter(_batch_results)
                     for _plan in _call_plan:
                         if _plan[0] == 'error':
@@ -5382,6 +5496,11 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                         tool_call_count += 1  # Increment tool call counter for guardrails
                         tool_results.append(tool_result)  # Store the result
                         accumulated_tool_results.append(tool_result)  # Accumulate across iterations
+
+                        if is_ollama:
+                            self._record_ollama_tool_result(
+                                ollama_tool_result_mapping, function_name, tool_result
+                            )
 
                         if verbose:
                             display_message = f"Agent {agent_name} called function '{function_name}' with arguments: {arguments}\n"

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1791,17 +1791,18 @@ Respond with ONLY a valid JSON tool call in this format:
     ) -> Dict[str, Any]:
         """Delegate Ollama function-name substitution to the provider adapter."""
         adapter = getattr(self, "_provider_adapter", None)
-        resolver = getattr(adapter, "resolve_chained_arguments", None)
-        if resolver is not None:
+        if adapter is not None:
             try:
-                return resolver(
+                return adapter.resolve_chained_arguments(
                     arguments,
                     tool_result_mapping,
                     correlation_id=self._ollama_correlation_id(),
                 )
-            except TypeError:
+            except (AttributeError, TypeError):
                 # Keep compatibility with lightweight test/custom adapters.
-                return resolver(arguments, tool_result_mapping)
+                resolver = getattr(adapter, "resolve_chained_arguments", None)
+                if resolver is not None:
+                    return resolver(arguments, tool_result_mapping)
         from .adapters import resolve_ollama_chained_arguments
 
         return resolve_ollama_chained_arguments(
@@ -1818,10 +1819,16 @@ Respond with ONLY a valid JSON tool call in this format:
     ) -> None:
         """Delegate exact Ollama result recording to the provider adapter."""
         adapter = getattr(self, "_provider_adapter", None)
-        recorder = getattr(adapter, "record_tool_result", None)
-        if recorder is not None:
-            recorder(tool_result_mapping, function_name, tool_result)
-            return
+        if adapter is not None:
+            try:
+                adapter.record_tool_result(
+                    tool_result_mapping, function_name, tool_result
+                )
+                return
+            except AttributeError:
+                # Lightweight custom adapters may not implement this optional
+                # hook; retain the module-level fallback below.
+                pass
         from .adapters import record_ollama_tool_result
 
         record_ollama_tool_result(tool_result_mapping, function_name, tool_result)
@@ -3803,13 +3810,14 @@ Respond with ONLY a valid JSON tool call in this format:
                                 messages.append(self._tool_parse_error_message(function_name, tool_call_id))
                                 continue
 
-                            # Validate and filter arguments for Ollama provider
-                            if is_ollama and tools:
-                                # First check if any argument references a previous tool result
+                            # First resolve any reference to a previous tool
+                            # result, then filter unknown argument keys.
+                            if is_ollama:
                                 arguments = self._resolve_ollama_chained_args(
                                     arguments, tool_result_mapping
                                 )
-                                
+                            # Validate and filter arguments for Ollama provider
+                            if is_ollama and tools:
                                 arguments = self._validate_and_filter_ollama_arguments(function_name, arguments, tools)
 
                             logging.debug(f"[TOOL_EXEC_DEBUG] About to execute tool {function_name} with args: {arguments}")
@@ -4539,22 +4547,17 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                     self._tool_parse_error_message(function_name, tool_call_id)
                                 )
                                 continue
-                            # Validate and filter arguments for Ollama provider.
-                            # Pre-dispatch, so this is streaming-safe: nothing has
-                            # been yielded that would need retracting. Weak local
-                            # models routinely emit arguments belonging to a
-                            # different function, and dispatching those calls the
-                            # user's tool with parameters it never declared.
+                            # Resolve any same-turn result reference first.
+                            if is_ollama:
+                                arguments = self._resolve_ollama_chained_args(
+                                    arguments, ollama_tool_result_mapping
+                                )
+                            # Validate and filter before dispatch. Nothing has
+                            # been yielded yet, so streaming consumers remain
+                            # framed even when a weak model emits extra keys.
                             if is_ollama and tools:
-                                # In the sequential Ollama path, resolve and
-                                # validate immediately before each dispatch so
-                                # same-turn results are available to later calls.
-                                if parallel_tool_calls:
-                                    arguments = self._resolve_ollama_chained_args(
-                                        arguments, ollama_tool_result_mapping
-                                    )
-                                    arguments = self._validate_and_filter_ollama_arguments(
-                                        function_name, arguments, tools)
+                                arguments = self._validate_and_filter_ollama_arguments(
+                                    function_name, arguments, tools)
                             tool_calls_batch.append(ToolCall(
                                 function_name=function_name,
                                 arguments=arguments, 
@@ -4583,12 +4586,10 @@ Output MUST be JSON with 'reflection' and 'satisfactory'.
                                 _tool_call.arguments = self._resolve_ollama_chained_args(
                                     _tool_call.arguments, ollama_tool_result_mapping
                                 )
-                                if tools:
-                                    _tool_call.arguments = self._validate_and_filter_ollama_arguments(
-                                        _tool_call.function_name,
-                                        _tool_call.arguments,
-                                        tools,
-                                    )
+                                # The batch-preparation filter above has
+                                # already removed unknown keys. Chained
+                                # substitution changes values only, so no
+                                # second filtering pass is needed here.
                                 _result = executor.execute_batch(
                                     [_tool_call], execute_tool_fn,
                                     timeout_ms=self.tool_timeout_ms,

--- a/src/praisonai-agents/praisonaiagents/llm/llm.py
+++ b/src/praisonai-agents/praisonaiagents/llm/llm.py
@@ -1771,39 +1771,60 @@ Respond with ONLY a valid JSON tool call in this format:
             adapter = OllamaAdapter()
         return adapter.format_tool_result_message(function_name, tool_result)
 
-    @staticmethod
+    def _ollama_correlation_id(self) -> str:
+        """Return the active trace/session id for Ollama chaining diagnostics."""
+        try:
+            from ..trace.context_events import get_context_emitter
+
+            session_id = getattr(get_context_emitter(), "_session_id", None)
+            if session_id:
+                return str(session_id)
+        except Exception:
+            pass
+        # A stable per-LLM fallback still lets interleaved debug logs be grouped.
+        return f"llm:{id(self):x}"
+
     def _resolve_ollama_chained_args(
+        self,
         arguments: Dict[str, Any],
         tool_result_mapping: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Replace Ollama's function-name references with prior tool results."""
-        if not tool_result_mapping:
-            return arguments
-        for arg_name, arg_value in list(arguments.items()):
-            if isinstance(arg_value, str) and arg_value in tool_result_mapping:
-                arguments[arg_name] = tool_result_mapping[arg_value]
-                logging.debug(
-                    "[OLLAMA_FIX] Replaced %s with %s in %s arguments",
-                    arg_value,
-                    tool_result_mapping[arg_value],
-                    arg_name,
+        """Delegate Ollama function-name substitution to the provider adapter."""
+        adapter = getattr(self, "_provider_adapter", None)
+        resolver = getattr(adapter, "resolve_chained_arguments", None)
+        if resolver is not None:
+            try:
+                return resolver(
+                    arguments,
+                    tool_result_mapping,
+                    correlation_id=self._ollama_correlation_id(),
                 )
-        return arguments
+            except TypeError:
+                # Keep compatibility with lightweight test/custom adapters.
+                return resolver(arguments, tool_result_mapping)
+        from .adapters import resolve_ollama_chained_arguments
 
-    @staticmethod
+        return resolve_ollama_chained_arguments(
+            arguments,
+            tool_result_mapping,
+            correlation_id=self._ollama_correlation_id(),
+        )
+
     def _record_ollama_tool_result(
+        self,
         tool_result_mapping: Dict[str, Any],
         function_name: str,
         tool_result: Any,
     ) -> None:
-        """Record a tool result in the form weak Ollama models can chain."""
-        if isinstance(tool_result, (int, float)):
-            tool_result_mapping[function_name] = tool_result
-        elif isinstance(tool_result, str):
-            match = re.search(r"\b(\d+)\b", tool_result)
-            tool_result_mapping[function_name] = (
-                int(match.group(1)) if match else tool_result
-            )
+        """Delegate exact Ollama result recording to the provider adapter."""
+        adapter = getattr(self, "_provider_adapter", None)
+        recorder = getattr(adapter, "record_tool_result", None)
+        if recorder is not None:
+            recorder(tool_result_mapping, function_name, tool_result)
+            return
+        from .adapters import record_ollama_tool_result
+
+        record_ollama_tool_result(tool_result_mapping, function_name, tool_result)
 
     def _try_append_multimodal_tool_result(
         self,

--- a/src/praisonai-agents/tests/unit/llm/test_ollama_tool_chaining.py
+++ b/src/praisonai-agents/tests/unit/llm/test_ollama_tool_chaining.py
@@ -8,6 +8,40 @@ import praisonaiagents.llm.llm as llm_module
 from praisonaiagents.llm.llm import LLM
 
 
+def test_ollama_chaining_preserves_exact_tool_results():
+    llm = LLM.__new__(LLM)
+    llm._provider_adapter = None
+    mapping = {
+        "lookup": {"city": "Paris", "temperature": -5.5},
+        "list_items": ["a", 2],
+        "text": "Paris: 21C sunny",
+    }
+
+    assert llm._resolve_ollama_chained_args(
+        {
+            "first": "lookup",
+            "second": "list_items",
+            "third": "text",
+        },
+        mapping,
+    ) == {
+        "first": {"city": "Paris", "temperature": -5.5},
+        "second": ["a", 2],
+        "third": "Paris: 21C sunny",
+    }
+
+
+def test_ollama_chaining_records_none_and_structured_results():
+    llm = LLM.__new__(LLM)
+    llm._provider_adapter = None
+    mapping = {}
+
+    llm._record_ollama_tool_result(mapping, "empty", None)
+    llm._record_ollama_tool_result(mapping, "structured", {"ok": True})
+
+    assert mapping == {"empty": None, "structured": {"ok": True}}
+
+
 @pytest.mark.asyncio
 async def test_async_ollama_resolves_same_turn_tool_result_references(monkeypatch):
     class Response(SimpleNamespace):

--- a/src/praisonai-agents/tests/unit/llm/test_ollama_tool_chaining.py
+++ b/src/praisonai-agents/tests/unit/llm/test_ollama_tool_chaining.py
@@ -1,0 +1,94 @@
+"""Regression coverage for Ollama tool-result references on async paths."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import praisonaiagents.llm.llm as llm_module
+from praisonaiagents.llm.llm import LLM
+
+
+@pytest.mark.asyncio
+async def test_async_ollama_resolves_same_turn_tool_result_references(monkeypatch):
+    class Response(SimpleNamespace):
+        def __getitem__(self, key):
+            return getattr(self, key)
+
+    class Choice(SimpleNamespace):
+        def __getitem__(self, key):
+            return getattr(self, key)
+
+    llm = LLM.__new__(LLM)
+    llm.model = "ollama/llama3"
+    llm.verbose = False
+    llm.self_reflect = False
+    llm.reasoning_steps = False
+    llm._console = None
+    llm.max_iter = 4
+    llm._provider_adapter = SimpleNamespace(
+        handle_empty_response_with_tools=lambda context: False,
+        supports_streaming=lambda: False,
+        supports_streaming_with_tools=lambda: False,
+        recover_tool_calls_from_text=lambda text, tools: [],
+        should_summarize_tools=lambda iteration: False,
+    )
+    llm._build_messages = lambda **kwargs: ([], kwargs["prompt"])
+    llm._format_tools_for_litellm = lambda tools: [{"type": "function"}]
+    llm._supports_responses_api = lambda: False
+    llm._is_ollama_provider = lambda: True
+    llm._build_completion_params = lambda **kwargs: kwargs
+    llm._serialize_tool_calls = lambda calls: calls
+    llm._extract_tool_call_info = lambda call, is_ollama: (
+        call["function"]["name"],
+        {} if call["function"]["name"] == "first" else {"value": "first"},
+        call["id"],
+    )
+    llm._validate_and_filter_ollama_arguments = lambda name, args, tools: args
+    llm._format_ollama_tool_result_message = (
+        lambda name, result: {"role": "user", "content": str(result)}
+    )
+    llm._record_finish_reason = lambda response: None
+
+    responses = [
+        Response(
+            choices=[
+                Choice(
+                    message={
+                        "content": "use tools",
+                        "tool_calls": [
+                            {"id": "call-1", "function": {"name": "first"}},
+                            {"id": "call-2", "function": {"name": "second"}},
+                        ],
+                    }
+                )
+            ]
+        ),
+        Response(
+            choices=[Choice(message={"content": "final answer", "tool_calls": []})]
+        ),
+        Response(
+            choices=[Choice(message={"content": "final answer", "tool_calls": []})]
+        ),
+    ]
+
+    async def completion(**kwargs):
+        return responses.pop(0)
+
+    llm._acompletion_with_retry = completion
+    seen = []
+
+    async def dispatch(execute_tool_fn, function_name, arguments, tool_call_id, iteration_index):
+        seen.append((function_name, arguments))
+        return 3 if function_name == "first" else 9
+
+    monkeypatch.setattr(llm_module, "_dispatch_async_tool", dispatch)
+
+    result = await llm.get_response_async(
+        "question",
+        tools=[lambda: None],
+        execute_tool_fn=lambda *args: None,
+        stream=False,
+    )
+
+    assert result == "final answer"
+    assert seen == [("first", {}), ("second", {"value": 3})]

--- a/src/praisonai-agents/tests/unit/llm/test_ollama_tool_chaining.py
+++ b/src/praisonai-agents/tests/unit/llm/test_ollama_tool_chaining.py
@@ -109,6 +109,28 @@ async def test_async_ollama_resolves_same_turn_tool_result_references(monkeypatc
             ]
         ),
         Response(
+            choices=[
+                Choice(
+                    message={
+                        "content": "ok",
+                        "tool_calls": [],
+                    }
+                )
+            ]
+        ),
+        Response(
+            choices=[
+                Choice(
+                    message={
+                        "content": "continue",
+                        "tool_calls": [
+                            {"id": "call-3", "function": {"name": "second"}},
+                        ],
+                    }
+                )
+            ]
+        ),
+        Response(
             choices=[Choice(message={"content": "final answer", "tool_calls": []})]
         ),
         Response(
@@ -136,4 +158,8 @@ async def test_async_ollama_resolves_same_turn_tool_result_references(monkeypatc
     )
 
     assert result == "final answer"
-    assert seen == [("first", {}), ("second", {"value": 3})]
+    assert seen == [
+        ("first", {}),
+        ("second", {"value": 3}),
+        ("second", {"value": "first"}),
+    ]

--- a/src/praisonai-agents/tests/unit/llm/test_ollama_tool_chaining.py
+++ b/src/praisonai-agents/tests/unit/llm/test_ollama_tool_chaining.py
@@ -42,6 +42,17 @@ def test_ollama_chaining_records_none_and_structured_results():
     assert mapping == {"empty": None, "structured": {"ok": True}}
 
 
+def test_ollama_chaining_does_not_record_error_payloads():
+    llm = LLM.__new__(LLM)
+    llm._provider_adapter = None
+    mapping = {}
+
+    llm._record_ollama_tool_result(mapping, "failed", {"error": "failed: 42"})
+    llm._record_ollama_tool_result(mapping, "failed-list", [{"error": "failed"}])
+
+    assert mapping == {}
+
+
 @pytest.mark.asyncio
 async def test_async_ollama_resolves_same_turn_tool_result_references(monkeypatch):
     class Response(SimpleNamespace):

--- a/src/praisonai-agents/tests/unit/llm/test_stream_tool_dispatch.py
+++ b/src/praisonai-agents/tests/unit/llm/test_stream_tool_dispatch.py
@@ -78,3 +78,82 @@ def test_streaming_tool_call_is_executed_before_follow_up(monkeypatch):
     assert len(batches) == 1
     assert batches[0][0].function_name == "lookup"
     assert batches[0][0].iteration_index == 0
+
+
+def test_streaming_ollama_resolves_same_turn_tool_result_references(monkeypatch):
+    llm = LLM.__new__(LLM)
+    llm.model = "ollama/llama3"
+    llm.tool_timeout_ms = None
+    llm._build_messages = lambda **kwargs: ([], kwargs["prompt"])
+    llm._format_tools_for_litellm = lambda tools: [{"type": "function"}]
+    llm._supports_streaming_tools = lambda: True
+    llm._build_completion_params = lambda **kwargs: kwargs
+    llm._process_stream_delta = lambda *args, **kwargs: (
+        "",
+        [
+            {"id": "call-1", "function": {"name": "first", "arguments": "{}"}},
+            {
+                "id": "call-2",
+                "function": {"name": "second", "arguments": '{"value": "first"}'},
+            },
+        ],
+    )
+    llm._is_ollama_provider = lambda: True
+    llm._serialize_tool_calls = lambda calls: calls
+    llm._extract_tool_call_info = lambda call, is_ollama: (
+        call["function"]["name"],
+        {} if call["function"]["name"] == "first" else {"value": "first"},
+        call["id"],
+    )
+    llm._validate_and_filter_ollama_arguments = lambda name, args, tools: args
+    llm._register_deferred_if_any = lambda result: None
+    llm._create_tool_message = lambda *args: {"role": "user", "content": "ok"}
+
+    completion_calls = []
+
+    def completion(**kwargs):
+        completion_calls.append(kwargs)
+        if kwargs["stream"]:
+            delta = SimpleNamespace(content=None, tool_calls=[object(), object()])
+            return iter([SimpleNamespace(choices=[SimpleNamespace(delta=delta)])])
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="final answer"))]
+        )
+
+    llm._completion_with_retry = completion
+    seen_batches = []
+
+    class Executor:
+        def execute_batch(self, tool_calls, execute_tool_fn, timeout_ms=None):
+            seen_batches.append(tool_calls)
+            call = tool_calls[0]
+            result = 3 if call.function_name == "first" else 9
+            return [
+                SimpleNamespace(
+                    error=None,
+                    function_name=call.function_name,
+                    arguments=call.arguments,
+                    result=result,
+                    tool_call_id=call.tool_call_id,
+                    is_ollama=True,
+                )
+            ]
+
+    monkeypatch.setattr(
+        llm_module,
+        "create_tool_call_executor",
+        lambda parallel=False: Executor(),
+    )
+
+    chunks = list(
+        llm.get_response_stream(
+            "question",
+            tools=[lambda: None],
+            execute_tool_fn=lambda *args: None,
+        )
+    )
+
+    assert chunks == ["final answer"]
+    assert len(seen_batches) == 2
+    assert seen_batches[0][0].arguments == {}
+    assert seen_batches[1][0].arguments == {"value": 3}

--- a/src/praisonai-agents/tests/unit/llm/test_stream_tools_reach_the_model.py
+++ b/src/praisonai-agents/tests/unit/llm/test_stream_tools_reach_the_model.py
@@ -115,6 +115,43 @@ class TestNonStreamingFallbackRunsTools:
                                      tools=[get_weather], execute_tool_fn=execute))
         assert state["turns"] == 2, "the tool result was never sent back"
 
+    def test_ollama_chain_mapping_is_scoped_to_one_turn(self):
+        llm = LLM(model="ollama/llama3.2")
+        seen = []
+        state = {"turns": 0}
+
+        def first() -> int:
+            return 3
+
+        def second(value):
+            seen.append(value)
+            return 9
+
+        def completion(**kwargs):
+            state["turns"] += 1
+            if state["turns"] == 1:
+                message = types.SimpleNamespace(
+                    content=None, tool_calls=[_tool_call("first", "{}")])
+            elif state["turns"] == 2:
+                message = types.SimpleNamespace(
+                    content=None,
+                    tool_calls=[_tool_call("second", '{"value":"first"}')],
+                )
+            else:
+                message = types.SimpleNamespace(content="Done.", tool_calls=None)
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=message, finish_reason="stop")])
+
+        llm._completion_with_retry = completion
+        out = list(llm.get_response_stream(
+            prompt="chain", system_prompt="x", tools=[first, second],
+            execute_tool_fn=lambda name, args: first() if name == "first" else second(**args),
+        ))
+
+        assert state["turns"] == 3
+        assert seen == ["first"]
+        assert "Done." in "".join(out)
+
     def test_a_turn_with_no_tool_calls_still_yields_its_prose(self):
         llm = LLM(model="anthropic/claude-sonnet-4-20250514")
         message = types.SimpleNamespace(content="plain answer", tool_calls=None)


### PR DESCRIPTION
## Summary\n\nAddresses item 3 of #5013. Ollama tool-result references are now resolved in streaming and async tool loops, including same-turn sequential calls; result recording is shared with the synchronous path. Explicit parallel execution remains parallel, while the default sequential Ollama path preserves chaining semantics.\n\n## Verification\n\n- 3 focused streaming/async Ollama tests passed\n- Python compileall and git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama tool-call chaining when later tools use results from earlier calls.
  * Preserved successful tool results, including structured data and empty results, during chained calls.
  * Prevented failed tool results from being passed to subsequent calls.
  * Improved chained argument handling across standard, streaming, fallback, and asynchronous workflows.
  * Ensured dependent tool calls execute sequentially and receive expected values.
  * Isolated chained results between assistant turns to prevent stale references.

* **Tests**
  * Added regression coverage for synchronous, streaming, and asynchronous tool chaining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->