### PR TITLE
fix(ci): merge-only waits for Opus verdict on busy PRs

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -223,6 +223,26 @@ assert(
   ], null, '2026-06-27T09:55:00Z') === null
 );
 
+// merge-only must not use a short time window — fresh Opus APPROVE after assess wins on HEAD.
+assert(
+  'merge path finds APPROVE on HEAD without minCreatedAt window',
+  mg.findMergeGateVerdict(
+    [{ body: 'MERGE_GATE_VERDICT: APPROVE', created_at: '2026-06-12T10:00:00Z' }],
+    null,
+    '2026-06-12T09:00:00Z',
+    { excludeAutomatedFallback: true }
+  ) === 'APPROVE'
+);
+assert(
+  '25min minCreatedAt excludes older APPROVE (scan/dispatch paths only)',
+  mg.findMergeGateVerdict(
+    [{ body: 'MERGE_GATE_VERDICT: APPROVE', created_at: '2026-06-12T08:00:00Z' }],
+    '2026-06-12T09:30:00Z',
+    '2026-06-12T07:00:00Z',
+    { excludeAutomatedFallback: true }
+  ) === null
+);
+
 const finalWithFinished = [
   { user: { login: 'MervinPraison' }, body: '@claude You are the FINAL architecture reviewer.', created_at: '2026-06-27T10:00:00Z' },
   { user: { login: 'praisonai-triage-agent[bot]' }, body: 'Claude finished', created_at: '2026-06-27T10:05:00Z' },

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -797,22 +797,67 @@ function manualReviewReasonForAgentPy(agentChange) {
   return null;
 }
 
-async function listAllComments(github, owner, repo, issueNumber) {
-  if (typeof github.paginate === 'function') {
-    return github.paginate(github.rest.issues.listComments, {
-      owner,
-      repo,
-      issue_number: issueNumber,
-      per_page: 100,
-    });
-  }
-  const { data } = await github.rest.issues.listComments({
+async function listAllComments(github, owner, repo, issueNumber, options = {}) {
+  const { since } = options;
+  const params = {
     owner,
     repo,
     issue_number: issueNumber,
     per_page: 100,
-  });
-  return data;
+  };
+  if (since) params.since = since;
+
+  // Always page explicitly — github-script's paginate helper can return only the
+  // first page on busy PRs, so fresh MERGE_GATE_VERDICT comments on page 2+ are missed.
+  const all = [];
+  for (let page = 1; page <= 50; page++) {
+    const { data } = await github.rest.issues.listComments({ ...params, page });
+    all.push(...data);
+    if (data.length < 100) break;
+  }
+  return all;
+}
+
+/** Poll until Opus posts MERGE_GATE_VERDICT on HEAD (merge-only runs right after assess). */
+async function waitForMergeGateVerdict(github, owner, repo, prNumber, options = {}) {
+  const {
+    headPushedAt = null,
+    excludeAutomatedFallback = true,
+    maxAttempts = 18,
+    intervalMs = 10000,
+    since = null,
+    core: log = null,
+  } = options;
+
+  let resolvedHeadPushedAt = headPushedAt;
+  const commentSince =
+    since ||
+    (resolvedHeadPushedAt
+      ? new Date(new Date(resolvedHeadPushedAt).getTime() - 5 * 60 * 1000).toISOString()
+      : null);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (!resolvedHeadPushedAt) {
+      const ctx = await loadPrContext(github, owner, repo, prNumber);
+      resolvedHeadPushedAt = ctx.headPushedAt;
+    }
+    const comments = await listAllComments(github, owner, repo, prNumber, {
+      since: commentSince || undefined,
+    });
+    const verdict = findMergeGateVerdict(comments, null, resolvedHeadPushedAt, {
+      excludeAutomatedFallback,
+    });
+    if (verdict) {
+      return { verdict, headPushedAt: resolvedHeadPushedAt };
+    }
+    if (attempt < maxAttempts) {
+      log?.info?.(
+        `Verdict not visible yet (attempt ${attempt}/${maxAttempts}), waiting ${intervalMs / 1000}s...`
+      );
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  }
+  return { verdict: null, headPushedAt: resolvedHeadPushedAt };
 }
 
 async function getHeadCommitDate(github, owner, repo, prNumber) {
@@ -1119,6 +1164,7 @@ module.exports = {
   secretScanReasons,
   sdkTestChecksReason,
   listAllComments,
+  waitForMergeGateVerdict,
   getHeadCommitDate,
   isStaleFinalAfterPush,
   needsStaleFinalRecovery,

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -547,10 +547,12 @@ jobs:
 
             try {
               const ctx = await mergeGate.loadPrContext(github, owner, repo, prNumber);
-              const comments = ctx.comments;
-              const verdictMin = new Date(Date.now() - 25 * 60 * 1000).toISOString();
-              const verdict = mergeGate.findMergeGateVerdict(
-                comments, verdictMin, ctx.headPushedAt, { excludeAutomatedFallback: true }
+              const { verdict } = await mergeGate.waitForMergeGateVerdict(
+                github, owner, repo, prNumber, {
+                  headPushedAt: ctx.headPushedAt,
+                  excludeAutomatedFallback: true,
+                  core,
+                }
               );
               if (verdict !== 'APPROVE') {
                 core.info(`Skip merge: verdict=${verdict || 'NONE'}`);


### PR DESCRIPTION
## Summary
- Fix `merge-only` skipping real Opus **APPROVE** verdicts on busy PRs (e.g. #5040–#5044 stuck despite assess success).
- Paginate issue comments explicitly (github-script often returned only page 1).
- Poll for `MERGE_GATE_VERDICT` on HEAD via `waitForMergeGateVerdict` instead of a one-shot 25-minute window lookup.

## Test plan
- [x] `node .github/scripts/merge-gate-selftest.js` (67/67 pass)
- [ ] Next merge-gate run on a merge-ready PR auto-merges after Opus APPROVE


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved merge-gate reliability by waiting for a current approval verdict before proceeding with automated merges.
  - Added support for checking comments across multiple pages and filtering verdicts by recency.
  - Prevented older approval verdicts from being incorrectly used during merge validation.

- **Tests**
  - Added coverage for fresh approval verdicts and for excluding outdated verdicts based on the applicable time window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->