### PR TITLE
fix(config): load AutonomyConfig lazily in feature_configs

### DIFF
--- a/src/praisonai-agents/praisonaiagents/config/feature_configs.py
+++ b/src/praisonai-agents/praisonaiagents/config/feature_configs.py
@@ -33,11 +33,13 @@ Usage:
 
 from dataclasses import dataclass, field
 import math
-from typing import Dict, List, Any, Optional, Callable, Tuple, Union, FrozenSet
+from typing import Dict, List, Any, Optional, Callable, Tuple, Union, FrozenSet, TYPE_CHECKING
 from enum import Enum
 
-# Import AutonomyConfig from canonical location (no circular dep)
-from ..agent.autonomy import AutonomyConfig
+if TYPE_CHECKING:
+    # Type-only: the eager import pulled agent.autonomy and escalation.types onto
+    # every `from praisonaiagents import Agent` path (see resolve_autonomy).
+    from ..agent.autonomy import AutonomyConfig
 
 # Default tool output limit (16000 chars ≈ 4000 tokens)
 # Single source of truth shared by OutputConfig.tool_output_limit and
@@ -1785,13 +1787,16 @@ def resolve_caching(value: CachingParam) -> Optional[CachingConfig]:
     return _resolve(value, CachingConfig)
 
 
-def resolve_autonomy(value: AutonomyParam) -> Optional[AutonomyConfig]:
+def resolve_autonomy(value: AutonomyParam) -> Optional["AutonomyConfig"]:
     """
     Resolve autonomy= parameter following precedence ladder.
     
     Delegates to the canonical resolver in param_resolver.py.
     Kept for backward compatibility with tests.
     """
+    # Lazy: agent.autonomy (and, through it, escalation.types) is only needed
+    # when a caller actually resolves an autonomy= value.
+    from ..agent.autonomy import AutonomyConfig
     from .param_resolver import resolve_autonomy as _resolve
     return _resolve(value, AutonomyConfig)
 
@@ -2052,10 +2057,18 @@ def __getattr__(name):
 
     ``ToolSearchConfig`` is resolved (and the tools subsystem imported) only on
     first access, so ``from praisonaiagents import Agent`` does not eagerly load
-    the entire tools package (issue #3191).
+    the entire tools package (issue #3191). ``AutonomyConfig`` follows the same
+    pattern (issue #5056).
     """
     if name == "ToolSearchConfig":
         cfg = _resolve_tool_search_config()
         globals()["ToolSearchConfig"] = cfg  # cache for subsequent access
         return cfg
+    if name == "AutonomyConfig":
+        # Same idea for AutonomyConfig: keep the historical import path
+        # (``from ...feature_configs import AutonomyConfig``) working without
+        # loading agent.autonomy / escalation.types at module import (#5056).
+        from ..agent.autonomy import AutonomyConfig
+        globals()["AutonomyConfig"] = AutonomyConfig
+        return AutonomyConfig
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/praisonai-agents/tests/unit/test_lazy_imports.py
+++ b/src/praisonai-agents/tests/unit/test_lazy_imports.py
@@ -51,6 +51,20 @@ class TestLazyImports:
         """Clean up after each test."""
         restore_modules()
     
+    def test_autonomy_not_loaded_on_agent_import(self):
+        """agent.autonomy / escalation.types must not load on the default Agent path (#5056)."""
+        from praisonaiagents import Agent  # noqa: F401
+        assert 'praisonaiagents.agent.autonomy' not in sys.modules, \
+            "agent.autonomy should be loaded lazily, not on `from praisonaiagents import Agent`"
+        assert 'praisonaiagents.escalation.types' not in sys.modules, \
+            "escalation.types should not ride along on the default Agent import"
+
+    def test_autonomy_config_still_importable_from_feature_configs(self):
+        """The lazy re-export keeps the historical import path working."""
+        from praisonaiagents.config.feature_configs import AutonomyConfig
+        from praisonaiagents.agent.autonomy import AutonomyConfig as Canonical
+        assert AutonomyConfig is Canonical
+
     def test_litellm_not_loaded_on_import(self):
         """litellm should NOT be loaded when importing praisonaiagents."""
         import praisonaiagents  # noqa: F401


### PR DESCRIPTION
## Summary

`config/feature_configs.py` imported `AutonomyConfig` eagerly at module level, so every `from praisonaiagents import Agent` loaded `praisonaiagents.agent.autonomy` and, through it, `praisonaiagents.escalation.types`, even though the class is only needed when a caller actually resolves an `autonomy=` value.

This PR makes that import lazy without changing any public import path:

- the top-level import moves under `TYPE_CHECKING` (annotations only; the return annotation of `resolve_autonomy` becomes a string)
- `resolve_autonomy()` imports `AutonomyConfig` inside the function, where it is used
- the existing PEP 562 module `__getattr__` (already used for `ToolSearchConfig`, #3191) now also serves `AutonomyConfig`, so `from praisonaiagents.config.feature_configs import AutonomyConfig` keeps working and caches the class on first access

Closes #5056

## Tests

Added to `tests/unit/test_lazy_imports.py`:

- `test_autonomy_not_loaded_on_agent_import`: `from praisonaiagents import Agent` no longer puts `praisonaiagents.agent.autonomy` or `praisonaiagents.escalation.types` into `sys.modules`
- `test_autonomy_config_still_importable_from_feature_configs`: the lazy re-export is the canonical class from `agent.autonomy`

```
python -m pytest tests/unit/test_lazy_imports.py tests/unit/test_autonomy_system_fixes.py -q
40 passed
```

Also verified by hand that `resolve_autonomy(True)` still returns an `AutonomyConfig` instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved startup behavior when importing `Agent` by deferring loading of autonomy-related functionality.
  * Preserved access to `AutonomyConfig` through its existing import path.

* **Tests**
  * Added coverage confirming autonomy modules are not loaded unnecessarily during `Agent` imports.
  * Added verification that `AutonomyConfig` remains available, resolves correctly on demand, and stays consistent when accessed directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->